### PR TITLE
cpu, arch-arm: Add IsPseudo tag for gem5 pseudo instructions

### DIFF
--- a/src/arch/arm/isa/insts/m5ops.isa
+++ b/src/arch/arm/isa/insts/m5ops.isa
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010, 2012-2013 ARM Limited
+// Copyright (c) 2010, 2012-2013, 2023 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -47,7 +47,8 @@ let {{
                                  { "code": gem5OpCode % "RegABI64" +
                                    'X0 = ret;',
                                    "predicate_test": predicateTest },
-                                 [ "IsNonSpeculative", "IsUnverifiable" ]);
+                                 [ "IsNonSpeculative", "IsUnverifiable",
+                                   "IsPseudo" ]);
     header_output += BasicDeclare.subst(gem5OpIop)
     decoder_output += BasicConstructor.subst(gem5OpIop)
     exec_output += PredOpExecute.subst(gem5OpIop)
@@ -57,7 +58,8 @@ let {{
                                    'R0 = bits(ret, 31, 0);\n' + \
                                    'R1 = bits(ret, 63, 32);',
                                    "predicate_test": predicateTest },
-                                 [ "IsNonSpeculative", "IsUnverifiable" ]);
+                                 [ "IsNonSpeculative", "IsUnverifiable",
+                                   "IsPseudo" ]);
     header_output += BasicDeclare.subst(gem5OpIop)
     decoder_output += BasicConstructor.subst(gem5OpIop)
     exec_output += PredOpExecute.subst(gem5OpIop)

--- a/src/cpu/StaticInstFlags.py
+++ b/src/cpu/StaticInstFlags.py
@@ -1,4 +1,14 @@
-# Copyright (c) 2020 ARM Limited
+# Copyright (c) 2020, 2023 Arm Limited
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2003-2005 The Regents of The University of Michigan
 # Copyright (c) 2013 Advanced Micro Devices, Inc.
 # All rights reserved.
@@ -75,6 +85,7 @@ class StaticInstFlags(Enum):
         "IsNonSpeculative",  # Should not be executed speculatively
         "IsQuiesce",  # Is a quiesce instruction
         "IsUnverifiable",  # Can't be verified by a checker
+        "IsPseudo",  # Is a gem5 pseudo-op
         "IsSyscall",  # Causes a system call to be emulated in syscall
         # emulation mode.
         # Flags for microcode

--- a/src/cpu/static_inst.hh
+++ b/src/cpu/static_inst.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 ARM Limited
+ * Copyright (c) 2017, 2020, 2023 Arm Limited
  * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved
  *
@@ -182,6 +182,7 @@ class StaticInst : public RefCounted, public StaticInstFlags
     bool isNonSpeculative() const { return flags[IsNonSpeculative]; }
     bool isQuiesce() const { return flags[IsQuiesce]; }
     bool isUnverifiable() const { return flags[IsUnverifiable]; }
+    bool isPseudo() const { return flags[IsPseudo]; }
     bool isSyscall() const { return flags[IsSyscall]; }
     bool isMacroop() const { return flags[IsMacroop]; }
     bool isMicroop() const { return flags[IsMicroop]; }


### PR DESCRIPTION
This only applies to pseudo instructions with their own encoding (m5 ops)... In other
words memory mapped m5 operations are not supported. This make sense as they should
rather be treated as device accesses... Though it is something to take into consideration
when relying on the flag