### PR TITLE
arch-x86: properly initialize the auxv platform string

### DIFF
--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -997,7 +997,8 @@ X86Process::argsInit(int pageSize,
     initVirtMem->write(auxv_array_end, zero);
     auxv_array_end += sizeof(zero);
 
-    initVirtMem->writeString(aux_data_base, platform.c_str());
+    initVirtMem->writeString(aux_data_base + numRandomBytes,
+                             platform.c_str());
 
     copyStringArray(envp, envp_array_base, env_data_base,
                     ByteOrder::little, *initVirtMem);


### PR DESCRIPTION
The auxv platform string was not copied to the same location that was pointed to by the value of AT_PLATFORM; instead, it was copied over the auxv random buffer. This patch fixes this by copying the auxv platform string to the right offset in the initial program stack.

GitHub issue: https://github.com/gem5/gem5/issues/346

Change-Id: Ied4b660d5fc444a94acb97b799be0a3722438b5e