### PR TITLE
Decoupled front end

### DIFF
--- a/configs/example/gem5_library/fdp-hello.py
+++ b/configs/example/gem5_library/fdp-hello.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2023 The University of Edinburgh
+# Copyright (c) 2025 Technical University of Munich
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+Fetch directed instruction prefetch (FDP) example
+
+This gem5 configuation script creates a simple simulation setup with a single
+O3 CPU model and decoupled front-end. Is serves as a starting point for the
+FDP implementation. As workload a simple "Hello World!" program is used.
+
+FDP is tested with the X86, Arm, RISC-V isa which can be specified
+using the --isa flag.
+
+Usage
+-----
+
+```
+scons build/ALL/gem5.opt
+./build/ALL/gem5.opt \
+    configs/example/gem5_library/fdp-hello.py \
+    --isa <isa> \
+    [--disable-fdp]
+```
+"""
+
+import argparse
+
+from m5.objects import (
+    TAGE_SC_L_64KB,
+    BranchPredictor,
+    FetchDirectedPrefetcher,
+    L2XBar,
+    MultiPrefetcher,
+    SimpleBTB,
+    TaggedPrefetcher,
+)
+
+from gem5.components.boards.abstract_board import AbstractBoard
+from gem5.components.boards.simple_board import SimpleBoard
+from gem5.components.cachehierarchies.classic.caches.l1dcache import L1DCache
+from gem5.components.cachehierarchies.classic.caches.l1icache import L1ICache
+from gem5.components.cachehierarchies.classic.caches.l2cache import L2Cache
+from gem5.components.cachehierarchies.classic.caches.mmu_cache import MMUCache
+from gem5.components.cachehierarchies.classic.private_l1_private_l2_cache_hierarchy import (
+    PrivateL1PrivateL2CacheHierarchy,
+)
+from gem5.components.memory import SingleChannelDDR3_1600
+from gem5.components.processors.base_cpu_processor import BaseCPUProcessor
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_core import SimpleCore
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import (
+    BinaryResource,
+    obtain_resource,
+)
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
+
+isa_choices = {
+    "X86": ISA.X86,
+    "Arm": ISA.ARM,
+    "RISCV": ISA.RISCV,
+}
+
+workloads = {
+    "hello": {
+        "Arm": "arm-hello64-static",
+        "X86": "x86-hello64-static",
+        "RISCV": "riscv-hello",
+    },
+}
+
+
+parser = argparse.ArgumentParser(
+    description="An example configuration script to run FDP."
+)
+
+parser.add_argument(
+    "--isa",
+    type=str,
+    default="X86",
+    help="The ISA to simulate.",
+    choices=isa_choices.keys(),
+)
+
+parser.add_argument(
+    "--workload",
+    type=str,
+    default="hello",
+    help="The workload to simulate.",
+    choices=workloads.keys(),
+)
+
+parser.add_argument(
+    "--disable-fdp",
+    action="store_true",
+    help="Disable FDP to evaluate baseline performance.",
+)
+
+args = parser.parse_args()
+
+
+# This check ensures the gem5 binary is compiled to the correct ISA target.
+# If not, an exception will be thrown.
+requires(isa_required=isa_choices[args.isa])
+
+# We use a single channel DDR3_1600 memory system
+memory = SingleChannelDDR3_1600(size="32MiB")
+
+
+# 1. Instruction prefetcher ---------------------------------------------
+# The decoupled front-end is only the first part.
+# Now we also need the instruction prefetcher which listens to the
+# insertions into the fetch target queue (FTQ) to issue prefetches.
+
+
+class CacheHierarchy(PrivateL1PrivateL2CacheHierarchy):
+    def __init__(self, l1i_size, l1d_size, l2_size):
+        super().__init__(l1i_size, l1d_size, l2_size)
+
+    def incorporate_cache(self, board: AbstractBoard) -> None:
+        board.connect_system_port(self.membus.cpu_side_ports)
+
+        for _, port in board.get_memory().get_mem_ports():
+            self.membus.mem_side_ports = port
+
+        self.l1icaches = [
+            L1ICache(size=self._l1i_size)
+            for i in range(board.get_processor().get_num_cores())
+        ]
+
+        # Add the prefetchers to the L1I caches and register the MMU.
+        for i in range(board.get_processor().get_num_cores()):
+            cpu = board.get_processor().cores[i].core
+
+            self.l1icaches[i].prefetcher = MultiPrefetcher()
+            if not args.disable_fdp:
+                pf = FetchDirectedPrefetcher(
+                    use_virtual_addresses=True, cpu=cpu
+                )
+                # Optionally register the cache to prefetch into to enable
+                # cache snooping
+                pf.registerCache(self.l1icaches[i])
+                self.l1icaches[i].prefetcher.prefetchers.append(pf)
+
+            self.l1icaches[i].prefetcher.prefetchers.append(
+                TaggedPrefetcher(use_virtual_addresses=True)
+            )
+
+            for pf in self.l1icaches[i].prefetcher.prefetchers:
+                pf.registerMMU(cpu.mmu)
+
+        self.l1dcaches = [
+            L1DCache(size=self._l1d_size)
+            for i in range(board.get_processor().get_num_cores())
+        ]
+        self.l2buses = [
+            L2XBar() for i in range(board.get_processor().get_num_cores())
+        ]
+        self.l2caches = [
+            L2Cache(size=self._l2_size)
+            for i in range(board.get_processor().get_num_cores())
+        ]
+        self.mmucaches = [
+            MMUCache(size="8KiB")
+            for _ in range(board.get_processor().get_num_cores())
+        ]
+
+        self.mmubuses = [
+            L2XBar(width=64)
+            for i in range(board.get_processor().get_num_cores())
+        ]
+
+        if board.has_coherent_io():
+            self._setup_io_cache(board)
+
+        for i, cpu in enumerate(board.get_processor().get_cores()):
+
+            cpu.connect_icache(self.l1icaches[i].cpu_side)
+            self.l1icaches[i].mem_side = self.l2buses[i].cpu_side_ports
+
+            cpu.connect_dcache(self.l1dcaches[i].cpu_side)
+            self.l1dcaches[i].mem_side = self.l2buses[i].cpu_side_ports
+
+            self.mmucaches[i].mem_side = self.l2buses[i].cpu_side_ports
+
+            self.mmubuses[i].mem_side_ports = self.mmucaches[i].cpu_side
+            self.l2buses[i].mem_side_ports = self.l2caches[i].cpu_side
+
+            self.membus.cpu_side_ports = self.l2caches[i].mem_side
+
+            cpu.connect_walker_ports(
+                self.mmubuses[i].cpu_side_ports,
+                self.mmubuses[i].cpu_side_ports,
+            )
+
+            if board.get_processor().get_isa() == ISA.X86:
+                int_req_port = self.membus.mem_side_ports
+                int_resp_port = self.membus.cpu_side_ports
+                cpu.connect_interrupt(int_req_port, int_resp_port)
+            else:
+                cpu.connect_interrupt()
+
+
+cache_hierarchy = CacheHierarchy(
+    l1i_size="32KiB", l1d_size="32KiB", l2_size="1MiB"
+)
+
+
+# 2. Decoupled front-end ------------------------------------------------
+# Next setup the decoupled front-end. Its implemented in the O3 core.
+# Create the processor with one core
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.O3, isa=isa_choices[args.isa], num_cores=1
+)
+
+for core in processor.cores:
+    cpu = core.core
+
+    # We need to configure the decoupled front-end with specific parameters.
+    # First the fetch buffer and fetch target size. We want double the size of
+    # the fetch buffer to be able to run ahead of fetch
+    cpu.fetchBufferSize = 16
+    cpu.fetchTargetWidth = 32
+
+    # The decoupled front-end leverages the BTB to find branches in the fetch
+    # stream. Starting from the end of the last fetch target it will search
+    # all addresses until a hit. However, for fixed size ISA's like Arm only
+    # every n-th address must be checked.
+    if args.isa == "Arm":
+        cpu.minInstSize = (
+            4  # Note Arm has a 2 byte thumb mode but we ignore it here
+        )
+    elif args.isa == "RISCV":
+        cpu.minInstSize = 2  # RiscV has a 2 byte compressed mode.
+    else:  # Variable length ISA (x86) must search every byte
+        cpu.minInstSize = 1
+
+    # The `decoupledFrontEnd` parameter enables the decoupled front-end.
+    # Disable it to get the baseline.
+    if args.disable_fdp:
+        cpu.decoupledFrontEnd = False
+    else:
+        cpu.decoupledFrontEnd = True
+
+
+# 3. Branch Predictor Unit --------------------------------
+# The decoupled front-end relies on the BTB to discover
+# branches and uses `takenOnlyHistory`.
+# At the moment not all branch predictors are supported
+# and must implement the `branchPlaceholder` method.
+# Currently, only LTAGE and TAGE-SC-L are supported.
+
+
+class BTB(SimpleBTB):
+    numEntries = 16 * 1024
+    associativity = 8
+
+
+class BPU(BranchPredictor):
+    # For fixed size ISAs like Arm and RISC-V the lower order bits are
+    # always zero and do not add any entropy to the branch predictor.
+    # The `instShiftAmt` is used to shift the address by the number of
+    # unused bits.
+    instShiftAmt = 2 if args.isa == "Arm" else 1 if args.isa == "RISCV" else 0
+    btb = BTB()
+    conditionalBranchPred = TAGE_SC_L_64KB()
+    requiresBTBHit = True
+    takenOnlyHistory = True
+
+
+# Set the branch predictor for all cores.
+for c in processor.cores:
+    c.core.branchPred = BPU()
+
+
+print(
+    f"Running {args.workload} on {args.isa}, "
+    f"FDP {'disabled' if args.disable_fdp else 'enabled'}"
+)
+
+
+# The gem5 library simple board which can be used to run simple SE-mode
+# simulations.
+board = SimpleBoard(
+    clk_freq="3GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+)
+
+# Here we set the workload. In this case we want to run a simple "Hello World!"
+# program compiled to the specified ISA. The `Resource` class will automatically
+# download the binary from the gem5 Resources cloud bucket if it's not already
+# present.
+board.set_se_binary_workload(
+    obtain_resource(workloads[args.workload][args.isa])
+)
+
+# Lastly we run the simulation.
+simulator = Simulator(board=board)
+simulator.run()
+
+print("Simulation done.")

--- a/src/arch/x86/decoder.cc
+++ b/src/arch/x86/decoder.cc
@@ -696,7 +696,14 @@ Decoder::decode(PCStateBase &next_pc)
 StaticInstPtr
 Decoder::fetchRomMicroop(MicroPC micropc, StaticInstPtr curMacroop)
 {
-    return microcodeRom.fetchMicroop(micropc, curMacroop);
+    // The decoupled front-end and return address predictor require
+    // the instruction size to be set. '4' is of no particular reason and
+    // may require a better method. However, since the microop addresses
+    // are anyway not used in the branch predictor and rom instructions
+    // are rare it should not make a large difference.
+    auto si = microcodeRom.fetchMicroop(micropc, curMacroop);
+    si->size(4);
+    return si;
 }
 
 } // namespace X86ISA

--- a/src/arch/x86/tlb.hh
+++ b/src/arch/x86/tlb.hh
@@ -115,8 +115,10 @@ namespace X86ISA
 
             statistics::Scalar rdAccesses;
             statistics::Scalar wrAccesses;
+            statistics::Scalar exAccesses;
             statistics::Scalar rdMisses;
             statistics::Scalar wrMisses;
+            statistics::Scalar exMisses;
         } stats;
 
         Fault translateInt(bool read, RequestPtr req, ThreadContext *tc);

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2016, 2019 ARM Limited
+# Copyright (c) 2022-2023 The University of Edinburgh
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -36,6 +37,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from m5.citations import add_citation
 from m5.defines import buildEnv
 from m5.objects.BaseCPU import BaseCPU
 
@@ -85,6 +87,8 @@ class BaseO3CPU(BaseCPU):
     )
     cacheLoadPorts = Param.Unsigned(200, "Cache Ports. Constrains loads only.")
 
+    # Backward pipeline delays
+    fetchToBacDelay = Param.Cycles(1, "Fetch to Branch address calc. delay")
     decodeToFetchDelay = Param.Cycles(1, "Decode to fetch delay")
     renameToFetchDelay = Param.Cycles(1, "Rename to fetch delay")
     iewToFetchDelay = Param.Cycles(1, "Issue/Execute/Writeback to fetch delay")
@@ -100,6 +104,9 @@ class BaseO3CPU(BaseCPU):
         1, "Issue/Execute/Writeback to decode delay"
     )
     commitToDecodeDelay = Param.Cycles(1, "Commit to decode delay")
+
+    # Forward pipeline delays
+    bacToFetchDelay = Param.Cycles(1, "Branch address calc. to fetch delay")
     fetchToDecodeDelay = Param.Cycles(1, "Fetch to decode delay")
     decodeWidth = Param.Unsigned(8, "Decode width")
 
@@ -220,3 +227,43 @@ class BaseO3CPU(BaseCPU):
     recvRespBufferSize = Param.Unsigned(
         64, "Maximum number of receive response bytes per cycle"
     )
+
+    ## Parameters for decoupled front-end
+    decoupledFrontEnd = Param.Bool(False, "Enables the decoupled front-end")
+    numFTQEntries = Param.Unsigned(
+        8,
+        "Number of entries in the Fetch target queue. (only used for "
+        "decoupled front-end)",
+    )
+    minInstSize = Param.Unsigned(
+        1,
+        "Minimum instruction size (bytes). Determines the granularity "
+        "of the instruction minimum search width per cycle",
+    )
+    fetchTargetWidth = Param.Unsigned(
+        32,
+        "Max width (bytes) of Fetch target. "
+        "Determines the maximum search width per cycle",
+    )
+    maxFTPerCycle = Param.Unsigned(4, "Max number of FT created per cycle")
+    maxTakenPredPerCycle = Param.Unsigned(
+        1, "Max number of taken predictions per cycle"
+    )
+
+
+add_citation(
+    BaseO3CPU,
+    """@inproceedings{10.1145/3613424.3614258,
+  author    = {Schall, David and
+               Sandberg, Andreas and
+               Grot, Boris},
+  title     = {Warming Up a Cold Front-End with Ignite},
+  year      = {2023},
+  publisher = {Association for Computing Machinery},
+  address   = {Toronto, ON, Canada},
+  doi       = {10.1145/3613424.3614258},
+  booktitle = {Proceedings of the 56th Annual IEEE/ACM International Symposium on Microarchitecture (MICRO '23)},
+  series    = {MICRO'23}
+}
+""",
+)

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -37,12 +37,14 @@ if env['CONF']['BUILD_ISA']:
         sim_objects=['BaseO3CPU'],
         enums=['SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
 
+    Source('bac.cc')
     Source('commit.cc')
     Source('cpu.cc')
     Source('decode.cc')
     Source('dyn_inst.cc')
     Source('fetch.cc')
     Source('free_list.cc')
+    Source('ftq.cc')
     Source('fu_pool.cc')
     Source('iew.cc')
     Source('inst_queue.cc')
@@ -58,7 +60,9 @@ if env['CONF']['BUILD_ISA']:
     Source('thread_context.cc')
     Source('thread_state.cc')
 
+    DebugFlag('BAC')
     DebugFlag('CommitRate')
+    DebugFlag('FTQ')
     DebugFlag('IEW')
     DebugFlag('IQ')
     DebugFlag('LSQ')
@@ -71,7 +75,8 @@ if env['CONF']['BUILD_ISA']:
     DebugFlag('StoreSet')
     DebugFlag('Writeback')
 
-    CompoundFlag('O3CPUAll', [ 'Fetch', 'Decode', 'Rename', 'IEW', 'Commit',
+    CompoundFlag('O3CPUAll', [ 'BAC', 'FTQ', 'Fetch', 'Decode', 'Rename',
+        'IEW', 'Commit',
         'IQ', 'ROB', 'FreeList', 'LSQ', 'LSQUnit', 'StoreSet', 'MemDepUnit',
         'DynInst', 'O3CPU', 'Activity', 'Scoreboard', 'Writeback' ])
 

--- a/src/cpu/o3/bac.cc
+++ b/src/cpu/o3/bac.cc
@@ -1,0 +1,1031 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/o3/bac.hh"
+
+#include <algorithm>
+
+#include "arch/generic/pcstate.hh"
+#include "base/trace.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/ftq.hh"
+#include "cpu/o3/limits.hh"
+#include "debug/Activity.hh"
+#include "debug/BAC.hh"
+#include "debug/Branch.hh"
+#include "debug/Drain.hh"
+#include "debug/FTQ.hh"
+#include "debug/Fetch.hh"
+#include "debug/O3PipeView.hh"
+#include "params/BaseO3CPU.hh"
+#include "sim/full_system.hh"
+
+using namespace gem5::branch_prediction;
+
+namespace gem5
+{
+
+namespace o3
+{
+
+// clang-format off
+std::string BAC::BACStats::statusStrings[ThreadStatusMax] = {
+    "Idle",
+    "Running",
+    "Squashing",
+    "Blocked",
+    "FTQFull",
+    "FTQLocked",
+};
+// clang-format on
+
+BAC::BAC(CPU *_cpu, const BaseO3CPUParams &params)
+    : cpu(_cpu),
+      bpu(params.branchPred),
+      ftq(nullptr),
+      wroteToTimeBuffer(false),
+      decoupledFrontEnd(params.decoupledFrontEnd),
+      fetchToBacDelay(params.fetchToBacDelay),
+      decodeToFetchDelay(params.decodeToFetchDelay),
+      commitToFetchDelay(params.commitToFetchDelay),
+      bacToFetchDelay(params.bacToFetchDelay),
+      cacheBlkSize(cpu->cacheLineSize()),
+      fetchTargetWidth(params.fetchTargetWidth),
+      minInstSize(params.minInstSize),
+      numThreads(params.numThreads),
+      maxFTPerCycle(params.maxFTPerCycle),
+      maxTakenPredPerCycle(params.maxTakenPredPerCycle),
+      stats(_cpu, this)
+{
+    fatal_if(decoupledFrontEnd && (fetchTargetWidth < params.fetchBufferSize),
+             "Fetch target width should be larger than fetch buffer size!");
+    fatal_if(decoupledFrontEnd && (numThreads > 1),
+             "More than 1 thread has not been tested with the decoupled "
+             "front end");
+    fatal_if(bpu == nullptr, "Branch predictor not configured");
+
+    for (int i = 0; i < MaxThreads; i++) {
+        bacPC[i].reset(params.isa[0]->newPCState());
+        stalls[i] = {false, false, false};
+    }
+}
+
+std::string
+BAC::name() const
+{
+    return cpu->name() + ".bac";
+}
+
+void
+BAC::setTimeBuffer(TimeBuffer<TimeStruct> *time_buffer)
+{
+    timeBuffer = time_buffer;
+
+    // Create wires to get information from proper places in time buffer.
+    fromFetch = timeBuffer->getWire(-fetchToBacDelay);
+    fromDecode = timeBuffer->getWire(-decodeToFetchDelay);
+    fromCommit = timeBuffer->getWire(-commitToFetchDelay);
+}
+
+void
+BAC::setActiveThreads(std::list<ThreadID> *at_ptr)
+{
+    activeThreads = at_ptr;
+}
+
+void
+BAC::setFetchTargetQueue(FTQ *_ptr)
+{
+    // Set pointer to the fetch target queue
+    ftq = _ptr;
+}
+
+void
+BAC::startupStage()
+{
+    resetStage();
+    // For decoupled BPU the BAC need to start together with fetch
+    // so it must start up in active state.
+    switchToActive();
+}
+
+void
+BAC::clearStates(ThreadID tid)
+{
+    bacStatus[tid] = Running;
+    set(bacPC[tid], cpu->pcState(tid));
+
+    stalls[tid].fetch = false;
+    stalls[tid].drain = false;
+    stalls[tid].bpu = false;
+
+    assert(ftq != nullptr);
+    ftq->resetState(tid);
+}
+
+void
+BAC::resetStage()
+{
+    // Setup PC and nextPC with initial state.
+    for (ThreadID tid = 0; tid < numThreads; ++tid) {
+        clearStates(tid);
+    }
+
+    wroteToTimeBuffer = false;
+    _status = Inactive;
+}
+
+void
+BAC::drainResume()
+{
+    DPRINTF(Drain, "Resume from draining.\n");
+    for (ThreadID i = 0; i < numThreads; ++i) {
+        stalls[i].drain = false;
+    }
+}
+
+void
+BAC::drainSanityCheck() const
+{
+    assert(isDrained());
+
+    for (ThreadID i = 0; i < numThreads; ++i) {
+        assert(bacStatus[i] == Idle || stalls[i].drain);
+        assert(ftq->isEmpty(i));
+    }
+
+    bpu->drainSanityCheck();
+}
+
+bool
+BAC::isDrained() const
+{
+    // Make sure the FTQ is empty and the state of all threads is idle.
+    for (ThreadID i = 0; i < numThreads; ++i) {
+        // Verify the FTQ is drained
+        if (!ftq->isEmpty(i)) {
+            return false;
+        }
+
+        // Return false if not in an idle state
+        if (bacStatus[i] != Idle) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void
+BAC::drainStall(ThreadID tid)
+{
+    assert(cpu->isDraining());
+    assert(!stalls[tid].drain);
+    DPRINTF(Drain, "%i: Thread drained.\n", tid);
+    stalls[tid].drain = true;
+}
+
+void
+BAC::switchToActive()
+{
+    if (_status == Inactive) {
+        DPRINTF(Activity, "Activating stage.\n");
+        cpu->activateStage(CPU::BACIdx);
+        _status = Active;
+    }
+}
+
+void
+BAC::switchToInactive()
+{
+    if (_status == Active) {
+        DPRINTF(Activity, "Deactivating stage.\n");
+        cpu->deactivateStage(CPU::BACIdx);
+        _status = Inactive;
+    }
+}
+
+bool
+BAC::checkStall(ThreadID tid) const
+{
+    bool ret_val = false;
+
+    if (stalls[tid].fetch) {
+        DPRINTF(BAC, "[tid:%i] Fetch stall detected.\n", tid);
+        ret_val = true;
+    }
+
+    if (stalls[tid].bpu) {
+        DPRINTF(BAC, "[tid:%i] BPU stall detected.\n", tid);
+        ret_val = true;
+    }
+
+    return ret_val;
+}
+
+void
+BAC::updateBACStatus()
+{
+    // Check Running
+    for (ThreadID tid : *activeThreads) {
+
+        if (bacStatus[tid] == Running || bacStatus[tid] == Squashing) {
+
+            if (_status == Inactive) {
+                DPRINTF(Activity, "[tid:%i] Activating stage.\n", tid);
+
+                cpu->activateStage(CPU::BACIdx);
+            }
+
+            _status = Active;
+            return;
+        }
+    }
+
+    // Stage is switching from active to inactive, notify CPU of it.
+    if (_status == Active) {
+        DPRINTF(Activity, "Deactivating stage.\n");
+
+        cpu->deactivateStage(CPU::BACIdx);
+    }
+
+    _status = Inactive;
+}
+
+bool
+BAC::checkAndUpdateBPUSignals(ThreadID tid)
+{
+    // Check squash signals from commit.
+    if (fromCommit->commitInfo[tid].squash) {
+
+        DPRINTF(BAC, "[tid:%i] Squashing from commit. PC = %s\n", tid,
+                *fromCommit->commitInfo[tid].pc);
+
+        // In any case, squash the FTQ and the branch histories in the
+        // FTQ first.
+        squashBpuHistories(tid);
+        squash(*fromCommit->commitInfo[tid].pc, tid);
+
+        // If it was a branch mispredict on a control instruction, update the
+        // branch predictor with that instruction, otherwise just kill the
+        // invalid state we generated in after sequence number
+        if (fromCommit->commitInfo[tid].mispredictInst &&
+            fromCommit->commitInfo[tid].mispredictInst->isControl()) {
+
+            bpu->squash(fromCommit->commitInfo[tid].doneSeqNum,
+                        *fromCommit->commitInfo[tid].pc,
+                        fromCommit->commitInfo[tid].branchTaken, tid, true);
+            stats.branchMisspredict++;
+            stats.squashBranchCommit++;
+        } else {
+            bpu->squash(fromCommit->commitInfo[tid].doneSeqNum, tid);
+            if (fromCommit->commitInfo[tid].mispredictInst) {
+                DPRINTF(BAC,
+                        "[tid:%i] Squashing due to mispredict of "
+                        "non-control instruction: %s\n",
+                        tid,
+                        fromCommit->commitInfo[tid]
+                            .mispredictInst->staticInst->disassemble(
+                                fromCommit->commitInfo[tid]
+                                    .mispredictInst->pcState()
+                                    .instAddr()));
+            }
+            stats.noBranchMisspredict++;
+        }
+        return true;
+
+    } else if (fromCommit->commitInfo[tid].doneSeqNum) {
+        // Update the branch predictor if it wasn't a squashed instruction
+        // that was broadcasted.
+        bpu->update(fromCommit->commitInfo[tid].doneSeqNum, tid);
+    }
+
+    // Check squash signals from decode.
+    if (fromDecode->decodeInfo[tid].squash) {
+        DPRINTF(Fetch, "[tid:%i] Squashing from decode. PC = %s\n", tid,
+                *fromDecode->decodeInfo[tid].nextPC);
+
+        // Squash.
+        squashBpuHistories(tid);
+        squash(*fromDecode->decodeInfo[tid].nextPC, tid);
+
+        // Update the branch predictor.
+        if (fromDecode->decodeInfo[tid].branchMispredict) {
+
+            bpu->squash(fromDecode->decodeInfo[tid].doneSeqNum,
+                        *fromDecode->decodeInfo[tid].nextPC,
+                        fromDecode->decodeInfo[tid].branchTaken, tid, false);
+            stats.branchMisspredict++;
+            stats.squashBranchDecode++;
+        } else {
+            bpu->squash(fromDecode->decodeInfo[tid].doneSeqNum, tid);
+            stats.noBranchMisspredict++;
+        }
+        return true;
+    }
+
+    // Check squash signals from fetch.
+    if (fromFetch->fetchInfo[tid].squash && bacStatus[tid] != Squashing) {
+        DPRINTF(BAC, "Squashing from fetch with PC = %s\n",
+                *fromFetch->fetchInfo[tid].nextPC);
+
+        // Squash unless we're already squashing
+        squashBpuHistories(tid);
+        squash(*fromFetch->fetchInfo[tid].nextPC, tid);
+        return true;
+    }
+    return false;
+}
+
+bool
+BAC::checkSignalsAndUpdate(ThreadID tid)
+{
+    // Check if there's a squash signal, squash if there is.
+    // Check stall signals, block if necessary.
+    if (checkAndUpdateBPUSignals(tid)) {
+        return true;
+    }
+
+    // Check stalls
+    if (stalls[tid].drain) {
+        assert(cpu->isDraining());
+        DPRINTF(BAC, "[tid:%i] Drain stall detected.\n", tid);
+        // Squash BPU histories and disable the FTQ.
+        squashBpuHistories(tid);
+        ftq->squash(tid);
+
+        bacStatus[tid] = Idle;
+        return true;
+    }
+
+    if (checkStall(tid)) {
+        bacStatus[tid] = Blocked;
+        return true;
+    }
+
+    // If at this point the FTQ is still invalid we need to wait for
+    // A resteer/squash signal.
+    if (!ftq->isReady(tid) && bacStatus[tid] != Idle) {
+        DPRINTF(BAC, "[tid:%i] FTQ is invalid. Wait for resteer.\n", tid);
+
+        bacStatus[tid] = Idle;
+        return true;
+    }
+
+    // Check if the FTQ got blocked or unblocked
+    if ((bacStatus[tid] == Running) && ftq->isLocked(tid)) {
+
+        DPRINTF(BAC, "[tid:%i] FTQ is locked\n", tid);
+        bacStatus[tid] = FTQLocked;
+        return true;
+    }
+    if ((bacStatus[tid] == FTQLocked) && !ftq->isLocked(tid)) {
+
+        DPRINTF(BAC, "[tid:%i] FTQ not locked anymore -> Running\n", tid);
+        bacStatus[tid] = Running;
+        return true;
+    }
+
+    // Check if the FTQ became free in that cycle.
+    if ((bacStatus[tid] == FTQFull) && !ftq->isFull(tid)) {
+
+        DPRINTF(BAC, "[tid:%i] FTQ not full anymore -> Running\n", tid);
+        bacStatus[tid] = Running;
+        return true;
+    }
+
+    if (bacStatus[tid] == Squashing) {
+
+        // Switch status to running after squashing FTQ and setting the PC.
+        DPRINTF(BAC, "[tid:%i] Done squashing, switching to running.\n", tid);
+        bacStatus[tid] = Running;
+        return true;
+    }
+
+    if (ftq->isFull(tid)) {
+        // If the FTQ is full, we need to block the BAC.
+        if (bacStatus[tid] != FTQFull) {
+            DPRINTF(BAC, "[tid:%i] FTQ is full. Blocking BAC.\n", tid);
+            bacStatus[tid] = FTQFull;
+        }
+        return true;
+    }
+
+    // Now all stall/squash conditions are checked.
+    // Attempt to run the BAC if not already running.
+    if (ftq->isReady(tid) &&
+        ((bacStatus[tid] == Idle) || (bacStatus[tid] == Blocked))) {
+
+        DPRINTF(BAC, "[tid:%i] Attempt to run\n", tid);
+        bacStatus[tid] = Running;
+        return true;
+    }
+
+    // If we've reached this point, we have not gotten any signals that
+    // cause BAC to change its status.  BAC remains the same as before.
+    return false;
+}
+
+void
+BAC::squashBpuHistories(ThreadID tid)
+{
+    if (!decoupledFrontEnd) {
+        return;
+    }
+
+    DPRINTF(BAC, "%s(tid:%i): FTQ sz: %i\n", __func__, tid, ftq->size(tid));
+
+    // Iterate over the FTQ in reverse order to
+    // revert all predictions made.
+    ftq->forAllBackward(tid, [this, tid](FetchTargetPtr &ft) {
+        if (ft->bpuHistory) {
+            bpu->squashHistory(tid, ft->bpuHistory);
+            assert(ft->bpuHistory == nullptr);
+            ft->bpuHistory = nullptr;
+        }
+    });
+}
+
+void
+BAC::squash(const PCStateBase &new_pc, ThreadID tid)
+{
+    if (!decoupledFrontEnd) {
+        return;
+    }
+
+    DPRINTF(BAC, "[tid:%i] Squashing FTQ.\n", tid);
+
+    // Set status to squashing.
+    bacStatus[tid] = Squashing;
+
+    // Set the new PC
+    set(bacPC[tid], new_pc);
+
+    // Then squash all fetch targets
+    ftq->squash(tid);
+}
+
+void
+BAC::tick()
+{
+    bool activity = false;
+    bool status_change = false;
+
+    if (decoupledFrontEnd) {
+        // FDP ---------------------------------------------
+        // In the decoupled frontend the BAC stage is active as all
+        // others. Its main purpose is generate fetch targets by using
+        // the branch predction unit.
+
+        for (const ThreadID tid : *activeThreads) {
+            // Check stall and squash signals first.
+            status_change = status_change || checkSignalsAndUpdate(tid);
+
+            // Generate fetch targets if BAC is in running state
+            if (bacStatus[tid] == Running) {
+                generateFetchTargets(tid, status_change);
+                activity = true;
+            }
+            stats.status[bacStatus[tid]]++;
+        }
+
+    } else {
+        // No FDP -------------------------------------------
+        // In the non-decoupled frontend the BAC stage is passive and
+        // only manages the branch prediction unit.
+        // It is always idle.
+
+        for (const ThreadID tid : *activeThreads) {
+            // Update only the branch prediction signals.
+            checkAndUpdateBPUSignals(tid);
+            if (bacStatus[tid] != Idle) {
+                bacStatus[tid] = Idle;
+                status_change = true;
+            }
+        }
+    } // ----------------------------------------------------
+
+    if (status_change) {
+        updateBACStatus();
+    }
+
+    if (activity) {
+        DPRINTF(Activity, "Activity this cycle.\n");
+
+        cpu->activityThisCycle();
+    }
+}
+
+FetchTargetPtr
+BAC::newFetchTarget(ThreadID tid, const PCStateBase &start_pc)
+{
+    auto ft = std::make_shared<FetchTarget>(tid, start_pc,
+                                            cpu->getAndIncrementFTSeq());
+
+    DPRINTF(BAC, "Create new fetch target ftn:%llu\n", ft->ftNum());
+    stats.fetchTargets++;
+    return ft;
+}
+
+bool
+BAC::predict(ThreadID tid, const StaticInstPtr &inst, const FetchTargetPtr &ft,
+             PCStateBase &pc)
+{
+
+    /** Perform the prediction.
+     * The prediction history object is pushed onto the fetch target. This
+     * allows tracking which object belongs to which branch. It also allows
+     * inserting `dummy` objects for branches that where not detected by the
+     * BAC state due to BTB misses.
+     * The postFetch() function will move the history from the FT to the
+     * main history of the BPU and insert these missing histories.
+     */
+    assert(ft->bpuHistory == nullptr);
+    bool taken = bpu->predict(inst, ft->ftNum(), pc, tid, ft->bpuHistory);
+
+    DPRINTF(Branch, "[tid:%i, ftn:%llu] History added.\n", tid, ft->ftNum());
+    return taken;
+}
+
+void
+BAC::generateFetchTargets(ThreadID tid, bool &status_change)
+{
+    /**
+     * This function implements the head of the decoupled frontend.
+     * Instead of waiting for the pre-decoding the current instruction, as
+     * done in the standared front-end, the BTB is leveraged for finding
+     * branches in the instruction stream.
+     *
+     * Starting from the current address we search all consecutive addresses
+     * if a entry exits in the BTB. As soon as the BTB hits, we know we have
+     * reached a branch instruction and make a prediction for the branch.
+     * The start and end address of this so called fetch target is stored
+     * together with the prediction in the FTQ.
+     *
+     * Depending on the prediction of the BPU the branch target or the
+     * fallthrough address determine the start address for the next
+     * fetch target and search cycle.
+     *
+     * For simplicity each fetch target contains at max one branch. However,
+     * as a not-taken branch does not require redirecting the fetch unit
+     * CPU's may continue fetching past a not taken branch. Therefore, this
+     * implementationt may create multiple fetach targets per cycle.
+     * A cycle ends when (1) the fetch target size is reached, (2) an upper
+     * bound of fetch targets per cycle is reached, or (3) a branch is
+     * predicted as taken.
+     *
+     * The same mechanism enables us to simulate making multiple `taken`
+     * predictions per cycles as it is the case in very recent commercial
+     * CPU's.
+     */
+
+    PCStateBase &cur_pc = *bacPC[tid];
+    int num_ft = 0;
+    int num_taken = 0;
+
+    while ((num_ft < maxFTPerCycle) && (num_taken < maxTakenPredPerCycle)) {
+        // Get a reference to the current PC state for this thread.
+        // The search itself is done on the instruction address to speed up
+        // simulation time.
+        Addr search_addr = cur_pc.instAddr();
+        Addr start_addr = search_addr;
+
+        // Create a new fetch target starting with the current PC.
+        FetchTargetPtr curFT = newFetchTarget(tid, cur_pc);
+        num_ft++;
+
+        bool branch_found = false;
+        bool predict_taken = false;
+
+        // Scan through the instruction stream and search for branches.
+        // The BTB contains only branches where taken at least once.
+        // Search stopped either because a branch was found in instruction
+        // stream or the maximum search width per cycle was reached.
+        // In the first case make the branch prediction and in the later
+        // advance the PC to start the search at the following address.
+        while (true) {
+
+            // Check if the current search address can be found in the BTB
+            // indicating the end of the branch.
+            branch_found = bpu->BTBValid(tid, search_addr);
+
+            // If its a branch stop searching
+            if (branch_found) {
+                break;
+            }
+
+            // If its not a branch check if the maximum search width is
+            // reached. If yes stop searching.
+            if ((search_addr - start_addr) >= fetchTargetWidth) {
+                break;
+            }
+
+            // Continue searching.
+            search_addr += minInstSize;
+        }
+
+        // Update the current PC to point to the last instruction
+        // in the fetch target
+        cur_pc.set(search_addr);
+
+        // Make a copy of the current PC since the BPU will update it.
+        std::unique_ptr<PCStateBase> next_pc(cur_pc.clone());
+        StaticInstPtr staticInst = nullptr;
+
+        if (branch_found) {
+            // Branch found in instruction stream. As the current
+            // BPU implementation required the static instruction we need to
+            // look it up from the BTB.
+            staticInst = bpu->BTBGetInst(tid, cur_pc.instAddr());
+            assert(staticInst);
+
+            // Now make the actual prediction. Note the BPU will advance
+            // the PC to the next instruction.
+            predict_taken = predict(tid, staticInst, curFT, *next_pc);
+
+            DPRINTF(BAC,
+                    "[tid:%i, ftn:%llu] Branch found at PC %#x "
+                    "taken?:%i, target:%#x\n",
+                    tid, curFT->ftNum(), cur_pc.instAddr(), predict_taken,
+                    next_pc->instAddr());
+
+            stats.branches++;
+            if (predict_taken) {
+                stats.predTakenBranches++;
+                num_taken++;
+            }
+        }
+
+        if (!predict_taken) {
+            // Not predicted taken. Start the next FT at the next address.
+            next_pc->set(cur_pc.instAddr() + minInstSize);
+        }
+
+        // x86 has some complex instruction like string copy where the branch
+        // is not the last instruction or have several branches within the same
+        // instruction. Those branches jump always! to itself. This messes up
+        // the searching approach and will result in an infinite loop until the
+        // branch is squashed.
+        // We handle this by assuming only one branch per instruction and go
+        // straight to the next address/instruction/fetch target. In case the
+        // decoder finds more branches in this instruction we squash the FTQ.
+        // (see postFetch())
+        // This could be circumvented by using not only the PC but also the
+        // microPC to make predictions. However, since such instructions are
+        // rare this is not implemented.
+        // However, Arm does not micro code branches and correspondingly does
+        // not set the `IsLastMicroop` flag which misleads the decoupling for
+        // Arm. Therefore, we check if an instruction is micro coded in the
+        // first place.
+        if (staticInst && staticInst->isMicroop() &&
+            !staticInst->isLastMicroop()) {
+            stats.branchesNotLastuOp++;
+            // The target is always to itself no matter if its taken or not.
+            // assert(next_pc->instAddr() == search_addr);
+            DPRINTF(BAC,
+                    "Branch detected which is not the last uOp %s. "
+                    "Continue with next address.\n",
+                    cur_pc);
+
+            next_pc->set(cur_pc.instAddr() + staticInst->size());
+        }
+
+        // Complete the fetch target if
+        // - a branch is found
+        // - or the maximum fetch bandwidth is reached.
+        curFT->finalize(cur_pc, branch_found, predict_taken, *next_pc);
+
+        ftq->insert(tid, curFT);
+        wroteToTimeBuffer = true;
+
+        DPRINTF(BAC,
+                "[tid:%i] [fn:%llu] %i addresses searched. "
+                "Branch found:%i. Continue with PC:%s in next cycle\n",
+                tid, curFT->ftNum(), (search_addr - start_addr), branch_found,
+                *next_pc);
+
+        stats.ftSizeDist.sample(search_addr - start_addr);
+
+        // Finally set the BPU PC to the next FT in the next cycle
+        set(cur_pc, *next_pc);
+
+        if (debug::FTQ) {
+            ftq->printFTQ(tid);
+        }
+        // Check whether the FTQ became full. In that case block until
+        // fetch has consumed one.
+        if (ftq->isFull(tid)) {
+            DPRINTF(BAC, "FTQ full\n");
+            bacStatus[tid] = FTQFull;
+            status_change = true;
+            break;
+        }
+    }
+    stats.ftNumber.sample(num_ft);
+}
+
+/// Post fetch part ------------------------------------------
+
+bool
+BAC::updatePreDecode(ThreadID tid, const InstSeqNum seqNum,
+                     const StaticInstPtr &inst, PCStateBase &pc,
+                     const FetchTargetPtr &ft)
+{
+    assert(ft != nullptr);
+    // The PC must be in the range of the fetch target.
+    assert(ft->inRange(pc.instAddr()));
+
+    assert(ft->ftNum() == ftq->readHead(tid)->ftNum());
+    BranchType brType = branch_prediction::getBranchType(inst);
+    stats.preDecUpdate[brType]++;
+
+    DPRINTF(BAC,
+            "%s(tid:%i, sn:%lu, inst: %s, PC:%#x, FT[%llu, taken=%i, "
+            "end=%#x])\n",
+            __func__, tid, seqNum, branch_prediction::toString(brType),
+            pc.instAddr(), ft->ftNum(), ft->predTaken(), ft->endAddress());
+
+    bool target_set = false;
+    BPredUnit::PredictorHistory *hist = nullptr;
+
+    // The fetch stage will call this function after pre-decoding an
+    // instruction finds a branch instruction. Check if this is the exit
+    // branch.
+    if (ft->isExitBranch(pc.instAddr()) && ft->bpuHistory != nullptr) {
+
+        // Pop the history from the FTQ to move it later to the
+        // history buffer.
+        std::swap(hist, ft->bpuHistory);
+
+        DPRINTF(BAC,
+                "Pop history from FT:%llu => sn:%llu, PC:%#x, taken:%i, "
+                "target:%#x\n",
+                ft->ftNum(), seqNum, hist->pc, hist->predTaken,
+                hist->target->instAddr());
+    }
+
+    // Special cases ------------------------------------------------
+    // We need to handle two corner cases for complex instructions
+    // 1. For complex instructions it can happen that several branches with
+    // different types exists in the same instruction. If the branch type
+    // does not match with the type of the prediction history its invalid.
+    // We squash everything  the history and we can make a fresh
+    // prediction
+    if (hist && (hist->type != brType)) {
+        DPRINTF(Branch, "Branch types dont match. Delete history\n", tid);
+        stats.typeMissmatch++;
+
+        // Push the history back to the FTQ to allow it to be sqaushed
+        // in correct order. Then squash all histories right away.
+        std::swap(ft->bpuHistory, hist);
+        squashBpuHistories(tid);
+
+        // Lock the FTQ. The complex instruction needs to
+        // be completed before unlocking. Unlocking is performed by resetting
+        // the BAC stage.
+        ftq->lock(tid);
+    }
+
+    // 2. For complex instruction comprising multiple branches the history is
+    // already used. We only predict the first branch in a complex instruction
+    // (see createFetchTarget() function).
+    // In that case we squash the FTQ and lock it until the full instruction
+    // Afterwards the fetch stage will reset the BAC stage with a
+    // bacResteer() call. Hence, operation for complex instructions is:
+    // Detecting multi branch inst. -> lock FTQ util inst. done. -> reset BAC.
+    //
+    // Note we might end up here multiple times until the full instruction
+    // is completed.
+    if (inst->isMicroop() && !inst->isLastMicroop() && (hist == nullptr)) {
+
+        DPRINTF(Branch, "No history for complex instruction found. \n");
+        stats.multiBranchInst++;
+
+        // First squash all histories that are already in the FTQ
+        // to have a clean state.
+        squashBpuHistories(tid);
+
+        // Then lock the FTQ. The complex instruction needs to
+        // be completed before unlocking. Unlocking is performed by
+        // resetting the BAC stage with a bacResteer() call from the
+        // fetch stage.
+        ftq->lock(tid);
+
+        // Finally we can make a fresh prediction.
+        bpu->predict(inst, ft->ftNum(), pc, tid, hist);
+        target_set = true;
+    }
+
+    // Normal case --------------------------------------------------
+    // Check if we have a valid history. If not we need to create one.
+    if (hist == nullptr) {
+        DPRINTF(BAC, "[tid:%i, sn:%llu] No branch history for PC:%#x\n", tid,
+                seqNum, pc.instAddr());
+        stats.noHistByType[brType]++;
+
+        // The branch was not detected by the BAC stage in the first place
+        // because the BTB did not had an entry for this PC. It can happen
+        // if this is the first time the branch is encountered, the branch
+        // was never taken before, or the entry got evicted.
+        //
+        // Create a "dummy" history object by assuming the branch is not
+        // taken. This will allow the BPU to fix its histories and internal
+        // state in case the assumption was wrong. It works because for
+        // FDP we use "taken" history where not taken branches don't modify
+        // the global history.
+
+        hist =
+            new BPredUnit::PredictorHistory(tid, seqNum, pc.instAddr(), inst);
+        bpu->branchPlaceholder(tid, pc.instAddr(), inst->isUncondCtrl(),
+                               hist->bpHistory);
+
+        set(hist->target, std::unique_ptr<PCStateBase>(pc.clone()));
+        inst->advancePC(*hist->target);
+    }
+
+    assert(hist != nullptr);
+    assert(hist->type == brType);
+
+    // Assign the branch instruction instance its sequence number
+    // and push the history to the main history buffer.
+    hist->seqNum = seqNum;
+    bpu->insertPredictorHistory(tid, hist);
+
+    // Finally update the current fetch PC if not already done.
+    // For taken branches the target is stored in the FTQ. For not taken
+    // branches we need to advance the PC.
+    if (!target_set) {
+        if (hist->predTaken) {
+            set(pc, ft->readPredTarg());
+        } else {
+            inst->advancePC(pc);
+        }
+    }
+
+    DPRINTF(BAC, "%s done. next PC:%s\n", __func__, pc);
+    return hist->predTaken;
+}
+
+bool
+BAC::updatePC(const DynInstPtr &inst, PCStateBase &fetch_pc,
+              FetchTargetPtr &ft)
+{
+    // This function will update the fetch PC to the next instruction.
+    // If the current instruction is a branch it will make
+    // the branch prediction.
+    bool predict_taken;
+    ThreadID tid = inst->threadNumber;
+
+    if (inst->isControl()) {
+        // The instruction is a control instruction.
+
+        if (decoupledFrontEnd) {
+            // With a decoupled front-end the branch prediction was done
+            // while creating the fetch target. Now update the prediction
+            // with the information from the predecoding.
+            predict_taken = updatePreDecode(tid, inst->seqNum,
+                                            inst->staticInst, fetch_pc, ft);
+        } else {
+            // With a coupled front-end we need to make the branch prediction
+            // here.
+            predict_taken =
+                bpu->predict(inst->staticInst, inst->seqNum, fetch_pc, tid);
+        }
+
+        DPRINTF(BAC,
+                "[tid:%i] [sn:%llu] Branch at PC %#x "
+                "predicted %s to go to %s\n",
+                tid, inst->seqNum, inst->pcState().instAddr(),
+                predict_taken ? "taken" : "not taken", fetch_pc);
+        inst->setPredTarg(fetch_pc);
+        inst->setPredTaken(predict_taken);
+
+        ++stats.branches;
+
+        if (predict_taken) {
+            ++stats.predTakenBranches;
+        }
+
+    } else {
+
+        // For non-branch instructions simply advance the PC.
+        inst->staticInst->advancePC(fetch_pc);
+        inst->setPredTarg(fetch_pc);
+        inst->setPredTaken(false);
+        predict_taken = false;
+    }
+
+    if (decoupledFrontEnd) {
+
+        // For the decoupled front-end we need to check if this instruction
+        // is the exit instruction of the fetch target. It does not need
+        // to be a branch.
+        // If the instruction is micro coded check if its the last uOp.
+        // Also remove the fetch target if the FTQ became invalid.
+        if ((ft->isExitInst(inst->pcState().instAddr()) &&
+             (!inst->isMicroop() || inst->isLastMicroop())) ||
+            !ftq->isReady(tid)) {
+
+            DPRINTF(BAC, "[tid:%i][ft:%llu] Reached end of Fetch Target\n",
+                    tid, ft->ftNum());
+
+            ft = nullptr;
+        }
+    }
+
+    return predict_taken;
+}
+
+BAC::BACStats::BACStats(o3::CPU *cpu, BAC *bac)
+    : statistics::Group(cpu, "bac"),
+      ADD_STAT(status, statistics::units::Cycle::get(),
+               "Number of cycles BAC in state"),
+      ADD_STAT(fetchTargets, statistics::units::Count::get(),
+               "Number of fetch targets created "),
+      ADD_STAT(branches, statistics::units::Count::get(),
+               "Number of branches that BAC encountered"),
+      ADD_STAT(predTakenBranches, statistics::units::Count::get(),
+               "Number of branches that BAC predicted taken."),
+      ADD_STAT(branchesNotLastuOp, statistics::units::Count::get(),
+               "Number of branches that fetch encountered which are not the "
+               "last uOp within a macrooperation. Jump to itself."),
+      ADD_STAT(branchMisspredict, statistics::units::Count::get(),
+               "Number of mispredicted branches"),
+      ADD_STAT(noBranchMisspredict, statistics::units::Count::get(),
+               "Number of non-branch instructions mispredicted"),
+      ADD_STAT(squashBranchDecode, statistics::units::Count::get(),
+               "Number of branches squashed from decode"),
+      ADD_STAT(squashBranchCommit, statistics::units::Count::get(),
+               "Number of branches squashed from commit"),
+      ADD_STAT(preDecUpdate, statistics::units::Count::get(),
+               "Number of branches extracted from the predecoder"),
+      ADD_STAT(noHistByType, statistics::units::Count::get(),
+               "Number and type of branches that were undetected by the BPU."),
+      ADD_STAT(typeMissmatch, statistics::units::Count::get(),
+               "Number branches where the branch type miss match"),
+      ADD_STAT(multiBranchInst, statistics::units::Count::get(),
+               "Number branches because its not the last branch."),
+      ADD_STAT(ftSizeDist, statistics::units::Count::get(),
+               "Number of bytes per fetch target"),
+      ADD_STAT(ftNumber, statistics::units::Count::get(),
+               "Number of fetch target inserted to the FTQ per cycle")
+{
+    using namespace statistics;
+    status.init(ThreadStatusMax).flags(statistics::pdf | statistics::nozero);
+    for (int i = 0; i < ThreadStatusMax; ++i) {
+        status.subname(i, statusStrings[i]);
+        status.subdesc(i, "Number of cycles BAC is " + statusStrings[i]);
+    }
+
+    ftSizeDist
+        .init(/* base value */ 0,
+              /* last value */ bac->fetchTargetWidth,
+              /* bucket size */ 4)
+        .flags(statistics::pdf);
+
+    preDecUpdate.init(enums::Num_BranchType).flags(total | pdf);
+    noHistByType.init(enums::Num_BranchType).flags(total | pdf);
+    ftNumber.init(0, bac->maxFTPerCycle, 1);
+
+    for (int i = 0; i < enums::Num_BranchType; i++) {
+        preDecUpdate.subname(i, enums::BranchTypeStrings[i]);
+        noHistByType.subname(i, enums::BranchTypeStrings[i]);
+    }
+}
+
+} // namespace o3
+} // namespace gem5

--- a/src/cpu/o3/bac.hh
+++ b/src/cpu/o3/bac.hh
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_O3_BAC_HH__
+#define __CPU_O3_BAC_HH__
+
+#include <list>
+
+#include "base/statistics.hh"
+#include "cpu/o3/comm.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
+#include "cpu/o3/limits.hh"
+#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/branch_type.hh"
+#include "cpu/timebuf.hh"
+
+namespace gem5
+{
+
+struct BaseO3CPUParams;
+
+namespace o3
+{
+
+class CPU;
+class FTQ;
+class FetchTarget;
+typedef std::shared_ptr<FetchTarget> FetchTargetPtr;
+
+/********************************************************************
+ * BAC: Branch and Address Calculation
+ *
+ * The BAC stage handles branch prediction and next PC address
+ * calculation and mainly consists of two parts:
+ *
+ * (1) The branch prediction part that manages the branch predictor.
+ *     It checks the backward communication signals from the pipleline
+ *     to update the branch predictor accordingly.
+ *     This part can be decoupled from the fetch stage and used to
+ *     feed the FTQ with fetch targets which will be consumed by the
+ *     fetch stage.
+ *     When decoupling is enabled this part is active and acts as
+ *     a separate pipeline stage. Otherwise the stage remains idle and
+ *     everything is in sync with the fetch stage. The branch prediction
+ *     itself is then triggered from the PC calculation part.
+ *
+ * (2) The PC calculation part that is tightly coupled to the
+ *     fetch stage. Fetch calls the updatePC() method after each
+ *     predecoded instruction to advance the PC to the next instruction.
+ *
+ * Note that this organization means that the BAC stage spans
+ * two pipeline stages and the second part is in the same stage as
+ * the fetch stage which is not the nicest organization. However,
+ * it allows to keep the fetch stage simple and most of the decoupling
+ * in the BAC stage.
+ */
+class BAC
+{
+    typedef branch_prediction::BranchType BranchType;
+
+  public:
+    /** Overall decoupled BPU stage status. Used to determine if the CPU can
+     * deschedule itself due to a lack of activity.
+     */
+    enum BACStatus
+    {
+        Active,
+        Inactive
+    };
+
+    /** Individual thread status. */
+    enum ThreadStatus
+    {
+        Idle,
+        Running,
+        Squashing,
+        Blocked,
+        FTQFull,
+        FTQLocked,
+        ThreadStatusMax
+    };
+
+  private:
+    /** Decode status. */
+    BACStatus _status;
+
+    /** Per-thread status. */
+    ThreadStatus bacStatus[MaxThreads];
+
+  public:
+    /** BAC constructor. */
+    BAC(CPU *_cpu, const BaseO3CPUParams &params);
+
+    // Interfaces to CPU ----------------------------------
+    // These functions are to manage the BAC stage
+    // and the interface with the remaining CPU.
+
+    /** Returns the name of the stage. */
+    std::string name() const;
+
+    /** Registers probes and listeners. */
+    void
+    regProbePoints()
+    {}
+
+    /** Sets the main backwards communication time buffer pointer. */
+    void setTimeBuffer(TimeBuffer<TimeStruct> *tb_ptr);
+
+    /** Sets pointer to list of active threads. */
+    void setActiveThreads(std::list<ThreadID> *at_ptr);
+
+    /** Connect the FTQ */
+    void setFetchTargetQueue(FTQ *_ptr);
+
+    /** Initialize stage. */
+    void startupStage();
+
+    /** Clear all thread-specific states*/
+    void clearStates(ThreadID tid);
+
+    /** Resume after a drain. */
+    void drainResume();
+
+    /** Perform sanity checks after a drain. */
+    void drainSanityCheck() const;
+
+    /** Has the stage drained? */
+    bool isDrained() const;
+
+    /**
+     * Stall the fetch stage after reaching a safe drain point.
+     *
+     * The CPU uses this method to stop fetching instructions from a
+     * thread that has been drained. The drain stall is different from
+     * all other stalls in that it is signaled instantly from the
+     * commit stage (without the normal communication delay) when it
+     * has reached a safe point to drain from.
+     */
+    void drainStall(ThreadID tid);
+
+    /** Takes over from another CPU's thread. */
+    void
+    takeOverFrom()
+    {
+        resetStage();
+    }
+
+    void deactivateThread(ThreadID tid) {};
+
+    /** Process all input signals and create the next fetch target. */
+    void tick();
+
+  private:
+    /** Reset this pipeline stage */
+    void resetStage();
+
+    /** Changes the status of this stage to active, and indicates this
+     * to the CPU.
+     */
+    void switchToActive();
+
+    /** Changes the status of this stage to inactive, and indicates
+     * this to the CPU.
+     */
+    void switchToInactive();
+
+    /** Checks if a thread is stalled. */
+    bool checkStall(ThreadID tid) const;
+
+    /** Updates overall BAC stage status; to be called at the end of each
+     * cycle. */
+    void updateBACStatus();
+
+    /** Checks all input signals and updates the status as necessary.
+     *  @return: Returns true if the status changed due to input signals.
+     */
+    bool checkSignalsAndUpdate(ThreadID tid);
+
+    /** Check the backward signals that update the BPU. */
+    bool checkAndUpdateBPUSignals(ThreadID tid);
+
+  private:
+    /* ----------------------------------------------------------------
+     * Decoupled Frontend Functionality
+     *
+     * In a decoupled frontend the Branch predictor unit (BPU)
+     * is not directly queried by Fetch once it pre-decodes
+     * a branch. Instead BPU and Fetch is separated and
+     * connected via a queue fetch target queue (FTQ). The BPU generates
+     * fetch targets, similar to basic blocks (BB) and inserts them in
+     * the queue. Fetch will consume the addresses and read them from the
+     * I-cache.
+     * The advantages are that it (1) cuts the critical path and (2)
+     * allow a precise, BPU guided prefetching of the fetch targets.
+     *
+     * For determining next PC addresses the BPU relies solely on the BTB.
+     *
+     * The following functions are only used in the decoupled scenario.
+     */
+
+    /**
+     * Create a new fetch target.
+     * @param start_pc The current PC. Will be the start address of the
+     * fetch target.
+     */
+    FetchTargetPtr newFetchTarget(ThreadID tid, const PCStateBase &start_pc);
+
+    /**
+     * The prediction function for the BAC stage. In the decoupled scenario
+     * the branch history is not added to the BPUs very own predictor history
+     * because at the moment a prediction is made the sequence number in
+     * not known.
+     * @param inst The branch instruction.
+     * @param ft The fetch target that is currently processed.
+     * @param PC The predicted PC is passed back through this parameter.
+     * @return Returns if the branch is taken or not.
+     */
+    bool predict(ThreadID tid, const StaticInstPtr &inst,
+                 const FetchTargetPtr &ft, PCStateBase &pc);
+
+    /**
+     * Main function that feeds the FTQ with new fetch targets.
+     * By leveraging the BTB up to N consecutive addresses are searched
+     * to detect a branch instruction. For every BTB hit the direction
+     * predictor is asked to make a prediction.
+     * In every cycle one fetch target is created. A fetch target ends
+     * once the first branch instruction is detected or the maximum
+     * search bandwidth for a cycle is reached.
+     **/
+    void generateFetchTargets(ThreadID tid, bool &status_change);
+
+    /* ----------------------------------------------------------------
+     * Next PC address calculation
+     *
+     * To update the PC the fetch stage will call the updatePC() method
+     * with the currently pre-decoded instruction.
+     * The BAC stage will then check if the instruction is a branch and
+     * either perform the branch prediction (non-decoupled scenario) or
+     * read the branch prediction from the currently processed fetch
+     * target (decoupled scenario).
+     */
+  public:
+    /**
+     * Calculate the next PC address depending on the instruction type
+     * and the branch prediction.
+     * @param inst The currently processed dynamic instruction.
+     * @param fetch_pc The current fetch PC passed in by reference. It will
+     * be updated with what the next PC will be.
+     * @param ft The currently processed fetch target. Can be nullptr for
+     * the non-decoupled scenario.
+     * @return Whether or not a branch was predicted as taken.
+     */
+    bool updatePC(const DynInstPtr &inst, PCStateBase &fetch_pc,
+                  FetchTargetPtr &ft);
+
+  private:
+    /** Pre-decode update -----------------------------------------
+     * After predecoding instruction in the fetch stage all instructions
+     * are known together and a sequence number is assigned to them.
+     * The fetch stage will call this function for every branch instruction
+     * to allow the BAC stage to update the branch predictor history.
+     *
+     * There can be the following two cases:
+     * - The branch was detected by the BAC stage and a prediction was made.
+     *   In that case the branch history is moved from the FTQ to the BPU.
+     *
+     * - The branch was not detected by the BAC stage. In that case a "dummy"
+     *   branch history is created and inserted into the BPU. For this dummy
+     *   prediction it is assumed that the branch is not taken.
+     *   If it turns unconditional or is taken decode or commit will squash
+     *   the branch.
+     *
+     * This function performs the following steps:
+     *  - For every branch where a prediction was made in the first place
+     * It moves the branch history from the FTQ to the BPU.
+     *
+     * Together with inserting an instruction into the instruction queue
+     *  instruction matches the predicted
+     * instruction type. If so update the information with the new.
+     * In case the types dont match something is wrong and we need
+     * to squash. (should not be the case.)
+     * @param seq_num The branches sequence that we want to update.
+     * @param inst The new pre-decoded branch instruction.
+     * @param tid The thread id.
+     * @return Returns if the update was successful.
+     */
+    bool updatePreDecode(ThreadID tid, const InstSeqNum seqNum,
+                         const StaticInstPtr &inst, PCStateBase &pc,
+                         const FetchTargetPtr &ft);
+
+  private:
+    /** Squashes BAC for a specific thread and resets the PC. */
+    void squash(const PCStateBase &new_pc, ThreadID tid);
+
+    /**
+     * Squashes the BPU histories in the FTQ.
+     * by iterating from tail to head and reverts the predictions made.
+     **/
+    void squashBpuHistories(ThreadID tid);
+
+  private:
+    /** Pointer to the main CPU. */
+    CPU *cpu;
+
+    /** BPredUnit. */
+    branch_prediction::BPredUnit *bpu;
+
+    /** Fetch target Queue. */
+    FTQ *ftq;
+
+    /** Time buffer interface. */
+    TimeBuffer<TimeStruct> *timeBuffer;
+
+    /** Wire to get fetches's information from backwards time buffer. */
+    TimeBuffer<TimeStruct>::wire fromFetch;
+
+    /** Wire to get decode's information from backwards time buffer. */
+    TimeBuffer<TimeStruct>::wire fromDecode;
+
+    /** Wire to get commit's information from backwards time buffer. */
+    TimeBuffer<TimeStruct>::wire fromCommit;
+
+    /** Wire used to write any information heading to fetch. */
+    TimeBuffer<FetchStruct>::wire toFetch;
+
+    /** The decoupled PC which runs ahead of fetch */
+    std::unique_ptr<PCStateBase> bacPC[MaxThreads];
+
+    /** Variable that tracks if BAC has written to the time buffer this
+     * cycle. Used to tell CPU if there is activity this cycle.
+     */
+    bool wroteToTimeBuffer;
+
+    /** Source of possible stalls. */
+    struct Stalls
+    {
+        bool fetch;
+        bool drain;
+        bool bpu;
+    };
+
+    /** Tracks which stages are telling the ftq to stall. */
+    Stalls stalls[MaxThreads];
+
+    /** Enables the decoupled front-end */
+    const bool decoupledFrontEnd;
+
+    /** Fetch to BAC delay. */
+    const Cycles fetchToBacDelay;
+
+    /** Decode to fetch delay. (Same delay for BAC as for fetch) */
+    const Cycles decodeToFetchDelay;
+
+    /** Commit to fetch delay. (Same delay for BAC as for fetch) */
+    const Cycles commitToFetchDelay;
+
+    /** BAC to fetch delay. */
+    const Cycles bacToFetchDelay;
+
+    /** Cache block size. */
+    const unsigned int cacheBlkSize;
+
+    /** The maximum width of a fetch target. This also determines the
+     * maximum addresses searched in one cycle. (FT width / minInstSize) */
+    const unsigned fetchTargetWidth;
+
+    /** The minimum size an instruction can have in the current
+     * architecture. It determines the search granularity of the decoupled
+     * front-end. I.e. for x86 this must be 1. For fixed size ISA's it
+     * should be equal to the instruction size to speedup simulation time.*/
+    const unsigned minInstSize;
+
+    /** List of Active FTQ Threads */
+    std::list<ThreadID> *activeThreads;
+
+    /** Number of threads. */
+    const ThreadID numThreads;
+
+    /* Max number of FT added to the FTQ per Cycle */
+    const unsigned maxFTPerCycle;
+
+    /* Max number taken prediction by the BPU per Cycle*/
+    const unsigned maxTakenPredPerCycle;
+
+    /** Align a address to the start of a cache block. */
+    inline Addr
+    alignToCacheBlock(Addr addr)
+    {
+        return (addr & ~(cacheBlkSize - 1));
+    }
+
+  protected:
+    struct BACStats : public statistics::Group
+    {
+        static std::string statusStrings[ThreadStatusMax];
+
+        BACStats(CPU *cpu, BAC *bac);
+
+        /** Stat for total number of cycles spent in each BAC state */
+        statistics::Vector status;
+
+        /** Stat for total number fetch targets created. */
+        statistics::Scalar fetchTargets;
+        /** Total number of branches detected. */
+        statistics::Scalar branches;
+        /** Total number of branches predicted taken. */
+        statistics::Scalar predTakenBranches;
+        /** Total number of fetched branches. */
+        statistics::Scalar branchesNotLastuOp;
+
+        /** Stat for total number of misspredicted instructions. */
+        statistics::Scalar branchMisspredict;
+        statistics::Scalar noBranchMisspredict;
+
+        /** Stat for the number of squashes from decode and commit. */
+        statistics::Scalar squashBranchDecode;
+        statistics::Scalar squashBranchCommit;
+
+        /** Number of post updates */
+        statistics::Vector preDecUpdate;
+        /** Number of branches undetected by the BPU */
+        statistics::Vector noHistByType;
+
+        /** Stat for the two corner cases */
+        statistics::Scalar typeMissmatch;
+        statistics::Scalar multiBranchInst;
+
+        /** Distribution of number of bytes per fetch target. */
+        statistics::Distribution ftSizeDist;
+        statistics::Distribution ftNumber;
+
+    } stats;
+    /** @} */
+};
+
+} // namespace o3
+} // namespace gem5
+
+#endif // __CPU_O3_BAC_HH__

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011, 2016-2017 ARM Limited
  * Copyright (c) 2013 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -111,6 +112,16 @@ struct IssueStruct
 /** Struct that defines all backwards communication. */
 struct TimeStruct
 {
+    struct FetchComm
+    {
+        bool block;
+        /** Signals to redirect BAC if something goes wrong. */
+        bool squash;
+        std::unique_ptr<PCStateBase> nextPC;
+    };
+
+    FetchComm fetchInfo[MaxThreads];
+
     struct DecodeComm
     {
         std::unique_ptr<PCStateBase> nextPC;
@@ -121,7 +132,7 @@ struct TimeStruct
         uint64_t branchAddr = 0;
         unsigned branchCount = 0;
         bool squash = false;
-        bool predIncorrect = false;
+        bool controlMispredict = false;
         bool branchMispredict = false;
         bool branchTaken = false;
     };

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011-2012, 2014, 2016, 2017, 2019-2020, 2024 Arm Limited
  * Copyright (c) 2013 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -72,26 +73,24 @@ namespace o3
 CPU::CPU(const BaseO3CPUParams &params)
     : BaseCPU(params),
       mmu(params.mmu),
-      tickEvent([this]{ tick(); }, "O3CPU tick",
-                false, Event::CPU_Tick_Pri),
-      threadExitEvent([this]{ exitThreads(); }, "O3CPU exit threads",
-                false, Event::CPU_Exit_Pri),
+      tickEvent([this] { tick(); }, "O3CPU tick", false, Event::CPU_Tick_Pri),
+      threadExitEvent([this] { exitThreads(); }, "O3CPU exit threads", false,
+                      Event::CPU_Exit_Pri),
 #ifndef NDEBUG
       instcount(0),
 #endif
       removeInstsThisCycle(false),
+      bac(this, params),
+      ftq(this, params),
       fetch(this, params),
       decode(this, params),
       rename(this, params),
       iew(this, params),
       commit(this, params),
 
-      regFile(params.numPhysIntRegs,
-              params.numPhysFloatRegs,
-              params.numPhysVecRegs,
-              params.numPhysVecPredRegs,
-              params.numPhysMatRegs,
-              params.numPhysCCRegs,
+      regFile(params.numPhysIntRegs, params.numPhysFloatRegs,
+              params.numPhysVecRegs, params.numPhysVecPredRegs,
+              params.numPhysMatRegs, params.numPhysCCRegs,
               params.isa[0]->regClasses()),
 
       freeList(name() + ".freelist", &regFile),
@@ -108,10 +107,10 @@ CPU::CPU(const BaseO3CPUParams &params)
       renameQueue(params.backComSize, params.forwardComSize),
       iewQueue(params.backComSize, params.forwardComSize),
       activityRec(name(), NumStages,
-                  params.backComSize + params.forwardComSize,
-                  params.activity),
+                  params.backComSize + params.forwardComSize, params.activity),
 
       globalSeqNum(1),
+      globalFTSeqNum(1),
       system(params.system),
       lastRunningCycle(curCycle()),
       cpuStats(this)
@@ -148,6 +147,7 @@ CPU::CPU(const BaseO3CPUParams &params)
     // to the upper level CPU, and not this CPU.
 
     // Set up Pointers to the activeThreads list for each stage
+    bac.setActiveThreads(&activeThreads);
     fetch.setActiveThreads(&activeThreads);
     decode.setActiveThreads(&activeThreads);
     rename.setActiveThreads(&activeThreads);
@@ -155,6 +155,7 @@ CPU::CPU(const BaseO3CPUParams &params)
     commit.setActiveThreads(&activeThreads);
 
     // Give each of the stages the time buffer they will use.
+    bac.setTimeBuffer(&timeBuffer);
     fetch.setTimeBuffer(&timeBuffer);
     decode.setTimeBuffer(&timeBuffer);
     rename.setTimeBuffer(&timeBuffer);
@@ -162,6 +163,8 @@ CPU::CPU(const BaseO3CPUParams &params)
     commit.setTimeBuffer(&timeBuffer);
 
     // Also setup each of the stages' queues.
+    bac.setFetchTargetQueue(&ftq);
+    fetch.setBACandFTQPtr(&bac, &ftq);
     fetch.setFetchQueue(&fetchQueue);
     decode.setFetchQueue(&fetchQueue);
     commit.setFetchQueue(&fetchQueue);
@@ -330,6 +333,8 @@ CPU::regProbePoints()
         std::pair<DynInstPtr, PacketPtr>>(
                 getProbeManager(), "DataAccessComplete");
 
+    ftq.regProbePoints();
+    bac.regProbePoints();
     fetch.regProbePoints();
     rename.regProbePoints();
     iew.regProbePoints();
@@ -372,6 +377,8 @@ CPU::tick()
 //    activity = false;
 
     //Tick each of the stages
+    bac.tick();
+
     fetch.tick();
 
     decode.tick();
@@ -440,6 +447,7 @@ CPU::startup()
 {
     BaseCPU::startup();
 
+    bac.startupStage();
     fetch.startupStage();
     decode.startupStage();
     iew.startupStage();
@@ -483,6 +491,7 @@ CPU::deactivateThread(ThreadID tid)
         activeThreads.erase(active_it);
     }
 
+    bac.deactivateThread(tid);
     fetch.deactivateThread(tid);
     commit.deactivateThread(tid);
 }
@@ -646,6 +655,7 @@ CPU::removeThread(ThreadID tid)
     // clear all thread-specific states in each stage of the pipeline
     // since this thread is going to be completely removed from the CPU
     commit.clearStates(tid);
+    bac.clearStates(tid);
     fetch.clearStates(tid);
     decode.clearStates(tid);
     rename.clearStates(tid);
@@ -657,6 +667,7 @@ CPU::removeThread(ThreadID tid)
     assert(iew.instQueue.getCount(tid) == 0);
     assert(iew.ldstQueue.getCount(tid) == 0);
     assert(commit.rob->isEmpty(tid));
+    assert(ftq.isEmpty(tid));
 
     // Reset ROB/IQ/LSQ Entries
 
@@ -795,6 +806,7 @@ void
 CPU::drainSanityCheck() const
 {
     assert(isCpuDrained());
+    bac.drainSanityCheck();
     fetch.drainSanityCheck();
     decode.drainSanityCheck();
     rename.drainSanityCheck();
@@ -809,6 +821,11 @@ CPU::isCpuDrained() const
 
     if (!instList.empty() || !removeList.empty()) {
         DPRINTF(Drain, "Main CPU structures not drained.\n");
+        drained = false;
+    }
+
+    if (!bac.isDrained()) {
+        DPRINTF(Drain, "BAC not drained.\n");
         drained = false;
     }
 
@@ -840,7 +857,12 @@ CPU::isCpuDrained() const
     return drained;
 }
 
-void CPU::commitDrained(ThreadID tid) { fetch.drainStall(tid); }
+void
+CPU::commitDrained(ThreadID tid)
+{
+    bac.drainStall(tid);
+    fetch.drainStall(tid);
+}
 
 void
 CPU::drainResume()
@@ -851,6 +873,7 @@ CPU::drainResume()
     DPRINTF(Drain, "Resuming...\n");
     verifyMemoryMode();
 
+    bac.drainResume();
     fetch.drainResume();
     commit.drainResume();
 
@@ -890,6 +913,7 @@ CPU::takeOverFrom(BaseCPU *oldCPU)
 {
     BaseCPU::takeOverFrom(oldCPU);
 
+    bac.takeOverFrom();
     fetch.takeOverFrom();
     decode.takeOverFrom();
     rename.takeOverFrom();

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2014, 2025 Arm Limited
+ * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -308,14 +309,14 @@ Decode::unblock(ThreadID tid)
 }
 
 void
-Decode::squash(const DynInstPtr &inst, ThreadID tid)
+Decode::squash(const DynInstPtr &inst, bool control_miss, ThreadID tid)
 {
     DPRINTF(Decode, "[tid:%i] [sn:%llu] Squashing due to incorrect branch "
             "prediction detected at decode.\n", tid, inst->seqNum);
 
     // Send back mispredict information.
     toFetch->decodeInfo[tid].branchMispredict = true;
-    toFetch->decodeInfo[tid].predIncorrect = true;
+    toFetch->decodeInfo[tid].controlMispredict = control_miss;
     toFetch->decodeInfo[tid].mispredictInst = inst;
     toFetch->decodeInfo[tid].squash = true;
     toFetch->decodeInfo[tid].doneSeqNum = inst->seqNum;
@@ -715,7 +716,7 @@ Decode::decodeInsts(ThreadID tid)
 
             // Might want to set some sort of boolean and just do
             // a check at the end
-            squash(inst, inst->threadNumber);
+            squash(inst, true, inst->threadNumber);
 
             break;
         }
@@ -734,7 +735,7 @@ Decode::decodeInsts(ThreadID tid)
 
                 // Might want to set some sort of boolean and just do
                 // a check at the end
-                squash(inst, inst->threadNumber);
+                squash(inst, false, inst->threadNumber);
 
                 DPRINTF(Decode,
                         "[tid:%i] [sn:%llu] "

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2025 Arm Limited
+ * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -193,8 +194,12 @@ class Decode
 
     /** Squashes if there is a PC-relative branch that was predicted
      * incorrectly. Sends squash information back to fetch.
+     * @param inst The instruction that was mispredicted.
+     * @param control_miss The instuction was either predicted as control
+     * but was actually no control instruction or was not predicted
+     * as control instruction but was control actually a instruction.
      */
-    void squash(const DynInstPtr &inst, ThreadID tid);
+    void squash(const DynInstPtr &inst, bool control_miss, ThreadID tid);
 
   public:
     /** Squashes due to commit signalling a squash. Changes status to

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010-2012, 2014 ARM Limited
+ * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -45,8 +46,10 @@
 #include "arch/generic/mmu.hh"
 #include "base/random.hh"
 #include "base/statistics.hh"
+#include "cpu/o3/bac.hh"
 #include "cpu/o3/comm.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
+#include "cpu/o3/ftq.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/pc_event.hh"
 #include "cpu/pred/bpred_unit.hh"
@@ -180,6 +183,7 @@ class Fetch
         IcacheWaitResponse,
         IcacheWaitRetry,
         IcacheAccessComplete,
+        FTQEmpty,
         NoGoodAddr
     };
 
@@ -222,6 +226,9 @@ class Fetch
 
     /** Sets pointer to time buffer used to communicate to the next stage. */
     void setFetchQueue(TimeBuffer<FetchStruct> *fq_ptr);
+
+    /** Sets pointer to branch address calculation stage and FTQ */
+    void setBACandFTQPtr(BAC *bac_ptr, FTQ *ftq_ptr);
 
     /** Initialize stage. */
     void startupStage();
@@ -278,17 +285,6 @@ class Fetch
     void switchToInactive();
 
     /**
-     * Looks up in the branch predictor to see if the next PC should be
-     * either next PC+=MachInst or a branch target.
-     * @param next_PC Next PC variable passed in by reference.  It is
-     * expected to be set to the current PC; it will be updated with what
-     * the next PC will be.
-     * @param next_NPC Used for ISAs which use delay slots.
-     * @return Whether or not a branch was predicted as taken.
-     */
-    bool lookupAndUpdateNextPC(const DynInstPtr &inst, PCStateBase &pc);
-
-    /**
      * Fetches the cache line that contains the fetch PC.  Returns any
      * fault that happened.  Puts the data into the class variable
      * fetchBuffer, which may not hold the entire fetched cache line.
@@ -319,8 +315,14 @@ class Fetch
                           const DynInstPtr squashInst,
                           const InstSeqNum seq_num, ThreadID tid);
 
+    /** Signal BAC to redirect. */
+    void bacResteer(const PCStateBase &new_pc, ThreadID tid);
+
     /** Checks if a thread is stalled. */
     bool checkStall(ThreadID tid) const;
+
+    /** Checks if the FTQ is ready. Always true for coupled frontend. */
+    bool ftqReady(ThreadID tid, bool &status_change);
 
     /** Updates overall fetch stage status; to be called at the end of each
      * cycle. */
@@ -331,8 +333,8 @@ class Fetch
      * remove any instructions that are not in the ROB. The source of this
      * squash should be the commit stage.
      */
-    void squash(const PCStateBase &new_pc, const InstSeqNum seq_num,
-                DynInstPtr squashInst, ThreadID tid);
+    void squashFromCommit(const PCStateBase &new_pc, const InstSeqNum seq_num,
+                          DynInstPtr squashInst, ThreadID tid);
 
     /** Ticks the fetch stage, processing all inputs signals and fetching
      * as many instructions as possible.
@@ -408,12 +410,18 @@ class Fetch
     /** Wire to get commit's information from backwards time buffer. */
     TimeBuffer<TimeStruct>::wire fromCommit;
 
+    /** Wire used to write any information backward to BAC. */
+    TimeBuffer<TimeStruct>::wire toBAC;
+
     //Might be annoying how this name is different than the queue.
     /** Wire used to write any information heading to decode. */
     TimeBuffer<FetchStruct>::wire toDecode;
 
-    /** BPredUnit. */
-    branch_prediction::BPredUnit *branchPred;
+    /** BPredict. */
+    BAC *bac;
+
+    /** Fetch Target Queue */
+    FTQ *ftq;
 
     std::unique_ptr<PCStateBase> pc[MaxThreads];
 
@@ -445,23 +453,26 @@ class Fetch
     /** Tracks which stages are telling fetch to stall. */
     Stalls stalls[MaxThreads];
 
+    /** Enables the decoupled front-end */
+    const bool decoupledFrontEnd;
+
     /** Decode to fetch delay. */
-    Cycles decodeToFetchDelay;
+    const Cycles decodeToFetchDelay;
 
     /** Rename to fetch delay. */
-    Cycles renameToFetchDelay;
+    const Cycles renameToFetchDelay;
 
     /** IEW to fetch delay. */
-    Cycles iewToFetchDelay;
+    const Cycles iewToFetchDelay;
 
     /** Commit to fetch delay. */
-    Cycles commitToFetchDelay;
+    const Cycles commitToFetchDelay;
 
     /** The width of fetch in instructions. */
-    unsigned fetchWidth;
+    const unsigned fetchWidth;
 
     /** The width of decode in instructions. */
-    unsigned decodeWidth;
+    const unsigned decodeWidth;
 
     /** Is the cache blocked?  If so no threads can access it. */
     bool cacheBlocked;
@@ -530,6 +541,10 @@ class Fetch
     /** Event used to delay fault generation of translation faults */
     FinishTranslationEvent finishTranslationEvent;
 
+    /*Max number of FT added to the FTQ per Cycle*/
+    const unsigned maxFTPerCycle;
+    const unsigned maxTakenPredPerCycle;
+
   protected:
     struct FetchStatGroup : public statistics::Group
     {
@@ -544,6 +559,8 @@ class Fetch
         statistics::Scalar squashCycles;
         /** Stat for total number of cycles spent waiting for translation */
         statistics::Scalar tlbCycles;
+        /** Stat for total number of cycles spent waiting for FTQ to fill. */
+        statistics::Scalar ftqStallCycles;
         /** Stat for total number of cycles
          *  spent blocked due to other stages in
          * the pipeline.
@@ -578,6 +595,8 @@ class Fetch
         statistics::Distribution nisnDist;
         /** Rate of how often fetch was idle. */
         statistics::Formula idleRate;
+        /*Number of fetch target processed per cycle*/
+        statistics::Distribution ftNumber;
     } fetchStats;
 };
 

--- a/src/cpu/o3/ftq.cc
+++ b/src/cpu/o3/ftq.cc
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/o3/ftq.hh"
+
+#include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "cpu/o3/cpu.hh"
+#include "debug/FTQ.hh"
+#include "params/BaseO3CPU.hh"
+
+namespace gem5
+{
+
+namespace o3
+{
+
+/** Fetch Target Methods -------------------------------- */
+FetchTarget::FetchTarget(const ThreadID _tid, const PCStateBase &_start_pc,
+                         InstSeqNum _seqNum)
+    : ftSeqNum(_seqNum),
+      tid(_tid),
+      is_branch(false),
+      taken(false),
+      bpuHistory(nullptr)
+{
+    set(startPC, _start_pc);
+}
+
+void
+FetchTarget::finalize(const PCStateBase &exit_pc, bool _is_branch,
+                      bool pred_taken, const PCStateBase &pred_pc)
+{
+    set(endPC, exit_pc);
+    set(predPC, pred_pc);
+    taken = pred_taken;
+    is_branch = _is_branch;
+}
+
+std::string
+FetchTarget::toString()
+{
+    std::stringstream ss;
+    ss << "FT[" << ftSeqNum << "]: [0x" << std::hex << startPC->instAddr()
+       << "->0x" << endPC->instAddr() << "|B:" << is_branch << "]";
+    return ss.str();
+}
+
+/** Fetch Target Queue Methods ----------------------------- */
+
+FTQ::FTQ(CPU *_cpu, const BaseO3CPUParams &params)
+    : cpu(_cpu),
+      numThreads(params.numThreads),
+      numEntries(params.numFTQEntries),
+      stats(_cpu, params.numFTQEntries)
+{
+    for (ThreadID tid = 0; tid < MaxThreads; tid++) {
+        resetState(tid);
+    }
+}
+
+void
+FTQ::resetState(ThreadID tid)
+{
+    ftq[tid].clear();
+    ftqStatus[tid] = Valid;
+}
+
+std::string
+FTQ::name() const
+{
+    return cpu->name() + ".ftq";
+}
+
+void
+FTQ::regProbePoints()
+{
+    ppFTQInsert =
+        new ProbePointArg<FetchTargetPtr>(cpu->getProbeManager(), "FTQInsert");
+    ppFTQRemove =
+        new ProbePointArg<FetchTargetPtr>(cpu->getProbeManager(), "FTQRemove");
+}
+
+unsigned
+FTQ::numFreeEntries(ThreadID tid)
+{
+    return numEntries - ftq[tid].size();
+}
+
+unsigned
+FTQ::size(ThreadID tid)
+{
+    return ftq[tid].size();
+}
+
+bool
+FTQ::isFull(ThreadID tid)
+{
+    return ftq[tid].size() >= numEntries;
+}
+
+bool
+FTQ::isEmpty(ThreadID tid) const
+{
+    return ftq[tid].empty();
+}
+
+void
+FTQ::invalidate(ThreadID tid)
+{
+    /** Only a not empty ftq can be invalidated */
+    if (!ftq[tid].empty()) {
+        ftqStatus[tid] = Invalid;
+    }
+}
+
+bool
+FTQ::isReady(ThreadID tid)
+{
+    return ftqStatus[tid] != Invalid;
+}
+
+void
+FTQ::lock(ThreadID tid)
+{
+    ftqStatus[tid] = Locked;
+}
+
+bool
+FTQ::isLocked(ThreadID tid)
+{
+    return ftqStatus[tid] == Locked;
+}
+
+void
+FTQ::forAllForward(ThreadID tid, std::function<void(FetchTargetPtr &)> f)
+{
+    for (auto it = ftq[tid].begin(); it != ftq[tid].end(); it++) {
+        f(*it);
+    }
+}
+
+void
+FTQ::forAllBackward(ThreadID tid, std::function<void(FetchTargetPtr &)> f)
+{
+    for (auto it = ftq[tid].rbegin(); it != ftq[tid].rend(); it++) {
+        f(*it);
+    }
+}
+
+void
+FTQ::insert(ThreadID tid, FetchTargetPtr fetchTarget)
+{
+    assert(ftq[tid].size() < numEntries);
+    ftq[tid].push_back(fetchTarget);
+    ppFTQInsert->notify(fetchTarget);
+    stats.inserts++;
+    stats.occupancy.sample(ftq[tid].size());
+
+    DPRINTF(FTQ, "Insert %s in FTQ[T:%i]. size FTQ:%i\n",
+            fetchTarget->toString(), tid, ftq[tid].size());
+}
+
+void
+FTQ::squash(ThreadID tid)
+{
+    for (auto ft : ftq[tid]) {
+        assert(ft->bpuHistory == nullptr);
+        ppFTQRemove->notify(ft);
+    }
+    ftq[tid].clear();
+    ftqStatus[tid] = Valid;
+    stats.squashes++;
+}
+
+void
+FTQ::squashSanityCheck(ThreadID tid)
+{
+    for (auto ft : ftq[tid]) {
+        assert(ft->bpuHistory == nullptr);
+    }
+}
+
+bool
+FTQ::isHeadReady(ThreadID tid)
+{
+    return (ftqStatus[tid] != Invalid) && (ftq[tid].size() > 0);
+}
+
+FetchTargetPtr
+FTQ::readHead(ThreadID tid)
+{
+    if (ftqStatus[tid] == Invalid) {
+        return nullptr;
+    }
+    if (ftq[tid].empty()) {
+        return nullptr;
+    }
+
+    return ftq[tid].front();
+}
+
+bool
+FTQ::popHead(ThreadID tid)
+{
+    assert(!ftq[tid].empty());
+    if (ftq[tid].front()->bpuHistory != nullptr) {
+        DPRINTF(FTQ, "Pop FT:[fn%llu] failed. Still contains BP history.\n",
+                ftq[tid].front()->ftNum());
+        ftqStatus[tid] = Invalid;
+        return false;
+    }
+
+    bool ret_val = true;
+
+    // TODO make this more efficient
+    // Once the head of the FTQ gets updated and
+    // the FTQ got blocked by a complex instruction resteer
+    // we unblock by squashing
+    if (ftqStatus[tid] == Locked) {
+        DPRINTF(FTQ, "Pop FT:[fn%llu] unblocks FTQ. Require squash.\n",
+                ftq[tid].front()->ftNum());
+        ftqStatus[tid] = Invalid;
+        ret_val = false;
+    }
+
+    ppFTQRemove->notify(ftq[tid].front());
+    ftq[tid].pop_front();
+    stats.removals++;
+    return ret_val;
+}
+
+void
+FTQ::printFTQ(ThreadID tid)
+{
+    int i = 0;
+    for (auto ft : ftq[tid]) {
+        DPRINTF(FTQ, "FTQ[tid:%i][%i]: %s.\n", tid, i, ft->toString());
+        i++;
+    }
+}
+
+FTQ::FTQStats::FTQStats(o3::CPU *cpu, unsigned numFTQEntries)
+    : statistics::Group(cpu, "ftq"),
+      ADD_STAT(inserts, statistics::units::Count::get(),
+               "The number of FTQ insertions"),
+      ADD_STAT(removals, statistics::units::Count::get(),
+               "The number of FTQ removals. Not including squashes"),
+      ADD_STAT(squashes, statistics::units::Count::get(),
+               "The number of FTQ squashes"),
+      ADD_STAT(locks, statistics::units::Count::get(),
+               "The number of times the FTQ got locked."),
+      ADD_STAT(occupancy, statistics::units::Count::get(),
+               "Distribution of the FTQ occupation.")
+{
+    occupancy
+        .init(/* base value */ 0,
+              /* last value */ numFTQEntries,
+              /* bucket size */ 4)
+        .flags(statistics::pdf);
+}
+
+} // namespace o3
+} // namespace gem5

--- a/src/cpu/o3/ftq.hh
+++ b/src/cpu/o3/ftq.hh
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_O3_FTQ_HH__
+#define __CPU_O3_FTQ_HH__
+
+#include <list>
+#include <string>
+
+#include "arch/generic/pcstate.hh"
+#include "base/statistics.hh"
+#include "base/types.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/limits.hh"
+#include "cpu/pred/bpred_unit.hh"
+#include "sim/probe/probe.hh"
+
+namespace gem5
+{
+
+struct BaseO3CPUParams;
+
+namespace o3
+{
+
+class CPU;
+
+struct DerivO3CPUParams;
+
+// Fetch target sequence type. Basically the same as the instruction sequence
+// number but since the fetch target is generated before instructions.
+typedef InstSeqNum FTSeqNum;
+
+/** The fetch target class.
+ * A fetch target is used to cary branch prediction information from the
+ * decoupled branch predictor to the fetch stage. It is similar to a basic
+ * block in that it contains a continous block of instructios and typically
+ * ends with a branch. The fetch target may not contain a branch if the
+ * block exceeds the maximum size of the fetch target. In this case the
+ * next fetch target will start with the susequent address of the current
+ * fetch targets end.
+ * A fetch target may also span multiple 'surprise' branches which
+ * are branches that are never taken and thus not in the BTB and therfore
+ * invisible to the branch predictor which will treat these branches as
+ * ordinary instructions.
+ */
+class FetchTarget
+{
+  public:
+    FetchTarget(const ThreadID _tid, const PCStateBase &_start_pc,
+                FTSeqNum _seqNum);
+
+  private:
+    /** Start address of the fetch target */
+    std::unique_ptr<PCStateBase> startPC;
+
+    /** End address of the fetch target */
+    std::unique_ptr<PCStateBase> endPC;
+
+    /** Predicted target address of the fetch target.
+     *  Only valid when the ft ends with branch. */
+    std::unique_ptr<PCStateBase> predPC;
+
+    /* Fetch targets sequence number */
+    const FTSeqNum ftSeqNum;
+
+    /** The thread this FT belongs to. */
+    const ThreadID tid;
+
+    /** Whether the exit instruction is a branch */
+    bool is_branch;
+
+    /** If the exit branch is predicted taken */
+    bool taken;
+
+  public:
+    /** Anchor point to attach a branch predictor history.
+     * Will carry information while FT is waiting in th FTQ. */
+    branch_prediction::BPredUnit::PredictorHistory *bpuHistory;
+
+    /* Start address of the basic block */
+    Addr
+    startAddress()
+    {
+        return startPC->instAddr();
+    }
+
+    /* End address of the basic block */
+    Addr
+    endAddress()
+    {
+        return (endPC) ? endPC->instAddr() : MaxAddr;
+    }
+
+    /* Fetch Target size (number of bytes) */
+    unsigned
+    size()
+    {
+        return endAddress() - startAddress();
+    }
+
+    bool
+    inRange(Addr addr)
+    {
+        return addr >= startAddress() && addr <= endAddress();
+    }
+
+    bool
+    isExitInst(Addr addr)
+    {
+        return addr == endAddress();
+    }
+
+    bool
+    isExitBranch(Addr addr)
+    {
+        return (addr == endAddress()) && is_branch;
+    }
+
+    bool
+    hasExceeded(Addr addr)
+    {
+        return addr > endAddress();
+    }
+
+    /** Returns the fetch target number. */
+    FTSeqNum
+    ftNum()
+    {
+        return ftSeqNum;
+    }
+
+    /** Returns the thread ID. */
+    ThreadID
+    getTid()
+    {
+        return tid;
+    }
+
+    /** Set the predicted target of the exit branch. */
+    void
+    setPredTarg(const PCStateBase &pred_pc)
+    {
+        set(predPC, pred_pc);
+    }
+
+    /** Read the predicted target of the exit branch. */
+    const PCStateBase &
+    readPredTarg()
+    {
+        assert(predPC != nullptr);
+        return *predPC;
+    }
+
+    /** Read the start address PC */
+    const PCStateBase &
+    readStartPC()
+    {
+        assert(startPC != nullptr);
+        return *startPC;
+    }
+
+    /** Read the exit/end address PC */
+    const PCStateBase &
+    readEndPC()
+    {
+        assert(endPC != nullptr);
+        return *endPC;
+    }
+
+    /** Check if the exit branch was predicted taken. */
+    bool
+    predTaken()
+    {
+        return taken;
+    }
+
+    /** Complete a fetch target with the exit instruction */
+    void finalize(const PCStateBase &exit_pc, bool _is_branch, bool pred_taken,
+                  const PCStateBase &pred_pc);
+
+    /** Print the fetch target for debugging. */
+    std::string toString();
+};
+
+typedef std::shared_ptr<FetchTarget> FetchTargetPtr;
+
+/**
+ * FTQ class.
+ */
+class FTQ
+{
+  public:
+    /** FTQ constructor.
+     *  @param _cpu   The cpu object pointer.
+     *  @param params The cpu params incl. several FTQ-specific parameters.
+     */
+    FTQ(CPU *_cpu, const BaseO3CPUParams &params);
+
+    std::string name() const;
+
+  private:
+    /** Possible FTQ statuses. */
+    enum Status
+    {
+        Invalid,
+        Valid,
+        Full,
+        Locked
+    };
+
+    /** Per-thread FTQ status. */
+    std::array<Status, MaxThreads> ftqStatus;
+
+    /** Pointer to the CPU. */
+    CPU *cpu;
+
+    /** Max number of threads */
+    const unsigned numThreads;
+
+    /** Number of fetch targets in the FTQ. (per thread) */
+    const unsigned numEntries;
+
+    /** Probe points to attach the FDP prefetcher. */
+    ProbePointArg<FetchTargetPtr> *ppFTQInsert;
+    ProbePointArg<FetchTargetPtr> *ppFTQRemove;
+
+    /** FTQ List of Fetch targets */
+    std::array<std::list<FetchTargetPtr>, MaxThreads> ftq;
+
+  public:
+    /** Registers probes. */
+    void regProbePoints();
+
+    /** Reset the FTQ state */
+    void resetState(ThreadID tid);
+
+    /** Returns the number of free entries in a specific FTQ paritition. */
+    unsigned numFreeEntries(ThreadID tid);
+
+    /** Returns the size of the ftq for a specific partition*/
+    unsigned size(ThreadID tid);
+
+    /** Returns whether or not a specific thread's queue is full. */
+    bool isFull(ThreadID tid);
+
+    /** Returns whether or not a specific thread's queue is empty. */
+    bool isEmpty(ThreadID tid) const;
+
+    /** Invalidates all fetch targets in the FTQ.
+     * Requires squash to recover. */
+    void invalidate(ThreadID tid);
+
+    /** Returns if the FTQ is in a ready state and its safe to consmume
+     * fetch targets. */
+    bool isReady(ThreadID tid);
+
+    /** Locks the fetch target queue for a given thread. Locking is different
+     * from invalidating in that the head/front fetch targets are still
+     * valid and accessible. However, all other FTs are invalid and the
+     * FTQ must be squashed to recover. */
+    void lock(ThreadID tid);
+
+    /** Check if the FTQ is locked. */
+    bool isLocked(ThreadID tid);
+
+    /** Iterates forward over all fetch targets in the FTQ from head/front to
+     * tail/back and applies a given function. */
+    void forAllForward(ThreadID tid, std::function<void(FetchTargetPtr &)> f);
+
+    /** Iterates backward over all fetch targets in the FTQ from tail/back to
+     * head/front and applies a given function. */
+    void forAllBackward(ThreadID tid, std::function<void(FetchTargetPtr &)> f);
+
+    /** Pushes a fetch target into the back/tail of the FTQ.
+     *  @param fetchTarget Pointer to the fetch target to be inserted.
+     */
+    void insert(ThreadID tid, FetchTargetPtr fetchTarget);
+
+    /** Squashes all fetch targets in the FTQ for a specific thread. */
+    void squash(ThreadID tid);
+
+    /** Sanity check to verify that the fetch targets in the ftq do not
+     * have a valid `bpu_history`. It should be set to `nullptr` on squash.
+     */
+    void squashSanityCheck(ThreadID tid);
+
+    /** Is the head entry ready for the fetch stage to be consumed. */
+    bool isHeadReady(ThreadID tid);
+
+    /** Returns a pointer to the head fetch target of a specific thread within
+     *  the FTQ.
+     *  @return Pointer to the FetchTarget that is at the head of the FTQ.
+     */
+    FetchTargetPtr readHead(ThreadID tid);
+
+    /** Pops the head fetch target once its fully processed.
+     * In case there is still a branch history attached to the
+     * head fetch target the FTQ goes into invalid state.
+     * @return Whether or not the update was successful.
+     */
+    bool popHead(ThreadID tid);
+
+    /** Print the all fetch targets in the FTQ for debugging. */
+    void printFTQ(ThreadID tid);
+
+  private:
+    struct FTQStats : public statistics::Group
+    {
+        FTQStats(CPU *cpu, unsigned numFTQEntries);
+
+        statistics::Scalar inserts;
+        statistics::Scalar removals;
+        statistics::Scalar squashes;
+        statistics::Scalar locks;
+
+        statistics::Distribution occupancy;
+    } stats;
+};
+
+} // namespace o3
+} // namespace gem5
+
+#endif //__CPU_O3_FTQ_HH__

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -111,8 +111,11 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
     return taken;
 }
 
-
-
+void
+BPredUnit::insertPredictorHistory(ThreadID tid, PredictorHistory *&bpu_history)
+{
+    predHist[tid].push_front(bpu_history);
+}
 
 bool
 BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
@@ -441,7 +444,7 @@ BPredUnit::squashHistory(ThreadID tid, PredictorHistory* &history)
                         history->indirectHistory);
     }
 
-    // This call should delete the bpHistory.
+    // This call will  delete the bpHistory.
     cPred->squash(tid, history->bpHistory);
 
     delete history;
@@ -465,7 +468,6 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
     //     PC-relative, branch was predicted incorrectly. If so, a signal
     //     to the fetch stage is sent to squash history after the mispredict
 
-    History &pred_hist = predHist[tid];
     DPRINTF(Branch, "[tid:%i] Squash from %s start from sequence number %i, "
             "setting target to %s\n", tid, from_commit ? "commit" : "decode",
             squashed_sn, corr_target);
@@ -479,9 +481,9 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
     // If there's a squash due to a syscall, there may not be an entry
     // corresponding to the squash.  In that case, don't bother trying to
     // fix up the entry.
-    if (!pred_hist.empty()) {
+    if (!predHist[tid].empty()) {
 
-        PredictorHistory *hist = pred_hist.front();
+        PredictorHistory *hist = predHist[tid].front();
 
         DPRINTF(Branch, "[tid:%i] [squash sn:%llu] Mispredicted: %s, PC:%#x\n",
                     tid, squashed_sn, toString(hist->type), hist->pc);
@@ -574,8 +576,10 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
         if (actually_taken && updateBTBAtSquash) { updateBTB(tid, hist); }
 
     } else {
-        DPRINTF(Branch, "[tid:%i] [sn:%llu] pred_hist empty, can't "
-                "update\n", tid, squashed_sn);
+        DPRINTF(Branch,
+                "[tid:%i] [sn:%llu] predHist empty, can't "
+                "update\n",
+                tid, squashed_sn);
     }
 }
 

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -408,6 +408,11 @@ BPredUnit::squash(const InstSeqNum &squashed_sn, ThreadID tid)
 
         auto hist = predHist[tid].front();
 
+        DPRINTF(Branch,
+                "[tid:%i, squash sn:%llu] Removing history for "
+                "sn:%llu, PC:%#x\n",
+                tid, squashed_sn, hist->seqNum, hist->pc);
+
         squashHistory(tid, hist);
 
         predHist[tid].pop_front();

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -75,9 +75,6 @@ class BPredUnit : public SimObject
 
     /** Branch Predictor Unit (BPU) interface functions */
   public:
-
-
-
     /**
      * @param params The params object, that has the size of the BP and BTB.
      */
@@ -130,12 +127,6 @@ class BPredUnit : public SimObject
     void squash(const InstSeqNum &squashed_sn, const PCStateBase &corr_target,
                 bool actually_taken, ThreadID tid, bool from_commit=true);
 
-  protected:
-
-    /** *******************************************************
-     * Interface functions to the conditional branch predictor
-     *
-    */
     /**
      * Looks up a given PC in the BTB to see if a matching entry exists.
      * @param tid The thread id.
@@ -208,11 +199,7 @@ class BPredUnit : public SimObject
     void branchPlaceholder(ThreadID tid, Addr pc,
                             bool uncond, void * &bp_history);
 
-
     void dump();
-
-  private:
-
 
     /** Branch Predictor Unit (BPU) history object `PredictorHistory`
      * This class holds all information needed to manage the speculative
@@ -317,7 +304,7 @@ class BPredUnit : public SimObject
         }
 
         /** The sequence number for the predictor history entry. */
-        const InstSeqNum seqNum;
+        InstSeqNum seqNum;
 
         /** The thread id. */
         const ThreadID tid;
@@ -375,8 +362,14 @@ class BPredUnit : public SimObject
 
     };
 
-    typedef std::deque<PredictorHistory*> History;
-
+    /**
+     * Pushes a `PredictorHistory` object into the branch predictor history
+     * queue. This is used by the decoupled front-end to move predictions
+     * histories from the fetch target back to the branch predictor.
+     * @param tid The thread id.
+     * @param bpu_history The history to be inserted.
+     */
+    void insertPredictorHistory(ThreadID tid, PredictorHistory *&bpu_history);
 
     /**
      * Internal prediction function.
@@ -433,7 +426,7 @@ class BPredUnit : public SimObject
      * as instructions are committed, or restore it to the proper state after
      * a squash.
      */
-    std::vector<History> predHist;
+    std::vector<std::deque<PredictorHistory *>> predHist;
 
     /** The BTB. */
     BranchTargetBuffer * btb;

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -392,6 +392,15 @@ TAGE_SC_L_TAGE::extraAltCalc(TAGEBase::BranchInfo* bi)
     tage_scl_bi->altConf = (abs(2*ctr + 1) > 1);
 }
 
+void
+TAGE_SC_L::branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
+                             void *&bp_history)
+{
+    TageSCLBranchInfo *bi = new TageSCLBranchInfo(*tage, *statisticalCorrector,
+                                                  *loopPredictor, pc, !uncond);
+    bp_history = (void *)(bi);
+}
+
 bool
 TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
 {

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -180,9 +180,8 @@ class TAGE_SC_L: public LTAGE
     void updateHistories(ThreadID tid, Addr pc, bool uncond,
                          bool taken, Addr target, const StaticInstPtr &inst,
                          void * &bp_history) override;
-    void branchPlaceholder(ThreadID tid, Addr pc,
-                                bool uncond, void * &bp_history) override
-    { panic("Not implemented for this BP!\n"); }
+    void branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
+                           void *&bp_history) override;
 
   protected:
 

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -129,8 +129,9 @@ BaseCache::BaseCache(const BaseCacheParams &p, unsigned blk_size)
         genTagExtractor(tags->params().indexing_policy));
 
     tags->tagsInit();
-    if (prefetcher)
+    if (prefetcher) {
         prefetcher->setParentInfo(system, getProbeManager(), getBlockSize());
+    }
 
     fatal_if(compressor && !dynamic_cast<CompressedTags*>(tags),
         "The tags of compressed cache %s must derive from CompressedTags",

--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2012, 2014, 2019, 2022-2024 Arm Limited
+# Copyright (c) 2023 The University of Edinburgh
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -36,6 +37,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from m5.citations import add_citation
 from m5.objects.ClockedObject import ClockedObject
 from m5.objects.IndexingPolicies import *
 from m5.objects.ReplacementPolicies import *
@@ -727,3 +729,59 @@ class PIFPrefetcher(QueuedPrefetcher):
         self.addEvent(
             HWPProbeEventRetiredInsts(self, simObj, "RetiredInstsPC")
         )
+
+
+class FetchDirectedPrefetcher(BasePrefetcher):
+    type = "FetchDirectedPrefetcher"
+    cxx_class = "gem5::prefetch::FetchDirectedPrefetcher"
+    cxx_header = "mem/cache/prefetch/fdp.hh"
+    cxx_exports = [PyBindMethod("setCache")]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._cache = None
+
+    def regProbeListeners(self):
+        if self._cache:
+            self.getCCObject().setCache(self._cache.getCCObject())
+        super().regProbeListeners()
+
+    def registerCache(self, simObj):
+        if not isinstance(simObj, SimObject):
+            raise TypeError("argument must be a SimObject type")
+        self._cache = simObj
+
+    cpu = Param.BaseCPU(Parent.any, "The CPU to train the predictor")
+
+    latency = Param.Cycles(1, "Latency for generated prefetches")
+    pfq_size = Param.Unsigned(64, "Maximum number of queued prefetches")
+    tq_size = Param.Unsigned(64, "Maximum number of outstanding translations")
+
+    mark_req_as_prefetch = Param.Bool(
+        True,
+        "Mark memory requests as prefetches. Allows different handlings of "
+        "request. E.g. the Arm TLB drops prefetch requests on a miss.",
+    )
+    squash_prefetches = Param.Bool(
+        True,
+        "Squash the prefetch associated with a fetch target in case it gets "
+        "removded fron the the FTQ (Fetch consumes it or a pipeline flush).",
+    )
+
+
+add_citation(
+    FetchDirectedPrefetcher,
+    """@inproceedings{10.1145/3613424.3614258,
+  author    = {Schall, David and
+               Sandberg, Andreas and
+               Grot, Boris},
+  title     = {Warming Up a Cold Front-End with Ignite},
+  year      = {2023},
+  publisher = {Association for Computing Machinery},
+  address   = {Toronto, ON, Canada},
+  doi       = {10.1145/3613424.3614258},
+  booktitle = {Proceedings of the 56th Annual IEEE/ACM International Symposium on Microarchitecture (MICRO '23)},
+  series    = {MICRO'23}
+}
+""",
+)

--- a/src/mem/cache/prefetch/SConscript
+++ b/src/mem/cache/prefetch/SConscript
@@ -36,7 +36,9 @@ SimObject('Prefetcher.py', sim_objects=[
     'AccessMapPatternMatching', 'AMPMPrefetcher',
     'DeltaCorrelatingPredictionTables', 'DCPTPrefetcher',
     'IrregularStreamBufferPrefetcher', 'SlimAMPMPrefetcher',
-    'BOPPrefetcher', 'SBOOEPrefetcher', 'STeMSPrefetcher', 'PIFPrefetcher'])
+    'BOPPrefetcher', 'SBOOEPrefetcher', 'STeMSPrefetcher', 'PIFPrefetcher',
+    'FetchDirectedPrefetcher'
+    ])
 
 Source('access_map_pattern_matching.cc')
 Source('base.cc')
@@ -55,3 +57,4 @@ Source('slim_ampm.cc')
 Source('spatio_temporal_memory_streaming.cc')
 Source('stride.cc')
 Source('tagged.cc')
+Source('fdp.cc')

--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -52,6 +52,7 @@
 #include "base/compiler.hh"
 #include "base/statistics.hh"
 #include "base/types.hh"
+#include "mem/cache/base.hh"
 #include "mem/cache/cache_probe_arg.hh"
 #include "mem/packet.hh"
 #include "mem/request.hh"
@@ -404,13 +405,13 @@ class Base : public ClockedObject
 
     virtual Tick nextPrefetchReadyTime() const = 0;
 
-    void
+    virtual void
     prefetchUnused()
     {
         prefetchStats.pfUnused++;
     }
 
-    void
+    virtual void
     incrDemandMhsrMisses()
     {
         prefetchStats.demandMshrMisses++;

--- a/src/mem/cache/prefetch/fdp.cc
+++ b/src/mem/cache/prefetch/fdp.cc
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/cache/prefetch/fdp.hh"
+
+#include <utility>
+
+#include "debug/HWPrefetch.hh"
+#include "mem/cache/base.hh"
+#include "params/FetchDirectedPrefetcher.hh"
+
+namespace gem5
+{
+
+namespace prefetch
+{
+
+FetchDirectedPrefetcher::FetchDirectedPrefetcher(
+    const FetchDirectedPrefetcherParams &p)
+    : Base(p),
+      cpu(p.cpu),
+      cache(nullptr),
+      markReqAsPrefetch(p.mark_req_as_prefetch),
+      squashPrefetches(p.squash_prefetches),
+      latency(cyclesToTicks(p.latency)),
+      pfqSize(p.pfq_size),
+      tqSize(p.tq_size),
+      cacheSnoop(true),
+      stats(this, p.pfq_size, p.tq_size)
+{}
+
+void
+FetchDirectedPrefetcher::notifyFTQInsert(const o3::FetchTargetPtr &ft)
+{
+    Addr blk_addr = blockAddress(ft->startAddress());
+
+    // Check if the address is already in the prefetch queue
+    auto it = std::find(pfq.begin(), pfq.end(), blk_addr);
+    if (it != pfq.end()) {
+        DPRINTF(HWPrefetch, "%#x already in prefetch_queue\n", blk_addr);
+        stats.pfInPFQ++;
+        return;
+    }
+
+    it = std::find(translationq.begin(), translationq.end(), blk_addr);
+    if (it != translationq.end()) {
+        DPRINTF(HWPrefetch, "%#x already in translation queue\n", blk_addr);
+        stats.pfInTQ++;
+        return;
+    }
+
+    stats.pfIdentified++;
+
+    if (translationq.size() >= tqSize) {
+        DPRINTF(HWPrefetch, "Translation queue full, dropping %#x\n",
+                blk_addr);
+        stats.tqDrops++;
+        return;
+    }
+    // TODO add also check for pfq to save unnecessary translations
+    // Maybe merge the two queues
+    translationq.emplace_back(*this, blk_addr, ft->getTid(), ft->ftNum());
+    DPRINTF(HWPrefetch, "Start translation for %#x, reqID=%i, ctxID=%i\n",
+            blk_addr, translationq.back().req->requestorId(),
+            translationq.back().req->contextId());
+    translationq.back().startTranslation();
+    stats.tqInserts++;
+    stats.tqSizeDistAtNotify.sample(translationq.size());
+    stats.pfqSizeDistAtNotify.sample(pfq.size());
+}
+
+void
+FetchDirectedPrefetcher::notifyFTQRemove(const o3::FetchTargetPtr &ft)
+{
+    if (!squashPrefetches) {
+        return;
+    }
+    // Remove the prefetch or translation request that belong too this
+    // fetch target. Start from the back.
+    for (auto it = pfq.begin(); it != pfq.end(); it++) {
+        if (it->ftn == ft->ftNum()) {
+            pfq.erase(it);
+            stats.pfSquashed++;
+            return;
+        }
+    }
+}
+
+void
+FetchDirectedPrefetcher::translationComplete(PrefetchRequest *pfr, bool failed)
+{
+    auto it = translationq.begin();
+    while (it != translationq.end()) {
+        if (&(*it) == pfr) {
+            break;
+        }
+        ++it;
+    }
+    assert(it != translationq.end());
+    warn_if_once(cacheSnoop && (cache == nullptr),
+                 "Cache is not set. Cache snooping will not work!\n");
+
+    if (failed) {
+        DPRINTF(HWPrefetch, "Translation of %#x failed\n", it->addr);
+        stats.translationFail++;
+    } else {
+        DPRINTF(HWPrefetch, "Translation of %#x succeeded\n", it->addr);
+        stats.translationSuccess++;
+
+        if (it->req->isUncacheable()) {
+            DPRINTF(HWPrefetch, "Drop uncacheable requests.\n");
+        } else if (cacheSnoop && cache &&
+                   (cache->inCache(it->req->getPaddr(), it->req->isSecure()) ||
+                    (cache->inMissQueue(it->req->getPaddr(),
+                                        it->req->isSecure())))) {
+            stats.pfInCache++;
+            DPRINTF(HWPrefetch, "Drop Packet. In Cache / MSHR\n");
+        } else {
+            if (pfq.size() < pfqSize) {
+                it->createPkt();
+                it->readyTime = curTick() + latency;
+                stats.pfPacketsCreated++;
+                DPRINTF(HWPrefetch,
+                        "Addr:%#x Add packet to PFQ. pkt PA:%#x, "
+                        "PFQ sz:%i\n",
+                        it->addr, it->pkt->getAddr(), pfq.size());
+
+                stats.pfCandidatesAdded++;
+                pfq.push_back(*it);
+                stats.pfqInserts++;
+            } else {
+                DPRINTF(HWPrefetch, "Prefetch queue full, dropping %#x\n",
+                        it->addr);
+                stats.pfqDrops++;
+            }
+        }
+    }
+    translationq.erase(it);
+    stats.tqPops++;
+}
+
+PacketPtr
+FetchDirectedPrefetcher::getPacket()
+{
+    if (pfq.size() == 0) {
+        return nullptr;
+    }
+    PacketPtr pkt = pfq.front().pkt;
+
+    DPRINTF(HWPrefetch, "Issue Prefetch to: pkt:%#x, PC:%#x, PFQ size:%i\n",
+            pkt->getAddr(), pfq.front().addr, pfq.size());
+
+    pfq.pop_front();
+    stats.pfqPops++;
+
+    prefetchStats.pfIssued++;
+    return pkt;
+}
+
+FetchDirectedPrefetcher::PrefetchRequest::PrefetchRequest(
+    FetchDirectedPrefetcher &_owner, uint64_t _addr, ThreadID tid,
+    o3::FTSeqNum _ftn)
+    : owner(_owner),
+      addr(_addr),
+      ftn(_ftn),
+      req(nullptr),
+      pkt(nullptr),
+      readyTime(MaxTick)
+{
+    req = std::make_shared<Request>(addr, owner.blkSize, Request::INST_FETCH,
+                                    owner.requestorId, addr,
+                                    owner.cpu->getContext(tid)->contextId());
+    if (owner.markReqAsPrefetch) {
+        req->setFlags(Request::PREFETCH);
+    }
+    assert(req);
+}
+
+void
+FetchDirectedPrefetcher::PrefetchRequest::createPkt()
+{
+    req->taskId(context_switch_task_id::Prefetcher);
+    pkt = new Packet(req, MemCmd::HardPFReq);
+    pkt->allocate();
+}
+
+void
+FetchDirectedPrefetcher::PrefetchRequest::startTranslation()
+{
+    assert(owner.mmu != nullptr);
+    auto tc = owner.system->threads[req->contextId()];
+    owner.mmu->translateTiming(req, tc, this, BaseMMU::Execute);
+}
+
+void
+FetchDirectedPrefetcher::PrefetchRequest::finish(const Fault &fault,
+                                                 const RequestPtr &req,
+                                                 ThreadContext *tc,
+                                                 BaseMMU::Mode mode)
+{
+    bool failed = (fault != NoFault);
+    owner.translationComplete(this, failed);
+}
+
+void
+FetchDirectedPrefetcher::regProbeListeners()
+{
+    Base::regProbeListeners();
+
+    if (cpu == nullptr) {
+        warn("FetchDirectedPrefetcher: No CPU to listen from registered\n");
+        return;
+    }
+    typedef ProbeListenerArgFunc<o3::FetchTargetPtr> FetchTargetListener;
+    listeners.push_back(cpu->getProbeManager()->connect<FetchTargetListener>(
+        "FTQInsert",
+        [this](const o3::FetchTargetPtr &ft) { notifyFTQInsert(ft); }));
+
+    listeners.push_back(cpu->getProbeManager()->connect<FetchTargetListener>(
+        "FTQRemove",
+        [this](const o3::FetchTargetPtr &ft) { notifyFTQRemove(ft); }));
+}
+
+FetchDirectedPrefetcher::Stats::Stats(statistics::Group *parent, int pfq_size,
+                                      int tq_size)
+    : statistics::Group(parent),
+      ADD_STAT(fdipInsertions, statistics::units::Count::get(),
+               "Number of notifications from an insertion in the FTQ"),
+      ADD_STAT(pfIdentified, statistics::units::Count::get(),
+               "Number of prefetches identified."),
+      ADD_STAT(pfSquashed, statistics::units::Count::get(),
+               "Number of prefetches squashed."),
+      ADD_STAT(pfInPFQ, statistics::units::Count::get(),
+               "Number of prefetches hit in the prefetch queue"),
+      ADD_STAT(pfInTQ, statistics::units::Count::get(),
+               "Number of prefetches hit in the translation queue"),
+      ADD_STAT(pfInCache, statistics::units::Count::get(),
+               "Number of prefetches hit in in cache"),
+      ADD_STAT(pfInCachePrefetched, statistics::units::Count::get(),
+               "Number of prefetches hit in cache but prefetched"),
+      ADD_STAT(pfPacketsCreated, statistics::units::Count::get(),
+               "Number of prefetch packets created"),
+      ADD_STAT(pfCandidatesAdded, statistics::units::Count::get(),
+               "Number of prefetch candidates added to the prefetch queue"),
+      ADD_STAT(translationFail, statistics::units::Count::get(),
+               "Number of prefetches that failed translation"),
+      ADD_STAT(translationSuccess, statistics::units::Count::get(),
+               "Number of prefetches that succeeded translation"),
+      ADD_STAT(pfqSizeDistAtNotify, statistics::units::Count::get(),
+               "Distribution of the prefetch queue size at the time of "
+               "notification of a new fetch target"),
+      ADD_STAT(tqSizeDistAtNotify, statistics::units::Count::get(),
+               "Distribution of the translation queue size at the time of "
+               "notification of a new fetch target"),
+      ADD_STAT(pfqInserts, statistics::units::Count::get(),
+               "Number of insertions into the prefetch candidate queue"),
+      ADD_STAT(pfqPops, statistics::units::Count::get(),
+               "Number of uses into the prefetch candidate queue"),
+      ADD_STAT(pfqDrops, statistics::units::Count::get(),
+               "Number of drops into the prefetch candidate queue"),
+      ADD_STAT(tqInserts, statistics::units::Count::get(),
+               "Number of insertions into the prefetch translation queue"),
+      ADD_STAT(tqPops, statistics::units::Count::get(),
+               "Number of uses into the prefetch translation queue"),
+      ADD_STAT(tqDrops, statistics::units::Count::get(),
+               "Number of drops into the prefetch translation queue")
+{
+    pfqSizeDistAtNotify.init(0, pfq_size, 4);
+    tqSizeDistAtNotify.init(0, tq_size, 4);
+}
+
+} // namespace prefetch
+} // namespace gem5

--- a/src/mem/cache/prefetch/fdp.hh
+++ b/src/mem/cache/prefetch/fdp.hh
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022-2023 The University of Edinburgh
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Implementation of the fetch directed instruction prefetcher.
+ */
+
+#ifndef __MEM_CACHE_PREFETCH_FDP_HH__
+#define __MEM_CACHE_PREFETCH_FDP_HH__
+
+#include <list>
+
+#include "arch/generic/mmu.hh"
+#include "cpu/base.hh"
+#include "cpu/o3/ftq.hh"
+#include "mem/cache/prefetch/base.hh"
+
+namespace gem5
+{
+
+struct FetchDirectedPrefetcherParams;
+
+namespace prefetch
+{
+
+class FetchDirectedPrefetcher : public Base
+{
+
+  public:
+    FetchDirectedPrefetcher(const FetchDirectedPrefetcherParams &p);
+    ~FetchDirectedPrefetcher() = default;
+
+    /** Base class overrides */
+    void regProbeListeners() override;
+    void
+    setCache(BaseCache *_cache)
+    {
+        cache = _cache;
+    }
+
+    /** Gets a packet from the prefetch queue to be prefetched. */
+    PacketPtr getPacket() override;
+
+    Tick
+    nextPrefetchReadyTime() const override
+    {
+        return pfq.empty() ? MaxTick : pfq.front().readyTime;
+    }
+
+    /** Notify functions are not used by this prefetcher. */
+    void notify(const CacheAccessProbeArg &acc,
+                const PrefetchInfo &pfi) override {};
+
+  private:
+    /** Array of probe listeners */
+    std::vector<ProbeListenerPtr<>> listeners;
+
+    /** Pointer to the CPU object that contains the FTQ */
+    BaseCPU *cpu;
+
+    /** Pointer to the cache it is attached to */
+    BaseCache *cache;
+
+    /** Mark memory requests as prefetches. */
+    const bool markReqAsPrefetch;
+
+    /** Squash prefetches in case its fetch target is removed from the FTQ. */
+    const bool squashPrefetches;
+
+    /** The latency of the prefetcher */
+    const unsigned int latency;
+
+    /** Prefetch queue size: Maximum number of queued prefetches */
+    const unsigned int pfqSize;
+
+    /** Translation queue size: Maximum number of outstanding translations */
+    const unsigned int tqSize;
+
+    /** Probe the cache before a prefetch gets inserted into the PFQ */
+    const bool cacheSnoop;
+
+    /** The prefetch queue entry objects */
+    struct PrefetchRequest : public BaseMMU::Translation
+    {
+        PrefetchRequest(FetchDirectedPrefetcher &_owner, uint64_t _addr,
+                        ThreadID tid, o3::FTSeqNum ftn);
+
+        /** Owner of the packet */
+        FetchDirectedPrefetcher &owner;
+
+        /** The virtual address. Used to scan for redundant prefetches.*/
+        const uint64_t addr;
+
+        /** The fetch target number that created this request */
+        const o3::FTSeqNum ftn;
+
+        /** The request and packet that will be sent to the cache. */
+        RequestPtr req;
+        PacketPtr pkt;
+
+        /** The time when the prefetch is ready to be sent to the cache. */
+        Tick readyTime;
+
+        bool
+        operator==(const int &a) const
+        {
+            return this->addr == a;
+        }
+
+        /** Creates the packet that is send to the memory. */
+        void createPkt();
+
+        void finish(const Fault &fault, const RequestPtr &req,
+                    ThreadContext *tc, BaseMMU::Mode mode) override;
+
+        /** Issues the translation request */
+        void startTranslation();
+
+        void
+        markDelayed() override
+        {}
+    };
+
+    /** The prefetch queue */
+    std::list<PrefetchRequest> pfq;
+    std::list<PrefetchRequest> translationq;
+
+    /** Notifies the prefetcher that a new fetch target was
+     * inserted into the FTQ. */
+    void notifyFTQInsert(const o3::FetchTargetPtr &ft);
+
+    /** Notifies the prefetcher that a fetch target was
+     * removed from the FTQ */
+    void notifyFTQRemove(const o3::FetchTargetPtr &ft);
+
+    /** A translation has completed and can now be added to the PFQ. */
+    void translationComplete(PrefetchRequest *pf_req, const bool failed);
+
+  protected:
+    struct Stats : public statistics::Group
+    {
+        Stats(statistics::Group *parent, int pfq_size, int tq_size);
+        statistics::Scalar fdipInsertions;
+
+        statistics::Scalar pfIdentified;
+        statistics::Scalar pfSquashed;
+        statistics::Scalar pfInPFQ;
+        statistics::Scalar pfInTQ;
+        statistics::Scalar pfInCache;
+        statistics::Scalar pfInCachePrefetched;
+        statistics::Scalar pfPacketsCreated;
+        statistics::Scalar pfCandidatesAdded;
+
+        statistics::Scalar translationFail;
+        statistics::Scalar translationSuccess;
+
+        statistics::Distribution pfqSizeDistAtNotify;
+        statistics::Distribution tqSizeDistAtNotify;
+        statistics::Scalar pfqInserts;
+        statistics::Scalar pfqPops;
+        statistics::Scalar pfqDrops;
+        statistics::Scalar tqInserts;
+        statistics::Scalar tqPops;
+        statistics::Scalar tqDrops;
+    } stats;
+};
+
+} // namespace prefetch
+} // namespace gem5
+
+#endif // __MEM_CACHE_PREFETCH_FDP_HH__

--- a/src/mem/cache/prefetch/multi.cc
+++ b/src/mem/cache/prefetch/multi.cc
@@ -90,5 +90,21 @@ Multi::getPacket()
     return nullptr;
 }
 
+void
+Multi::prefetchUnused()
+{
+    for (auto pf : prefetchers) {
+        pf->prefetchUnused();
+    }
+}
+
+void
+Multi::incrDemandMhsrMisses()
+{
+    for (auto pf : prefetchers) {
+        pf->incrDemandMhsrMisses();
+    }
+}
+
 } // namespace prefetch
 } // namespace gem5

--- a/src/mem/cache/prefetch/multi.hh
+++ b/src/mem/cache/prefetch/multi.hh
@@ -56,10 +56,12 @@ class Multi : public Base
     Multi(const MultiPrefetcherParams &p);
 
   public:
-    void
-    setParentInfo(System *sys, ProbeManager *pm, unsigned blk_size) override;
+    void setParentInfo(System *sys, ProbeManager *pm,
+                       unsigned blk_size) override;
     PacketPtr getPacket() override;
     Tick nextPrefetchReadyTime() const override;
+    void prefetchUnused() override;
+    void incrDemandMhsrMisses() override;
 
     /** @{ */
     /**

--- a/tests/gem5/fdp_tests/README.md
+++ b/tests/gem5/fdp_tests/README.md
@@ -1,0 +1,8 @@
+# CPU Tests
+
+These tests run the Bubblesort and FloatMM workloads with the decoupled front-end against different ISAs.
+To run these tests by themselves, you can run the following command in the tests directory:
+
+```bash
+./main.py run gem5/fdp_tests --length=[length]
+```

--- a/tests/gem5/fdp_tests/ref/Bubblesort
+++ b/tests/gem5/fdp_tests/ref/Bubblesort
@@ -1,0 +1,2 @@
+Global frequency set at 1000000000000 ticks per second
+-50000

--- a/tests/gem5/fdp_tests/ref/FloatMM
+++ b/tests/gem5/fdp_tests/ref/FloatMM
@@ -1,0 +1,2 @@
+Global frequency set at 1000000000000 ticks per second
+-776.000061

--- a/tests/gem5/fdp_tests/run.py
+++ b/tests/gem5/fdp_tests/run.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2018 The Regents of the University of California
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+
+import m5
+from m5.objects import *
+
+
+class L1Cache(Cache):
+    """Simple L1 Cache with default values"""
+
+    assoc = 8
+    tag_latency = 1
+    data_latency = 1
+    response_latency = 1
+    mshrs = 16
+    tgts_per_mshr = 20
+
+    def connectBus(self, bus):
+        """Connect this cache to a memory-side bus"""
+        self.mem_side = bus.cpu_side_ports
+
+    def connectCPU(self, cpu):
+        """Connect this cache's port to a CPU-side port
+        This must be defined in a subclass"""
+        raise NotImplementedError
+
+
+class L1ICache(L1Cache):
+    """Simple L1 instruction cache with default values"""
+
+    # Set the default size
+    size = "32KiB"
+
+    def connectCPU(self, cpu):
+        """Connect this cache's port to a CPU icache port"""
+        self.cpu_side = cpu.icache_port
+
+
+class L1DCache(L1Cache):
+    """Simple L1 data cache with default values"""
+
+    # Set the default size
+    size = "32KiB"
+
+    def connectCPU(self, cpu):
+        """Connect this cache's port to a CPU dcache port"""
+        self.cpu_side = cpu.dcache_port
+
+
+class L2Cache(Cache):
+    """Simple L2 Cache with default values"""
+
+    # Default parameters
+    size = "512KiB"
+    assoc = 16
+    tag_latency = 10
+    data_latency = 10
+    response_latency = 1
+    mshrs = 20
+    tgts_per_mshr = 12
+
+    def connectCPUSideBus(self, bus):
+        self.cpu_side = bus.mem_side_ports
+
+    def connectMemSideBus(self, bus):
+        self.mem_side = bus.cpu_side_ports
+
+
+class MySimpleMemory(SimpleMemory):
+    latency = "1ns"
+
+
+valid_cpu = {
+    "X86DerivO3CPU": X86O3CPU,
+    "ArmDerivO3CPU": ArmO3CPU,
+    "RiscvDerivO3CPU": RiscvO3CPU,
+}
+
+valid_mem = {"SimpleMemory": MySimpleMemory, "DDR3_1600_8x8": DDR3_1600_8x8}
+
+parser = argparse.ArgumentParser()
+parser.add_argument("binary", type=str)
+parser.add_argument("--cpu")
+parser.add_argument("--mem", choices=valid_mem.keys(), default="SimpleMemory")
+
+args = parser.parse_args()
+
+system = System()
+
+system.workload = SEWorkload.init_compatible(args.binary)
+
+system.clk_domain = SrcClockDomain()
+system.clk_domain.clock = "1GHz"
+system.clk_domain.voltage_domain = VoltageDomain()
+
+system.mem_mode = "timing"
+
+system.mem_ranges = [AddrRange("512MiB")]
+
+system.cpu = valid_cpu[args.cpu]()
+
+
+## FDP specific configuration
+system.cpu.branchPred = BranchPredictor(
+    instShiftAmt=2 if "Arm" in args.cpu else 1 if "Riscv" in args.cpu else 0,
+    conditionalBranchPred=TAGE_SC_L_64KB(),
+    requiresBTBHit=True,
+    takenOnlyHistory=True,
+)
+system.cpu.decoupledFrontEnd = True
+system.cpu.fetchBufferSize = 16
+system.cpu.fetchTargetWidth = 32
+system.cpu.minInstSize = (
+    4 if "Arm" in args.cpu else 2 if "Riscv" in args.cpu else 1
+)
+
+system.cpu.l1i = L1ICache()
+system.cpu.l1i.prefetcher = FetchDirectedPrefetcher(
+    use_virtual_addresses=True,
+    cpu=system.cpu,
+)
+system.cpu.l1i.prefetcher.registerMMU(system.cpu.mmu)
+##
+
+
+system.cpu.l1d = L1DCache()
+system.l1_to_l2 = L2XBar()
+system.l2cache = L2Cache()
+system.membus = SystemXBar()
+system.cpu.l1d.connectCPU(system.cpu)
+system.cpu.l1d.connectBus(system.l1_to_l2)
+system.cpu.l1i.connectCPU(system.cpu)
+system.cpu.l1i.connectBus(system.l1_to_l2)
+system.l2cache.connectCPUSideBus(system.l1_to_l2)
+system.l2cache.connectMemSideBus(system.membus)
+
+system.cpu.createInterruptController()
+if args.cpu == "X86DerivO3CPU":
+    system.cpu.interrupts[0].pio = system.membus.mem_side_ports
+    system.cpu.interrupts[0].int_master = system.membus.cpu_side_ports
+    system.cpu.interrupts[0].int_slave = system.membus.mem_side_ports
+
+system.mem_ctrl = valid_mem[args.mem]()
+system.mem_ctrl.range = system.mem_ranges[0]
+system.mem_ctrl.port = system.membus.mem_side_ports
+system.system_port = system.membus.cpu_side_ports
+
+process = Process()
+process.cmd = [args.binary]
+system.cpu.workload = process
+system.cpu.createThreads()
+
+root = Root(full_system=False, system=system)
+m5.instantiate()
+
+exit_event = m5.simulate()
+
+if exit_event.getCause() != "exiting with last active thread context":
+    exit(1)

--- a/tests/gem5/fdp_tests/test.py
+++ b/tests/gem5/fdp_tests/test.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 Technical University of Munich
+# All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2018 The Regents of the University of California
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Test file containing simple workloads to run on CPU models.
+Each test takes ~10 seconds to run.
+"""
+
+from testlib import *
+
+workloads = ("Bubblesort", "FloatMM")
+
+valid_isas = {
+    constants.vega_x86_tag: "X86DerivO3CPU",
+    constants.arm_tag: "ArmDerivO3CPU",
+    constants.riscv_tag: "RiscvDerivO3CPU",
+}
+
+
+base_path = joinpath(config.bin_path, "fdp_tests")
+
+base_url = config.resource_url + "/test-progs/cpu-tests/bin/"
+
+isa_url = {
+    constants.vega_x86_tag: base_url + "x86",
+    constants.arm_tag: base_url + "arm",
+    constants.riscv_tag: base_url + "riscv",
+}
+
+for isa in valid_isas:
+    path = joinpath(base_path, isa.lower())
+    for workload in workloads:
+        ref_path = joinpath(getcwd(), "ref", workload)
+        verifiers = (verifier.MatchStdout(ref_path),)
+
+        url = isa_url[isa] + "/" + workload
+        workload_binary = DownloadedProgram(url, path, workload)
+        binary = joinpath(workload_binary.path, workload)
+
+        cpu = valid_isas[isa]
+        gem5_verify_config(
+            name=f"fdp_test_{cpu}_{workload}",
+            verifiers=verifiers,
+            config=joinpath(getcwd(), "run.py"),
+            config_args=[f"--cpu={cpu}", binary],
+            valid_isas=(constants.all_compiled_tag,),
+            fixtures=[workload_binary],
+        )


### PR DESCRIPTION
This PR adds support for a decoupled front-end to gem5. It was extensively tested with x86 and ARM.
The full implementation, as well as an example of how to use it, is described here:
https://github.com/dhschall/gem5-fdp

An example config file to run a simple hello world was added to the config folder: configs/example/gem5_library/fdp-hello.py