### PR TITLE
misc: Fix CI GitHub Action to stop if Workflow re-triggered

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   pre-commit:


### PR DESCRIPTION
This ensures that if the CI tests are running for a PR, and a new workflow is triggered (typically by pushing/rebasing the PR) then the older workflow is cancelled.