### PR TITLE
BPU refactoring

### DIFF
--- a/configs/common/cores/arm/HPI.py
+++ b/configs/common/cores/arm/HPI.py
@@ -1679,7 +1679,13 @@ class HPI_MMU(ArmMMU):
     dtb = ArmTLB(entry_type="data", size=256)
 
 
+class HPI_BTB(SimpleBTB):
+    numEntries = 128
+    tagBits = 18
+
+
 class HPI_BP(TournamentBP):
+    btb = HPI_BTB()
     localPredictorSize = 64
     localCtrBits = 2
     localHistoryTableSize = 64
@@ -1687,8 +1693,6 @@ class HPI_BP(TournamentBP):
     globalCtrBits = 2
     choicePredictorSize = 1024
     choiceCtrBits = 2
-    BTBEntries = 128
-    BTBTagSize = 18
     RASSize = 8
     instShiftAmt = 2
 

--- a/configs/common/cores/arm/O3_ARM_v7a.py
+++ b/configs/common/cores/arm/O3_ARM_v7a.py
@@ -107,14 +107,18 @@ class O3_ARM_v7a_FUP(FUPool):
     ]
 
 
+class O3_ARM_v7a_BTB(SimpleBTB):
+    numEntries = 2048
+    tagBits = 18
+
+
 # Bi-Mode Branch Predictor
 class O3_ARM_v7a_BP(BiModeBP):
+    btb = O3_ARM_v7a_BTB()
     globalPredictorSize = 8192
     globalCtrBits = 2
     choicePredictorSize = 8192
     choiceCtrBits = 2
-    BTBEntries = 2048
-    BTBTagSize = 18
     RASSize = 16
     instShiftAmt = 2
 

--- a/configs/common/cores/arm/ex5_big.py
+++ b/configs/common/cores/arm/ex5_big.py
@@ -104,14 +104,18 @@ class ex5_big_FUP(FUPool):
     ]
 
 
+class ex5_big_BTB(SimpleBTB):
+    numEntries = 4096
+    tagBits = 18
+
+
 # Bi-Mode Branch Predictor
 class ex5_big_BP(BiModeBP):
+    btb = ex5_big_BTB()
     globalPredictorSize = 4096
     globalCtrBits = 2
     choicePredictorSize = 1024
     choiceCtrBits = 3
-    BTBEntries = 4096
-    BTBTagSize = 18
     RASSize = 48
     instShiftAmt = 2
 

--- a/src/cpu/pred/2bit_local.cc
+++ b/src/cpu/pred/2bit_local.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2004-2006 The Regents of The University of Michigan
  * All rights reserved.
  *
@@ -67,15 +79,15 @@ LocalBP::LocalBP(const LocalBPParams &params)
 }
 
 void
-LocalBP::btbUpdate(ThreadID tid, Addr branch_addr, void * &bp_history)
+LocalBP::updateHistories(ThreadID tid, Addr pc, bool uncond,
+                         bool taken, Addr target, void * &bpHistory)
 {
-// Place holder for a function that is called to update predictor history when
-// a BTB entry is invalid or not found.
+// Place holder for a function that is called to update predictor history
 }
 
 
 bool
-LocalBP::lookup(ThreadID tid, Addr branch_addr, void * &bp_history)
+LocalBP::lookup(ThreadID tid, Addr branch_addr, void * &bpHistory)
 {
     bool taken;
     unsigned local_predictor_idx = getLocalIndex(branch_addr);
@@ -94,10 +106,10 @@ LocalBP::lookup(ThreadID tid, Addr branch_addr, void * &bp_history)
 }
 
 void
-LocalBP::update(ThreadID tid, Addr branch_addr, bool taken, void *bp_history,
+LocalBP::update(ThreadID tid, Addr branch_addr, bool taken, void * &bpHistory,
                 bool squashed, const StaticInstPtr & inst, Addr corrTarget)
 {
-    assert(bp_history == NULL);
+    assert(bpHistory == NULL);
     unsigned local_predictor_idx;
 
     // No state to restore, and we do not update on the wrong
@@ -135,10 +147,6 @@ LocalBP::getLocalIndex(Addr &branch_addr)
     return (branch_addr >> instShiftAmt) & indexMask;
 }
 
-void
-LocalBP::uncondBranch(ThreadID tid, Addr pc, void *&bp_history)
-{
-}
 
 } // namespace branch_prediction
 } // namespace gem5

--- a/src/cpu/pred/2bit_local.hh
+++ b/src/cpu/pred/2bit_local.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2011, 2014 ARM Limited
+ * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -56,7 +57,7 @@ namespace branch_prediction
 
 /**
  * Implements a local predictor that uses the PC to index into a table of
- * counters.  Note that any time a pointer to the bp_history is given, it
+ * counters.  Note that any time a pointer to the bpHistory is given, it
  * should be NULL using this predictor because it does not have any branch
  * predictor state that needs to be recorded or updated; the update can be
  * determined solely by the branch being taken or not taken.
@@ -69,36 +70,18 @@ class LocalBP : public BPredUnit
      */
     LocalBP(const LocalBPParams &params);
 
-    virtual void uncondBranch(ThreadID tid, Addr pc, void * &bp_history);
+    // Overriding interface functions
+    bool lookup(ThreadID tid, Addr pc, void * &bpHistory) override;
 
-    /**
-     * Looks up the given address in the branch predictor and returns
-     * a true/false value as to whether it is taken.
-     * @param branch_addr The address of the branch to look up.
-     * @param bp_history Pointer to any bp history state.
-     * @return Whether or not the branch is taken.
-     */
-    bool lookup(ThreadID tid, Addr branch_addr, void * &bp_history);
+    void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                         Addr target,  void * &bpHistory) override;
 
-    /**
-     * Updates the branch predictor to Not Taken if a BTB entry is
-     * invalid or not found.
-     * @param branch_addr The address of the branch to look up.
-     * @param bp_history Pointer to any bp history state.
-     * @return Whether or not the branch is taken.
-     */
-    void btbUpdate(ThreadID tid, Addr branch_addr, void * &bp_history);
+    void update(ThreadID tid, Addr pc, bool taken,
+                void * &bpHistory, bool squashed,
+                const StaticInstPtr &inst, Addr corrTarget) override;
 
-    /**
-     * Updates the branch predictor with the actual result of a branch.
-     * @param branch_addr The address of the branch to update.
-     * @param taken Whether or not the branch was taken.
-     */
-    void update(ThreadID tid, Addr branch_addr, bool taken, void *bp_history,
-                bool squashed, const StaticInstPtr & inst, Addr corrTarget);
-
-    void squash(ThreadID tid, void *bp_history)
-    { assert(bp_history == NULL); }
+    void squash(ThreadID tid, void * &bpHistory) override
+    { assert(bpHistory == NULL); }
 
   private:
     /**

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -59,6 +59,15 @@ class BranchType(Enum):
     ]
 
 
+class TargetProvider(Enum):
+    vals = [
+        "NoTarget",
+        "BTB",
+        "RAS",
+        "Indirect",
+    ]
+
+
 class ReturnAddrStack(SimObject):
     type = "ReturnAddrStack"
     cxx_class = "gem5::branch_prediction::ReturnAddrStack"
@@ -170,6 +179,11 @@ class BranchPredictor(SimObject):
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
     instShiftAmt = Param.Unsigned(2, "Number of bits to shift instructions by")
+    requiresBTBHit = Param.Bool(
+        False,
+        "Requires a BTB hit to detect if "
+        " a branch was a return or indirect branch.",
+    )
 
     RASSize = Param.Unsigned(16, "RAS size")
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -131,6 +131,12 @@ class IndirectPredictor(SimObject):
     abstract = True
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
+    takenOnlyHistory = Param.Bool(
+        False,
+        "Build the global "
+        "history using taken-only branch target history instead of direction "
+        "history from all branches",
+    )
 
 
 class SimpleIndirectPredictor(IndirectPredictor):
@@ -145,6 +151,12 @@ class SimpleIndirectPredictor(IndirectPredictor):
     indirectTagSize = Param.Unsigned(16, "Indirect target cache tag bits")
     indirectPathLength = Param.Unsigned(
         3, "Previous indirect targets to use for path history"
+    )
+    speculativePathLength = Param.Unsigned(
+        3,
+        "Additional buffer space to store speculative path history. "
+        "If there are more speculative branches in flight the history cannot "
+        "be recoverd.",
     )
     indirectGHRBits = Param.Unsigned(13, "Indirect GHR number of bits")
     instShiftAmt = Param.Unsigned(2, "Number of bits to shift instructions by")
@@ -167,7 +179,8 @@ class BranchPredictor(SimObject):
     )
     indirectBranchPred = Param.IndirectPredictor(
         SimpleIndirectPredictor(),
-        "Indirect branch predictor, set to NULL to disable indirect predictions",
+        "Indirect branch predictor, set to NULL to disable "
+        "indirect predictions",
     )
 
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -59,6 +59,22 @@ class BranchType(Enum):
     ]
 
 
+class ReturnAddrStack(SimObject):
+    type = "ReturnAddrStack"
+    cxx_class = "gem5::branch_prediction::ReturnAddrStack"
+    cxx_header = "cpu/pred/ras.hh"
+    # abstract = True
+
+    numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
+    numEntries = Param.Unsigned(Parent.RASSize, "Number of RAS entries")
+    corruptionDetection = Param.Bool(
+        False,
+        "When corruption detection is "
+        "enabled no entry will returned when "
+        "the stack was corrupted.",
+    )
+
+
 class BranchTargetBuffer(ClockedObject):
     type = "BranchTargetBuffer"
     cxx_class = "gem5::branch_prediction::BranchTargetBuffer"
@@ -146,7 +162,9 @@ class BranchPredictor(SimObject):
     RASSize = Param.Unsigned(16, "RAS size")
 
     btb = Param.BranchTargetBuffer(SimpleBTB(), "Branch target buffer (BTB)")
-
+    ras = Param.ReturnAddrStack(
+        ReturnAddrStack(), "Return address stack, set to NULL to disable RAS."
+    )
     indirectBranchPred = Param.IndirectPredictor(
         SimpleIndirectPredictor(),
         "Indirect branch predictor, set to NULL to disable indirect predictions",

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2022-2023 The University of Edinburgh
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2012 Mark D. Hill and David A. Wood
 # Copyright (c) 2015 The University of Wisconsin
 # All rights reserved.
@@ -25,9 +37,75 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.SimObject import SimObject
+from m5.SimObject import *
 from m5.params import *
 from m5.proxy import *
+
+from m5.objects.ClockedObject import ClockedObject
+from m5.objects.IndexingPolicies import *
+from m5.objects.ReplacementPolicies import *
+
+
+class BranchType(Enum):
+    vals = [
+        "NoBranch",
+        "Return",
+        "CallDirect",
+        "CallIndirect",  # 'Call',
+        "DirectCond",
+        "DirectUncond",  # 'Direct',
+        "IndirectCond",
+        "IndirectUncond",  #'Indirect',
+    ]
+
+
+class BranchTargetBuffer(ClockedObject):
+    type = "BranchTargetBuffer"
+    cxx_class = "gem5::branch_prediction::BranchTargetBuffer"
+    cxx_header = "cpu/pred/btb.hh"
+    abstract = True
+
+    numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
+
+
+class SimpleBTB(BranchTargetBuffer):
+    type = "SimpleBTB"
+    cxx_class = "gem5::branch_prediction::SimpleBTB"
+    cxx_header = "cpu/pred/simple_btb.hh"
+
+    numEntries = Param.Unsigned(4096, "Number of BTB entries")
+    tagBits = Param.Unsigned(16, "Size of the BTB tags, in bits")
+    instShiftAmt = Param.Unsigned(
+        Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )
+
+
+class AssociativeBTB(BranchTargetBuffer):
+    type = "AssociativeBTB"
+    cxx_class = "gem5::branch_prediction::AssociativeBTB"
+    cxx_header = "cpu/pred/associative_btb.hh"
+
+    numEntries = Param.MemorySize("4096", "Number of entries of BTB entries")
+    assoc = Param.Unsigned(8, "Associativity of the BTB")
+    indexing_policy = Param.BaseIndexingPolicy(
+        SetAssociative(
+            entry_size=1, assoc=Parent.assoc, size=Parent.numEntries
+        ),
+        "Indexing policy of the BTB",
+    )
+    replacement_policy = Param.BaseReplacementPolicy(
+        LRURP(), "Replacement policy of the table"
+    )
+
+    tagBits = Param.Unsigned(16, "Size of the BTB tags, in bits")
+    useTagCompression = Param.Bool(
+        False,
+        "Use a tag compression function as"
+        "described in https://ieeexplore.ieee.org/document/9528930",
+    )
+    instShiftAmt = Param.Unsigned(
+        Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )
 
 
 class IndirectPredictor(SimObject):
@@ -63,10 +141,11 @@ class BranchPredictor(SimObject):
     abstract = True
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
-    BTBEntries = Param.Unsigned(4096, "Number of BTB entries")
-    BTBTagSize = Param.Unsigned(16, "Size of the BTB tags, in bits")
-    RASSize = Param.Unsigned(16, "RAS size")
     instShiftAmt = Param.Unsigned(2, "Number of bits to shift instructions by")
+
+    RASSize = Param.Unsigned(16, "RAS size")
+
+    btb = Param.BranchTargetBuffer(SimpleBTB(), "Branch target buffer (BTB)")
 
     indirectBranchPred = Param.IndirectPredictor(
         SimpleIndirectPredictor(),

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -58,7 +58,7 @@ SimObject('BranchPredictor.py',
     'MultiperspectivePerceptronTAGE64KB', 'MPP_TAGE_8KB',
     'MPP_LoopPredictor_8KB', 'MPP_StatisticalCorrector_8KB',
     'MultiperspectivePerceptronTAGE8KB'],
-    enums=['BranchType'])
+    enums=['BranchType', 'TargetProvider'])
 
 Source('bpred_unit.cc')
 Source('2bit_local.cc')

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -1,5 +1,17 @@
 # -*- mode:python -*-
 
+# Copyright (c) 2022-2023 The University of Edinburgh
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2006 The Regents of The University of Michigan
 # All rights reserved.
 #
@@ -28,8 +40,12 @@
 
 Import('*')
 
-SimObject('BranchPredictor.py', sim_objects=[
-    'IndirectPredictor', 'SimpleIndirectPredictor', 'BranchPredictor',
+
+SimObject('BranchPredictor.py',
+    sim_objects=[
+    'BranchPredictor',
+    'IndirectPredictor', 'SimpleIndirectPredictor',
+    'BranchTargetBuffer', 'SimpleBTB', 'AssociativeBTB',
     'LocalBP', 'TournamentBP', 'BiModeBP', 'TAGEBase', 'TAGE', 'LoopPredictor',
     'TAGE_SC_L_TAGE', 'TAGE_SC_L_TAGE_64KB', 'TAGE_SC_L_TAGE_8KB',
     'LTAGE', 'TAGE_SC_L_LoopPredictor', 'StatisticalCorrector', 'TAGE_SC_L',
@@ -41,17 +57,16 @@ SimObject('BranchPredictor.py', sim_objects=[
     'MultiperspectivePerceptronTAGE', 'MPP_StatisticalCorrector_64KB',
     'MultiperspectivePerceptronTAGE64KB', 'MPP_TAGE_8KB',
     'MPP_LoopPredictor_8KB', 'MPP_StatisticalCorrector_8KB',
-    'MultiperspectivePerceptronTAGE8KB'])
+    'MultiperspectivePerceptronTAGE8KB'],
+    enums=['BranchType'])
 
-DebugFlag('Indirect')
 Source('bpred_unit.cc')
 Source('2bit_local.cc')
-Source('btb.cc')
 Source('simple_indirect.cc')
 Source('indirect.cc')
 Source('ras.cc')
 Source('tournament.cc')
-Source ('bi_mode.cc')
+Source('bi_mode.cc')
 Source('tage_base.cc')
 Source('tage.cc')
 Source('loop_predictor.cc')
@@ -66,6 +81,11 @@ Source('statistical_corrector.cc')
 Source('tage_sc_l.cc')
 Source('tage_sc_l_8KB.cc')
 Source('tage_sc_l_64KB.cc')
+Source('btb.cc')
+Source('simple_btb.cc')
+Source('associative_btb.cc')
+DebugFlag('Indirect')
+DebugFlag('BTB')
 DebugFlag('FreeList')
 DebugFlag('Branch')
 DebugFlag('Tage')

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -45,7 +45,7 @@ SimObject('BranchPredictor.py',
     sim_objects=[
     'BranchPredictor',
     'IndirectPredictor', 'SimpleIndirectPredictor',
-    'BranchTargetBuffer', 'SimpleBTB', 'AssociativeBTB',
+    'ReturnAddrStack', 'BranchTargetBuffer', 'SimpleBTB', 'AssociativeBTB',
     'LocalBP', 'TournamentBP', 'BiModeBP', 'TAGEBase', 'TAGE', 'LoopPredictor',
     'TAGE_SC_L_TAGE', 'TAGE_SC_L_TAGE_64KB', 'TAGE_SC_L_TAGE_8KB',
     'LTAGE', 'TAGE_SC_L_LoopPredictor', 'StatisticalCorrector', 'TAGE_SC_L',
@@ -86,6 +86,7 @@ Source('simple_btb.cc')
 Source('associative_btb.cc')
 DebugFlag('Indirect')
 DebugFlag('BTB')
+DebugFlag('RAS')
 DebugFlag('FreeList')
 DebugFlag('Branch')
 DebugFlag('Tage')

--- a/src/cpu/pred/associative_btb.cc
+++ b/src/cpu/pred/associative_btb.cc
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/pred/associative_btb.hh"
+
+#include "base/intmath.hh"
+#include "base/trace.hh"
+#include "debug/BTB.hh"
+#include "mem/cache/prefetch/associative_set_impl.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+AssociativeBTB::AssociativeBTB(const AssociativeBTBParams &p)
+    : BranchTargetBuffer(p),
+        btb(p.assoc, p.numEntries, p.indexing_policy,
+                p.replacement_policy),
+        numEntries(p.numEntries),
+        assoc(p.assoc),
+        tagBits(p.tagBits), compressedTags(p.useTagCompression),
+        numSets(numEntries/assoc),
+        setShift(0), setMask(numSets-1),
+        tagShift(floorLog2(numSets)),
+        instShiftAmt(p.instShiftAmt),
+        log2NumThreads(floorLog2(p.numThreads)),
+        assocStats(this)
+{
+    // The number of entries is divided into n ways.
+    uint64_t setBits = floorLog2(numSets);
+
+    if (!isPowerOf2(numSets)) {
+        fatal("Number of sets is not a power of 2!");
+    }
+
+    idxBits = tagBits + setBits;
+    idxMask = (idxBits < 64) ? (1ULL << idxBits) - 1 : (uint64_t)(-1);
+
+    DPRINTF(BTB, "BTB: Creating Associative BTB (entries:%i, assoc:%i, "
+                "tagBits:%i/comp:%i, idx mask:%x, numSets:%i)\n",
+                numEntries, assoc, tagBits, compressedTags, idxMask, numSets);
+}
+
+void
+AssociativeBTB::memInvalidate()
+{
+    DPRINTF(BTB, "BTB: Invalidate all entries\n");
+
+    for (auto &entry : btb) {
+        entry.invalidate();
+    }
+}
+
+uint64_t
+AssociativeBTB::getIndex(ThreadID tid, Addr instPC)
+{
+    /**
+     * Compute the index into the BTB.
+     * - Shift PC over by the word offset
+     * - Mask the address to use only the specified number of TAG bits
+     *   plus the bits to for the set index.
+     *
+     *  64                          0
+     *  | xxx |   TAG    |  Set  |bb|
+     *         \_____BTB idx____/
+     *
+     * The TID will be hashed with as MSBs of the PC
+     */
+    uint64_t idx = (instPC >> instShiftAmt)
+                 ^ (tid << (idxBits - log2NumThreads -1));
+
+    if (compressedTags) {
+        /* For compressed tags the lower 8bit of the tag remain the original
+         * the upper bits of the PC are hased together to form the upper
+         * 8 bits of the tag.
+         * Details https://ieeexplore.ieee.org/document/9528930
+         */
+        uint64_t tag = (idx >> tagShift);
+
+        uint64_t upper = (tag>>16) ^ (tag>>24) ^ (tag>>32)
+                                   ^ (tag>>40) ^ (tag>>48);
+        tag ^= upper << 8;
+        idx = (tag << tagShift) | (idx & setMask);
+    }
+    return idx & idxMask;
+}
+
+bool
+AssociativeBTB::valid(ThreadID tid, Addr instPC, BranchType type)
+{
+    uint64_t idx = getIndex(tid, instPC);
+    BTBEntry * entry = btb.findEntry(idx, /* unused */ false);
+
+    if (entry != nullptr && entry->tid == tid) {
+        return true;
+    }
+    return false;
+}
+
+// @todo Create some sort of return struct that has both whether or not the
+// address is valid, and also the address.  For now will just use addr = 0 to
+// represent invalid entry.
+const PCStateBase *
+AssociativeBTB::lookup(ThreadID tid, Addr instPC, BranchType type)
+{
+    stats.lookups++;
+    if (type != BranchType::NoBranch) {
+        stats.lookupType[type]++;
+    }
+
+
+    uint64_t idx = getIndex(tid, instPC);
+    BTBEntry * entry = btb.findEntry(idx, /* unused */ false);
+
+    if (entry != nullptr && entry->tid == tid) {
+        // PC is different -> conflict hit.
+        if (entry->pc != instPC) {
+            assocStats.conflict++;
+        }
+
+        entry->accesses++;
+        btb.accessEntry(entry);
+        return entry->target;
+    }
+    stats.misses++;
+    if (type != BranchType::NoBranch) {
+        stats.missType[type]++;
+    }
+    return nullptr;
+}
+
+const StaticInstPtr
+AssociativeBTB::lookupInst(ThreadID tid, Addr instPC)
+{
+    uint64_t idx = getIndex(tid, instPC);
+    BTBEntry * entry = btb.findEntry(idx, /* unused */ false);
+
+    if (entry != nullptr && entry->tid == tid) {
+        return entry->inst;
+    }
+    return nullptr;
+}
+
+void
+AssociativeBTB::update(ThreadID tid, Addr instPC,
+                    const PCStateBase &target,
+                    BranchType type, StaticInstPtr inst)
+{
+    uint64_t idx = getIndex(tid, instPC);
+    BTBEntry * entry = btb.findEntry(idx, /* unused */ false);
+
+    updateEntry(entry, tid, instPC, target, type, inst);
+}
+
+void
+AssociativeBTB::updateEntry(BTBEntry* &entry, ThreadID tid, Addr instPC,
+                    const PCStateBase &target, BranchType type,
+                    StaticInstPtr inst)
+{
+    if (type != BranchType::NoBranch) {
+        stats.updates[type]++;
+    }
+
+    uint64_t idx = getIndex(tid, instPC);
+
+    if (entry != nullptr && entry->tid == tid) {
+        DPRINTF(BTB, "BTB::%s: Updated existing entry. PC:%#x, idx:%#x \n",
+                     __func__, instPC, idx);
+        btb.accessEntry(entry);
+        entry->accesses++;
+        if (entry->pc != instPC)
+            assocStats.conflict++;
+
+    } else {
+        uint64_t set = (idx >> setShift) & setMask;
+        DPRINTF(BTB, "BTB::%s: Replace entry. PC:%#x, idx:%#x, set:%i\n",
+                     __func__, instPC, idx, set);
+        stats.evictions++;
+        entry = btb.findVictim(idx);
+        assert(entry != nullptr);
+        btb.insertEntry(idx, false, entry);
+
+        // Measure the number of accesses.
+        assocStats.accesses.sample(entry->accesses == 0 ? 0
+                                : floorLog2(entry->accesses));
+        entry->accesses = 0;
+    }
+
+    entry->pc = instPC;
+    entry->tid = tid;
+    set(entry->target, &target);
+    entry->inst = inst;
+}
+
+
+AssociativeBTB::AssociativeBTBStats::AssociativeBTBStats(
+                                                AssociativeBTB *parent)
+    : statistics::Group(parent),
+    ADD_STAT(accesses, statistics::units::Count::get(),
+             "Distribution of accesses (log2) per allocated entry."),
+    ADD_STAT(conflict, statistics::units::Ratio::get(),
+             "Number of conflicts. Tag hit but PC different.")
+{
+    using namespace statistics;
+    accesses
+        .init(8)
+        .flags(pdf);
+}
+
+
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/cpu/pred/associative_btb.hh
+++ b/src/cpu/pred/associative_btb.hh
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_PRED_ASSOCIATIVE_BTB_HH__
+#define __CPU_PRED_ASSOCIATIVE_BTB_HH__
+
+#include "base/logging.hh"
+#include "base/types.hh"
+#include "cpu/pred/btb.hh"
+#include "mem/cache/prefetch/associative_set.hh"
+#include "params/AssociativeBTB.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+class AssociativeBTB : public BranchTargetBuffer
+{
+  public:
+    AssociativeBTB(const AssociativeBTBParams &params);
+
+    virtual void memInvalidate() override;
+    virtual const PCStateBase *lookup(ThreadID tid, Addr instPC,
+                           BranchType type = BranchType::NoBranch) override;
+    virtual bool valid(ThreadID tid, Addr instPC,
+                           BranchType type = BranchType::NoBranch) override;
+    virtual void update(ThreadID tid, Addr instPC,
+                        const PCStateBase &target_pc,
+                        BranchType type = BranchType::NoBranch,
+                        StaticInstPtr inst = nullptr) override;
+    const StaticInstPtr lookupInst(ThreadID tid, Addr instPC) override;
+
+  protected:
+
+    struct BTBEntry : public TaggedEntry
+    {
+        BTBEntry()
+            : pc(MaxAddr), target(nullptr), tid(0), valid(false),
+              accesses(0), inst(nullptr) {}
+        /** The entry's tag. */
+        Addr pc = 0;
+
+        /** The entry's target. */
+        PCStateBase * target;
+
+        /** The entry's thread id. */
+        ThreadID tid;
+
+        /** Whether or not the entry is valid. */
+        bool valid;
+
+        unsigned accesses;
+
+        StaticInstPtr inst;
+    };
+
+
+    /** Returns the index into the BTB, based on the branch's PC.
+     *  @param inst_PC The branch to look up.
+     *  @return Returns the index into the BTB.
+     */
+    uint64_t getIndex(ThreadID tid, Addr instPC);
+
+    /** Internal update call */
+    void updateEntry(BTBEntry* &entry, ThreadID tid, Addr instPC,
+                    const PCStateBase &target, BranchType type,
+                    StaticInstPtr inst);
+
+    /** The actual BTB. */
+    AssociativeSet<BTBEntry> btb;
+
+    /** The number of entries in the BTB. */
+    const unsigned numEntries;
+
+    /** The associativity of the BTB */
+    const unsigned assoc;
+
+    /** The number of tag bits per entry. */
+    const unsigned tagBits;
+    /** Use a tag compression function. */
+    const bool compressedTags;
+
+    /** Helper to avoid recomputation for every lookup */
+    const uint64_t numSets;
+    const uint64_t setShift;
+    const uint64_t setMask;
+    const uint64_t tagShift;
+
+    /** Number of bits to shift PC when calculating index. */
+    const uint64_t instShiftAmt;
+
+    /** Log2 NumThreads used for hashing threadid */
+    const unsigned log2NumThreads;
+
+    /** The number of BTB index bits and mask. */
+    uint64_t idxBits;
+    uint64_t idxMask;
+
+
+    struct AssociativeBTBStats : public statistics::Group
+    {
+        AssociativeBTBStats(AssociativeBTB *parent);
+
+        statistics::SparseHistogram accesses;
+        statistics::Scalar conflict;
+    } assocStats;
+
+};
+
+} // namespace branch_prediction
+} // namespace gem5
+
+#endif // __CPU_PRED_ASSOCIATIVE_BTB_HH__

