### PR TITLE
Fix early-quit in commit stage

### DIFF
--- a/src/cpu/o3/commit.hh
+++ b/src/cpu/o3/commit.hh
@@ -44,6 +44,7 @@
 #ifndef __CPU_O3_COMMIT_HH__
 #define __CPU_O3_COMMIT_HH__
 
+#include <array>
 #include <queue>
 
 #include "base/statistics.hh"
@@ -518,6 +519,9 @@ class DefaultCommit
 
     /** Number of cycles where the commit bandwidth limit is reached. */
     Stats::Scalar commitEligibleSamples;
+
+private:
+    std::array<bool, Impl::MaxThreads> skipThisCycle{};
 };
 
 #endif // __CPU_O3_COMMIT_HH__


### PR DESCRIPTION
 When one thread is unable to commit more instructions, other threads should continue committing. In original implementation, if one thread cannot commit, it quits the commit loop and all other threads cannot commit any more.