### PR TITLE
util: Add 'sudo' to rm WORK_DIR command

### DIFF
--- a/util/github-runners-vagrant/action-run.sh
+++ b/util/github-runners-vagrant/action-run.sh
@@ -76,6 +76,6 @@ while true; do
     ./run.sh # This will complete with the runner being destroyed
 
     # 4. Cleanup the machine
-    rm -rf "${WORK_DIR}"
+    sudo rm -rf "${WORK_DIR}"
     docker system prune --force --volumes --all
 done


### PR DESCRIPTION
Unfortunately Actions uses docker contaienrs to create files on the system with root permissions. The 'vagrant' user which we login to run the Actions Runner, can't remove these files. However, 'vagrant' is part of the sudo group and can therefore use sudo to remove these files.

I don't like this, but it works.
