### PR TITLE
scons: add explicit dependency on m4

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -161,6 +161,7 @@ main = Environment(tools=[
 
 main.Tool(SCons.Tool.FindTool(['gcc', 'clang'], main))
 main.Tool(SCons.Tool.FindTool(['g++', 'clang++'], main))
+main.Tool(SCons.Tool.FindTool(['m4'], main))
 
 Export('main')
 


### PR DESCRIPTION
At least on NixOS it does not find m4 otherwise and misses the M4 attribute.
It somehow ignores $PATH and only lookup m4 in `/usr/bin`. Having this explicit check helps.
Since it also improves build errors, this should help on all fronts.

Change-Id: I290bd4cc321d83b1669c116c745ed40e39a048bb