### PR TITLE
util-docker: Add GitHub Action to create Docker Images

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,42 @@
+#
+name: Docker images build and push
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'util/docker/ubuntu-20.04_all-depenencies'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ubuntu-20.04_all-depenencies
+#
+jobs:
+  # This builds and pushes the docker image.
+  push:
+    runs-on: [self-hosted, linux, x64, run]
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build image
+        run: |
+          cd util/docker/ubuntu-20.04_all-depenencies
+          docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # This changes all uppercase characters to lowercase.
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
+          docker push $IMAGE_ID::latest


### PR DESCRIPTION
This is built to test the following assumptions:

1. We can trigger a GitHub action event on the changing of a file/directory.
2. We can use GitHub actions to build a docker image.
3. We can use GitHub actions to push a docker image to a container registry.
4. We can use GitHub's container registry.

Right now this will only build and push ubuntu-20.04_all-depenencies, as a test.