### PR TITLE
util-docker: Fix clang-version-8 docker container

### DIFF
--- a/util/dockerfiles/ubuntu-20.04_clang-version/Dockerfile
+++ b/util/dockerfiles/ubuntu-20.04_clang-version/Dockerfile
@@ -40,7 +40,10 @@ RUN apt -y update && apt -y upgrade && \
     apt -y install git m4 scons zlib1g zlib1g-dev libprotobuf-dev \
     protobuf-compiler libprotoc-dev libgoogle-perftools-dev python3-dev \
     python-is-python3 doxygen libboost-all-dev libhdf5-serial-dev \
-    python3-pydot libpng-dev clang-${version} make
+    python3-pydot libpng-dev clang-${version} make \
+    # This is needed as clang-8 does not have the libstdc++-10-dev package.
+    # It is necessary for compilation.
+    libstdc++-10-dev
 
 RUN apt-get --purge -y remove gcc
 


### PR DESCRIPTION
clang v8, when installed in this manner via Docker, did not install the libstdc++. This caused compilation errors. This patch adds the libstdc++-10-dev package to this Dockerfile.