### PR TITLE
arch-x86,cpu-kvm: Fix gem5.fast due to unused variable

### DIFF
--- a/src/arch/x86/kvm/x86_cpu.cc
+++ b/src/arch/x86/kvm/x86_cpu.cc
@@ -1459,7 +1459,8 @@ X86KvmCPU::updateCPUID()
             m5_supported.push_back(makeKvmCpuid(function, idx, cpuid));
         } else {
             while (true) {
-                bool rv = isa->cpuid->doCpuid(tc, function, idx, cpuid);
+                [[maybe_unused]] bool rv = isa->cpuid->doCpuid(
+                    tc, function, idx, cpuid);
                 assert(rv);
 
                 if (idx &&
@@ -1493,7 +1494,8 @@ X86KvmCPU::updateCPUID()
             m5_supported.push_back(makeKvmCpuid(function, idx, cpuid));
         } else {
             while (true) {
-                bool rv = isa->cpuid->doCpuid(tc, function, idx, cpuid);
+                [[maybe_unused]] bool rv = isa->cpuid->doCpuid(
+                    tc, function, idx, cpuid);
                 assert(rv);
 
                 if (idx &&


### PR DESCRIPTION
Detected via this failing workload:
https://github.com/gem5/gem5/actions/runs/5861958237

Ir caused the following compilation error to be thrown:

```
src/arch/x86/kvm/x86_cpu.cc:1462:22: error: unused variable ‘rv’ [-Werror=unused-variable]
 1462 |                 bool rv = isa->cpuid->doCpuid(tc, function, idx, cpuid);
      |                      ^~
```

`rv` is unused in the .fast compilation as it's only used in the `assert` statement immediately after. 

To fix this, the `[[maybe_unused]]` annotation is used.
