### PR TITLE
base: Added missing backup dummy __has_builtin definition

### DIFF
--- a/src/base/bitfield.hh
+++ b/src/base/bitfield.hh
@@ -310,6 +310,13 @@ namespace {
 template<typename T>
 constexpr bool
 hasBuiltinCtz() {
+// Since the defined(__has_builtin) in the subsequent #if statement
+// won't short-circuit the macro expansion of
+// __has_builtin(__builtin_ctz), we must explicitly define it as zero
+// if it's undefined to avoid a preprocessor error.
+#ifndef __has_builtin
+#   define __has_builtin(foo) 0
+#endif
 #if defined(__has_builtin) && __has_builtin(__builtin_ctz)
     return sizeof(unsigned long long) >= sizeof(T);
 #else


### PR DESCRIPTION
Added dummy definition of __has_builtin to bitfield.hh's hasBuiltinCtz, which is already being done in popCount.

Change-Id: I4a1760a142209462bb807c6df4bc868284b6f5f3