### PR TITLE
mem-ruby: Far atomics fix

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -304,7 +304,7 @@ bool fromSequencer(CHIRequestType reqType) {
          reqType == CHIRequestType:Store ||
          reqType == CHIRequestType:StoreLine ||
          reqType == CHIRequestType:AtomicLoad ||
-         tbe.reqType == CHIRequestType:AtomicStore;
+         reqType == CHIRequestType:AtomicStore;
 }
 
 bool inCache(Addr addr) {


### PR DESCRIPTION
The PR is fixing the CHI fromSequencer helper function which is making
use of the undefined tbe entry.

This has been broken by #177

Change-Id: I52feff4b5ab2faf0aa91edd6572e3e767c88e257