### PR TITLE
misc: Add missing dependency to daily tests

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -168,7 +168,7 @@ jobs:
       matrix:
         test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt, gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: build-gem5
+    needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The refactoring to the daily tests was missing the dependency on the 'name-artifacts' job, which is necessary for downloading all the gem5 artifacts.  This adds it in so the tests run as expected.

Change-Id: I0d71ab147395f41c881f2b24597bc07006e1f9c0