### PR TITLE
util: Fix runners to extent to max disk size

### DIFF
--- a/util/github-runners-vagrant/provision_root.sh
+++ b/util/github-runners-vagrant/provision_root.sh
@@ -75,3 +75,4 @@ apt-get autoremove -y
 
 # Resize the root partition to fill up all the free size on the disk
 lvextend -l +100%FREE $(df / --output=source | sed 1d)
+resize2fs $(df / --output=source | sed 1d)


### PR DESCRIPTION
THe `lvextend` command extends the logical volume. However, the `resize2fs` command is needed to extend the filesystem to fill the logical volume.

Prior to this patch the filesystem ran out of space despite there being enough room in the volume. This was just wasted free space.