### PR TITLE
stdlib,configs,tests: Remove deprecated Resource classes usage

### DIFF
--- a/configs/example/gem5_library/arm-hello.py
+++ b/configs/example/gem5_library/arm-hello.py
@@ -43,7 +43,7 @@ scons build/ARM/gem5.opt
 
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.boards.simple_board import SimpleBoard
@@ -84,7 +84,7 @@ board.set_se_binary_workload(
     # Any resource specified in this file will be automatically retrieved.
     # At the time of writing, this file is a WIP and does not contain all
     # resources. Jira ticket: https://gem5.atlassian.net/browse/GEM5-1096
-    Resource("arm-hello64-static")
+    obtain_resource("arm-hello64-static")
 )
 
 # Lastly we run the simulation.

--- a/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
@@ -48,7 +48,7 @@ scons build/RISCV/gem5.opt
 
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.boards.simple_board import SimpleBoard
@@ -89,8 +89,8 @@ board = SimpleBoard(
 # configs/example/gem5_library/checkpoints/riscv-hello-save-checkpoint.py
 board.set_se_binary_workload(
     # the workload should be the same as the save-checkpoint script
-    Resource("riscv-hello"),
-    checkpoint=Resource("riscv-hello-example-checkpoint-v23"),
+    obtain_resource("riscv-hello"),
+    checkpoint=obtain_resource("riscv-hello-example-checkpoint-v23"),
 )
 
 simulator = Simulator(

--- a/configs/example/gem5_library/checkpoints/riscv-hello-save-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/riscv-hello-save-checkpoint.py
@@ -46,7 +46,7 @@ scons build/RISCV/gem5.opt
 import argparse
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.boards.simple_board import SimpleBoard
@@ -101,7 +101,7 @@ board.set_se_binary_workload(
     # Any resource specified in this file will be automatically retrieved.
     # At the time of writing, this file is a WIP and does not contain all
     # resources. Jira ticket: https://gem5.atlassian.net/browse/GEM5-1096
-    Resource("riscv-hello")
+    obtain_resource("riscv-hello")
 )
 
 # Lastly we run the simulation.

--- a/configs/example/gem5_library/dramsys/arm-hello-dramsys.py
+++ b/configs/example/gem5_library/dramsys/arm-hello-dramsys.py
@@ -35,7 +35,7 @@ correctly. If this is not done correctly this script will run with error.
 
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.memory import DRAMSysDDR3_1600
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.boards.simple_board import SimpleBoard
@@ -78,7 +78,7 @@ board.set_se_binary_workload(
     # Any resource specified in this file will be automatically retrieved.
     # At the time of writing, this file is a WIP and does not contain all
     # resources. Jira ticket: https://gem5.atlassian.net/browse/GEM5-1096
-    Resource("arm-hello64-static")
+    obtain_resource("arm-hello64-static")
 )
 
 # Lastly we run the simulation.

--- a/configs/example/gem5_library/power-hello.py
+++ b/configs/example/gem5_library/power-hello.py
@@ -43,7 +43,7 @@ scons build/POWER/gem5.opt
 
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.memory import SingleChannelDDR4_2400
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.boards.simple_board import SimpleBoard
@@ -75,7 +75,7 @@ board = SimpleBoard(
     cache_hierarchy=cache_hierarchy,
 )
 
-board.set_se_binary_workload(Resource("power-hello"))
+board.set_se_binary_workload(obtain_resource("power-hello"))
 
 # Lastly we run the simulation.
 simulator = Simulator(board=board)

--- a/configs/example/gem5_library/riscv-fs.py
+++ b/configs/example/gem5_library/riscv-fs.py
@@ -48,7 +48,7 @@ from gem5.components.cachehierarchies.classic.private_l1_private_l2_cache_hierar
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 
 # Run a check to ensure the right version of gem5 is being used.
@@ -79,8 +79,8 @@ board = RiscvBoard(
 
 # Set the Full System workload.
 board.set_kernel_disk_workload(
-    kernel=Resource("riscv-bootloader-vmlinux-5.10"),
-    disk_image=Resource("riscv-disk-img"),
+    kernel=obtain_resource("riscv-bootloader-vmlinux-5.10"),
+    disk_image=obtain_resource("riscv-disk-img"),
 )
 
 simulator = Simulator(board=board)

--- a/configs/example/gem5_library/riscvmatched-hello.py
+++ b/configs/example/gem5_library/riscvmatched-hello.py
@@ -37,7 +37,7 @@ scons build/RISCV/gem5.opt
 ```
 """
 
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 from gem5.prebuilt.riscvmatched.riscvmatched_board import RISCVMatchedBoard
 from gem5.isas import ISA
@@ -49,7 +49,7 @@ requires(isa_required=ISA.RISCV)
 board = RISCVMatchedBoard()
 
 # set the hello world riscv binary as the board workload
-board.set_se_binary_workload(Resource("riscv-hello"))
+board.set_se_binary_workload(obtain_resource("riscv-hello"))
 
 # run the simulation with the RISCV Matched board
 simulator = Simulator(board=board, full_system=False)

--- a/configs/example/gem5_library/x86-gapbs-benchmarks.py
+++ b/configs/example/gem5_library/x86-gapbs-benchmarks.py
@@ -63,7 +63,7 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.coherence_protocol import CoherenceProtocol
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
 
@@ -203,10 +203,10 @@ board.set_kernel_disk_workload(
     # The x86 linux kernel will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
     # gapbs benchamarks was tested with kernel version 4.19.83
-    kernel=Resource("x86-linux-kernel-4.19.83"),
+    kernel=obtain_resource("x86-linux-kernel-4.19.83"),
     # The x86-gapbs image will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
-    disk_image=Resource("x86-gapbs"),
+    disk_image=obtain_resource("x86-gapbs"),
     readfile_contents=command,
 )
 

--- a/configs/example/gem5_library/x86-npb-benchmarks.py
+++ b/configs/example/gem5_library/x86-npb-benchmarks.py
@@ -60,7 +60,7 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.coherence_protocol import CoherenceProtocol
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.simulator import ExitEvent
 
@@ -204,10 +204,10 @@ board.set_kernel_disk_workload(
     # The x86 linux kernel will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
     # npb benchamarks was tested with kernel version 4.19.83
-    kernel=Resource("x86-linux-kernel-4.19.83"),
+    kernel=obtain_resource("x86-linux-kernel-4.19.83"),
     # The x86-npb image will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
-    disk_image=Resource("x86-npb"),
+    disk_image=obtain_resource("x86-npb"),
     readfile_contents=command,
 )
 

--- a/configs/example/gem5_library/x86-parsec-benchmarks.py
+++ b/configs/example/gem5_library/x86-parsec-benchmarks.py
@@ -59,7 +59,7 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.coherence_protocol import CoherenceProtocol
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
 
@@ -185,10 +185,10 @@ board.set_kernel_disk_workload(
     # The x86 linux kernel will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
     # PARSEC benchamarks were tested with kernel version 4.19.83
-    kernel=Resource("x86-linux-kernel-4.19.83"),
+    kernel=obtain_resource("x86-linux-kernel-4.19.83"),
     # The x86-parsec image will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
-    disk_image=Resource("x86-parsec"),
+    disk_image=obtain_resource("x86-parsec"),
     readfile_contents=command,
 )
 

--- a/configs/example/gem5_library/x86-spec-cpu2006-benchmarks.py
+++ b/configs/example/gem5_library/x86-spec-cpu2006-benchmarks.py
@@ -65,7 +65,7 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.coherence_protocol import CoherenceProtocol
-from gem5.resources.resource import Resource, CustomDiskImageResource
+from gem5.resources.resource import Resource, DiskImageResource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
 
@@ -261,9 +261,7 @@ board.set_kernel_disk_workload(
     # 5.4.49
     kernel=Resource("x86-linux-kernel-4.19.83"),
     # The location of the x86 SPEC CPU 2017 image
-    disk_image=CustomDiskImageResource(
-        args.image, root_partition=args.partition
-    ),
+    disk_image=DiskImageResource(args.image, root_partition=args.partition),
     readfile_contents=command,
 )
 

--- a/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
+++ b/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
@@ -63,7 +63,7 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.coherence_protocol import CoherenceProtocol
-from gem5.resources.resource import obtain_resource, CustomDiskImageResource
+from gem5.resources.resource import obtain_resource, DiskImageResource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
 
@@ -277,9 +277,7 @@ board.set_kernel_disk_workload(
     # SPEC CPU2017 benchamarks were tested with kernel version 4.19.83
     kernel=obtain_resource("x86-linux-kernel-4.19.83"),
     # The location of the x86 SPEC CPU 2017 image
-    disk_image=CustomDiskImageResource(
-        args.image, root_partition=args.partition
-    ),
+    disk_image=DiskImageResource(args.image, root_partition=args.partition),
     readfile_contents=command,
 )
 

--- a/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
+++ b/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
@@ -268,7 +268,7 @@ except FileExistsError:
 
 command = f"{args.benchmark} {args.size} {output_dir}"
 
-# For enabling CustomResource, we pass an additional parameter to mount the
+# For enabling DiskImageResource, we pass an additional parameter to mount the
 # correct partition.
 
 board.set_kernel_disk_workload(

--- a/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
+++ b/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
@@ -63,7 +63,7 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.coherence_protocol import CoherenceProtocol
-from gem5.resources.resource import Resource, CustomDiskImageResource
+from gem5.resources.resource import obtain_resource, CustomDiskImageResource
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
 
@@ -275,7 +275,7 @@ board.set_kernel_disk_workload(
     # The x86 linux kernel will be automatically downloaded to the
     # `~/.cache/gem5` directory if not already present.
     # SPEC CPU2017 benchamarks were tested with kernel version 4.19.83
-    kernel=Resource("x86-linux-kernel-4.19.83"),
+    kernel=obtain_resource("x86-linux-kernel-4.19.83"),
     # The location of the x86 SPEC CPU 2017 image
     disk_image=CustomDiskImageResource(
         args.image, root_partition=args.partition

--- a/configs/example/lupv/run_lupv.py
+++ b/configs/example/lupv/run_lupv.py
@@ -42,7 +42,7 @@ from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import obtain_resource, CustomResource
+from gem5.resources.resource import obtain_resource
 
 import argparse
 

--- a/configs/example/lupv/run_lupv.py
+++ b/configs/example/lupv/run_lupv.py
@@ -42,7 +42,7 @@ from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.isas import ISA
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource, CustomResource
+from gem5.resources.resource import obtain_resource, CustomResource
 
 import argparse
 
@@ -98,8 +98,8 @@ board = LupvBoard(
 # Set the Full System workload.
 
 board.set_kernel_disk_workload(
-    kernel=Resource("riscv-lupio-linux-kernel"),
-    disk_image=Resource("riscv-lupio-busybox-img"),
+    kernel=obtain_resource("riscv-lupio-linux-kernel"),
+    disk_image=obtain_resource("riscv-lupio-busybox-img"),
 )
 
 

--- a/configs/example/sst/riscv_fs.py
+++ b/configs/example/sst/riscv_fs.py
@@ -29,7 +29,7 @@ from m5.objects import *
 from os import path
 
 # For downloading the disk image
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 
 import argparse
 
@@ -139,7 +139,7 @@ cpu_clock_rate = args.cpu_clock_rate
 memory_size = args.memory_size
 
 # Try downloading the Resource
-bbl_resource = Resource("riscv-boot-exit-nodisk")
+bbl_resource = obtain_resource("riscv-boot-exit-nodisk")
 bbl_path = bbl_resource.get_local_path()
 
 system = System()

--- a/src/python/gem5/resources/workload.py
+++ b/src/python/gem5/resources/workload.py
@@ -52,7 +52,7 @@ class AbstractWorkload:
     workload = CustomWorkload(
         function = "set_se_binary_workload",
         parameters = {
-            "binary" : Resource("x86-print-this"),
+            "binary" : obtain_resource("x86-print-this"),
             "arguments" : ["hello", 6]
         },
     )
@@ -64,7 +64,7 @@ class AbstractWorkload:
 
     ```py
     board.set_se_binary_workload(
-        binary = Resource("x86-print-this"),
+        binary = obtain_resource("x86-print-this"),
         arguments = ["hello", 6],
     )
     ```
@@ -121,7 +121,7 @@ class CustomWorkload(AbstractWorkload):
     workload = CustomWorkload(
         function = "set_se_binary_workload",
         parameters = {
-            "binary" : Resource("x86-print-this"),
+            "binary" : obtain_resource("x86-print-this"),
             "arguments" : ["hello", 6]
         },
     )
@@ -148,7 +148,8 @@ class Workload(AbstractWorkload):
 
     # Optionally we can override a parameter in the workload. In this example
     # we are going to run this workload with a difference kernel.
-    workload.set_parameter("kernel", Resource("arm64-linux-kernel-4.14.134"))
+    workload.set_parameter("kernel", \
+        obtain_resource("arm64-linux-kernel-4.14.134"))
 
     # We then set this workload to the board.
     board.set_workload(workload)
@@ -193,8 +194,8 @@ class Workload(AbstractWorkload):
 
         ```python
         board.set_kernel_disk_workload(
-            kernel = Resource("x86-linux-kernel-5.4.49"),
-            disk-image = Resource("x86-ubuntu-18.04-img"),
+            kernel = obtain_resource("x86-linux-kernel-5.4.49"),
+            disk-image = obtain_resource("x86-ubuntu-18.04-img"),
             readfile_contents = "m5_exit; echo 'hello'; m5_exit",
         )
         ```

--- a/src/python/gem5/resources/workload.py
+++ b/src/python/gem5/resources/workload.py
@@ -148,8 +148,9 @@ class Workload(AbstractWorkload):
 
     # Optionally we can override a parameter in the workload. In this example
     # we are going to run this workload with a difference kernel.
-    workload.set_parameter("kernel", \
-        obtain_resource("arm64-linux-kernel-4.14.134"))
+    workload.set_parameter("kernel",
+        obtain_resource("arm64-linux-kernel-4.14.134")
+    )
 
     # We then set this workload to the board.
     board.set_workload(workload)

--- a/src/python/gem5/utils/multiprocessing/README.md
+++ b/src/python/gem5/utils/multiprocessing/README.md
@@ -48,8 +48,8 @@ def run_sim(name):
     from gem5.simulate.simulator import Simulator
     board = X86DemoBoard()
     board.set_kernel_disk_workload(
-        kernel=Resource("x86-linux-kernel-5.4.49"),
-        disk_image=Resource("x86-ubuntu-18.04-img"),
+        kernel=obtain_resource("x86-linux-kernel-5.4.49"),
+        disk_image=obtain_resource("x86-ubuntu-18.04-img"),
     )
     simulator = Simulator(board=board)
     simulator.run(max_ticks=10000000)

--- a/tests/gem5/configs/arm_boot_exit_run.py
+++ b/tests/gem5/configs/arm_boot_exit_run.py
@@ -36,7 +36,7 @@ Characteristics
 from gem5.isas import ISA
 from m5.objects import ArmDefaultRelease
 from gem5.utils.requires import requires
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 from m5.objects import VExpress_GEM5_Foundation
 from gem5.coherence_protocol import CoherenceProtocol
@@ -199,15 +199,15 @@ board = ArmBoard(
 
 # Set the Full System workload.
 board.set_kernel_disk_workload(
-    kernel=Resource(
+    kernel=obtain_resource(
         "arm64-linux-kernel-5.4.49",
         resource_directory=args.resource_directory,
     ),
-    bootloader=Resource(
+    bootloader=obtain_resource(
         "arm64-bootloader-foundation",
         resource_directory=args.resource_directory,
     ),
-    disk_image=Resource(
+    disk_image=obtain_resource(
         "arm64-ubuntu-20.04-img",
         resource_directory=args.resource_directory,
     ),

--- a/tests/gem5/configs/boot_kvm_fork_run.py
+++ b/tests/gem5/configs/boot_kvm_fork_run.py
@@ -55,7 +55,7 @@ from gem5.components.processors.cpu_types import (
 from gem5.components.processors.simple_switchable_processor import (
     SimpleSwitchableProcessor,
 )
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.runtime import get_runtime_coherence_protocol
 from gem5.utils.requires import requires
 
@@ -179,10 +179,10 @@ kernel_args = motherboard.get_default_kernel_args() + [args.kernel_args]
 
 # Set the Full System workload.
 motherboard.set_kernel_disk_workload(
-    kernel=Resource(
+    kernel=obtain_resource(
         "x86-linux-kernel-5.4.49", resource_directory=args.resource_directory
     ),
-    disk_image=Resource(
+    disk_image=obtain_resource(
         "x86-ubuntu-18.04-img", resource_directory=args.resource_directory
     ),
     readfile_contents=dedent(

--- a/tests/gem5/configs/boot_kvm_switch_exit.py
+++ b/tests/gem5/configs/boot_kvm_switch_exit.py
@@ -45,7 +45,7 @@ from gem5.components.processors.cpu_types import (
 from gem5.components.processors.simple_switchable_processor import (
     SimpleSwitchableProcessor,
 )
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.runtime import get_runtime_coherence_protocol
 from gem5.simulate.simulator import Simulator
 from gem5.simulate.exit_event import ExitEvent
@@ -165,10 +165,10 @@ kernal_args = motherboard.get_default_kernel_args() + [args.kernel_args]
 
 # Set the Full System workload.
 motherboard.set_kernel_disk_workload(
-    kernel=Resource(
+    kernel=obtain_resource(
         "x86-linux-kernel-5.4.49", resource_directory=args.resource_directory
     ),
-    disk_image=Resource(
+    disk_image=obtain_resource(
         "x86-ubuntu-18.04-img", resource_directory=args.resource_directory
     ),
     # The first exit signals to switch processors.

--- a/tests/gem5/configs/parsec_disk_run.py
+++ b/tests/gem5/configs/parsec_disk_run.py
@@ -37,7 +37,7 @@ Notes
 
 import m5.stats
 
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.boards.x86_board import X86Board
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.processors.simple_switchable_processor import (
@@ -205,10 +205,10 @@ command = (
 )
 
 board.set_kernel_disk_workload(
-    kernel=Resource(
+    kernel=obtain_resource(
         "x86-linux-kernel-5.4.49", resource_directory=args.resource_directory
     ),
-    disk_image=Resource(
+    disk_image=obtain_resource(
         "x86-parsec", resource_directory=args.resource_directory
     ),
     readfile_contents=command,

--- a/tests/gem5/configs/simple_binary_run.py
+++ b/tests/gem5/configs/simple_binary_run.py
@@ -30,7 +30,7 @@ The system has no cache heirarchy and is as "bare-bones" as you can get in
 gem5 while still being functinal.
 """
 
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.processors.cpu_types import (
     get_cpu_types_str_set,
     get_cpu_type_from_str,
@@ -135,7 +135,9 @@ motherboard = SimpleBoard(
 )
 
 # Set the workload
-binary = Resource(args.resource, resource_directory=args.resource_directory)
+binary = obtain_resource(
+    args.resource, resource_directory=args.resource_directory
+)
 motherboard.set_se_binary_workload(binary, arguments=args.arguments)
 
 # Run the simulation

--- a/tests/gem5/configs/simulator_exit_event_run.py
+++ b/tests/gem5/configs/simulator_exit_event_run.py
@@ -45,7 +45,7 @@ By default a generator is passed to define the evit_event. A list of functions
 can also be passed. This is enabled by passing the `--list-format` flag.
 """
 
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.boards.simple_board import SimpleBoard
 from gem5.components.cachehierarchies.classic.no_cache import NoCache
@@ -101,7 +101,7 @@ motherboard = SimpleBoard(
 # Set the workload
 # Note: Here we're using the "x86-m5-exit-repeat" resource. This calls an
 # `m5_exit(0)` command in an infinite while-loop.
-binary = Resource(
+binary = obtain_resource(
     "x86-m5-exit-repeat", resource_directory=args.resource_directory
 )
 motherboard.set_se_binary_workload(binary)

--- a/tests/gem5/to_tick/configs/tick-exit.py
+++ b/tests/gem5/to_tick/configs/tick-exit.py
@@ -28,7 +28,7 @@
 
 """
 
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.isas import ISA
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.boards.simple_board import SimpleBoard
@@ -76,7 +76,7 @@ motherboard = SimpleBoard(
 )
 
 # Set the workload
-binary = Resource(
+binary = obtain_resource(
     "x86-hello64-static", resource_directory=args.resource_directory
 )
 motherboard.set_se_binary_workload(binary)

--- a/tests/gem5/to_tick/configs/tick-to-max.py
+++ b/tests/gem5/to_tick/configs/tick-to-max.py
@@ -33,7 +33,7 @@ run before, at, or after the running of `simulator.run`.
 time.
 """
 
-from gem5.resources.resource import Resource
+from gem5.resources.resource import obtain_resource
 from gem5.isas import ISA
 from gem5.components.memory import SingleChannelDDR3_1600
 from gem5.components.boards.simple_board import SimpleBoard
@@ -97,7 +97,7 @@ motherboard = SimpleBoard(
 )
 
 # Set the workload
-binary = Resource(
+binary = obtain_resource(
     "x86-hello64-static", resource_directory=args.resource_directory
 )
 motherboard.set_se_binary_workload(binary)

--- a/tests/pyunit/stdlib/resources/pyunit_workload_checks.py
+++ b/tests/pyunit/stdlib/resources/pyunit_workload_checks.py
@@ -72,14 +72,14 @@ class CustomWorkloadTestSuite(unittest.TestCase):
         )
 
     def test_get_function_str(self) -> None:
-        # Tests `CustomResource.get_function_str`
+        # Tests `CustomWorkload.get_function_str`
 
         self.assertEqual(
             "set_se_binary_workload", self.custom_workload.get_function_str()
         )
 
     def test_get_parameters(self) -> None:
-        # Tests `CustomResource.get_parameter`
+        # Tests `CustomWorkload.get_parameter`
 
         parameters = self.custom_workload.get_parameters()
         self.assertTrue(isinstance(parameters, Dict))
@@ -95,7 +95,7 @@ class CustomWorkloadTestSuite(unittest.TestCase):
         self.assertEquals(6, parameters["arguments"][1])
 
     def test_add_parameters(self) -> None:
-        # Tests `CustomResource.set_parameter` for the case where we add a new
+        # Tests `CustomWorkload.set_parameter` for the case where we add a new
         # parameter value.
 
         self.custom_workload.set_parameter("test_param", 10)
@@ -109,7 +109,7 @@ class CustomWorkloadTestSuite(unittest.TestCase):
         del self.custom_workload.get_parameters()["test_param"]
 
     def test_override_parameter(self) -> None:
-        # Tests `CustomResource.set_parameter` for the case where we override
+        # Tests `CustomWorkload.set_parameter` for the case where we override
         # a parameter's value.
 
         old_value = self.custom_workload.get_parameters()["binary"]


### PR DESCRIPTION
The following resource classes are deprecated:

* `Resource`: Replaced with `obtain_resource`.
* `CustomResource`: Replaced with specializations.
* `CustomDiskImage`: Replaced with `DiskImageResource`.

There was still some usage in our codebase. In our "configs/example" scripts, in our tests, and some references, in comments, in the main gem5 source. This removes them.

This stops gem5 from regularly throwing warnings as we're using deprecated classes.