### PR TITLE
misc: Add merge queues to pull request testing

### DIFF
--- a/.github/workflows/merge-group-tests.yaml
+++ b/.github/workflows/merge-group-tests.yaml
@@ -1,51 +1,11 @@
-# This workflow runs after a pull-request has been approved by a reviewer.
+# This workflow runs when a pull request enters the merge queue.
 
-name: CI Tests
+name: Merge Group Tests
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+    merge_group:
 
 jobs:
-  pre-commit:
-    # runs on github hosted runner
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
-
-  # ensures we have a change-id in every commit, needed for gerrit
-  check-for-change-id:
-    # runs on github hosted runner
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check for Change-Id
-        run: |
-          # loop through all the commits in the pull request
-          for commit in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
-              git checkout $commit
-              if (git log -1 --pretty=format:"%B" | grep -q "Change-Id: ")
-              then
-                # passes as long as at least one change-id exists in the pull request
-                exit 0
-              fi
-          done
-          # if we reach this part, none of the commits had a change-id
-          echo "None of the commits in this pull request contains a Change-ID, which we require for any changes made to gem5. "\
-            "To automatically insert one, run the following:\n f=`git rev-parse --git-dir`/hooks/commit-msg ; mkdir -p $(dirname $f) ; "\
-            "curl -Lo $f https://gerrit-review.googlesource.com/tools/hooks/commit-msg ; chmod +x $f\n Then amend the commit with git commit --amend --no-edit, and update your pull request."
-          exit 1
-
   build-gem5:
     runs-on: [self-hosted, linux, x64, build]
     if: github.event.pull_request.draft == false
@@ -116,3 +76,21 @@ jobs:
           path: output.zip
           retention-days: 7
       - run: echo "This job's status is ${{ job.status }}."
+
+  all-tests-pass:
+  # runs on github hosted runner
+    runs-on: ubuntu-latest
+    needs: [unittests-all-opt, testlib-quick]
+    # forces tests to always run
+    if: ${{ always() }}
+    steps:
+    # first check if previous steps failed, exit with error code if so
+    - name: failing tests, reject from queue
+      if: ${{ always() && (needs.unittests-all-opt.result == 'failure' || needs.testlib-quick.result == 'failure' || needs.unittests-all-opt.result == 'skipped' || needs.testlib-quick.result == 'skipped') }}
+      run: |
+        echo "this does not pass the tests"
+        exit 1
+    # only reaches this point and passes if both jobs pass
+    - name: passing tests
+      if: ${{ needs.unittests-all-opt.result == 'success' && needs.testlib-quick.result == 'success' }}
+      run: echo "actually passed"

--- a/.github/workflows/pull-request-tests.yaml
+++ b/.github/workflows/pull-request-tests.yaml
@@ -1,0 +1,51 @@
+# This workflow runs after a pull-request has been created.
+
+name: Pull Request Tests
+
+on:
+  # workflow_dispatch:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+jobs:
+  pre-commit:
+    # runs on github hosted runner
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
+
+  # ensures we have a change-id in every commit, needed for gerrit
+  check-for-change-id:
+    # runs on github hosted runner
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for Change-Id
+        run: |
+          # loop through all the commits in the pull request
+          for commit in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
+              git checkout $commit
+              if (git log -1 --pretty=format:"%B" | grep -q "Change-Id: ")
+              then
+                # passes as long as at least one change-id exists in the pull request
+                exit 0
+              fi
+          done
+          # if we reach this part, none of the commits had a change-id
+          echo "None of the commits in this pull request contains a Change-ID, which we require for any changes made to gem5. "\
+            "To automatically insert one, run the following:\n f=`git rev-parse --git-dir`/hooks/commit-msg ; mkdir -p $(dirname $f) ; "\
+            "curl -Lo $f https://gerrit-review.googlesource.com/tools/hooks/commit-msg ; chmod +x $f\n Then amend the commit with git commit --amend --no-edit, and update your pull request."
+          exit 1
+
+
+  all-tests-pass:
+    # runs on github hosted runner
+    runs-on: ubuntu-22.04
+    needs: [pre-commit, check-for-change-id]
+    steps:
+      - name: PR Checks are successful!
+        run: echo "PR Checks are successful!"


### PR DESCRIPTION
This change removes the ci-tests.yaml file, and replaces it with a set of pull request tests, and merge group tests.  Everything in pull-request-tests.yaml runs every time a PR is created.  These PRS won't be able to merge until those tests pass.  Once they're mergable, they enter a merge queue, where the merge-group-tests run.  These changes will automatically merge if these tests pass.  This requires the job "all-tests-pass" to be added as a status-check, and for merge queues to be enabled in branch settings.  This will be marked as a draft, as it should go through a round of internal testing to make sure faulty pull requests don't go through. Preliminary tests for these changes were done here: https://github.com/darchr/gem5-permission-test

Change-Id: I998b65e7410bab9805de815c17e06fcdc9ced01a