### PR TITLE
arch-arm: Fix assert fail when UQRSHL shiftAmt==0

### DIFF
--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -3403,7 +3403,7 @@ let {{
                     destElem = (srcElem1 >> shiftAmt);
                 }
                 destElem += rBit;
-            } else {
+            } else if (shiftAmt > 0) {
                 if (shiftAmt >= sizeof(Element) * 8) {
                     if (srcElem1 != 0) {
                         destElem = mask(sizeof(Element) * 8);
@@ -3421,6 +3421,8 @@ let {{
                         destElem = srcElem1 << shiftAmt;
                     }
                 }
+            } else {
+                destElem = srcElem1;
             }
             FpscrQc = fpscr;
     '''


### PR DESCRIPTION
When shiftAmt is 0 for a UQRSHL instruction, the code called bits() with incorrect arguments. This fixes a left-shift of 0 to be a NOP/mov, as required.

Change-Id: Ic86ca40ac42bfb767a09e8c65a53cec56382a008