### PR TITLE
stdlib: Del comment stating SE mode limited to single thread

### DIFF
--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -75,7 +75,6 @@ class SEBinaryWorkload:
         """Set up the system to run a specific binary.
 
         **Limitations**
-        * Only supports single threaded applications.
         * Dynamically linked executables are partially supported when the host
           ISA and the simulated ISA are the same.
 


### PR DESCRIPTION
This comment was left in the codebase in error. The `set_se_binary_workload` function works fine with multi-threaded applications. This hasn't been a restriction for some time.