### PR TITLE
configs,stdlib,tests: Remove get_runtime_isa()

### DIFF
--- a/configs/common/Caches.py
+++ b/configs/common/Caches.py
@@ -41,7 +41,6 @@ from m5.defines import buildEnv
 from m5.objects import *
 
 from gem5.isas import ISA
-from gem5.runtime import get_runtime_isa
 
 # Base implementations of L1, L2, IO and TLB-walker caches. There are
 # used in the regressions and also as base components in the
@@ -87,21 +86,3 @@ class IOCache(Cache):
     mshrs = 20
     size = "1kB"
     tgts_per_mshr = 12
-
-
-class PageTableWalkerCache(Cache):
-    assoc = 2
-    tag_latency = 2
-    data_latency = 2
-    response_latency = 2
-    mshrs = 10
-    size = "1kB"
-    tgts_per_mshr = 12
-
-    # the x86 table walker actually writes to the table-walker cache
-    if get_runtime_isa() in [ISA.X86, ISA.RISCV]:
-        is_read_only = False
-    else:
-        is_read_only = True
-        # Writeback clean lines as well
-        writeback_clean = True

--- a/configs/common/ObjectList.py
+++ b/configs/common/ObjectList.py
@@ -41,6 +41,7 @@ from textwrap import TextWrapper
 import m5.internal.params
 import m5.objects
 
+from gem5.isas import ISA
 from gem5.runtime import get_supported_isas
 
 
@@ -158,6 +159,38 @@ class CPUList(ObjectList):
                     module, self._is_obj_class
                 ):
                     self._sub_classes[name] = cls
+
+    def get_isa(self, name: str) -> ISA:
+        """For a given CPU (string representation) determine the ISA of the
+        CPU."""
+
+        cls = self.get(name)
+
+        def class_exist(className: str) -> bool:
+            """Check if a class exists."""
+            import types
+
+            result = False
+            try:
+                result = eval("type(" + className + ")") == types.ClassType
+            except NameError:
+                pass
+            return result
+
+        if class_exist(m5.objects.X86CPU) and issubclass(
+            cls, m5.objects.X86CPU
+        ):
+            return ISA.X86
+        elif class_exist(m5.objects.ArmCPU) and issubclass(
+            cls, m5.objects.ArmCPU
+        ):
+            return ISA.ARM
+        elif class_exist(m5.objects.RiscvCPU) and issubclass(
+            cls, m5.objects.RiscvCPU
+        ):
+            return ISA.RISCV
+        else:
+            raise ValueError("Unable to determine CPU ISA.")
 
 
 class EnumList(ObjectList):

--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -45,6 +45,8 @@ import m5
 from m5.defines import buildEnv
 from m5.objects import *
 
