### PR TITLE
arch-arm: Remove Jazelle state + ThumbEE support

### DIFF
--- a/src/arch/arm/fastmodel/CortexA76/thread_context.cc
+++ b/src/arch/arm/fastmodel/CortexA76/thread_context.cc
@@ -228,7 +228,7 @@ Iris::ThreadContext::IdxNameMap CortexA76TC::miscRegIdxNameMap({
         // ArmISA::MISCREG_SCTLR_RST?
         { ArmISA::MISCREG_SEV_MAILBOX, "SEV_STATE" },
 
-        // AArch32 CP14 registers (debug/trace/ThumbEE control)
+        // AArch32 CP14 registers (debug/trace control)
         // ArmISA::MISCREG_DBGDIDR?
         // ArmISA::MISCREG_DBGDSCRint?
         // ArmISA::MISCREG_DBGDCCINT?

--- a/src/arch/arm/fastmodel/CortexA76/thread_context.cc
+++ b/src/arch/arm/fastmodel/CortexA76/thread_context.cc
@@ -228,7 +228,7 @@ Iris::ThreadContext::IdxNameMap CortexA76TC::miscRegIdxNameMap({
         // ArmISA::MISCREG_SCTLR_RST?
         { ArmISA::MISCREG_SEV_MAILBOX, "SEV_STATE" },
 
-        // AArch32 CP14 registers (debug/trace/ThumbEE/Jazelle control)
+        // AArch32 CP14 registers (debug/trace/ThumbEE control)
         // ArmISA::MISCREG_DBGDIDR?
         // ArmISA::MISCREG_DBGDSCRint?
         // ArmISA::MISCREG_DBGDCCINT?

--- a/src/arch/arm/fastmodel/CortexR52/thread_context.cc
+++ b/src/arch/arm/fastmodel/CortexR52/thread_context.cc
@@ -188,7 +188,7 @@ Iris::ThreadContext::IdxNameMap CortexR52TC::miscRegIdxNameMap({
         // ArmISA::MISCREG_SCTLR_RST?
         // ArmISA::MISCREG_SEV_MAILBOX?
 
-        // AArch32 CP14 registers (debug/trace/ThumbEE/Jazelle control)
+        // AArch32 CP14 registers (debug/trace/ThumbEE control)
         // ArmISA::MISCREG_DBGDIDR?
         // ArmISA::MISCREG_DBGDSCRint?
         // ArmISA::MISCREG_DBGDCCINT?

--- a/src/arch/arm/fastmodel/CortexR52/thread_context.cc
+++ b/src/arch/arm/fastmodel/CortexR52/thread_context.cc
@@ -188,7 +188,7 @@ Iris::ThreadContext::IdxNameMap CortexR52TC::miscRegIdxNameMap({
         // ArmISA::MISCREG_SCTLR_RST?
         // ArmISA::MISCREG_SEV_MAILBOX?
 
-        // AArch32 CP14 registers (debug/trace/ThumbEE control)
+        // AArch32 CP14 registers (debug/trace control)
         // ArmISA::MISCREG_DBGDIDR?
         // ArmISA::MISCREG_DBGDSCRint?
         // ArmISA::MISCREG_DBGDCCINT?

--- a/src/arch/arm/fastmodel/iris/thread_context.cc
+++ b/src/arch/arm/fastmodel/iris/thread_context.cc
@@ -581,8 +581,6 @@ ThreadContext::pcState() const
 
     pc.thumb(cpsr.t);
     pc.nextThumb(pc.thumb());
-    pc.jazelle(cpsr.j);
-    pc.nextJazelle(cpsr.j);
     pc.aarch64(!cpsr.width);
     pc.nextAArch64(!cpsr.width);
     pc.illegalExec(false);

--- a/src/arch/arm/faults.cc
+++ b/src/arch/arm/faults.cc
@@ -565,7 +565,6 @@ ArmFault::invoke32(ThreadContext *tc, const StaticInstPtr &inst)
         cpsr.i = 1;
     }
     cpsr.it1 = cpsr.it2 = 0;
-    cpsr.j = 0;
     cpsr.pan = span ? 1 : saved_cpsr.pan;
     tc->setMiscReg(MISCREG_CPSR, cpsr);
 
@@ -622,8 +621,6 @@ ArmFault::invoke32(ThreadContext *tc, const StaticInstPtr &inst)
     PCState pc(new_pc);
     pc.thumb(cpsr.t);
     pc.nextThumb(pc.thumb());
-    pc.jazelle(cpsr.j);
-    pc.nextJazelle(pc.jazelle());
     pc.aarch64(!cpsr.width);
     pc.nextAArch64(!cpsr.width);
     pc.illegalExec(false);
@@ -666,7 +663,6 @@ ArmFault::invoke64(ThreadContext *tc, const StaticInstPtr &inst)
         // Force some bitfields to 0
         spsr.q = 0;
         spsr.it1 = 0;
-        spsr.j = 0;
         spsr.ge = 0;
         spsr.it2 = 0;
         spsr.t = 0;

--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -407,7 +407,6 @@ ISA::readMiscReg(RegIndex idx)
     if (idx == MISCREG_CPSR) {
         cpsr = miscRegs[idx];
         auto pc = tc->pcState().as<PCState>();
-        cpsr.j = pc.jazelle() ? 1 : 0;
         cpsr.t = pc.thumb() ? 1 : 0;
         return cpsr;
     }
@@ -678,7 +677,6 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                 miscRegs[idx], cpsr, cpsr.f, cpsr.i, cpsr.a, cpsr.mode);
         PCState pc = tc->pcState().as<PCState>();
         pc.nextThumb(cpsr.t);
-        pc.nextJazelle(cpsr.j);
         pc.illegalExec(cpsr.il == 1);
         selfDebug->setDebugMask(cpsr.d == 1);
 

--- a/src/arch/arm/isa/formats/branch.isa
+++ b/src/arch/arm/isa/formats/branch.isa
@@ -212,10 +212,6 @@ def format Thumb32BranchesAndMiscCtrl() {{
                     {
                         const uint32_t op = bits(machInst, 7, 4);
                         switch (op) {
-                          case 0x0:
-                            return new Leavex(machInst);
-                          case 0x1:
-                            return new Enterx(machInst);
                           case 0x2:
                             return new Clrex(machInst);
                           case 0x4:

--- a/src/arch/arm/isa/insts/data.isa
+++ b/src/arch/arm/isa/insts/data.isa
@@ -268,7 +268,6 @@ let {{
             CondCodesGE = new_cpsr.ge;
 
             NextThumb = (new_cpsr).t;
-            NextJazelle = (new_cpsr).j;
             NextItState = (((new_cpsr).it2 << 2) & 0xFC)
                 | ((new_cpsr).it1 & 0x3);
             SevMailbox = 1;

--- a/src/arch/arm/isa/insts/macromem.isa
+++ b/src/arch/arm/isa/insts/macromem.isa
@@ -668,7 +668,6 @@ let {{
                                      0xF, true, sctlr.nmfi, xc->tcBase());
                     Cpsr = ~CondCodesMask & new_cpsr;
                     NextThumb = new_cpsr.t;
-                    NextJazelle = new_cpsr.j;
                     NextItState = ((((CPSR)URb).it2 << 2) & 0xFC)
                                     | (((CPSR)URb).it1 & 0x3);
                     CondCodesNZ = new_cpsr.nz;

--- a/src/arch/arm/isa/insts/misc.isa
+++ b/src/arch/arm/isa/insts/misc.isa
@@ -173,9 +173,8 @@ let {{
         CondCodesGE = new_cpsr.ge;
 
         NextThumb = (new_cpsr).t;
-                    NextJazelle = (new_cpsr).j;
-                    NextItState = (((new_cpsr).it2 << 2) & 0xFC)
-                        | ((new_cpsr).it1 & 0x3);
+        NextItState = (((new_cpsr).it2 << 2) & 0xFC)
+            | ((new_cpsr).it1 & 0x3);
 
         NPC = (old_cpsr.mode == MODE_HYP) ? ElrHyp : LR;
     '''
@@ -1082,28 +1081,6 @@ let {{
     decoder_output += McrrOpConstructor.subst(mcrr15Iop)
     exec_output += PredOpExecute.subst(mcrr15Iop)
 
-
-    enterxCode = '''
-        NextThumb = true;
-        NextJazelle = true;
-    '''
-    enterxIop = ArmInstObjParams("enterx", "Enterx", "PredOp",
-                                 { "code": enterxCode,
-                                   "predicate_test": predicateTest }, [])
-    header_output += BasicDeclare.subst(enterxIop)
-    decoder_output += BasicConstructor.subst(enterxIop)
-    exec_output += PredOpExecute.subst(enterxIop)
-
-    leavexCode = '''
-        NextThumb = true;
-        NextJazelle = false;
-    '''
-    leavexIop = ArmInstObjParams("leavex", "Leavex", "PredOp",
-                                 { "code": leavexCode,
-                                   "predicate_test": predicateTest }, [])
-    header_output += BasicDeclare.subst(leavexIop)
-    decoder_output += BasicConstructor.subst(leavexIop)
-    exec_output += PredOpExecute.subst(leavexIop)
 
     setendCode = '''
         CPSR cpsr = Cpsr;

--- a/src/arch/arm/isa/operands.isa
+++ b/src/arch/arm/isa/operands.isa
@@ -526,7 +526,6 @@ def operands {{
     'IWNPC': PCStateReg('instIWNPC', srtPC),
     'Thumb': PCStateReg('thumb', srtPC),
     'NextThumb': PCStateReg('nextThumb', srtMode),
-    'NextJazelle': PCStateReg('nextJazelle', srtMode),
     'NextItState': PCStateReg('nextItstate', srtMode),
     'Itstate': PCStateReg('itstate', srtMode),
     'NextAArch64': PCStateReg('nextAArch64', srtMode),

--- a/src/arch/arm/process.cc
+++ b/src/arch/arm/process.cc
@@ -169,7 +169,7 @@ ArmProcess32::armHwcapImpl() const
     };
 
     return Arm_Swp | Arm_Half | Arm_Thumb | Arm_FastMult |
-           Arm_Vfp | Arm_Edsp | Arm_ThumbEE | Arm_Neon |
+           Arm_Vfp | Arm_Edsp | Arm_Neon |
            Arm_Vfpv3 | Arm_Vfpv3d16;
 }
 

--- a/src/arch/arm/regs/misc.hh
+++ b/src/arch/arm/regs/misc.hh
@@ -96,7 +96,7 @@ namespace ArmISA
         MISCREG_SEV_MAILBOX,
         MISCREG_TLBINEEDSYNC,
 
-        // AArch32 CP14 registers (debug/trace/ThumbEE/Jazelle control)
+        // AArch32 CP14 registers (debug/trace/ThumbEE control)
         MISCREG_DBGDIDR,
         MISCREG_DBGDSCRint,
         MISCREG_DBGDCCINT,

--- a/src/arch/arm/regs/misc.hh
+++ b/src/arch/arm/regs/misc.hh
@@ -96,7 +96,7 @@ namespace ArmISA
         MISCREG_SEV_MAILBOX,
         MISCREG_TLBINEEDSYNC,
 
-        // AArch32 CP14 registers (debug/trace/ThumbEE control)
+        // AArch32 CP14 registers (debug/trace control)
         MISCREG_DBGDIDR,
         MISCREG_DBGDSCRint,
         MISCREG_DBGDCCINT,

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -54,7 +54,7 @@ namespace ArmISA
         Bitfield<28> v;
         Bitfield<27> q;
         Bitfield<26, 25> it1;
-        Bitfield<24> j;
+        Bitfield<24> dit;       // AArch64
         Bitfield<23> uao;       // AArch64
         Bitfield<22> pan;
         Bitfield<21> ss;        // AArch64

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -457,8 +457,6 @@ namespace ArmISA
         Bitfield<7>    itd;     // IT disable
                                 // (ARMv8 AArch32 and AArch64 SCTLR_EL1 only)
         Bitfield<6, 3> rao4;    // Read as one
-        Bitfield<6>    thee;    // ThumbEE enable
-                                // (ARMv8 AArch32 and AArch64 SCTLR_EL1 only)
         Bitfield<5>    cp15ben; // CP15 barrier enable
                                 // (AArch32 and AArch64 SCTLR_EL1 only)
         Bitfield<4>    sa0;     // Stack Alignment Check Enable for EL0

--- a/src/arch/arm/tracers/tarmac_base.cc
+++ b/src/arch/arm/tracers/tarmac_base.cc
@@ -107,12 +107,12 @@ TarmacBaseRecord::pcToISetState(const PCStateBase &pc)
 
     if (apc.aarch64())
         isetstate = TarmacBaseRecord::ISET_A64;
-    else if (!apc.thumb() && !apc.jazelle())
+    else if (!apc.thumb())
         isetstate = TarmacBaseRecord::ISET_ARM;
-    else if (apc.thumb() && !apc.jazelle())
+    else if (apc.thumb())
         isetstate = TarmacBaseRecord::ISET_THUMB;
     else
-        // No Jazelle state in TARMAC
+        // Unsupported state in TARMAC
         isetstate = TarmacBaseRecord::ISET_UNSUPPORTED;
 
     return isetstate;


### PR DESCRIPTION
This PR removes Jazelle state (while still keeping a "Trivial Jazelle implementation",
see Arm Architecture Reference Manual) and ThumbEE support