### PR TITLE
Unit tests miscellaneous patches

### DIFF
--- a/src/base/amo.test.cc
+++ b/src/base/amo.test.cc
@@ -64,9 +64,10 @@ TEST(AmoTest, AtomicOpMin)
     std::string test_string_smaller = "apple";
     std::string test_string_bigger = "cat";
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpMin<int>(10);
-    TypedAtomicOpFunctor<std::string> *amo_op_string =
-        new AtomicOpMin<std::string>("base");
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpMin<int>>(10);
+    std::unique_ptr<TypedAtomicOpFunctor<std::string>> amo_op_string =
+        std::make_unique<AtomicOpMin<std::string>>("base");
     amo_op_int->execute(&test_int_smaller);
     amo_op_int->execute(&test_int_bigger);
     amo_op_string->execute(&test_string_smaller);
@@ -85,9 +86,10 @@ TEST(AmoTest, AtomicOpMax)
     std::string test_string_smaller = "apple";
     std::string test_string_bigger = "cat";
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpMax<int>(10);
-    TypedAtomicOpFunctor<std::string> *amo_op_string =
-        new AtomicOpMax<std::string>("base");
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpMax<int>>(10);
+    std::unique_ptr<TypedAtomicOpFunctor<std::string>> amo_op_string =
+        std::make_unique<AtomicOpMax<std::string>>("base");
     amo_op_int->execute(&test_int_smaller);
     amo_op_int->execute(&test_int_bigger);
     amo_op_string->execute(&test_string_smaller);
@@ -104,8 +106,10 @@ TEST(AmoTest, AtomicOpDec)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpDec<int>();
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpDec<char>();
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpDec<int>>();
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpDec<char>>();
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -118,8 +122,10 @@ TEST(AmoTest, AtomicOpInc)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpInc<int>();
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpInc<char>();
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpInc<int>>();
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpInc<char>>();
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -132,8 +138,10 @@ TEST(AmoTest, AtomicOpSub)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpSub<int>(2);
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpSub<char>('a');
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpSub<int>>(2);
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpSub<char>>('a');
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -146,8 +154,10 @@ TEST(AmoTest, AtomicOpAdd)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpAdd<int>(2);
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpAdd<char>(2);
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpAdd<int>>(2);
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpAdd<char>>(2);
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -160,8 +170,10 @@ TEST(AmoTest, AtomicOpExch)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpExch<int>(2);
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpExch<char>('a');
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpExch<int>>(2);
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpExch<char>>('a');
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -174,8 +186,10 @@ TEST(AmoTest, AtomicOpXor)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpXor<int>(2);
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpXor<char>('a');
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpXor<int>>(2);
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpXor<char>>('a');
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -188,8 +202,10 @@ TEST(AmoTest, AtomicOpOr)
     int test_int = 8;
     bool test_bool = true;
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpOr<int>(2);
-    TypedAtomicOpFunctor<bool> *amo_op_bool = new AtomicOpOr<bool>(false);
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpOr<int>>(2);
+    std::unique_ptr<TypedAtomicOpFunctor<bool>> amo_op_bool =
+        std::make_unique<AtomicOpOr<bool>>(false);
     amo_op_int->execute(&test_int);
     amo_op_bool->execute(&test_bool);
 
@@ -202,8 +218,10 @@ TEST(AmoTest, AtomicOpAnd)
     int test_int = 10;
     char test_char = 'c';
 
-    TypedAtomicOpFunctor<int> *amo_op_int = new AtomicOpAnd<int>(6);
-    TypedAtomicOpFunctor<char> *amo_op_char = new AtomicOpAnd<char>('a');
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicOpAnd<int>>(6);
+    std::unique_ptr<TypedAtomicOpFunctor<char>> amo_op_char =
+        std::make_unique<AtomicOpAnd<char>>('a');
     amo_op_int->execute(&test_int);
     amo_op_char->execute(&test_char);
 
