### PR TITLE
adding -Wno-inconsistent-missing-override to avoid build errors on mac

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -557,7 +557,7 @@ if main['GCC'] or main['CLANG']:
     # Enable -Wall and -Wextra and then disable the few warnings that
     # we consistently violate
     main.Append(CCFLAGS=['-Wall', '-Wundef', '-Wextra',
-                         '-Wno-sign-compare', '-Wno-unused-parameter'])
+                         '-Wno-sign-compare', '-Wno-unused-parameter', '-Wno-inconsistent-missing-override'])
     # We always compile using C++11
     main.Append(CXXFLAGS=['-std=c++11'])
 else:


### PR DESCRIPTION
I was having build errors when building for ARM architecture through this command "**scons build/ARM/gem5.opt**"

I was receiving the following errors at multiple places -

**overrides a member function but is not marked 'override'
      [-Werror,-Winconsistent-missing-override]
**
Ex -

**build/ARM/mem/ruby/system/DMASequencer.hh:62:10: error:
      'isDeadlockEventScheduled' overrides a member function but is not marked 'override'
      [-Werror,-Winconsistent-missing-override]
    bool isDeadlockEventScheduled() const { return false; }**

Some research led me to this http://stackoverflow.com/questions/32626171/xcode-7-how-to-suppress-warning-overrides-a-member-function-but-is-not-marked 

I added the flag and here is the pull request.
