### PR TITLE
misc: Copy .github directory from develop to stable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us find and fix the bug
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -18,21 +17,18 @@ If you have modified gem5 in some way please state, to the best of your ability,
 
 **To Reproduce**
 Steps to reproduce the behavior. Please assume starting from a clean repository:
+
 1. Compile gem5 with command ...
 2. Execute the simulation with...
 
-If writing code, or a terminal command, use code blocks. Either an inline code block, \`scons build/ALL/gem5.opt\` (enclosed in two \`) or a multi-line codeblock:
+If writing code, or a terminal command, use code blocks. Either an inline code block, `scons build/ALL/gem5.opt` (enclosed in two '`') or a multi-line codeblock:
 
 
-\`\`\`
-
-int x=2;
-
-int y=3'
-
-print(x+y);
-
-\`\`\`
+```python
+int x=2
+int y=3
+print(x+y)
+```
 
 If possible, please include the Python configuration script used and state clearly any parameters passed.
 
@@ -40,11 +36,9 @@ If possible, please include the Python configuration script used and state clear
 If applicable, add the terminal output here. If long, only include the relevant lines.
 Please put the terminal output in code blocks. I.e.:
 
-\`\`\`
-
+```shell
 #Terminal output here#
-
-\`\`\`
+```
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,115 +1,179 @@
+---
 # This workflow runs after a pull-request has been approved by a reviewer.
 
 name: CI Tests
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
+    pull_request:
+        types: [opened, edited, synchronize, ready_for_review]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+    cancel-in-progress: true
 
 jobs:
-  pre-commit:
+    pre-commit:
     # runs on github hosted runner
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+        runs-on: ubuntu-22.04
+        if: github.event.pull_request.draft == false
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v3
+            - uses: pre-commit/action@v3.0.0
 
   # ensures we have a change-id in every commit, needed for gerrit
-  check-for-change-id:
-    # runs on github hosted runner
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check for Change-Id
-        run: |
-          # loop through all the commits in the pull request
-          for commit in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
-              git checkout $commit
-              if (git log -1 --pretty=format:"%B" | grep -q "Change-Id: ")
-              then
-                # passes as long as at least one change-id exists in the pull request
-                exit 0
-              fi
-          done
-          # if we reach this part, none of the commits had a change-id
-          echo "None of the commits in this pull request contains a Change-ID, which we require for any changes made to gem5. "\
-            "To automatically insert one, run the following:\n f=`git rev-parse --git-dir`/hooks/commit-msg ; mkdir -p $(dirname $f) ; "\
-            "curl -Lo $f https://gerrit-review.googlesource.com/tools/hooks/commit-msg ; chmod +x $f\n Then amend the commit with git commit --amend --no-edit, and update your pull request."
-          exit 1
+    check-for-change-id:
+        # runs on github hosted runner
+        runs-on: ubuntu-22.04
+        if: github.event.pull_request.draft == false
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - name: Check for Change-Id
+              run: |
+                  # loop through all the commits in the pull request
+                  for commit in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
+                      git checkout $commit
+                      if (git log -1 --pretty=format:"%B" | grep -q "Change-Id: ")
+                      then
+                        # passes as long as at least one change-id exists in the pull request
+                        exit 0
+                      fi
+                  done
+                  # if we reach this part, none of the commits had a change-id
+                  echo "None of the commits in this pull request contains a Change-ID, which we require for any changes made to gem5. "\
+                    "To automatically insert one, run the following:\n f=`git rev-parse --git-dir`/hooks/commit-msg ; mkdir -p $(dirname $f) ; "\
+                    "curl -Lo $f https://gerrit-review.googlesource.com/tools/hooks/commit-msg ; chmod +x $f\n Then amend the commit with git commit --amend --no-edit, and update your pull request."
+                  exit 1
 
-  build-gem5:
-    runs-on: [self-hosted, linux, x64, build]
-    if: github.event.pull_request.draft == false
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
-    outputs:
-      artifactname: ${{ steps.name.outputs.test }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: name
-        run: echo "test=$(date +"%Y-%m-%d_%H.%M.%S")-artifact" >> $GITHUB_OUTPUT
+    unittests-all-opt:
+        runs-on: [self-hosted, linux, x64]
+        if: github.event.pull_request.draft == false
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
+        timeout-minutes: 60
+        steps:
+            - uses: actions/checkout@v3
+            - name: CI Unittests
+              working-directory: ${{ github.workspace }}
+              run: scons build/ALL/unittests.opt -j $(nproc)
+            - run: echo "This job's status is ${{ job.status }}."
 
-      - name: Build gem5
-        run: |
-          scons build/ALL/gem5.opt -j $(nproc)
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.name.outputs.test }}
-          path: build/ALL/gem5.opt
-      - run: echo "This job's status is ${{ job.status }}."
+    testlib-quick-matrix:
+        runs-on: [self-hosted, linux, x64]
+        if: github.event.pull_request.draft == false
+    # In order to make sure the environment is exactly the same, we run in
+    # the same container we use to build gem5 and run the testlib tests. This
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [pre-commit, check-for-change-id]
+        steps:
+            - uses: actions/checkout@v3
 
