### PR TITLE
misc: Update ci-tests.yaml to always clean runner

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -103,6 +103,7 @@ jobs:
           path: output.zip
           retention-days: 7
       - name: Clean runner
+        if: success() || failure()
         run:
           rm -rf ./* || true
           rm -rf ./.??* || true


### PR DESCRIPTION
Adds line to make sure the runners are always cleaned whether or not the previous tests pass

Change-Id: I980c0232305999fb3548464ea1b6eaeca7bcdbd6