@@ -215,8 +233,8 @@ TEST(AmoTest, AtomicGeneric2Op)
 {
     int test_int = 9;
 
-    TypedAtomicOpFunctor<int> *amo_op_int =
-        new AtomicGeneric2Op<int>(9, multiply2Op);
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicGeneric2Op<int>>(9, multiply2Op);
     amo_op_int->execute(&test_int);
 
     EXPECT_EQ(test_int, 81);
@@ -226,8 +244,8 @@ TEST(AmoTest, AtomicGeneric3Op)
 {
     int test_int = 2;
 
-    TypedAtomicOpFunctor<int> *amo_op_int =
-        new AtomicGeneric3Op<int>(4, 3, multiply3Op);
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+        std::make_unique<AtomicGeneric3Op<int>>(4, 3, multiply3Op);
     amo_op_int->execute(&test_int);
 
     EXPECT_EQ(test_int, 24);
@@ -239,8 +257,8 @@ TEST(AmoTest, AtomicGenericPair3Op)
 
     std::array<int, 2> a = {6, 3};
     std::array<int, 2> c = {10, 8};
-    TypedAtomicOpFunctor<int> *amo_op_int =
-         new AtomicGenericPair3Op<int>(a, c, addSubColumns);
+    std::unique_ptr<TypedAtomicOpFunctor<int>> amo_op_int =
+            std::make_unique<AtomicGenericPair3Op<int>>(a, c, addSubColumns);
     amo_op_int->execute(&test_int);
 
     EXPECT_EQ(test_int, 10);

--- a/src/base/inifile.hh
+++ b/src/base/inifile.hh
@@ -72,7 +72,7 @@ class IniFile
         }
 
         /// Has this entry been used?
-        bool isReferenced() { return referenced; }
+        bool isReferenced() const { return referenced; }
 
         /// Fetch the value.
         const std::string &getValue() const;
@@ -94,7 +94,7 @@ class IniFile
     class Section
     {
         /// EntryTable type.  Map of strings to Entry object pointers.
-        typedef std::unordered_map<std::string, Entry *> EntryTable;
+        typedef std::unordered_map<std::string, Entry> EntryTable;
 
         EntryTable      table;          ///< Table of entries.
         mutable bool    referenced;     ///< Has this section been used?
@@ -107,7 +107,7 @@ class IniFile
         }
 
         /// Has this section been used?
-        bool isReferenced() { return referenced; }
+        bool isReferenced() const { return referenced; }
 
         /// Add an entry to the table.  If an entry with the same name
         /// already exists, the 'append' parameter is checked If true,
@@ -125,24 +125,25 @@ class IniFile
 
         /// Find the entry with the given name.
         /// @retval Pointer to the entry object, or NULL if none.
-        Entry *findEntry(const std::string &entryName) const;
+        Entry *findEntry(const std::string &entryName);
+        const Entry *findEntry(const std::string &entryName) const;
 
         /// Print the unreferenced entries in this section to cerr.
         /// Messages can be suppressed using "unref_section_ok" and
         /// "unref_entries_ok".
         /// @param sectionName Name of this section, for use in output message.
         /// @retval True if any entries were printed.
-        bool printUnreferenced(const std::string &sectionName);
+        bool printUnreferenced(const std::string &sectionName) const;
 
         /// Print the contents of this section to cout (for debugging).
-        void dump(const std::string &sectionName);
+        void dump(const std::string &sectionName) const;
 
         EntryTable::const_iterator begin() const;
         EntryTable::const_iterator end() const;
     };
 
     /// SectionTable type.  Map of strings to Section object pointers.
-    typedef std::unordered_map<std::string, Section *> SectionTable;
+    typedef std::unordered_map<std::string, Section> SectionTable;
 
   protected:
     /// Hash of section names to Section object pointers.
@@ -155,14 +156,12 @@ class IniFile
 
     /// Look up section with the given name.
     /// @retval Pointer to section object, or NULL if not found.
-    Section *findSection(const std::string &sectionName) const;
+    Section *findSection(const std::string &sectionName);
+    const Section *findSection(const std::string &sectionName) const;
 
   public:
     /// Constructor.
     IniFile();
-
-    /// Destructor.
-    ~IniFile();
 
     /// Load parameter settings from given istream.  This is a helper
     /// function for load(string) and loadCPP(), which open a file
@@ -206,7 +205,7 @@ class IniFile
 
     /// Print unreferenced entries in object.  Iteratively calls
     /// printUnreferend() on all the constituent sections.
-    bool printUnreferenced();
+    bool printUnreferenced() const;
 
     /// Dump contents to cout.  For debugging.
     void dump();

--- a/src/base/memoizer.hh
+++ b/src/base/memoizer.hh
@@ -85,7 +85,7 @@ class Memoizer
     using ret_type = Ret;
     using args_type = std::tuple<Args...>;
 
-    constexpr Memoizer(Ret _func(Args...))
+    constexpr Memoizer(Ret (*_func)(Args...))
      : func(_func)
     {
         validateMemoizer();

--- a/src/sim/serialize.cc
+++ b/src/sim/serialize.cc
@@ -145,8 +145,11 @@ CheckpointIn::setDir(const std::string &name)
     // appears to have a format placeholder in it.
     currentDirectory = (name.find("%") != std::string::npos) ?
         csprintf(name, curTick()) : name;
-    if (currentDirectory[currentDirectory.size() - 1] != '/')
+    auto isEmptyPath = currentDirectory.empty();
+    auto endsWithSlash = !isEmptyPath && currentDirectory.back() == '/';
+    if (!endsWithSlash) {
         currentDirectory += "/";
+    }
     return currentDirectory;
 }
 


### PR DESCRIPTION
Compiling and running unit tests with clang-16 and address sanitizer exhibits errors related to old-style memory management or permissive syntax. This pull request addresses these issues and provides opportunistic improvements along the way.