### PR TITLE
stdlib: Dividing range for linear multicore.

### DIFF
--- a/src/python/gem5/components/processors/abstract_generator.py
+++ b/src/python/gem5/components/processors/abstract_generator.py
@@ -35,6 +35,22 @@ from ..boards.abstract_board import AbstractBoard
 from typing import List
 
 
+def partition_range(
+    min_addr: int, max_addr: int, num_partitions: int
+) -> List[tuple]:
+    assert (
+        isinstance(min_addr, int)
+        and isinstance(max_addr, int)
+        and isinstance(num_partitions, int)
+    )
+    assert ((max_addr - min_addr) % num_partitions) == 0
+    chunk_size = int((max_addr - min_addr) / num_partitions)
+    return [
+        (min_addr + chunk_size * i, min_addr + chunk_size * (i + 1))
+        for i in range(num_partitions)
+    ]
+
+
 class AbstractGenerator(AbstractProcessor):
     """The abstract generator
     It defines the external interface of every generator component.

--- a/src/python/gem5/components/processors/complex_generator.py
+++ b/src/python/gem5/components/processors/complex_generator.py
@@ -27,6 +27,7 @@
 from ...utils.override import overrides
 from .complex_generator_core import ComplexGeneratorCore
 from .abstract_generator import AbstractGenerator
+from .abstract_generator import partition_range
 
 from typing import Iterator, List, Any
 
@@ -76,13 +77,14 @@ class ComplexGenerator(AbstractGenerator):
         :param data_limit: The amount of data in bytes to read/write by the
         generator before stopping generation.
         """
-        for core in self.cores:
+        ranges = partition_range(min_addr, max_addr, len(self.cores))
+        for i, core in enumerate(self.cores):
             core.add_linear(
                 duration,
                 rate,
                 block_size,
-                min_addr,
-                max_addr,
+                ranges[i][0],
+                ranges[i][1],
                 rd_perc,
                 data_limit,
             )

--- a/src/python/gem5/components/processors/linear_generator.py
+++ b/src/python/gem5/components/processors/linear_generator.py
@@ -27,6 +27,7 @@
 from ...utils.override import overrides
 from .linear_generator_core import LinearGeneratorCore
 from .abstract_generator import AbstractGenerator
+from .abstract_generator import partition_range
 
 from typing import List
 
@@ -91,17 +92,20 @@ class LinearGenerator(AbstractGenerator):
         The helper function to create the cores for the generator, it will use
         the same inputs as the constructor function.
         """
+
+        ranges = partition_range(min_addr, max_addr, num_cores)
+
         return [
             LinearGeneratorCore(
                 duration=duration,
                 rate=rate,
                 block_size=block_size,
-                min_addr=min_addr,
-                max_addr=max_addr,
+                min_addr=ranges[i][0],
+                max_addr=ranges[i][1],
                 rd_perc=rd_perc,
                 data_limit=data_limit,
             )
-            for _ in range(num_cores)
+            for i in range(num_cores)
         ]
 
     @overrides(AbstractGenerator)


### PR DESCRIPTION
This patch, changes the way memory ranges are devided when using multiple cores for linear traffic. The current state assigns the same range to multiple linear generators so all the cores start generating the same trace. This patch devides the overall range assigned to the generator ([min_addr:max_addr]) between the cores.

Change-Id: I49f69b3d61b590899f8d54ee3be997ad22d7fa9b