### PR TITLE
misc: Move compiler tests to run on 'build' runners

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
         opts: [.opt, .fast]
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64, build]
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:
@@ -29,7 +29,7 @@ jobs:
         # therefore need to explicitly checkout the develop branch.
         ref: develop
     - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.image }}
-      run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }}
+      run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j$(nproc)
       timeout-minutes: 600  # 10 hours
 
   # Tests the two latest gcc and clang supported compilers against all gem5 compilations.
@@ -40,7 +40,7 @@ jobs:
         gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
         image: [gcc-version-12, clang-version-14]
         opts: [.opt]
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64, build]
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:
@@ -50,5 +50,5 @@ jobs:
         # therefore need to explicitly checkout the develop branch.
         ref: develop
     - name: Compile build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} with ${{ matrix.image }}
-      run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }}
+      run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} -j$(nproc)
       timeout-minutes: 600 # 10 hours


### PR DESCRIPTION
This is an experiment. The runners were sometimes running out of memory building gem5. The builders have more memory so should be able to handling this. The runners have 4-cores so compilation should be faster (note the inclusion of the `-j$(nproc)`.