### PR TITLE
misc: Update docker-build.yaml file

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,11 +2,6 @@
 name: Docker images build and push
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - 'util/docker/ubuntu-20.04_all-depenencies'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -18,6 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        name: Checkout the develop branch
+        with:
+            # Scheduled workflows run on the default branch by default. We
+            # therefore need to explicitly checkout the develop branch.
+            ref: develop
 
       - uses: docker/setup-qemu-action@v2
         name: Setup QEMU

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME: ubuntu-20.04_all-depenencies
+  IMAGE_NAME: ubuntu-20.04_all-dependencies
 #
 jobs:
   # This builds and pushes the docker image.

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,4 +1,3 @@
-#
 name: Docker images build and push
 
 on:
@@ -6,7 +5,7 @@ on:
 
 env:
   IMAGE_NAME: ubuntu-20.04_all-dependencies
-#
+
 jobs:
   # This builds and pushes the docker image.
   push:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,20 +19,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build image
-        run: |
-          cd util/docker/ubuntu-20.04_all-depenencies
-          docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+      - uses: docker/setup-qemu-action@v2
+        name: Setup QEMU
 
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - uses: docker/setup-buildx-action@v2
+        name: Set up Docker Buildx
 
-      - name: Push image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+      - uses: docker/login-action@v2
+        name: Login to the GitHub Container Registry
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-          # This changes all uppercase characters to lowercase.
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          docker tag $IMAGE_NAME $IMAGE_ID:latest
-          docker push $IMAGE_ID::latest
+      - uses: docker/build-push-action@v2
+        name: Build and push docker image '$IMAGE_NAME'
+        with:
+            context: util/dockerfiles/$IMAGE_NAME
+            push: true
+            platforms: |
+                linux/amd64,
+                linux/arm64,
+                darwin/amd64,
+                darwin/arm64
+            tags: ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:latest


### PR DESCRIPTION
Introduced in #236 the docker-build.yaml file showed itself to have some errors (see https://github.com/gem5/gem5/actions/runs/6035049860 as an example of a failure), and some inefficiencies or points which could be improved. This PR, broadly, improves this fix.

**Note**: This docker-build.yaml is still an experiment. Due to GitHub Actions not providing very good ways to test actions locally, I can only see this works by committing and observing it's affects. Right now, this workflow is just to test this basic idea before expanding to do this for all workloads.

This PR:

* Removes pointless empty comments.
* Fixes the `checkout` action to checkout the develop branch instead of the stable branch.
* Replaces the script-based actions to build and push the docker image with the docker actions.
* Uses the docker actions to create multi-platform images.
* Added a 'container' to the job. Without it the job  did not have the right permissions to work with the repository inside the GitHub Action Runner, resulting in failure.
* Fixed a typo in the `IMAGE_NAME` variable.
* Removed the 'on: push' trigger event. This may return in the future but it was hard to test.

As a recap of what the docker-build.yaml should prove we can:

1. Automatically build docker images via actions.
2. Automatically push these images to a container registry
3. Utilize GitHub's container registry (advantageous because they do not charge egress fees for images used in GitHub Action's runners).
5. Create multi-platform docker images. Right now we only build linux/amd64 docker images.


To prove/figure out at a later date:

1. Atomatically trigger the building and pushing of a Docker Image when we change it's Dockerfile or build parameters.
2. Utilize these GitHub hosted Docker images in our tests.
3. Use GitHub Action Workflow matrixes to handle the creation of these images in a structured, concise manner. 