### PR TITLE
arch-riscv: Fatal if specify RVV in RV32 mode

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -258,6 +258,11 @@ ISA::ISA(const Params &p) :
     enableRvv(p.enable_rvv)
 
 {
+    fatal_if(
+        _rvType == RV32 && getEnableRvv(),
+        "RVV instructions cannot run in RV32 mode."
+    );
+
     _regClasses.push_back(&intRegClass);
     _regClasses.push_back(&floatRegClass);
     _regClasses.push_back(&vecRegClass);
@@ -318,6 +323,11 @@ void ISA::clear()
     // mark FS is initial
     status.fs = INITIAL;
 
+    if (getEnableRvv()) {
+        status.vs = VPUStatus::INITIAL;
+        misa.rvv = 1;
+    }
+
     // _rvType dependent init.
     switch (_rvType) {
         case RV32:
@@ -326,10 +336,6 @@ void ISA::clear()
         case RV64:
           misa.rv64_mxl = 2;
           status.uxl = status.sxl = 2;
-          if (getEnableRvv()) {
-              status.vs = VPUStatus::INITIAL;
-              misa.rvv = 1;
-          }
           break;
         default:
           panic("%s: Unknown _rvType: %d", name(), (int)_rvType);

--- a/tests/gem5/asmtest/configs/riscv_asmtest.py
+++ b/tests/gem5/asmtest/configs/riscv_asmtest.py
@@ -96,6 +96,7 @@ if args.riscv_32bits:
     for simple_core in processor.cores:
         for i in range(len(simple_core.core.isa)):
             simple_core.core.isa[i].riscv_type = "RV32"
+            simple_core.core.isa[i].enable_rvv = False
 
 motherboard = SimpleBoard(
     clk_freq="3GHz",


### PR DESCRIPTION
Currently we only support RVV in RV64 mode, if users want to run RISC-V
in RV32 mode, the should disable RVV manually.

Change-Id: I1f224d2b927d576d13991aa440c9e2c2c3969f6a