### PR TITLE
arch-x86: make popx87 micro-op actually pop st(0)

### DIFF
--- a/src/arch/x86/isa/microops/fpop.isa
+++ b/src/arch/x86/isa/microops/fpop.isa
@@ -430,4 +430,6 @@ let {{
     class Pop87(Fp0Op):
         code = ''
         op_class = 'IntAluOp'
+        def __init__(self):
+            super().__init__(spm=1)
 }};


### PR DESCRIPTION
The popx87 micro-op did not in fact pop the st(0) floating-point register off the stack; it acted as a no-op. This patch fixes the bug by passing the spm=1 argument to PopX87's superclass to indicate the floating-point stack pointer should be incremented.

GitHub issue: https://github.com/gem5/gem5/issues/344

Change-Id: I6e731882b6bcf8f0e06ebd2f66f673bf9da80717