-  unittests-all-opt:
-    runs-on: [self-hosted, linux, x64, run]
-    if: github.event.pull_request.draft == false
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v3
-      - name: CI Unittests
-        working-directory: ${{ github.workspace }}
-        run: scons build/ALL/unittests.opt -j $(nproc)
-      - run: echo "This job's status is ${{ job.status }}."
+      # Unfortunately the 'ubunutu-latest' image doesn't have jq installed.
+      # We therefore need to install it as a step here.
+            - name: Install jq
+              run: apt install -y jq
 
-  testlib-quick:
-    runs-on: [self-hosted, linux, x64, run]
-    if: github.event.pull_request.draft == false
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [pre-commit, build-gem5, check-for-change-id]
-    timeout-minutes: 360     # 6 hours
-    steps:
-      - name: Clean runner
-        run:
-          rm -rf ./* || true
-          rm -rf ./.??* || true
-          rm -rf ~/.cache || true
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{needs.build-gem5.outputs.artifactname}}
-          path: build/ALL
-      - run: chmod u+x build/ALL/gem5.opt
-      - name: The TestLib CI Tests
-        working-directory: ${{ github.workspace }}/tests
-        run: ./main.py run --skip-build -vv
-      - name: create zip of results
-        if: success() || failure()
-        run: |
-          apt-get -y install zip
-          zip -r output.zip tests/testing-results
-      - name: upload zip
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        env:
-          MY_STEP_VAR: ${{github.job}}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
-        with:
-          name: ${{ env.MY_STEP_VAR }}
-          path: output.zip
-          retention-days: 7
-      - run: echo "This job's status is ${{ job.status }}."
+            - name: Get directories for testlib-quick
+              working-directory: ${{ github.workspace }}/tests
+              id: dir-matrix
+              run: echo "test-dirs-matrix=$(find gem5/* -type d -maxdepth 0 | jq -ncR '[inputs]')" >>$GITHUB_OUTPUT
+
+            - name: Get the build targets for testlib-quick-gem5-builds
+              working-directory: ${{ github.workspace }}/tests
+              id: build-matrix
+              run: echo "build-matrix=$(./main.py list --build-targets -q | jq -ncR '[inputs]')" >>$GITHUB_OUTPUT
+
+        outputs:
+            build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
+            test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}
+
+    testlib-quick-gem5-builds:
+        runs-on: [self-hosted, linux, x64]
+        if: github.event.pull_request.draft == false
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [pre-commit, check-for-change-id, testlib-quick-matrix]
+        strategy:
+            matrix:
+                build-target: ${{ fromJson(needs.testlib-quick-matrix.outputs.build-matrix) }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Build gem5
+              run: scons ${{ matrix.build-target }} -j $(nproc)
+
+        # Upload the gem5 binary as an artifact.
+        # Note: the "achor.txt" file is a hack to make sure the paths are
+        # preserverd in the artifact. The upload-artifact action finds the
+        # closest common directory and uploads everything relative to that.
+        # E.g., if we upload "build/ARM/gem5.opt" and "build/RISCV/gem5.opt"
+        # Then upload-artifact will upload "ARM/gem5.opt" and "RISCV/gem5.opt",
+        # stripping the "build" directory. By adding the "anchor.txt" file, we
+        # ensure the "build" directory is preserved.
+            - run: echo "anchor" > anchor.txt
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
+                  path: |
+                      build/*/gem5.*
+                      anchor.txt
+                  retention-days: 7
+
+    testlib-quick-execution:
+        runs-on: [self-hosted, linux, x64]
+        if: github.event.pull_request.draft == false
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [pre-commit, check-for-change-id, testlib-quick-matrix, testlib-quick-gem5-builds]
+        timeout-minutes: 360 # 6 hours
+        strategy:
+            fail-fast: false
+            matrix:
+                test-dir: ${{ fromJson(needs.testlib-quick-matrix.outputs.test-dirs-matrix) }}
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+
+        # Checkout the repository then download the gem5.opt artifact.
+            - uses: actions/checkout@v3
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
+
+        # Check that the gem5.opt artifact exists and is executable.
+            - name: Chmod gem5.{opt,debug,fast} to be executable
+              run: |
+                  find . -name "gem5.opt" -exec chmod u+x {} \;
+                  find . -name "gem5.debug" -exec chmod u+x {} \;
+                  find . -name "gem5.fast" -exec chmod u+x {} \;
+
+        # Run the testlib quick tests in the given directory.
+            - name: Run "tests/${{ matrix.test-dir }}" TestLib quick tests
+              id: run-tests
+              working-directory: ${{ github.workspace }}/tests
+              run: ./main.py run --skip-build -vv -j$(nproc) ${{ matrix.test-dir }}
+
+        # Get the basename of the matrix.test-dir path (to name the artifact).
+            - name: Sanatize test-dir for artifact name
+              id: sanitize-test-dir
+              if: success() || failure()
+              run: echo "sanatized-test-dir=$(echo '${{ matrix.test-dir }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
+
+        # Upload the tests/testing-results directory as an artifact.
+            - name: Upload test results
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-quick-${{ steps.sanitize-test-dir.outputs.sanatized-test-dir
+                      }}-status-${{ steps.run-tests.outcome }}-output
+                  path: tests/testing-results
+                  retention-days: 30
+
+    testlib-quick:
+    # It is 'testlib-quick' which needs to pass for the pull request to be
+    # merged. The 'testlib-quick-execution' is a matrix job which runs all the
+    # the testlib quick tests. This job is therefore a stub which will pass if
+    # all the testlib-quick-execution jobs pass.
+        runs-on: ubuntu-22.04
+        needs: testlib-quick-execution
+        steps:
+            - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -1,54 +1,70 @@
+---
 # This workflow runs all of the compiler tests
 
 name: Compiler Tests
