### PR TITLE
arch-riscv: Make RISC-V decodeInst overridable

### DIFF
--- a/src/arch/riscv/decoder.hh
+++ b/src/arch/riscv/decoder.hh
@@ -60,7 +60,7 @@ class Decoder : public InstDecoder
     ExtMachInst emi;
     uint32_t machInst;
 
-    StaticInstPtr decodeInst(ExtMachInst mach_inst);
+    virtual StaticInstPtr decodeInst(ExtMachInst mach_inst);
 
     /// Decode a machine instruction.
     /// @param mach_inst The binary instruction to decode.


### PR DESCRIPTION
The change will allow developers to implement and decode their non-standard instructions to the CPU models

Change-Id: I67f4abc71596f819c1265e325784f51c8e9bb359