### PR TITLE
mem-ruby: fix CHI sending the wrong snoop response

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 ARM Limited
+ * Copyright (c) 2021-2023 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -2316,7 +2316,7 @@ action(Send_SnpRespData, desc="") {
          ((tbe.dataDirty || tbe.dataUnique) && (tbe.reqType == CHIRequestType:SnpShared)) ||
          ((tbe.dataDirty || tbe.dataUnique) && (tbe.reqType == CHIRequestType:SnpUnique)));
 
-  if (tbe.dataToBeInvalid) {
+  if (tbe.dataToBeInvalid && tbe.dir_sharers.isEmpty()) {
     assert(tbe.dataMaybeDirtyUpstream == false);
     if (tbe.dataDirty) {
       tbe.snd_msgType := CHIDataType:SnpRespData_I_PD;


### PR DESCRIPTION
Do not respond with SnpRespData_I when the line is still present upstream.

Change-Id: I2592e5c6637cfc0e83042169a245837648276e61