### PR TITLE
util: Add docker prune cron to GitHub runners

### DIFF
--- a/util/github-runners-vagrant/provision_nonroot.sh
+++ b/util/github-runners-vagrant/provision_nonroot.sh
@@ -13,3 +13,7 @@ DOCKER_COMPOSE_VERSION=$(curl -s https://api.github.com/repos/docker/compose/rel
 mkdir -p "${HOME}/.docker/cli-plugins"
 curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o "${HOME}/.docker/cli-plugins/docker-compose"
 chmod +x "${HOME}/.docker/cli-plugins/docker-compose"
+
+# Setup crontab to run docker prune every 3 hours
+echo "0 */3 * * * docker system prune -af --volumes"> /tmp/cron
+crontab /tmp/cron


### PR DESCRIPTION
Issue-on: https://github.com/gem5/gem5/issues/254

This has been implemented in the runners. The regular pruning of the docker images should fix the issue.