### PR TITLE
New function to kernel_disk_workload to allow new disk device location

### DIFF
--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -354,7 +354,7 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         )
 
     @overrides(KernelDiskWorkload)
-    def get_disk_device(self):
+    def _get_default_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -354,7 +354,7 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         )
 
     @overrides(KernelDiskWorkload)
-    def get_default_disk_device(self):
+    def get_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -354,7 +354,7 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         )
 
     @overrides(KernelDiskWorkload)
-    def _get_default_disk_device(self):
+    def get_default_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -386,6 +386,7 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
             "lpj=19988480",
             "norandmaps",
             "root={root_value}",
+            "disk_device={disk_device}",
             "rw",
             f"mem={self.get_memory().get_size()}",
         ]

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -539,7 +539,7 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         return ["console=ttyLIO0", "root={root_value}", "rw"]
 
     @overrides(KernelDiskWorkload)
-    def set_default_disk_device(self) -> str:
+    def get_default_disk_device(self) -> str:
         return "/dev/lda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -539,7 +539,7 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         return ["console=ttyLIO0", "root={root_value}", "rw"]
 
     @overrides(KernelDiskWorkload)
-    def get_disk_device(self) -> str:
+    def set_default_disk_device(self) -> str:
         return "/dev/lda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -535,12 +535,17 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def get_default_kernel_args(self) -> List[str]:
-        return ["console=ttyLIO0", "root={root_value}", "rw"]
-
-    @overrides(KernelDiskWorkload)
     def get_default_disk_device(self) -> str:
         return "/dev/lda"
+
+    @overrides(KernelDiskWorkload)
+    def get_default_kernel_args(self) -> List[str]:
+        return [
+            "console=ttyLIO0",
+            "root={root_value}",
+            "disk_device={disk_device}",
+            "rw",
+        ]
 
     @overrides(KernelDiskWorkload)
     def _add_disk_to_board(self, disk_image: AbstractResource) -> None:

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -535,7 +535,7 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def get_default_disk_device(self) -> str:
+    def get_disk_device(self) -> str:
         return "/dev/lda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -39,7 +39,7 @@ import os
 from pathlib import Path
 
 import m5
-from m5 import warn
+from m5.util import inform
 
 
 class KernelDiskWorkload:
@@ -92,15 +92,15 @@ class KernelDiskWorkload:
         :returns: The disk device.
         """
         if self._disk_device is None:
-            warn("No disk device set, ie where the disk image is located. Defaulting to board disk device")
-            return _get_default_disk_device()
-        else:
+            self._disk_device = get_default_disk_device()
+            inform(f"Disk Device set to {self._disk_device}")
             return self._disk_device
-        
+        else:
+            inform(f"Disk Device set to {self._disk_device}")
+            return self._disk_device
 
-    
     @abstractmethod
-    def _get_default_disk_device(self) -> str:
+    def get_default_disk_device(self) -> str:
         """
         Set a default disk device, in case user does not specify a disk device.
 
@@ -154,7 +154,7 @@ class KernelDiskWorkload:
         kernel: KernelResource,
         disk_image: DiskImageResource,
         bootloader: Optional[BootloaderResource] = None,
-        _disk_device: Optional[str] = None,
+        disk_device: Optional[str] = None,
         readfile: Optional[str] = None,
         readfile_contents: Optional[str] = None,
         kernel_args: Optional[List[str]] = None,
@@ -188,7 +188,7 @@ class KernelDiskWorkload:
         assert isinstance(self, AbstractBoard)
 
         # Set the disk device
-        self._disk_device = _disk_device
+        self._disk_device = disk_device
 
         # If we are setting a workload of this type, we need to run as a
         # full-system simulation.
@@ -210,7 +210,6 @@ class KernelDiskWorkload:
 
         if bootloader is not None:
             self._bootloader = [bootloader.get_local_path()]
-
 
         # Set the readfile.
         if readfile:

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -190,7 +190,7 @@ class KernelDiskWorkload:
             disk_device=(
                 self._disk_device
                 if self._disk_device
-                else self.get_default_disk_device()
+                else self.get_disk_device()
             ),
         )
 

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -85,7 +85,7 @@ class KernelDiskWorkload:
         raise NotImplementedError
 
     @abstractmethod
-    def get_default_disk_device(self) -> str:
+    def get_disk_device(self) -> str:
         """
         Set a default disk device, in case user does not specify a disk device.
 

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -39,7 +39,6 @@ import os
 from pathlib import Path
 
 import m5
-from m5.util import inform
 
 
 class KernelDiskWorkload:
@@ -84,20 +83,6 @@ class KernelDiskWorkload:
         :returns: A default list of arguments for the workload kernel.
         """
         raise NotImplementedError
