### PR TITLE
cpu: Require BTB hit to detect branches.

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -137,6 +137,15 @@ class BranchPredictor(SimObject):
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
     instShiftAmt = Param.Unsigned(2, "Number of bits to shift instructions by")
+    requiresBTBHit = Param.Bool(
+        False,
+        "Requires the BTB to hit for returns and indirect branches. For an"
+        "advanced front-end there is no other way than a BTB hit to know "
+        "that the branch exists in the first place. Furthermore, the BPU "
+        "needs to know the branch type to make the correct RAS operations. "
+        "This info is only available from the BTB. "
+        "Low-end CPUs predecoding might be used to identify branches. ",
+    )
 
     btb = Param.BranchTargetBuffer(SimpleBTB(), "Branch target buffer (BTB)")
     ras = Param.ReturnAddrStack(

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -368,6 +368,14 @@ class BPredUnit : public SimObject
     /** Number of the threads for which the branch history is maintained. */
     const unsigned numThreads;
 
+    /** Requires the BTB to hit for returns and indirect branches. For an
+     * advanced front-end there is no other way than a BTB hit to know
+     * that the branch exists in the first place. Furthermore, the BPU needs
+     * to know the branch type to make the correct RAS operations.
+     * This info is only available from the BTB.
+     * Low-end CPUs predecoding might be used to identify branches. */
+    const bool requiresBTBHit;
+
     /** Number of bits to shift instructions by for predictor addresses. */
     const unsigned instShiftAmt;
 


### PR DESCRIPTION
In a high performance CPU there is no other way than a BTB hit
to know about a branch instruction and its type. For low-end CPU's
pre-decoding might sit in from of the BPU to provide this information.
Currently, the BPU models only low-end behavior and updates the
RAS and the indirect branch prediction even without a BTB hit.
This patch adds three things to model the correct behavior for high-end
CPUs.
1. A check before the RAS and indirect predictor wheather there was
a BTB hit or not. Only for BTB hits the BPU will consolidate RAS, and
indirect predictor.
2. Since, this check requires a BTB hit for indirect branches they must
also be installed into the BTB. For returns this was already done.
3. Finally, the BTB update previously happened at squash (decode
or commit). Since this can be out-of-order that means branches from
the false path can get installed without ever been retired.