### PR TITLE
python: Enable -m switch on gem5 binary

### DIFF
--- a/src/python/importer.py
+++ b/src/python/importer.py
@@ -38,6 +38,9 @@ class ByteCodeLoader(importlib.abc.Loader):
     def exec_module(self, module):
         exec(self.code, module.__dict__)
 
+    def get_code(self, _):
+        return self.code
+
 
 # Simple importer that allows python to import data from a dict of
 # code objects.  The keys are the module path, and the items are the


### PR DESCRIPTION
With -m, you can now run a module from the command line that is embedded in the gem5 binary.
This will allow us to put some common "scripts" in the stdlib instead of in the "configs" directory.

Change-Id: I5e544315dc2a02325ca5eca0579f6db59b26e045