### PR TITLE
misc,tests: Use GitHub Docker registry for 22.04 all-deps

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -49,7 +49,7 @@ jobs:
   build-gem5:
     runs-on: [self-hosted, linux, x64, build]
     if: github.event.pull_request.draft == false
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
     outputs:
       artifactname: ${{ steps.name.outputs.test }}
@@ -70,7 +70,7 @@ jobs:
   unittests-all-opt:
     runs-on: [self-hosted, linux, x64, run]
     if: github.event.pull_request.draft == false
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
     timeout-minutes: 60
     steps:
@@ -83,7 +83,7 @@ jobs:
   testlib-quick:
     runs-on: [self-hosted, linux, x64, run]
     if: github.event.pull_request.draft == false
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, build-gem5, check-for-change-id]
     timeout-minutes: 360     # 6 hours
     steps:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   obtain-dockerfiles:
     runs-on: [self-hosted, linux, x64, run]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Via this workflow we now can build and push our docker images to the GitHub Docker container registry:
https://github.com/gem5/gem5/blob/26a1ee4e61de85189b261fca1d595315a3f33721/.github/workflows/docker-build.yaml

GitHub does not charge for downloads to runners (hosted or self-hosted). This can therefore save the project money if we download from GitHub's Docker reigstry over Google Cloud's.

This is a test to ensure this works as intended.