### PR TITLE
ext: Updated the gem5 SST Bridge to use SST 13.0.0

### DIFF
--- a/configs/example/sst/riscv_fs.py
+++ b/configs/example/sst/riscv_fs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Regents of the University of California
+# Copyright (c) 2023 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -104,7 +104,7 @@ def createHiFivePlatform(system):
 
     system.platform.pci_host.pio = system.membus.mem_side_ports
 
-    system.platform.rtc = RiscvRTC(frequency=Frequency("100MHz"))
+    system.platform.rtc = RiscvRTC(frequency=Frequency("10MHz"))
     system.platform.clint.int_pin = system.platform.rtc.int_pin
 
     system.pma_checker = PMAChecker(

--- a/ext/sst/INSTALL.md
+++ b/ext/sst/INSTALL.md
@@ -1,8 +1,8 @@
 # Installing SST
 
-The links to download SST source code are available here
-[http://sst-simulator.org/SSTPages/SSTMainDownloads/].
-This guide is using the most recent SST version (11.0.0) as of September 2021.
+The links to download SST source code are available at
+<http://sst-simulator.org/SSTPages/SSTMainDownloads/>.
+This guide is using the most recent SST version (13.0.0) as of September 2023.
 The following guide assumes `$SST_CORE_HOME` as the location where SST will be
 installed.
 
@@ -11,14 +11,14 @@ installed.
 ### Downloading the SST-Core Source Code
 
 ```sh
-wget https://github.com/sstsimulator/sst-core/releases/download/v11.1.0_Final/sstcore-11.1.0.tar.gz
-tar xf sstcore-11.1.0.tar.gz
+wget https://github.com/sstsimulator/sst-core/releases/download/v13.0.0_Final/sstcore-13.0.0.tar.gz
+tar xvf sstcore-13.0.0.tar.gz
 ```
 
 ### Installing SST-Core
 
 ```sh
-cd sstcore-11.1.0
+cd sstcore-13.0.0
 ./configure --prefix=$SST_CORE_HOME --with-python=/usr/bin/python3-config \
             --disable-mpi # optional, used when MPI is not available.
 make all -j$(nproc)
@@ -36,14 +36,14 @@ export PATH=$SST_CORE_HOME/bin:$PATH
 ### Downloading the SST-Elements Source Code
 
 ```sh
-wget https://github.com/sstsimulator/sst-elements/releases/download/v11.1.0_Final/sstelements-11.1.0.tar.gz
-tar xf sstelements-11.1.0.tar.gz
+wget https://github.com/sstsimulator/sst-elements/releases/download/v13.0.0_Final/sstelements-13.0.0.tar.gz
+tar xvf sstelements-13.0.0.tar.gz
 ```
 
 ### Installing SST-Elements
 
 ```sh
-cd sst-elements-library-11.1.0
+cd sst-elements-library-13.0.0
 ./configure --prefix=$SST_CORE_HOME --with-python=/usr/bin/python3-config \
             --with-sst-core=$SST_CORE_HOME
 make all -j$(nproc)
@@ -58,24 +58,34 @@ echo "export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$SST_CORE_HOME/lib/pkgconfig/" >> 
 
 ### Building gem5 library
 
-At the root of gem5 folder,
-
+At the root of the gem5 folder, you need to compile gem5 as a library. This
+varies which OS you use. If you're using Linux, then type the following:
 ```sh
 scons build/RISCV/libgem5_opt.so -j $(nproc) --without-tcmalloc --duplicate-sources
 ```
+In case you're using Mac, then type the following:
+```sh
+scons build/RISCV/libgem5_opt.dylib -j $(nproc) --without-tcmalloc --duplicate-sources
+```
 
-**Note:** `--without-tcmalloc` is required to avoid a conflict with SST's malloc.
-`--duplicate-sources` is required as the compilation of SST depends on sources to be present in the "build" directory.
+**Note:**
+* `--without-tcmalloc` is required to avoid a conflict with SST's malloc.
+* `--duplicate-sources` is required as the compilation of SST depends on sources to be present in the "build" directory.
+* The Mac version was tested on a Macbook Air with M2 processor.
 
 ### Compiling the SST integration
 
-At the root of gem5 folder,
-
+Go to the SST directory in the gem5 repo.
 ```sh
 cd ext/sst
-make
 ```
-
+According to the OS that you're using, you need to rename the `Makefile.xxx` to `Makefile`.
+```sh
+cp Makefile.xxx Makefile    # linux or mac
+make -j4
+```
+Change `ARCH=RISCV` to `ARCH=ARM` in the `Makefile` in case you're compiling
+for ARM.
 ### Running an example simulation
 
 See `README.md`

--- a/ext/sst/Makefile.linux
+++ b/ext/sst/Makefile.linux
@@ -1,0 +1,21 @@
+SST_VERSION=SST-13.0.0 # Name of the .pc file in lib/pkgconfig where SST is installed
+GEM5_LIB=gem5_opt
+ARCH=RISCV
+OFLAG=3
+
+LDFLAGS=-shared -fno-common ${shell pkg-config ${SST_VERSION} --libs} -L../../build/${ARCH}/ -Wl,-rpath ../../build/${ARCH}
+CXXFLAGS=-std=c++17 -g -O${OFLAG} -fPIC ${shell pkg-config ${SST_VERSION} --cflags} ${shell python3-config --includes} -I../../build/${ARCH}/ -I../../ext/pybind11/include/ -I../../build/softfloat/ -I../../ext
+CPPFLAGS+=-MMD -MP
+SRC=$(wildcard *.cc)
+
+.PHONY: clean all
+
+all: libgem5.so
+
+libgem5.so: $(SRC:%.cc=%.o)
+	${CXX} ${CPPFLAGS} ${LDFLAGS} $? -o $@ -l${GEM5_LIB}
+
+-include $(SRC:%.cc=%.d)
+
+clean:
+	${RM} *.[do] libgem5.so

--- a/ext/sst/Makefile.mac
+++ b/ext/sst/Makefile.mac
@@ -1,4 +1,4 @@
-SST_VERSION=SST-11.1.0 # Name of the .pc file in lib/pkgconfig where SST is installed
+SST_VERSION=SST-13.0.0 # Name of the .pc file in lib/pkgconfig where SST is installed
 GEM5_LIB=gem5_opt
 ARCH=RISCV
 OFLAG=3
@@ -10,12 +10,12 @@ SRC=$(wildcard *.cc)
 
 .PHONY: clean all
 
-all: libgem5.so
+all: libgem5.dylib
 
-libgem5.so: $(SRC:%.cc=%.o)
+libgem5.dylib: $(SRC:%.cc=%.o)
 	${CXX} ${CPPFLAGS} ${LDFLAGS} $? -o $@ -l${GEM5_LIB}
 
 -include $(SRC:%.cc=%.d)
 
 clean:
-	${RM} *.[do] libgem5.so
+	${RM} *.[do] libgem5.dylib

--- a/ext/sst/gem5.cc
+++ b/ext/sst/gem5.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Regents of the University of California
+// Copyright (c) 2023 The Regents of the University of California
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,6 @@
 
 #include <sst/core/sst_config.h>
 #include <sst/core/componentInfo.h>
-#include <sst/core/interfaces/simpleMem.h>
 #include <sst/elements/memHierarchy/memEvent.h>
 #include <sst/elements/memHierarchy/memTypes.h>
 #include <sst/elements/memHierarchy/util.h>
@@ -169,16 +168,29 @@ gem5Component::gem5Component(SST::ComponentId_t id, SST::Params& params):
     registerAsPrimaryComponent();
     primaryComponentDoNotEndSim();
 
-    systemPort = \
-        loadUserSubComponent<SSTResponderSubComponent>("system_port",0);
-    cachePort = \
-        loadUserSubComponent<SSTResponderSubComponent>("cache_port", 0);
-
-    systemPort->setTimeConverter(timeConverter);
-    systemPort->setOutputStream(&(output));
-    cachePort->setTimeConverter(timeConverter);
-    cachePort->setOutputStream(&(output));
-
+    // We need to add another parameter when invoking gem5 scripts from SST to
+    // keep a track of all the OutgoingBridges. This will allow to add or
+    // remove OutgoingBridges from gem5 configs without the need to recompile
+    // the ext/sst source everytime.
+    std::string ports = params.find<std::string>("ports", "");
+    if (ports.empty()) {
+        output.fatal(
+            CALL_INFO, -1, "Component %s must have a 'ports' parameter.\n",
+            getName().c_str()
+        );
+    }
+    // Split the port names using the util method defined.
+    splitPortNames(ports);
+    for (int i = 0 ; i < sstPortCount ; i++) {
+        std::cout << sstPortNames[i] << std::endl;
+        sstPorts.push_back(
+            loadUserSubComponent<SSTResponderSubComponent>(sstPortNames[i], 0)
+        );
+        // If the name defined in the `ports` is incorrect, then the program
+        // will crash when calling `setTimeConverter`.
+        sstPorts[i]->setTimeConverter(timeConverter);
+        sstPorts[i]->setOutputStream(&(output));
+    }
 }
 
 gem5Component::~gem5Component()
@@ -216,8 +228,9 @@ gem5Component::init(unsigned phase)
 
         // find the corresponding SimObject for each SSTResponderSubComponent
         gem5::Root* gem5_root = gem5::Root::root();
-        systemPort->findCorrespondingSimObject(gem5_root);
-        cachePort->findCorrespondingSimObject(gem5_root);
+        for (auto &port : sstPorts) {
+            port->findCorrespondingSimObject(gem5_root);
+        }
 
         // initialize the gem5 event queue
         if (!(threadInitialized)) {
@@ -230,17 +243,18 @@ gem5Component::init(unsigned phase)
         }
 
     }