--- a/src/cpu/pred/bi_mode.hh
+++ b/src/cpu/pred/bi_mode.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The Regents of The University of Michigan
  * All rights reserved.
  *
@@ -61,15 +73,17 @@ class BiModeBP : public BPredUnit
 {
   public:
     BiModeBP(const BiModeBPParams &params);
-    void uncondBranch(ThreadID tid, Addr pc, void * &bp_history);
-    void squash(ThreadID tid, void *bp_history);
-    bool lookup(ThreadID tid, Addr branch_addr, void * &bp_history);
-    void btbUpdate(ThreadID tid, Addr branch_addr, void * &bp_history);
-    void update(ThreadID tid, Addr branch_addr, bool taken, void *bp_history,
-                bool squashed, const StaticInstPtr & inst, Addr corrTarget);
+    bool lookup(ThreadID tid, Addr pc, void * &bpHistory) override;
+    void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                         Addr target,  void * &bpHistory) override;
+    void squash(ThreadID tid, void * &bpHistory) override;
+    void update(ThreadID tid, Addr pc, bool taken,
+                void * &bpHistory, bool squashed,
+                const StaticInstPtr &inst, Addr corrTarget) override;
 
   private:
     void updateGlobalHistReg(ThreadID tid, bool taken);
+    void uncondBranch(ThreadID tid, Addr pc, void * &bpHistory);
 
     struct BPHistory
     {

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -156,10 +156,6 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                 tid, seqNum,  pred_taken, pc);
     }
 
-    const bool orig_pred_taken = pred_taken;
-    if (iPred) {
-        iPred->genIndirectInfo(tid, indirect_history);
-    }
 
     DPRINTF(Branch,
             "[tid:%i] [sn:%llu] Creating prediction history for PC %s\n",
@@ -240,11 +236,16 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                 predict_record.wasIndirect = true;
                 ++stats.indirectLookups;
                 //Consult indirect predictor on indirect control
-                if (iPred->lookup(pc.instAddr(), *target, tid)) {
+                const PCStateBase *itarget = iPred->lookup(tid, seqNum,
+                                    pc.instAddr(),
+                                    predict_record.indirectHistory);
+                if (itarget) {
                     // Indirect predictor hit
                     ++stats.indirectHits;
+                    set(target, *itarget);
+
                     DPRINTF(Branch,
-                            "[tid:%i] [sn:%llu] Instruction %s predicted "
+                            "[tid:%i, sn:%llu] Instruction %s predicted "
                             "indirect target is %s\n",
                             tid, seqNum, pc, *target);
                 } else {
@@ -252,9 +253,9 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                     pred_taken = false;
                     predict_record.predTaken = pred_taken;
                     DPRINTF(Branch,
-                            "[tid:%i] [sn:%llu] Instruction %s no indirect "
-                            "target\n",
-                            tid, seqNum, pc);
+                            "[tid:%i, sn:%llu] PC:%#x no indirect target\n",
+                            tid, seqNum, pc.instAddr());
+
                     if (!inst->isCall() && !inst->isReturn()) {
 
                     } else if (inst->isCall() && !inst->isUncondCtrl()) {
@@ -262,8 +263,6 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                     }
                     inst->advancePC(*target);
                 }
-                iPred->recordIndirect(pc.instAddr(), target->instAddr(),
-                        seqNum, tid);
             }
         }
     } else {
@@ -275,11 +274,10 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
 
     if (iPred) {
         // Update the indirect predictor with the direction prediction
-        // Note that this happens after indirect lookup, so it does not use
-        // the new information
-        // Note also that we use orig_pred_taken instead of pred_taken in
-        // as this is the actual outcome of the direction prediction
-        iPred->updateDirectionInfo(tid, orig_pred_taken);
+        iPred->update(tid, seqNum, predict_record.pc, false,
+                           predict_record.predTaken, *target,
+                           getBranchType(inst),
+                           predict_record.indirectHistory);
     }
 
     predHist[tid].push_front(predict_record);
@@ -307,8 +305,10 @@ BPredUnit::update(const InstSeqNum &done_sn, ThreadID tid)
                     predHist[tid].back().inst,
                     predHist[tid].back().target);
 
