### PR TITLE
configs: Add configurable GPU L1,L2 num banks and L2 latencies

### DIFF
--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -154,6 +154,8 @@ class TCPCntrl(TCP_Controller, CntrlBase):
             dataAccessLatency=options.TCP_latency,
         )
         self.L1cache.resourceStalls = options.no_resource_stalls
+        self.L1cache.dataArrayBanks = options.tcp_num_banks
+        self.L1cache.tagArrayBanks = options.tcp_num_banks
         self.L1cache.create(options)
         self.issue_latency = 1
         # TCP_Controller inherits this from RubyController
@@ -298,7 +300,10 @@ class TCC(RubyCache):
 class TCCCntrl(TCC_Controller, CntrlBase):
     def create(self, options, ruby_system, system):
         self.version = self.versionCount()
-        self.L2cache = TCC()
+        self.L2cache = TCC(
+            tagAccessLatency=options.tcc_tag_access_latency,
+            dataAccessLatency=options.tcc_data_access_latency,
+        )
         self.L2cache.create(options)
         self.L2cache.resourceStalls = options.no_tcc_resource_stalls
 
@@ -491,6 +496,30 @@ def define_options(parser):
     )
     parser.add_argument(
         "--glc-atomic-latency", type=int, default=1, help="GLC Atomic Latency"
+    )
+    parser.add_argument(
+        "--tcp-num-banks",
+        type=int,
+        default="16",
+        help="Num of banks in L1 cache",
+    )
+    parser.add_argument(
+        "--tcc-num-banks",
+        type=int,
+        default="16",
+        help="Num of banks in L2 cache",
+    )
+    parser.add_argument(
+        "--tcc-tag-access-latency",
+        type=int,
+        default="2",
+        help="Tag access latency in L2 cache",
+    )
+    parser.add_argument(
+        "--tcc-data-access-latency",
+        type=int,
+        default="8",
+        help="Data access latency in L2 cache",
     )
 
 


### PR DESCRIPTION
Previously, the L1, L2 number of banks and L2 latencies were not configurable through command line arguments. This commit adds support to configure them through the arguments '--tcp-num-banks' for number of banks in L1, '--tcc-num-banks' for number of banks in L2, and '--tcc-tag-access-latency', and '--tcc-data-access-latency'

Change-Id: Ie3b713ead16865fd7120e2d809ebfa56b69bc4a1