-run-name: ${{ github.actor }} is running compiler tests
-
 
 on:
   # Runs every Friday from 7AM UTC
-  schedule:
-    - cron:  '00 7 * * 5'
+    schedule:
+        - cron: 00 7 * * 5
   # Allows us to manually start workflow for testing
-  workflow_dispatch:
+    workflow_dispatch:
 
 jobs:
   # replication of compiler-tests.sh
-  all-compilers:
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
-        opts: [.opt, .fast]
-    runs-on: [self-hosted, linux, x64, build]
-    timeout-minutes: 2880     # 48 hours
-    container: gcr.io/gem5-test/${{ matrix.image }}:latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
+    all-compilers:
+        strategy:
+            fail-fast: false
+            matrix:
+                image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14,
+                    clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
+                    ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
+                opts: [.opt, .fast]
+        runs-on: [self-hosted, linux, x64]
+        timeout-minutes: 2880 # 48 hours
+        container: gcr.io/gem5-test/${{ matrix.image }}:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.image }}
-      run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j$(nproc)
-      timeout-minutes: 600  # 10 hours
+                  ref: develop
+            - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.image }}
+              run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j$(nproc)
+              timeout-minutes: 600 # 10 hours
 
   # Tests the two latest gcc and clang supported compilers against all gem5 compilations.
-  latest-compilers-all-gem5-builds:
-    strategy:
-      fail-fast: false
-      matrix:
-        gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
-        image: [gcc-version-12, clang-version-14]
-        opts: [.opt]
-    runs-on: [self-hosted, linux, x64, build]
-    timeout-minutes: 2880     # 48 hours
-    container: gcr.io/gem5-test/${{ matrix.image }}:latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
+    latest-compilers-all-gem5-builds:
+        strategy:
+            fail-fast: false
+            matrix:
+                gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level,
+                    NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86,
+                    GCN3_X86]
+                image: [gcc-version-12, clang-version-16]
+                opts: [.opt]
+        runs-on: [self-hosted, linux, x64]
+        timeout-minutes: 2880 # 48 hours
+        container: gcr.io/gem5-test/${{ matrix.image }}:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - name: Compile build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} with ${{ matrix.image }}
-      run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} -j$(nproc)
-      timeout-minutes: 600 # 10 hours
+                  ref: develop
+            - name: Compile build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} with ${{ matrix.image }}
+              run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} -j$(nproc)
+              timeout-minutes: 600 # 10 hours
+
+    compiler-tests:
+        # The dummy job is used to indicate whether the compiler tests have
+        # passed or not. This can be used as status check for pull requests.
+        # I.e., if we want to stop pull requests from being merged if the
+        # compiler tests are failing, we can add this job as a required status
+        # check.
+        runs-on: ubuntu-22.04
+        needs:
+            - latest-compilers-all-gem5-builds
+            - all-compilers
+        steps:
+            - run: echo "This compiler tests have passed."

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -1,286 +1,305 @@
+---
 # This workflow runs all of the long tests within main.py, extra tests in nightly.sh, and unittests
 
 name: Daily Tests
 
 on:
   # Runs every day from 7AM UTC
-  schedule:
-    - cron:  '0 7 * * *'
+    schedule:
+        - cron: 0 7 * * *
 
 jobs:
-  name-artifacts:
-    runs-on: ubuntu-latest
-    outputs:
-      build-name: ${{ steps.artifact-name.outputs.name }}
-    steps:
-    - uses: actions/checkout@v2
-    - id: artifact-name
-      run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S-")" >> $GITHUB_OUTPUT
+    name-artifacts:
+        runs-on: ubuntu-latest
+        outputs:
+            build-name: ${{ steps.artifact-name.outputs.name }}
+        steps:
+            - uses: actions/checkout@v2
+            - id: artifact-name
+              run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S-")" >> $GITHUB_OUTPUT
 
-  build-gem5:
-    strategy:
-      fail-fast: false
-      matrix:
+    build-gem5:
+        strategy:
+            fail-fast: false
+            matrix:
         # NULL is in quotes since it is considered a keyword in yaml files
-        image: [ALL, ALL_CHI, ARM, ALL_MSI, ALL_MESI_Two_Level, "NULL", NULL_MI_example, RISCV, VEGA_X86]
+                image: [ALL, ALL_CHI, ARM, ALL_MSI, ALL_MESI_Two_Level, 'NULL', NULL_MI_example, RISCV, VEGA_X86]
         # this allows us to pass additional command line parameters
         # the default is to add -j $(nproc), but some images
         # require more specifications when built