+        // Commite also Indirect predictor and RAS
         if (iPred) {
-            iPred->commit(done_sn, tid, predHist[tid].back().indirectHistory);
+            iPred->commit(tid, predHist[tid].back().seqNum,
+                            predHist[tid].back().indirectHistory);
         }
 
         if (ras) {
@@ -326,10 +326,6 @@ BPredUnit::squash(const InstSeqNum &squashed_sn, ThreadID tid)
 {
     History &pred_hist = predHist[tid];
 
-    if (iPred) {
-        iPred->squash(squashed_sn, tid);
-    }
-
     while (!pred_hist.empty() &&
            pred_hist.front().seqNum > squashed_sn) {
 
@@ -346,7 +342,8 @@ BPredUnit::squash(const InstSeqNum &squashed_sn, ThreadID tid)
         // This call should delete the bpHistory.
         squash(tid, pred_hist.front().bpHistory);
         if (iPred) {
-            iPred->deleteIndirectInfo(tid, pred_hist.front().indirectHistory);
+            iPred->squash(tid, pred_hist.front().seqNum,
+                               pred_hist.front().indirectHistory);
         }
 
         DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
@@ -430,9 +427,13 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
                pred_hist.front().bpHistory, true, pred_hist.front().inst,
                corr_target.instAddr());
 
+        // Correct Indirect predictor -------------------
         if (iPred) {
-            iPred->changeDirectionPrediction(tid,
-                pred_hist.front().indirectHistory, actually_taken);
+            iPred->update(tid, squashed_sn, (*hist_it).pc,
+                            true, actually_taken, corr_target,
+                            getBranchType(pred_hist.front().inst),
+                            (*hist_it).indirectHistory);
+
         }
 
         // Correct RAS ---------------------------------
@@ -475,11 +476,6 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
         if (actually_taken) {
             if (hist_it->wasIndirect) {
                 ++stats.indirectMispredicted;
-                if (iPred) {
-                    iPred->recordTarget(
-                        hist_it->seqNum, pred_hist.front().indirectHistory,
-                        corr_target, tid);
-                }
             } else {
                 DPRINTF(Branch,"[tid:%i] [squash sn:%llu] "
                         "BTB Update called for [sn:%llu] "

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -58,45 +58,16 @@ namespace branch_prediction
 BPredUnit::BPredUnit(const Params &params)
     : SimObject(params),
       numThreads(params.numThreads),
+      requiresBTBHit(params.requiresBTBHit),
+      instShiftAmt(params.instShiftAmt),
       predHist(numThreads),
       btb(params.btb),
       ras(params.ras),
       iPred(params.indirectBranchPred),
-      stats(this),
-      instShiftAmt(params.instShiftAmt)
+      stats(this,this)
 {
 }
 
-BPredUnit::BPredUnitStats::BPredUnitStats(statistics::Group *parent)
-    : statistics::Group(parent),
-      ADD_STAT(lookups, statistics::units::Count::get(),
-              "Number of BP lookups"),
-      ADD_STAT(condPredicted, statistics::units::Count::get(),
-               "Number of conditional branches predicted"),
-      ADD_STAT(condIncorrect, statistics::units::Count::get(),
-               "Number of conditional branches incorrect"),
-      ADD_STAT(BTBLookups, statistics::units::Count::get(),
-               "Number of BTB lookups"),
-      ADD_STAT(BTBUpdates, statistics::units::Count::get(),
-               "Number of BTB updates"),
-      ADD_STAT(BTBHits, statistics::units::Count::get(), "Number of BTB hits"),
-      ADD_STAT(BTBHitRatio, statistics::units::Ratio::get(), "BTB Hit Ratio",
-               BTBHits / BTBLookups),
-      ADD_STAT(RASUsed, statistics::units::Count::get(),
-               "Number of times the RAS was used to get a target."),
-      ADD_STAT(RASIncorrect, statistics::units::Count::get(),
-               "Number of incorrect RAS predictions."),
-      ADD_STAT(indirectLookups, statistics::units::Count::get(),
-               "Number of indirect predictor lookups."),
-      ADD_STAT(indirectHits, statistics::units::Count::get(),
-               "Number of indirect target hits."),
-      ADD_STAT(indirectMisses, statistics::units::Count::get(),
-               "Number of indirect misses."),
-      ADD_STAT(indirectMispredicted, statistics::units::Count::get(),
-               "Number of mispredicted indirect branches.")
-{
-    BTBHitRatio.precision(6);
-}
 
 probing::PMUUPtr
 BPredUnit::pmuProbePoint(const char *name)
@@ -123,245 +94,379 @@ BPredUnit::drainSanityCheck() const
         assert(ph.empty());
 }
 
+
 bool
 BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                    PCStateBase &pc, ThreadID tid)
 {
+    /** Perform the prediction. */
+    PredictorHistory* bpu_history = nullptr;
+    bool taken  = predict(inst, seqNum, pc, tid, bpu_history);
+
+    assert(bpu_history!=nullptr);
+
+    /** Push the record into the history buffer */
+    predHist[tid].push_front(bpu_history);
+
+    DPRINTF(Branch, "[tid:%i] [sn:%llu] History entry added. "
+            "predHist.size(): %i\n", tid, seqNum, predHist[tid].size());
+
+    return taken;
+}
+
+
+
+
+bool
+BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
+                   PCStateBase &pc, ThreadID tid, PredictorHistory* &hist)
+{
+    assert(hist==nullptr);
+
+    BranchType brType = getBranchType(inst);
+    hist = new PredictorHistory(tid, seqNum, pc.instAddr(), inst);
+
+    stats.lookups[tid][brType]++;
+    ppBranches->notify(1);
+
     // See if branch predictor predicts taken.
     // If so, get its target addr either from the BTB or the RAS.
     // Save off record of branch stuff so the RAS can be fixed
     // up once it's done.
 
-    bool pred_taken = false;
-    std::unique_ptr<PCStateBase> target(pc.clone());
 
-    ++stats.lookups;
-    ppBranches->notify(1);
-
-    void *bp_history = NULL;
-    void *indirect_history = NULL;
+    /* -----------------------------------------------
+     * Get branch direction
+     * -----------------------------------------------
+     * Lookup the direction predictor for every
+     * conditional branch. For unconditional branches
+     * the direction is always taken
+     */
 
     if (inst->isUncondCtrl()) {
-        DPRINTF(Branch, "[tid:%i] [sn:%llu] Unconditional control\n",
-            tid,seqNum);
-        pred_taken = true;
-        // Tell the BP there was an unconditional branch.
-        uncondBranch(tid, pc.instAddr(), bp_history);
+        // Unconditional branches -----
+        hist->condPred = true;
     } else {
+        // Conditional branches -------
         ++stats.condPredicted;
-        pred_taken = lookup(tid, pc.instAddr(), bp_history);
+        hist->condPred = lookup(tid, pc.instAddr(), hist->bpHistory);
 
-        DPRINTF(Branch, "[tid:%i] [sn:%llu] "
-                "Branch predictor predicted %i for PC %s\n",
-                tid, seqNum,  pred_taken, pc);
+        if (hist->condPred) {
+            ++stats.condPredictedTaken;
+        }
     }
-
+    hist->predTaken = hist->condPred;
 
     DPRINTF(Branch,
-            "[tid:%i] [sn:%llu] Creating prediction history for PC %s\n",
-            tid, seqNum, pc);
+            "[tid:%i, sn:%llu] Branch predictor predicted %i for PC:%#x %s\n",
+            tid, seqNum, hist->condPred, hist->pc, toString(brType));
 
-    PredictorHistory predict_record(seqNum, pc.instAddr(), pred_taken,
-                                    bp_history, indirect_history, tid, inst);
 
-    // Now lookup in the BTB or RAS.
-    if (pred_taken) {
-        // Note: The RAS may be both popped and pushed to
-        //       support coroutines.
-        if (inst->isReturn()) {
-            ++stats.RASUsed;
-            // If it's a return from a function call, then look up the
-            // RETURN address in the RAS.
-            const PCStateBase *return_addr = ras->pop(tid,
-                                                predict_record.rasHistory);
-            if (return_addr)
-                set(target, return_addr);
+    // The direction is done now get the target address
+    // from BTB, RAS or indirect predictor.
+    hist->targetProvider = TargetProvider::NoTarget;
 
-            DPRINTF(Branch, "[tid:%i] [sn:%llu] Instruction %s is a return, "
-                    "RAS predicted target: %s, RAS index: %i\n",
-                    tid, seqNum, pc, *target, predict_record.RASIndex);
+    /* -----------------------------------------------
+     * Branch Target Buffer (BTB)
+     * -----------------------------------------------
+     * First check for a BTB hit. This will be done
+     * regardless of whether the RAS or the indirect
+     * predictor provide the final target. That is
+     * necessary as modern front-end do not have a
+     * chance to detect a branch without a BTB hit.
+     */
+    stats.BTBLookups++;
+    const PCStateBase * btb_target = btb->lookup(tid, pc.instAddr(), brType);
+    if (btb_target) {
+        stats.BTBHits++;
+        hist->btbHit = true;
+
+        if (hist->predTaken) {
+            hist->targetProvider = TargetProvider::BTB;
+            set(hist->target, btb_target);
         }
+    }
 
+    DPRINTF(Branch, "[tid:%i, sn:%llu] PC:%#x BTB:%s\n",
+            tid, seqNum, hist->pc,  (hist->btbHit) ? "hit" : "miss");
+
+
+    // If we model a decoupled front-end the BP requires a BTB hit
+    // otherwise it cannot detect a branch.
+    const bool allow_btb_override =
+                    (hist->btbHit || !requiresBTBHit) ? true : false;
+
+
+    /* -----------------------------------------------
+     * Return Address Stack (RAS)
+     * -----------------------------------------------
+     * Perform RAS operations for calls and returns.
+     * Calls: push their RETURN address onto
+     *    the RAS.
+     * Return: pop the the return address from the
+     *    top of the RAS.
+     */
+    if (ras && allow_btb_override) {
         if (inst->isCall()) {
             // Incase of a call build the return address and
             // push it to the RAS.
             auto return_addr = inst->buildRetPC(pc, pc);
-            ras->push(tid, *return_addr, predict_record.rasHistory);
+            ras->push(tid, *return_addr, hist->rasHistory);
 
-            // Record that it was a call so that the top RAS entry can
-            // be popped off if the speculation is incorrect.
             DPRINTF(Branch, "[tid:%i] [sn:%llu] Instr. %s was "
                     "a call, push return address %s onto the RAS\n",
                     tid, seqNum, pc, *return_addr);
 
         }
+        else if (inst->isReturn()) {
 
-        // The target address is not predicted by RAS.
-        // Thus, BTB/IndirectBranch Predictor is employed.
-        if (!inst->isReturn()) {
-            if (inst->isDirectCtrl() || !iPred) {
-                ++stats.BTBLookups;
-                // Check BTB on direct branches
-                const PCStateBase * btb_target = btb->lookup(tid,
-                                                       pc.instAddr());
-                if (btb_target) {
-                    ++stats.BTBHits;
-                    // If it's not a return, use the BTB to get target addr.
-                    set(target, btb_target);
-                    DPRINTF(Branch,
-                            "[tid:%i] [sn:%llu] Instruction %s predicted "
-                            "target is %s\n",
-                            tid, seqNum, pc, *target);
-                } else {
-                    DPRINTF(Branch, "[tid:%i] [sn:%llu] BTB doesn't have a "
-                            "valid entry\n", tid, seqNum);
-                    pred_taken = false;
-                    predict_record.predTaken = pred_taken;
-                    // The Direction of the branch predictor is altered
-                    // because the BTB did not have an entry
-                    // The predictor needs to be updated accordingly
-                    if (!inst->isCall() && !inst->isReturn()) {
-                        btbUpdate(tid, pc.instAddr(), bp_history);
-                        DPRINTF(Branch,
-                                "[tid:%i] [sn:%llu] btbUpdate "
-                                "called for %s\n",
-                                tid, seqNum, pc);
-                    } else if (inst->isCall() && !inst->isUncondCtrl()) {
-                        ras->squash(tid, predict_record.rasHistory);
-                        predict_record.pushedRAS = false;
-                    }
-                    inst->advancePC(*target);
-                }
-            } else {
-                predict_record.wasIndirect = true;
-                ++stats.indirectLookups;
-                //Consult indirect predictor on indirect control
-                const PCStateBase *itarget = iPred->lookup(tid, seqNum,
-                                    pc.instAddr(),
-                                    predict_record.indirectHistory);
-                if (itarget) {
-                    // Indirect predictor hit
-                    ++stats.indirectHits;
-                    set(target, *itarget);
+            // If it's a return from a function call, then look up the
+            // RETURN address in the RAS.
+            const PCStateBase *return_addr = ras->pop(tid, hist->rasHistory);
+            if (return_addr) {
 
-                    DPRINTF(Branch,
-                            "[tid:%i, sn:%llu] Instruction %s predicted "
-                            "indirect target is %s\n",
-                            tid, seqNum, pc, *target);
-                } else {
-                    ++stats.indirectMisses;
-                    pred_taken = false;
-                    predict_record.predTaken = pred_taken;
-                    DPRINTF(Branch,
-                            "[tid:%i, sn:%llu] PC:%#x no indirect target\n",
-                            tid, seqNum, pc.instAddr());
+                // Set the target to the return address
+                set(hist->target, *return_addr);
+                hist->targetProvider = TargetProvider::RAS;
 
-                    if (!inst->isCall() && !inst->isReturn()) {
-
-                    } else if (inst->isCall() && !inst->isUncondCtrl()) {
-                        ras->squash(tid, predict_record.rasHistory);
-                    }
-                    inst->advancePC(*target);
-                }
+                DPRINTF(Branch, "[tid:%i] [sn:%llu] Instr. %s is a "
+                        "return, RAS poped return addr: %s\n",
+                        tid, seqNum, pc, *hist->target);
             }
         }
-    } else {
-        inst->advancePC(*target);
     }
-    predict_record.target = target->instAddr();
 
-    set(pc, *target);
+
+    /* -----------------------------------------------
+     *  Indirect Predictor
+     * -----------------------------------------------
+     * For indirect branches/calls check the indirect
+     * predictor if one is available. Not for returns.
+     * Note that depending on the implementation a
+     * indirect predictor might only return a target
+     * for an indirect branch with a changing target.
+     * As most indirect branches have a static target
+     * using the target from the BTB is the optimal
+     * to save space in the indirect preditor itself.
+     */
+    if (iPred) {
+        if (hist->predTaken && allow_btb_override &&
+            inst->isIndirectCtrl() && !inst->isReturn()) {
+
+            ++stats.indirectLookups;
+
+            const PCStateBase *itarget = iPred->lookup(tid, seqNum,
+                                                pc.instAddr(),
+                                        hist->indirectHistory);
+
+            if (itarget) {
+                // Indirect predictor hit
+                ++stats.indirectHits;
+                hist->targetProvider = TargetProvider::Indirect;
+                set(hist->target, *itarget);
+
+                DPRINTF(Branch,
+                        "[tid:%i, sn:%llu] Instruction %s predicted "
+                        "indirect target is %s\n",
+                        tid, seqNum, pc, *hist->target);
+            } else {
+                ++stats.indirectMisses;
+                DPRINTF(Branch,
+                        "[tid:%i, sn:%llu] PC:%#x no indirect target\n",
+                        tid, seqNum, pc.instAddr());
+            }
+        }
+    }
+
+
+    /** ----------------------------------------------
+     * Fallthrough
+     * -----------------------------------------------
+     * All the target predictors did their job.
+     * If there is no target its either not taken or
+     * a BTB miss. In that case we just fallthrough.
+     * */
+    if (hist->targetProvider == TargetProvider::NoTarget) {
+        set(hist->target, pc);
+        inst->advancePC(*hist->target);
+        hist->predTaken = false;
+    }
+    stats.targetProvider[tid][hist->targetProvider]++;
+
+    // The actual prediction is done.
+    // For now the BPU assume its correct. The update
+    // functions will correct the branch if needed.
+    // If prediction and actual direction are the same
+    // at commit the prediction was correct.
+    hist->actuallyTaken = hist->predTaken;
+    set(pc, *hist->target);
+
+    DPRINTF(Branch, "%s(tid:%i, sn:%i, PC:%#x, %s) -> taken:%i, target:%s "
+            "provider:%s\n", __func__, tid, seqNum, hist->pc,
+            toString(brType), hist->predTaken, *hist->target,
+            enums::TargetProviderStrings[hist->targetProvider]);
+
+
+    /** ----------------------------------------------
+     * Speculative history update
+     * -----------------------------------------------
+     * Now that the prediction is done the predictor
+     * may update its histories speculative. (local
+     * and global path). A later squash will revert
+     * the history update if needed.
+     * The actual prediction tables will updated once
+     * we know the correct direction.
+     **/
+    updateHistories(tid, hist->pc, hist->uncond,
+                    hist->predTaken, hist->target->instAddr(),
+                    hist->bpHistory);
+
 
     if (iPred) {
         // Update the indirect predictor with the direction prediction
-        iPred->update(tid, seqNum, predict_record.pc, false,
-                           predict_record.predTaken, *target,
-                           getBranchType(inst),
-                           predict_record.indirectHistory);
+        iPred->update(tid, seqNum, hist->pc, false, hist->predTaken,
+                      *hist->target, brType, hist->indirectHistory);
     }
 
-    predHist[tid].push_front(predict_record);
-
-    DPRINTF(Branch,
-            "[tid:%i] [sn:%llu] History entry added. "
-            "predHist.size(): %i\n",
-            tid, seqNum, predHist[tid].size());
-
-    return pred_taken;
+    // dump();
+    return hist->predTaken;
 }
+
 
 void
 BPredUnit::update(const InstSeqNum &done_sn, ThreadID tid)
 {
     DPRINTF(Branch, "[tid:%i] Committing branches until "
-            "sn:%llu]\n", tid, done_sn);
+            "[sn:%llu]\n", tid, done_sn);
+
+    // dump();
 
     while (!predHist[tid].empty() &&
-           predHist[tid].back().seqNum <= done_sn) {
-        // Update the branch predictor with the correct results.
-        update(tid, predHist[tid].back().pc,
-                    predHist[tid].back().predTaken,
-                    predHist[tid].back().bpHistory, false,
-                    predHist[tid].back().inst,
-                    predHist[tid].back().target);
+            predHist[tid].back()->seqNum <= done_sn) {
 
-        // Commite also Indirect predictor and RAS
-        if (iPred) {
-            iPred->commit(tid, predHist[tid].back().seqNum,
-                            predHist[tid].back().indirectHistory);
-        }
+        // Iterate from the back to front. Least recent
+        // sequence number until the most recent done number
+        commitBranch(tid, *predHist[tid].rbegin());
 
-        if (ras) {
-            ras->commit(tid, /** TODO */ false,
-                            getBranchType(predHist[tid].back().inst),
-                            predHist[tid].back().rasHistory);
-        }
-
+        delete predHist[tid].back();
         predHist[tid].pop_back();
+        DPRINTF(Branch, "[tid:%i] [commit sn:%llu] pred_hist.size(): %i\n",
+                tid, done_sn, predHist[tid].size());
     }
 }
+
+void
+BPredUnit::commitBranch(ThreadID tid, PredictorHistory* &hist)
+{
+
+    stats.committed[tid][hist->type]++;
+    if (hist->mispredict) {
+        stats.mispredicted[tid][hist->type]++;
+    }
+
+
+    DPRINTF(Branch, "Commit branch: sn:%llu, PC:%#x %s, "
+                    "pred:%i, taken:%i, target:%#x\n",
+                hist->seqNum, hist->pc, toString(hist->type),
+                hist->predTaken, hist->actuallyTaken,
+                hist->target->instAddr());
+
+    // Update the branch predictor with the correct results.
+    update(tid, hist->pc,
+                hist->actuallyTaken,
+                hist->bpHistory, false,
+                hist->inst,
+                hist->target->instAddr());
+
+    // Commite also Indirect predictor and RAS
+    if (iPred) {
+        iPred->commit(tid, hist->seqNum, hist->indirectHistory);
+    }
+
+    if (ras) {
+        ras->commit(tid, hist->mispredict,
+                         hist->type,
+                         hist->rasHistory);
+    }
+
+    // Update the BTB with commited branches.
+    // Install all taken
+    if (hist->actuallyTaken) {
+
+        DPRINTF(Branch,"[tid:%i] BTB Update called for [sn:%llu] "
+                    "PC %#x -> T: %#x\n", tid,
+                    hist->seqNum, hist->pc, hist->target->instAddr());
+
+        stats.BTBUpdates++;
+        btb->update(tid, hist->pc,
+                        *hist->target,
+                         hist->type,
+                         hist->inst);
+    }
+}
+
+
 
 void
 BPredUnit::squash(const InstSeqNum &squashed_sn, ThreadID tid)
 {
-    History &pred_hist = predHist[tid];
 
-    while (!pred_hist.empty() &&
-           pred_hist.front().seqNum > squashed_sn) {
+    while (!predHist[tid].empty() &&
+            predHist[tid].front()->seqNum > squashed_sn) {
 
-        if (pred_hist.front().rasHistory) {
-            assert(ras);
+        auto hist = predHist[tid].begin();
 
-            DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Incorrect call/return "
-                    "PC %#x. Fix RAS.\n", tid, pred_hist.front().seqNum,
-                    pred_hist.front().pc);
+        squashHistory(tid, *hist);
 
-            ras->squash(tid, pred_hist.front().rasHistory);
-        }
+        DPRINTF(Branch, "[tid:%i, squash sn:%llu] Removing history for "
+                "sn:%llu, PC:%#x\n", tid, squashed_sn, (*hist)->seqNum,
+                (*hist)->pc);
 
-        // This call should delete the bpHistory.
-        squash(tid, pred_hist.front().bpHistory);
-        if (iPred) {
-            iPred->squash(tid, pred_hist.front().seqNum,
-                               pred_hist.front().indirectHistory);
-        }
 
-        DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
-                "Removing history for [sn:%llu] "
-                "PC %#x\n", tid, squashed_sn, pred_hist.front().seqNum,
-                pred_hist.front().pc);
+        delete predHist[tid].front();
+        predHist[tid].pop_front();
 
-        pred_hist.pop_front();
-
-        DPRINTF(Branch, "[tid:%i] [squash sn:%llu] predHist.size(): %i\n",
+        DPRINTF(Branch, "[tid:%i] [squash sn:%llu] pred_hist.size(): %i\n",
                 tid, squashed_sn, predHist[tid].size());
     }
 }
 
+
+
+void
+BPredUnit::squashHistory(ThreadID tid, PredictorHistory* &history)
+{
+
+    stats.squashes[tid][history->type]++;
+    DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Incorrect: %s\n",
+                tid, history->seqNum,
+                toString(history->type));
+
+
+    if (history->rasHistory) {
+        assert(ras);
+
+        DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Incorrect call/return "
+                "PC %#x. Fix RAS.\n", tid, history->seqNum,
+                history->pc);
+
+        ras->squash(tid, history->rasHistory);
+    }
+
+    if (iPred) {
+        iPred->squash(tid, history->seqNum,
+                        history->indirectHistory);
+    }
+
+    // This call should delete the bpHistory.
+    squash(tid, history->bpHistory);
+}
+
+
 void
 BPredUnit::squash(const InstSeqNum &squashed_sn,
                   const PCStateBase &corr_target,
-                  bool actually_taken, ThreadID tid)
+                  bool actually_taken, ThreadID tid, bool from_commit)
 {
     // Now that we know that a branch was mispredicted, we need to undo
     // all the branches that have been seen up until this branch and
@@ -379,10 +484,15 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
     ++stats.condIncorrect;
     ppMisses->notify(1);
 
-    DPRINTF(Branch, "[tid:%i] Squashing from sequence number %i, "
-            "setting target to %s\n", tid, squashed_sn, corr_target);
+
+    DPRINTF(Branch, "[tid:%i] Squash from %s start from sequence number %i, "
+            "setting target to %s\n", tid, from_commit ? "commit" : "decode",
+            squashed_sn, corr_target);
+
+    // dump();
 
     // Squash All Branches AFTER this mispredicted branch
+    // First the Prefetch history then the main history.
     squash(squashed_sn, tid);
 
     // If there's a squash due to a syscall, there may not be an entry
@@ -390,25 +500,32 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
     // fix up the entry.
     if (!pred_hist.empty()) {
 
-        auto hist_it = pred_hist.begin();
-        //HistoryIt hist_it = find(pred_hist.begin(), pred_hist.end(),
-        //                       squashed_sn);
+        PredictorHistory* const hist = *(pred_hist.begin());
 
-        //assert(hist_it != pred_hist.end());
-        if (pred_hist.front().seqNum != squashed_sn) {
-            DPRINTF(Branch, "Front sn %i != Squash sn %i\n",
-                    pred_hist.front().seqNum, squashed_sn);
+        DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Mispredicted: %s, PC:%#x\n",
+                    tid, squashed_sn, toString(hist->type), hist->pc);
 
-            assert(pred_hist.front().seqNum == squashed_sn);
+        // Update stats
+        stats.corrected[tid][hist->type]++;
+        if (hist->target &&
+            (hist->target->instAddr() != corr_target.instAddr())) {
+                stats.targetWrong[tid][hist->targetProvider]++;
         }
 
-
-        if ((*hist_it).usedRAS) {
-            ++stats.RASIncorrect;
-            DPRINTF(Branch,
-                    "[tid:%i] [squash sn:%llu] Incorrect RAS [sn:%llu]\n",
-                    tid, squashed_sn, hist_it->seqNum);
+        ++stats.incorrect;
+        // If the squash is comming from decode it can be
+        // redirected earlier. Note that this branch might never get
+        // committed as a preceeding branch was mispredicted
+        if (!from_commit) {
+            stats.earlyResteers[tid][hist->type]++;
         }
+
+        if (actually_taken) {
+            ++stats.NotTakenMispredicted;
+        } else {
+           ++stats.TakenMispredicted;
+        }
+
 
         // There are separate functions for in-order and out-of-order
         // branch prediction, but not for update. Therefore, this
@@ -419,21 +536,21 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
         // local/global histories. The counter tables will be updated when
         // the branch actually commits.
 
-        // Remember the correct direction for the update at commit.
-        pred_hist.front().predTaken = actually_taken;
-        pred_hist.front().target = corr_target.instAddr();
+        // Remember the correct direction and target for the update at commit.
+        hist->mispredict = true;
+        hist->actuallyTaken = actually_taken;
+        set(hist->target,  corr_target);
 
-        update(tid, (*hist_it).pc, actually_taken,
-               pred_hist.front().bpHistory, true, pred_hist.front().inst,
-               corr_target.instAddr());
+        // Correct Direction predictor ------------------
+        update(tid, hist->pc, actually_taken, hist->bpHistory,
+               true, hist->inst, corr_target.instAddr());
+
 
         // Correct Indirect predictor -------------------
         if (iPred) {
-            iPred->update(tid, squashed_sn, (*hist_it).pc,
+            iPred->update(tid, squashed_sn, hist->pc,
                             true, actually_taken, corr_target,
-                            getBranchType(pred_hist.front().inst),
-                            (*hist_it).indirectHistory);
-
+                            hist->type, hist->indirectHistory);
         }
 
         // Correct RAS ---------------------------------
@@ -441,56 +558,58 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
             if (actually_taken) {
                 // The branch was taken but the RAS was not updated
                 // accordingly. Needs to be fixed.
-                if (hist_it->inst->isCall()
-                    && (hist_it->rasHistory == nullptr)) {
+                if (hist->call && (hist->rasHistory == nullptr)) {
 
                     // Incase of a call build the return address and
                     // push it to the RAS.
-                    auto return_addr = hist_it->inst->buildRetPC(
+                    auto return_addr = hist->inst->buildRetPC(
                                                     corr_target, corr_target);
 
                     DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
                             "Incorrectly predicted call: [sn:%llu,PC:%#x] "
                             " Push return address %s onto RAS\n", tid,
-                            squashed_sn, hist_it->seqNum, hist_it->pc,
+                            squashed_sn, hist->seqNum, hist->pc,
                             *return_addr);
-                    ras->push(tid, *return_addr, hist_it->rasHistory);
+                    ras->push(tid, *return_addr, hist->rasHistory);
                 }
 
-                if (hist_it->inst->isReturn()
-                    && (hist_it->rasHistory == nullptr)) {
+                if (hist->type == BranchType::Return
+                    && (hist->rasHistory == nullptr)) {
                     DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
                         "Incorrectly predicted return [sn:%llu] PC: %#x\n",
-                        tid, squashed_sn, hist_it->seqNum, hist_it->pc);
+                        tid, squashed_sn, hist->seqNum, hist->pc);
 
-                    ras->pop(tid, hist_it->rasHistory);
+                    ras->pop(tid, hist->rasHistory);
                 }
 
-            } else if (hist_it->rasHistory != nullptr) {
+            } else if (hist->rasHistory != nullptr) {
                 // The branch was not taken but the RAS was modified.
                 // Needs to be fixed.
-                ras->squash(tid, hist_it->rasHistory);
+                ras->squash(tid, hist->rasHistory);
             }
         }
 
-        if (actually_taken) {
-            if (hist_it->wasIndirect) {
-                ++stats.indirectMispredicted;
-            } else {
-                DPRINTF(Branch,"[tid:%i] [squash sn:%llu] "
-                        "BTB Update called for [sn:%llu] "
-                        "PC %#x\n", tid, squashed_sn,
-                        hist_it->seqNum, hist_it->pc);
+        // Correct BTB ---------------------------------
+        // Check if the misprediction was because there was a
+        // BTB miss.
+        if (actually_taken &&!hist->btbHit) {
+            ++stats.BTBMispredicted;
+            if (hist->condPred)
+                ++stats.predTakenBTBMiss;
 
-                ++stats.BTBUpdates;
-                btb->update(tid, hist_it->pc, corr_target);
-            }
+            btb->incorrectTarget(hist->pc, hist->type);
+
+            DPRINTF(Branch,"[tid:%i] [squash sn:%llu] "
+                "BTB miss PC %#x %s \n", tid, squashed_sn,
+                hist->pc, toString(hist->type));
         }
+
     } else {
         DPRINTF(Branch, "[tid:%i] [sn:%llu] pred_hist empty, can't "
                 "update\n", tid, squashed_sn);
     }
 }
+
 
 void
 BPredUnit::dump()
@@ -498,22 +617,122 @@ BPredUnit::dump()
     int i = 0;
     for (const auto& ph : predHist) {
         if (!ph.empty()) {
-            auto pred_hist_it = ph.begin();
+            auto hist = ph.begin();
 
             cprintf("predHist[%i].size(): %i\n", i++, ph.size());
 
-            while (pred_hist_it != ph.end()) {
+            while (hist != ph.end()) {
                 cprintf("sn:%llu], PC:%#x, tid:%i, predTaken:%i, "
-                        "bpHistory:%#x\n",
-                        pred_hist_it->seqNum, pred_hist_it->pc,
-                        pred_hist_it->tid, pred_hist_it->predTaken,
-                        pred_hist_it->bpHistory);
-                pred_hist_it++;
+                        "bpHistory:%#x, rasHistory:%#x\n",
+                        (*hist)->seqNum, (*hist)->pc,
+                        (*hist)->tid, (*hist)->predTaken,
+                        (*hist)->bpHistory, (*hist)->rasHistory);
+                hist++;
             }
 
             cprintf("\n");
         }
     }
+}
+
+
+BPredUnit::BPredUnitStats::BPredUnitStats(
+                                statistics::Group *parent, BPredUnit *bp)
+    : statistics::Group(parent),
+      ADD_STAT(lookups, statistics::units::Count::get(),
+              "Number of BP lookups"),
+      ADD_STAT(squashes, statistics::units::Count::get(),
+              "Number of branches that got squashed as an earlier branch was "
+              "mispredicted."),
+      ADD_STAT(corrected, statistics::units::Count::get(),
+              "Number of branches that got corrected but not yet commited. "),
+      ADD_STAT(committed, statistics::units::Count::get(),
+              "Number of branches finally committed "),
+      ADD_STAT(mispredicted, statistics::units::Count::get(),
+              "Number of committed branches that where mispredicted."),
+      ADD_STAT(targetProvider, statistics::units::Count::get(),
+              "Number of branches commited per branch type"),
+      ADD_STAT(targetWrong, statistics::units::Count::get(),
+              "Number of branches commited per branch type"),
+      ADD_STAT(earlyResteers, statistics::units::Count::get(),
+              "Number of branches that got squashed after decode."),
+
+      ADD_STAT(condPredicted, statistics::units::Count::get(),
+               "Number of conditional branches predicted"),
+      ADD_STAT(condPredictedTaken, statistics::units::Count::get(),
+               "Number of conditional branches predicted as taken"),
+      ADD_STAT(condIncorrect, statistics::units::Count::get(),
+               "Number of conditional branches incorrect"),
+      ADD_STAT(incorrect, statistics::units::Count::get(),
+               "Number of branches incorrect"),
+      ADD_STAT(BTBLookups, statistics::units::Count::get(),
+               "Number of BTB lookups"),
+      ADD_STAT(BTBUpdates, statistics::units::Count::get(),
+               "Number of BTB lookups"),
+      ADD_STAT(BTBHits, statistics::units::Count::get(),
+               "Number of BTB hits"),
+      ADD_STAT(BTBHitRatio, statistics::units::Ratio::get(), "BTB Hit Ratio",
+               BTBHits / BTBLookups),
+      ADD_STAT(BTBMispredicted, statistics::units::Count::get(),
+               "Number BTB misspredictions. No target found or target wrong"),
+      ADD_STAT(indirectLookups, statistics::units::Count::get(),
+               "Number of indirect predictor lookups."),
+      ADD_STAT(indirectHits, statistics::units::Count::get(),
+               "Number of indirect target hits."),
+      ADD_STAT(indirectMisses, statistics::units::Count::get(),
+               "Number of indirect misses."),
+      ADD_STAT(indirectMispredicted, statistics::units::Count::get(),
+               "Number of mispredicted indirect branches."),
+      ADD_STAT(predTakenBTBMiss, statistics::units::Count::get(),
+               "Number of branches predicted taken but miss in BTB"),
+      ADD_STAT(NotTakenMispredicted, statistics::units::Count::get(),
+               "Number branches predicted 'not taken' but turn out "
+               "to be taken"),
+      ADD_STAT(TakenMispredicted, statistics::units::Count::get(),
+               "Number branches predicted taken but turn out to be not taken")
+{
+    using namespace statistics;
+    BTBHitRatio.precision(6);
+
+    lookups
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    lookups.ysubnames(enums::BranchTypeStrings);
+
+    squashes
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    squashes.ysubnames(enums::BranchTypeStrings);
+
+    corrected
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    corrected.ysubnames(enums::BranchTypeStrings);
+
+    committed
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    committed.ysubnames(enums::BranchTypeStrings);
+
+    mispredicted
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    mispredicted.ysubnames(enums::BranchTypeStrings);
+
+    targetProvider
+        .init(bp->numThreads, enums::Num_TargetProvider)
+        .flags(total | pdf);
+    targetProvider.ysubnames(enums::TargetProviderStrings);
+
+    targetWrong
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    targetWrong.ysubnames(enums::BranchTypeStrings);
+
+    earlyResteers
+        .init(bp->numThreads, enums::Num_BranchType)
+        .flags(total | pdf);
+    earlyResteers.ysubnames(enums::BranchTypeStrings);
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011-2012, 2014 ARM Limited
- * Copyright (c) 2010 The University of Edinburgh
+ * Copyright (c) 2010,2022-2023 The University of Edinburgh
  * Copyright (c) 2012 Mark D. Hill and David A. Wood
  * All rights reserved
  *
@@ -59,10 +59,7 @@ BPredUnit::BPredUnit(const Params &params)
     : SimObject(params),
       numThreads(params.numThreads),
       predHist(numThreads),
-      BTB(params.BTBEntries,
-          params.BTBTagSize,
-          params.instShiftAmt,
-          params.numThreads),
+      btb(params.btb),
       RAS(numThreads),
       iPred(params.indirectBranchPred),
       stats(this),
@@ -218,10 +215,12 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
             if (inst->isDirectCtrl() || !iPred) {
                 ++stats.BTBLookups;
                 // Check BTB on direct branches
-                if (BTB.valid(pc.instAddr(), tid)) {
+                const PCStateBase * btb_target = btb->lookup(tid,
+                                                       pc.instAddr());
+                if (btb_target) {
                     ++stats.BTBHits;
                     // If it's not a return, use the BTB to get target addr.
-                    set(target, BTB.lookup(pc.instAddr(), tid));
+                    set(target, btb_target);
                     DPRINTF(Branch,
                             "[tid:%i] [sn:%llu] Instruction %s predicted "
                             "target is %s\n",
@@ -482,7 +481,7 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
                         hist_it->seqNum, hist_it->pc);
 
                 ++stats.BTBUpdates;
-                BTB.update(hist_it->pc, corr_target, tid);
+                btb->update(tid, hist_it->pc, corr_target);
             }
         } else {
            //Actually not Taken

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -60,13 +60,11 @@ BPredUnit::BPredUnit(const Params &params)
       numThreads(params.numThreads),
       predHist(numThreads),
       btb(params.btb),
-      RAS(numThreads),
+      ras(params.ras),
       iPred(params.indirectBranchPred),
       stats(this),
       instShiftAmt(params.instShiftAmt)
 {
-    for (auto& r : RAS)
-        r.init(params.RASSize);
 }
 
 BPredUnit::BPredUnitStats::BPredUnitStats(statistics::Group *parent)
@@ -176,19 +174,12 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
         //       support coroutines.
         if (inst->isReturn()) {
             ++stats.RASUsed;
-            predict_record.wasReturn = true;
-            // If it's a function return call, then look up the address
-            // in the RAS.
-            const PCStateBase *ras_top = RAS[tid].top();
-            if (ras_top)
-                set(target, inst->buildRetPC(pc, *ras_top));
-
-            // Record the top entry of the RAS, and its index.
-            predict_record.usedRAS = true;
-            predict_record.RASIndex = RAS[tid].topIdx();
-            set(predict_record.RASTarget, ras_top);
-
-            RAS[tid].pop();
+            // If it's a return from a function call, then look up the
+            // RETURN address in the RAS.
+            const PCStateBase *return_addr = ras->pop(tid,
+                                                predict_record.rasHistory);
+            if (return_addr)
+                set(target, return_addr);
 
             DPRINTF(Branch, "[tid:%i] [sn:%llu] Instruction %s is a return, "
                     "RAS predicted target: %s, RAS index: %i\n",
@@ -196,17 +187,17 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
         }
 
         if (inst->isCall()) {
-            RAS[tid].push(pc);
-            predict_record.pushedRAS = true;
+            // Incase of a call build the return address and
+            // push it to the RAS.
+            auto return_addr = inst->buildRetPC(pc, pc);
+            ras->push(tid, *return_addr, predict_record.rasHistory);
 
             // Record that it was a call so that the top RAS entry can
             // be popped off if the speculation is incorrect.
-            predict_record.wasCall = true;
+            DPRINTF(Branch, "[tid:%i] [sn:%llu] Instr. %s was "
+                    "a call, push return address %s onto the RAS\n",
+                    tid, seqNum, pc, *return_addr);
 
-            DPRINTF(Branch,
-                    "[tid:%i] [sn:%llu] Instruction %s was a call, adding "
-                    "%s to the RAS index: %i\n",
-                    tid, seqNum, pc, pc, RAS[tid].topIdx());
         }
 
         // The target address is not predicted by RAS.
@@ -240,7 +231,7 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                                 "called for %s\n",
                                 tid, seqNum, pc);
                     } else if (inst->isCall() && !inst->isUncondCtrl()) {
-                        RAS[tid].pop();
+                        ras->squash(tid, predict_record.rasHistory);
                         predict_record.pushedRAS = false;
                     }
                     inst->advancePC(*target);
@@ -267,8 +258,7 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                     if (!inst->isCall() && !inst->isReturn()) {
 
                     } else if (inst->isCall() && !inst->isUncondCtrl()) {
-                        RAS[tid].pop();
-                        predict_record.pushedRAS = false;
+                        ras->squash(tid, predict_record.rasHistory);
                     }
                     inst->advancePC(*target);
                 }
@@ -277,9 +267,6 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
             }
         }
     } else {
-        if (inst->isReturn()) {
-           predict_record.wasReturn = true;
-        }
         inst->advancePC(*target);
     }
     predict_record.target = target->instAddr();
