### PR TITLE
mem-ruby: This commit patches an error in AbstractController.cc

### DIFF
--- a/src/mem/ruby/slicc_interface/AbstractController.cc
+++ b/src/mem/ruby/slicc_interface/AbstractController.cc
@@ -125,6 +125,7 @@ AbstractController::resetStats()
     for (uint32_t i = 0; i < size; i++) {
         stats.delayVCHistogram[i]->reset();
     }
+    ClockedObject::resetStats();
 }
 
 void


### PR DESCRIPTION
Links to #293 

After calling m5_dump_reset_stats(0,0) in a test program, some statistics like
l1_controllers.L1Dcache.m_demand_hits,
l1_controllers.L1Dcache.m_demand_misses,
l1_controllers.L1Dcache.m_demand_accesses
were not getting reset in the newer stat dumps.
This one line patch fixes that. Changes were tested with calling two m5_dump_reset_stats(0,0) in a row for a system with 1 core, tested on both SE and FS.
Credits: @MeatBoy106

Change-Id: I19d75996fa53d31ef20f7b206024fd38dbeac643