### PR TITLE
Guard bitshift against undefined behavior

### DIFF
--- a/ext/fputils/fp80.c
+++ b/ext/fputils/fp80.c
@@ -161,7 +161,7 @@ fp80_cvtfp64(fp80_t fp80)
              * as normals */
             return build_fp64(sign, fp64_frac, fp64_exp);
         } else if (fp64_exp <= 0) {
-            uint64_t fp64_denormal_frac = fp64_frac >> (-fp64_exp);
+            uint64_t fp64_denormal_frac = fp64_exp > -64 ? fp64_frac >> (-fp64_exp) : 0;
             /* Generate a denormal or zero */
             return build_fp64(sign, fp64_denormal_frac, 0);
         } else {


### PR DESCRIPTION
The code previously had undefined behavior for numbers close to zero and zero because it would shift by a number larger than the width of the field.