### PR TITLE
redirect_path patch for restoring cpt

### DIFF
--- a/src/sim/fd_array.cc
+++ b/src/sim/fd_array.cc
@@ -422,14 +422,12 @@ FDArray::unserialize(CheckpointIn &cp, Process* process_ptr) {
 
         std::string path;
 
-        if (process_ptr)
-        {
+        if (process_ptr) {
             // Check if it is needed to redirect the app path to another host
             // path
             path = process_ptr->checkPathRedirect(this_ffd->getFileName());
         }
-        else
-        {
+        else {
             path = this_ffd->getFileName();
         }
 

--- a/src/sim/fd_array.cc
+++ b/src/sim/fd_array.cc
@@ -368,7 +368,7 @@ FDArray::serialize(CheckpointOut &cp) const {
 }
 
 void
-FDArray::unserialize(CheckpointIn &cp, SimObject* process_ptr) {
+FDArray::unserialize(CheckpointIn &cp, Process* process_ptr) {
     ScopedCheckpointSection sec(cp, "fdarray");
     uint64_t size;
     paramIn(cp, "size", size);
@@ -424,8 +424,9 @@ FDArray::unserialize(CheckpointIn &cp, SimObject* process_ptr) {
 
         if (process_ptr)
         {
-            Process* ptr = static_cast<Process*>(process_ptr);
-            path = ptr->checkPathRedirect(this_ffd->getFileName());
+            // Check if it is needed to redirect the app path to another host
+            // path
+            path = process_ptr->checkPathRedirect(this_ffd->getFileName());
         }
         else
         {

--- a/src/sim/fd_array.cc
+++ b/src/sim/fd_array.cc
@@ -420,23 +420,23 @@ FDArray::unserialize(CheckpointIn &cp, SimObject* process_ptr) {
 
         mode_t mode = this_ffd->getFileMode();
 
-        std::string const& path = this_ffd->getFileName();
+        std::string path;
+
+        if (process_ptr)
+        {
+            Process* ptr = static_cast<Process*>(process_ptr);
+            path = ptr->checkPathRedirect(this_ffd->getFileName());
+        }
+        else
+        {
+            path = this_ffd->getFileName();
+        }
 
         int flags = this_ffd->getFlags();
 
         // Re-open the file and assign a new sim_fd
         int sim_fd;
-        if (process_ptr)
-        {
-            Process* ptr = static_cast<Process*>(process_ptr);
-            std::string const& host_path =
-                            ptr->checkPathRedirect(this_ffd->getFileName());
-            sim_fd = openFile(host_path, flags, mode);
-        }
-        else
-        {
-            sim_fd = openFile(path, flags, mode);
-        }
+        sim_fd = openFile(path, flags, mode);
 
         this_ffd->setSimFD(sim_fd);
 

--- a/src/sim/fd_array.hh
+++ b/src/sim/fd_array.hh
@@ -36,9 +36,9 @@
 #include <map>
 #include <memory>
 #include <string>
-
 #include "sim/fd_entry.hh"
 #include "sim/serialize.hh"
+#include "sim/sim_object.hh"
 
 namespace gem5
 {
@@ -117,7 +117,11 @@ class FDArray : public Serializable
      * Serialization methods for file descriptors
      */
     void serialize(CheckpointOut &cp) const override;
-    void unserialize(CheckpointIn &cp) override;
+    void unserialize(CheckpointIn &cp, SimObject* process_ptr );
+    void unserialize(CheckpointIn &cp) override {
+      unserialize(cp, nullptr);
+    };
+
 
   private:
     /**

--- a/src/sim/fd_array.hh
+++ b/src/sim/fd_array.hh
@@ -36,12 +36,14 @@
 #include <map>
 #include <memory>
 #include <string>
+
 #include "sim/fd_entry.hh"
 #include "sim/serialize.hh"
-#include "sim/sim_object.hh"
 
 namespace gem5
 {
+
+class Process;
 
 class FDArray : public Serializable
 {
@@ -117,7 +119,7 @@ class FDArray : public Serializable
      * Serialization methods for file descriptors
      */
     void serialize(CheckpointOut &cp) const override;
-    void unserialize(CheckpointIn &cp, SimObject* process_ptr );
+    void unserialize(CheckpointIn &cp, Process* process_ptr );
     void unserialize(CheckpointIn &cp) override {
       unserialize(cp, nullptr);
     };

--- a/src/sim/process.cc
+++ b/src/sim/process.cc
@@ -387,7 +387,7 @@ Process::unserialize(CheckpointIn &cp)
 {
     memState->unserialize(cp);
     pTable->unserialize(cp);
-    fds->unserialize(cp);
+    fds->unserialize(cp, this);
 
     /**
      * Checkpoints for pipes, device drivers or sockets currently


### PR DESCRIPTION
Modify the FDArray::unserialize function to perform a checkPathRedirect if a Process pointer is passed in.
Currently when restoring a checkpoint, it doesn't perform checkPathRedirect for files that were opened during checkpointing. This patch adds a checkPathRedirect in the FDArray::unserialize to redirect app path for restoring checkpoints.