### PR TITLE
arch-x86: Fix wrong x86 assembly

### DIFF
--- a/src/arch/x86/isa/specialize.isa
+++ b/src/arch/x86/isa/specialize.isa
@@ -240,7 +240,7 @@ let {{
                     regFormat = \
                         "printReg(out, intRegClass[%s], regSize);\n"
                     regSuffix = "_R"
-                env.addToDisassembly(regFormat % ModRMRegIndex)
+                env.addToDisassembly(regFormat % ModRMRMIndex)
                 return doSplitDecode("MODRM_MOD",
                     {"3" : (specializeInst, Name + regSuffix,
                             copy.copy(opTypes), regEnv)},
@@ -268,7 +268,7 @@ let {{
                     regFormat = \
                         "printReg(out, intRegClass[%s], regSize);\n"
                     Name += "_R"
-                env.addToDisassembly(regFormat % ModRMRegIndex)
+                env.addToDisassembly(regFormat % ModRMRMIndex)
             elif opType.tag in ("X", "Y"):
                 # This type of memory addressing is for string instructions.
                 # They'll use the right index and segment internally.


### PR DESCRIPTION
The RM field of ModRM was printed as Reg field for several instructions.

For reference, this change fixes typos introduced by [1].

[1] https://gem5-review.googlesource.com/c/public/gem5/+/40339

Change-Id: I41eb58e6a70845c4ddd6774ccba81b8069888be5