### PR TITLE
Fix m5term select issues

### DIFF
--- a/util/term/term.c
+++ b/util/term/term.c
@@ -168,15 +168,6 @@ readwrite(int nfd)
             perror("Select Error:");
         }
 
-        if (n == 0) {
-            if (read(nfd, buf, 0) < 0)
-                return;
-            continue;
-        }
-
-        if (read(nfd, buf, 0) < 0)
-            return;
-
         if (FD_ISSET(nfd, &read_fds)) {
             if ((n = read(nfd, buf, sizeof(buf))) < 0)
                 return;


### PR DESCRIPTION
Running m5term on Ubuntu (Linux on Windows) fails with no STDIN input.
This is due to several unexpected sanity checks in readwrite() polling
loop.

Returning 0 from select() means timeout which should be expected as there
is a 1 second timeout set to the select().
And it is actually no need to perform "read(nfd) < 0" sanity checks.

This patch fixes the select() loop related issues.

Signed-off-by: Lv Zheng <zhenglv@smart-core.cn>