### PR TITLE
cpu: Add override to TraceCPU init function

### DIFF
--- a/src/cpu/trace/trace_cpu.hh
+++ b/src/cpu/trace/trace_cpu.hh
@@ -147,7 +147,7 @@ class TraceCPU : public ClockedObject
   public:
     TraceCPU(const TraceCPUParams &params);
 
-    void init();
+    void init() override;
 
     /**
      * Return totalOps as the number of committed micro-ops plus the


### PR DESCRIPTION
This introduces a fix that caused the clang compiler tests to fail here: https://github.com/gem5/gem5/actions/runs/6195015407

Change-Id: I48c61539f497976c038c6e8e379d00285e1c39c7