@@ -324,6 +311,12 @@ BPredUnit::update(const InstSeqNum &done_sn, ThreadID tid)
             iPred->commit(done_sn, tid, predHist[tid].back().indirectHistory);
         }
 
+        if (ras) {
+            ras->commit(tid, /** TODO */ false,
+                            getBranchType(predHist[tid].back().inst),
+                            predHist[tid].back().rasHistory);
+        }
+
         predHist[tid].pop_back();
     }
 }
@@ -339,30 +332,15 @@ BPredUnit::squash(const InstSeqNum &squashed_sn, ThreadID tid)
 
     while (!pred_hist.empty() &&
            pred_hist.front().seqNum > squashed_sn) {
-        if (pred_hist.front().wasCall && pred_hist.front().pushedRAS) {
-             // Was a call but predicated false. Pop RAS here
-             DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Squashing"
-                     "  Call [sn:%llu] PC: %s Popping RAS\n", tid, squashed_sn,
-                     pred_hist.front().seqNum, pred_hist.front().pc);
-             RAS[tid].pop();
-        }
-        if (pred_hist.front().usedRAS) {
-            if (pred_hist.front().RASTarget != nullptr) {
-                DPRINTF(Branch, "[tid:%i] [squash sn:%llu]"
-                        " Restoring top of RAS to: %i,"
-                        " target: %s\n", tid, squashed_sn,
-                        pred_hist.front().RASIndex,
-                        *pred_hist.front().RASTarget);
-            }
-            else {
-                DPRINTF(Branch, "[tid:%i] [squash sn:%llu]"
-                        " Restoring top of RAS to: %i,"
-                        " target: INVALID_TARGET\n", tid, squashed_sn,
-                        pred_hist.front().RASIndex);
-            }
 
-            RAS[tid].restore(pred_hist.front().RASIndex,
-                             pred_hist.front().RASTarget.get());
+        if (pred_hist.front().rasHistory) {
+            assert(ras);
+
+            DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Incorrect call/return "
+                    "PC %#x. Fix RAS.\n", tid, pred_hist.front().seqNum,
+                    pred_hist.front().pc);
+
+            ras->squash(tid, pred_hist.front().rasHistory);
         }
 
         // This call should delete the bpHistory.
