### PR TITLE
sim-se: Use tgt_stat64 instead of tgt_stat in newfstatatFunc

### DIFF
--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -1375,7 +1375,7 @@ statFunc(SyscallDesc *desc, ThreadContext *tc,
 template <class OS>
 SyscallReturn
 newfstatatFunc(SyscallDesc *desc, ThreadContext *tc, int dirfd,
-               VPtr<> pathname, VPtr<typename OS::tgt_stat> tgt_stat,
+               VPtr<> pathname, VPtr<typename OS::tgt_stat64> tgt_stat,
                int flags)
 {
     std::string path;
@@ -1405,7 +1405,7 @@ newfstatatFunc(SyscallDesc *desc, ThreadContext *tc, int dirfd,
     if (result < 0)
         return -errno;
 
-    copyOutStatBuf<OS>(tgt_stat, &host_buf);
+    copyOutStat64Buf<OS>(tgt_stat, &host_buf);
 
     return 0;
 }


### PR DESCRIPTION
The syscall emulation of newfstatat incorrectly treated the output stat buffer to be of type `OS::tgt_stat`, not `OS::tgt_stat64`, causing the invalid output stat buffer in the application to hold invalid data.

This patch fixes the bug by simply substituting the type `OS::tgt_stat` with `OS::tgt_stat64` in `newstatatFunc()`.

GitHub issue: https://github.com/gem5/gem5/issues/281

Change-Id: Ice97c1fc4cccbfb6824e313ebecde00f134ebf9c