### PR TITLE
tests: Temporarily cease using PARSEC disk image in tests

### DIFF
--- a/tests/gem5/gem5_library_example_tests/test_gem5_library_examples.py
+++ b/tests/gem5/gem5_library_example_tests/test_gem5_library_examples.py
@@ -171,7 +171,14 @@ gem5_verify_config(
     length=constants.long_tag,
 )
 
-if os.access("/dev/kvm", mode=os.R_OK | os.W_OK):
+print(
+    "WARNING: PARSEC tests are disabled. This is due to our GitHub "
+    "Actions self-hosted runners only having 60GB of disk space. The "
+    "PARSEC Disk image is too big to use."
+)
+# 'False' is used to disable the tests.
+if False:  # os.access("/dev/kvm", mode=os.R_OK | os.W_OK):
+
     # The x86-parsec-benchmarks uses KVM cores, this test will therefore only
     # be run on systems that support KVM.
     gem5_verify_config(

--- a/tests/gem5/gem5_resources/configs/download_check.py
+++ b/tests/gem5/gem5_resources/configs/download_check.py
@@ -53,6 +53,14 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--skip",
+    nargs="+",  # Accepts 1 or more arguments.
+    type=str,
+    help="The resource IDs to skip. If not set, no resources will be skipped.",
+    required=False,
+)
+
+parser.add_argument(
     "--gem5-version",
     type=str,
     required=False,
@@ -86,6 +94,8 @@ if len(ids) == 0:
 errors = str()
 
 for id in ids:
+    if args.skip and id in args.skip:
+        continue
     if id not in resource_list:
         errors += (
             f"Resource with ID '{id}' not found in "

--- a/tests/gem5/gem5_resources/test_download_resources.py
+++ b/tests/gem5/gem5_resources/test_download_resources.py
@@ -45,7 +45,12 @@ gem5_verify_config(
         "configs",
         "download_check.py",
     ),
-    config_args=["--download-directory", resource_path],
+    config_args=[
+        "--download-directory",
+        resource_path,
+        "--skip",
+        "x86-parsec",
+    ],
     valid_isas=(constants.all_compiled_tag,),
     length=constants.very_long_tag,
 )

--- a/tests/gem5/parsec_benchmarks/test_parsec.py
+++ b/tests/gem5/parsec_benchmarks/test_parsec.py
@@ -50,6 +50,13 @@ def test_parsec(
         # Don't run the tests if KVM is unavailable.
         return
 
+    print(
+        "WARNING: PARSEC tests are disabled. This is due to our GitHub "
+        "Actions self-hosted runners only having 60GB of disk space. The "
+        "PARSEC Disk image is too big to use."
+    )
+    return  # Remove this line to re-enable PARSEC tests.
+
     gem5_verify_config(
         name="{}-boot-cpu_{}-detailed-cpu_{}-cores_{}_{}_{}_parsec-test".format(
             boot_cpu, detailed_cpu, str(num_cpus), mem_system, benchmark, size


### PR DESCRIPTION
Due to a 60GB limit on the VMs the gem5 project's GitHub Actions self-hosted Runners execute within, we cannot run tests which need to download the gem5 Resource's PARSEC disk image (v1.0.0, http://resources.gem5.org/resources/x86-parsec?version=1.0.0). This image, 33GB, is too big and causes our runners to run out of disk space and fail.

These changes can be reverted when we are able to increase the size of our VMs.