### PR TITLE
tests: download_check.py to rm each resource after check

### DIFF
--- a/tests/gem5/configs/download_check.py
+++ b/tests/gem5/configs/download_check.py
@@ -127,9 +127,14 @@ for id in ids:
                 + f"({md5(Path(download_path))}) differs to that recorded in "
                 + f" gem5-resources ({resource_json['md5sum']}).{os.linesep}"
             )
+        # Remove the downloaded resource.
+        if os.path.isfile(download_path):
+            os.remove(download_path)
+        elif os.path.isdir(download_path):
+            shutil.rmtree(download_path, ignore_errors=True)
+        else:
+            raise Exception("{download_path} is not a file or directory.")
 
-# Remove the downloaded resource.
-shutil.rmtree(args.download_directory, ignore_errors=True)
 
 # If errors exist, raise an exception highlighting them.
 if errors:


### PR DESCRIPTION
"tests/gem5/configs/download_check.py" is used by the "test-resource-downloading" test (defined in
"tests/gem5/gem5-resources/test_download_resources.py" and ran as part of the "very-long" suite).

Prior to this change "download_check.py" would download each resource, check it's md5, then at the end of the script remove all the downloaded resources. This is inefficient on disk space and was causing our "very-long" suite of tests to require a machines with a lot of disk space to run.

This change alters 'download_check.py" to remove each resource after the md5 check. Thus, only one resource is ever downloaded and present at any given time during the running of this script.

Change-Id: I38fce100ab09f66c256ccddbcb6f29763839ac40