### PR TITLE
arch-riscv: Copy Misc Regs when swiching cpus

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -294,6 +294,10 @@ ISA::copyRegsFrom(ThreadContext *src)
         tc->setReg(id, &vc);
     }
 
+    // Copying Misc Regs
+    for (int i = 0; i < NUM_MISCREGS; i++)
+        tc->setMiscRegNoEffect(i, src->readMiscRegNoEffect(i));
+
     // Lastly copy PC/NPC
     tc->pcState(src->pcState());
 }


### PR DESCRIPTION
Misc Regs might contain rather important information about the state of a core, e.g., information in CSR registers.

This patch enforces copying the CSR registers when switching cpus. The bug and the proposed fix are reported here [1].

[1] https://github.com/gem5/gem5/issues/451

Change-Id: I611782e6e3bcd5530ddac346342a9e0e44b0f757