### PR TITLE
WIP: Add GPU tests to weekly.yaml file

### DIFF
--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -1,0 +1,82 @@
+# This workflow runs all of the very-long tests within main.py
+
+name: Weekly Tests
+
+on:
+  # Runs every Sunday from 7AM UTC
+  schedule:
+    - cron:  '00 7 * * 6'
+  # Allows us to manually start workflow for testing
+  workflow_dispatch:
+
+jobs:
+  name-artifacts:
+    runs-on: ubuntu-latest
+    outputs:
+      build-name: ${{ steps.artifact-name.outputs.name }}
+    steps:
+    - uses: actions/checkout@v2
+    - id: artifact-name
+      run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S-")" >> $GITHUB_OUTPUT
+
+  build-gem5:
+    strategy:
+      matrix:
+        image: [ALL, GCN3_X86]
+        # this allows us to pass additional command line parameters
+        # the default is to add -j $(nproc), but some images
+        # require more specifications when built
+        include:
+          - command-line: -j $(nproc)
+          - image: GCN3_X86
+            command-line: -j4 --ignore-style
+    runs-on: [self-hosted, linux, x64, build]
+    needs: name-artifacts
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    outputs:
+      build-name: ${{ steps.artifact-name.outputs.name }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+          ref: develop
+      - name: Build gem5
+        run: scons build/${{ matrix.image }}/gem5.opt ${{ matrix.command-line }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ needs.name-artifacts.outputs.build-name }}${{ matrix.image }}
+          path: build/${{ matrix.image }}/gem5.opt
+          retention-days: 5
+      - run: echo "This job's status is ${{ job.status }}."
+
+  HACC-tests:
+    runs-on: [self-hosted, linux, x64, build]
+    container: mkjost/testing-gpu-image:latest
+    needs: build-gem5
+    timeout-minutes: 4320 # 3 day
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+          ref: develop
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{needs.name-artifacts.outputs.build-name}}GCN3_X86
+          path: build/GCN3_X86
+      - run: chmod u+x build/GCN3_X86/gem5.opt
+      - name: make hip directory
+        run: mkdir hip
+      - name: Compile m5ops and x86
+        working-directory: ${{ github.workspace }}/util/m5
+        run: |
+          export TERM=xterm-256color
+          scons build/x86/out/m5
+      - name: Download tests
+        working-directory: ${{ github.workspace }}/hip
+        run: wget http://dist.gem5.org/dist/v22-1/test-progs/halo-finder/ForceTreeTest
+      - name: Run HACC tests
+        working-directory: ${{ github.workspace }}
+        run: |
+          build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root=hip -c ForceTreeTest --options="0.5 0.1 64 0.1 1 N 12 rcb"

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -10,8 +10,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  name-artifacts:
+    runs-on: ubuntu-latest
+    outputs:
+      build-name: ${{ steps.artifact-name.outputs.name }}
+    steps:
+    - uses: actions/checkout@v2
+    - id: artifact-name
+      run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S-")" >> $GITHUB_OUTPUT
+
   build-gem5:
+    strategy:
+      matrix:
+        image: [ALL, GCN3_X86]
+        # this allows us to pass additional command line parameters
+        # the default is to add -j $(nproc), but some images
+        # require more specifications when built
+        include:
+          - command-line: -j $(nproc)
+          - image: GCN3_X86
+            command-line: -j4 --ignore-style
     runs-on: [self-hosted, linux, x64, build]
+    needs: name-artifacts
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     outputs:
       build-name: ${{ steps.artifact-name.outputs.name }}
@@ -21,15 +41,12 @@ jobs:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
           ref: develop
-      - id: artifact-name
-        run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S")-ALL" >> $GITHUB_OUTPUT
       - name: Build gem5
-        run: |
-          scons build/ALL/gem5.opt -j $(nproc)
+        run: scons build/${{ matrix.image }}/gem5.opt ${{ matrix.command-line }}
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.artifact-name.outputs.name }}
-          path: build/ALL/gem5.opt
+          name: ${{ needs.name-artifacts.outputs.build-name }}${{ matrix.image }}
+          path: build/${{ matrix.image }}/gem5.opt
           retention-days: 5
       - run: echo "This job's status is ${{ job.status }}."
 
@@ -41,7 +58,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, run]
     continue-on-error: true
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [build-gem5]
+    needs: [build-gem5, name-artifact]
     timeout-minutes: 4320 # 3 days
     steps:
     - name: Clean runner
@@ -56,7 +73,7 @@ jobs:
         ref: develop
     - uses: actions/download-artifact@v3
       with:
