### PR TITLE
cpu-o3: Mark getWritableRegOperand() in O3CPU as a regwrite

### DIFF
--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -989,10 +989,10 @@ CPU::getWritableReg(PhysRegIdPtr phys_reg, ThreadID tid)
 {
     switch (phys_reg->classValue()) {
       case VecRegClass:
-        executeStats[tid]->numVecRegReads++;
+        executeStats[tid]->numVecRegWrites++;
         break;
       case VecPredRegClass:
-        executeStats[tid]->numVecPredRegReads++;
+        executeStats[tid]->numVecPredRegWrites++;
         break;
       default:
         break;


### PR DESCRIPTION
As discussed here, [1], O3CPU counts getWritableRegOperand() as a reg read, while SimpleCPU variants count getWriableRegOperand() as a reg write.

This patch fixes this inconsistency. Here, I assume that if getWritableRegOperand() is used, setReg() will not be used again to write to the destination register.

[1] https://github.com/gem5/gem5/pull/341

Change-Id: If00049eb598f6722285e9e09419aef98ceed759f