### PR TITLE
sim: provide a signal constructor with an init_state

### DIFF
--- a/src/sim/signal.hh
+++ b/src/sim/signal.hh
@@ -79,6 +79,7 @@ class SignalSinkPort : public Port
         _source = dynamic_cast<SignalSourcePort<State> *>(&peer);
         fatal_if(!_source, "Attempt to bind signal pin %s to "
                 "incompatible pin %s", name(), peer.name());
+        _state = _source->state();
         Port::bind(peer);
     }
     void
@@ -94,12 +95,21 @@ class SignalSourcePort : public Port
 {
   private:
     SignalSinkPort<State> *sink = nullptr;
-    State _state = {};
+    State _state;
 
   public:
-    SignalSourcePort(const std::string &_name, PortID _id=InvalidPortID) :
-        Port(_name, _id)
-    {}
+    SignalSourcePort(const std::string &_name, PortID _id = InvalidPortID)
+        : Port(_name, _id)
+    {
+        _state = {};
+    }
+
+    SignalSourcePort(const std::string &_name, PortID _id,
+                     const State &init_state)
+        : SignalSourcePort(_name, _id)
+    {
+        _state = init_state;
+    }
 
     void
     set(const State &new_state)
@@ -126,6 +136,6 @@ class SignalSourcePort : public Port
     }
 };
 
-} // namespace gem5
+}  // namespace gem5
 
-#endif //__SIM_SIGNAL_HH__
+#endif  //__SIM_SIGNAL_HH__

--- a/src/sim/signal.hh
+++ b/src/sim/signal.hh
@@ -79,6 +79,7 @@ class SignalSinkPort : public Port
         _source = dynamic_cast<SignalSourcePort<State> *>(&peer);
         fatal_if(!_source, "Attempt to bind signal pin %s to "
                 "incompatible pin %s", name(), peer.name());
+        // The state of sink has to match the state of source.
         _state = _source->state();
         Port::bind(peer);
     }
@@ -104,6 +105,7 @@ class SignalSourcePort : public Port
         _state = {};
     }
 
+    // Give an initial value to the _state instead of using a default value.
     SignalSourcePort(const std::string &_name, PortID _id,
                      const State &init_state)
         : SignalSourcePort(_name, _id)


### PR DESCRIPTION
The current SignalSinkPort and SignalSourcePort have no ways to assign the init value of the state. Add a new constructor for them with the param init_state

Bug: 293410800
Test: boot to linux
Change-Id: Idde0a12aa0ddd0c9c599ef47059674fb12aa5d68
Reviewed-on: https://soc-sim-external-review.googlesource.com/c/gem5/gem5/+/13159
Gem5-Virtual-Platform-Presubmit-Ready: Johnny Ko <johnnyko@google.com>
Reviewed-by: Yu-hsin Wang <yuhsingw@google.com>
Perf-Presubmit-Ready: Johnny Ko <johnnyko@google.com>
Gem5-Virtual-Platform-Verified: kokoro <noreply+kokoro@google.com>
Perf-Verified: kokoro <noreply+kokoro@google.com>