### PR TITLE
sim-se: zero out memory allocated via brk()

### DIFF
--- a/src/sim/mem_state.hh
+++ b/src/sim/mem_state.hh
@@ -278,11 +278,6 @@ class MemState : public Serializable
     Addr _mmapEnd;
 
     /**
-     * Keeps record of the furthest mapped heap location.
-     */
-    Addr _endBrkPoint;
-
-    /**
      * The _vmaList member is a list of virtual memory areas in the target
      * application space that have been allocated by the target. In most
      * operating systems, lazy allocation is used and these structures (or


### PR DESCRIPTION
The syscall emulation of brk() incorrectly did not ensure that newly allocated memory was zero-initialized, which Linux guarantees and which seems to be the expectation of glibc's malloc() and free() implementation. This patch fixes the incorrect behavior by zero- initalizing all memory allocations via brk().

GitHub issue: https://github.com/gem5/gem5/issues/342

Change-Id: I53cf29d6f3f83285c8e813e18c06c2e9a69d7cc2