### PR TITLE
configs: Fix missing param exchange for GPUFS

### DIFF
--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -619,6 +619,7 @@ def construct_gpudirs(options, system, ruby_system, network):
         dir_cntrl.create(options, [addr_range], ruby_system, system)
         dir_cntrl.number_of_TBEs = options.num_tbes
         dir_cntrl.useL3OnWT = False
+        dir_cntrl.L2isWB = options.WB_L2
 
         # Connect the Directory controller to the ruby network
         dir_cntrl.requestFromCores = MessageBuffer(ordered=True)


### PR DESCRIPTION
PR #367 adds an option to configs/ruby/GPU_VIPER.py that was not added to the corresponding dGPU equal for GPUFS and thus all GPUFS runs are failing. Fixed in this patch.

Change-Id: I773ff567c94f8e8515e343611fa1d7b66a7187e6