### PR TITLE
mem-ruby: patch fixes a protocol error in MOESI_CMP_Directory

### DIFF
--- a/src/mem/ruby/protocol/MOESI_CMP_directory-dir.sm
+++ b/src/mem/ruby/protocol/MOESI_CMP_directory-dir.sm
@@ -1014,6 +1014,31 @@ machine(MachineType:Directory, "Directory protocol")
     i_popIncomingRequestQueue;
   }
 
+  //this happens when there is race between FwdGetX
+  //and PUTX on owner. Owner in this case hands off
+  //ownership to GetX requestor and PUTX still goes
+  //through. But since owner has changed, state should
+  //go back to M and PUTX is essentially trashed.
+  transition(MI, Unblock, M) {
+    w_deallocateTBE;
+    j_popIncomingUnblockQueue;
+  }
+
+  transition(MIS, Unblock, M) {
+    w_deallocateTBE;
+    j_popIncomingUnblockQueue;
+  }
+
+  transition(OS, Unblock, O) {
+    //In OS state there is no TBE for some reason
+    // w_deallocateTBE;
+    j_popIncomingUnblockQueue;
+  }
+
+  transition(OSS, Unblock, O) {
+    j_popIncomingUnblockQueue;
+  }
+
   transition(WBI, Memory_Ack, I) {
     clearWBAck;
     w_deallocateTBE;


### PR DESCRIPTION
When there is race between FwdGetX
and PUTX on owner. Owner in this case hands off
ownership to GetX requestor and PUTX still goes
through. But since owner has changed, state should go back to M and PUTX is essentially trashed.
An Unblock to the Directory in this case will give an undefined transition. I have added transitions which indicate that when an Unblock is served to the Directory, it means that some kind of ownership transfer has happened while a PUTX/PUTO was in progress.

Change-Id: I37439b5a363417096030a0875a51c605bd34c127