### PR TITLE
util: Ignore line length check for #include pragma in C/C++ files

### DIFF
--- a/src/sst/sst_responder_interface.hh
+++ b/src/sst/sst_responder_interface.hh
@@ -30,7 +30,7 @@
 
 #include <string>
 
-#include "mem/port.hh"
+#include "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaamem/port.hh"
 
 /**
  *  SSTResponderInterface provides an interface specified gem5's expectations

--- a/src/sst/sst_responder_interface.hh
+++ b/src/sst/sst_responder_interface.hh
@@ -30,7 +30,7 @@
 
 #include <string>
 
-#include "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaamem/port.hh"
+#include "mem/port.hh"
 
 /**
  *  SSTResponderInterface provides an interface specified gem5's expectations

--- a/util/style/verifiers.py
+++ b/util/style/verifiers.py
@@ -424,7 +424,11 @@ class LineLength(LineVerifier):
     test_name = "line length"
     opt_name = "length"
 
-    def check_line(self, line, **kwargs):
+    def check_line(self, line, language, **kwargs):
+        # Ignore line length check for include pragmas of C/C++.
+        if language in {"C", "C++"}:
+            if line.startswith("#include"):
+                return True
         return style.normalized_len(line) <= 79
 
     def fix(self, filename, regions=all_regions, **kwargs):


### PR DESCRIPTION
The length of the path of #include pragmas can be more than
79-character long. The length of the path of a #include pragma
can be outside of user's control.