### PR TITLE
util: Add gdb to gcn-gpu Dockerfile

### DIFF
--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -29,7 +29,7 @@ RUN apt -y update && apt -y upgrade && \
     apt -y install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev python-is-python3 doxygen libboost-all-dev \
-    libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config
+    libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config gdb
 
 # Requirements for ROCm
 RUN apt -y install cmake mesa-common-dev libgflags-dev libgoogle-glog-dev


### PR DESCRIPTION
gdb was originally part of the ROCm 1.6 Dockerfile a few years ago. It got removed when updating to ROCm 4.0. This adds it back as being able to debug things is quite useful.

Change-Id: I3f8148cde79e6cc5233fa3c8c830b64817f01d3a