-        include:
-          - command-line: -j $(nproc)
-          - image: ALL_CHI
-            command-line: --default=ALL PROTOCOL=CHI -j $(nproc)
-          - image: ALL_MSI
-            command-line: --default=ALL PROTOCOL=MSI -j $(nproc)
-          - image: ALL_MESI_Two_Level
-            command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
-          - image: NULL_MI_example
-            command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
-    runs-on: [self-hosted, linux, x64, build]
-    needs: name-artifacts
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
+                include:
+                    - command-line: -j $(nproc)
+                    - image: ALL_CHI
+                      command-line: --default=ALL PROTOCOL=CHI -j $(nproc)
+                    - image: ALL_MSI
+                      command-line: --default=ALL PROTOCOL=MSI -j $(nproc)
+                    - image: ALL_MESI_Two_Level
+                      command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
+                    - image: NULL_MI_example
+                      command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
+        runs-on: [self-hosted, linux, x64]
+        needs: name-artifacts
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
-          ref: develop
-      - name: Build gem5
-        run: scons build/${{ matrix.image }}/gem5.opt ${{ matrix.command-line }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ needs.name-artifacts.outputs.build-name }}${{ matrix.image }}
-          path: build/${{ matrix.image }}/gem5.opt
-          retention-days: 5
-      - run: echo "This job's status is ${{ job.status }}."
+                  ref: develop
+            - name: Build gem5
+              run: scons build/${{ matrix.image }}/gem5.opt ${{ matrix.command-line }}
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ needs.name-artifacts.outputs.build-name }}${{ matrix.image }}
+                  path: build/${{ matrix.image }}/gem5.opt
+                  retention-days: 5
+            - run: echo "This job's status is ${{ job.status }}."
 
   # this builds both unittests.fast and unittests.debug
-  unittests-fast-debug:
-    strategy:
-      matrix:
-        type: [fast, debug]
-    runs-on: [self-hosted, linux, x64, run]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    unittests-fast-debug:
+        strategy:
+            matrix:
+                type: [fast, debug]
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        timeout-minutes: 60
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
-          ref: develop
-      - name: ALL/unittests.${{ matrix.type }} UnitTests
-        run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
+                  ref: develop
+            - name: ALL/unittests.${{ matrix.type }} UnitTests
+              run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
 
   # start running all of the long tests
-  testlib-long-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [arm_boot_tests, fs, gem5_library_example_tests, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests, stdlib, x86_boot_tests]
-    runs-on: [self-hosted, linux, x64, run]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [name-artifacts, build-gem5]
-    timeout-minutes: 1440 # 24 hours for entire matrix to run
-    steps:
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
-    - uses: actions/checkout@v3
-      with:
+    testlib-long-tests:
+        strategy:
+            fail-fast: false
+            matrix:
+                test-type: [arm_boot_tests, fs, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests,
+                    stdlib, x86_boot_tests]
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        needs: [name-artifacts, build-gem5]
+        timeout-minutes: 1440 # 24 hours for entire matrix to run
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
+                  ref: develop
     # download all artifacts for each test
     # since long tests can't start until the build matrix completes,
     # we download all artifacts from the build for each test
     # in this matrix
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}ALL
-        path: build/ALL
-    - run: chmod u+x build/ALL/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}ALL_CHI
-        path: build/ALL_CHI
-    - run: chmod u+x build/ALL_CHI/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}ARM
-        path: build/ARM
-    - run: chmod u+x build/ARM/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}ALL_MSI
-        path: build/ALL_MSI
-    - run: chmod u+x build/ALL_MSI/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}ALL_MESI_Two_Level
-        path: build/ALL_MESI_Two_Level
-    - run: chmod u+x build/ALL_MESI_Two_Level/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}NULL
-        path: build/NULL
-    - run: chmod u+x build/NULL/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}NULL_MI_example
-        path: build/NULL_MI_example
-    - run: chmod u+x build/NULL_MI_example/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}RISCV
-        path: build/RISCV
-    - run: chmod u+x build/RISCV/gem5.opt
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}VEGA_X86
-        path: build/VEGA_X86
-    - run: chmod u+x build/VEGA_X86/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}ALL
+                  path: build/ALL
+            - run: chmod u+x build/ALL/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}ALL_CHI
+                  path: build/ALL_CHI
+            - run: chmod u+x build/ALL_CHI/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}ARM
+                  path: build/ARM
+            - run: chmod u+x build/ARM/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}ALL_MSI
+                  path: build/ALL_MSI
+            - run: chmod u+x build/ALL_MSI/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}ALL_MESI_Two_Level
+                  path: build/ALL_MESI_Two_Level
+            - run: chmod u+x build/ALL_MESI_Two_Level/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}NULL
+                  path: build/NULL
+            - run: chmod u+x build/NULL/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}NULL_MI_example
+                  path: build/NULL_MI_example
+            - run: chmod u+x build/NULL_MI_example/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}RISCV
+                  path: build/RISCV
+            - run: chmod u+x build/RISCV/gem5.opt
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}VEGA_X86
+                  path: build/VEGA_X86
+            - run: chmod u+x build/VEGA_X86/gem5.opt
     # run test
