### PR TITLE
misc: Update gem5 to use clang-15 and clang-16

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
+        image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
         opts: [.opt, .fast]
     runs-on: [self-hosted, linux, x64, build]
     timeout-minutes: 2880     # 48 hours
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
-        image: [gcc-version-12, clang-version-14]
+        image: [gcc-version-12, clang-version-16]
         opts: [.opt]
     runs-on: [self-hosted, linux, x64, build]
     timeout-minutes: 2880     # 48 hours

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -254,7 +254,7 @@ Commit::setActiveThreads(std::list<ThreadID> *at_ptr)
 }
 
 void
-Commit::setRenameMap(UnifiedRenameMap rm_ptr[])
+Commit::setRenameMap(UnifiedRenameMap rm_ptr[MaxThreads])
 {
     for (ThreadID tid = 0; tid < numThreads; tid++)
         renameMap[tid] = &rm_ptr[tid];

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -286,7 +286,7 @@ Rename::setActiveThreads(std::list<ThreadID> *at_ptr)
 
 
 void
-Rename::setRenameMap(UnifiedRenameMap rm_ptr[])
+Rename::setRenameMap(UnifiedRenameMap rm_ptr[MaxThreads])
 {
     for (ThreadID tid = 0; tid < numThreads; tid++)
         renameMap[tid] = &rm_ptr[tid];

--- a/util/dockerfiles/docker-compose.yaml
+++ b/util/dockerfiles/docker-compose.yaml
@@ -127,6 +127,18 @@ services:
             args:
                 - version=14
         image: gcr.io/gem5-test/clang-version-14:latest
+    clang-15:
+        build:
+            context: ubuntu-22.04_clang-version
+            dockerfile: Dockerfile
+            args:
+                - version=15
+        image: gcr.io/gem5-test/clang-version-15:latest
+    clang-16:
+        build:
+            context: ubuntu-22.04_clang-16
+            dockerfile: Dockerfile
+        image: gcr.io/gem5-test/clang-version-16:latest
     llvm-gnu-cross-compiler-riscv64:
         build:
             context: llvm-gnu-cross-compiler-riscv64

--- a/util/dockerfiles/ubuntu-22.04_clang-16/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_clang-16/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 The Regents of the University of California
+# Copyright (c) 2023 The Regents of the University of California
 # All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,7 @@
 FROM ubuntu:22.04
 
 # Valid version values:
-# 13
-# 15
+# 16
 ARG version
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -35,7 +34,16 @@ RUN apt -y update && apt -y upgrade && \
     apt -y install git m4 scons zlib1g zlib1g-dev libprotobuf-dev \
     protobuf-compiler libprotoc-dev libgoogle-perftools-dev python3-dev \
     python-is-python3 doxygen libboost-all-dev libhdf5-serial-dev \
-    python3-pydot libpng-dev clang-${version} make
+    python3-pydot libpng-dev make
+
+RUN apt-get update && apt-get -y install sudo wget
+
+# extra installations to have wget work
+RUN apt -y install lsb-release wget software-properties-common gnupg
+RUN wget https://apt.llvm.org/llvm.sh
++
+RUN chmod u+x llvm.sh
+RUN ./llvm.sh 16
 
 RUN apt-get --purge -y remove gcc
 

--- a/util/dockerfiles/ubuntu-22.04_clang-16/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_clang-16/Dockerfile
@@ -25,33 +25,25 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 FROM ubuntu:22.04
 
-# Valid version values:
-# 16
-ARG version
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \
     apt -y install git m4 scons zlib1g zlib1g-dev libprotobuf-dev \
     protobuf-compiler libprotoc-dev libgoogle-perftools-dev python3-dev \
     python-is-python3 doxygen libboost-all-dev libhdf5-serial-dev \
-    python3-pydot libpng-dev make
+    python3-pydot libpng-dev make lsb-release wget \
+    software-properties-common gnupg
 
-RUN apt-get update && apt-get -y install sudo wget
-
-# extra installations to have wget work
-RUN apt -y install lsb-release wget software-properties-common gnupg
-RUN wget https://apt.llvm.org/llvm.sh
-+
-RUN chmod u+x llvm.sh
+COPY llvm.sh /llvm.sh
 RUN ./llvm.sh 16
 
 RUN apt-get --purge -y remove gcc
 
 RUN update-alternatives --install \
-    /usr/bin/clang++ clang++ /usr/bin/clang++-${version} 100
+    /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
 RUN update-alternatives --install \
-    /usr/bin/clang clang /usr/bin/clang-${version} 100
+    /usr/bin/clang clang /usr/bin/clang-16 100
 RUN update-alternatives --install \
-    /usr/bin/c++ c++ /usr/bin/clang++-${version} 100
+    /usr/bin/c++ c++ /usr/bin/clang++-16 100
 RUN update-alternatives --install \
-    /usr/bin/cc cc /usr/bin/clang-${version} 100
+    /usr/bin/cc cc /usr/bin/clang-16 100

--- a/util/dockerfiles/ubuntu-22.04_clang-16/llvm.sh
+++ b/util/dockerfiles/ubuntu-22.04_clang-16/llvm.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+################################################################################
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+################################################################################
+#
+# This script will install the llvm toolchain on the different
+# Debian and Ubuntu versions
+
+set -eux
+
+usage() {
+    set +x
+    echo "Usage: $0 [llvm_major_version] [all] [OPTIONS]" 1>&2
+    echo -e "all\t\t\tInstall all packages." 1>&2
+    echo -e "-n=code_name\t\tSpecifies the distro codename, for example bionic" 1>&2
+    echo -e "-h\t\t\tPrints this help." 1>&2
+    echo -e "-m=repo_base_url\tSpecifies the base URL from which to download." 1>&2
+    exit 1;
+}
+
+CURRENT_LLVM_STABLE=17
+BASE_URL="http://apt.llvm.org"
+
+# Check for required tools
+needed_binaries=(lsb_release wget add-apt-repository gpg)
+missing_binaries=()
+for binary in "${needed_binaries[@]}"; do
+    if ! which $binary &>/dev/null ; then
+        missing_binaries+=($binary)
+    fi
+done
+if [[ ${#missing_binaries[@]} -gt 0 ]] ; then
+    echo "You are missing some tools this script requires: ${missing_binaries[@]}"
+    echo "(hint: apt install lsb-release wget software-properties-common gnupg)"
+    exit 4
+fi
+
+# Set default values for commandline arguments
+# We default to the current stable branch of LLVM
+LLVM_VERSION=$CURRENT_LLVM_STABLE
+ALL=0
+DISTRO=$(lsb_release -is)
+VERSION=$(lsb_release -sr)
+UBUNTU_CODENAME=""
+CODENAME_FROM_ARGUMENTS=""
+# Obtain VERSION_CODENAME and UBUNTU_CODENAME (for Ubuntu and its derivatives)
+source /etc/os-release
+DISTRO=${DISTRO,,}
+case ${DISTRO} in
+    debian)
+        # Debian Trixie has a workaround because of
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038383
+        if [[ "${VERSION}" == "unstable" ]] || [[ "${VERSION}" == "testing" ]] || [[ "${VERSION_CODENAME}" == "trixie" ]]; then
+            CODENAME=unstable
+            LINKNAME=
+        else
+            # "stable" Debian release
+            CODENAME=${VERSION_CODENAME}
+            LINKNAME=-${CODENAME}
+        fi
+        ;;
+    *)
+        # ubuntu and its derivatives
+        if [[ -n "${UBUNTU_CODENAME}" ]]; then
+            CODENAME=${UBUNTU_CODENAME}
+            if [[ -n "${CODENAME}" ]]; then
+                LINKNAME=-${CODENAME}
+            fi
+        fi
+        ;;
+esac
+
+# read optional command line arguments
+if [ "$#" -ge 1 ] && [ "${1::1}" != "-" ]; then
+    if [ "$1" != "all" ]; then
+        LLVM_VERSION=$1
+    else
+        # special case for ./llvm.sh all
+        ALL=1
+    fi
+    OPTIND=2
+    if [ "$#" -ge 2 ]; then
+      if [ "$2" == "all" ]; then
+          # Install all packages
+          ALL=1
+          OPTIND=3
+      fi
+    fi
+fi
+
+while getopts ":hm:n:" arg; do
+    case $arg in
+    h)
+        usage
+        ;;
+    m)
+        BASE_URL=${OPTARG}
+        ;;
+    n)
+        CODENAME=${OPTARG}
+        if [[ "${CODENAME}" == "unstable" ]]; then
+            # link name does not apply to unstable repository
+            LINKNAME=
+        else
+            LINKNAME=-${CODENAME}
+        fi
+        CODENAME_FROM_ARGUMENTS="true"
+        ;;
+    esac
+done
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root!"
+   exit 1
+fi
+
+declare -A LLVM_VERSION_PATTERNS
+LLVM_VERSION_PATTERNS[9]="-9"
+LLVM_VERSION_PATTERNS[10]="-10"
+LLVM_VERSION_PATTERNS[11]="-11"
+LLVM_VERSION_PATTERNS[12]="-12"
+LLVM_VERSION_PATTERNS[13]="-13"
+LLVM_VERSION_PATTERNS[14]="-14"
+LLVM_VERSION_PATTERNS[15]="-15"
+LLVM_VERSION_PATTERNS[16]="-16"
+LLVM_VERSION_PATTERNS[17]="-17"
+LLVM_VERSION_PATTERNS[18]=""
+
+if [ ! ${LLVM_VERSION_PATTERNS[$LLVM_VERSION]+_} ]; then
+    echo "This script does not support LLVM version $LLVM_VERSION"
+    exit 3
+fi
+
+LLVM_VERSION_STRING=${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}
+
+# join the repository name
+if [[ -n "${CODENAME}" ]]; then
+    REPO_NAME="deb ${BASE_URL}/${CODENAME}/  llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING} main"
+
+    # check if the repository exists for the distro and version
+    if ! wget -q --method=HEAD ${BASE_URL}/${CODENAME} &> /dev/null; then
+        if [[ -n "${CODENAME_FROM_ARGUMENTS}" ]]; then
+            echo "Specified codename '${CODENAME}' is not supported by this script."
+        else
+            echo "Distribution '${DISTRO}' in version '${VERSION}' is not supported by this script."
+        fi
+        exit 2
+    fi
+fi
+
+
+# install everything
+
+if [[ ! -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc ]]; then
+    # download GPG key once
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+fi
+
+if [[ -z "`apt-key list 2> /dev/null | grep -i llvm`" ]]; then
+    # Delete the key in the old format
+    apt-key del AF4F7421
+fi
+add-apt-repository "${REPO_NAME}"
+apt-get update
+PKG="clang-$LLVM_VERSION lldb-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION"
+if [[ $ALL -eq 1 ]]; then
+    # same as in test-install.sh
+    # No worries if we have dups
+    PKG="$PKG clang-tidy-$LLVM_VERSION clang-format-$LLVM_VERSION clang-tools-$LLVM_VERSION llvm-$LLVM_VERSION-dev lld-$LLVM_VERSION lldb-$LLVM_VERSION llvm-$LLVM_VERSION-tools libomp-$LLVM_VERSION-dev libc++-$LLVM_VERSION-dev libc++abi-$LLVM_VERSION-dev libclang-common-$LLVM_VERSION-dev libclang-$LLVM_VERSION-dev libclang-cpp$LLVM_VERSION-dev libunwind-$LLVM_VERSION-dev"
+    if test $LLVM_VERSION -gt 14; then
+        PKG="$PKG libclang-rt-$LLVM_VERSION-dev libpolly-$LLVM_VERSION-dev"
+    fi
+fi
+apt-get install -y $PKG


### PR DESCRIPTION
This introduces the changes necessary for clang-15 and clang-16 to run within gem5, and adds them to the compiler tests.

This also updates the dockerfiles for ubuntu 22.04 to include the steps necessary to compile clang-15 and clang-16.