-
-    systemPort->init(phase);
-    cachePort->init(phase);
+    for (auto &port : sstPorts) {
+        port->init(phase);
+    }
 }
 
 void
 gem5Component::setup()
 {
     output.verbose(CALL_INFO, 1, 0, "Component is being setup.\n");
-    systemPort->setup();
-    cachePort->setup();
+    for (auto &port : sstPorts) {
+        port->setup();
+    }
 }
 
 void
@@ -426,4 +440,17 @@ gem5Component::splitCommandArgs(std::string &cmd, std::vector<char*> &args)
 
     for (auto part: parsed_args)
         args.push_back(strdup(part.c_str()));
+}
+
+void
+gem5Component::splitPortNames(std::string port_names)
+{
+    std::vector<std::string> parsed_args = tokenizeString(
+        port_names, {'\\', ' ', '\'', '\"'}
+    );
+    sstPortCount = 0;
+    for (auto part: parsed_args) {
+        sstPortNames.push_back(strdup(part.c_str()));
+        sstPortCount++;
+    }
 }

--- a/ext/sst/gem5.hh
+++ b/ext/sst/gem5.hh
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Regents of the University of California
+// Copyright (c) 2023 The Regents of the University of California
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -108,15 +108,20 @@ class gem5Component: public SST::Component
 
   private:
     SST::Output output;