-    - name: long ${{ matrix.test-type }} tests
-      working-directory: ${{ github.workspace }}/tests
-      run: ./main.py run gem5/${{ matrix.test-type }} --length=long --skip-build -vv -t $(nproc)
-    - name: create zip of results
-      if: success() || failure()
-      run: |
-        apt-get -y install zip
-        zip -r output.zip tests/testing-results
-    - name: upload zip
-      if: success() || failure()
-      uses: actions/upload-artifact@v3
-      env:
-        MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
-      with:
-        name: ${{ env.MY_STEP_VAR }}
-        path: output.zip
-        retention-days: 7
-    - run: echo "This job's status is ${{ job.status }}."
+            - name: long ${{ matrix.test-type }} tests
+              working-directory: ${{ github.workspace }}/tests
+              run: ./main.py run gem5/${{ matrix.test-type }} --length=long --skip-build -vv -t $(nproc)
+            - name: create zip of results
+              if: success() || failure()
+              run: |
+                  apt-get -y install zip
+                  zip -r output.zip tests/testing-results
+            - name: upload zip
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              env:
+                  MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
+              with:
+                  name: ${{ env.MY_STEP_VAR }}
+                  path: output.zip
+                  retention-days: 7
+            - run: echo "This job's status is ${{ job.status }}."
 
   # split library example tests into runs based on Suite UID
   # so that they don't hog the runners for too long
-  testlib-long-gem5_library_example_tests:
-    runs-on: [self-hosted, linux, x64, run]
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt, gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [name-artifacts, build-gem5]
-    timeout-minutes: 1440 # 24 hours
-    steps:
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
-    - uses: actions/checkout@v3
-      with:
+    testlib-long-gem5_library_example_tests:
+        runs-on: [self-hosted, linux, x64]
+        strategy:
+            fail-fast: false
+            matrix:
+                test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt,
+                    gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        needs: [name-artifacts, build-gem5]
+        timeout-minutes: 1440 # 24 hours
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.name-artifacts.outputs.build-name}}ALL
-        path: build/ALL
-    - run: chmod u+x build/ALL/gem5.opt
-    - name: long ${{ matrix.test-type }} gem5_library_example_tests
-      working-directory: ${{ github.workspace }}/tests
-      run: ./main.py run --uid SuiteUID:tests/gem5/gem5_library_example_tests/test_gem5_library_examples.py:test-${{ matrix.test-type }} --length=long --skip-build -vv
-    - name: create zip of results
-      if: success() || failure()
-      run: |
-        apt-get -y install zip
-        zip -r output.zip tests/testing-results
-    - name: upload zip
-      if: success() || failure()
-      uses: actions/upload-artifact@v3
-      env:
-        MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
-      with:
-        name: ${{ env.MY_STEP_VAR }}
-        path: output.zip
-        retention-days: 7
-    - run: echo "This job's status is ${{ job.status }}."
+                  ref: develop
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.name-artifacts.outputs.build-name}}ALL
+                  path: build/ALL
+            - run: chmod u+x build/ALL/gem5.opt
+            - name: long ${{ matrix.test-type }} gem5_library_example_tests
+              working-directory: ${{ github.workspace }}/tests
+              run: ./main.py run --uid SuiteUID:tests/gem5/gem5_library_example_tests/test_gem5_library_examples.py:test-${{ matrix.test-type }} --length=long
+                  --skip-build -vv
+            - name: create zip of results
+              if: success() || failure()
+              run: |
+                  apt-get -y install zip
+                  zip -r output.zip tests/testing-results
+            - name: upload zip
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              env:
+                  MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
+              with:
+                  name: ${{ env.MY_STEP_VAR }}
+                  path: output.zip
+                  retention-days: 7
+            - run: echo "This job's status is ${{ job.status }}."
 
   # This runs the SST-gem5 integration compilation and tests it with
   # ext/sst/sst/example.py.
-  sst-test:
-    runs-on: [self-hosted, linux, x64, build]
-    container: gcr.io/gem5-test/sst-env:latest
-    timeout-minutes: 180
+    sst-test:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/sst-env:latest
+        timeout-minutes: 180
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - name: Build RISCV/libgem5_opt.so with SST
-      run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style -j $(nproc)
-    - name: Compile ext/sst
-      working-directory: ${{ github.workspace }}/ext/sst
-      run: make -j $(nproc)
-    - name: Run SST test
-      working-directory: ${{ github.workspace }}/ext/sst
-      run: sst --add-lib-path=./ sst/example.py
+                  ref: develop
+            - name: Build RISCV/libgem5_opt.so with SST
+              run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style -j $(nproc)
+            - name: Makefile ext/sst
+              working-directory: ${{ github.workspace }}/ext/sst
+              run: mv Makefile.linux Makefile
+            - name: Compile ext/sst
+              working-directory: ${{ github.workspace }}/ext/sst
+              run: make -j $(nproc)
+            - name: Run SST test
+              working-directory: ${{ github.workspace }}/ext/sst
+              run: sst --add-lib-path=./ sst/example.py
 
   # This runs the gem5 within SystemC ingration and runs a simple hello-world
   # simulation with it.
