### PR TITLE
scons: Add extra parent dir to CPPPATH if --no-duplicate-sources

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -536,6 +536,14 @@ Export('DebugFormatFlag')
 # the corresponding build directory to pick up generated include
 # files.
 env.Append(CPPPATH=Dir('.'))
+parent_dir_set = set()
+
+for extra_dir in extras_dir_list:
+    parent_dir_set.add(str(Dir(extra_dir).Dir('..').abspath))
+
+if not GetOption('duplicate_sources'):
+    for parent_dir in parent_dir_set:
+        env.Append(CPPPATH=Dir(parent_dir))
 
 for extra_dir in extras_dir_list:
     env.Append(CPPPATH=Dir(extra_dir))


### PR DESCRIPTION
In the previous version of gem5, the source files of extra directories will copy to build directory for compilation. It will not be a problem if the extra directories include *.h(*.hh) from the other extra directories.

After the patch applied from the change
(https://gem5-review.googlesource.com/c/public/gem5/+/68758). The source files of extra directories will not copy to the build directory unless the user compiles gem5 with "--duplicate-sources". It will cause the compilation error if the code includes a header file from other repositories.

For example, assume we want to compile gem5 with "foo/bar1" and "foo/bar2" repositories and they are gem5-independent. There are some header files in "foo/bar1/a.h" "foo/bar1/b.h" and "foo/bar2/d.h". If the code "foo/bar1/sample.c" tries to include the file "foo/bar2/d.h". They usually include the file by declare "#include bar2/d.h" in foo/bar1/sample.c. It can work if --duplicate-sources is specified in gem5 build because they will copy to <builddir>/bar1 and <builddir>/bar2 respectively, and -I<builddir> is specified by default whether duplicate_sources or not. It will raise the compilation error if the user does not specify it.

The change is aimed to let the situation work without duplicate-sources specified by adding parent extra directory, and adding them before the extra directories. If the --duplicate-sources specified, it will not add parent extra directories to avoid repeat include paths.

Change-Id: I461e1dcb8266d785f1f38eeff77f9d515d47c03d