### PR TITLE
stdlib: Remove duplicated FU in RISCVMatched

### DIFF
--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
@@ -82,7 +82,6 @@ class U74VecFU(MinorDefaultVecFU):
 class U74FUPool(MinorFUPool):
     funcUnits = [
         U74IntFU(),
-        U74IntFU(),
         U74IntMulFU(),
         U74IntDivFU(),
         U74FloatSimdFU(),


### PR DESCRIPTION
This patch removes the duplicate "U74IntFU()"
in the U74FUPool in the RISCVMatched Core.

Change-Id: Idc65166d3c0bf739f2c6a0866267d2ecb963cb9e