-  systemc-test:
-    runs-on: [self-hosted, linux, x64, build]
-    container: gcr.io/gem5-test/systemc-env:latest
-    timeout-minutes: 180
+    systemc-test:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/systemc-env:latest
+        timeout-minutes: 180
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - name: Build ARM/gem5.opt
-      run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources -j$(nproc)
-    - name: Build ARM/libgem5_opt.so
-      run: scons build/ARM/libgem5_opt.so --with-cxx-config --without-python --without-tcmalloc USE_SYSTEMC=0 -j$(nproc) --duplicate-sources
-    - name: Compile gem5 withing SystemC
-      working-directory: ${{ github.workspace }}/util/systemc/gem5_within_systemc
-      run: make
-    - name: Run gem5 within SystemC test
-      run: ./build/ARM/gem5.opt configs/deprecated/example/se.py -c tests/test-progs/hello/bin/arm/linux/hello
-    - name: Continue gem5 within SystemC test
-      run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
+                  ref: develop
+            - name: Build ARM/gem5.opt
+              run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources -j$(nproc)
+            - name: Build ARM/libgem5_opt.so
+              run: scons build/ARM/libgem5_opt.so --with-cxx-config --without-python --without-tcmalloc USE_SYSTEMC=0 -j$(nproc) --duplicate-sources
+            - name: Compile gem5 withing SystemC
+              working-directory: ${{ github.workspace }}/util/systemc/gem5_within_systemc
+              run: make
+            - name: Run gem5 within SystemC test
+              run: ./build/ARM/gem5.opt configs/deprecated/example/se.py -c tests/test-progs/hello/bin/arm/linux/hello
+            - name: Continue gem5 within SystemC test
+              run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
 
   # Runs the gem5 Nighyly GPU tests.
-  gpu-tests:
-    runs-on: [self-hosted, linux, x64, build]
-    container: gcr.io/gem5-test/gcn-gpu:latest
-    timeout-minutes: 720 # 12 hours
+    gpu-tests:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/gcn-gpu:latest
+        timeout-minutes: 720 # 12 hours
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - name: Compile build/GCN3_X86/gem5.opt
-      run: scons build/GCN3_X86/gem5.opt -j $(nproc)
-    - name: Get Square test-prog from gem5-resources
-      uses: wei/wget@v1
-      with:
-        args: -q http://dist.gem5.org/dist/develop/test-progs/square/square # Removed -N bc it wasn't available within actions, should be okay bc workspace is clean every time: https://github.com/coder/sshcode/issues/102
-    - name: Run Square test with GCN3_X86/gem5.opt (SE mode)
-      run: |
-        mkdir -p tests/testing-results
-        ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c square
-    - name: Get allSyncPrims-1kernel from gem5-resources
-      uses: wei/wget@v1
-      with:
-        args: -q http://dist.gem5.org/dist/develop/test-progs/heterosync/gcn3/allSyncPrims-1kernel # Removed -N bc it wasn't available within actions, should be okay bc workspace is clean every time
-    - name: Run allSyncPrims-1kernel sleepMutex test with GCN3_X86/gem5.opt (SE mode)
-      run: ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c allSyncPrims-1kernel --options="sleepMutex 10 16 4"
-    - name: Run allSyncPrims-1kernel lfTreeBarrUsing test with GCN3_X86/gem5.opt (SE mode)
-      run: ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c allSyncPrims-1kernel --options="lfTreeBarrUniq 10 16 4"
+                  ref: develop
+            - name: Compile build/GCN3_X86/gem5.opt
+              run: scons build/GCN3_X86/gem5.opt -j $(nproc)
+            - name: Get Square test-prog from gem5-resources
+              uses: wei/wget@v1
+              with:
+                  args: -q http://dist.gem5.org/dist/develop/test-progs/square/square # Removed -N bc it wasn't available within actions, should be okay bc workspace is clean every time: https://github.com/coder/sshcode/issues/102
+            - name: Run Square test with GCN3_X86/gem5.opt (SE mode)
+              run: |
+                  mkdir -p tests/testing-results
+                  ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c square
+            - name: Get allSyncPrims-1kernel from gem5-resources
+              uses: wei/wget@v1
+              with:
+                  args: -q http://dist.gem5.org/dist/develop/test-progs/heterosync/gcn3/allSyncPrims-1kernel # Removed -N bc it wasn't available within actions, should be okay bc workspace is clean every time
+            - name: Run allSyncPrims-1kernel sleepMutex test with GCN3_X86/gem5.opt (SE mode)
+              run: ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c allSyncPrims-1kernel --options="sleepMutex 10 16
+                  4"
+            - name: Run allSyncPrims-1kernel lfTreeBarrUsing test with GCN3_X86/gem5.opt (SE mode)
+              run: ./build/GCN3_X86/gem5.opt configs/example/apu_se.py --reg-alloc-policy=dynamic -n3 -c allSyncPrims-1kernel --options="lfTreeBarrUniq
+                  10 16 4"
+    daily-tests:
+        # The dummy job is used to indicate whether the daily tests have
+        # passed or not. This can be used as status check for pull requests.
+        # I.e., if we want to stop pull requests from being merged if the
+        # daily tests are failing we can add this job as a required status
+        # check.
+        runs-on: ubuntu-22.04
+        needs:
+            - unittests-fast-debug
+            - testlib-long-tests
+            - testlib-long-gem5_library_example_tests
+            - sst-test
+            - systemc-test
+            - gpu-tests
+        steps:
+            - run: echo "This daily tests have passed."

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,42 +1,54 @@
-#
+---
 name: Docker images build and push
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - 'util/docker/ubuntu-20.04_all-depenencies'
-  workflow_dispatch:
-
-env:
-  IMAGE_NAME: ubuntu-20.04_all-depenencies
-#
+    workflow_dispatch:
 jobs:
+    obtain-dockerfiles:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+
+        steps:
+            - uses: actions/checkout@v3
+              with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+                  ref: develop
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: dockerfiles
+                  path: util/dockerfiles
+
   # This builds and pushes the docker image.
