### PR TITLE
util,resources,stdlib: Add 'obtain-resource.py' utility to easily obtain resources from the CLI

### DIFF
--- a/src/python/gem5/resources/downloader.py
+++ b/src/python/gem5/resources/downloader.py
@@ -204,6 +204,7 @@ def get_resource(
     resource_version: Optional[str] = None,
     clients: Optional[List] = None,
     gem5_version: Optional[str] = core.gem5Version,
+    quiet: bool = False,
 ) -> None:
     """
     Obtains a gem5 resource and stored it to a specified location. If the
@@ -235,6 +236,9 @@ def get_resource(
     :param gem5_version: The gem5 version to use when obtaining the resource.
     By default, the version of gem5 being used is used. This is used primarily
     for testing purposes.
+
+    :param quiet: If true, no output will be printed to the console (baring
+    exceptions). False by default.
 
     :raises Exception: An exception is thrown if a file is already present at
     `to_path` but it does not have the correct md5 sum. An exception will also
@@ -326,37 +330,41 @@ def get_resource(
             )
             shutil.copy(file_uri_path, download_dest)
         else:
-            # TODO: Might be nice to have some kind of download status bar here.
-            # TODO: There might be a case where this should be silenced.
-            print(
-                "Resource '{}' was not found locally. Downloading to '{}'...".format(
-                    resource_name, download_dest
+            # TODO: Might be nice to have some kind of download status bar here..
+            if not quiet:
+                print(
+                    f"Resource '{resource_name}' was not found locally. "
+                    f"Downloading to '{download_dest}'..."
                 )
-            )
 
             # Get the URL.
             url = resource_json["url"]
 
             _download(url=url, download_to=download_dest)
-            print(f"Finished downloading resource '{resource_name}'.")
+            if not quiet:
+                print(f"Finished downloading resource '{resource_name}'.")
 
         if run_unzip:
-            print(
-                f"Decompressing resource '{resource_name}' ('{download_dest}')..."
-            )
+            if not quiet:
+                print(
+                    f"Decompressing resource '{resource_name}' "
+                    f"('{download_dest}')..."
+                )
             unzip_to = download_dest[: -len(zip_extension)]
             with gzip.open(download_dest, "rb") as f:
                 with open(unzip_to, "wb") as o:
                     shutil.copyfileobj(f, o)
             os.remove(download_dest)
             download_dest = unzip_to
-            print(f"Finished decompressing resource '{resource_name}'.")
+            if not quiet:
+                print(f"Finished decompressing resource '{resource_name}'.")
 
         if run_tar_extract:
-            print(
-                f"Unpacking the the resource '{resource_name}' "
-                f"('{download_dest}')"
-            )
+            if not quiet:
+                print(
+                    f"Unpacking the the resource '{resource_name}' "
+                    f"('{download_dest}')"
+                )
             unpack_to = download_dest[: -len(tar_extension)]
             with tarfile.open(download_dest) as f:
 

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -621,6 +621,7 @@ def obtain_resource(
     resource_version: Optional[str] = None,
     clients: Optional[List] = None,
     gem5_version=core.gem5Version,
+    quiet: bool = False,
 ) -> AbstractResource:
     """
     This function primarily serves as a factory for resources. It will return
@@ -644,6 +645,7 @@ def obtain_resource(
     :param gem5_version: The gem5 version to use to filter incompatible
     resource versions. By default set to the current gem5 version. If None,
     this filtering is not performed.
+    :param quiet: If True, suppress output. False by default.
     """
 
     # Obtain the resource object entry for this resource
@@ -695,6 +697,7 @@ def obtain_resource(
             resource_version=resource_version,
             clients=clients,
             gem5_version=gem5_version,
+            quiet=quiet,
         )
 
     # Obtain the type from the JSON. From this we will determine what subclass

--- a/util/obtain-resource.py
+++ b/util/obtain-resource.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 The Regents of the University of California
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Obtain a resource from gem5 resource.
+
+Usage
+-----
+
+```sh
+scons build/ALL/gem5.opt -j$(nproc)
+build/ALL/gem5.opt util/obtain-resource.py <resource_id> [-p <path>] [-q]
+# Example:
+# `build/ALL/gem5.opt util/obtain-resource.py arm-hello64-static -p arm-hello`
+# This will download the resource with id `arm-hello64-static` to the
+# "arm-hello" in the CWD.
+```
+"""
+
+if __name__ == "__m5_main__":
+    from gem5.resources.resource import obtain_resource
+    import argparse
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "id",
+        type=str,
+        help="The resource id to download.",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--path",
+        type=str,
+        required=False,
+        help="The path the resource is to be downloaded to. If not specified, "
+        "the resource will be downloaded to the default location in the "
+        "gem5 local cache of resources",
+    )
+
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Suppress output.",
+    )
+
+    args = parser.parse_args()
+
+    resource = obtain_resource(
+        resource_id=args.id,
+        quiet=args.quiet,
+        to_path=args.path,
+    )
+
+    if not args.quiet:
+        print(f"Resource at: '" + str(resource.get_local_path()) + "'")
+
+    exit(0)
+
+print("Error: This script is meant to be run with the gem5 binary")
+exit(1)


### PR DESCRIPTION
This allows users to obtain resources via the CLI instead of having to write a python script to do so. It is essentially a nice CLI wrapper for "gem5.resources.resource.obtain_resource"

## Usage

```sh
> scons build/ALL/gem5.opt -j `nproc`
> ./build/ALL/gem5.opt util/obtain-resource.py --help

usage: obtain-resource.py [-h] [-p PATH] [-q] id

positional arguments:
  id                    The resource id to download.

options:
  -h, --help            show this help message and exit
  -p PATH, --path PATH  The path the resource is to be downloaded to. If not specified, the resource will be downloaded to the default
                        location in the gem5 local cache of resources
  -q, --quiet           Suppress output.
```

E.g.:

```sh
./build/ALL/gem5.opt util/obtain-resource.py arm-hello64-static -p arm-hello
```

Will download the resource with ID `arm-hello64-static` to `arm-hello` in the CWD.