### PR TITLE
cpu: Set SLC bit for GPU tester

### DIFF
--- a/src/cpu/testers/gpu_ruby_test/gpu_wavefront.cc
+++ b/src/cpu/testers/gpu_ruby_test/gpu_wavefront.cc
@@ -189,6 +189,7 @@ GpuWavefront::issueAtomicOps()
                                              AtomicOpFunctorPtr(amo_op));
         req->setPaddr(address);
         req->setReqInstSeqNum(tester->getActionSeqNum());
+        req->setCacheCoherenceFlags(Request::SLC_BIT);
         // set protocol-specific flags
         setExtraRequestFlags(req);
 


### PR DESCRIPTION
This fixes issue #131 by reverting to the old behavior of performing all atomics at the system level. To do this the SLC bit needs to be set for all atomic requests.

Change-Id: I63f4e449be1b02c933832d09700237f8c8026f4c