### PR TITLE
sim: Add a way to specify the pools allocators for each process

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -755,6 +755,11 @@ def addSEOptions(parser):
         action="store_true",
         help="Wait for remote GDB to connect.",
     )
+    parser.add_argument(
+        "--pool_ids",
+        default="",
+        help="Specify the available mem pool id for each process.",
+    )
 
 
 def addFSOptions(parser):

--- a/configs/example/se.py
+++ b/configs/example/se.py
@@ -86,12 +86,27 @@ def get_processes(args):
     if args.options != "":
         pargs = args.options.split(";")
 
+    # Use ';' to separate the list of memory pool id available for each process
+    pool_ids_sv = args.pool_ids.split(";") if args.pool_ids != "" else ["0"]
+    # If no id is specified,
+    # each process can be allocated from mem_pool 0 by default
+    pool_ids_sv += ["0"] * (len(workloads) - len(pool_ids_sv))
+
     idx = 0
     for wrkld in workloads:
         process = Process(pid=100 + idx)
         process.executable = wrkld
         process.cwd = os.getcwd()
         process.gid = os.getgid()
+
+        # Split the pool ids available for the process by ','
+        pool_ids_v = list(map(int, pool_ids_sv[idx].split(",")))
+        # A negative value indicates that
+        # the process cannot allocate memory in any pool
+        pool_ids_v = [] if min(pool_ids_v) < 0 else pool_ids_v
+        # Pass this parameter,
+        # and the pool corresponding to the parameter should exist
+        process.pool_ids = pool_ids_v
 
         if args.env:
             with open(args.env, "r") as f:
