### PR TITLE
arch-riscv: Dynamically add V extension to device tree

### DIFF
--- a/src/arch/riscv/RiscvISA.py
+++ b/src/arch/riscv/RiscvISA.py
@@ -13,6 +13,7 @@
 #
 # Copyright (c) 2016 RISC-V Foundation
 # Copyright (c) 2016 The University of Virginia
+# Copyright (c) 2023 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -94,3 +95,18 @@ class RiscvISA(BaseISA):
         "Length of each vector element in bits. \
         ELEN in Ch. 2 of RISC-V vector spec",
     )
+
+    def get_isa_string(self):
+        isa_extensions = []
+        # check for the base ISA type
+        if self.riscv_type.value == "RV32":
+            isa_extensions.append("rv32")
+        elif self.riscv_type.value == "RV64":
+            isa_extensions.append("rv64")
+        # use imafdc by default
+        isa_extensions.extend(["i", "m", "a", "f", "d", "c"])
+        # check for the vector extension
+        if self.enable_rvv.value == True:
+            isa_extensions.append("v")
+        isa_string = "".join(isa_extensions)
+        return isa_string

--- a/src/dev/riscv/HiFive.py
+++ b/src/dev/riscv/HiFive.py
@@ -251,7 +251,7 @@ class HiFive(HiFiveBase):
     def annotateCpuDeviceNode(self, cpu, state):
         cpu.append(FdtPropertyStrings("mmu-type", "riscv,sv48"))
         cpu.append(FdtPropertyStrings("status", "okay"))
-        cpu.append(FdtPropertyStrings("riscv,isa", "rv64imafdcsu"))
+        cpu.append(FdtPropertyStrings("riscv,isa", "rv64imafdc"))
         cpu.appendCompatible(["riscv"])
 
         int_node = FdtNode("interrupt-controller")

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -316,7 +316,7 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
             node.append(FdtPropertyWords("reg", state.CPUAddrCells(i)))
             node.append(FdtPropertyStrings("mmu-type", "riscv,sv48"))
             node.append(FdtPropertyStrings("status", "okay"))
-            node.append(FdtPropertyStrings("riscv,isa", "rv64imafdcsu"))
+            node.append(FdtPropertyStrings("riscv,isa", "rv64imafdc"))
             # TODO: Should probably get this from the core.
             freq = self.clk_domain.clock[0].frequency
             node.appendCompatible(["riscv"])

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -280,7 +280,11 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
             node.append(FdtPropertyWords("reg", state.CPUAddrCells(i)))
             node.append(FdtPropertyStrings("mmu-type", "riscv,sv48"))
             node.append(FdtPropertyStrings("status", "okay"))
-            node.append(FdtPropertyStrings("riscv,isa", "rv64imafdc"))
+            node.append(
+                FdtPropertyStrings(
+                    "riscv,isa", core.core.isa[0].get_isa_string()
+                )
+            )
             # TODO: Should probably get this from the core.
             freq = self.clk_domain.clock[0].frequency
             node.append(FdtPropertyWords("clock-frequency", freq))

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
@@ -214,3 +214,4 @@ class U74Core(BaseCPUCore):
         core_id,
     ):
         super().__init__(core=U74CPU(cpu_id=core_id), isa=ISA.RISCV)
+        self.core.isa[0].enable_rvv = False


### PR DESCRIPTION
Currently, we are hardcoding the ISA string in the device tree
generator. The ISA string from the device tree affects which
ISA extensions will be used by the bootloader/kernel.

This function allows generating the ISA string from the gem5's
ISA object rather than using hardcoded values.

This series of changes also correct a couple of hardcoded
RISC-V ISA strings in the standard library, as well as not
enable RVV instructions for the U74 core model.

Signed-off-by: Hoa Nguyen <hn@hnpl.org>