### PR TITLE
base: Add a warning when failing to insert a whole symbol table

### DIFF
--- a/src/base/loader/symtab.cc
+++ b/src/base/loader/symtab.cc
@@ -79,8 +79,11 @@ SymbolTable::insert(const SymbolTable &other)
                           nameMap.begin(), nameMap.end(),
                           std::inserter(intersection, intersection.begin()),
                           nameMap.value_comp());
-    if (!intersection.empty())
+    if (!intersection.empty()) {
+        warn("Cannot insert a new symbol table due to name collisions. "
+             "Adding prefix to each symbol's name can resolve this issue.");
         return false;
+    }
 
     for (const Symbol &symbol: other)
         insert(symbol);


### PR DESCRIPTION
Currently we drop the insertion of a whole symbol table if the name of one symbol already exists in the base table. Having similar symbols across different binaries is common.

This change adds a warning and recommends a fix instead of silently dropping the table.

Change-Id: I9e4cf06037cd70926fb5cee3c4dab464daf0912e