### PR TITLE
misc,tests: Add dummy jobs to workflows for status checks

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -173,7 +173,7 @@ jobs:
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
-        runs-on: [self-hosted, linux, x64]
+        runs-on: ubuntu-22.04
         needs: testlib-quick-execution
         steps:
             - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -55,3 +55,16 @@ jobs:
             - name: Compile build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} with ${{ matrix.image }}
               run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} -j$(nproc)
               timeout-minutes: 600 # 10 hours
+
+    compiler-tests:
+        # The dummy job is used to indicate whether the compiler tests have
+        # passed or not. This can be used as status check for pull requests.
+        # I.e., if we want to stop pull requests from being merged if the
+        # compiler tests are failing, we can add this job as a required status
+        # check.
+        runs-on: ubuntu-22.04
+        needs:
+            - latest-compilers-all-gem5-builds
+            - all-compilers
+        steps:
+            - run: echo "This compiler tests have passed."

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -284,3 +284,19 @@ jobs:
             - name: Run allSyncPrims-1kernel lfTreeBarrUsing test with GCN3_X86/gem5.opt (SE mode)
               run: ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c allSyncPrims-1kernel --options="lfTreeBarrUniq
                   10 16 4"
+    daily-tests:
+        # The dummy job is used to indicate whether the daily tests have
+        # passed or not. This can be used as status check for pull requests.
+        # I.e., if we want to stop pull requests from being merged if the
+        # daily tests are failing we can add this job as a required status
+        # check.
+        runs-on: ubuntu-22.04
+        needs:
+            - unittests-fast-debug
+            - testlib-long-tests
+            - testlib-long-gem5_library_example_tests
+            - sst-test
+            - systemc-test
+            - gpu-tests
+        steps:
+            - run: echo "This daily tests have passed."

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -106,3 +106,15 @@ jobs:
                   ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/arm-hello-dramsys.py
                   ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/dramsys-traffic.py
                   ./build/ALL/gem5.opt configs/example/dramsys.py
+    weekly-tests:
+        # The dummy job is used to indicate whether the weekly tests have
+        # passed or not. This can be used as status check for pull requests.
+        # I.e., if we want to stop pull requests from being merged if the
+        # weekly tests are failing we can add this job as a required status
+        # check.
+        runs-on: ubuntu-22.04
+        needs:
+            - testlib-very-long-tests
+            - dramsys-tests
+        steps:
+            - run: echo "This weekly tests have passed."


### PR DESCRIPTION
With this change we can block PRs if the compiler, daily, and/or weekly tests are failing by setting these dummy jobs as require status checks.