-    SSTResponderSubComponent* systemPort;
-    SSTResponderSubComponent* cachePort;
     uint64_t clocksProcessed;
     SST::TimeConverter* timeConverter;
     gem5::GlobalSimLoopExitEvent *simulateLimitEvent;
     std::vector<char*> args;
 
+    // We need a list of incoming port names so that we don't need to recompile
+    // everytime when we add a new OutgoingBridge from python.
+    std::vector<SSTResponderSubComponent*> sstPorts;
+    std::vector<std::string> sstPortNames;
+    int sstPortCount;
+
     void initPython(int argc, char **argv);
     void splitCommandArgs(std::string &cmd, std::vector<char*> &args);
+    void splitPortNames(std::string port_names);
 
     bool threadInitialized;
 
@@ -139,6 +144,7 @@ class gem5Component: public SST::Component
     )
 
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+        // These are the generally expected ports.
         {"system_port", "Connection to gem5 system_port", "gem5.gem5Bridge"},
         {"cache_port", "Connection to gem5 CPU", "gem5.gem5Bridge"}
     )

--- a/ext/sst/sst/arm_example.py
+++ b/ext/sst/sst/arm_example.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2021 Arm Limited
-# All rights reserved.
-#
-# The license below extends only to copyright in the software and shall
-# not be construed as granting a license to any other intellectual
-# property including but not limited to intellectual property relating
-# to a hardware implementation of the functionality of the software
-# licensed hereunder.  You may use the software subject to the license
-# terms below provided that you ensure that this notice is replicated
-# unmodified and in its entirety in all distributions of the software,
-# modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2021 The Regents of the University of California
+# Copyright (c) 2023 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,6 +23,18 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Copyright (c) 2021 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
 
 import sst
 import sys
