### PR TITLE
stdlib: Extend SE Binary Workload std file params to accept strings

### DIFF
--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -111,10 +111,8 @@ class SEBinaryWorkload:
             else:  # stdin_file is a string
                 process.input = FileResource(Path(stdin_file)).get_local_path()
         if stdout_file is not None:
-            if isinstance(stdout_file, Path):
-                process.output = stdout_file.as_posix()
-            else:  # stdout_file is a string
-                process.output = Path(stdout_file).as_posix()
+            assert isinstance(stdout_file, Path) or isinstance(stdout_file, str)
+            process.output = str(stdout_file)
         if stderr_file is not None:
             if isinstance(stderr_file, Path):
                 process.errout = stderr_file.as_posix()


### PR DESCRIPTION
This patch improves the stdin_file, stdout_file, stderr_file processing in SE Binary Workload.

Earlier, it assumed that Paths would be passed into the function.

Therefore, these parameters could not be defined
in the Resource JSON file as a string to use as is, since the processing functions like as_posix() would fail.

This is a current pain point of trying to make a Suite JSON of SPEC Resources, since they use the stdin, stdout and stderr files.

This patch converts the string of the Path in the JSON file into a Path object, while also retaining the old functionality of allowing Paths to be passed in.

The processing for both remains the same.

Change-Id: I8fd7d385ff301549a7db2166c9ad0174ec0c201a