+from gem5.runtime import get_supported_isas
+
 vio_9p_help = """\
 Enable the Virtio 9P device and set the path to share. The default 9p path is
 m5ou5/9p/share, and it can be changed by setting VirtIO9p.root with --param. A
@@ -250,7 +252,7 @@ def addCommonOptions(parser):
     )
     parser.add_argument(
         "--cpu-type",
-        default="AtomicSimpleCPU",
+        default=list(get_supported_isas())[0].name + "AtomicSimpleCPU",
         choices=ObjectList.cpu_list.get_names(),
         help="type of cpu to run with",
     )

--- a/configs/common/Simulation.py
+++ b/configs/common/Simulation.py
@@ -81,7 +81,10 @@ def setCPUClass(options):
             TmpClass, test_mem_mode = getCPUClass(options.restore_with_cpu)
     elif options.fast_forward:
         CPUClass = TmpClass
-        TmpClass = AtomicSimpleCPU
+        TmpClass = getCPUClass(
+            ObjectList.CPUList().get_isa(options.cpu_type).name
+            + "AtomicSimpleCPU"
+        )
         test_mem_mode = "atomic"
 
     # Ruby only supports atomic accesses in noncaching mode

--- a/configs/deprecated/example/fs.py
+++ b/configs/deprecated/example/fs.py
@@ -53,7 +53,6 @@ from m5.util import (
 from m5.util.fdthelper import *
 
 from gem5.isas import ISA
-from gem5.runtime import get_runtime_isa
 
 addToPath("../../")
 
@@ -86,9 +85,8 @@ def cmd_line_template():
     return None
 
 
-def build_test_system(np):
+def build_test_system(np, isa: ISA):
     cmdline = cmd_line_template()
-    isa = get_runtime_isa()
     if isa == ISA.MIPS:
         test_sys = makeLinuxMipsSystem(test_mem_mode, bm[0], cmdline=cmdline)
     elif isa == ISA.SPARC:
@@ -384,7 +382,8 @@ else:
 
 np = args.num_cpus
 
-test_sys = build_test_system(np)
+isa = ObjectList.CPUList.get_isa(args.cpu_type)
+test_sys = build_test_system(np, isa)
 
 if len(bm) == 2:
     drive_sys = build_drive_system(np)

--- a/configs/deprecated/example/se.py
+++ b/configs/deprecated/example/se.py
@@ -55,7 +55,6 @@ from m5.util import (
 )
 
 from gem5.isas import ISA
-from gem5.runtime import get_runtime_isa
 
 addToPath("../../")
 
@@ -119,7 +118,7 @@ def get_processes(args):
         idx += 1
 
     if args.smt:
-        assert args.cpu_type == "DerivO3CPU"
+        assert isinstance(args.cpu_type, DerivO3CPU)
         return multiprocesses, idx
     else:
         return multiprocesses, 1
@@ -150,7 +149,7 @@ if args.bench:
 
     for app in apps:
         try:
-            if get_runtime_isa() == ISA.ARM:
+            if ObjectList.CPUList().get_isa(args.cpu_type) == ISA.ARM:
                 exec(
                     "workload = %s('arm_%s', 'linux', '%s')"
                     % (app, args.arm_iset, args.spec_input)
@@ -165,7 +164,7 @@ if args.bench:
             multiprocesses.append(workload.makeProcess())
         except:
             print(
-                f"Unable to find workload for {get_runtime_isa().name()}: {app}",
+                f"Unable to find workload for ISA: {app}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -40,7 +40,7 @@ from m5.objects import *
 from m5.util import addToPath
 
 from gem5.isas import ISA
-from gem5.runtime import get_runtime_isa
+from gem5.runtime import get_supported_isas
 
 addToPath("../")
 
@@ -786,7 +786,7 @@ system.clk_domain = SrcClockDomain(
 
 if fast_forward:
     have_kvm_support = "BaseKvmCPU" in globals()
-    if have_kvm_support and get_runtime_isa() == ISA.X86:
+    if have_kvm_support and get_supported_isas().contains(ISA.X86):
         system.vm = KvmVM()
         system.m5ops_base = 0xFFFF0000
         for i in range(len(host_cpu.workload)):
@@ -825,7 +825,7 @@ for i in range(args.num_cpus):
     system.cpu[i].dcache_port = ruby_port.in_ports
 
     ruby_port.mem_request_port = system.piobus.cpu_side_ports
-    if get_runtime_isa() == ISA.X86:
+    if get_supported_isas().contains(ISA.X86):
         system.cpu[i].interrupts[0].pio = system.piobus.mem_side_ports
         system.cpu[i].interrupts[
             0

--- a/configs/example/hmc_hello.py
+++ b/configs/example/hmc_hello.py
@@ -37,17 +37,23 @@ import m5
 from m5.objects import *
 from m5.util import *
 
-from gem5.runtime import get_runtime_isa
-
 addToPath("../")
 
 from common import (
     HMC,
     MemConfig,
+    ObjectList,
 )
 
 pd = "Simple 'hello world' example using HMC as main memory"
 parser = argparse.ArgumentParser(description=pd)
+parser.add_argument(
+    "--cpu-type",
+    type=str,
+    default="X86TimingSimpleCPU",
+    choices=ObjectList.CPUList().get_names(),
+    help="CPU model to use",
+)
 HMC.add_options(parser)
 options = parser.parse_args()
 # create the system we are going to simulate
@@ -58,8 +64,8 @@ system.mem_mode = "timing"
 clk = "1GHz"
 vd = VoltageDomain(voltage="1V")
 system.clk_domain = SrcClockDomain(clock=clk, voltage_domain=vd)
-# create a simple CPU
-system.cpu = TimingSimpleCPU()
+# create a CPU
+system.cpu = ObjectList().get(options.cpu_type)()
 # config memory system
 MemConfig.config_mem(options, system)
 # hook the CPU ports up to the membus
@@ -70,10 +76,15 @@ system.cpu.createInterruptController()
 # connect special port in the system to the membus. This port is a
 # functional-only port to allow the system to read and write memory.
 system.system_port = system.membus.cpu_side_ports
-# get ISA for the binary to run.
-isa = get_runtime_isa()
 # run 'hello' and use the compiled ISA to find the binary
-binary = "tests/test-progs/hello/bin/" + isa.name.lower() + "/linux/hello"
+
+
+binary = (
+    "tests/test-progs/hello/bin/"
+    + ObjectList.CPUList().get_isa(options.cpu_type).name.lower()
+    + "/linux/hello"
+)
+
 # create a process for a simple "Hello World" application
 process = Process()
 # cmd is a list which begins with the executable (like argv)

--- a/configs/learning_gem5/part1/two_level.py
+++ b/configs/learning_gem5/part1/two_level.py
@@ -43,8 +43,6 @@ import m5
 # import all of the SimObjects
 from m5.objects import *
 
-from gem5.runtime import get_runtime_isa
-
 # Add the common scripts to our path
 m5.util.addToPath("../../")
 

--- a/configs/network/Network.py
+++ b/configs/network/Network.py
@@ -37,8 +37,8 @@ from m5.util import (
 
 
 def define_options(parser):
-    # By default, ruby uses the simple timing cpu
-    parser.set_defaults(cpu_type="TimingSimpleCPU")
+    # By default, ruby uses the simple timing cpu and the X86 ISA
+    parser.set_defaults(cpu_type="X86TimingSimpleCPU")
 
     parser.add_argument(
         "--topology",

--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -48,7 +48,6 @@ from m5.util import (
 )
 
 from gem5.isas import ISA
-from gem5.runtime import get_runtime_isa
 
 addToPath("../")
 
@@ -62,8 +61,8 @@ from topologies import *
 
 
 def define_options(parser):
-    # By default, ruby uses the simple timing cpu
-    parser.set_defaults(cpu_type="TimingSimpleCPU")
+    # By default, ruby uses the simple timing cpu and the X86 ISA
+    parser.set_defaults(cpu_type="X86TimingSimpleCPU")
 
     parser.add_argument(
         "--ruby-clock",
@@ -331,9 +330,9 @@ def send_evicts(options):
     # 1. The O3 model must keep the LSQ coherent with the caches
     # 2. The x86 mwait instruction is built on top of coherence invalidations
     # 3. The local exclusive monitor in ARM systems
-    if options.cpu_type == "DerivO3CPU" or get_runtime_isa() in (
-        ISA.X86,
-        ISA.ARM,
-    ):
+
+    if isinstance(
+        options.cpu_type, DerivO3CPU
+    ) or ObjectList.CPUList().get_isa(options.cpu_type) in [ISA.X86, ISA.ARM]:
         return True
     return False

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -40,7 +40,6 @@ from m5.objects import (
 from m5.params import PcCountPair
 
 from ...isas import ISA
-from ...runtime import get_runtime_isa
 from ...utils.override import overrides
 from ...utils.requires import requires
 from .abstract_core import AbstractCore
@@ -51,17 +50,19 @@ class BaseCPUCore(AbstractCore):
     An stdlib AbstractCore subclass which wraps a BaseCPU SimObject type.
     """
 
