### PR TITLE
util: Revert "Add docker prune cron to GitHub..."

### DIFF
--- a/util/github-runners-vagrant/provision_nonroot.sh
+++ b/util/github-runners-vagrant/provision_nonroot.sh
@@ -13,7 +13,3 @@ DOCKER_COMPOSE_VERSION=$(curl -s https://api.github.com/repos/docker/compose/rel
 mkdir -p "${HOME}/.docker/cli-plugins"
 curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o "${HOME}/.docker/cli-plugins/docker-compose"
 chmod +x "${HOME}/.docker/cli-plugins/docker-compose"
-
-# Setup crontab to run docker prune every 3 hours
-echo "0 */3 * * * docker system prune -af --volumes"> /tmp/cron
-crontab /tmp/cron


### PR DESCRIPTION
This reverts commit 0249d47acc3a87a82c9d7417dba4804cda4a3f4b, https://github.com/gem5/gem5/pull/271.

This solution doesn't work. GitHub runners pull the images they need at the start of job (i.e., all the images they may need for each step). They then create the containers later, at the step they are needed. This solution therefore breaks in the case a cleanup happens during the running of a job. I.e., a `docker system prune` happens after setup, therefore deleting all the images, then the job tries to use one of the images during a step.

This crontab solution may work if we can only do it when the runner is in an idle state. Whether this is possible is unknown.