### PR TITLE
base: Add `maybe_unused` to `findLsbSetFallback`

### DIFF
--- a/src/base/bitfield.hh
+++ b/src/base/bitfield.hh
@@ -324,6 +324,7 @@ hasBuiltinCtz() {
 #endif
 }
 
+[[maybe_unused]]
 int
 findLsbSetFallback(uint64_t val) {
     // Create a mask with val's trailing zeros flipped to 1, lsb set flipped to


### PR DESCRIPTION
When compiling with clang-14 I received the following error:

```
src/base/bitfield.hh:328:1: error: function 'findLsbSetFallback' is not needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
```

This function was introduced in PR #76.
This fixes this compiler warning/error by using `[[maybe_unused]]`.

Change-Id: I0b99eab0a9e42ee1687e7a0594a5a7bf9588b422