-    def __init__(self, core: BaseCPU, isa: Optional[ISA] = None):
+    def __init__(self, core: BaseCPU, isa: ISA):
         super().__init__()
 
         # There is some annoying redundancy here. The BaseCPU type already
         # defines the ISA, so here we are defining it twice. However, there
         # currently isn't a good way to get the ISA from the BaseCPU Type.
-        if isa:
-            requires(isa_required=isa)
-            self._isa = isa
-        else:
-            self._isa = get_runtime_isa()
+        #
+        # TODO: Have some helper function to get the ISA from a BaseCPU type.
+        # This may just be a cause of using `instanceof`:
+        # e.g., `if instanceof(cpu, X86Cpu): return ISA.X86`.
+        #
+        requires(isa_required=isa)
+        self._isa = isa
 
         self.core = core
         self.core.createThreads()

--- a/src/python/gem5/components/processors/simple_processor.py
+++ b/src/python/gem5/components/processors/simple_processor.py
@@ -41,28 +41,14 @@ class SimpleProcessor(BaseCPUProcessor):
     same CPUType.
     """
 
-    def __init__(
-        self, cpu_type: CPUTypes, num_cores: int, isa: Optional[ISA] = None
-    ) -> None:
+    def __init__(self, cpu_type: CPUTypes, num_cores: int, isa: ISA) -> None:
         """
         :param cpu_type: The CPU type for each type in the processor.
 
         :param num_cores: The number of CPU cores in the processor.
 
