### PR TITLE
misc: Update matrix runs in scheduled tests

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -15,11 +15,11 @@ jobs:
   # replication of compiler-tests.sh
   all-compilers:
     strategy:
+      fail-fast: false
       matrix:
         image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
         opts: [.opt, .fast]
     runs-on: [self-hosted, linux, x64, run]
-    continue-on-error: true
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:
@@ -35,12 +35,12 @@ jobs:
   # Tests the two latest gcc and clang supported compilers against all gem5 compilations.
   latest-compilers-all-gem5-builds:
     strategy:
+      fail-fast: false
       matrix:
         gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
         image: [gcc-version-12, clang-version-14]
         opts: [.opt]
     runs-on: [self-hosted, linux, x64, run]
-    continue-on-error: true
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -19,6 +19,7 @@ jobs:
 
   build-gem5:
     strategy:
+      fail-fast: false
       matrix:
         # NULL is in quotes since it is considered a keyword in yaml files
         image: [ALL, ALL_CHI, ARM, ALL_MSI, ALL_MESI_Two_Level, "NULL", NULL_MI_example, RISCV, VEGA_X86]
@@ -36,7 +37,6 @@ jobs:
           - image: NULL_MI_example
             command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
     runs-on: [self-hosted, linux, x64, build]
-    continue-on-error: true
     needs: name-artifacts
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     steps:
@@ -74,10 +74,10 @@ jobs:
   # start running all of the long tests
   testlib-long-tests:
     strategy:
+      fail-fast: false
       matrix:
         test-type: [arm_boot_tests, fs, gem5_library_example_tests, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests, stdlib, x86_boot_tests]
     runs-on: [self-hosted, linux, x64, run]
-    continue-on-error: true
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours for entire matrix to run
@@ -166,10 +166,10 @@ jobs:
   testlib-long-gem5_library_example_tests:
     runs-on: [self-hosted, linux, x64, run]
     strategy:
+      fail-fast: false
       matrix:
         test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt, gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    continue-on-error: true
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours
     steps:

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -36,10 +36,10 @@ jobs:
   # start running the very-long tests
   testlib-very-long-tests:
     strategy:
+      fail-fast: false
       matrix:
         test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
     runs-on: [self-hosted, linux, x64, run]
-    continue-on-error: true
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [build-gem5]
     timeout-minutes: 4320 # 3 days


### PR DESCRIPTION
This changes continue-on-error to be fail-fast instead, as continue-on-error will mark failed matrix runs as
successful, whereas fail-fast makes sure everything in the matrix runs, but gets marked as failed if part of it fails.

Change-Id: Ie20652c229b6cce9f1c0a45958b088391e7aae97