### PR TITLE
misc: Add sphinx stdlib documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cscope.out
 .*.swo
 m5out
 /src/doxygen/html
+/docs/_build
 /ext/dramsim2/DRAMSim2
 /ext/mcpat/regression/*/*.out
 /util/m5/*.o

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README
+++ b/docs/README
@@ -1,0 +1,35 @@
+# How to build Sphinx documentation
+
+In order to build documentation for the standard library, first install sphinx
+
+```bash
+python -m venv build/
+source build/bin/activate
+pip install sphinx
+
+```
+
+Next, build gem5, then cd to the docs directory
+
+```bash
+scons build/ALL/gem5.opt
+cd docs
+```
+
+In order to generate the RST files, run `../build/ALL/gem5.opt gem5-sphinx-apidoc -o . ../src/python/gem5 -F -e`
+
+To generate the documentation, run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html`
+
+In order to view this documentation as a website, run the commands below:
+
+```bash
+cd _build/html
+python -m http.server 8000
+```
+
+Note: In order to generate additional documentation for memory within gem5, also build ALL_CHI/gem5.opt, and run the SPHINXBUILD command, as shown below:
+
+```bash
+scons build/ALL_CHI/gem5.opt
+`SPHINXBUILD="../build/ALL_CHI/gem5.opt gem5-sphinx" make html`
+```

--- a/docs/README
+++ b/docs/README
@@ -3,7 +3,7 @@
 In order to build documentation for the standard library, first install sphinx
 
 ```bash
-python -m venv build/
+python3 -m venv build/
 source build/bin/activate
 pip install sphinx
 
@@ -24,12 +24,14 @@ In order to view this documentation as a website, run the commands below:
 
 ```bash
 cd _build/html
-python -m http.server 8000
+python3 -m http.server 8000
 ```
 
-Note: In order to generate additional documentation for memory within gem5, also build ALL_CHI/gem5.opt, and run the SPHINXBUILD command, as shown below:
+If you want to use a different Sphinx theme, follow these steps:
 
-```bash
-scons build/ALL_CHI/gem5.opt
-`SPHINXBUILD="../build/ALL_CHI/gem5.opt gem5-sphinx" make html`
-```
+- Install the desired theme, e.g., `pip install sphinx-rtd-theme`
+- Update the `html_theme` in `conf.py` by setting `html_theme = "sphinx_rtd_theme"`
+- Run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html` to apply the changes.
+
+Note: We are aware that some modules currently display a blank page in the documentation.
+This will be addressed in the future.

--- a/docs/README
+++ b/docs/README
@@ -1,6 +1,6 @@
 # How to build Sphinx documentation
 
-In order to build documentation for the standard library, first install sphinx
+In order to build documentation for the standard library, first install sphinx. Run these commands in the `gem5` directory.
 
 ```bash
 python3 -m venv build/
@@ -9,18 +9,18 @@ pip install sphinx
 
 ```
 
-Next, build gem5, then cd to the docs directory
+Next, build gem5, then cd to the `docs` directory.
 
 ```bash
 scons build/ALL/gem5.opt
 cd docs
 ```
 
-In order to generate the RST files, run `../build/ALL/gem5.opt gem5-sphinx-apidoc -o . ../src/python/gem5 -F -e`
+In the `docs` directory, run `../build/ALL/gem5.opt gem5-sphinx-apidoc -o . ../src/python/gem5 -F -e` in order to generate the RST files.
 
 To generate the documentation, run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html`
 
-In order to view this documentation as a website, run the commands below:
+In order to view this documentation as a website, run the following commands while still in the `docs` directory:
 
 ```bash
 cd _build/html
@@ -30,8 +30,8 @@ python3 -m http.server 8000
 If you want to use a different Sphinx theme, follow these steps:
 
 - Install the desired theme, e.g., `pip install sphinx-rtd-theme`
-- Update the `html_theme` in `conf.py` by setting `html_theme = "sphinx_rtd_theme"`
-- Run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html` to apply the changes.
+- Update the `html_theme` in `docs/conf.py` by setting `html_theme = "sphinx_rtd_theme"`
+- Run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html` in the `docs` directory to apply the changes.
 
 Note: We are aware that some modules currently display a blank page in the documentation.
 This will be addressed in the future.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,42 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'gem5'
+copyright = ''
+author = ''
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.todo',
+]
+
+templates_path = ['_templates']
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    'build/lib64/python3.8/site-packages',
+    'build/lib/python3.8/site-packages'
+]
+
+language = 'en'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+# -- Options for todo extension ----------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#configuration
+
+todo_include_todos = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,35 +6,35 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'gem5'
-copyright = ''
-author = ''
+project = "gem5"
+copyright = ""
+author = ""
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.todo',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = [
-    '_build',
-    'Thumbs.db',
-    '.DS_Store',
-    'build/lib64/python3.8/site-packages',
-    'build/lib/python3.8/site-packages'
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "build/lib64/python3.8/site-packages",
+    "build/lib/python3.8/site-packages",
 ]
 
-language = 'en'
+language = "en"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]
 
 # -- Options for todo extension ----------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#configuration

--- a/docs/gem5-sphinx
+++ b/docs/gem5-sphinx
@@ -1,0 +1,1 @@
+import sphinx.__main__

--- a/docs/gem5-sphinx-apidoc
+++ b/docs/gem5-sphinx-apidoc
@@ -1,0 +1,14 @@
+import re
+import sys
+
+extensions = ['myst_parser']
+
+source_suffix = {
+    '.md': 'markdown',
+    '.py': 'markdown'
+}
+
+from sphinx.ext.apidoc import main
+if __name__ == '__m5_main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())


### PR DESCRIPTION
This PR adds documentation to the standard library using Sphinx. For details on how the documentation was generated, refer to https://gem5.atlassian.net/browse/GEM5-1314. Currently, some modules like `dramsys` and `mesi_three_level` appear as blank pages. To view the current state of the documentation locally, run: `cd docs/_build/html; python3 -m http.server 8000`

Change-Id: Ic7cfab4da32ea29bdda958c48ea3c6d26cfd6765