-        :param isa: The ISA of the processor. This argument is optional. If not
-                    set the ``runtime.get_runtime_isa`` is used to determine the
-                    ISA at runtime. **WARNING**: This functionality is deprecated.
-                    It is recommended you explicitly set your ISA via SimpleProcessor
-                    construction.
+        :param isa: The ISA of the processor.
         """
-        if not isa:
-            warn(
-                "An ISA for the SimpleProcessor was not set. This will "
-                "result in usage of `runtime.get_runtime_isa` to obtain the "
-                "ISA. This function is deprecated and will be removed in "
-                "future releases of gem5. Please explicitly state the ISA "
-                "via the processor constructor."
-            )
         super().__init__(
             cores=[
                 SimpleCore(cpu_type=cpu_type, core_id=i, isa=isa)

--- a/src/python/gem5/components/processors/simple_switchable_processor.py
+++ b/src/python/gem5/components/processors/simple_switchable_processor.py
@@ -53,30 +53,17 @@ class SimpleSwitchableProcessor(SwitchableProcessor):
         starting_core_type: CPUTypes,
         switch_core_type: CPUTypes,
         num_cores: int,
-        isa: Optional[ISA] = None,
+        isa: ISA = None,
     ) -> None:
         """
         :param starting_core_type: The CPU type for each type in the processor
                                    to start with (i.e., when the simulation has
                                    just started).
+        :param switch_core_types: The CPU type for each core, to be switched
+        to.
 