@@ -457,16 +435,44 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
                 pred_hist.front().indirectHistory, actually_taken);
         }
 
-        if (actually_taken) {
-            if (hist_it->wasReturn && !hist_it->usedRAS) {
-                 DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
-                        "Incorrectly predicted "
-                        "return [sn:%llu] PC: %#x\n", tid, squashed_sn,
-                        hist_it->seqNum,
-                        hist_it->pc);
-                 RAS[tid].pop();
-                 hist_it->usedRAS = true;
+        // Correct RAS ---------------------------------
+        if (ras) {
+            if (actually_taken) {
+                // The branch was taken but the RAS was not updated
+                // accordingly. Needs to be fixed.
+                if (hist_it->inst->isCall()
+                    && (hist_it->rasHistory == nullptr)) {
+
+                    // Incase of a call build the return address and
+                    // push it to the RAS.
+                    auto return_addr = hist_it->inst->buildRetPC(
+                                                    corr_target, corr_target);
+
+                    DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
+                            "Incorrectly predicted call: [sn:%llu,PC:%#x] "
+                            " Push return address %s onto RAS\n", tid,
+                            squashed_sn, hist_it->seqNum, hist_it->pc,
+                            *return_addr);
+                    ras->push(tid, *return_addr, hist_it->rasHistory);
+                }
+
+                if (hist_it->inst->isReturn()
+                    && (hist_it->rasHistory == nullptr)) {
+                    DPRINTF(Branch, "[tid:%i] [squash sn:%llu] "
+                        "Incorrectly predicted return [sn:%llu] PC: %#x\n",
+                        tid, squashed_sn, hist_it->seqNum, hist_it->pc);
+
+                    ras->pop(tid, hist_it->rasHistory);
+                }
+
+            } else if (hist_it->rasHistory != nullptr) {
+                // The branch was not taken but the RAS was modified.
+                // Needs to be fixed.
+                ras->squash(tid, hist_it->rasHistory);
             }
+        }
+
+        if (actually_taken) {
             if (hist_it->wasIndirect) {
                 ++stats.indirectMispredicted;
                 if (iPred) {
@@ -483,42 +489,6 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
                 ++stats.BTBUpdates;
                 btb->update(tid, hist_it->pc, corr_target);
             }
-        } else {
-           //Actually not Taken
-           if (hist_it->wasCall && hist_it->pushedRAS) {
-                 //Was a Call but predicated false. Pop RAS here
-                 DPRINTF(Branch,
-                        "[tid:%i] [squash sn:%llu] "
-                        "Incorrectly predicted "
-                        "Call [sn:%llu] PC: %s Popping RAS\n",
-                        tid, squashed_sn,
-                        hist_it->seqNum, hist_it->pc);
-                 RAS[tid].pop();
-                 hist_it->pushedRAS = false;
-           }
-           if (hist_it->usedRAS) {
-
-                std::string RASTarget;
-
-                DPRINTF(Branch,
-                        "[tid:%i] [squash sn:%llu] Incorrectly predicted "
-                        "return [sn:%llu] PC: %#x Restoring RAS\n", tid,
-                        squashed_sn,
-                        hist_it->seqNum, hist_it->pc);
-                if (hist_it->RASTarget) {
-                    std::ostringstream os;
-                    os << *hist_it->RASTarget.get();
-                    RASTarget = os.str();
-                } else {
-                    RASTarget = "no RAS";
-                }
-                DPRINTF(Branch,
-                        "[tid:%i] [squash sn:%llu] Restoring top of RAS "
-                        "to: %i, target: %s\n", tid, squashed_sn,
-                        hist_it->RASIndex, RASTarget.c_str());
-                RAS[tid].restore(hist_it->RASIndex, hist_it->RASTarget.get());
-                hist_it->usedRAS = false;
-           }
         }
     } else {
         DPRINTF(Branch, "[tid:%i] [sn:%llu] pred_hist empty, can't "

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -46,12 +46,13 @@
 
 #include "base/statistics.hh"
 #include "base/types.hh"
+#include "cpu/inst_seq.hh"
 #include "cpu/pred/branch_type.hh"
 #include "cpu/pred/btb.hh"
 #include "cpu/pred/indirect.hh"
 #include "cpu/pred/ras.hh"
-#include "cpu/inst_seq.hh"
 #include "cpu/static_inst.hh"
+#include "enums/TargetProvider.hh"
 #include "params/BranchPredictor.hh"
 #include "sim/probe/pmu.hh"
 #include "sim/sim_object.hh"
@@ -68,8 +69,14 @@ namespace branch_prediction
  */
 class BPredUnit : public SimObject
 {
+    typedef BranchPredictorParams Params;
+    typedef enums::TargetProvider TargetProvider;
+
+    /** Branch Predictor Unit (BPU) interface functions */
   public:
-      typedef BranchPredictorParams Params;
+
+
+
     /**
      * @param params The params object, that has the size of the BP and BTB.
      */
@@ -90,9 +97,6 @@ class BPredUnit : public SimObject
      */
     bool predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                  PCStateBase &pc, ThreadID tid);
-
-    // @todo: Rename this function.
-    virtual void uncondBranch(ThreadID tid, Addr pc, void * &bp_history) = 0;
 
     /**
      * Tells the branch predictor to commit any updates until the given
@@ -118,35 +122,70 @@ class BPredUnit : public SimObject
      * @param corr_target The correct branch target.
      * @param actually_taken The correct branch direction.
      * @param tid The thread id.
+     * @param inst The static instruction that caused the misprediction
+     * @param from_commit Indicate whether the squash is comming from commit
+     *              or from decode. Its optional and used for statistics.
      */
     void squash(const InstSeqNum &squashed_sn,
                 const PCStateBase &corr_target,
-                bool actually_taken, ThreadID tid);
+                bool actually_taken, ThreadID tid, bool from_commit=true);
+
+  protected:
+
+    /** *******************************************************
+     * Interface functions to the conditional branch predictor
+     *
+    */
 
     /**
-     * @param bp_history Pointer to the history object.  The predictor
-     * will need to update any state and delete the object.
-     */
-    virtual void squash(ThreadID tid, void *bp_history) = 0;
-
-    /**
-     * Looks up a given PC in the BP to see if it is taken or not taken.
-     * @param inst_PC The PC to look up.
-     * @param bp_history Pointer that will be set to an object that
+     * Looks up a given conditional branch PC of in the BP to see if it
+     * is taken or not taken.
+     * @param PC The PC to look up.
+     * @param bpHistory Pointer that will be set to an object that
      * has the branch predictor state associated with the lookup.
      * @return Whether the branch is taken or not taken.
      */
-    virtual bool lookup(ThreadID tid, Addr instPC, void * &bp_history) = 0;
+    virtual bool lookup(ThreadID tid, Addr pc, void * &bpHistory) = 0;
 
-     /**
-     * If a branch is not taken, because the BTB address is invalid or missing,
-     * this function sets the appropriate counter in the global and local
-     * predictors to not taken.
-     * @param inst_PC The PC to look up the local predictor.
-     * @param bp_history Pointer that will be set to an object that
+    /**
+     * Once done with the prediction this function updates the
+     * path and global history. All branches call this function
+     * including unconditional once.
+     * @param PC The branch's PC that will be updated.
+     * @param uncond Wheather or not this branch is an unconditional branch.
+     * @param taken Whether or not the branch was taken
+     * @param target The final target of branch. Some modern
+     * predictors use the target in their history.
+     * @param bpHistory Pointer that will be set to an object that
      * has the branch predictor state associated with the lookup.
      */
-    virtual void btbUpdate(ThreadID tid, Addr instPC, void * &bp_history) = 0;
+    virtual void updateHistories(ThreadID tid, Addr pc, bool uncond,
+                            bool taken, Addr target, void * &bpHistory) = 0;
+
+    /**
+     * @param bpHistory Pointer to the history object.  The predictor
+     * will need to update any state and delete the object.
+     */
+    virtual void squash(ThreadID tid, void * &bpHistory) = 0;
+
+
+    /**
+     * Updates the BP with taken/not taken information.
+     * @param PC The branch's PC that will be updated.
+     * @param taken Whether the branch was taken or not taken.
+     * @param bpHistory Pointer to the branch predictor state that is
+     * associated with the branch lookup that is being updated.
+     * @param squashed Set to true when this function is called during a
+     * squash operation.
+     * @param inst Static instruction information
+     * @param corrTarget The resolved target of the branch (only needed
+     * for squashed branches)
+     * @todo Make this update flexible enough to handle a global predictor.
+     */
+    virtual void update(ThreadID tid, Addr pc, bool taken,
+                   void * &bpHistory, bool squashed,
+                   const StaticInstPtr &inst, Addr corrTarget) = 0;
+
 
     /**
      * Looks up a given PC in the BTB to see if a matching entry exists.
@@ -176,21 +215,26 @@ class BPredUnit : public SimObject
     }
 
     /**
-     * Updates the BP with taken/not taken information.
-     * @param inst_PC The branch's PC that will be updated.
-     * @param taken Whether the branch was taken or not taken.
-     * @param bp_history Pointer to the branch predictor state that is
-     * associated with the branch lookup that is being updated.
-     * @param squashed Set to true when this function is called during a
-     * squash operation.
-     * @param inst Static instruction information
-     * @param corrTarget The resolved target of the branch (only needed
-     * for squashed branches)
-     * @todo Make this update flexible enough to handle a global predictor.
+     * Looks up a given PC in the BTB to get current static instruction
+     * information. This is necessary in a decoupled frontend as
+     * the information does not usually exist at that this point.
+     * Only for instructions (branches) that hit in the BTB this information
+     * is available as the BTB stores them together with the target.
+     *
+     * @param inst_PC The PC to look up.
+     * @return The static instruction info of the given PC if existant.
      */
-    virtual void update(ThreadID tid, Addr instPC, bool taken,
-                   void *bp_history, bool squashed,
-                   const StaticInstPtr &inst, Addr corrTarget) = 0;
+    const StaticInstPtr
+    BTBLookupInst(ThreadID tid, Addr instPC)
+    {
+        return btb->lookupInst(tid, instPC);
+    }
+    const StaticInstPtr
+    BTBLookupInst(ThreadID tid, PCStateBase &instPC)
+    {
+        return BTBLookupInst(tid, instPC.instAddr());
+    }
+
     /**
      * Updates the BTB with the target of a branch.
      * @param inst_PC The branch's PC that will be updated.
@@ -213,27 +257,27 @@ class BPredUnit : public SimObject
          * Makes a predictor history struct that contains any
          * information needed to update the predictor, BTB, and RAS.
          */
-        PredictorHistory(const InstSeqNum &seq_num, Addr instPC,
-                         bool pred_taken, void *bp_history,
-                         void *indirect_history, ThreadID _tid,
+        PredictorHistory(ThreadID _tid, InstSeqNum sn, Addr _pc,
                          const StaticInstPtr & inst)
-            : seqNum(seq_num), pc(instPC), bpHistory(bp_history),
-              indirectHistory(indirect_history), rasHistory(nullptr),
-              tid(_tid),
-              predTaken(pred_taken), inst(inst)
-        {}
+            : seqNum(sn), tid(_tid), pc(_pc),
+              inst(inst), type(getBranchType(inst)),
+              call(inst->isCall()), uncond(inst->isUncondCtrl()),
+              predTaken(false), actuallyTaken(false), condPred(false),
+              btbHit(false), targetProvider(TargetProvider::NoTarget),
+              resteered(false), mispredict(false), target(nullptr),
+              bpHistory(nullptr),
+              indirectHistory(nullptr), rasHistory(nullptr)
+        { }
 
-        PredictorHistory(const PredictorHistory &other) :
-            seqNum(other.seqNum), pc(other.pc), bpHistory(other.bpHistory),
-            indirectHistory(other.indirectHistory),
-            rasHistory(other.rasHistory), RASIndex(other.RASIndex),
-            tid(other.tid), predTaken(other.predTaken), usedRAS(other.usedRAS),
-            pushedRAS(other.pushedRAS), wasCall(other.wasCall),
-            wasReturn(other.wasReturn), wasIndirect(other.wasIndirect),
-            target(other.target), inst(other.inst)
+        ~PredictorHistory()
         {
-            set(RASTarget, other.RASTarget);
+            assert(bpHistory == nullptr);
+            assert(indirectHistory == nullptr);
+            assert(rasHistory == nullptr);
         }
+
+        PredictorHistory (const PredictorHistory&) = delete;
+        PredictorHistory& operator= (const PredictorHistory&) = delete;
 
         bool
         operator==(const PredictorHistory &entry) const
@@ -242,14 +286,55 @@ class BPredUnit : public SimObject
         }
 
         /** The sequence number for the predictor history entry. */
-        InstSeqNum seqNum;
+        const InstSeqNum seqNum;
+
+        /** The thread id. */
+        const ThreadID tid;
 
         /** The PC associated with the sequence number. */
-        Addr pc;
+        const Addr pc;
 
-        /** Pointer to the history object passed back from the branch
-         * predictor.  It is used to update or restore state of the
-         * branch predictor.
+        /** The branch instrction */
+        const StaticInstPtr inst;
+
+        /** The type of the branch */
+        const BranchType type;
+
+        /** Whether or not the instruction was a call. */
+        const bool call;
+
+        /** Was unconditional control */
+        const bool uncond;
+
+        /** Whether or not it was predicted taken. */
+        bool predTaken;
+
+        /** To record the actual outcome of the branch */
+        bool actuallyTaken;
+
+        /** The prediction of the conditional predictor */
+        bool condPred;
+
+        /** Was BTB hit at prediction time */
+        bool btbHit;
+
+        /** Which component provided the target */
+        TargetProvider targetProvider;
+
+        /** Resteered */
+        bool resteered;
+
+        /** The branch was corrected hence was mispredicted. */
+        bool mispredict;
+
+        /** The predicted target */
+        std::unique_ptr<PCStateBase> target;
+
+        /**
+         * Pointer to the history objects passed back from the branch
+         * predictor subcomponents.
+         * It is used to update or restore state.
+         * Respectively for conditional, indirect and RAS.
          */
         void *bpHistory = nullptr;
 
@@ -257,47 +342,44 @@ class BPredUnit : public SimObject
 
         void *rasHistory = nullptr;
 
-        /** The RAS target (only valid if a return). */
-        std::unique_ptr<PCStateBase> RASTarget;
-
-        /** The RAS index of the instruction (only valid if a call). */
-        unsigned RASIndex = 0;
-
-        /** The thread id. */
-        ThreadID tid;
-
-        /** Whether or not it was predicted taken. */
-        bool predTaken;
-
-        /** Whether or not the RAS was used. */
-        bool usedRAS = false;
-
-        /* Whether or not the RAS was pushed */
-        bool pushedRAS = false;
-
-        /** Whether or not the instruction was a call. */
-        bool wasCall = false;
-
-        /** Whether or not the instruction was a return. */
-        bool wasReturn = false;
-
-        /** Wether this instruction was an indirect branch */
-        bool wasIndirect = false;
-
-        /** Target of the branch. First it is predicted, and fixed later
-         *  if necessary
-         */
-        Addr target = MaxAddr;
-
-        /** The branch instrction */
-        const StaticInstPtr inst;
     };
 
