### PR TITLE
stdlib: Improve handing of errors in Atlas request failures

### DIFF
--- a/src/python/gem5/resources/client_api/abstract_client.py
+++ b/src/python/gem5/resources/client_api/abstract_client.py
@@ -30,26 +30,6 @@ import urllib.parse
 
 
 class AbstractClient(ABC):
-    def verify_status_code(self, status_code: int) -> None:
-        """
-        Verifies that the status code is 200.
-        :param status_code: The status code to verify.
-        """
-        if status_code == 200:
-            return
-        if status_code == 429:
-            raise Exception("Panic: Too many requests")
-        if status_code == 401:
-            raise Exception("Panic: Unauthorized")
-        if status_code == 404:
-            raise Exception("Panic: Not found")
-        if status_code == 400:
-            raise Exception("Panic: Bad request")
-        if status_code == 500:
-            raise Exception("Panic: Internal server error")
-
-        raise Exception(f"Panic: Unknown status code {status_code}")
-
     def _url_validator(self, url: str) -> bool:
         """
         Validates the provided URL.

--- a/src/python/gem5/resources/client_api/atlasclient.py
+++ b/src/python/gem5/resources/client_api/atlasclient.py
@@ -30,7 +30,7 @@ import json
 import time
 import itertools
 from .abstract_client import AbstractClient
-
+from urllib.error import HTTPError
 from m5.util import warn
 
 
@@ -77,7 +77,7 @@ class AtlasClient(AbstractClient):
 
     def get_token(self):
         return self._atlas_http_json_req(
-            self.url,
+            self.authUrl,
             data_json={"key": self.apiKey},
             headers={"Content-Type": "application/json"},
             purpose_of_request="Get Access Token with API key",
@@ -122,7 +122,7 @@ class AtlasClient(AbstractClient):
             try:
                 response = request.urlopen(req)
                 break
-            except Exception as e:
+            except HTTPError as e:
                 if attempt >= max_failed_attempts:
                     raise AtlasClientHttpJsonRequestError(
                         client=self,
@@ -167,7 +167,10 @@ class AtlasClient(AbstractClient):
         }
 
         resources = self._atlas_http_json_req(
-            url, data=data, headers=headers, purpose_of_request="Get Resources"
+            url,
+            data_json=data,
+            headers=headers,
+            purpose_of_request="Get Resources",
         )["documents"]
 
         # I do this as a lazy post-processing step because I can't figure out

--- a/src/python/gem5/resources/client_api/client_wrapper.py
+++ b/src/python/gem5/resources/client_api/client_wrapper.py
@@ -30,6 +30,7 @@ from _m5 import core
 from typing import Optional, Dict, List, Tuple
 import itertools
 from m5.util import warn
+import sys
 
 
 class ClientWrapper:
@@ -114,7 +115,12 @@ class ClientWrapper:
                     self.clients[client].get_resources_by_id(resource_id)
                 )
             except Exception as e:
-                warn(f"Error getting resources from client {client}: {str(e)}")
+                print(
+                    f"Exception thrown while getting resource '{resource_id}' "
+                    f"from client '{client}'\n",
+                    file=sys.stderr,
+                )
+                raise e
         # check if no 2 resources have the same id and version
         for res1, res2 in itertools.combinations(resources, 2):
             if res1["resource_version"] == res2["resource_version"]:

--- a/tests/pyunit/stdlib/resources/pyunit_client_wrapper_checks.py
+++ b/tests/pyunit/stdlib/resources/pyunit_client_wrapper_checks.py
@@ -34,6 +34,10 @@ import io
 import contextlib
 from pathlib import Path
 
+from gem5.resources.client_api.atlasclient import (
+    AtlasClientHttpJsonRequestError,
+)
+
 mock_json_path = Path(__file__).parent / "refs/resources.json"
 mock_config_json = {
     "sources": {
@@ -419,21 +423,11 @@ class ClientWrapperTestSuite(unittest.TestCase):
     @patch("urllib.request.urlopen", side_effect=mocked_requests_post)
     def test_invalid_auth_url(self, mock_get):
         resource_id = "test-resource"
-        f = io.StringIO()
-        with self.assertRaises(Exception) as context:
-            with contextlib.redirect_stderr(f):
-                get_resource_json_obj(
-                    resource_id,
-                    gem5_version="develop",
-                )
-        self.assertTrue(
-            "Error getting resources from client gem5-resources:"
-            " Panic: Not found" in str(f.getvalue())
-        )
-        self.assertTrue(
-            "Resource with ID 'test-resource' not found."
-            in str(context.exception)
-        )
+        with self.assertRaises(AtlasClientHttpJsonRequestError) as context:
+            get_resource_json_obj(
+                resource_id,
+                gem5_version="develop",
+            )
 
     @patch(
         "gem5.resources.client.clientwrapper",
@@ -442,21 +436,11 @@ class ClientWrapperTestSuite(unittest.TestCase):
     @patch("urllib.request.urlopen", side_effect=mocked_requests_post)
     def test_invalid_url(self, mock_get):
         resource_id = "test-resource"
-        f = io.StringIO()
-        with self.assertRaises(Exception) as context:
-            with contextlib.redirect_stderr(f):
-                get_resource_json_obj(
-                    resource_id,
-                    gem5_version="develop",
-                )
-        self.assertTrue(
-            "Error getting resources from client gem5-resources:"
-            " Panic: Not found" in str(f.getvalue())
-        )
-        self.assertTrue(
-            "Resource with ID 'test-resource' not found."
-            in str(context.exception)
-        )
+        with self.assertRaises(AtlasClientHttpJsonRequestError) as context:
+            get_resource_json_obj(
+                resource_id,
+                gem5_version="develop",
+            )
 
     @patch(
         "gem5.resources.client.clientwrapper",
@@ -465,18 +449,8 @@ class ClientWrapperTestSuite(unittest.TestCase):
     @patch("urllib.request.urlopen", side_effect=mocked_requests_post)
     def test_invalid_url(self, mock_get):
         resource_id = "test-too-many"
-        f = io.StringIO()
-        with self.assertRaises(Exception) as context:
-            with contextlib.redirect_stderr(f):
-                get_resource_json_obj(
-                    resource_id,
-                    gem5_version="develop",
-                )
-        self.assertTrue(
-            "Error getting resources from client gem5-resources:"
-            " Panic: Too many requests" in str(f.getvalue())
-        )
-        self.assertTrue(
-            "Resource with ID 'test-too-many' not found."
-            in str(context.exception)
-        )
+        with self.assertRaises(AtlasClientHttpJsonRequestError) as context:
+            get_resource_json_obj(
+                resource_id,
+                gem5_version="develop",
+            )


### PR DESCRIPTION
Now:

* The Atlas Client will attempt a connection 4 times, using an exponential backoff approach between attempts.
* When a failure does arise a rich output is given so problems can be easily diagnosed.

Addresses: #340