### PR TITLE
arch-riscv: Implement Zcb instructions

### DIFF
--- a/src/arch/riscv/isa/bitfields.isa
+++ b/src/arch/riscv/isa/bitfields.isa
@@ -98,7 +98,9 @@ def bitfield RL <25>;
 
 // Compressed
 def bitfield COPCODE <15:13>;
+def bitfield CFUNCT6LOW3 <12:10>;
 def bitfield CFUNCT1 <12>;
+def bitfield CFUNCT1BIT6 <6>;
 def bitfield CFUNCT2HIGH <11:10>;
 def bitfield CFUNCT2LOW <6:5>;
 def bitfield RC1 <11:7>;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -107,6 +107,49 @@ decode QUADRANT default Unknown::unknown() {
                 }});
             }
         }
+        0x4: decode CFUNCT6LOW3 {
+            format CompressedLoad {
+                0x0: c_lbu({{
+                    offset = (CIMM2<0:0> << 1) | CIMM2<1:1>;
+                }}, {{
+                    Rp2 = Mem_ub;
+                }}, {{
+                    EA = rvZext(Rp1 + offset);
+                }});
+                0x1: decode CFUNCT1BIT6 {
+                    0x0: c_lhu({{
+                        offset = CIMM2<0:0> << 1;
+                    }}, {{
+                        Rp2 = Mem_uh;
+                    }}, {{
+                        EA = rvZext(Rp1 + offset);
+                    }});
+                    0x1: c_lh({{
+                        offset = CIMM2<0:0> << 1;
+                    }}, {{
+                        Rp2_sd = Mem_sh;
+                    }}, {{
+                        EA = rvZext(Rp1 + offset);
+                    }});
+                }
+            }
+            format CompressedStore {
+                0x2: c_sb({{
+                    offset = (CIMM2<0:0> << 1) | CIMM2<1:1>;
+                }}, {{
+                    Mem_ub = Rp2_ub;
+                }}, ea_code={{
+                    EA = rvZext(Rp1 + offset);
+                }});
+                0x3: c_sh({{
+                    offset = (CIMM2<0:0> << 1);
+                }}, {{
+                    Mem_uh = Rp2_uh;
+                }}, ea_code={{
+                    EA = rvZext(Rp1 + offset);
+                }});
+            }
+        }
         format CompressedStore {
             0x5: c_fsd({{
                 offset = CIMM3 << 3 | CIMM2 << 6;
@@ -264,13 +307,40 @@ decode QUADRANT default Unknown::unknown() {
                             Rp1 = rvSext(Rp1 & Rp2);
                         }});
                     }
-                    0x1: decode RVTYPE {
-                        0x1: decode CFUNCT2LOW {
-                            0x0: c_subw({{
+                    0x1: decode CFUNCT2LOW {
+                        0x0: decode RVTYPE {
+                            0x1: c_subw({{
                                 Rp1_sd = (int32_t)Rp1_sd - Rp2_sw;
                             }});
+                        }
+                        0x1: decode RVTYPE {
                             0x1: c_addw({{
                                 Rp1_sd = (int32_t)Rp1_sd + Rp2_sw;
+                            }});
+                        }
+                        0x2: c_mul({{
+                            Rp1_sd = rvSext(Rp1_sd * Rp2_sd);
+                        }}, IntMultOp);
+                        0x3: decode RP2 {
+                            0x0: c_zext_b({{
+                                Rp1 = Rp1 & 0xFFULL;
+                            }});
+                            0x1: c_sext_b({{
+                                Rp1 = sext<8>(Rp1 & 0xFFULL);
+                            }});
+                            0x2: c_zext_h({{
+                                Rp1 = Rp1 & 0xFFFFULL;
+                            }});
+                            0x3: c_sext_h({{
+                                Rp1 = sext<16>(Rp1 & 0xFFFFULL);
+                            }});
+                            0x4: decode RVTYPE {
+                                0x1: c_zext_w({{
+                                    Rp1 = bits(Rp1, 31, 0);
+                                }});
+                            }
+                            0x5: c_not({{
+                                Rp1 = ~Rp1;
                             }});
                         }
                     }

--- a/src/arch/riscv/isa/formats/compressed.isa
+++ b/src/arch/riscv/isa/formats/compressed.isa
@@ -150,8 +150,9 @@ def template CBasicExecute {{
         std::vector<RegId> indices = {%(regs)s};
         std::stringstream ss;
         ss << mnemonic << ' ';
-        ss << registerName(indices[0]) << ", ";
-        ss << registerName(indices[1]);
+        ss << registerName(indices[0]);
+        if (_numSrcRegs >= 2)
+            ss << ", " << registerName(indices[1]);
         return ss.str();
     }
 }};


### PR DESCRIPTION
Added the following instructions:
c.lbu
c.lh
c.lhu
c.sb
c.sh
c.zext.b
c.sext.b
c.zext.h
c.sext.h
c.zext.w
c.not
c.mul

Reference: https://github.com/riscv/riscv-code-size-reduction
Change-Id: Ib04820bf5591b365a3bfbbd8b90655a8a1d844cf