-    typedef std::deque<PredictorHistory> History;
+    typedef std::deque<PredictorHistory*> History;
 
+
+    /**
+     * Internal prediction function.
+    */
+    bool predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
+               PCStateBase &pc, ThreadID tid, PredictorHistory* &bpu_history);
+
+    /**
+     * Squashes a particular branch instance
+     * @param tid The thread id.
+     * @param bpu_history The history to be squashed.
+     */
+    void squashHistory(ThreadID tid, PredictorHistory* &bpu_history);
+
+
+    /**
+     * Commit a particular branch
+     * @param tid The thread id.
+     * @param bpu_history The history of the branch to be commited.
+     */
+    void commitBranch(ThreadID tid, PredictorHistory* &bpu_history);
+
+
+
+  protected:
     /** Number of the threads for which the branch history is maintained. */
     const unsigned numThreads;
 
+    /** Requires the BTB to hit for returns and indirect branches. For an
+     * advances front-end there is no other way to know about the branch. */
+    const bool requiresBTBHit;
+
+    /** Number of bits to shift instructions by for predictor addresses. */
+    const unsigned instShiftAmt;
 
     /**
      * The per-thread predictor history. This is used to update the predictor
@@ -315,28 +397,51 @@ class BPredUnit : public SimObject
     /** The indirect target predictor. */
     IndirectPredictor * iPred;
 
+    /** Statistics */
     struct BPredUnitStats : public statistics::Group
     {
-        BPredUnitStats(statistics::Group *parent);
+        BPredUnitStats(statistics::Group *parent, BPredUnit *bp);
 
         /** Stat for number of BP lookups. */
-        statistics::Scalar lookups;
+        statistics::Vector2d lookups;
+        /** Stat for branches that got squashed as an earlier branch was
+         * mispredicted. */
+        statistics::Vector2d squashes;
+        /** Stat for branches that got corrected but not yet commited.
+         * A corrected branch might not be commited in case an earlier
+         * branch was mispredicted */
+        statistics::Vector2d corrected;
+        /** Stat for branches finally committed */
+        statistics::Vector2d committed;
+        /** Stat for the number of committed branches that where
+         * mispredicted by the BPU */
+        statistics::Vector2d mispredicted;
+        /** Stat for the target provider of taken branches*/
+        statistics::Vector2d targetProvider;
+        /** Stat for branches where the target was incorrect or not
+         * available at prediction */
+        statistics::Vector2d targetWrong;
+        /** Stat for branches squashed from decode */
+        statistics::Vector2d earlyResteers;
+
         /** Stat for number of conditional branches predicted. */
         statistics::Scalar condPredicted;
+        /** Stat for n of conditional branches predicted as taken. */
+        statistics::Scalar condPredictedTaken;
         /** Stat for number of conditional branches predicted incorrectly. */
         statistics::Scalar condIncorrect;
+        /** Stat for number of branches predicted incorrectly. */
+        statistics::Scalar incorrect;
         /** Stat for number of BTB lookups. */
         statistics::Scalar BTBLookups;
         /** Stat for number of BTB updates. */
         statistics::Scalar BTBUpdates;
         /** Stat for number of BTB hits. */
         statistics::Scalar BTBHits;
-        /** Stat for the ratio between BTB hits and BTB lookups. */
+        /** Stat for number for the ratio between BTB hits and BTB lookups. */
         statistics::Formula BTBHitRatio;
-        /** Stat for number of times the RAS is used to get a target. */
-        statistics::Scalar RASUsed;
-        /** Stat for number of times the RAS is incorrect. */
-        statistics::Scalar RASIncorrect;
+        /** Stat for number BTB misspredictions. No or wrong target found */
+        statistics::Scalar BTBMispredicted;
 
         /** Stat for the number of indirect target lookups.*/
         statistics::Scalar indirectLookups;
@@ -346,11 +451,20 @@ class BPredUnit : public SimObject
         statistics::Scalar indirectMisses;
         /** Stat for the number of indirect target mispredictions.*/
         statistics::Scalar indirectMispredicted;
+
+        /** Stat for the number of branches predicted taken but miss in BTB*/
+        statistics::Scalar predTakenBTBMiss;
+        /** Stat for the number of branches predicted not taken but
+         * turn out to be taken*/
+        statistics::Scalar NotTakenMispredicted;
+        /** Stat for the number of branches predicted taken but turn
+         * out to be not taken*/
+        statistics::Scalar TakenMispredicted;
+
+
     } stats;
 
   protected:
-    /** Number of bits to shift instructions by for predictor addresses. */
-    const unsigned instShiftAmt;
 
     /**
      * @{

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -218,13 +218,15 @@ class BPredUnit : public SimObject
                          void *indirect_history, ThreadID _tid,
                          const StaticInstPtr & inst)
             : seqNum(seq_num), pc(instPC), bpHistory(bp_history),
-              indirectHistory(indirect_history), tid(_tid),
+              indirectHistory(indirect_history), rasHistory(nullptr),
+              tid(_tid),
               predTaken(pred_taken), inst(inst)
         {}
 
         PredictorHistory(const PredictorHistory &other) :
             seqNum(other.seqNum), pc(other.pc), bpHistory(other.bpHistory),
-            indirectHistory(other.indirectHistory), RASIndex(other.RASIndex),
+            indirectHistory(other.indirectHistory),
+            rasHistory(other.rasHistory), RASIndex(other.RASIndex),
             tid(other.tid), predTaken(other.predTaken), usedRAS(other.usedRAS),
             pushedRAS(other.pushedRAS), wasCall(other.wasCall),
             wasReturn(other.wasReturn), wasIndirect(other.wasIndirect),
@@ -252,6 +254,8 @@ class BPredUnit : public SimObject
         void *bpHistory = nullptr;
 
         void *indirectHistory = nullptr;
+
+        void *rasHistory = nullptr;
 
         /** The RAS target (only valid if a return). */
         std::unique_ptr<PCStateBase> RASTarget;
@@ -303,10 +307,10 @@ class BPredUnit : public SimObject
     std::vector<History> predHist;
 
     /** The BTB. */
-    BranchTargetBuffer* btb;
+    BranchTargetBuffer * btb;
 
-    /** The per-thread return address stack. */
-    std::vector<ReturnAddrStack> RAS;
+    /** The return address stack. */
+    ReturnAddrStack * ras;
 
     /** The indirect target predictor. */
     IndirectPredictor * iPred;

--- a/src/cpu/pred/indirect.hh
+++ b/src/cpu/pred/indirect.hh
@@ -1,6 +1,16 @@
 /*
  * Copyright (c) 2014 ARM Limited
- * All rights reserved.
+ * Copyright (c) 2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -26,11 +36,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* @file
+ * Indirect target predictor interface
+ */
+
 #ifndef __CPU_PRED_INDIRECT_BASE_HH__
 #define __CPU_PRED_INDIRECT_BASE_HH__
 
 #include "arch/generic/pcstate.hh"
 #include "cpu/inst_seq.hh"
+#include "cpu/pred/branch_type.hh"
 #include "params/IndirectPredictor.hh"
 #include "sim/sim_object.hh"
 
@@ -51,21 +66,55 @@ class IndirectPredictor : public SimObject
     {
     }
 
