### PR TITLE
Proof-of-concept: Using the 'act' tool to run GitHub Actions locally

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -6,11 +6,23 @@ on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
 
+env:
+    # This give us a way to skip the pre-commit and check-for-change-id
+    # jobs. On GitHub Actions, these remain false and therefore these jobs
+    # are always run. When running locally via `act`, pre-commit and
+    # check-for-change-id failed to run due to a lack of ref-head and ref-base.
+    # `act` has an argument `-e` which allows users to set a JSON file
+    # specifying these environment variables. A copy of this file can be found
+    # in "act-event-env.json". This file, if loaded via `-e` will has the local
+    #`act` skipping these jobs.
+    github.event.skip-pre-commit: false
+    github.event.skip-check-for-change-id: false
 
 jobs:
   pre-commit:
     # runs on github hosted runner
     runs-on: ubuntu-22.04
+    if: ${{ !github.event.skip-pre-commit }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
@@ -18,6 +30,7 @@ jobs:
 
   # ensures we have a change-id in every commit, needed for gerrit
   check-for-change-id:
+    if: ${{ !github.event.skip-check-for-change-id }}
     # runs on github hosted runner
     runs-on: ubuntu-22.04
     steps:
@@ -45,6 +58,8 @@ jobs:
     runs-on: [self-hosted, linux, x64, build]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
+    # build-gem5 should still run if pre-commit and check-for-change-id are skipped.
+    if : ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     outputs:
       artifactname: ${{ steps.name.outputs.test }}
     steps:
@@ -65,6 +80,8 @@ jobs:
     runs-on: [self-hosted, linux, x64, run]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
+    # unittests-all-opt should still run if pre-commit and check-for-change-id are skipped.
+    if : ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -77,6 +94,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, run]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, build-gem5, check-for-change-id]
+    # The only true requirement is that build-gem5 passes. pre-commit and
+    # check-for-change-id may be skipped.
+    if : ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.build-gem5.result == 'success' }}
     timeout-minutes: 360     # 6 hours
     steps:
       - name: Clean runner

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+    "tasks": [
+        {
+            "type": "docker-build",
+            "label": "Build act Docker Image",
+            "detail": "Builds the Docker Image act needs. It's our Ubuntu 22.04 image but with nodejs installed.",
+            "dockerBuild": {
+                "context": "${workspaceFolder}/act-docker",
+                "dockerfile": "${workspaceFolder}/act-docker/Dockerfile",
+                "tag": "act-docker:latest"
+            }
+        },
+        {
+            "type": "shell",
+            "label": "GitHub CI Tests",
+            "detail": "Runs the GitHub CI Tests, via act. Requires act and docker to be installed.",
+            "command": "act",
+            "dependsOn": ["Build act Docker Image"],
+            "args": [
+                "pull_request",
+                "-W=${workspaceFolder}/.github/workflows/ci-tests.yaml",
+                "--container-architecture=linux/amd64",
+                "--rm",
+                "--defaultbranch=stable",
+                "--rebuild=False",
+                "-e=${workspaceFolder}/act-event-env.json",
+                "-P=ubuntu-latest=catthehacker/ubuntu:act-latest",
+                "-P=ubuntu-22.04=catthehacker/ubuntu:act-22.04",
+                "-P=ubuntu-20.04=catthehacker/ubuntu:act-20.04",
+                "-P=ubuntu-18.04=catthehacker/ubuntu:act-18.04",
+                "-P=gcr.io/gem5-test/ubuntu-22.04_all-dependencies-test:latest=act-docker:latest"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "dedicated",
+                "showReuseMessage": false,
+                "clear": true
+            }
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/act-docker/Dockerfile
+++ b/act-docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+RUN apt -y update && apt -y install nodejs

--- a/act-event-env.json
+++ b/act-event-env.json
@@ -1,0 +1,4 @@
+{
+	"skip-pre-commit": true,
+    "skip-check-for-change-id": true
+}


### PR DESCRIPTION
https://github.com/nektos/act allows users to run GitHub Actions locally. This gives gem5 developers a way to run testing jobs prior to pushing. I've been playing around with

**pre-reqs**:
* `act` must be installed: https://github.com/nektos/act#installation
* docker must be installed

**Issues and solutions**:

There are two issues using `act` I've run into thus far:

* As we're not really doing a pull request, ergo there's no ref-head and
      ref-base for actions to know what commits are within the pull request.
      As such, jobs such as 'pre-commit' and 'check-for-change-id' fail.
      Users, if they wish, can specify these values and pass them to act:
      https://github.com/nektos/act#events. However, for now, these jobs
      are skipped. To do this `-e=act-event-env.json` is passed as an
      argument.
* `act` does not perfectly emulate the github actions environment and
      how it executes the jobs. I have found that our 22.04 docker image is
      missing nodeJS, which act requires. Therefore, included in this patch
      "act-docker/Dockerfile". This docker image can be build with
       `docker build . -t act-docker` and `act` can be told to replace docker
       images used in the actions with the `-P` flag. Such as:
       `-P=gcr.io/gem5-test/ubuntu-22.04_all-dependencies-test:latest=act-docker:latest`.

**To run**:

```
    act \
     pull_request # trigger the pull request actions. \
     -W=.github/workflows/ci-tests.yaml # Only from this workflowfile.  \
     --container-architecture=linux/amd64 #Specify container architecture. \
     --rm #Destroy the container after completion. \
     --defaultbranch=stable # Our default branch is stable \
     --rebuild=False \
     --e=act-event-env.json # Set the event environment variables. \
     -P=ubuntu-latest=catthehacker/ubuntu:act-latest #we can't use Github 'runs-on' \
     -P=ubuntu-22.04=catthehacker/ubuntu:act-22.04 \
     -P=ubuntu-20.04=catthehacker/ubuntu:act-20.04 \
     -P=ubuntu-18.04=catthehacker/ubuntu:act-18.04  \
     -P=gcr.io/gem5-test/ubuntu-22.04_all-dependencies-test:latest=act-docker:latest"
```

**In addition: utilizing VS Code Tasks**

I've been trying to find better ways to improve gem5 development experience in VS code. As such I've been playing around with Tasks. It's not ground breaking, but included in this PR is a patch which adds a "GitHub CI Tests" task which runs these within VS Code.

We probably don't want to distribute this, but just thought I'd share since this is just a draft PR for now.
