### PR TITLE
misc: Fix buggy special path comparisons

### DIFF
--- a/src/kern/linux/linux.cc
+++ b/src/kern/linux/linux.cc
@@ -58,19 +58,19 @@ Linux::openSpecialFile(std::string path, Process *process,
     bool matched = false;
     std::string data;
 
-    if (path.compare(0, 13, "/proc/meminfo") == 0) {
+    if (path == "/proc/meminfo") {
         data = Linux::procMeminfo(process, tc);
         matched = true;
-    } else if (path.compare(0, 11, "/etc/passwd") == 0) {
+    } else if (path == "/etc/passwd") {
         data = Linux::etcPasswd(process, tc);
         matched = true;
-    } else if (path.compare(0, 15, "/proc/self/maps") == 0) {
+    } else if (path == "/proc/self/maps") {
         data = Linux::procSelfMaps(process, tc);
         matched = true;
-    } else if (path.compare(0, 30, "/sys/devices/system/cpu/online") == 0) {
+    } else if (path == "/sys/devices/system/cpu/online") {
         data = Linux::cpuOnline(process, tc);
         matched = true;
-    } else if (path.compare(0, 12 ,"/dev/urandom") == 0) {
+    } else if (path == "/dev/urandom") {
         data = Linux::devRandom(process, tc);
         matched = true;
     }


### PR DESCRIPTION
This patch fixes the buggy special path comparisons in src/kern/linux/linux.cc Linux::openSpecialFile(), which only checked for equality of path prefixes, but not equality of the paths themselves. This patch replaces those buggy comparisons with regular std::string::operator== string equality comparisons.

GitHub issue: https://github.com/gem5/gem5/issues/269

Change-Id: I216ff8019b9a6a3e87e364c2e197d9b991959ec1