-    virtual bool lookup(Addr br_addr, PCStateBase& br_target,
-                        ThreadID tid) = 0;
-    virtual void recordIndirect(Addr br_addr, Addr tgt_addr,
-                                InstSeqNum seq_num, ThreadID tid) = 0;
-    virtual void commit(InstSeqNum seq_num, ThreadID tid,
-                        void * indirect_history) = 0;
-    virtual void squash(InstSeqNum seq_num, ThreadID tid) = 0;
-    virtual void recordTarget(InstSeqNum seq_num, void * indirect_history,
-                              const PCStateBase& target, ThreadID tid) = 0;
-    virtual void genIndirectInfo(ThreadID tid, void* & indirect_history) = 0;
-    virtual void updateDirectionInfo(ThreadID tid, bool actually_taken) = 0;
-    virtual void deleteIndirectInfo(ThreadID tid, void * indirect_history) = 0;
-    virtual void changeDirectionPrediction(ThreadID tid,
-                                           void * indirect_history,
-                                           bool actually_taken) = 0;
+    virtual void reset() {};
+
+    /**
+     * Predicts the indirect target of an indirect branch.
+     * @param tid Thread ID of the branch.
+     * @param sn The sequence number of the branch.
+     * @param PC The branch PC address.
+     * @param iHistory The pointer to the history object.
+     * @return For a hit the predictor returns a pointer to the target PCState
+     *         otherwise a nullptr is returned.
+     */
+    virtual const PCStateBase* lookup(ThreadID tid, InstSeqNum sn,
+                                      Addr pc, void * &iHistory) = 0;
+
+    /**
+     * Updates the indirect predictor with history information of a branch.
+     * Is called right after the prediction which updates the state
+     * speculatively. In case the branch was mispredicted the function
+     * is called again with the corrected information.
+     * The function is called for ALL branches as some predictors incooperate
+     * all branches in their history.
+     * @param PC The branch PC address.
+     * @param squash Whether the update is called at a misprediction
+     * @param taken Whether a conditional branch was taken
+     * @param target The target address if this branch.
+     * @param brType The branch instruction type.
+     * @param iHistory The pointer to the history object.
+     */
+    virtual void update(ThreadID tid, InstSeqNum sn, Addr pc, bool squash,
+                        bool taken, const PCStateBase& target,
+                        BranchType brType, void * &iHistory) = 0;
+
+    /**
+     * Squashes a branch. If the branch modified the history
+     * reverts the modification.
+     * @param tid Thread ID
+     * @param sn The sequence number of the branch.
+     * @param iHistory The pointer to the history object.
+     */
+    virtual void squash(ThreadID tid, InstSeqNum sn, void * &iHistory) = 0;
+
+    /**
+     * A branch gets finally commited. Updates the internal state of
+     * the indirect predictor (counter and target information).
+     * @param tid Thread ID
+     * @param sn The sequence number of the branch.
+     * @param iHistory The pointer to the history object.
+     */
+    virtual void commit(ThreadID tid, InstSeqNum sn, void * &iHistory) = 0;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/loop_predictor.cc
+++ b/src/cpu/pred/loop_predictor.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The University of Wisconsin
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
@@ -320,10 +332,13 @@ LoopPredictor::squashLoop(BranchInfo* bi)
 void
 LoopPredictor::updateStats(bool taken, BranchInfo* bi)
 {
-    if (taken == bi->loopPred) {
-        stats.correct++;
-    } else {
-        stats.wrong++;
+    if (bi->loopPredUsed) {
+        stats.used++;
+        if (taken == bi->loopPred) {
+            stats.correct++;
+        } else {
+            stats.wrong++;
+        }
     }
 }
 
@@ -354,6 +369,8 @@ LoopPredictor::condBranchUpdate(ThreadID tid, Addr branch_pc, bool taken,
 LoopPredictor::LoopPredictorStats::LoopPredictorStats(
     statistics::Group *parent)
     : statistics::Group(parent),
+      ADD_STAT(used, statistics::units::Count::get(),
+               "Number of times the loop predictor is the provider."),
       ADD_STAT(correct, statistics::units::Count::get(),
                "Number of times the loop predictor is the provider and the "
                "prediction is correct"),

--- a/src/cpu/pred/loop_predictor.hh
+++ b/src/cpu/pred/loop_predictor.hh
@@ -1,6 +1,17 @@
 /*
- * Copyright (c) 2014 The University of Wisconsin
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
  *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Copyright (c) 2014 The University of Wisconsin
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
  * Informatique et en Automatique  / French National Research Institute
  * for Computer Science and Applied Mathematics)
@@ -92,6 +103,7 @@ class LoopPredictor : public SimObject
     struct LoopPredictorStats : public statistics::Group
     {
         LoopPredictorStats(statistics::Group *parent);
+        statistics::Scalar used;
         statistics::Scalar correct;
         statistics::Scalar wrong;
     } stats;

--- a/src/cpu/pred/ltage.cc
+++ b/src/cpu/pred/ltage.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The University of Wisconsin
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
@@ -94,12 +106,12 @@ LTAGE::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void* &b)
 
 // PREDICTOR UPDATE
 void
-LTAGE::update(ThreadID tid, Addr branch_pc, bool taken, void* bp_history,
+LTAGE::update(ThreadID tid, Addr branch_pc, bool taken, void* &bpHistory,
               bool squashed, const StaticInstPtr & inst, Addr corrTarget)
 {
-    assert(bp_history);
+    assert(bpHistory);
 
-    LTageBranchInfo* bi = static_cast<LTageBranchInfo*>(bp_history);
+    LTageBranchInfo* bi = static_cast<LTageBranchInfo*>(bpHistory);
 
     if (squashed) {
         if (tage->isSpeculativeUpdateEnabled()) {
@@ -132,19 +144,19 @@ LTAGE::update(ThreadID tid, Addr branch_pc, bool taken, void* bp_history,
     tage->updateHistories(tid, branch_pc, taken, bi->tageBranchInfo, false,
                           inst, corrTarget);
 
-    delete bi;
+    delete bi; bpHistory = nullptr;
 }
 
 void
-LTAGE::squash(ThreadID tid, void *bp_history)
+LTAGE::squash(ThreadID tid, void * &bpHistory)
 {
-    LTageBranchInfo* bi = (LTageBranchInfo*)(bp_history);
+    LTageBranchInfo* bi = (LTageBranchInfo*)(bpHistory);
 
     if (bi->tageBranchInfo->condBranch) {
         loopPredictor->squash(tid, bi->lpBranchInfo);
     }
 
-    TAGE::squash(tid, bp_history);
+    TAGE::squash(tid, bpHistory);
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/ltage.hh
+++ b/src/cpu/pred/ltage.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The University of Wisconsin
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
@@ -69,8 +81,8 @@ class LTAGE : public TAGE
     LTAGE(const LTAGEParams &params);
 
     // Base class methods.
-    void squash(ThreadID tid, void *bp_history) override;
-    void update(ThreadID tid, Addr branch_addr, bool taken, void *bp_history,
+    void squash(ThreadID tid, void * &bpHistory) override;
+    void update(ThreadID tid, Addr branch_addr, bool taken, void * &bpHistory,
                 bool squashed, const StaticInstPtr & inst,
                 Addr corrTarget) override;
 
@@ -97,7 +109,7 @@ class LTAGE : public TAGE
 
         virtual ~LTageBranchInfo()
         {
-            delete lpBranchInfo;
+            delete lpBranchInfo; lpBranchInfo = nullptr;
         }
     };
 

--- a/src/cpu/pred/multiperspective_perceptron.cc
+++ b/src/cpu/pred/multiperspective_perceptron.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2019 Texas A&M University
  *
  * Redistribution and use in source and binary forms, with or without
@@ -547,14 +559,23 @@ MultiperspectivePerceptron::train(ThreadID tid, MPPBranchInfo &bi, bool taken)
     }
 }
 
+
 void
-MultiperspectivePerceptron::uncondBranch(ThreadID tid, Addr pc,
-                                         void * &bp_history)
+MultiperspectivePerceptron::updateHistories(ThreadID tid, Addr pc,
+                    bool uncond, bool taken, Addr target, void * &bpHistory)
 {
+    assert(uncond || bpHistory);
+
+    // For perceptron there is no speculative history correction.
+    // Conditional branches are done.
+    if (!uncond)
+        return;
+
+    // For uncondition branches create branch info.
     MPPBranchInfo *bi = new MPPBranchInfo(pc, pcshift, false);
     std::vector<unsigned int> &ghist_words = threadData[tid]->ghist_words;
 
-    bp_history = (void *)bi;
+    bpHistory = (void *)bi;
     unsigned short int pc2 = pc >> 2;
     bool ab = !(pc & (1<<pcbit));
     for (int i = 0; i < ghist_length / blockSize + 1; i += 1) {
@@ -572,10 +593,10 @@ MultiperspectivePerceptron::uncondBranch(ThreadID tid, Addr pc,
 
 bool
 MultiperspectivePerceptron::lookup(ThreadID tid, Addr instPC,
-                                   void * &bp_history)
+                                   void * &bpHistory)
 {
     MPPBranchInfo *bi = new MPPBranchInfo(instPC, pcshift, true);
-    bp_history = (void *)bi;
+    bpHistory = (void *)bi;
 
     bool use_static = false;
 
@@ -614,19 +635,19 @@ MultiperspectivePerceptron::lookup(ThreadID tid, Addr instPC,
 
 void
 MultiperspectivePerceptron::update(ThreadID tid, Addr instPC, bool taken,
-                                   void *bp_history, bool squashed,
+                                   void * &bpHistory, bool squashed,
                                    const StaticInstPtr & inst,
                                    Addr corrTarget)
 {
-    assert(bp_history);
-    MPPBranchInfo *bi = static_cast<MPPBranchInfo*>(bp_history);
+    assert(bpHistory);
+    MPPBranchInfo *bi = static_cast<MPPBranchInfo*>(bpHistory);
     if (squashed) {
         //delete bi;
         return;
     }
 
     if (bi->isUnconditional()) {
-        delete bi;
+        delete bi; bpHistory = nullptr;
         return;
     }
 
@@ -812,21 +833,15 @@ MultiperspectivePerceptron::update(ThreadID tid, Addr instPC, bool taken,
     // update last ghist bit, used to index filter
     threadData[tid]->last_ghist_bit = taken;
 
-    delete bi;
+    delete bi; bpHistory = nullptr;
 }
 
 void
-MultiperspectivePerceptron::btbUpdate(ThreadID tid, Addr branch_pc,
-                                      void* &bp_history)
+MultiperspectivePerceptron::squash(ThreadID tid, void * &bpHistory)
 {
-}
-
-void
-MultiperspectivePerceptron::squash(ThreadID tid, void *bp_history)
-{
-    assert(bp_history);
-    MPPBranchInfo *bi = static_cast<MPPBranchInfo*>(bp_history);
-    delete bi;
+    assert(bpHistory);
+    MPPBranchInfo *bi = static_cast<MPPBranchInfo*>(bpHistory);
+    delete bi; bpHistory = nullptr;
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/multiperspective_perceptron.hh
+++ b/src/cpu/pred/multiperspective_perceptron.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2019 Texas A&M University
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1048,14 +1060,14 @@ class MultiperspectivePerceptron : public BPredUnit
 
     void init() override;
 
-    void uncondBranch(ThreadID tid, Addr pc, void * &bp_history) override;
-    void squash(ThreadID tid, void *bp_history) override;
-    bool lookup(ThreadID tid, Addr instPC, void * &bp_history) override;
-    void update(ThreadID tid, Addr instPC, bool taken,
-            void *bp_history, bool squashed,
-            const StaticInstPtr & inst,
-            Addr corrTarget) override;
-    void btbUpdate(ThreadID tid, Addr branch_addr, void* &bp_history) override;
+    // Base class methods.
+    bool lookup(ThreadID tid, Addr branch_addr, void* &bpHistory) override;
+    void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                         Addr target,  void * &bpHistory) override;
+    void update(ThreadID tid, Addr branch_addr, bool taken, void * &bpHistory,
+                bool squashed, const StaticInstPtr & inst,
+                Addr corrTarget) override;
+    void squash(ThreadID tid, void * &bpHistory) override;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/multiperspective_perceptron_tage.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2019 Texas A&M University
  *
  * Redistribution and use in source and binary forms, with or without
@@ -516,12 +528,12 @@ MultiperspectivePerceptronTAGE::updateHistories(ThreadID tid,
 
 bool
 MultiperspectivePerceptronTAGE::lookup(ThreadID tid, Addr instPC,
-                                   void * &bp_history)
+                                   void * &bpHistory)
 {
     MPPTAGEBranchInfo *bi =
         new MPPTAGEBranchInfo(instPC, pcshift, true, *tage, *loopPredictor,
                               *statisticalCorrector);
-    bp_history = (void *)bi;
+    bpHistory = (void *)bi;
     bool pred_taken = tage->tagePredict(tid, instPC, true, bi->tageBranchInfo);
 
     pred_taken = loopPredictor->loopPredict(tid, instPC, true,
@@ -589,12 +601,12 @@ MPP_StatisticalCorrector::condBranchUpdate(ThreadID tid, Addr branch_pc,
 
 void
 MultiperspectivePerceptronTAGE::update(ThreadID tid, Addr instPC, bool taken,
-                                   void *bp_history, bool squashed,
+                                   void * &bpHistory, bool squashed,
                                    const StaticInstPtr & inst,
                                    Addr corrTarget)
 {
-    assert(bp_history);
-    MPPTAGEBranchInfo *bi = static_cast<MPPTAGEBranchInfo*>(bp_history);
+    assert(bpHistory);
+    MPPTAGEBranchInfo *bi = static_cast<MPPTAGEBranchInfo*>(bpHistory);
 
     if (squashed) {
         if (tage->isSpeculativeUpdateEnabled()) {
@@ -664,25 +676,32 @@ MultiperspectivePerceptronTAGE::update(ThreadID tid, Addr instPC, bool taken,
                                   false, inst, corrTarget);
         }
     }
-    delete bi;
+    delete bi; bpHistory = nullptr;
 }
 
 void
-MultiperspectivePerceptronTAGE::uncondBranch(ThreadID tid, Addr pc,
-                                             void * &bp_history)
+MultiperspectivePerceptronTAGE::updateHistories(ThreadID tid, Addr pc,
+                                            bool uncond, bool taken,
+                                            Addr target, void * &bpHistory)
 {
+    assert(uncond || bpHistory);
+
+    // For perceptron there is no speculative history correction.
+    // Conditional branches are done.
+    if (!uncond) return;
+
     MPPTAGEBranchInfo *bi =
         new MPPTAGEBranchInfo(pc, pcshift, false, *tage, *loopPredictor,
                               *statisticalCorrector);
-    bp_history = (void *) bi;
+    bpHistory = (void *) bi;
 }
 
 void
-MultiperspectivePerceptronTAGE::squash(ThreadID tid, void *bp_history)
+MultiperspectivePerceptronTAGE::squash(ThreadID tid, void * &bpHistory)
 {
-    assert(bp_history);
-    MPPTAGEBranchInfo *bi = static_cast<MPPTAGEBranchInfo*>(bp_history);
-    delete bi;
+    assert(bpHistory);
+    MPPTAGEBranchInfo *bi = static_cast<MPPTAGEBranchInfo*>(bpHistory);
+    delete bi; bpHistory = nullptr;
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/multiperspective_perceptron_tage.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2019 Texas A&M University
  *
  * Redistribution and use in source and binary forms, with or without
@@ -234,14 +246,15 @@ class MultiperspectivePerceptronTAGE : public MultiperspectivePerceptron
 
     void init() override;
 
-    bool lookup(ThreadID tid, Addr instPC, void * &bp_history) override;
+    bool lookup(ThreadID tid, Addr instPC, void * &bpHistory) override;
 
     void update(ThreadID tid, Addr instPC, bool taken,
-            void *bp_history, bool squashed,
+            void * &bpHistory, bool squashed,
             const StaticInstPtr & inst,
             Addr corrTarget) override;
-    void uncondBranch(ThreadID tid, Addr pc, void * &bp_history) override;
-    void squash(ThreadID tid, void *bp_history) override;
+    void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                         Addr target,  void * &bpHistory) override;
+    void squash(ThreadID tid, void * &bpHistory) override;
 
 };
 

--- a/src/cpu/pred/ras.cc
+++ b/src/cpu/pred/ras.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2004-2005 The Regents of The University of Michigan
  * All rights reserved.
  *
@@ -28,31 +40,58 @@
 
 #include "cpu/pred/ras.hh"
 
+#include <iomanip>
+
+#include "debug/RAS.hh"
+
 namespace gem5
 {
 
 namespace branch_prediction
 {
 
+
 void
-ReturnAddrStack::init(unsigned _numEntries)
+ReturnAddrStack::AddrStack::init(unsigned _numEntries)
 {
     numEntries = _numEntries;
     addrStack.resize(numEntries);
+    for (unsigned i = 0; i < numEntries; ++i) {
+        addrStack[i] = nullptr;
+    }
     reset();
 }
 
 void
-ReturnAddrStack::reset()
+ReturnAddrStack::AddrStack::reset()
 {
     usedEntries = 0;
     tos = 0;
+    cdTos = 0;
+    firstWrap = 0;
 }
 
-void
-ReturnAddrStack::push(const PCStateBase &return_addr)
+const PCStateBase *
+ReturnAddrStack::AddrStack::top()
 {
+    if (usedEntries > 0) {
+        return addrStack[tos].get();
+    }
+    return nullptr;
+}
+
+
+void
+ReturnAddrStack::AddrStack::push(const PCStateBase &return_addr)
+{
+
     incrTos();
+    // If TOS is now at the same position as CD-TOS it means
+    // the entry was overwritten.
+    // Increase the CD-TOS to indicate the last valid entry.
+    if (tos == cdTos) {
+        incrCdTos();
+    }
 
     set(addrStack[tos], return_addr);
 
@@ -61,26 +100,259 @@ ReturnAddrStack::push(const PCStateBase &return_addr)
     }
 }
 
-void
-ReturnAddrStack::pop()
+bool
+ReturnAddrStack::AddrStack::pop()
 {
     if (usedEntries > 0) {
         --usedEntries;
     }
 
     decrTos();
+    // The entry is invalid in case the TOS and CD-TOS
+    // point to the same entry and the first wrap bit is unset.
+    // Check the bit before decrementing the CD-TOS
+    bool corrupted = (tos == cdTos) && !firstWrap;
+
+    if (tos == cdTos){
+        decrCdTos();
+    }
+    return corrupted;
 }
 
+
 void
-ReturnAddrStack::restore(unsigned top_entry_idx, const PCStateBase *restored)
+ReturnAddrStack::AddrStack::restore(unsigned _tos, unsigned _cdTos,
+                                    const PCStateBase *restored)
 {
-    tos = top_entry_idx;
-
-    set(addrStack[tos], restored);
-
     if (usedEntries != numEntries) {
         ++usedEntries;
     }
+
+    tos = _tos;
+    cdTos = _cdTos;
+    set(addrStack[tos], restored);
+}
+
+std::string
+ReturnAddrStack::AddrStack::print(int n)
+{
+    std::stringstream ss;
+    ss << "";
+    for (int i = 0; i<n; i++) {
+        int idx = int(tos)-i;
+        if (idx < 0 || addrStack[idx] == nullptr) {
+            break;
+        }
+        ss << std::dec << idx << ":0x" << std::setfill('0') << std::setw(8)
+           << std::hex << addrStack[idx]->instAddr() << ";";
+    }
+    return ss.str();
+}
+
+
+// Return address stack class.
+//
+
+ReturnAddrStack::ReturnAddrStack(const Params &p)
+    : SimObject(p),
+      numEntries(p.numEntries),
+      numThreads(p.numThreads),
+      stats(this)
+{
+    DPRINTF(RAS, "Create RAS stacks.\n");
+
+    for (unsigned i = 0; i < numThreads; ++i) {
+        addrStacks.emplace_back(*this);
+        addrStacks[i].init(numEntries);
+    }
+}
+
+void
+ReturnAddrStack::reset()
+{
+    DPRINTF(RAS, "RAS Reset.\n");
+    for (auto& r : addrStacks)
+        r.reset();
+}
+
+void
+ReturnAddrStack::push(ThreadID tid, const PCStateBase &pc,
+                        void * &ras_history)
+{
+    assert(ras_history==nullptr);
+    stats.pushes++;
+
+    RASHistory *history = new RASHistory;
+    ras_history = static_cast<void*>(history);
+    history->pushed = true;
+    history->poped = false;
+
+    addrStacks[tid].push(pc);
+
+    DPRINTF(RAS, "%s: RAS[%i] <= %#x. Entries used: %i, tid:%i\n", __func__,
+                    addrStacks[tid].tos, pc.instAddr(),
+                    addrStacks[tid].usedEntries,tid);
+    DPRINTF(RAS, "[%s]\n", addrStacks[tid].print(10));
+}
+
+
+const PCStateBase*
+ReturnAddrStack::pop(ThreadID tid, void * &ras_history)
+{
+    assert(ras_history==nullptr);
+    stats.pops++;
+    stats.used++;
+
+    RASHistory *history = new RASHistory;
+    ras_history = static_cast<void*>(history);
+    history->pushed = false;
+    history->tos = addrStacks[tid].tos;
+    history->cdTos = addrStacks[tid].cdTos;
+
+    if (addrStacks[tid].empty()) {
+        history->poped = false;
+        history->ras_entry = nullptr;
+        DPRINTF(RAS, "RAS empty. Don't pop entry.\n");
+        return nullptr;
+    }
+
+    history->poped = true;
+    set(history->ras_entry, addrStacks[tid].top());
+    history->corrupted = addrStacks[tid].pop();
+
+    DPRINTF(RAS, "%s: RAS[%i] => %#x. corrupted:%i, "
+                "Entries used: %i, tid:%i\n", __func__, history->tos,
+                history->ras_entry->instAddr(), history->corrupted,
+                addrStacks[tid].usedEntries, tid);
+    DPRINTF(RAS, "[%s]\n", addrStacks[tid].print(10));
+
+    // TODO: return depending on config.
+    if (history->corrupted) {
+        stats.corrupt++;
+
+        // If BTB fallback is enabled the RAS will return an invalid
+        // address and the BPU will use the BTB as provider for the
+        // target address.
+        if (useBtbFallback) {
+            return nullptr;
+        }
+    }
+    return history->ras_entry.get();
+}
+
+void
+ReturnAddrStack::squash(ThreadID tid, void * &ras_history)
+{
+    if (ras_history == nullptr) {
+        // If ras_history is null no stack operation was performed for
+        // this branch. Nothing to be done.
+        return;
+    }
+    stats.squashes++;
+
+    RASHistory *history = static_cast<RASHistory*>(ras_history);
+
+    if (history->pushed) {
+        stats.pops++;
+        addrStacks[tid].pop();
+
+        DPRINTF(RAS, "RAS::%s Incorrect push. Pop RAS[%i]. "
+            "Entries used: %i, tid:%i\n", __func__,
+            addrStacks[tid].tos,
+            addrStacks[tid].usedEntries, tid);
+
+
+    } else if (history->poped) {
+        stats.pushes++;
+        addrStacks[tid].restore(history->tos, history->cdTos,
+                                history->ras_entry.get());
+        DPRINTF(RAS, "RAS::%s Incorrect pop. Restore to: RAS[%i]:%#x. "
+            "Entries used: %i, tid:%i\n", __func__,
+            history->tos, history->ras_entry->instAddr(),
+            addrStacks[tid].usedEntries, tid);
+    }
+    DPRINTF(RAS, "[%s]\n", addrStacks[tid].print(10));
+    // DPRINTF(RAS, "RAS: Delete hist:%#x\n", history);
+    delete history; ras_history = nullptr;
+}
+
+void
+ReturnAddrStack::commit(ThreadID tid, bool misp,
+                        const BranchType brType, void * &ras_history)
+{
+    // Skip branches that are not call or returns
+    if (!(brType == BranchType::Return ||
+          brType == BranchType::CallDirect ||
+          brType == BranchType::CallIndirect)) {
+        // If its not a call or return there should be no ras history.
+        assert(ras_history == nullptr);
+        return;
+    }
+
+    DPRINTF(RAS, "RAS::%s Commit Branch inst: %s, tid:%i\n",
+                __func__, toString(brType),tid);
+
+
+    if (ras_history == nullptr) {
+        /**
+         * The only case where we could have no history at this point is
+         * for a conditional call that is not taken.
+         *
+         * Conditional calls
+         *
+         * Conditional calls have different scenarios:
+         * 1. the call was predicted as non taken but was actually taken
+         * 2. the call was predicted taken but was actually not taken.
+         * 3. the call was taken but the target was incorrect.
+         * 4. the call was correct.
+         *
+         * In case of mispredictions they will be handled during squashing
+         * of the BPU. It will push and pop the RAS accordingly.
+         **/
+        return;
+    }
+
+    /* Handle all other commited returns and calls */
+    RASHistory *history = static_cast<RASHistory*>(ras_history);
+
+    if (history->poped) {
+        stats.used++;
+        if (misp) {
+            stats.wrong++;
+        } else {
+            stats.correct++;
+        }
+
+        DPRINTF(RAS, "RAS::%s Commit Return PC %#x, correct:%i, tid:%i\n",
+                __func__, !misp,
+                history->ras_entry->instAddr(), tid);
+    }
+    delete history; ras_history = nullptr;
+}
+
+
+
+ReturnAddrStack::ReturnAddrStackStats::ReturnAddrStackStats(
+    statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(pushes, statistics::units::Count::get(),
+               "Number of times a PC was pushed onto the RAS"),
+      ADD_STAT(pops, statistics::units::Count::get(),
+               "Number of times a PC was poped from the RAS"),
+      ADD_STAT(squashes, statistics::units::Count::get(),
+               "Number of times the stack operation was squashed due to "
+               "wrong speculation."),
+      ADD_STAT(corrupt, statistics::units::Count::get(),
+               "Number of times the RAS is corrupted during a pop."),
+      ADD_STAT(used, statistics::units::Count::get(),
+               "Number of times the RAS is the provider"),
+      ADD_STAT(correct, statistics::units::Count::get(),
+               "Number of times the RAS is the provider and the "
+               "prediction is correct"),
+      ADD_STAT(wrong, statistics::units::Count::get(),
+               "Number of times the loop predictor is the provider and the "
+               "prediction is wrong")
+{
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/simple_btb.cc
+++ b/src/cpu/pred/simple_btb.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Copyright (c) 2004-2005 The Regents of The University of Michigan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/pred/simple_btb.hh"
+
+#include "base/intmath.hh"
+#include "base/trace.hh"
+#include "debug/BTB.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+SimpleBTB::SimpleBTB(const SimpleBTBParams &p)
+    : BranchTargetBuffer(p),
+        numEntries(p.numEntries),
+        tagBits(p.tagBits),
+        instShiftAmt(p.instShiftAmt),
+        log2NumThreads(floorLog2(p.numThreads))
+{
+    DPRINTF(BTB, "BTB: Creating BTB object.\n");
+
+    if (!isPowerOf2(numEntries)) {
+        fatal("BTB entries is not a power of 2!");
+    }
+
+    btb.resize(numEntries);
+
+    for (unsigned i = 0; i < numEntries; ++i) {
+        btb[i].valid = false;
+    }
+
+    idxMask = numEntries - 1;
+
+    tagMask = (1 << tagBits) - 1;
+
+    tagShiftAmt = instShiftAmt + floorLog2(numEntries);
+}
+
+void
+SimpleBTB::memInvalidate()
+{
+    for (unsigned i = 0; i < numEntries; ++i) {
+        btb[i].valid = false;
+    }
+}
+
+inline
+unsigned
+SimpleBTB::getIndex(Addr instPC, ThreadID tid)
+{
+    // Need to shift PC over by the word offset.
+    return ((instPC >> instShiftAmt)
+            ^ (tid << (tagShiftAmt - instShiftAmt - log2NumThreads)))
+            & idxMask;
+}
+
+inline
+Addr
+SimpleBTB::getTag(Addr instPC)
+{
+    return (instPC >> tagShiftAmt) & tagMask;
+}
+
+bool
+SimpleBTB::valid(ThreadID tid, Addr instPC, BranchType type)
+{
+    unsigned btb_idx = getIndex(instPC, tid);
+
+    Addr inst_tag = getTag(instPC);
+
+    assert(btb_idx < numEntries);
+
+    if (btb[btb_idx].valid
+        && inst_tag == btb[btb_idx].tag
+        && btb[btb_idx].tid == tid) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// @todo Create some sort of return struct that has both whether or not the
+// address is valid, and also the address.  For now will just use addr = 0 to
+// represent invalid entry.
+const PCStateBase *
+SimpleBTB::lookup(ThreadID tid, Addr instPC, BranchType type)
+{
+    unsigned btb_idx = getIndex(instPC, tid);
+    Addr inst_tag = getTag(instPC);
+
+    assert(btb_idx < numEntries);
+
+    stats.lookups++;
+    if (type != BranchType::NoBranch) {
+        stats.lookupType[type]++;
+    }
+
+    if (btb[btb_idx].valid
+        && inst_tag == btb[btb_idx].tag
+        && btb[btb_idx].tid == tid) {
+        return btb[btb_idx].target.get();
+    } else {
+        stats.misses++;
+        if (type != BranchType::NoBranch) {
+            stats.missType[type]++;
+        }
+        return nullptr;
+    }
+}
+
+void
+SimpleBTB::update(ThreadID tid, Addr instPC,
+                    const PCStateBase &target,
+                    BranchType type, StaticInstPtr inst)
+{
+    unsigned btb_idx = getIndex(instPC, tid);
+
+    assert(btb_idx < numEntries);
+
+    if (type != BranchType::NoBranch) {
+        stats.updates[type]++;
+    }
+
+    btb[btb_idx].tid = tid;
+    btb[btb_idx].valid = true;
+    set(btb[btb_idx].target, target);
+    btb[btb_idx].tag = getTag(instPC);
+}
+
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/cpu/pred/simple_btb.hh
+++ b/src/cpu/pred/simple_btb.hh
@@ -38,7 +38,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef __CPU_PRED_SIMPLE_BTB_HH__
+#define __CPU_PRED_SIMPLE_BTB_HH__
+
+#include "base/logging.hh"
+#include "base/types.hh"
 #include "cpu/pred/btb.hh"
+#include "params/SimpleBTB.hh"
 
 namespace gem5
 {
@@ -46,65 +52,76 @@ namespace gem5
 namespace branch_prediction
 {
 
-BranchTargetBuffer::BranchTargetBuffer(const Params &params)
-    : ClockedObject(params),
-      numThreads(params.numThreads),
-      stats(this)
+class SimpleBTB : public BranchTargetBuffer
 {
-}
+  public:
+    SimpleBTB(const SimpleBTBParams &params);
 
-const StaticInstPtr
-BranchTargetBuffer::lookupInst(ThreadID tid, Addr instPC)
-{
-    panic("Not implemented for this BTB");
-    return nullptr;
-}
+    void memInvalidate() override;
+    const PCStateBase *lookup(ThreadID tid, Addr instPC,
+                           BranchType type = BranchType::NoBranch) override;
+    bool valid(ThreadID tid, Addr instPC,
+                           BranchType type = BranchType::NoBranch) override;
+    void update(ThreadID tid, Addr instPC, const PCStateBase &target_pc,
+                           BranchType type = BranchType::NoBranch,
+                           StaticInstPtr inst = nullptr) override;
 
-BranchTargetBuffer::BranchTargetBufferStats::BranchTargetBufferStats(
-                                                statistics::Group *parent)
-    : statistics::Group(parent),
-      ADD_STAT(lookups, statistics::units::Count::get(),
-               "Number of BTB lookups"),
-      ADD_STAT(lookupType, statistics::units::Count::get(),
-               "Number of BTB lookups per branch type"),
-      ADD_STAT(misses, statistics::units::Count::get(),
-               "Number of BTB misses"),
-      ADD_STAT(missType, statistics::units::Count::get(),
-               "Number of BTB misses per branch type"),
-      ADD_STAT(missRatio, statistics::units::Ratio::get(), "BTB Hit Ratio",
-               misses / lookups),
-      ADD_STAT(updates, statistics::units::Count::get(),
-               "Number of BTB updates"),
-      ADD_STAT(mispredict, statistics::units::Count::get(),
-               "Number of BTB mispredicts"),
-      ADD_STAT(evictions, statistics::units::Count::get(),
-               "Number of BTB evictions")
-{
-    using namespace statistics;
-    missRatio.precision(6);
-    lookupType
-        .init(enums::Num_BranchType)
-        .flags(total | pdf);
 
-    missType
-        .init(enums::Num_BranchType)
-        .flags(total | pdf);
+  private:
+    struct BTBEntry
+    {
+        /** The entry's tag. */
+        Addr tag = 0;
 
-    updates
-        .init(enums::Num_BranchType)
-        .flags(total | pdf);
+        /** The entry's target. */
+        std::unique_ptr<PCStateBase> target;
 
-    mispredict
-        .init(enums::Num_BranchType)
-        .flags(total | pdf);
+        /** The entry's thread id. */
+        ThreadID tid;
 
-    for (int i = 0; i < enums::Num_BranchType; i++) {
-        lookupType.subname(i, enums::BranchTypeStrings[i]);
-        missType.subname(i, enums::BranchTypeStrings[i]);
-        updates.subname(i, enums::BranchTypeStrings[i]);
-        mispredict.subname(i, enums::BranchTypeStrings[i]);
-    }
-}
+        /** Whether or not the entry is valid. */
+        bool valid = false;
+    };
+
+
+    /** Returns the index into the BTB, based on the branch's PC.
+     *  @param inst_PC The branch to look up.
+     *  @return Returns the index into the BTB.
+     */
+    inline unsigned getIndex(Addr instPC, ThreadID tid);
+
+    /** Returns the tag bits of a given address.
+     *  @param inst_PC The branch's address.
+     *  @return Returns the tag bits.
+     */
+    inline Addr getTag(Addr instPC);
+
+    /** The actual BTB. */
+    std::vector<BTBEntry> btb;
+
+    /** The number of entries in the BTB. */
+    unsigned numEntries;
+
+    /** The index mask. */
+    unsigned idxMask;
+
+    /** The number of tag bits per entry. */
+    unsigned tagBits;
+
+    /** The tag mask. */
+    unsigned tagMask;
+
+    /** Number of bits to shift PC when calculating index. */
+    unsigned instShiftAmt;
+
+    /** Number of bits to shift PC when calculating tag. */
+    unsigned tagShiftAmt;
+
+    /** Log2 NumThreads used for hashing threadid */
+    unsigned log2NumThreads;
+};
 
 } // namespace branch_prediction
 } // namespace gem5
+
+#endif // __CPU_PRED_SIMPLE_BTB_HH__

--- a/src/cpu/pred/simple_indirect.hh
+++ b/src/cpu/pred/simple_indirect.hh
@@ -1,6 +1,16 @@
 /*
  * Copyright (c) 2014 ARM Limited
- * All rights reserved.
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,6 +41,8 @@
 
 #include <deque>
 
+#include "base/circular_queue.hh"
+#include "base/statistics.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/pred/indirect.hh"
 #include "params/SimpleIndirectPredictor.hh"
@@ -46,26 +58,32 @@ class SimpleIndirectPredictor : public IndirectPredictor
   public:
     SimpleIndirectPredictor(const SimpleIndirectPredictorParams &params);
 
-    bool lookup(Addr br_addr, PCStateBase& br_target, ThreadID tid);
-    void recordIndirect(Addr br_addr, Addr tgt_addr, InstSeqNum seq_num,
-                        ThreadID tid);
-    void commit(InstSeqNum seq_num, ThreadID tid, void * indirect_history);
-    void squash(InstSeqNum seq_num, ThreadID tid);
-    void recordTarget(InstSeqNum seq_num, void * indirect_history,
-                      const PCStateBase& target, ThreadID tid);
-    void genIndirectInfo(ThreadID tid, void* & indirect_history);
-    void updateDirectionInfo(ThreadID tid, bool actually_taken);
-    void deleteIndirectInfo(ThreadID tid, void * indirect_history);
-    void changeDirectionPrediction(ThreadID tid, void * indirect_history,
-                                   bool actually_taken);
+    /** Indirect predictor interface */
+    void reset() override;
 
+    const PCStateBase * lookup(ThreadID tid, InstSeqNum sn,
+                                Addr pc, void * &iHistory) override;
+    void update(ThreadID tid, InstSeqNum sn, Addr pc, bool squash,
+                bool taken, const PCStateBase& target,
+                BranchType brType, void * &iHistory) override;
+    void squash(ThreadID tid, InstSeqNum sn, void * &iHistory) override;
+    void commit(ThreadID tid, InstSeqNum sn, void * &iHistory) override;
+
+
+
+    /** ------------------
+     * The actual predictor
+     * -------------------
+     * */
   private:
     const bool hashGHR;
     const bool hashTargets;
+    const bool takenHistory;
     const unsigned numSets;
     const unsigned numWays;
     const unsigned tagBits;
     const unsigned pathLength;
+    const unsigned speculativePathLength;
     const unsigned instShift;
     const unsigned ghrNumBits;
     const unsigned ghrMask;
@@ -78,27 +96,107 @@ class SimpleIndirectPredictor : public IndirectPredictor
 
     std::vector<std::vector<IPredEntry> > targetCache;
 
-    Addr getSetIndex(Addr br_addr, unsigned ghr, ThreadID tid);
-    Addr getTag(Addr br_addr);
+
 
     struct HistoryEntry
     {
         HistoryEntry(Addr br_addr, Addr tgt_addr, InstSeqNum seq_num)
             : pcAddr(br_addr), targetAddr(tgt_addr), seqNum(seq_num) { }
+        HistoryEntry() : pcAddr(0), targetAddr(0), seqNum(0) { }
         Addr pcAddr;
         Addr targetAddr;
         InstSeqNum seqNum;
     };
 
+    using HistoryBuffer = CircularQueue<HistoryEntry>;
+
+    /** Branch history information */
+    struct IndirectHistory
+    {
+        /* data */
+        Addr pcAddr;
+        Addr targetAddr;
+        InstSeqNum seqNum;
+
+        Addr set_index;
+        Addr tag;
+        bool hit;
+        unsigned ghr;
+        uint64_t pathHist;
+        HistoryBuffer::iterator histTail;
+
+        bool dir_taken;
+        bool was_indirect;
+
+        IndirectHistory()
+            : pcAddr(MaxAddr), targetAddr(MaxAddr),
+              dir_taken(false), was_indirect(false)
+        {}
+    };
+
+    struct PathHistoryRegister
+    {
+        unsigned numTgtBits;
+        unsigned pathLength;
+        unsigned instShift;
+        uint64_t reg;
+        void update(Addr target) {
+            uint64_t v = (target >> instShift) & (numTgtBits-1);
+            reg = (reg << numTgtBits) | v;
+        }
+    };
 
     struct ThreadInfo
     {
         std::deque<HistoryEntry> pathHist;
+        HistoryBuffer indirectHist;
+        HistoryBuffer::iterator histTail;
         unsigned headHistEntry = 0;
+        // Global direction history register
         unsigned ghr = 0;
+        // Path history register
+        uint64_t phr = 0;
+        ThreadInfo(size_t buffer_size)
+          : indirectHist(buffer_size) { }
     };
 
     std::vector<ThreadInfo> threadInfo;
+    std::vector<PathHistoryRegister> pathReg;
+
+
+    // ---- Internal functions ----- //
+    bool lookup(ThreadID tid, Addr br_addr,
+                PCStateBase * &target, IndirectHistory * &history);
+    void recordTarget(ThreadID tid, InstSeqNum sn,
+                      const PCStateBase& target, IndirectHistory * &history);
+
+    // Helper functions to generate and modify the
+    // direction info
+    void genIndirectInfo(ThreadID tid, void* &iHistory);
+    void updateDirectionInfo(ThreadID tid, bool taken, Addr pc, Addr target);
+
+    // Helper to compute set and tag
+    inline Addr getSetIndex(Addr br_addr, ThreadID tid);
+    inline Addr getTag(Addr br_addr);
+
+    inline bool isIndirectNoReturn(BranchType type) {
+        return (type == BranchType::CallIndirect) ||
+               (type == BranchType::IndirectUncond);
+    }
+
+  protected:
+    struct IndirectStats : public statistics::Group
+    {
+        IndirectStats(statistics::Group *parent);
+        // STATS
+        statistics::Scalar lookups;
+        statistics::Scalar hits;
+        statistics::Scalar misses;
+        statistics::Scalar targetRecords;
+        statistics::Scalar indirectRecords;
+        statistics::Scalar speculativeOverflows;
+
+    } stats;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/tage.hh
+++ b/src/cpu/pred/tage.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The University of Wisconsin
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
@@ -87,13 +99,13 @@ class TAGE: public BPredUnit
     TAGE(const TAGEParams &params);
 
     // Base class methods.
-    void uncondBranch(ThreadID tid, Addr br_pc, void* &bp_history) override;
-    bool lookup(ThreadID tid, Addr branch_addr, void* &bp_history) override;
-    void btbUpdate(ThreadID tid, Addr branch_addr, void* &bp_history) override;
-    void update(ThreadID tid, Addr branch_addr, bool taken, void *bp_history,
+    bool lookup(ThreadID tid, Addr branch_addr, void* &bpHistory) override;
+    void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                         Addr target,  void * &bpHistory) override;
+    void update(ThreadID tid, Addr branch_addr, bool taken, void * &bpHistory,
                 bool squashed, const StaticInstPtr & inst,
                 Addr corrTarget) override;
-    virtual void squash(ThreadID tid, void *bp_history) override;
+    virtual void squash(ThreadID tid, void * &bpHistory) override;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/tage_base.cc
+++ b/src/cpu/pred/tage_base.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The University of Wisconsin
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en

--- a/src/cpu/pred/tage_base.hh
+++ b/src/cpu/pred/tage_base.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2014 The University of Wisconsin
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2018 Metempsy Technology Consulting
  * All rights reserved.
  *
@@ -410,12 +422,12 @@ TAGE_SC_L::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void* &b)
 }
 
 void
