### PR TITLE
cpu-minor: Separate the reg_index of VecClassReg and VecElemReg

### DIFF
--- a/src/cpu/minor/scoreboard.cc
+++ b/src/cpu/minor/scoreboard.cc
@@ -62,8 +62,11 @@ Scoreboard::findIndex(const RegId& reg, Index &scoreboard_index)
         ret = true;
         break;
       case VecRegClass:
-      case VecElemClass:
         scoreboard_index = vecRegOffset + reg.index();
+        ret = true;
+        break;
+      case VecElemClass:
+        scoreboard_index = vecRegElemOffset + reg.index();
         ret = true;
         break;
       case VecPredRegClass:

--- a/src/cpu/minor/scoreboard.hh
+++ b/src/cpu/minor/scoreboard.hh
@@ -71,6 +71,7 @@ class Scoreboard : public Named
     const unsigned floatRegOffset;
     const unsigned ccRegOffset;
     const unsigned vecRegOffset;
+    const unsigned vecRegElemOffset;
     const unsigned vecPredRegOffset;
     const unsigned matRegOffset;
 
@@ -115,7 +116,8 @@ class Scoreboard : public Named
         floatRegOffset(intRegOffset + reg_classes.at(IntRegClass)->numRegs()),
         ccRegOffset(floatRegOffset + reg_classes.at(FloatRegClass)->numRegs()),
         vecRegOffset(ccRegOffset + reg_classes.at(CCRegClass)->numRegs()),
-        vecPredRegOffset(vecRegOffset +
+        vecRegElemOffset(vecRegOffset + reg_classes.at(VecRegClass)->numRegs()),
+        vecPredRegOffset(vecRegElemOffset +
                 reg_classes.at(VecElemClass)->numRegs()),
         matRegOffset(vecPredRegOffset +
                 reg_classes.at(VecPredRegClass)->numRegs()),


### PR DESCRIPTION
In the RISC-V system, we need to VecClassReg to run RISC-V vector instruction, and VecElemReg is not applicable because the element length of vector can be resizable via vset\*vl\* instruction.

The change will seperate the reg_index for VecReg and VecElemReg to ensure that have the space for VecReg when VecElemReg is not applicable.

Change-Id: I99a82dec273baeee31df89a0ee0f5e87f3ff187c