### PR TITLE
Sanitizer libraries static linking

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -562,10 +562,11 @@ for variant_path in variant_paths:
     if sanitizers:
         sanitizers = ','.join(sanitizers)
         if env['GCC'] or env['CLANG']:
+            libsan = '-static-libasan' if env['GCC'] else '-static-libsan'
             env.Append(CCFLAGS=['-fsanitize=%s' % sanitizers,
                                  '-fno-omit-frame-pointer'],
-                        LINKFLAGS=['-fsanitize=%s' % sanitizers,
-                                   '-static-libasan'])
+                       LINKFLAGS=['-fsanitize=%s' % sanitizers,
+                                   libsan])
 
             if main["BIN_TARGET_ARCH"] == "x86_64":
                 # Sanitizers can enlarge binary size drammatically, north of

--- a/SConstruct
+++ b/SConstruct
@@ -562,11 +562,14 @@ for variant_path in variant_paths:
     if sanitizers:
         sanitizers = ','.join(sanitizers)
         if env['GCC'] or env['CLANG']:
-            libsan = '-static-libasan' if env['GCC'] else '-static-libsan'
+            libsan = (
+                ['-static-libubsan', '-static-libasan']
+                if env['GCC']
+                else ['-static-libsan']
+            )
             env.Append(CCFLAGS=['-fsanitize=%s' % sanitizers,
                                  '-fno-omit-frame-pointer'],
-                       LINKFLAGS=['-fsanitize=%s' % sanitizers,
-                                   libsan])
+                       LINKFLAGS=['-fsanitize=%s' % sanitizers] + libsan)
 
             if main["BIN_TARGET_ARCH"] == "x86_64":
                 # Sanitizers can enlarge binary size drammatically, north of


### PR DESCRIPTION
GCC uses `-static-libasan` and `-static-libubsan` to statically link with address and undefined behavior sanitizers while CLANG uses `-static-libsan`. This patch discriminates between the two cases and introduces static link with libubsan when using GCC as well.

Change-Id: I2441466c5c9343afd938185b8ec5047d4e95ac70