### PR TITLE
mem,tests: Set Ruby Mem Test atomic percent to 0

### DIFF
--- a/configs/example/ruby_mem_test.py
+++ b/configs/example/ruby_mem_test.py
@@ -65,7 +65,7 @@ parser.add_argument(
 parser.add_argument(
     "--atomic",
     type=int,
-    default=30,
+    default=0,
     help="percentage of accesses that should be atomic",
 )
 parser.add_argument(


### PR DESCRIPTION
Fixes https://github.com/gem5/gem5/issues/450
(https://github.com/gem5/gem5/pull/477 fixes non-ruby memtests, so only a partial fix).
