### PR TITLE
arch-x86: fix negative overflow check bug in PACK micro-op

### DIFF
--- a/src/arch/x86/isa/microops/mediaop.isa
+++ b/src/arch/x86/isa/microops/mediaop.isa
@@ -393,7 +393,7 @@ let {{
 
                 // Handle saturation.
                 if (signBit) {
-                    if (overflow != mask(destBits - srcBits + 1)) {
+                    if (overflow != mask(srcBits - destBits + 1)) {
                         if (signedOp())
                             picked = (1ULL << (destBits - 1));
                         else
@@ -421,7 +421,7 @@ let {{
 
                 // Handle saturation.
                 if (signBit) {
-                    if (overflow != mask(destBits - srcBits + 1)) {
+                    if (overflow != mask(srcBits - destBits + 1)) {
                         if (signedOp())
                             picked = (1ULL << (destBits - 1));
                         else


### PR DESCRIPTION
The implementation of the x86 PACK micro-op had a logical bug that caused the `PACKSSWB` and `PACKSSDW` instructions to produce incorrect results. Specifically, due to a signedness error, the overflow check for negative integers being packed always evaluated to true, resulting in all negative integers being packed as -1 in the output.

This patch fixes the signedness error that causes the bug.

GitHub issue: https://github.com/gem5/gem5/issues/331

Change-Id: I44b7328a8ce31742a3c0dfaebd747f81751e8851