### PR TITLE
stdlib,resources: Generalize exception for request retry

### DIFF
--- a/src/python/gem5/resources/client_api/atlasclient.py
+++ b/src/python/gem5/resources/client_api/atlasclient.py
@@ -30,7 +30,6 @@ import json
 import time
 import itertools
 from .abstract_client import AbstractClient
-from urllib.error import HTTPError
 from m5.util import warn
 
 
@@ -122,7 +121,7 @@ class AtlasClient(AbstractClient):
             try:
                 response = request.urlopen(req)
                 break
-            except HTTPError as e:
+            except Exception as e:
                 if attempt >= max_failed_attempts:
                     raise AtlasClientHttpJsonRequestError(
                         client=self,


### PR DESCRIPTION
In commit bbc301f2f027f10976c23ae4f64b81f48aade826 the generalized `Exception` was changed back to the more specific `HTTPError`.

In this case we do not desire specific error handling. If the connection to the database fails I want the exception handled in the way outlined: i.e., i want the connection to be retried 4 times before giving up. With `HTTPError`, only `HTTPError`s warrent a retry.

Changing this to `HTTPError` cause tests to fail due to a failure to retry downloading of a resource. Here is an example: https://github.com/gem5/gem5/actions/runs/6521543885/job/17710779784

In this case `request.urlopen` raised a `URLError`. I suspect this was some issued to do with reaching the DNS servers. It likely would've succeeded if it had just tried again.