### PR TITLE
sim-se: Fix tgkill logic bug in handling signal argument

### DIFF
--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -2409,7 +2409,7 @@ tgkillFunc(SyscallDesc *desc, ThreadContext *tc, int tgid, int tid, int sig)
         }
     }
 
-    if (sig != 0 || sig != OS::TGT_SIGABRT)
+    if (sig != 0 && sig != OS::TGT_SIGABRT)
         return -EINVAL;
 
     if (tgt_proc == nullptr)


### PR DESCRIPTION
The syscall emulation of tgkill contained a simple logic bug (a `||` instead of a `&&`), causing the signal argument to always be considered invalid. This patch fixes the bug by simply changing the `||` to a `&&`.

GitHub issue: https://github.com/gem5/gem5/issues/284

Change-Id: Ic4c367df337459e51407426cd65eb964f7ad60a9