### PR TITLE
configs: GPUFS option to disable KVM perf counters

### DIFF
--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -168,6 +168,13 @@ def addRunFSOptions(parser):
         "be disabled for correct functionality ",
     )
 
+    parser.add_argument(
+        "--no-kvm-perf",
+        default=False,
+        action="store_true",
+        help="Disable KVM perf counters (use this with LSF / ETX)",
+    )
+
 
 def runGpuFSSystem(args):
     """

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -296,6 +296,12 @@ def makeGpuFSSystem(args):
                 obj.eventq_index = 0
             cpu.eventq_index = i + 1
 
+    # Disable KVM Perf counters if specified. This is useful for machines
+    # with more restrictive KVM paranoid levels.
+    if args.no_kvm_perf and ObjectList.is_kvm_cpu(TestCPUClass):
+        for i, cpu in enumerate(system.cpu[:-1]):
+            cpu.usePerf = False
+
     gpu_port_idx = (
         len(system.ruby._cpu_ports)
         - args.num_compute_units


### PR DESCRIPTION
Add a --no-kvm-perf option to disable KVM perf counters for GPUFS scripts. This is useful for users who have KVM enabled but configured with more restrictive settings, which seems to be the default in newer Linux distros.

Change-Id: I7508113d0f7c74deb21ea7b2770522885a0ec822