### PR TITLE
tests,misc: Fix compilation tests failures

### DIFF
--- a/ext/drampower/src/CmdScheduler.h
+++ b/ext/drampower/src/CmdScheduler.h
@@ -84,8 +84,7 @@ class cmdScheduler {
     std::string  name;
     physicalAddr PhysicalAddr;
     // sorting the commands according to their scheduling time.
-    struct commandItemSorter : public std::binary_function<commandItem&,
-                                                           commandItem&, bool>{
+    struct commandItemSorter {
       bool operator()(const commandItem& lhs,
                       const commandItem& rhs) const
       {

--- a/src/arch/arm/pcstate.hh
+++ b/src/arch/arm/pcstate.hh
@@ -92,7 +92,7 @@ class PCState : public GenericISA::UPCState<4>
 
   public:
     void
-    set(Addr val)
+    set(Addr val) override
     {
         Base::set(val);
         npc(val + (thumb() ? 2 : 4));

--- a/src/arch/generic/pcstate.hh
+++ b/src/arch/generic/pcstate.hh
@@ -489,7 +489,7 @@ class DelaySlotPCState : public SimplePCState<InstWidth>
     void nnpc(Addr val) { _nnpc = val; }
 
     void
-    set(Addr val)
+    set(Addr val) override
     {
         Base::set(val);
         nnpc(val + 2 * InstWidth);
@@ -563,7 +563,7 @@ class DelaySlotUPCState : public DelaySlotPCState<InstWidth>
     }
 
     void
-    set(Addr val)
+    set(Addr val) override
     {
         Base::set(val);
         this->upc(0);

--- a/src/arch/x86/pcstate.hh
+++ b/src/arch/x86/pcstate.hh
@@ -66,7 +66,7 @@ class PCState : public GenericISA::UPCState<8>
     }
 
     void
-    set(Addr val)
+    set(Addr val) override
     {
         Base::set(val);
         _size = 0;


### PR DESCRIPTION
Exposed in our failing compiler tests: https://github.com/gem5/gem5/actions/runs/6348223508, this PR:

* Adds missing overrides to `PCState`'s `set` function.
* Removes `std::binary_function` from DramPower (it was deprecated in CPP-11 and officially removed in CPP-17).