### PR TITLE
util: Fix TLM configs making use of TraceCPU replayer

### DIFF
--- a/util/tlm/conf/tlm_elastic_slave.py
+++ b/util/tlm/conf/tlm_elastic_slave.py
@@ -65,7 +65,7 @@ from Caches import *
 
 # Setup System:
 system = System(
-    cpu=TraceCPU(cpu_id=0),
+    cpu=TraceCPU(),
     mem_mode="timing",
     mem_ranges=[AddrRange("512MB")],
     cache_line_size=64,
@@ -89,8 +89,7 @@ system.cpu_clk_domain = SrcClockDomain(
     clock="1GHz", voltage_domain=system.cpu_voltage_domain
 )
 
-# Setup CPU and its L1 caches:
-system.cpu.createInterruptController()
+# Setup CPU's L1 caches:
 system.cpu.icache = L1_ICache(size="32kB")
 system.cpu.dcache = L1_DCache(size="32kB")
 system.cpu.icache.cpu_side = system.cpu.icache_port
@@ -114,10 +113,10 @@ system.tlm.port_data = "transactor"
 
 # Connect everything:
 system.membus = SystemXBar()
-system.system_port = system.membus.slave
-system.cpu.icache.mem_side = system.membus.slave
-system.cpu.dcache.mem_side = system.membus.slave
-system.membus.master = system.tlm.port
+system.system_port = system.membus.cpu_side_ports
+system.cpu.icache.mem_side = system.membus.cpu_side_ports
+system.cpu.dcache.mem_side = system.membus.cpu_side_ports
+system.membus.mem_side_ports = system.tlm.port
 
 # Start the simulation:
 root = Root(full_system=False, system=system)

--- a/util/tlm/examples/tlm_elastic_slave_with_l2.py
+++ b/util/tlm/examples/tlm_elastic_slave_with_l2.py
@@ -72,7 +72,7 @@ from Caches import *
 
 # Setup System:
 system = System(
-    cpu=TraceCPU(cpu_id=0),
+    cpu=TraceCPU(),
     mem_mode="timing",
     mem_ranges=[AddrRange("1024MB")],
     cache_line_size=64,
@@ -96,8 +96,7 @@ system.cpu_clk_domain = SrcClockDomain(
     clock="1GHz", voltage_domain=system.cpu_voltage_domain
 )
 
-# Setup CPU and its L1 caches:
-system.cpu.createInterruptController()
+# Setup CPU's L1 caches:
 system.cpu.icache = L1_ICache(size="32kB")
 system.cpu.dcache = L1_DCache(size="32kB")
 system.cpu.icache.cpu_side = system.cpu.icache_port
@@ -122,12 +121,12 @@ system.tlm.port_data = "transactor1"
 
 # Connect everything:
 system.membus = SystemXBar()
-system.system_port = system.membus.slave
-system.cpu.icache.mem_side = system.tol2bus.slave
-system.cpu.dcache.mem_side = system.tol2bus.slave
-system.tol2bus.master = system.l2cache.cpu_side
-system.l2cache.mem_side = system.membus.slave
-system.membus.master = system.tlm.port
+system.system_port = system.membus.cpu_side_ports
+system.cpu.icache.mem_side = system.tol2bus.cpu_side_ports
+system.cpu.dcache.mem_side = system.tol2bus.cpu_side_ports
+system.tol2bus.mem_side_ports = system.l2cache.cpu_side
+system.l2cache.mem_side = system.membus.cpu_side_ports
+system.membus.mem_side_ports = system.tlm.port
 
 # Start the simulation:
 root = Root(full_system=False, system=system)


### PR DESCRIPTION
A recent PR [1] moved the TraceCPU away from the BaseCPU hierarchy. While the common etrace_replayer.py has been amended, I missed these hybrid TLM + TraceCPU example scripts.

[1]: https://github.com/gem5/gem5/pull/302