### PR TITLE
misc,tests: Fix GPU Daily Tests

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -254,9 +254,33 @@ jobs:
     - name: Continue gem5 within SystemC test
       run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
 
+  gpu-tests-test-progs:
+    runs-on: [self-hosted, linux, x64, run]
+    timeout-minutes: 5
+    steps:
+      - name: Wget Square test-prog
+        uses: wei/wget@v1
+        with:
+          args: -q http://dist.gem5.org/dist/develop/test-progs/square/square
+      - name: Wget allSyncPrims-1kernel test-prog
+        uses: wei/wget@v1
+        with:
+          args: -q http://dist.gem5.org/dist/develop/test-progs/heterosync/gcn3/allSyncPrims-1kernel
+      - name: Upload test-progs as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: daily-tests-test-progs
+          path: |
+            square
+            allSyncPrims-1kernel
+          retention-days: 1
+      - name: Cleanup
+        run: rm square allSyncPrims-1kernel
+
   # Runs the gem5 Nighyly GPU tests.
   gpu-tests:
     runs-on: [self-hosted, linux, x64, build]
+    needs: gpu-tests-test-progs
     container: gcr.io/gem5-test/gcn-gpu:latest
     timeout-minutes: 720 # 12 hours
 
@@ -266,20 +290,16 @@ jobs:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
         ref: develop
+    - name: Get Square Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: daily-tests-test-progs
     - name: Compile build/GCN3_X86/gem5.opt
       run: scons build/GCN3_X86/gem5.opt -j $(nproc)
-    - name: Get Square test-prog from gem5-resources
-      uses: wei/wget@v1
-      with:
-        args: -q http://dist.gem5.org/dist/develop/test-progs/square/square # Removed -N bc it wasn't available within actions, should be okay bc workspace is clean every time: https://github.com/coder/sshcode/issues/102
     - name: Run Square test with GCN3_X86/gem5.opt (SE mode)
       run: |
         mkdir -p tests/testing-results
         ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c square
-    - name: Get allSyncPrims-1kernel from gem5-resources
-      uses: wei/wget@v1
-      with:
-        args: -q http://dist.gem5.org/dist/develop/test-progs/heterosync/gcn3/allSyncPrims-1kernel # Removed -N bc it wasn't available within actions, should be okay bc workspace is clean every time
     - name: Run allSyncPrims-1kernel sleepMutex test with GCN3_X86/gem5.opt (SE mode)
       run: ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c allSyncPrims-1kernel --options="sleepMutex 10 16 4"
     - name: Run allSyncPrims-1kernel lfTreeBarrUsing test with GCN3_X86/gem5.opt (SE mode)


### PR DESCRIPTION
Fixes the following error:
https://github.com/gem5/gem5/actions/runs/6106624129/job/16572039810

In GitHub Actions certain actions require Docker. You can therefore not run them within a container. The 'gpu-tests' job runs in the 'gcr.io/gem5-test/gcn-gpu:latest' container. 'wei/wget' depends on docker and therefore fails.

This is fixed by separating the running of `wei/wget` to a different jobs, with the test-progs uploaded as artifacts for use in 'gpu-tests'.