### PR TITLE
base: Fix for Integer overflow in AddrRange

### DIFF
--- a/src/base/addr_range.test.cc
+++ b/src/base/addr_range.test.cc
@@ -1544,6 +1544,20 @@ TEST(AddrRangeTest, SubtractionAssignmentOfRangeListFromRangeList)
                 expected_range3, expected_range4));
 }
 
+TEST(AddrRangeTest, isNotSubsetLastByte)
+{
+    /* An issue raised in https://github.com/gem5/gem5/issues/240 where if an
+     * address range ends at the last byte of a 64 bit address space, it will
+     * be considered a subset of any other address range that starts at the
+     * first byte of the range.
+     */
+
+    AddrRange first_four_bytes = RangeSize(0x0, 4);
+    AddrRange last_four_bytes = RangeSize(0xfffffffffffffffc, 4);
+
+    EXPECT_FALSE(last_four_bytes.isSubset(first_four_bytes));
+}
+
 /*
  * InterleavingRanges:
  * The exclude method does not support interleaving ranges


### PR DESCRIPTION
This concerns Issue #240 

**This is not a full fix yet. Ergo a draft**

Right now only a test has been developed. This test, `AddrRangeTest_isSubsetLastByte`, checks that if an address range , "A", ending in the last byte of a 64 bit space is not a subset of an address range, "B",  starting at the beginning of the space. https://github.com/gem5/gem5/issues/240 highlights that this does not hold due to an integer overflow error where end of range "A" is set to the beggining of the range, where "B" begins, thus making "A" a subset of "B".

The AddressRange tests can be ran from the root of the gem5 repo with:

```sh
scons build/NULL/base/addr_range.test.opt
./build/NULL/base/addr_range.test.opt
```

