### PR TITLE
misc: fix clang13 overloaded-virtual warning

### DIFF
--- a/src/systemc/ext/core/sc_port.hh
+++ b/src/systemc/ext/core/sc_port.hh
@@ -114,10 +114,6 @@ class sc_port_base : public sc_object
     virtual sc_port_policy _portPolicy() const = 0;
 };
 
-// The overloaded virtual is intended in SystemC, so we'll disable the warning.
-// Please check section 9.3 of SystemC 2.3.1 release note for more details.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 template <class IF>
 class sc_port_b : public sc_port_base
 {
@@ -248,7 +244,6 @@ class sc_port_b : public sc_port_base
     sc_port_b(const sc_port_b<IF> &) {}
     sc_port_b<IF> &operator = (const sc_port_b<IF> &) { return *this; }
 };
-#pragma GCC diagnostic pop
 
 template <class IF, int N=1, sc_port_policy P=SC_ONE_OR_MORE_BOUND>
 class sc_port : public sc_port_b<IF>

--- a/src/systemc/ext/tlm_core/2/sockets/initiator_socket.hh
+++ b/src/systemc/ext/tlm_core/2/sockets/initiator_socket.hh
@@ -51,6 +51,10 @@ template <unsigned int BUSWIDTH, typename FW_IF, typename BW_IF, int N,
           sc_core::sc_port_policy POL>
 class tlm_base_target_socket;
 
+// The overloaded virtual is intended in SystemC, so we'll disable the warning.
+// Please check section 9.3 of SystemC 2.3.1 release note for more details.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 template <unsigned int BUSWIDTH=32, typename FW_IF=tlm_fw_transport_if<>,
           typename BW_IF=tlm_bw_transport_if<>, int N=1,
           sc_core::sc_port_policy POL=sc_core::SC_ONE_OR_MORE_BOUND>
@@ -170,6 +174,7 @@ class tlm_base_initiator_socket :
   protected:
     export_type m_export;
 };
+#pragma GCC diagnostic pop
 
 //
 // Convenience socket classes


### PR DESCRIPTION
Like #363 clang is also unhappy about the overloaded virtual. However,
clang needs to have the diagnostic in a different place

Fixes #437

Change-Id: I3cd30051552acd5c8689928ebca137c71505c340
Signed-off-by: Jason Lowe-Power <jason@lowepower.com>