### PR TITLE
scons: Explicit some config options HAVE_* to boolean type

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -636,7 +636,7 @@ for variant_path in variant_paths:
                 LINKFLAGS=['-Wl,--no-as-needed', '-lprofiler',
                     '-Wl,--as-needed'])
 
-    env['HAVE_PKG_CONFIG'] = env.Detect('pkg-config')
+    env['HAVE_PKG_CONFIG'] = env.Detect('pkg-config') == 'pkg-config'
 
     with gem5_scons.Configure(env) as conf:
         # On Solaris you need to use libsocket for socket ops

--- a/src/base/SConsopts
+++ b/src/base/SConsopts
@@ -69,11 +69,13 @@ werror_env.Append(CCFLAGS=['-Werror'])
 with gem5_scons.Configure(werror_env) as conf:
 
     # Store result in the main environment
-    main['CONF']['HAVE_DEPRECATED_NAMESPACE'] = conf.TryCompile('''
-        int main() {return 0;}
-        namespace [[gnu::deprecated("Test namespace deprecation")]]
-        test_deprecated_namespace {}
-    ''', '.cc')
+    main['CONF']['HAVE_DEPRECATED_NAMESPACE'] = bool(
+        conf.TryCompile('''
+            int main() {return 0;}
+            namespace [[gnu::deprecated("Test namespace deprecation")]]
+            test_deprecated_namespace {}
+        ''', '.cc')
+    )
 
     if not main['CONF']['HAVE_DEPRECATED_NAMESPACE']:
         warning("Deprecated namespaces are not supported by this compiler.\n"

--- a/src/proto/SConsopts
+++ b/src/proto/SConsopts
@@ -57,11 +57,13 @@ with gem5_scons.Configure(main) as conf:
     # automatically added to the LIBS environment variable. After
     # this, we can use the HAVE_PROTOBUF flag to determine if we have
     # got both protoc and libprotobuf available.
-    conf.env['CONF']['HAVE_PROTOBUF'] = conf.env['HAVE_PROTOC'] and (
-        (conf.env['HAVE_PKG_CONFIG'] and
-         conf.CheckPkgConfig('protobuf', '--cflags', '--libs')) or
-        conf.CheckLibWithHeader('protobuf', 'google/protobuf/message.h',
-                                'C++', 'GOOGLE_PROTOBUF_VERIFY_VERSION;'))
+    conf.env['CONF']['HAVE_PROTOBUF'] = bool(
+        conf.env['HAVE_PROTOC'] and (
+            (conf.env['HAVE_PKG_CONFIG'] and
+            conf.CheckPkgConfig('protobuf', '--cflags', '--libs')) or
+            conf.CheckLibWithHeader('protobuf', 'google/protobuf/message.h',
+                                    'C++', 'GOOGLE_PROTOBUF_VERIFY_VERSION;'))
+    )
 
 # If we have the compiler but not the library, print another warning.
 if main['HAVE_PROTOC'] and not main['CONF']['HAVE_PROTOBUF']:


### PR DESCRIPTION
The config options HAVE_* is used in the conditional code and it should be the boolean type