@@ -178,7 +193,10 @@ mp0_path = multiprocesses[0].executable
 system = System(
     cpu=[CPUClass(cpu_id=i) for i in range(np)],
     mem_mode=test_mem_mode,
-    mem_ranges=[AddrRange(args.mem_size)],
+    mem_ranges=[
+        AddrRange(args.mem_size),
+        # AddrRange(0x10000000000,size=args.mem_size) # Add a new test memory
+    ],
     cache_line_size=args.cacheline_size,
 )
 

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -180,12 +180,15 @@ X86_64Process::initState()
     if (kvmInSE) {
         PortProxy physProxy = system->physProxy;
 
-        Addr syscallCodePhysAddr = seWorkload->allocPhysPages(1);
-        Addr gdtPhysAddr = seWorkload->allocPhysPages(1);
-        Addr idtPhysAddr = seWorkload->allocPhysPages(1);
-        Addr istPhysAddr = seWorkload->allocPhysPages(1);
-        Addr tssPhysAddr = seWorkload->allocPhysPages(1);
-        Addr pfHandlerPhysAddr = seWorkload->allocPhysPages(1);
+        /*
+         * Pass the available memory pool is the member of the current process
+         */
+        Addr syscallCodePhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr gdtPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr idtPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr istPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr tssPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr pfHandlerPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
 
         /*
          * Set up the gdt.

--- a/src/sim/Process.py
+++ b/src/sim/Process.py
@@ -59,6 +59,8 @@ class Process(SimObject):
     ppid = Param.Int(0, "parent process id")
     pgid = Param.Int(100, "process group id")
 
+    pool_ids = VectorParam.Int([], "Available mem pools")
+
     executable = Param.String("", "executable (overrides cmd[0] if set)")
     cmd = VectorParam.String("command line (executable plus arguments)")
     env = VectorParam.String([], "environment settings")

--- a/src/sim/mem_pool.cc
+++ b/src/sim/mem_pool.cc
@@ -116,10 +116,10 @@ MemPool::allocate(Addr npages)
 {
     Addr return_addr = freePageAddr();
     freePageNum += npages;
-
-    fatal_if(freePages() <= 0,
-            "Out of memory, please increase size of physical memory.");
-
+    // current pool has exhausted
+    if (freePages() <= 0)
+        return POOL_EXHAUSTED;
+    // fatal_if is transferred to the upper level function
     return return_addr;
 }
 

--- a/src/sim/mem_pool.hh
+++ b/src/sim/mem_pool.hh
@@ -38,6 +38,9 @@
 #include "base/types.hh"
 #include "sim/serialize.hh"
 
+// The memory pool corresponding to the current id is exhausted
+#define POOL_EXHAUSTED 0x7FFFFFFFFFFFFFFF
+
 namespace gem5
 {
 

--- a/src/sim/process.cc
+++ b/src/sim/process.cc
@@ -128,6 +128,7 @@ Process::Process(const ProcessParams &params, EmulationPageTable *pTable,
       _gid(params.gid), _egid(params.egid),
       _pid(params.pid), _ppid(params.ppid),
       _pgid(params.pgid), drivers(params.drivers),
+      pool_ids(params.pool_ids),// Pass in the available memory pool_ids vector
       fds(std::make_shared<FDArray>(
                   params.input, params.output, params.errout)),
       childClearTID(0),
@@ -336,7 +337,8 @@ Process::allocateMem(Addr vaddr, int64_t size, bool clobber)
     }
 
     const int npages = divCeil(size, page_size);
-    const Addr paddr = seWorkload->allocPhysPages(npages);
+    // try to allocate in all available memory pools
+    const Addr paddr = seWorkload->allocPhysPages(npages, pool_ids);
     const Addr pages_size = npages * page_size;
     pTable->map(page_addr, paddr, pages_size,
                 clobber ? EmulationPageTable::Clobber :
@@ -348,7 +350,8 @@ Process::replicatePage(Addr vaddr, Addr new_paddr, ThreadContext *old_tc,
                        ThreadContext *new_tc, bool allocate_page)
 {
     if (allocate_page)
-        new_paddr = seWorkload->allocPhysPages(1);
+        // try to allocate in all available memory pools
+        new_paddr = seWorkload->allocPhysPages(1, pool_ids);
 
     // Read from old physical page.
     uint8_t buf_p[pTable->pageSize()];

--- a/src/sim/process.hh
+++ b/src/sim/process.hh
@@ -281,6 +281,9 @@ class Process : public SimObject
     uint64_t _pgid;
     uint64_t _tgid;
 
+    // Memory pool ids available to this process
+    std::vector<int> pool_ids;
+
     // Emulated drivers available to this process
     std::vector<EmulatedDriver *> drivers;
 

--- a/src/sim/se_workload.cc
+++ b/src/sim/se_workload.cc
@@ -77,6 +77,24 @@ SEWorkload::allocPhysPages(int npages, int pool_id)
     return memPools.allocPhysPages(npages, pool_id);
 }
 
+// Implementing the new allocation function
+Addr
+SEWorkload::allocPhysPages(int npages, std::vector<int>& pools_id)
+{
+    Addr allocated_addr = POOL_EXHAUSTED;
+    // Try in all available memory pools
+    for (int pool_id : pools_id){
+        allocated_addr = memPools.allocPhysPages(npages, pool_id);
+        if (allocated_addr != POOL_EXHAUSTED)
+            break;
+    }
+
+    fatal_if(allocated_addr == POOL_EXHAUSTED,
+            "Out of memory, please increase size of physical memory.");
+
+    return allocated_addr;
+}
+
 Addr
 SEWorkload::memSize(int pool_id) const
 {

--- a/src/sim/se_workload.hh
+++ b/src/sim/se_workload.hh
@@ -90,6 +90,12 @@ class SEWorkload : public Workload
     void event(ThreadContext *tc) override { syscall(tc); }
 
     Addr allocPhysPages(int npages, int pool_id=0);
+    /*
+     * Define a new allocation function
+     * uses the available memory pool ids vector as an argument
+     */
+    Addr allocPhysPages(int npages, std::vector<int>& pools_id);
+
     Addr memSize(int pool_id=0) const;
     Addr freeMemSize(int pool_id=0) const;
 };


### PR DESCRIPTION
The system supports the specification of multiple blocks of memory and the ability to specify different pool allocators. However, it seems that the relevant memory allocation functions currently use the default pool_id parameter, which prevents subsequent memory blocks from being used. This patch adds a parameter and modifies the allocation function to make it easier to specify the set of pool ids available for each process.