### PR TITLE
arch-arm: Make interrupt masking handle VHE/SEL2 cases

### DIFF
--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -129,6 +129,8 @@ class Interrupts : public BaseInterrupts
     };
 
     bool takeInt(InterruptTypes int_type) const;
+    bool takeInt32(InterruptTypes int_type) const;
+    bool takeInt64(InterruptTypes int_type) const;
 
     bool
     checkInterrupts() const override


### PR DESCRIPTION
The new implementation matches the table in the ARM Architecture
Reference Manual (version DDI 0487J.a, section D1.3.6, table R_SXLWJ)

It takes into consideration features like FEAT_SEL2 (scr.eel2 bit) and
FEAT_VHE (hcr.e2h bit) which affect the masking of interrupts under
certain circumstances