@@ -46,9 +46,10 @@ cache_link_latency = "1ps"
 
 kernel = "vmlinux_exit.arm64"
 cpu_clock_rate = "3GHz"
-# gem5 will send requests to physical addresses of range [0x80000000, inf) to memory
-# currently, we do not subtract 0x80000000 from the request's address to get the "real" address
-# so, the mem_size would always be 2GiB larger than the desired memory size
+# gem5 will send requests to physical addresses of range [0x80000000, inf) to
+# memory currently, we do not subtract 0x80000000 from the request's address to
+# get the "real" address so, the mem_size would always be 2GiB larger than the
+# desired memory size
 memory_size_gem5 = "4GiB"
 memory_size_sst = "16GiB"
 addr_range_end = UnitAlgebra(memory_size_sst).getRoundedValue()
@@ -69,9 +70,22 @@ gem5_command = f" ../../configs/example/sst/arm_fs.py \
     --cpu-clock-rate {cpu_clock_rate} \
     --memory-size {memory_size_gem5}"
 
+# We keep a track of all the memory ports that we have.
+sst_ports = {
+    "system_port" : "system.system_outgoing_bridge",
+    "cache_port" : "system.memory_outgoing_bridge"
+}
+
+# We need a list of ports.
+port_list = []
+for port in sst_ports:
+    port_list.append(port)
+
 cpu_params = {
     "frequency": cpu_clock_rate,
     "cmd": gem5_command,
+    "ports" : " ".join(port_list),
+    "debug_flags" : ""
 }
 
 gem5_node = sst.Component("gem5_node", "gem5.gem5Component")
@@ -79,16 +93,16 @@ gem5_node.addParams(cpu_params)
 
 cache_bus = sst.Component("cache_bus", "memHierarchy.Bus")
 cache_bus.addParams( { "bus_frequency" : cpu_clock_rate } )
-
-system_port = gem5_node.setSubComponent("system_port", "gem5.gem5Bridge", 0) # for initialization
+# for initialization
+system_port = gem5_node.setSubComponent("system_port", "gem5.gem5Bridge", 0)
 system_port.addParams({
-    "response_receiver_name": "system.system_outgoing_bridge",
+    "response_receiver_name": sst_ports["system_port"],
     "mem_size": memory_size_sst
 })
-
-cache_port = gem5_node.setSubComponent("cache_port", "gem5.gem5Bridge", 0) # SST -> gem5
+# SST -> gem5
+cache_port = gem5_node.setSubComponent("cache_port", "gem5.gem5Bridge", 0)
 cache_port.addParams({
-    "response_receiver_name": "system.memory_outgoing_bridge",
+    "response_receiver_name": sst_ports["cache_port"],
     "mem_size": memory_size_sst
 })
 
@@ -98,11 +112,12 @@ l1_cache.addParams(l1_params)
 
 # Memory
 memctrl = sst.Component("memory", "memHierarchy.MemController")
