### PR TITLE
mem-ruby: Added support for non-system-scope atomics in VIPER

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -61,6 +61,7 @@ machine(MachineType:TCC, "TCC Cache")
     WrVicBlkBack,           desc="L1 Write Through(dirty cache)";
     WrVicBlkEvict,          desc="L1 Write Through(dirty cache) and evict";
     Atomic,                 desc="Atomic Op";
+    AtomicPassOn,           desc="Atomic Op Passed on to Directory";
     AtomicDone,             desc="AtomicOps Complete";
     AtomicNotDone,          desc="AtomicOps not Complete";
     Data,                   desc="data messgae";
@@ -355,11 +356,17 @@ machine(MachineType:TCC, "TCC Cache")
                 trigger(Event:WrVicBlk, in_msg.addr, cache_entry, tbe);
             }
         } else if (in_msg.Type == CoherenceRequestType:Atomic) {
-          // Currently the Atomic requests do not have GLC/SLC bit handing
-          // support. The assert ensures that the requests do not have
-          // these set, and therefore do not expect to bypass the cache
-          assert(!in_msg.isSLCSet);
-          trigger(Event:Atomic, in_msg.addr, cache_entry, tbe);
+          // If the request is system-level, or if the address isn't in the cache,
+          // then send the request to the directory. Since non-SLC atomics won't be
+          // performed by the directory, TCC will perform the atomic on the return path
+          // on Event:Data.
+          // The action will invalidate the cache line if SLC is set and the address is
+          // in the cache.
+          if(in_msg.isSLCSet || !presentOrAvail(in_msg.addr)) {
+            trigger(Event:AtomicPassOn, in_msg.addr, cache_entry, tbe);
+          } else {
+            trigger(Event:Atomic, in_msg.addr, cache_entry, tbe);
+          }
         } else if (in_msg.Type == CoherenceRequestType:RdBlk) {
           if (in_msg.isSLCSet) {
             // If SLC bit is set, the request needs to go directly to memory.
@@ -502,6 +509,22 @@ machine(MachineType:TCC, "TCC Cache")
   }
 
   action(ar_sendAtomicResponse, "ar", desc="send Atomic Ack") {
+    peek(coreRequestNetwork_in, CPURequestMsg) {
+        enqueue(responseToCore_out, ResponseMsg, l2_response_latency) {
+          out_msg.addr := address;
+          out_msg.Type := CoherenceResponseType:TDSysResp;
+          out_msg.Destination.clear();
+          out_msg.Destination.add(in_msg.Requestor);
+          out_msg.Sender := machineID;
+          out_msg.MessageSize := MessageSizeType:Response_Data;
+          out_msg.DataBlk := cache_entry.DataBlk;
+          out_msg.isGLCSet := in_msg.isGLCSet;
+          out_msg.isSLCSet := in_msg.isSLCSet;
+        }
+    }
+  }
+
+  action(bar_sendBypassedAtomicResponse, "bar", desc="send bypassed Atomic Ack") {
     peek(responseFromNB_in, ResponseMsg) {
         enqueue(responseToCore_out, ResponseMsg, l2_response_latency) {
           out_msg.addr := address;
@@ -614,6 +637,8 @@ machine(MachineType:TCC, "TCC Cache")
         out_msg.Type := CoherenceRequestType:Atomic;
         out_msg.Dirty := true;
         out_msg.writeMask.orMask(in_msg.writeMask);
+        out_msg.isGLCSet := in_msg.isGLCSet;
+        out_msg.isSLCSet := in_msg.isSLCSet;
       }
     }
   }
@@ -688,6 +713,10 @@ machine(MachineType:TCC, "TCC Cache")
     triggerQueue_in.dequeue(clockEdge());
   }
 
+  action(pa_performAtomic, "pa", desc="Perform atomic") {
+    cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask);
+  }
+
   // END ACTIONS
 
   // BEGIN TRANSITIONS
@@ -699,7 +728,7 @@ machine(MachineType:TCC, "TCC Cache")
   // Stalling transitions do NOT check the tag array...and if they do,
   // they can cause a resource stall deadlock!
 
