### PR TITLE
tests: Update test workflows for new runners

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: Run "tests/${{ matrix.test-dir }}" TestLib quick tests
         id: run-tests
         working-directory: ${{ github.workspace }}/tests
-        run: ./main.py run --skip-build -vv ${{ matrix.test-dir }}
+        run: ./main.py run --skip-build -t $(nproc) -vv ${{ matrix.test-dir }}
 
         # Get the basename of the matrix.test-dir path (to name the artifact).
       - name: Sanatize test-dir for artifact name

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -47,7 +47,7 @@ jobs:
           exit 1
 
   unittests-all-opt:
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     if: github.event.pull_request.draft == false
     container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
@@ -60,7 +60,7 @@ jobs:
       - run: echo "This job's status is ${{ job.status }}."
 
   testlib-quick-matrix:
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     if: github.event.pull_request.draft == false
     # In order to make sure the environment is exactly the same, we run in
     # the same container we use to build gem5 and run the testlib tests. This
@@ -89,7 +89,7 @@ jobs:
         test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}
 
   testlib-quick-gem5-builds:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     if: github.event.pull_request.draft == false
     container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id, testlib-quick-matrix]
@@ -119,7 +119,7 @@ jobs:
           retention-days: 7
 
   testlib-quick-execution:
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     if: github.event.pull_request.draft == false
     container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     needs: [pre-commit, check-for-change-id, testlib-quick-matrix, testlib-quick-gem5-builds]
@@ -174,7 +174,7 @@ jobs:
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     needs: testlib-quick-execution
     steps:
       - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
         opts: [.opt, .fast]
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:
@@ -38,7 +38,7 @@ jobs:
         gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
         image: [gcc-version-12, clang-version-16]
         opts: [.opt]
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 2880     # 48 hours
     container: gcr.io/gem5-test/${{ matrix.image }}:latest
     steps:

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -36,7 +36,7 @@ jobs:
             command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
           - image: NULL_MI_example
             command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     needs: name-artifacts
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     steps:
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         type: [fast, debug]
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     timeout-minutes: 60
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [arm_boot_tests, fs, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests, stdlib, x86_boot_tests]
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [name-artifacts, build-gem5]
     timeout-minutes: 1440 # 24 hours for entire matrix to run
@@ -164,7 +164,7 @@ jobs:
   # split library example tests into runs based on Suite UID
   # so that they don't hog the runners for too long
   testlib-long-gem5_library_example_tests:
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -210,7 +210,7 @@ jobs:
   # This runs the SST-gem5 integration compilation and tests it with
   # ext/sst/sst/example.py.
   sst-test:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/sst-env:latest
     timeout-minutes: 180
 
@@ -232,7 +232,7 @@ jobs:
   # This runs the gem5 within SystemC ingration and runs a simple hello-world
   # simulation with it.
   systemc-test:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/systemc-env:latest
     timeout-minutes: 180
 
@@ -256,7 +256,7 @@ jobs:
 
   # Runs the gem5 Nighyly GPU tests.
   gpu-tests:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/gcn-gpu:latest
     timeout-minutes: 720 # 12 hours
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   obtain-dockerfiles:
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
 
     steps:
@@ -20,7 +20,7 @@ jobs:
 
   # This builds and pushes the docker image.
   build-and-push:
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     needs: obtain-dockerfiles
     permissions:
       packages: write

--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-gem5:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/gcn-gpu:latest
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
       - run: echo "This job's status is ${{ job.status }}."
 
   HACC-tests:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/gcn-gpu:latest
     needs: build-gem5
     timeout-minutes: 120 # 2 hours

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-gem5:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     outputs:
       build-name: ${{ steps.artifact-name.outputs.name }}
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
-    runs-on: [self-hosted, linux, x64, run]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     needs: [build-gem5]
     timeout-minutes: 4320 # 3 days
@@ -79,7 +79,7 @@ jobs:
     - run: echo "This job's status is ${{ job.status }}."
 
   dramsys-tests:
-    runs-on: [self-hosted, linux, x64, build]
+    runs-on: [self-hosted, linux, x64]
     container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
     timeout-minutes: 4320 # 3 days
     steps:

--- a/util/github-runners-vagrant/Vagrantfile
+++ b/util/github-runners-vagrant/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
       runner.vm.provision "file", source: "./action-run.sh", destination: "/tmp/action-run.sh"
       runner.vm.provision :shell, privileged: false,  inline: "cp /tmp/action-run.sh ."
       # Execute the actions-run.sh script on every boot. This configures the and starts the runner.
-      runner.vm.provision :shell, privileged: false, run: 'always', inline: "./action-run.sh #{PERSONAL_ACCESS_TOKEN} #{GITHUB_ORG} "run,build" >> action-run.log 2>&1 &"
+      runner.vm.provision :shell, privileged: false, run: 'always', inline: "./action-run.sh #{PERSONAL_ACCESS_TOKEN} #{GITHUB_ORG} >> action-run.log 2>&1 &"
     end
   end
 end


### PR DESCRIPTION
#371 Updates the runners. This PR updates the tests to:

1. Drop the 'run' and 'build' labels (all runners are now of the same type).
2. Utilize the threading where possible (runners now have 4 cores minimum).