### PR TITLE
cpu,mem,sim: Optimize code using MAGPIE

### DIFF
--- a/src/cpu/pc_event.hh
+++ b/src/cpu/pc_event.hh
@@ -121,6 +121,7 @@ class PCEventQueue : public PCEventScope
 
         return doService(pc, tc);
     }
+    bool empty() const { return pcMap.empty(); }
 
     range_t equal_range(Addr pc);
     range_t equal_range(PCEvent *event) { return equal_range(event->pc()); }

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -122,6 +122,9 @@ BaseSimpleCPU::BaseSimpleCPU(const BaseSimpleCPUParams &p)
 void
 BaseSimpleCPU::checkPcEventQueue()
 {
+    //if empty now then no whole PCEventQueue is empty so no need to check
+    if (threadInfo[curThread]->thread->pcEventQueue.empty()) return;
+
     Addr oldpc, pc = threadInfo[curThread]->thread->pcState().instAddr();
     do {
         oldpc = pc;

--- a/src/cpu/simple/timing.cc
+++ b/src/cpu/simple/timing.cc
@@ -1077,16 +1077,6 @@ TimingSimpleCPU::completeDataAccess(PacketPtr pkt)
 }
 
 void
-TimingSimpleCPU::updateCycleCounts()
-{
-    const Cycles delta(curCycle() - previousCycle);
-
-    baseStats.numCycles += delta;
-
-    previousCycle = curCycle();
-}
-
-void
 TimingSimpleCPU::DcachePort::recvTimingSnoopReq(PacketPtr pkt)
 {
     for (ThreadID tid = 0; tid < cpu->numThreads; tid++) {

--- a/src/cpu/simple/timing.hh
+++ b/src/cpu/simple/timing.hh
@@ -253,7 +253,14 @@ class TimingSimpleCPU : public BaseSimpleCPU
 
     };
 
-    void updateCycleCounts();
+    void updateCycleCounts()
+    {
+        const Cycles delta(curCycle() - previousCycle);
+
+        baseStats.numCycles += delta;
+
+        previousCycle = curCycle();
+    }
 
     IcachePort icachePort;
     DcachePort dcachePort;

--- a/src/mem/snoop_filter.cc
+++ b/src/mem/snoop_filter.cc
@@ -156,30 +156,6 @@ SnoopFilter::lookupRequest(const Packet* cpkt, const ResponsePort&
     return snoopSelected(maskToPortList(interested & ~req_port), lookupLatency);
 }
 
-void
-SnoopFilter::finishRequest(bool will_retry, Addr addr, bool is_secure)
-{
-    if (reqLookupResult.it != cachedLocations.end()) {
-        // since we rely on the caller, do a basic check to ensure
-        // that finishRequest is being called following lookupRequest
-        assert(reqLookupResult.it->first == \
-                (is_secure ? ((addr & ~(Addr(linesize - 1))) | LineSecure) : \
-                 (addr & ~(Addr(linesize - 1)))));
-        if (will_retry) {
-            SnoopItem retry_item = reqLookupResult.retryItem;
-            // Undo any changes made in lookupRequest to the snoop filter
-            // entry if the request will come again. retryItem holds
-            // the previous value of the snoopfilter entry.
-            reqLookupResult.it->second = retry_item;
-
-            DPRINTF(SnoopFilter, "%s:   restored SF value %x.%x\n",
-                    __func__,  retry_item.requested, retry_item.holder);
-        }
-
-        eraseIfNullEntry(reqLookupResult.it);
-    }
-}
-
 std::pair<SnoopFilter::SnoopList, Cycles>
 SnoopFilter::lookupSnoop(const Packet* cpkt)
 {

--- a/src/sim/eventq.cc
+++ b/src/sim/eventq.cc
@@ -109,20 +109,6 @@ Event::insertBefore(Event *event, Event *curr)
 }
 
 void
-Event::acquire()
-{
-    if (flags.isSet(Event::Managed))
-        acquireImpl();
-}
-
-void
-Event::release()
-{
-    if (flags.isSet(Event::Managed))
-        releaseImpl();
-}
-
-void
 Event::acquireImpl()
 {
 }

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -383,12 +383,22 @@ class Event : public EventBase, public Serializable
     /**
      * Managed event scheduled and being held in the event queue.
      */
-    void acquire();
+    void
+    acquire()
+    {
+        if (flags.isSet(Managed))
+            acquireImpl();
+    }
 
     /**
      * Managed event removed from the event queue.
      */
-    void release();
+    void
+    release()
+    {
+        if (flags.isSet(Managed))
+            releaseImpl();
+    }
 
     virtual void acquireImpl();
 


### PR DESCRIPTION
This patch was created using the Machine Automated General Performance Improvement via Evolution of Software (MAGPIE) framework (https://github.com/bloa/magpie).

It made the following optimizations:

* In "src/mem/snoop_filter.{cc/hh}": Moves the body of `finishRequest` inline from .cc to .hh; Adds const to args in `finishRequest`.
* In "src/mem/eventq.{cc/hh}": Inlines `aquire` and `release` from .cc .hh.
* In "src/cpu/pc_event.hh": Adds `empty` to check return `pcMap.empty()`
* In "src/cpu/simple/base.cc": Adds check in `checkPcEventQueue` to skip checks if `pcEventQueue.empty()`.
* In "src/cpu/simple/timing.{cc/hh}: `updatecycleCounts()` inlined from .cc to .hh.

MAGPIE Bibtex:

```
https://github.com/Article{blot:2022:magpie,
  author    = {Aymeric Blot and
               Justyna Petke},
  title     = {{MAGPIE:} {M}achine Automated General Performance Improvement via Evolution of Software},
  journal   = {Computing Research Repository},
  volume    = {abs/2208.02811},
  url       = {https://arxiv.org/abs/2208.02811},
  doi       = {10.48550/arXiv.2208.02811},
  year      = {2022},
}
```

Co-authored-by: Americ Blot <a.blot@cs.ucl.ac.uk>
Co-authored-by: Justyna Petke <j.petke@ucl.ac.uk>
Co-authored-by: William B. Langdon <w.langdon@cs.ucl.ac.uk>