### PR TITLE
misc: Add GitHub Runner API rate limiting

### DIFF
--- a/util/github-runners-vagrant/action-run.sh
+++ b/util/github-runners-vagrant/action-run.sh
@@ -62,6 +62,15 @@ while true; do
 
     token=$(echo ${token_curl} | jq -r '.token')
 
+    if [[ "${token}" == "null" ]];
+    then
+        # If "null" is returned, this can be because the GitHub API rate limit
+        # has been exceeded. To be safe we wait for 15 mintues before
+        # continuing.
+        sleep 900 # 15 minutes.
+        continue
+    fi
+
     # 2. Configure the runner.
     ./config.sh --unattended \
                 --url https://github.com/${GITHUB_ORG} \
@@ -78,4 +87,9 @@ while true; do
     # 4. Cleanup the machine
     rm -rf "${WORK_DIR}"
     docker system prune --force --volumes --all
+
+    # 5. Sleep for a few minutes
+    #    GitHub has a api rate limit. This sleep ensures we dont ping GitHub
+    #    too frequently.
+    sleep 180 # 3 minutes.
 done


### PR DESCRIPTION
This stops the 'action-run.sh' from exhausting the GitHub API by adding sleeps.