### PR TITLE
sim: Specify the available pool allocators for each process

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -755,7 +755,12 @@ def addSEOptions(parser):
         action="store_true",
         help="Wait for remote GDB to connect.",
     )
-
+    parser.add_argument(
+        "--pool_ids",
+        default="",
+        help="Specify the available mem pool id for each process.",
+    )
+    
 
 def addFSOptions(parser):
     from common.FSConfig import os_types

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -180,12 +180,15 @@ X86_64Process::initState()
     if (kvmInSE) {
         PortProxy physProxy = system->physProxy;
 
-        Addr syscallCodePhysAddr = seWorkload->allocPhysPages(1);
-        Addr gdtPhysAddr = seWorkload->allocPhysPages(1);
-        Addr idtPhysAddr = seWorkload->allocPhysPages(1);
-        Addr istPhysAddr = seWorkload->allocPhysPages(1);
-        Addr tssPhysAddr = seWorkload->allocPhysPages(1);
-        Addr pfHandlerPhysAddr = seWorkload->allocPhysPages(1);
+        /*
+         * Pass the available memory pool is the member of the current process
+         */
+        Addr syscallCodePhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr gdtPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr idtPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr istPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr tssPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
+        Addr pfHandlerPhysAddr = seWorkload->allocPhysPages(1, pool_ids);
 
         /*
          * Set up the gdt.

--- a/src/sim/Process.py
+++ b/src/sim/Process.py
@@ -59,6 +59,8 @@ class Process(SimObject):
     ppid = Param.Int(0, "parent process id")
     pgid = Param.Int(100, "process group id")
 
+    pool_ids = VectorParam.Int([0], "Available mem pools")
+
     executable = Param.String("", "executable (overrides cmd[0] if set)")
     cmd = VectorParam.String("command line (executable plus arguments)")
     env = VectorParam.String([], "environment settings")

--- a/src/sim/mem_pool.cc
+++ b/src/sim/mem_pool.cc
@@ -116,10 +116,10 @@ MemPool::allocate(Addr npages)
 {
     Addr return_addr = freePageAddr();
     freePageNum += npages;
-
-    fatal_if(freePages() <= 0,
-            "Out of memory, please increase size of physical memory.");
-
+    // current pool has exhausted
+    if (freePages() <= 0)
+        return POOL_EXHAUSTED;
+    // fatal_if is transferred to the upper level function
     return return_addr;
 }
 

--- a/src/sim/mem_pool.hh
+++ b/src/sim/mem_pool.hh
@@ -38,6 +38,9 @@
 #include "base/types.hh"
 #include "sim/serialize.hh"
 
+// The memory pool corresponding to the current id is exhausted
+#define POOL_EXHAUSTED 0x7FFFFFFFFFFFFFFF
+
 namespace gem5
 {
 

--- a/src/sim/process.hh
+++ b/src/sim/process.hh
@@ -280,6 +280,9 @@ class Process : public SimObject
     uint64_t _pgid;
     uint64_t _tgid;
 
+    // Memory pool ids available to this process
+    std::vector<int> pool_ids;
+
     // Emulated drivers available to this process
     std::vector<EmulatedDriver *> drivers;
 

--- a/src/sim/se_workload.cc
+++ b/src/sim/se_workload.cc
@@ -77,6 +77,24 @@ SEWorkload::allocPhysPages(int npages, int pool_id)
     return memPools.allocPhysPages(npages, pool_id);
 }
 
+// Implementing the new allocation function
+Addr
+SEWorkload::allocPhysPages(int npages, std::vector<int>& pools_id)
+{
+    Addr allocated_addr = POOL_EXHAUSTED;
+    // Try in all available memory pools
+    for (int pool_id : pools_id){
+        allocated_addr = memPools.allocPhysPages(npages, pool_id);
+        if (allocated_addr != POOL_EXHAUSTED)
+            break;
+    }
+
+    fatal_if(allocated_addr == POOL_EXHAUSTED,
+            "Out of memory, please increase size of physical memory.");
+
+    return allocated_addr;
+}
+
 Addr
 SEWorkload::memSize(int pool_id) const
 {

--- a/src/sim/se_workload.hh
+++ b/src/sim/se_workload.hh
@@ -90,6 +90,12 @@ class SEWorkload : public Workload
     void event(ThreadContext *tc) override { syscall(tc); }
 
     Addr allocPhysPages(int npages, int pool_id=0);
+    /*
+     * Define a new allocation function
+     * uses the available memory pool ids vector as an argument
+     */
+    Addr allocPhysPages(int npages, std::vector<int>& pools_id);
+
     Addr memSize(int pool_id=0) const;
     Addr freeMemSize(int pool_id=0) const;
 };


### PR DESCRIPTION
The system supports the specification of multiple blocks of memory and the ability to specify different pool allocators. However, it seems that the relevant memory allocation functions currently use the default pool_id parameter, which prevents subsequent memory blocks from being used. This patch adds a parameter and modifies the allocation function to make it easier to specify the set of pool ids available for each process.