-TAGE_SC_L::update(ThreadID tid, Addr branch_pc, bool taken, void *bp_history,
+TAGE_SC_L::update(ThreadID tid, Addr branch_pc, bool taken, void * &bpHistory,
         bool squashed, const StaticInstPtr & inst, Addr corrTarget)
 {
-    assert(bp_history);
+    assert(bpHistory);
 
-    TageSCLBranchInfo* bi = static_cast<TageSCLBranchInfo*>(bp_history);
+    TageSCLBranchInfo* bi = static_cast<TageSCLBranchInfo*>(bpHistory);
     TAGE_SC_L_TAGE::BranchInfo* tage_bi =
         static_cast<TAGE_SC_L_TAGE::BranchInfo *>(bi->tageBranchInfo);
 
@@ -462,7 +474,7 @@ TAGE_SC_L::update(ThreadID tid, Addr branch_pc, bool taken, void *bp_history,
                               inst, corrTarget);
     }
 
-    delete bi;
+    delete bi; bpHistory = nullptr;
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2018 Metempsy Technology Consulting
  * All rights reserved.
  *
@@ -162,7 +174,7 @@ class TAGE_SC_L: public LTAGE
     bool predict(
         ThreadID tid, Addr branch_pc, bool cond_branch, void* &b) override;
 
-    void update(ThreadID tid, Addr branch_addr, bool taken, void *bp_history,
+    void update(ThreadID tid, Addr branch_addr, bool taken, void * &bpHistory,
                 bool squashed, const StaticInstPtr & inst,
                 Addr corrTarget) override;
 

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
@@ -95,7 +95,7 @@ class U74FUPool(MinorFUPool):
 
 
 class U74BP(TournamentBP):
-    BTBEntries = 32
+    btb = SimpleBTB(numEntries=32)
     RASSize = 12
     localHistoryTableSize = 4096  # is 3.6 KiB but gem5 requires power of 2
     localPredictorSize = 16384


### PR DESCRIPTION
This set of patches combines multiple enhancements in the branch predictor unit. Specifically it:
- Adds a new BranchType class useful for better statistics and debugging.
- Creates Separate SimObjects for BTB, RAS and Indirect branch predictor to allow different implementation of each.
- Moves the logics log RAS and indirect branch predictor management out of the main BPU to simplify its design.
- Improves statistics

The changes to the branch predictor are required to implement the decoupled front-end