### PR TITLE
arch-riscv: Fix write back register issue of vmask_mv_micro

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -555,7 +555,7 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
     Fault
     execute(ExecContext* xc, trace::InstRecord* traceData) const override
     {
-        vreg_t tmp_d0 = *(vreg_t *)xc->getWritableRegOperand(this, 0);
+        vreg_t& tmp_d0 = *(vreg_t *)xc->getWritableRegOperand(this, 0);
         auto Vd = tmp_d0.as<uint8_t>();
         constexpr uint8_t elems_per_vreg = VLENB / sizeof(ElemType);
         size_t bit_cnt = elems_per_vreg;


### PR DESCRIPTION
After removing the setRegOperand in VecRegOperand
https://github.com/gem5/gem5/pull/341. The vmask_vm_micro will not write back to register because tmp_d0 is not the reference type. The PR will make tmp_d0 as reference of regFile.

Change-Id: I2a934ad28045ac63950d4e2ed3eecc4a7d137919