### PR TITLE
sim: add bypass_on_change to the set() of a signal

### DIFF
--- a/src/sim/signal.hh
+++ b/src/sim/signal.hh
@@ -54,14 +54,16 @@ class SignalSinkPort : public Port
     OnChangeFunc _onChange;
 
   protected:
+    // if bypass_on_change is specified true, it will not call the _onChange
+    // function. Only _state will be updated if needed.
     void
-    set(const State &new_state)
+    set(const State &new_state, const bool bypass_on_change = false)
     {
         if (new_state == _state)
             return;
 
         _state = new_state;
-        if (_onChange)
+        if (!bypass_on_change && _onChange)
             _onChange(_state);
     }
 
@@ -113,11 +115,13 @@ class SignalSourcePort : public Port
         _state = init_state;
     }
 
+    // if bypass_on_change is specified true, it will not call the _onChange
+    // function. Only _state will be updated if needed.
     void
-    set(const State &new_state)
+    set(const State &new_state, const bool bypass_on_change = false)
     {
         _state = new_state;
-        sink->set(new_state);
+        sink->set(new_state, bypass_on_change);
     }
 
     const State &state() const { return _state; }


### PR DESCRIPTION
When reset a port, we don't want to trigger a onChange(). Offer an option to bypass it and update state only.

Change-Id: Ia53b7a76d2a320ea67101096cdbfe2eafaf440d2