### PR TITLE
mem: Make functional request a response when satisfied by queue

### DIFF
--- a/src/mem/mem_ctrl.cc
+++ b/src/mem/mem_ctrl.cc
@@ -1496,6 +1496,11 @@ MemCtrl::MemoryPort::recvFunctional(PacketPtr pkt)
         // calls recvAtomic() and throws away the latency; we can save a
         // little here by just not calculating the latency.
         ctrl.recvFunctional(pkt);
+    } else {
+        // The packet's request is satisfied by the queue, but queue
+        // does not call makeResponse.
+        // Here, change the packet to the corresponding response
+        pkt->makeResponse();
     }
 
     pkt->popLabel();


### PR DESCRIPTION
In the memory controller, MemCtrl::MemoryPort::recvFunctional, when the functional request is satisfied by the ctrl-response queue, correctly make the packet a response.

This change mirrors AbstractMemory::functionalAccess, which uses Packet::makeResponse() after satisfying the request.

Note:
`bool trySatisfyFunctional(..)` functions return `true` or `false` based on whether the request was satisfied.
`void recvFunctional(..)` functions modify the packet to indicate successful request satisfaction.