-  push:
-    runs-on: [self-hosted, linux, x64, run]
-    permissions:
-      packages: write
-      contents: read
+    build-and-push:
+        runs-on: [self-hosted, linux, x64]
+        needs: obtain-dockerfiles
+        permissions:
+            packages: write
+            contents: read
 
-    steps:
-      - uses: actions/checkout@v3
+        steps:
+            - uses: actions/download-artifact@v3
+              with:
+                  name: dockerfiles
+                  path: dockerfiles-docker-build
 
-      - name: Build image
-        run: |
-          cd util/docker/ubuntu-20.04_all-depenencies
-          docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+            - uses: docker/setup-qemu-action@v2
+              name: Setup QEMU
 
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+            - uses: docker/setup-buildx-action@v2
+              name: Set up Docker Buildx
 
-      - name: Push image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+            - uses: docker/login-action@v2
+              name: Login to the GitHub Container Registry
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-          # This changes all uppercase characters to lowercase.
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          docker tag $IMAGE_NAME $IMAGE_ID:latest
-          docker push $IMAGE_ID::latest
+            - name: Build and push with bake
+              uses: docker/bake-action@v4
+              with:
+                  workdir: ./dockerfiles-docker-build
+                  files: docker-bake.hcl
+                  push: true

--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -1,0 +1,61 @@
+---
+# This workflow runs all of the very-long tests within main.py
+
+name: Weekly Tests
+
+on:
+  # Runs every Sunday from 7AM UTC
+    schedule:
+        - cron: 00 7 * * 6
+  # Allows us to manually start workflow for testing
+    workflow_dispatch:
+
+jobs:
+    build-gem5:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/gcn-gpu:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+                  ref: develop
+            - name: Build gem5
+              run: scons build/GCN3_X86/gem5.opt -j $(nproc) --ignore-style
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-gcn3
+                  path: build/GCN3_X86/gem5.opt
+                  retention-days: 5
+            - run: echo "This job's status is ${{ job.status }}."
+
+    HACC-tests:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/gcn-gpu:latest
+        needs: build-gem5
+        timeout-minutes: 120 # 2 hours
+        steps:
+            - uses: actions/checkout@v3
+              with:
+          # Scheduled workflows run on the default branch by default. We
+          # therefore need to explicitly checkout the develop branch.
+                  ref: develop
+            - uses: actions/download-artifact@v3
+              with:
+                  name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-gcn3
+                  path: build/GCN3_X86
+            - run: chmod u+x build/GCN3_X86/gem5.opt
+            - name: make hip directory
+              run: mkdir hip
+            - name: Compile m5ops and x86
+              working-directory: ${{ github.workspace }}/util/m5
+              run: |
+                  export TERM=xterm-256color
+                  scons build/x86/out/m5
+            - name: Download tests
+              working-directory: ${{ github.workspace }}/hip
+              run: wget http://dist.gem5.org/dist/v22-1/test-progs/halo-finder/ForceTreeTest
+            - name: Run HACC tests
+              working-directory: ${{ github.workspace }}
+              run: |
+                  build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root=hip -c ForceTreeTest --options="0.5 0.1 64 0.1 1 N 12 rcb"

--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -1,19 +1,21 @@
+---
 # This workflow file contains miscellaneous tasks to manage the repository.
 name: Utils for Repository
 on:
-  schedule:
-    - cron: '30 1 * * *'
-  workflow_dispatch:
+    schedule:
+        - cron: 30 1 * * *
+    workflow_dispatch:
 
 jobs:
   # This job runs the stale action to close issues that have been inactive for 30 days.
   # It is scheduled to run every day at 1:30 AM UTC.
-  close-stale-issues:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v8.0.0
-        with:
-          close-issue-message: 'This issue is being closed because it has been inactive waiting for response for 30 days. If this is still an issue, please open a new issue and reference this one.'
-          days-before-stale: 21
-          days-before-close: 7
-          any-of-labels: 'needs details'
+    close-stale-issues:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v8.0.0
+              with:
+                  close-issue-message: This issue is being closed because it has been inactive waiting for response for 30 days. If this is still an issue,
+                      please open a new issue and reference this one.
+                  days-before-stale: 21
+                  days-before-close: 7
+                  any-of-labels: needs details

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -1,110 +1,120 @@
+---
 # This workflow runs all of the very-long tests within main.py
 
 name: Weekly Tests
 
 on:
   # Runs every Sunday from 7AM UTC
-  schedule:
-    - cron:  '00 7 * * 6'
+    schedule:
+        - cron: 00 7 * * 6
   # Allows us to manually start workflow for testing
-  workflow_dispatch:
+    workflow_dispatch:
 
 jobs:
-  build-gem5:
-    runs-on: [self-hosted, linux, x64, build]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    outputs:
-      build-name: ${{ steps.artifact-name.outputs.name }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    build-gem5:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        outputs:
+            build-name: ${{ steps.artifact-name.outputs.name }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
-          ref: develop
-      - id: artifact-name
-        run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S")-ALL" >> $GITHUB_OUTPUT
-      - name: Build gem5
-        run: |
-          scons build/ALL/gem5.opt -j $(nproc)
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.artifact-name.outputs.name }}
-          path: build/ALL/gem5.opt
-          retention-days: 5
-      - run: echo "This job's status is ${{ job.status }}."
+                  ref: develop
+            - id: artifact-name
+              run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S")-ALL" >> $GITHUB_OUTPUT
+            - name: Build gem5
+              run: |
+                  scons build/ALL/gem5.opt -j $(nproc)
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ steps.artifact-name.outputs.name }}
+                  path: build/ALL/gem5.opt
+                  retention-days: 5
+            - run: echo "This job's status is ${{ job.status }}."
 
   # start running the very-long tests
