### PR TITLE
misc: Update CI tests to not run on draft PRs

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -11,6 +11,7 @@ jobs:
   pre-commit:
     # runs on github hosted runner
     runs-on: ubuntu-22.04
+    if: github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
@@ -20,6 +21,7 @@ jobs:
   check-for-change-id:
     # runs on github hosted runner
     runs-on: ubuntu-22.04
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
         with:
@@ -43,6 +45,7 @@ jobs:
 
   build-gem5:
     runs-on: [self-hosted, linux, x64, build]
+    if: github.event.pull_request.draft == false
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
     outputs:
@@ -63,6 +66,7 @@ jobs:
 
   unittests-all-opt:
     runs-on: [self-hosted, linux, x64, run]
+    if: github.event.pull_request.draft == false
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
     timeout-minutes: 60
@@ -75,6 +79,7 @@ jobs:
 
   testlib-quick:
     runs-on: [self-hosted, linux, x64, run]
+    if: github.event.pull_request.draft == false
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, build-gem5, check-for-change-id]
     timeout-minutes: 360     # 6 hours


### PR DESCRIPTION
This updates all the jobs for our CI tests to make sure they don't run tests on draft pull request, and only trigger when ready for review

Change-Id: I3fe7ae373c39fc6ef594c0c71c6f10e7319553d8