### PR TITLE
misc: Improve ".github/ISSUE_TEMPLATE/bug_report.md"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,9 +25,9 @@ If writing code, or a terminal command, use code blocks. Either an inline code b
 
 
 ```python
-int x=2;
-int y=3'
-print(x+y);
+int x=2
+int y=3
+print(x+y)
 ```
 
 If possible, please include the Python configuration script used and state clearly any parameters passed.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ Steps to reproduce the behavior. Please assume starting from a clean repository:
 If writing code, or a terminal command, use code blocks. Either an inline code block, `scons build/ALL/gem5.opt` (enclosed in two '`') or a multi-line codeblock:
 
 
-```
+```python
 int x=2;
 int y=3'
 print(x+y);
@@ -36,7 +36,7 @@ If possible, please include the Python configuration script used and state clear
 If applicable, add the terminal output here. If long, only include the relevant lines.
 Please put the terminal output in code blocks. I.e.:
 
-```
+```shell
 #Terminal output here#
 ```
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us find and fix the bug
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -18,6 +17,7 @@ If you have modified gem5 in some way please state, to the best of your ability,
 
 **To Reproduce**
 Steps to reproduce the behavior. Please assume starting from a clean repository:
+
 1. Compile gem5 with command ...
 2. Execute the simulation with...
 
@@ -25,13 +25,9 @@ If writing code, or a terminal command, use code blocks. Either an inline code b
 
 
 ```
-
 int x=2;
-
 int y=3'
-
 print(x+y);
-
 ```
 
 If possible, please include the Python configuration script used and state clearly any parameters passed.
@@ -41,9 +37,7 @@ If applicable, add the terminal output here. If long, only include the relevant 
 Please put the terminal output in code blocks. I.e.:
 
 ```
-
 #Terminal output here#
-
 ```
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,10 +21,10 @@ Steps to reproduce the behavior. Please assume starting from a clean repository:
 1. Compile gem5 with command ...
 2. Execute the simulation with...
 
-If writing code, or a terminal command, use code blocks. Either an inline code block, \`scons build/ALL/gem5.opt\` (enclosed in two \`) or a multi-line codeblock:
+If writing code, or a terminal command, use code blocks. Either an inline code block, `scons build/ALL/gem5.opt` (enclosed in two '`') or a multi-line codeblock:
 
 
-\`\`\`
+```
 
 int x=2;
 
@@ -32,7 +32,7 @@ int y=3'
 
 print(x+y);
 
-\`\`\`
+```
 
 If possible, please include the Python configuration script used and state clearly any parameters passed.
 
@@ -40,11 +40,11 @@ If possible, please include the Python configuration script used and state clear
 If applicable, add the terminal output here. If long, only include the relevant lines.
 Please put the terminal output in code blocks. I.e.:
 
-\`\`\`
+```
 
 #Terminal output here#
 
-\`\`\`
+```
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.


### PR DESCRIPTION
The bug report template used escape characters. This is not necessary as the bug report is not rendered when creating a bug report. It is displayed to the user in plain text for them to edit.

In addition languages have been added to the code-blocks and newlines have been added and removed where appropriate to cleanup the document.