-  testlib-very-long-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
-    runs-on: [self-hosted, linux, x64, run]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [build-gem5]
-    timeout-minutes: 4320 # 3 days
-    steps:
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
-    - uses: actions/checkout@v3
-      with:
+    testlib-very-long-tests:
+        strategy:
+            fail-fast: false
+            matrix:
+                test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        needs: [build-gem5]
+        timeout-minutes: 4320 # 3 days
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
-        ref: develop
-    - uses: actions/download-artifact@v3
-      with:
-        name: ${{needs.build-gem5.outputs.build-name}}
-        path: build/ALL
-    - run: chmod u+x build/ALL/gem5.opt
-    - name: very-long ${{ matrix.test-type }}
-      working-directory: ${{ github.workspace }}/tests
-      run: ./main.py run gem5/${{ matrix.test-type }} --length very-long --skip-build -vv -t $(nproc)
-    - name: create zip of results
-      if: success() || failure()
-      run: |
-        apt-get -y install zip
-        zip -r output.zip tests/testing-results
-    - name: upload zip
-      if: success() || failure()
-      uses: actions/upload-artifact@v3
-      env:
-        MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
-      with:
-        name: ${{ env.MY_STEP_VAR }}
-        path: output.zip
-        retention-days: 7
-    - run: echo "This job's status is ${{ job.status }}."
+                  ref: develop
+            - uses: actions/download-artifact@v3
+              with:
+                  name: ${{needs.build-gem5.outputs.build-name}}
+                  path: build/ALL
+            - run: chmod u+x build/ALL/gem5.opt
+            - name: very-long ${{ matrix.test-type }}
+              working-directory: ${{ github.workspace }}/tests
+              run: ./main.py run gem5/${{ matrix.test-type }} --length very-long --skip-build -vv -t $(nproc)
+            - name: create zip of results
+              if: success() || failure()
+              run: |
+                  apt-get -y install zip
+                  zip -r output.zip tests/testing-results
+            - name: upload zip
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              env:
+                  MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
+              with:
+                  name: ${{ env.MY_STEP_VAR }}
+                  path: output.zip
+                  retention-days: 7
+            - run: echo "This job's status is ${{ job.status }}."
 
-  dramsys-tests:
-    runs-on: [self-hosted, linux, x64, build]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    timeout-minutes: 4320 # 3 days
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    dramsys-tests:
+        runs-on: [self-hosted, linux, x64]
+        container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        timeout-minutes: 4320 # 3 days
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
-          ref: develop
+                  ref: develop
 
-      - name: Checkout DRAMSys
-        working-directory: ${{ github.workspace }}/ext/dramsys
-        run: |
-          git clone https://github.com/tukl-msd/DRAMSys DRAMSys
-          cd DRAMSys
-          git checkout -b gem5 09f6dcbb91351e6ee7cadfc7bc8b29d97625db8f
-          git submodule update --init --recursive
+            - name: Checkout DRAMSys
+              working-directory: ${{ github.workspace }}/ext/dramsys
+              run: |
+                  git clone https://github.com/tukl-msd/DRAMSys DRAMSys
+                  cd DRAMSys
+                  git checkout -b gem5 09f6dcbb91351e6ee7cadfc7bc8b29d97625db8f
+                  git submodule update --init --recursive
 
       # gem5 is built separately because it depends on the DRAMSys library
-      - name: Build gem5
-        working-directory: ${{ github.workspace }}
-        run: scons build/ALL/gem5.opt -j $(nproc)
+            - name: Build gem5
+              working-directory: ${{ github.workspace }}
+              run: scons build/ALL/gem5.opt -j $(nproc)
 
-      - name: Run DRAMSys Checks
-        working-directory: ${{ github.workspace }}
-        run: |
-          ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/arm-hello-dramsys.py
-          ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/dramsys-traffic.py
-          ./build/ALL/gem5.opt configs/example/dramsys.py
+            - name: Run DRAMSys Checks
+              working-directory: ${{ github.workspace }}
+              run: |
+                  ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/arm-hello-dramsys.py
+                  ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/dramsys-traffic.py
+                  ./build/ALL/gem5.opt configs/example/dramsys.py
+    weekly-tests:
+        # The dummy job is used to indicate whether the weekly tests have
+        # passed or not. This can be used as status check for pull requests.
+        # I.e., if we want to stop pull requests from being merged if the
+        # weekly tests are failing we can add this job as a required status
+        # check.
+        runs-on: ubuntu-22.04
+        needs:
+            - testlib-very-long-tests
+            - dramsys-tests
+        steps:
+            - run: echo "This weekly tests have passed."


### PR DESCRIPTION
This is done periodically as the Github Action's infrastructure reads files from the repos main branch (`stable`) where as changes are made to `develop`'s ".github" which should be made live ASAP.

This does not affect the gem5 build or any configuration scripts, only how testing is performed via GitHub and other info used by Github (e.g., ".github/ISSUE_TEMPLATE" which outlines the templates for creating issues via our GitHub issues page.