### PR TITLE
arch,arch-riscv: Remove setRegOperand in VecRegOperand

### DIFF
--- a/src/arch/isa_parser/operand_types.py
+++ b/src/arch/isa_parser/operand_types.py
@@ -372,7 +372,6 @@ class VecRegOperand(RegOperand):
 
     def makeWrite(self):
         return f"""
-        xc->setRegOperand(this, {self.dest_reg_idx}, &tmp_d{self.dest_reg_idx});
         if (traceData) {{
             traceData->setData({self.reg_class}, &tmp_d{self.dest_reg_idx});
         }}

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -579,7 +579,6 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
                 memcpy(Vd + i * byte_offset, s + i * byte_offset, byte_offset);
             }
         }
-        xc->setRegOperand(this, 0, &tmp_d0);
         if (traceData)
             traceData->setData(vecRegClass, &tmp_d0);
         return NoFault;


### PR DESCRIPTION
The RISC-V vector instructions still work without setRegOperand.
We should fix the register statistic issue by https://github.com/gem5/gem5/pull/360 to avoid duplicate statistic register write count



Change-Id: Ib6a52935e00c3e557b366abfcf60450dca05614d