### PR TITLE
util: Update & fix bug in m5stats2streamline.py

### DIFF
--- a/util/streamline/m5stats2streamline.py
+++ b/util/streamline/m5stats2streamline.py
@@ -668,7 +668,7 @@ def parseProcessInfo(task_file):
     task_name_failure_warned = False
 
     for line in process_file:
-        match = re.match(process_re, line.decode("ISO-8859-1"))
+        match = re.match(process_re, line.decode())
         if match:
             tick = int(match.group(1))
             if start_tick < 0:

--- a/util/streamline/m5stats2streamline.py
+++ b/util/streamline/m5stats2streamline.py
@@ -221,6 +221,7 @@ def packed32(x):
     ret = []
     more = True
     while more:
+        x = int(x)
         b = x & 0x7F
         x = x >> 7
         if ((x == 0) and ((b & 0x40) == 0)) or (
@@ -383,7 +384,13 @@ def timestampList(x):
 
 def writeBinary(outfile, binary_list):
     for i in binary_list:
-        outfile.write(f"{i:c}")
+        if isinstance(i, str):
+            byteVal = bytes(i, "utf-8")
+        elif isinstance(i, int):
+            byteVal = bytes([i])
+        else:
+            byteVal = i
+        outfile.write(byteVal)
 
 
 ############################################################
@@ -661,7 +668,7 @@ def parseProcessInfo(task_file):
     task_name_failure_warned = False
 
     for line in process_file:
-        match = re.match(process_re, line)
+        match = re.match(process_re, line.decode("ISO-8859-1"))
         if match:
             tick = int(match.group(1))
             if start_tick < 0:


### PR DESCRIPTION
There is conversion error in ./util/streamline/m5stats2streamline.py script to convert gem5 stats.txt,sys, system.tasks.txt to the apc folder required by DS-5 streamline. The fix to the bug can convert to apc folder without error. The zipped apc folder can then be imported in older DS-5 v5.24 for visualization (didn't work with DS-5 v5.29).

Changes:
1) writeBinary function binary_list can have either string or ints and it needs to be properly converted to bytes 
2) packed32(x) function can have x as int or float. Incase of float it needs to be converted to int

The bug was reported and solved primarily in the issue https://github.com/gem5/gem5/issues/145 

Change-Id: I6a52aa59e1582dd6bb06b2d1c49ddaf8fe61c997