### PR TITLE
arch-riscv: Set default check alignment True

### DIFF
--- a/src/arch/riscv/RiscvISA.py
+++ b/src/arch/riscv/RiscvISA.py
@@ -53,6 +53,6 @@ class RiscvISA(BaseISA):
     cxx_header = "arch/riscv/isa.hh"
 
     check_alignment = Param.Bool(
-        False, "whether to check memory access alignment"
+        True, "whether to check memory access alignment"
     )
     riscv_type = Param.RiscvType("RV64", "RV32 or RV64")


### PR DESCRIPTION
Raise misaligned trap if effective address if not aligned by default

Change-Id: I634aa7ddbf5282fc583316fc77ab1e37bfe415e3