### PR TITLE
dev-amdgpu: Tell OS about PCIe atomic support

### DIFF
--- a/src/dev/pci/pcireg.h
+++ b/src/dev/pci/pcireg.h
@@ -326,7 +326,7 @@ struct MSIXPbaEntry
  *  Defines the PCI Express capability register and its associated bitfields
  *  for a PCIe device.
  */
-struct PXCAP
+union PXCAP
 {
     uint8_t data[48];
     struct


### PR DESCRIPTION
configs,dev-amdgpu: Add PCI express capability info

The ROCm stack requires PCI express atomics. Currently the first PCI
CapabilityPtr does not point to anything, which signals to the OS
(Linux) that this is an early generation PCI device. As PCI express
atomics were introduced later, the CapabilityPtr needs to point to at
least a PCI express capability structure. This capability is defined as
0x10 in Linux. We additionally set the PCI atomic based bits and
implement device specific PCI configuration space reads and writes to
the amdgpu device.

The second commit, output of simulation when loading the amdgpu
driver no longer outputs "PCIE atomics not supported". Further, an
application which uses PCIe atomics (PyTorch with a reduce_sum kernel)
now makes further progress.

First commit is a minor typo fix changing PCI capability struct to
union.