### PR TITLE
arch-x86: initialize and correct bitwidth for FPU tag word

### DIFF
--- a/src/arch/x86/isa.cc
+++ b/src/arch/x86/isa.cc
@@ -262,7 +262,7 @@ ISA::setMiscRegNoEffect(RegIndex idx, RegVal val)
         reg_width = 3;
         break;
       case misc_reg::Ftw:
-        reg_width = 8;
+        reg_width = 16;
         break;
       case misc_reg::Fsw:
       case misc_reg::Fcw:

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -397,6 +397,7 @@ X86_64Process::initState()
             tc->setMiscReg(misc_reg::Cr8, cr8);
 
             tc->setMiscReg(misc_reg::Mxcsr, 0x1f80);
+            tc->setMiscReg(misc_reg::Ftw, 0xffff);
 
             tc->setMiscReg(misc_reg::ApicBase, 0xfee00900);
 
@@ -593,6 +594,7 @@ X86_64Process::initState()
             tc->setMiscReg(misc_reg::Cr0, cr0);
 
             tc->setMiscReg(misc_reg::Mxcsr, 0x1f80);
+            tc->setMiscReg(misc_reg::Ftw, 0xffff);
 
             // Setting CR3 to the process pid so that concatinated
             // page addr with lower 12 bits of CR3 can be used in SE
@@ -727,6 +729,7 @@ I386Process::initState()
         tc->setMiscReg(misc_reg::Cr0, cr0);
 
         tc->setMiscReg(misc_reg::Mxcsr, 0x1f80);
+        tc->setMiscReg(misc_reg::Ftw, 0xffff);
     }
 }
 


### PR DESCRIPTION
The x87 FPU tag word (FTW) was not explicitly initialized in {X86_64,i386}Process::initState(), resulting in holding an initial value of zero, resulting in an invalid x87 FPU state. This commit initializes FTW to 0xFFFF, indicating the FPU is empty at program start during syscall emulation.

The 16-bit FTW register was also incorrectly masked down to 8-bits in X86ISA::ISA::setMiscRegNoEffect(), leading to an invalid X87 FPU state that later caused crashes in the X86KvmCPU. This commit corrects the bitwidth of the mask to 16.

GitHub issue: https://github.com/gem5/gem5/issues/303

Change-Id: I97892d707998a87c1ff8546e08c15fede7eed66f