### PR TITLE
misc: Add additional `pre-commit` hook checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
           - id: check-ast
           - id: check-case-conflict
           - id: check-merge-conflict
+          - id: check-symlinks
           - id: requirements-txt-fixer
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
           - id: check-added-large-files
           - id: mixed-line-ending
             args: [--fix=lf]
+          - id: check-ast
           - id: check-case-conflict
           - id: requirements-txt-fixer
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,7 @@ repos:
           - id: check-case-conflict
           - id: check-merge-conflict
           - id: check-symlinks
+          - id: destroyed-symlinks
           - id: requirements-txt-fixer
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
             args: [--fix=lf]
           - id: check-ast
           - id: check-case-conflict
+          - id: check-merge-conflict
           - id: requirements-txt-fixer
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3


### PR DESCRIPTION
Adds the following hooks:

1. `check-ast`: Verifies all Python files have a AST indicating they are valid Python.
2. `check-merge-conflict`: Checks to see if files have merge conflict strings and blocks commits if so.
3. `check-symlinks`: Checks that symlinks in the repo still point to a valid location.
4. `destroyed-symlinks`: Checks if symlink is replaced with a file and if that file is identical to the file it was previously pointing too.

None of these commits change any code. They are all checks to ensure bad code is not committed.