### PR TITLE
misc: Remove 'run-name' from compiler-tests.yaml

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -1,8 +1,6 @@
 # This workflow runs all of the compiler tests
 
 name: Compiler Tests
-run-name: ${{ github.actor }} is running compiler tests
-
 
 on:
   # Runs every Friday from 7AM UTC


### PR DESCRIPTION
This isn't necessary. Without 'run-name' the action's default name is 'run-name'. Displaying the actor who launched the action is pointless for scheduled tests.