### PR TITLE
arch-riscv: Fix clearLoadReservation merge

### DIFF
--- a/src/arch/generic/isa.hh
+++ b/src/arch/generic/isa.hh
@@ -70,7 +70,6 @@ class BaseISA : public SimObject
   public:
     virtual PCStateBase *newPCState(Addr new_inst_addr=0) const = 0;
     virtual void clear() {}
-    virtual void clearLoadReservation(ContextID cid) {}
 
     virtual RegVal readMiscRegNoEffect(RegIndex idx) const = 0;
     virtual RegVal readMiscReg(RegIndex idx) = 0;

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -136,6 +136,12 @@ class ISA : public BaseISA
 
     RiscvType rvType() const { return rv_type; }
 
+    void
+    clearLoadReservation(ContextID cid)
+    {
+        Addr& load_reservation_addr = load_reservation_addrs[cid];
+        load_reservation_addr = INVALID_RESERVATION_ADDR;
+    }
 };
 
 } // namespace RiscvISA


### PR DESCRIPTION
The previous change
(https://gem5-review.googlesource.com/c/public/gem5/+/71818) makes the clearLoadReservation be RISC-V only.