### PR TITLE
misc: Add workflow to close stale issues

### DIFF
--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -1,0 +1,19 @@
+# This workflow file contains miscellaneous tasks to manage the repository.
+name: Utils for Repository
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  # This job runs the stale action to close issues that have been inactive for 30 days.
+  # It is scheduled to run every day at 1:30 AM UTC.
+  close-stale-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8.0.0
+        with:
+          close-issue-message: 'This issue is being closed because it has been inactive waiting for response for 30 days. If this is still an issue, please open a new issue and reference this one.'
+          days-before-stale: 21
+          days-before-close: 7
+          any-of-labels: 'needs details'


### PR DESCRIPTION
Create a new workflow file that will hold jobs that are for managing the
repository, issues, prs, etc. This changeset then adds a job to close
issues that have been open for 30 days without a response someone marks
the issue as "needs details."

Let me know if I shouldn't have created this PR on stable. I'm still a bit confused about develop vs stable for these files :).

I haven't tested this, but I think it's straightforward. The only thing I'm not sure about is the permissions on the token.