### PR TITLE
mem-ruby: Update cache recorder to use RubyPort and remove BUILD_GPU guards

### DIFF
--- a/src/mem/ruby/slicc_interface/AbstractController.hh
+++ b/src/mem/ruby/slicc_interface/AbstractController.hh
@@ -70,9 +70,7 @@ namespace ruby
 {
 
 class Network;
-#ifdef BUILD_GPU
 class GPUCoalescer;
-#endif
 class DMASequencer;
 
 // used to communicate that an in_port peeked the wrong message type

--- a/src/mem/ruby/system/CacheRecorder.hh
+++ b/src/mem/ruby/system/CacheRecorder.hh
@@ -38,7 +38,6 @@
 #include <vector>
 
 #include "base/types.hh"
-#include "config/build_gpu.hh"
 #include "mem/ruby/common/Address.hh"
 #include "mem/ruby/common/DataBlock.hh"
 #include "mem/ruby/common/TypeDefines.hh"
@@ -51,10 +50,7 @@ namespace ruby
 {
 
 class Sequencer;
-#if BUILD_GPU
-class GPUCoalescer;
-#endif
-
+class RubyPort;
 /*!
  * Class for recording cache contents. Note that the last element of the
  * class is an array of length zero. It is used for creating variable
@@ -80,18 +76,10 @@ class CacheRecorder
     CacheRecorder();
     ~CacheRecorder();
 
-#if BUILD_GPU
     CacheRecorder(uint8_t* uncompressed_trace,
                   uint64_t uncompressed_trace_size,
-                  std::vector<Sequencer*>& SequencerMap,
-                  std::vector<GPUCoalescer*>& CoalescerMap,
+                  std::vector<RubyPort*>& ruby_port_map,
                   uint64_t block_size_bytes);
-#else
-    CacheRecorder(uint8_t* uncompressed_trace,
-                  uint64_t uncompressed_trace_size,
-                  std::vector<Sequencer*>& SequencerMap,
-                  uint64_t block_size_bytes);
-#endif
     void addRecord(int cntrl, Addr data_addr, Addr pc_addr,
                    RubyRequestType type, Tick time, DataBlock& data);
 
@@ -126,10 +114,7 @@ class CacheRecorder
     std::vector<TraceRecord*> m_records;
     uint8_t* m_uncompressed_trace;
     uint64_t m_uncompressed_trace_size;
-    std::vector<Sequencer*> m_seq_map;
-#if BUILD_GPU
-    std::vector<GPUCoalescer*> m_coalescer_map;
-#endif
+    std::vector<RubyPort*> m_ruby_port_map;
     uint64_t m_bytes_read;
     uint64_t m_records_read;
     uint64_t m_records_flushed;

--- a/src/mem/ruby/system/GPUCoalescer.hh
+++ b/src/mem/ruby/system/GPUCoalescer.hh
@@ -32,10 +32,6 @@
 #ifndef __MEM_RUBY_SYSTEM_GPU_COALESCER_HH__
 #define __MEM_RUBY_SYSTEM_GPU_COALESCER_HH__
 
-#include "config/build_gpu.hh"
-
-#if BUILD_GPU
-
 #include <iostream>
 #include <unordered_map>
 
@@ -550,5 +546,4 @@ operator<<(std::ostream& out, const GPUCoalescer& obj)
 } // namespace ruby
 } // namespace gem5
 
-#endif // BUILD_GPU
 #endif // __MEM_RUBY_SYSTEM_GPU_COALESCER_HH__

--- a/src/mem/ruby/system/VIPERCoalescer.hh
+++ b/src/mem/ruby/system/VIPERCoalescer.hh
@@ -32,10 +32,6 @@
 #ifndef __MEM_RUBY_SYSTEM_VIPERCOALESCER_HH__
 #define __MEM_RUBY_SYSTEM_VIPERCOALESCER_HH__
 
-#include "config/build_gpu.hh"
-
-#if BUILD_GPU
-
 #include <iostream>
 
 #include "mem/ruby/common/Address.hh"
@@ -96,5 +92,4 @@ class VIPERCoalescer : public GPUCoalescer
 } // namespace ruby
 } // namespace gem5
 
-#endif // BUILD_GPU
 #endif //__MEM_RUBY_SYSTEM_VIPERCOALESCER_HH__


### PR DESCRIPTION
This PR updates cache recorder to use a vector of RubyPorts for cache cooldown and warmup instead of Sequencer or GPUCoalescer vectors (refer to issue #403 for more details). It also removes the extra guards that were added in #377 to prevent compile-time failures in non-GPU builds.