-        :param switch_core_types: The CPU type for each core, to be switched to.
-
-        :param isa: The ISA of the processor. This argument is optional. If not
-                    set the ``runtime.get_runtime_isa`` is used to determine the
-                    ISA at runtime. **WARNING**: This functionality is deprecated.
-                    It is recommended you explicitly set your ISA via
-                    SimpleSwitchableProcessor construction.
+        :param isa: The ISA of the processor.
         """
-
-        if not isa:
-            warn(
-                "An ISA for the SimpleSwitchableProcessor was not set. This "
-                "will result in usage of `runtime.get_runtime_isa` to obtain "
-                "the ISA. This function is deprecated and will be removed in "
-                "future releases of gem5. Please explicitly state the ISA "
-                "via the processor constructor."
-            )
 
         if num_cores <= 0:
             raise AssertionError("Number of cores must be a positive integer!")

--- a/src/python/gem5/runtime.py
+++ b/src/python/gem5/runtime.py
@@ -60,43 +60,6 @@ def get_supported_isas() -> Set[ISA]:
     return supported_isas
 
 
-def get_runtime_isa() -> ISA:
-    """
-    Returns a single target ISA at runtime.
-
-    This determined via the "TARGET_ISA" parameter, which is set at
-    compilation. If not set, but only one ISA is compiled, we assume it's the
-    one ISA. If neither the "TARGET_ISA" parameter is set and there are
-    multiple ISA targets, an exception is thrown.
-
-    .. warning::
-
-       This function is deprecated and may be removed in future versions of
-       gem5. This function should not be relied upon to run gem5 simulations.
-
-    :returns: The target ISA.
-    """
-
-    warn(
-        "The `get_runtime_isa` function is deprecated. Please migrate away "
-        "from using this function."
-    )
-
-    if "TARGET_ISA" in buildEnv.keys():
-        return get_isa_from_str(buildEnv["TARGET_ISA"])
-
-    supported_isas = get_supported_isas()
-
-    if len(supported_isas) == 1:
-        return next(iter(supported_isas))
-
-    raise Exception(
-        "Cannot determine the the runtime ISA. Either the "
-        "'TARGET_ISA' parameter must be set or the binary only "
-        "compiled to one ISA."
-    )
-
-
 def get_runtime_coherence_protocol() -> CoherenceProtocol:
     """Gets the cache coherence protocol.
 

--- a/tests/gem5/multi_isa/README.md
+++ b/tests/gem5/multi_isa/README.md
@@ -1,6 +1,6 @@
 # Multi ISA
 
-These tests check that all our ISAs are both currrently supported within gem5, as well as checking that get_runtime_isa() works as expected.
+These tests check that all our ISAs are both currrently supported within gem5.
 
 To run these tests by themselves, you can run the following command in the tests directory:
 

--- a/tests/gem5/multi_isa/test_multi_isa.py
+++ b/tests/gem5/multi_isa/test_multi_isa.py
@@ -39,26 +39,6 @@ isa_map = {
 
 for isa in isa_map.keys():
     if isa in ("x86", "arm", "riscv"):
-        # We only do these checks for X86, ARM, and RISCV to save compiling
-        # other ISAs.
-        gem5_verify_config(
-            name=f"runtime-isa-check_{isa}-compiled-alone",
-            verifiers=(),
-            fixtures=(),
-            config=joinpath(
-                config.base_dir,
-                "tests",
-                "gem5",
-                "multi_isa",
-                "configs",
-                "runtime_isa_check.py",
-            ),
-            config_args=["-e", isa],
-            valid_isas=(isa_map[isa],),
-            valid_hosts=constants.supported_hosts,
-            length=constants.long_tag,
-        )
-
         gem5_verify_config(
             name=f"supported-isas-check_{isa}-compiled-alone",
             verifiers=(),

--- a/tests/gem5/parsec_benchmarks/configs/parsec_disk_run.py
+++ b/tests/gem5/parsec_benchmarks/configs/parsec_disk_run.py
@@ -51,10 +51,6 @@ from gem5.components.processors.simple_switchable_processor import (
 )
 from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
-from gem5.runtime import (
-    get_runtime_coherence_protocol,
-    get_runtime_isa,
-)
 from gem5.simulate.exit_event import ExitEvent
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires


### PR DESCRIPTION
`get_runtime_isa()` has been deprecated for some time. It is a leftover piece of code from when gem5 was compiled to a single ISA and that ISA used to configure the simulated system to use that ISA. Since multi-ISA compilations are possible, `get_runtime_isa()` should not be used. Unless the gem5 binary is compiled to a single ISA, a failure will occur.

The new proceedure for specify which ISA to use is by the setting of the correct `BaseCPU` implementation. E.g., `X86SimpleTimingCPU` of `ArmO3CPU`.

This patch removes the remaining `get_runtime_isa()` instances and removes the function itself. The `SimpleCore` class has been updated to allow for it's CPU factory to return a class, needed by scripts in "configs/common".

The deprecated functionality in the standard library, which allowed for the specifying of an ISA when setting up a processor and/or core has also been removed. Setting an ISA is now manditory.

Fixes #216.