### PR TITLE
arch-vega: Ignore s_setprio instruction instead of panic

### DIFF
--- a/src/arch/amdgpu/vega/insts/instructions.cc
+++ b/src/arch/amdgpu/vega/insts/instructions.cc
@@ -4728,6 +4728,7 @@ namespace VegaISA
     Inst_SOPP__S_SETPRIO::Inst_SOPP__S_SETPRIO(InFmt_SOPP *iFmt)
         : Inst_SOPP(iFmt, "s_setprio")
     {
+        setFlag(ALU);
     } // Inst_SOPP__S_SETPRIO
 
     Inst_SOPP__S_SETPRIO::~Inst_SOPP__S_SETPRIO()
@@ -4742,7 +4743,10 @@ namespace VegaISA
     void
     Inst_SOPP__S_SETPRIO::execute(GPUDynInstPtr gpuDynInst)
     {
-        panicUnimplemented();
+        ScalarRegU16 simm16 = instData.SIMM16;
+        ScalarRegU32 userPrio = simm16 & 0x3;
+
+        warn_once("S_SETPRIO ignored -- Requested priority %d\n", userPrio);
     } // execute
     // --- Inst_SOPP__S_SENDMSG class methods ---
 


### PR DESCRIPTION
This instruction is used by ML frameworks to prioritize certain wavefronts. Since gem5 does not have any support for wavefront scheduling based on priority (besides wavefront age), we ignore this instruction and warn_once rather than calling panic. Since hardware can override this priority anyways, we can be sure that ignoring the value will not inhibit forward progress resulting in application hangs.

Change-Id: Ic5eef14f9685dd2b316c5cf76078bb78d5bfe3cc