### PR TITLE
arch-riscv: Check CSR before executing VMem instructions

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -177,6 +177,12 @@ Fault
     %(op_rd)s;
     %(ea_code)s;
 
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
 
@@ -345,6 +351,12 @@ Fault
 
     RiscvISA::vreg_t tmp_v0;
     uint8_t *v0;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     if(!machInst.vm) {
@@ -531,6 +543,12 @@ Fault
         trace::InstRecord* traceData) const
 {
     Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     %(op_decl)s;
     %(op_rd)s;
     %(ea_code)s;
@@ -651,6 +669,12 @@ Fault
                             trace::InstRecord* traceData) const
 {
     Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     %(op_src_decl)s;
     %(op_rd)s;
     %(ea_code)s;
@@ -810,6 +834,12 @@ Fault
 {
     Fault fault = NoFault;
     Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_src_decl)s;
@@ -1001,6 +1031,12 @@ Fault
 {
     Fault fault = NoFault;
     Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     RiscvISA::vreg_t tmp_v0;
@@ -1182,6 +1218,12 @@ Fault
     using vu = std::make_unsigned_t<ElemType>;
     Fault fault = NoFault;
     Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_src_decl)s;
@@ -1382,6 +1424,12 @@ Fault
     using vu = std::make_unsigned_t<ElemType>;
     Fault fault = NoFault;
     Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_src_decl)s;

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -137,6 +137,8 @@ Fault
         return std::make_shared<IllegalInstFault>(
             "RVV is disabled or VPU is off", machInst);
     }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     if(!machInst.vm) {
         xc->getRegOperand(this, _numSrcRegs - 1, &tmp_v0);
         v0 = tmp_v0.as<uint8_t>();
@@ -174,6 +176,9 @@ Fault
     %(op_src_decl)s;
     %(op_rd)s;
     %(ea_code)s;
+
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
 
     uint32_t mem_size = width_EEW(this->machInst.width) / 8 * this->microVl;
     const std::vector<bool> byte_enable(mem_size, true);
@@ -297,6 +302,8 @@ Fault
         return std::make_shared<IllegalInstFault>(
             "RVV is disabled or VPU is off", machInst);
     }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     if(!machInst.vm) {
         xc->getRegOperand(this, _numSrcRegs - 1, &tmp_v0);
         v0 = tmp_v0.as<uint8_t>();
@@ -338,6 +345,8 @@ Fault
 
     RiscvISA::vreg_t tmp_v0;
     uint8_t *v0;
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     if(!machInst.vm) {
         xc->getRegOperand(this, _numSrcRegs - 1, &tmp_v0);
         v0 = tmp_v0.as<uint8_t>();
@@ -761,6 +770,8 @@ Fault
         return std::make_shared<IllegalInstFault>(
             "RVV is disabled or VPU is off", machInst);
     }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_decl)s;
     %(op_rd)s;
     constexpr uint8_t elem_size = sizeof(Vd[0]);
@@ -799,7 +810,8 @@ Fault
 {
     Fault fault = NoFault;
     Addr EA;
-
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_src_decl)s;
     %(op_rd)s;
     constexpr uint8_t elem_size = sizeof(Vd[0]);
@@ -953,6 +965,8 @@ Fault
         return std::make_shared<IllegalInstFault>(
             "RVV is disabled or VPU is off", machInst);
     }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_decl)s;
     %(op_rd)s;
     constexpr uint8_t elem_size = sizeof(Vs3[0]);
@@ -987,7 +1001,8 @@ Fault
 {
     Fault fault = NoFault;
     Addr EA;
-
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     RiscvISA::vreg_t tmp_v0;
     uint8_t *v0;
     if(!machInst.vm) {
@@ -1126,6 +1141,8 @@ Fault
         return std::make_shared<IllegalInstFault>(
             "RVV is disabled or VPU is off", machInst);
     }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_decl)s;
     %(op_rd)s;
     %(ea_code)s;
@@ -1165,7 +1182,8 @@ Fault
     using vu = std::make_unsigned_t<ElemType>;
     Fault fault = NoFault;
     Addr EA;
-
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_src_decl)s;
     %(op_rd)s;
     constexpr uint8_t elem_size = sizeof(Vd[0]);
@@ -1327,6 +1345,8 @@ Fault
         return std::make_shared<IllegalInstFault>(
             "RVV is disabled or VPU is off", machInst);
     }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_decl)s;
     %(op_rd)s;
     %(ea_code)s;
@@ -1362,7 +1382,8 @@ Fault
     using vu = std::make_unsigned_t<ElemType>;
     Fault fault = NoFault;
     Addr EA;
-
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
     %(op_src_decl)s;
     %(op_rd)s;
     %(ea_code)s;


### PR DESCRIPTION
. Any instructions require vector register should check if vector is enabled. Any instructions need vtype CSR to execute them should check vill bit beforehead.