### PR TITLE
misc: Update where runners are cleaned in workflow files

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -79,6 +79,11 @@ jobs:
     needs: [pre-commit, build-gem5, check-for-change-id]
     timeout-minutes: 360     # 6 hours
     steps:
+      - name: Clean runner
+        run:
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          rm -rf ~/.cache || true
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
@@ -102,10 +107,4 @@ jobs:
           name: ${{ env.MY_STEP_VAR }}
           path: output.zip
           retention-days: 7
-      - name: Clean runner
-        if: success() || failure()
-        run:
-          rm -rf ./* || true
-          rm -rf ./.??* || true
-          rm -rf ~/.cache || true
       - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -80,6 +80,11 @@ jobs:
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours for entire matrix to run
     steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
     - uses: actions/checkout@v3
       with:
         # Scheduled workflows run on the default branch by default. We
@@ -152,12 +157,6 @@ jobs:
         name: ${{ env.MY_STEP_VAR }}
         path: output.zip
         retention-days: 7
-    - name: Clean runner
-      if: success() || failure()
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
     - run: echo "This job's status is ${{ job.status }}."
 
   # split library example tests into runs based on Suite UID
@@ -171,6 +170,11 @@ jobs:
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours
     steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
     - uses: actions/checkout@v3
       with:
         # Scheduled workflows run on the default branch by default. We
@@ -198,12 +202,6 @@ jobs:
         name: ${{ env.MY_STEP_VAR }}
         path: output.zip
         retention-days: 7
-    - name: Clean runner
-      if: success() || failure()
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
     - run: echo "This job's status is ${{ job.status }}."
 
   # This runs the SST-gem5 integration compilation and tests it with

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -43,6 +43,11 @@ jobs:
     needs: [build-gem5]
     timeout-minutes: 4320 # 3 days
     steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
     - uses: actions/checkout@v3
       with:
         # Scheduled workflows run on the default branch by default. We
@@ -70,9 +75,4 @@ jobs:
         name: ${{ env.MY_STEP_VAR }}
         path: output.zip
         retention-days: 7
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
     - run: echo "This job's status is ${{ job.status }}."


### PR DESCRIPTION
This moves the clean runner step in our yaml files to be at the beginning of a job, so that if a runner goes down and is unable to clean at the end, we can ensure that
subsequent jobs still run as expected.

Change-Id: Iba52694aefe03c550ad0bfdb5b5f938305273988