### PR TITLE
dev: add debug flag in register bank.

### DIFF
--- a/src/dev/SConscript
+++ b/src/dev/SConscript
@@ -54,4 +54,4 @@ Source('pixelpump.cc')
 DebugFlag('Intel8254Timer')
 DebugFlag('MC146818')
 
-GTest('reg_bank.test', 'reg_bank.test.cc')
+GTest('reg_bank.test', 'reg_bank.test.cc', with_tag('gem5 trace'))


### PR DESCRIPTION
Print extra logs for the full/partial read/write access to the registers through the register bank. The debug flag is empty by default and would not print anything.

Test: run unittest of dev/reg_bank.test.xml to check the behavior would not affect the original functionality.
run gem5 with debug flags and use m5term to poke on registers.

Change-Id: I6af4b79c50c36acbbde763c1b3020d7243088261