+# `addr_range_end` should be changed accordingly to memory_size_sst
 memctrl.addParams({
     "debug" : "0",
     "clock" : "1GHz",
     "request_width" : "64",
-    "addr_range_end" : addr_range_end, # should be changed accordingly to memory_size_sst
+    "addr_range_end" : addr_range_end,
 })
 memory = memctrl.setSubComponent("backend", "memHierarchy.simpleMem")
 memory.addParams({

--- a/ext/sst/sst/example.py
+++ b/ext/sst/sst/example.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Regents of the University of California
+# Copyright (c) 2023 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -34,9 +34,10 @@ cache_link_latency = "1ps"
 
 bbl = "riscv-boot-exit-nodisk"
 cpu_clock_rate = "3GHz"
-# gem5 will send requests to physical addresses of range [0x80000000, inf) to memory
-# currently, we do not subtract 0x80000000 from the request's address to get the "real" address
-# so, the mem_size would always be 2GiB larger than the desired memory size
+# gem5 will send requests to physical addresses of range [0x80000000, inf) to
+# memory currently, we do not subtract 0x80000000 from the request's address to
+# get the "real" address so, the mem_size would always be 2GiB larger than the
+# desired memory size
 memory_size_gem5 = "4GiB"
 memory_size_sst = "6GiB"
 addr_range_end = UnitAlgebra(memory_size_sst).getRoundedValue()
@@ -52,10 +53,24 @@ l1_params = {
     "L1" : "1",
 }
 
+# We keep a track of all the memory ports that we have.
+sst_ports = {
+    "system_port" : "system.system_outgoing_bridge",
+    "cache_port" : "system.memory_outgoing_bridge"
+}
+
+# We need a list of ports.
+port_list = []
+for port in sst_ports:
+    port_list.append(port)
+
 cpu_params = {
     "frequency": cpu_clock_rate,
-    "cmd": " ../../configs/example/sst/riscv_fs.py --cpu-clock-rate {} --memory-size {}".format(cpu_clock_rate, memory_size_gem5),
-    "debug_flags": ""
+    "cmd": " ../../configs/example/sst/riscv_fs.py"
+            + f" --cpu-clock-rate {cpu_clock_rate}"
+            + f" --memory-size {memory_size_gem5}",
+    "debug_flags": "",
+    "ports" : " ".join(port_list)
 }
 
 gem5_node = sst.Component("gem5_node", "gem5.gem5Component")
@@ -64,11 +79,14 @@ gem5_node.addParams(cpu_params)
 cache_bus = sst.Component("cache_bus", "memHierarchy.Bus")
 cache_bus.addParams( { "bus_frequency" : cpu_clock_rate } )
 
-system_port = gem5_node.setSubComponent("system_port", "gem5.gem5Bridge", 0) # for initialization
-system_port.addParams({ "response_receiver_name": "system.system_outgoing_bridge"}) # tell the SubComponent the name of the corresponding SimObject
+# for initialization
+system_port = gem5_node.setSubComponent(port_list[0], "gem5.gem5Bridge", 0)
+# tell the SubComponent the name of the corresponding SimObject
+system_port.addParams({ "response_receiver_name": sst_ports["system_port"]})
 
-cache_port = gem5_node.setSubComponent("cache_port", "gem5.gem5Bridge", 0) # SST -> gem5
-cache_port.addParams({ "response_receiver_name": "system.memory_outgoing_bridge"})
+# SST -> gem5
+cache_port = gem5_node.setSubComponent(port_list[1], "gem5.gem5Bridge", 0)
+cache_port.addParams({ "response_receiver_name": sst_ports["cache_port"]})
 
 # L1 cache
 l1_cache = sst.Component("l1_cache", "memHierarchy.Cache")
@@ -76,11 +94,12 @@ l1_cache.addParams(l1_params)
 
 # Memory
 memctrl = sst.Component("memory", "memHierarchy.MemController")
+# `addr_range_end` should be changed accordingly to memory_size_sst
 memctrl.addParams({
     "debug" : "0",
     "clock" : "1GHz",
     "request_width" : "64",
-    "addr_range_end" : addr_range_end, # should be changed accordingly to memory_size_sst
+    "addr_range_end" : addr_range_end,
 })
 memory = memctrl.setSubComponent("backend", "memHierarchy.simpleMem")
 memory.addParams({

--- a/ext/sst/sst_responder.hh
+++ b/ext/sst/sst_responder.hh
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Regents of the University of California
+// Copyright (c) 2023 The Regents of the University of California
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,9 +35,8 @@
 #include <sst/core/sst_config.h>
 #include <sst/core/component.h>
 
-#include <sst/core/simulation.h>
 #include <sst/core/interfaces/stringEvent.h>
-#include <sst/core/interfaces/simpleMem.h>
+#include <sst/core/interfaces/stdMem.h>
 
 #include <sst/core/eli/elementinfo.h>
 #include <sst/core/link.h>

--- a/ext/sst/sst_responder_subcomponent.hh
+++ b/ext/sst/sst_responder_subcomponent.hh
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Regents of the University of California
+// Copyright (c) 2023 The Regents of the University of California
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -36,10 +36,8 @@
 
 #include <sst/core/sst_config.h>
 #include <sst/core/component.h>
-
-#include <sst/core/simulation.h>
 #include <sst/core/interfaces/stringEvent.h>
-#include <sst/core/interfaces/simpleMem.h>
+#include <sst/core/interfaces/stdMem.h>
 
 #include <sst/core/eli/elementinfo.h>
 #include <sst/core/link.h>
@@ -59,12 +57,12 @@ class SSTResponderSubComponent: public SST::SubComponent
     gem5::OutgoingRequestBridge* responseReceiver;
     gem5::SSTResponderInterface* sstResponder;
 
-    SST::Interfaces::SimpleMem* memoryInterface;
+    SST::Interfaces::StandardMem* memoryInterface;
     SST::TimeConverter* timeConverter;
     SST::Output* output;
     std::queue<gem5::PacketPtr> responseQueue;
 
-    std::vector<SST::Interfaces::SimpleMem::Request*> initRequests;
+    std::vector<SST::Interfaces::StandardMem::Request*> initRequests;
 
     std::string gem5SimObjectName;
     std::string memSize;
@@ -78,7 +76,7 @@ class SSTResponderSubComponent: public SST::SubComponent
     void setOutputStream(SST::Output* output_);
 
     void setResponseReceiver(gem5::OutgoingRequestBridge* gem5_bridge);
-    void portEventHandler(SST::Interfaces::SimpleMem::Request* request);
+    void portEventHandler(SST::Interfaces::StandardMem::Request* request);
 
     bool blocked();
     void setup();
@@ -86,18 +84,18 @@ class SSTResponderSubComponent: public SST::SubComponent
     // return true if the SimObject could be found
     bool findCorrespondingSimObject(gem5::Root* gem5_root);
 
-    bool handleTimingReq(SST::Interfaces::SimpleMem::Request* request);
+    bool handleTimingReq(SST::Interfaces::StandardMem::Request* request);
     void handleRecvRespRetry();
     void handleRecvFunctional(gem5::PacketPtr pkt);
-    void handleSwapReqResponse(SST::Interfaces::SimpleMem::Request* request);
+    void handleSwapReqResponse(SST::Interfaces::StandardMem::Request* request);
 
     TPacketMap sstRequestIdToPacketMap;
 
   public: // register the component to SST
     SST_ELI_REGISTER_SUBCOMPONENT_API(SSTResponderSubComponent);
-    SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
+    SST_ELI_REGISTER_SUBCOMPONENT(
         SSTResponderSubComponent,
-        "gem5", // SST will look for libgem5.so
+        "gem5", // SST will look for libgem5.so or libgem5.dylib
         "gem5Bridge",
         SST_ELI_ELEMENT_VERSION(1, 0, 0),
         "Initialize gem5 and link SST's ports to gem5's ports",
@@ -106,7 +104,7 @@ class SSTResponderSubComponent: public SST::SubComponent
 
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
         {"memory", "Interface to the memory subsystem", \
-         "SST::Interfaces::SimpleMem"}
+         "SST::Interfaces::StandardMem"}
     )
 
     SST_ELI_DOCUMENT_PORTS(


### PR DESCRIPTION
This change updates the gem5 SST Bridge to use SST 13.0.0. Changes are made to replace SimpleMem class to StandardMem class as SimpleMem will be deprecated in SST 14 and above. In addition, the translator.hh is updated to translate more types of gem5 packets. A new parameter ports was added on SST's side when invoking the gem5 component which does not require recompiling the gem5 component whenever a new outgoing bridge is added in a gem5 config.