### PR TITLE
ext: Update DRAMSys README

### DIFF
--- a/ext/dramsys/README
+++ b/ext/dramsys/README
@@ -1,9 +1,10 @@
 Follow these steps to get DRAMSys as part of gem5
 
 1. Go to ext/dramsys (this directory)
-2. Clone DRAMSys: 'git clone --recursive git@github.com:tukl-msd/DRAMSys.git DRAMSys'
+2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys DRAMSys'
 3. Change directory to DRAMSys: 'cd DRAMSys'
 4. Checkout the correct commit: 'git checkout -b gem5 09f6dcbb91351e6ee7cadfc7bc8b29d97625db8f'
+5. Recursively obtain the submodules: 'git submodule update --init --recursive'
 
 If you wish to run a simulation using the gem5 processor cores, make sure to enable the storage mode in DRAMSys.
 This is done by setting the value of the "StoreMode" key to "Store" in the base configuration file.


### PR DESCRIPTION
This fixes:

1. Most importantly: The submodule recursive update was incorrect. This adds the recursive obtaining of submodules as a seperate explicity step.
2. Changes the `git clone` to use https.