### PR TITLE
mem: fix bug in 3-level cache

### DIFF
--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
@@ -193,10 +193,10 @@ class MESIThreeLevelCacheHierarchy(
         if board.has_dma_ports():
             dma_ports = board.get_dma_ports()
             for i, port in enumerate(dma_ports):
-                ctrl = DMAController(self.ruby_system.network, cache_line_size)
-                ctrl.dma_sequencer = DMASequencer(version=i, in_ports=port)
+                ctrl = DMAController(
+                    DMASequencer(version=i, in_ports=port), self.ruby_system
+                )
                 self._dma_controllers.append(ctrl)
-                ctrl.ruby_system = self.ruby_system
 
         self.ruby_system.num_of_sequencers = len(self._l1_controllers) + len(
             self._dma_controllers


### PR DESCRIPTION
The L3 cache did not work due to argument type mismatch in the call to the constructor `DMAController`. The second argument is expecting a `RubySystem` type but the code passes in a `cache_line_size` variable.
After I change the second argument to `self.ruby_system` everything works.