### PR TITLE
configs,tests: Remove `mkdir` in simpoint-se-checkpoint.py

### DIFF
--- a/configs/example/gem5_library/checkpoints/simpoints-se-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/simpoints-se-checkpoint.py
@@ -128,7 +128,6 @@ board.set_se_simpoint_workload(
 )
 
 dir = Path(args.checkpoint_path)
-dir.mkdir(exist_ok=True)
 
 simulator = Simulator(
     board=board,


### PR DESCRIPTION
This `mkdir` is problematic as it doesn't create the directory recursively. This casues errors if `dir` is `X/Y/Z` and both `Y` and `Z` has not been created. An error will be returned (`No such file or directory`).

This issue was fixed with: https://github.com/gem5/gem5/pull/263. The checkpointing code already recursively creates directories as needed. Ergo was can remove this `mkdir` statement.