### PR TITLE
mem-ruby: Added WIB State to VIPER TCC Cache

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -81,6 +81,7 @@ machine(MachineType:TCC, "TCC Cache")
     I, AccessPermission:Invalid,    desc="Invalid";
     IV, AccessPermission:Busy,      desc="Waiting for Data";
     WI, AccessPermission:Busy,      desc="Waiting on Writethrough Ack";
+    WIB, AccessPermission:Busy,      desc="Waiting on Writethrough Ack; Will be Bypassed";
     A, AccessPermission:Busy,       desc="Invalid waiting on atomici Data";
   }
 
@@ -289,7 +290,9 @@ machine(MachineType:TCC, "TCC Cache")
             is_slc_set := tbe.isSLCSet;
         }
 
-        if (is_slc_set) {
+        if (in_msg.Type == CoherenceResponseType:NBSysWBAck) {
+          trigger(Event:WBAck, in_msg.addr, cache_entry, tbe);
+        } else if (is_slc_set) {
             // If the SLC bit is set, the response needs to bypass the cache
             // and should not be allocated an entry.
             trigger(Event:Bypass, in_msg.addr, cache_entry, tbe);
@@ -300,8 +303,6 @@ machine(MachineType:TCC, "TCC Cache")
             Addr victim :=  L2cache.cacheProbe(in_msg.addr);
             trigger(Event:L2_Repl, victim, getCacheEntry(victim), TBEs.lookup(victim));
           }
-        } else if (in_msg.Type == CoherenceResponseType:NBSysWBAck) {
-          trigger(Event:WBAck, in_msg.addr, cache_entry, tbe);
         } else {
           error("Unexpected Response Message to Core");
         }
@@ -699,6 +700,12 @@ machine(MachineType:TCC, "TCC Cache")
       // woken up
       st_stallAndWaitRequest;
   }
+  transition(WIB, {RdBlk, WrVicBlk, Atomic, WrVicBlkBack}) { //TagArrayRead} {
+      // by putting the stalled requests in a buffer, we reduce resource contention
+      // since they won't try again every cycle and will instead only try again once
+      // woken up
+      st_stallAndWaitRequest;
+  }
   transition(A, {RdBlk, WrVicBlk, WrVicBlkBack}) { //TagArrayRead} {
       // by putting the stalled requests in a buffer, we reduce resource contention
       // since they won't try again every cycle and will instead only try again once
@@ -751,7 +758,7 @@ machine(MachineType:TCC, "TCC Cache")
 // Transition to be called when a read request with SLC flag set arrives at
 // entry in state W. It evicts and invalidates the cache entry before
 // forwarding the request to global memory
-  transition(W, RdBypassEvict, I) {TagArrayRead} {
+  transition(W, RdBypassEvict, WIB) {TagArrayRead} {
     p_profileMiss;
     t_allocateTBE;
     wb_writeBack;
@@ -763,7 +770,7 @@ machine(MachineType:TCC, "TCC Cache")
 // Transition to be called when a read request with SLC flag set arrives at
 // entry in state M. It evicts and invalidates the cache entry before
 // forwarding the request to global memory to main memory
-  transition(M, RdBypassEvict, I) {TagArrayRead} {
+  transition(M, RdBypassEvict, WIB) {TagArrayRead} {
     p_profileMiss;
     t_allocateTBE;
     wb_writeBack;
@@ -785,7 +792,7 @@ machine(MachineType:TCC, "TCC Cache")
 
 // Transition to be called when a read request with SLC flag arrives at entry
 // in transient state. The request stalls until the pending transition is complete.
-  transition({WI, IV}, RdBypassEvict)  {
+  transition({WI, WIB, IV}, RdBypassEvict)  {
     st_stallAndWaitRequest;
   }
 
@@ -972,6 +979,10 @@ transition(I, Atomic, A) {TagArrayRead} {
   transition(WI, WBAck,I) {
     dt_deallocateTBE;
     wada_wakeUpAllDependentsAddr;
+    pr_popResponseQueue;
+  }
+
+  transition(WIB, WBAck,I) {
     pr_popResponseQueue;
   }
 }


### PR DESCRIPTION
Added WIB (Waiting on Writethrough Ack; Will be Bypassed) state which is transitioned to when a dirty line in the TCC is evicted in a bypassed read. Previously, we were transitioning to invalid.

While a WI (Waiting on Writethrough Ack) state exists, transitions from it on WBAck deallocates the TBE, which contains SLC bit information needed to trigger the Bypass event when the read response from the directory comes in.

Without this change, WB acknowledgements from the directory in read bypass evicts (with the SLC bit set) were being treated as if they were read responses, leading to an invalid transition panic.