### PR TITLE
misc: Add continue-on-error to matrix runs

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -19,6 +19,7 @@ jobs:
         image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
         opts: [.opt, .fast]
     runs-on: [self-hosted, linux, x64, run]
+    continue-on-error: true
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:
@@ -39,6 +40,7 @@ jobs:
         image: [gcc-version-12, clang-version-14]
         opts: [.opt]
     runs-on: [self-hosted, linux, x64, run]
+    continue-on-error: true
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -36,6 +36,7 @@ jobs:
           - image: NULL_MI_example
             command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
     runs-on: [self-hosted, linux, x64, build]
+    continue-on-error: true
     needs: name-artifacts
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     steps:
@@ -76,6 +77,7 @@ jobs:
       matrix:
         test-type: [arm_boot_tests, fs, gem5_library_example_tests, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests, stdlib, x86_boot_tests]
     runs-on: [self-hosted, linux, x64, run]
+    continue-on-error: true
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours for entire matrix to run
@@ -167,6 +169,7 @@ jobs:
       matrix:
         test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt, gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    continue-on-error: true
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours
     steps:

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -39,6 +39,7 @@ jobs:
       matrix:
         test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
     runs-on: [self-hosted, linux, x64, run]
+    continue-on-error: true
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [build-gem5]
     timeout-minutes: 4320 # 3 days


### PR DESCRIPTION
This sets continue-on-error to true on any scheduled test that uses a matrix so we can have all sets of tests run regardless if one of them fails or not.

Change-Id: I8f6137ebdf62a5cecd582387316c330c8a1401ca