### PR TITLE
arch-riscv: Fix inst flags for jal and jalr

### DIFF
--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -267,7 +267,7 @@ def template JumpConstructor {{
                 flags[IsCall] = true;
 
             // Handle "Jalr" instruction
-            if (FUNCT3 == 0x0) {
+            if (FUNCT3 == 0x0 && OPCODE5 == 0x19) {
                 // If RD is not link and RS1 is link, then pop RAS
                 if (!rd_link && rs1_link) flags[IsReturn] = true;
                 else if (rd_link) {


### PR DESCRIPTION
The jal and jalr share the same instruction format JumpConstructor, which sets the IsCall and IsReturn flags by the register ID. However, it may cause wrong instruction flags set for jal because the section "handle the 'Jalr' instruction" misses the opcode checking. The PR fix the issue to ensure the IsReturn can be only set in Jalr.

Change-Id: I9ad867a389256f9253988552e6567d2b505a6901