-        name: ${{needs.build-gem5.outputs.build-name}}
+        name: ${{needs.name-artifacts.outputs.build-name}}ALL
         path: build/ALL
     - run: chmod u+x build/ALL/gem5.opt
     - name: very-long ${{ matrix.test-type }}
@@ -77,3 +94,209 @@ jobs:
         path: output.zip
         retention-days: 7
     - run: echo "This job's status is ${{ job.status }}."
+
+  # These tests run successfully
+  LULESH-tests:
+    runs-on: [self-hosted, linux, x64, build]
+    container: mkjost/testing-gpu-image:latest
+    needs: [build-gem5, name-artifact]
+    timeout-minutes: 4320 # 3 days
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+          ref: develop
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{needs.name-artifacts.outputs.build-name}}GCN3_X86
+          path: build/GCN3_X86
+      - run: chmod u+x build/GCN3_X86/gem5.opt
+      - name: checkout gem5 resources
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone https://gem5.googlesource.com/public/gem5-resources
+          cd gem5-resources
+          git checkout develop
+      - name: Compile m5ops and x86
+        working-directory: ${{ github.workspace }}/util/m5
+        run: |
+          export TERM=xterm-256color
+          scons build/x86/out/m5
+      - name: Build LULESH
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/lulesh
+        run:  make
+      - name: Run LULUESH tests
+        working-directory: ${{ github.workspace }}
+        run: build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --mem-size=8GB --reg-alloc-policy=dynamic --benchmark-root="gem5-resources/src/gpu/lulesh/bin" -c lulesh
+
+  # These tests fail due to the setting up of cachefiles
+  DNNMark-tests:
+    runs-on: [self-hosted, linux, x64, build]
+    container:
+      image: mkjost/testing-gpu-image:latest
+      # volumes:
+      #   - ${{ github.workspace }}:${{ github.workspace }}
+      #   - ${{ github.workspace }}/cachefiles:/~/.cache/miopen/2.9.0
+    needs: [build-gem5, name-artifact]
+    timeout-minutes: 4320 # 3 days
+    steps:
+      - name: Clean runner
+        run:
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          rm -rf ~/.cache || true
+          rm -rf ${{ github.workspace }}/gem5-resources || true
+      - uses: actions/checkout@v3
+        with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+          ref: develop
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{needs.name-artifacts.outputs.build-name}}GCN3_X86
+          path: build/GCN3_X86
+      - run: chmod u+x build/GCN3_X86/gem5.opt
+      - name: checkout gem5 resources
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone https://gem5.googlesource.com/public/gem5-resources
+          cd gem5-resources
+          git checkout develop
+      - name: Compile m5ops and x86
+        working-directory: ${{ github.workspace }}/util/m5
+        run: |
+          export TERM=xterm-256color
+          scons build/x86/out/m5
+      - name: Setup cmark for DNNMark #potentially can combine all these steps
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/DNNMark
+        run: ./setup.sh HIP
+      - name: Make the DNNMark library
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/DNNMark/build
+        run: make -j4
+      - name: Generate cachefiles #iffy on working directory
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/DNNMark/
+        run: python3 generate_cachefiles.py cachefiles.csv --gfx-version=gfx801 --num-cus=4
+      - name: Generate mmap data
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/DNNMark
+        run: |
+          g++ -std=c++0x generate_rand_data.cpp -o generate_rand_data
+          ./generate_rand_data
+      - name: Run DNNMark
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/DNNMark
+        run: |
+          ../../../../build/GCN3_X86/gem5.opt ../../../../configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root="build/benchmarks/test_fwd_softmax" -c dnnmark_test_fwd_softmax --options="-config config_example/softmax_config.dnnmark -mmap mmap.bin"
+          ../../../../build/GCN3_X86/gem5.opt ../../../../configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root="build/benchmarks/test_fwd_pool" -c dnnmark_test_fwd_pool --options="-config config_example/pool_config.dnnmark -mmap mmap.bin"
+          ../../../../build/GCN3_X86/gem5.opt ../../../../configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root="build/benchmarks/test_bwd_bn" -c dnnmark_test_bwd_bn --options="-config config_example/bn_config.dnnmark -mmap mmap.bin"
+
+  # These tests run successfully
+  HACC-tests:
+    runs-on: [self-hosted, linux, x64, build]
+    container: mkjost/testing-gpu-image:latest
+    needs: [build-gem5, name-artifact]
+    timeout-minutes: 4320 # 3 days
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+          ref: develop
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{needs.name-artifacts.outputs.build-name}}GCN3_X86
+          path: build/GCN3_X86
+      - run: chmod u+x build/GCN3_X86/gem5.opt
+      - name: checkout gem5 resources
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone https://gem5.googlesource.com/public/gem5-resources
+          cd gem5-resources
+          git checkout develop
+      - name: Compile m5ops and x86
+        working-directory: ${{ github.workspace }}/util/m5
+        run: |
+          export TERM=xterm-256color
+          scons build/x86/out/m5
+      - name: Build HACC
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu/halo-finder/src
+        run: make hip/ForceTreeTest
+      - name: Run HACC tests
+        working-directory: ${{ github.workspace }}
+        run: build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root=gem5-resources/src/gpu/halo-finder/src/hip -c ForceTreeTest --options="0.5 0.1 64 0.1 1 N 12 rcb"
+
+  # These tests fail to make gem5-fusion due to not finding gem5/m5ops.h
+  pannotia-tests:
+    runs-on: [self-hosted, linux, x64, build]
+    container: mkjost/testing-gpu-image:latest
+    needs: [build-gem5, name-artifact]
+    timeout-minutes: 4320 # 3 days
+    strategy:
+      matrix:
+        test-name: [BC, "Color Max", "Color Max Min", FW, MIS, "PageRank Default", "PageRank (SPMV)", "SSSP (CSR)", "SSSP (ELL)"]
+        include:
+          - export: export GEM5_PATH=${{ github.workspace }}
+          - test-name: BC
+            working-directory: /pannotia/bc
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/bc/bin -c bc.gem5 --options="1k_128k.gr"
+          - test-name: "Color Max"
+            working-directory: /pannotia/color
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/color/bin -c color_max.gem5 --options="1k_128k.gr 0"
+          - test-name: "Color Max Min"
+            working-directory: /pannotia/color
+            export: export GEM5_PATH=${{ github.workspace }}; export VARIANT=MAXMIN
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/color/bin -c color_maxmin.gem5 --options="1k_128k.gr 0"
+          - test-name: FW
+            working-directory: /pannotia/fw
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="1k_128k.gr"
+          - test-name: MIS
+            working-directory: /pannotia/mis
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/mis/bin -c mis_hip.gem5 --options="1k_128k.gr 0"
+          - test-name: "PageRank Default"
+            working-directory: /pannotia/pagerank
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank.gem5 --options="coAuthorsDBLP.graph 1"
+          - test-name: "PageRank (SPMV)"
+            working-directory: /pannotia/pagerank
+            export: export GEM5_PATH=${{ github.workspace }}; export VARIANT=SPMV
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank_spmv.gem5 --options="coAuthorsDBLP.graph 1"
+          - test-name: "SSSP (CSR)"
+            working-directory: /pannotia/sssp
+            export: export GEM5_PATH=${{ github.workspace }}; export VARIANT=CSR
+            command-line: --benchmark-root=${gem5_root}/gem5-resources/src/gpu/pannotia/sssp/bin -c sssp.gem5 --options="1k_128k.gr 0"
+          - test-name: "SSSP (ELL)"
+            working-directory: /pannotia/sssp
+            export: export GEM5_PATH=${{ github.workspace }}; export VARIANT=ELL
+            command-line: --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_ell.gem5 --options="1k_128k.gr 0"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+          ref: develop
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{needs.name-artifacts.outputs.build-name}}GCN3_X86
+          path: build/GCN3_X86
+      - run: chmod u+x build/GCN3_X86/gem5.opt
+      - name: checkout gem5 resources
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone https://gem5.googlesource.com/public/gem5-resources
+          cd gem5-resources
+          git checkout develop
+      - name: Compile m5ops and x86
+        working-directory: ${{ github.workspace }}/util/m5
+        run: |
+          export TERM=xterm-256color
+          scons build/x86/out/m5
+      # test pannotia
+      - name: Build ${{ matrix.test-name }}
+        working-directory: ${{ github.workspace }}/gem5-resources/src/gpu${{ matrix.working-directory }}
+        run: |
+          export GEM5_PATH=${{ github.workspace }}
+          make gem5-fusion
+      - name: Run ${{ matrix.test-name }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr # for bc
+          wget http://dist.gem5.org/dist/develop/datasets/pannotia/pagerank/coAuthorsDBLP.graph # for pagerank
+          build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --mem-size=8GB --reg-alloc-policy=dynamic ${{ matrix.command-line }}


### PR DESCRIPTION
This change adds all the GPU tests to our weekly tests, though some tests aren't fully working yet, and it uses a temporary docker container that needs to be replaced.

The current issues that need to be addressed within the GPU test implementation is that the DNNMark tests currently fail due to the setting up of the cachefiles, the Pannotia tests fail to make gem5-fusion due to not finding gem5/m5ops.h, the current docker image being used is one I created locally and should be updated to be included within gem5, and we should upload all the resources used so that we don't need to clone gem5 resources within these tests.

Change-Id: I7507d2fe00b652591c4aaef4897829b19b73a182