-  transition(WI, {RdBlk, WrVicBlk, Atomic, WrVicBlkBack}) { //TagArrayRead} {
+  transition(WI, {RdBlk, WrVicBlk, Atomic, AtomicPassOn, WrVicBlkBack}) { //TagArrayRead} {
       // by putting the stalled requests in a buffer, we reduce resource contention
       // since they won't try again every cycle and will instead only try again once
       // woken up
@@ -717,18 +746,21 @@ machine(MachineType:TCC, "TCC Cache")
       // woken up
       st_stallAndWaitRequest;
   }
-  transition(IV, {WrVicBlk, Atomic, WrVicBlkBack}) { //TagArrayRead} {
+
+  transition(IV, {WrVicBlk, Atomic, AtomicPassOn, WrVicBlkBack}) { //TagArrayRead} {
       // by putting the stalled requests in a buffer, we reduce resource contention
       // since they won't try again every cycle and will instead only try again once
       // woken up
       st_stallAndWaitRequest;
   }
+
   transition({M, V}, RdBlk) {TagArrayRead, DataArrayRead} {
     p_profileHit;
     sd_sendData;
     ut_updateTag;
     p_popRequestQueue;
   }
+
   transition(W, RdBlk, WI) {TagArrayRead, DataArrayRead} {
     t_allocateTBE;
     wb_writeBack;
@@ -801,21 +833,21 @@ machine(MachineType:TCC, "TCC Cache")
     st_stallAndWaitRequest;
   }
 
-  transition(V, Atomic, A) {TagArrayRead} {
+  transition(V, Atomic, M) {TagArrayRead, DataArrayWrite} {
     p_profileHit;
-    i_invL2;
-    t_allocateTBE;
-    at_atomicThrough;
-    ina_incrementNumAtomics;
+    wdb_writeDirtyBytes;
+    pa_performAtomic;
+    ar_sendAtomicResponse;
     p_popRequestQueue;
   }
 
-transition(I, Atomic, A) {TagArrayRead} {
+  transition(I, Atomic, M) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     p_profileMiss;
-    i_invL2;
-    t_allocateTBE;
-    at_atomicThrough;
-    ina_incrementNumAtomics;
+    a_allocateBlock;
+    ut_updateTag;
+    wdb_writeDirtyBytes;
+    pa_performAtomic;
+    ar_sendAtomicResponse;
     p_popRequestQueue;
   }
 
@@ -827,7 +859,45 @@ transition(I, Atomic, A) {TagArrayRead} {
     st_stallAndWaitRequest;
   }
 
-  transition({M, W}, Atomic, WI) {TagArrayRead} {
+  transition({M, W}, Atomic) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
+    p_profileHit;
+    wdb_writeDirtyBytes;
+    pa_performAtomic;
+    ar_sendAtomicResponse;
+    p_popRequestQueue;
+  }
+
+  // The following atomic pass on actions will send the request to the directory,
+  // and are triggered when an atomic request is received that is not in TCC,
+  // and/or if SLC is set.
+
+  transition(V, AtomicPassOn, A) {TagArrayRead} {
+    p_profileHit;
+    i_invL2;
+    t_allocateTBE;
+    at_atomicThrough;
+    ina_incrementNumAtomics;
+    p_popRequestQueue;
+  }
+
+  transition(I, AtomicPassOn, A) {TagArrayRead} {
+    p_profileMiss;
+    i_invL2;
+    t_allocateTBE;
+    at_atomicThrough;
+    ina_incrementNumAtomics;
+    p_popRequestQueue;
+  }
+
+  transition(A, AtomicPassOn) {
+    p_profileMiss;
+    // by putting the stalled requests in a buffer, we reduce resource contention
+    // since they won't try again every cycle and will instead only try again once
+    // woken up
+    st_stallAndWaitRequest;
+  }
+
+  transition({M, W}, AtomicPassOn, WI) {TagArrayRead} {
     t_allocateTBE;
     wb_writeBack;
     // after writing back the current line, we need to wait for it to be done
@@ -946,6 +1016,18 @@ transition(I, Atomic, A) {TagArrayRead} {
     dt_deallocateTBE;
   }
 
+  transition(A, Bypass) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
+    bar_sendBypassedAtomicResponse;
+    dna_decrementNumAtomics;
+    pr_popResponseQueue;
+  }
+
+  transition(WI, Bypass, I) {
+    pr_popResponseQueue;
+    wada_wakeUpAllDependentsAddr;
+    dt_deallocateTBE;
+  }
+
   transition(IV, Data, V) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     a_allocateBlock;
     ut_updateTag;
@@ -956,9 +1038,10 @@ transition(I, Atomic, A) {TagArrayRead} {
     dt_deallocateTBE;
   }
 
-  transition(A, Data) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
+  transition(A, Data, M) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     a_allocateBlock;
-    ar_sendAtomicResponse;
+    pa_performAtomic;
+    bar_sendBypassedAtomicResponse;
     dna_decrementNumAtomics;
     pr_popResponseQueue;
   }

--- a/src/mem/ruby/protocol/MOESI_AMD_Base-dir.sm
+++ b/src/mem/ruby/protocol/MOESI_AMD_Base-dir.sm
@@ -161,6 +161,7 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     uint64_t probe_id,        desc="probe id for lifetime profiling";
     WriteMask writeMask,    desc="outstanding write through mask";
     int Len,            desc="Length of memory request for DMA";
+    bool isSLCSet,      desc="Bypass L1 and L2 Cache";
   }
 
   structure(TBETable, external="yes") {
@@ -975,6 +976,7 @@ machine(MachineType:Directory, "AMD Baseline protocol")
         tbe.atomicData := true;
         tbe.WTRequestor := in_msg.WTRequestor;
         tbe.LastSender := in_msg.Requestor;
+        tbe.isSLCSet := in_msg.isSLCSet;
       }
       tbe.Dirty := false;
       if (in_msg.Type == CoherenceRequestType:WriteThrough) {
@@ -995,7 +997,11 @@ machine(MachineType:Directory, "AMD Baseline protocol")
 
   action(wd_writeBackData, "wd", desc="Write back data if needed") {
     if (tbe.wtData || tbe.atomicData || tbe.Dirty == false) {
-      if (tbe.atomicData) {
+    // If SLC is not set, the atomic is handled in the L2
+    // Atomic needs to be done at the L3 only if this is
+    // not the case
+
+      if (tbe.atomicData && tbe.isSLCSet) {
         tbe.DataBlk.atomicPartial(tbe.DataBlk, tbe.writeMask);
       }
       enqueue(memQueue_out, MemoryMsg, to_memory_controller_latency) {


### PR DESCRIPTION
Added support for performing non-SLC-set atomics in the TCC. Previously, all atomics were being passed on by the TCC to the directory. With this change, atomics will only be passed on if the SLC bit is set or if the line isn't present or available in the TCC.

If a non-SLC atomic is passed on to the directory because it is not present in the TCC, the atomic will be performed on the return path on the Data event. To accommodate the directory not performing the atomic in this case, this change also passes the SLC bit on to the directory.

The previously-named "Atomic" action has been renamed to "AtomicPassOn", with the new "Atomic" corresponding to an atomic performed directly in the TCC.

Change-Id: Ibf92f71ddceb38bd1b0da70b0a786cc4c3cf2669