-
-    def get_disk_device(self) -> str:
-        """
-        Get the disk device, e.g., "/dev/sda", where the disk image is placed.
-
-        :returns: The disk device.
-        """
-        to_return = (
-            self._disk_device
-            if self._disk_device
-            else self.get_default_disk_device()
-        )
-        assert to_return is not None
-        return to_return
 
     @abstractmethod
     def get_default_disk_device(self) -> str:
@@ -202,7 +187,11 @@ class KernelDiskWorkload:
             " ".join(kernel_args or self.get_default_kernel_args())
         ).format(
             root_value=self.get_default_kernel_root_val(disk_image=disk_image),
-            disk_device=self.get_disk_device(),
+            disk_device=(
+                self._disk_device
+                if self._disk_device
+                else self.get_default_disk_device()
+            ),
         )
 
         # Setting the bootloader information for ARM board. The current

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -91,13 +91,13 @@ class KernelDiskWorkload:
 
         :returns: The disk device.
         """
-        if self._disk_device is None:
-            self._disk_device = get_default_disk_device()
-            inform(f"Disk Device set to {self._disk_device}")
-            return self._disk_device
-        else:
-            inform(f"Disk Device set to {self._disk_device}")
-            return self._disk_device
+        to_return = (
+            self._disk_device
+            if self._disk_device
+            else self.get_default_disk_device()
+        )
+        assert to_return is not None
+        return to_return
 
     @abstractmethod
     def get_default_disk_device(self) -> str:
@@ -201,7 +201,8 @@ class KernelDiskWorkload:
         self.workload.command_line = (
             " ".join(kernel_args or self.get_default_kernel_args())
         ).format(
-            root_value=self.get_default_kernel_root_val(disk_image=disk_image)
+            root_value=self.get_default_kernel_root_val(disk_image=disk_image),
+            disk_device=self.get_disk_device(),
         )
 
         # Setting the bootloader information for ARM board. The current

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -467,7 +467,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def get_default_disk_device(self):
+    def get_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -467,7 +467,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def get_disk_device(self):
+    def _get_default_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -494,4 +494,9 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
 
     @overrides(KernelDiskWorkload)
     def get_default_kernel_args(self) -> List[str]:
-        return ["console=ttyS0", "root={root_value}", "rw"]
+        return [
+            "console=ttyS0",
+            "root={root_value}",
+            "disk_device={disk_device}",
+            "rw",
+        ]

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -467,7 +467,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def _get_default_disk_device(self):
+    def get_default_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -296,7 +296,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload):
         ]
 
     @overrides(KernelDiskWorkload)
-    def get_disk_device(self):
+    def _get_default_disk_device(self):
         return "/dev/hda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -296,7 +296,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload):
         ]
 
     @overrides(KernelDiskWorkload)
-    def get_default_disk_device(self):
+    def get_disk_device(self):
         return "/dev/hda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -296,7 +296,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload):
         ]
 
     @overrides(KernelDiskWorkload)
-    def _get_default_disk_device(self):
+    def get_default_disk_device(self):
         return "/dev/hda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -318,4 +318,5 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload):
             "console=ttyS0",
             "lpj=7999923",
             "root={root_value}",
+            "disk_device={disk_device}",
         ]

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -539,7 +539,7 @@ class RISCVMatchedBoard(
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def _get_default_disk_device(self):
+    def get_default_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -539,7 +539,7 @@ class RISCVMatchedBoard(
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def get_default_disk_device(self):
+    def get_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -566,7 +566,12 @@ class RISCVMatchedBoard(
 
     @overrides(KernelDiskWorkload)
     def get_default_kernel_args(self) -> List[str]:
-        return ["console=ttyS0", "root={root_value}", "rw"]
+        return [
+            "console=ttyS0",
+            "root={root_value}",
+            "disk_device={disk_device}",
+            "rw",
+        ]
 
     @overrides(KernelDiskWorkload)
     def set_kernel_disk_workload(

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -539,7 +539,7 @@ class RISCVMatchedBoard(
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
 
     @overrides(KernelDiskWorkload)
-    def get_disk_device(self):
+    def _get_default_disk_device(self):
         return "/dev/vda"
 
     @overrides(KernelDiskWorkload)


### PR DESCRIPTION
Added a parameter (_disk_device) to kernel_disk_workload which allows users to change the disk device location. get_disk_device() now chooses between the parameter and, if no parameter was passed, it calls a new function _get_default_disk_device() which is implemented by each board and has a default disk device according to each board, eg /dev/hda in the x86_board. The previous way of setting a disk device still exists as a default, however, with the new function users can now override this default