### PR TITLE
cpu: BPU support for decoupled front-end

### DIFF
--- a/src/cpu/pred/2bit_local.cc
+++ b/src/cpu/pred/2bit_local.cc
@@ -79,8 +79,9 @@ LocalBP::LocalBP(const LocalBPParams &params)
 }
 
 void
-LocalBP::updateHistories(ThreadID tid, Addr pc, bool uncond,
-                         bool taken, Addr target, void * &bp_history)
+LocalBP::updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history)
 {
 // Place holder for a function that is called to update predictor history
 }

--- a/src/cpu/pred/2bit_local.hh
+++ b/src/cpu/pred/2bit_local.hh
@@ -74,7 +74,8 @@ class LocalBP : public BPredUnit
     bool lookup(ThreadID tid, Addr pc, void * &bp_history) override;
 
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target,  void * &bp_history) override;
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
 
     void update(ThreadID tid, Addr pc, bool taken,
                 void * &bp_history, bool squashed,

--- a/src/cpu/pred/bi_mode.cc
+++ b/src/cpu/pred/bi_mode.cc
@@ -97,8 +97,9 @@ BiModeBP::uncondBranch(ThreadID tid, Addr pc, void * &bp_history)
 }
 
 void
-BiModeBP::updateHistories(ThreadID tid, Addr pc, bool uncond,
-                         bool taken, Addr target, void * &bp_history)
+BiModeBP::updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                          Addr target, const StaticInstPtr &inst,
+                          void * &bp_history)
 {
     assert(uncond || bp_history);
     if (uncond) {

--- a/src/cpu/pred/bi_mode.hh
+++ b/src/cpu/pred/bi_mode.hh
@@ -75,7 +75,8 @@ class BiModeBP : public BPredUnit
     BiModeBP(const BiModeBPParams &params);
     bool lookup(ThreadID tid, Addr pc, void * &bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target,  void * &bp_history) override;
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
     void squash(ThreadID tid, void * &bp_history) override;
     void update(ThreadID tid, Addr pc, bool taken,
                 void * &bp_history, bool squashed,

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -94,6 +94,12 @@ BPredUnit::drainSanityCheck() const
         assert(ph.empty());
 }
 
+void
+BPredUnit::branchPlaceholder(ThreadID tid, Addr pc,
+                             bool uncond, void * &bp_history)
+{
+    panic("BPredUnit::branchPlaceholder() not implemented for this BP.\n");
+}
 
 bool
 BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
@@ -318,7 +324,7 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
      * we know the correct direction.
      **/
     updateHistories(tid, hist->pc, hist->uncond, hist->predTaken,
-                    hist->target->instAddr(), hist->bpHistory);
+                    hist->target->instAddr(), hist->inst, hist->bpHistory);
 
 
     if (iPred) {
@@ -400,12 +406,6 @@ BPredUnit::squash(const InstSeqNum &squashed_sn, ThreadID tid)
 
         squashHistory(tid, hist);
 
-        DPRINTF(Branch, "[tid:%i, squash sn:%llu] Removing history for "
-                "sn:%llu, PC:%#x\n", tid, squashed_sn, hist->seqNum,
-                hist->pc);
-
-
-        delete predHist[tid].front();
         predHist[tid].pop_front();
 
         DPRINTF(Branch, "[tid:%i] [squash sn:%llu] pred_hist.size(): %i\n",
@@ -442,6 +442,9 @@ BPredUnit::squashHistory(ThreadID tid, PredictorHistory* &history)
 
     // This call should delete the bpHistory.
     squash(tid, history->bpHistory);
+
+    delete history;
+    history = nullptr;
 }
 
 

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -91,6 +91,7 @@ class BPredUnit : public SimObject
      * Predicts whether or not the instruction is a taken branch, and the
      * target of the branch if it is taken.
      * @param inst The branch instruction.
+     * @param seqNum The sequence number of the instruction.
      * @param PC The predicted PC is passed back through this parameter.
      * @param tid The thread id.
      * @return Returns if the branch is taken or not.
@@ -138,6 +139,7 @@ class BPredUnit : public SimObject
     /**
      * Looks up a given conditional branch PC of in the BP to see if it
      * is taken or not taken.
+     * @param tid The thread id.
      * @param pc The PC to look up.
      * @param bp_history Pointer that will be set to an object that
      * has the branch predictor state associated with the lookup.
@@ -150,16 +152,19 @@ class BPredUnit : public SimObject
      * path and global history. All branches call this function
      * including unconditional once.
      * @param tid The thread id.
-     * @param PC The branch's PC that will be updated.
+     * @param pc The branch's pc that will be updated.
      * @param uncond Wheather or not this branch is an unconditional branch.
      * @param taken Whether or not the branch was taken
      * @param target The final target of branch. Some modern
      * predictors use the target in their history.
+     * @param inst Static instruction information
      * @param bp_history Pointer that will be set to an object that
      * has the branch predictor state associated with the lookup.
+     *
      */
     virtual void updateHistories(ThreadID tid, Addr pc, bool uncond,
-                            bool taken, Addr target, void * &bp_history) = 0;
+                           bool taken, Addr target,
+                           const StaticInstPtr &inst, void * &bp_history) = 0;
 
     /**
      * @param tid The thread id.
@@ -172,7 +177,7 @@ class BPredUnit : public SimObject
     /**
      * Updates the BP with taken/not taken information.
      * @param tid The thread id.
-     * @param PC The branch's PC that will be updated.
+     * @param pc The branch's PC that will be updated.
      * @param taken Whether the branch was taken or not taken.
      * @param bp_history Pointer to the branch predictor state that is
      * associated with the branch lookup that is being updated.
@@ -184,19 +189,36 @@ class BPredUnit : public SimObject
      * @todo Make this update flexible enough to handle a global predictor.
      */
     virtual void update(ThreadID tid, Addr pc, bool taken,
-                   void * &bp_history, bool squashed,
-                   const StaticInstPtr &inst, Addr target) = 0;
+                        void * &bp_history, bool squashed,
+                        const StaticInstPtr &inst, Addr target) = 0;
 
+    /**
+     * Special function for the decoupled front-end. In it there can be
+     * branches which are not detected by the BPU in the first place as it
+     * requires a BTB hit. This function will generate a placeholder for
+     * such a branch once it is pre-decoded in the fetch stage. It will
+     * only create the branch history object but not update any internal state
+     * of the BPU.
+     * If the branch turns to be wrong then decode or commit will
+     * be able to use the normal squash functionality to correct the branch.
+     * Note that not all branch predictors implement this functionality.
+     * @param tid The thread id.
+     * @param pc The branch's PC.
+     * @param uncond Whether or not this branch is an unconditional branch.
+     * @param bp_history Pointer that will be set to an branch history object.
+     */
+    virtual void branchPlaceholder(ThreadID tid, Addr pc,
+                                   bool uncond, void * &bp_history);
 
     /**
      * Looks up a given PC in the BTB to see if a matching entry exists.
      * @param tid The thread id.
-     * @param inst_PC The PC to look up.
+     * @param pc The PC to look up.
      * @return Whether the BTB contains the given PC.
      */
-    bool BTBValid(ThreadID tid, Addr instPC)
+    bool BTBValid(ThreadID tid, Addr pc)
     {
-        return btb->valid(tid, instPC);
+        return btb->valid(tid, pc);
     }
 
     /**
@@ -204,13 +226,13 @@ class BPredUnit : public SimObject
      * be changed or deleted in the future, so it needs to be used immediately,
      * and/or copied for use later.
      * @param tid The thread id.
-     * @param inst_PC The PC to look up.
+     * @param pc The PC to look up.
      * @return The address of the target of the branch.
      */
     const PCStateBase *
-    BTBLookup(ThreadID tid, PCStateBase &instPC)
+    BTBLookup(ThreadID tid, PCStateBase &pc)
     {
-        return btb->lookup(tid, instPC.instAddr());
+        return btb->lookup(tid, pc.instAddr());
     }
 
     /**
@@ -219,32 +241,103 @@ class BPredUnit : public SimObject
      * the information does not usually exist at that this point.
      * Only for instructions (branches) that hit in the BTB this information
      * is available as the BTB stores them together with the target.
-     *
-     * @param inst_PC The PC to look up.
+     * @param tid The thread id.
+     * @param pc The PC to look up.
      * @return The static instruction info of the given PC if existant.
      */
     const StaticInstPtr
-    BTBGetInst(ThreadID tid, Addr instPC)
+    BTBGetInst(ThreadID tid, Addr pc)
     {
-        return btb->getInst(tid, instPC);
+        return btb->getInst(tid, pc);
     }
 
     /**
      * Updates the BTB with the target of a branch.
-     * @param inst_PC The branch's PC that will be updated.
-     * @param target_PC The branch's target that will be added to the BTB.
+     * @param tid The thread id.
+     * @param pc The branch's PC that will be updated.
+     * @param target The branch's target that will be added to the BTB.
      */
     void
-    BTBUpdate(ThreadID tid, Addr instPC, const PCStateBase &target)
+    BTBUpdate(ThreadID tid, Addr pc, const PCStateBase &target)
     {
         ++stats.BTBUpdates;
-        return btb->update(tid, instPC, target);
+        return btb->update(tid, pc, target);
     }
 
 
     void dump();
 
   private:
+
+
+    /** Branch Predictor Unit (BPU) history object `PredictorHistory`
+     * This class holds all information needed to manage the speculative
+     * state of a in-flight branch prediction.
+     * In case of the default (coupled/synchronous) front-end, the branch
+     * predictor is queried whenever the a branch is decoded by the fetch
+     * unit. In case of the decoupled front-end, the branch predictor is
+     * queried whenever a branch is detected using the BTB.
+     *
+     * Lifetime of a PredictorHistory (coupled front-end):
+     *
+     *   + ------------------------------------------- +
+     *   | FETCH:                                      |
+     *   |  - The fetch unit pre-decodes a branch.     |
+     *   |  - The BPU is queried to make a prediction  |
+     *   |    using the `predict` function             |
+     *   |  - A PredictorHistory object is created.    |
+     *   + ------------------------------------------- +
+     *                          |
+     *                          |
+     *   + ------------------------------------------- +
+     *   | DECODE:                                     |
+     *   |  - The branch is decoded and the target for |
+     *   |    direct branches is available.            |
+     *   + ------------------------------------------- +
+     *                          |
+     *                 ( target correct ? ) ----------------+
+     *                          |                           |
+     *         +-------------------------------------+      |
+     *         | Squash all predictions made AFTER   |      |
+     *         | this branch using `squashHistories`.|      |
+     *         | Will revert all speculative history |      |
+     *         | updates and delete the history      |      |
+     *         | history updates of those branches.  |      |
+     *         | It also corrects the target of the  |      |
+     *         | mispredicted branch using the       |      |
+     *         | `squash` function.                  |      |
+     *         +-------------------------------------+      |
+     *                          |                           |
+     *                          | <-------------------------+
+     *                          |
+     *  + --------------------------------------------+
+     *  | COMMIT:                                     |
+     *  |  - The branch is resolved and the correct   |
+     *  |    branch direction and target is known.    |
+     *  + --------------------------------------------+
+     *                          |
+     *              ( prediction correct ? ) ----------------+
+     *                          |                           |
+     *         +-------------------------------------+      |
+     *         | Squash all predictions made AFTER   |      |
+     *         | this branch using `squashHistories`.|      |
+     *         | Will revert all speculative history |      |
+     *         | updates and delete the history      |      |
+     *         | history updates of those branches.  |      |
+     *         | It also corrects the target and     |      |
+     *         | the direction of the mispredicted   |      |
+     *         | branch using the `squash` function. |      |
+     *         +-------------------------------------+      |
+     *                          |                           |
+     *                          | <-------------------------+
+     *                          |
+     *         +-------------------------------------+
+     *         | Update the internal state (counter) |
+     *         | of the BPU using the `update`       |
+     *         | function.                           |
+     *         +-------------------------------------+
+     *
+     */
     struct PredictorHistory
     {
         /**
@@ -343,12 +436,13 @@ class BPredUnit : public SimObject
 
     /**
      * Internal prediction function.
-    */
+     */
     bool predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                PCStateBase &pc, ThreadID tid, PredictorHistory* &bpu_history);
 
     /**
-     * Squashes a particular branch instance
+     * Squashes a particular branch instance. Reverts
+     * all speculative updated state and deletes the history object
      * @param tid The thread id.
      * @param bpu_history The history to be squashed.
      */

--- a/src/cpu/pred/ltage.cc
+++ b/src/cpu/pred/ltage.cc
@@ -72,11 +72,21 @@ LTAGE::init()
     TAGE::init();
 }
 
+void
+LTAGE::branchPlaceholder(ThreadID tid, Addr pc,
+                         bool uncond, void * &bpHistory)
+{
+    LTageBranchInfo *bi = new LTageBranchInfo(*tage, *loopPredictor,
+                                              pc, !uncond);
+    bpHistory = (void*)(bi);
+}
+
 //prediction
 bool
 LTAGE::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void* &b)
 {
-    LTageBranchInfo *bi = new LTageBranchInfo(*tage, *loopPredictor);
+    LTageBranchInfo *bi = new LTageBranchInfo(*tage, *loopPredictor,
+                                              branch_pc, cond_branch);
     b = (void*)(bi);
 
     bool pred_taken = tage->tagePredict(tid, branch_pc, cond_branch,
@@ -116,7 +126,7 @@ LTAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
         if (tage->isSpeculativeUpdateEnabled()) {
             // This restores the global history, then update it
             // and recomputes the folded histories.
-            tage->squash(tid, taken, bi->tageBranchInfo, target);
+            tage->squash(tid, taken, target, inst, bi->tageBranchInfo);
 
             if (bi->tageBranchInfo->condBranch) {
                 loopPredictor->squashLoop(bi->lpBranchInfo);
@@ -140,8 +150,8 @@ LTAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
             nrand, target, bi->lpBranchInfo->predTaken);
     }
 
-    tage->updateHistories(tid, pc, taken, bi->tageBranchInfo, false,
-                          inst, target);
+    tage->updateHistories(tid, pc, false, taken, target,
+                           inst, bi->tageBranchInfo);
 
     delete bi;
     bp_history = nullptr;

--- a/src/cpu/pred/ltage.hh
+++ b/src/cpu/pred/ltage.hh
@@ -85,6 +85,8 @@ class LTAGE : public TAGE
     void update(ThreadID tid, Addr pc, bool taken,
                 void * &bp_history, bool squashed,
                 const StaticInstPtr & inst, Addr target) override;
+    virtual void branchPlaceholder(ThreadID tid, Addr pc,
+                                   bool uncond, void * &bp_history) override;
 
     void init() override;
 
@@ -103,8 +105,10 @@ class LTAGE : public TAGE
     struct LTageBranchInfo : public TageBranchInfo
     {
         LoopPredictor::BranchInfo *lpBranchInfo;
-        LTageBranchInfo(TAGEBase &tage, LoopPredictor &lp)
-          : TageBranchInfo(tage), lpBranchInfo(lp.makeBranchInfo())
+        LTageBranchInfo(TAGEBase &tage, LoopPredictor &lp,
+                        Addr pc, bool conditional)
+          : TageBranchInfo(tage, pc, conditional),
+            lpBranchInfo(lp.makeBranchInfo())
         {}
 
         virtual ~LTageBranchInfo()

--- a/src/cpu/pred/multiperspective_perceptron.cc
+++ b/src/cpu/pred/multiperspective_perceptron.cc
@@ -561,7 +561,8 @@ MultiperspectivePerceptron::train(ThreadID tid, MPPBranchInfo &bi, bool taken)
 
 void
 MultiperspectivePerceptron::updateHistories(ThreadID tid, Addr pc,
-                    bool uncond, bool taken, Addr target, void * &bp_history)
+                                bool uncond, bool taken, Addr target,
+                                const StaticInstPtr &inst, void * &bp_history)
 {
     assert(uncond || bp_history);
 

--- a/src/cpu/pred/multiperspective_perceptron.hh
+++ b/src/cpu/pred/multiperspective_perceptron.hh
@@ -1066,10 +1066,11 @@ class MultiperspectivePerceptron : public BPredUnit
     // Base class methods.
     bool lookup(ThreadID tid, Addr branch_addr, void* &bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target,  void * &bp_history) override;
-    void update(ThreadID tid, Addr pc, bool taken,
-                void * &bp_history, bool squashed,
-                const StaticInstPtr & inst, Addr target) override;
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
+    void update(ThreadID tid, Addr branch_addr, bool taken, void *&bp_history,
+                bool squashed, const StaticInstPtr & inst,
+                Addr corrTarget) override;
     void squash(ThreadID tid, void * &bp_history) override;
 };
 

--- a/src/cpu/pred/multiperspective_perceptron_tage.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage.hh
@@ -76,7 +76,8 @@ class MPP_TAGE : public TAGEBase
   public:
     struct BranchInfo : public TAGEBase::BranchInfo
     {
-        BranchInfo(TAGEBase &tage) : TAGEBase::BranchInfo(tage)
+        BranchInfo(TAGEBase &tage, Addr pc, bool cond)
+        : TAGEBase::BranchInfo(tage, pc, cond)
         {}
         virtual ~BranchInfo()
         {}
@@ -98,12 +99,9 @@ class MPP_TAGE : public TAGEBase
 
     unsigned getUseAltIdx(TAGEBase::BranchInfo* bi, Addr branch_pc) override;
     void adjustAlloc(bool & alloc, bool taken, bool pred_taken) override;
-    void updateHistories(ThreadID tid, Addr branch_pc, bool taken,
-                         TAGEBase::BranchInfo* b, bool speculative,
-                         const StaticInstPtr &inst, Addr target) override;
-
-    void updatePathAndGlobalHistory(ThreadHistory& tHist, int brtype,
-                                    bool taken, Addr branch_pc, Addr target);
+    void updateHistories(ThreadID tid, Addr branch_pc, bool speculative,
+                         bool taken, Addr target, const StaticInstPtr & inst,
+                         TAGEBase::BranchInfo* bi) override;
 };
 
 class MPP_LoopPredictor : public LoopPredictor
@@ -225,7 +223,7 @@ class MultiperspectivePerceptronTAGE : public MultiperspectivePerceptron
                           LoopPredictor &loopPredictor,
                           StatisticalCorrector &statisticalCorrector)
           : MPPBranchInfo(pc, pcshift, cond),
-            tageBranchInfo(tage.makeBranchInfo()),
+            tageBranchInfo(tage.makeBranchInfo(pc, cond)),
             lpBranchInfo(loopPredictor.makeBranchInfo()),
             scBranchInfo(statisticalCorrector.makeBranchInfo()),
             predictedTaken(false)
@@ -256,8 +254,12 @@ class MultiperspectivePerceptronTAGE : public MultiperspectivePerceptron
                 void * &bp_history, bool squashed,
                 const StaticInstPtr & inst, Addr target) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target,  void * &bp_history) override;
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
     void squash(ThreadID tid, void * &bp_history) override;
+    void branchPlaceholder(ThreadID tid, Addr pc,
+                                bool uncond, void * &bp_history) override
+    { panic("Not implemented for this BP!\n"); }
 
 };
 

--- a/src/cpu/pred/tage.cc
+++ b/src/cpu/pred/tage.cc
@@ -69,7 +69,7 @@ TAGE::TAGE(const TAGEParams &params) : BPredUnit(params), tage(params.tage)
 // PREDICTOR UPDATE
 void
 TAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
-              bool squashed, const StaticInstPtr & inst, Addr target)
+             bool squashed, const StaticInstPtr & inst, Addr target)
 {
     assert(bp_history);
 
@@ -79,7 +79,7 @@ TAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
     if (squashed) {
         // This restores the global history, then update it
         // and recomputes the folded histories.
-        tage->squash(tid, taken, tage_bi, target);
+        tage->squash(tid, taken, target, inst, tage_bi);
         return;
     }
 
@@ -93,7 +93,7 @@ TAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
     }
 
     // optional non speculative update of the histories
-    tage->updateHistories(tid, pc, taken, tage_bi, false, inst, target);
+    tage->updateHistories(tid, pc, false, taken, target, inst, tage_bi);
     delete bi;
     bp_history = nullptr;
 }
@@ -102,6 +102,7 @@ void
 TAGE::squash(ThreadID tid, void * &bp_history)
 {
     TageBranchInfo *bi = static_cast<TageBranchInfo*>(bp_history);
+    tage->restoreHistState(tid, bi->tageBranchInfo);
     DPRINTF(Tage, "Deleting branch info: %lx\n", bi->tageBranchInfo->branchPC);
     delete bi;
     bp_history = nullptr;
@@ -110,7 +111,7 @@ TAGE::squash(ThreadID tid, void * &bp_history)
 bool
 TAGE::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
 {
-    TageBranchInfo *bi = new TageBranchInfo(*tage);//nHistoryTables+1);
+    TageBranchInfo *bi = new TageBranchInfo(*tage, pc, cond_branch);
     b = (void*)(bi);
     return tage->tagePredict(tid, pc, cond_branch, bi->tageBranchInfo);
 }
@@ -126,18 +127,29 @@ TAGE::lookup(ThreadID tid, Addr pc, void* &bp_history)
 }
 
 void
-TAGE::updateHistories(ThreadID tid, Addr pc, bool uncond,
-                         bool taken, Addr target, void * &bp_history)
+TAGE::updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                      Addr target, const StaticInstPtr &inst,
+                      void * &bp_history)
 {
-    assert(uncond || bp_history);
-    if (uncond) {
-        DPRINTF(Tage, "UnConditionalBranch: %lx\n", pc);
+    if (bp_history == nullptr) {
+
+        // We should only see unconditional branches
+        assert(uncond);
+
         predict(tid, pc, false, bp_history);
     }
 
     // Update the global history for all branches
     TageBranchInfo *bi = static_cast<TageBranchInfo*>(bp_history);
-    tage->updateHistories(tid, pc, taken, bi->tageBranchInfo, true);
+    tage->updateHistories(tid, pc, true, taken, target, inst,
+                          bi->tageBranchInfo);
+}
+
+void
+TAGE::branchPlaceholder(ThreadID tid, Addr pc, bool uncond, void * &bpHistory)
+{
+    TageBranchInfo *bi = new TageBranchInfo(*tage, pc, !uncond);
+    bpHistory = (void*)(bi);
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/tage.hh
+++ b/src/cpu/pred/tage.hh
@@ -85,7 +85,8 @@ class TAGE: public BPredUnit
     {
         TAGEBase::BranchInfo *tageBranchInfo;
 
-        TageBranchInfo(TAGEBase &tage) : tageBranchInfo(tage.makeBranchInfo())
+        TageBranchInfo(TAGEBase &tage, Addr pc, bool conditional)
+        : tageBranchInfo(tage.makeBranchInfo(pc, conditional))
         {}
 
         virtual ~TageBranchInfo()
@@ -104,11 +105,14 @@ class TAGE: public BPredUnit
     // Base class methods.
     bool lookup(ThreadID tid, Addr pc, void* &bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target,  void * &bp_history) override;
-    void update(ThreadID tid, Addr pc, bool taken,
-                void * &bp_history, bool squashed,
-                const StaticInstPtr & inst, Addr target) override;
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
+    void update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
+                bool squashed, const StaticInstPtr &inst,
+                Addr target) override;
     virtual void squash(ThreadID tid, void * &bp_history) override;
+    virtual void branchPlaceholder(ThreadID tid, Addr pc,
+                                   bool uncond, void * &bp_history) override;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/tage_base.cc
+++ b/src/cpu/pred/tage_base.cc
@@ -79,8 +79,8 @@ TAGEBase::TAGEBase(const TAGEBaseParams &p)
 }
 
 TAGEBase::BranchInfo*
-TAGEBase::makeBranchInfo() {
-    return new BranchInfo(*this);
+TAGEBase::makeBranchInfo(Addr pc, bool conditional) {
+    return new BranchInfo(*this, pc, conditional);
 }
 
 void
@@ -103,7 +103,7 @@ TAGEBase::init()
     assert(logUResetPeriod != 0);
     tCounter = initialTCounterValue;
 
-    assert(histBufferSize > maxHist * 2);
+    assert(histBufferSize > maxHist * 3);
 
     useAltPredForNewlyAllocated.resize(numUseAltOnNa, 0);
 
@@ -181,25 +181,6 @@ TAGEBase::calculateParameters()
                        pow ((double) (maxHist) / (double) minHist,
                            (double) (i - 1) / (double) ((nHistoryTables- 1))))
                        + 0.5);
-    }
-}
-
-void
-TAGEBase::btbUpdate(ThreadID tid, Addr branch_pc, BranchInfo* &bi)
-{
-    if (speculativeHistUpdate) {
-        ThreadHistory& tHist = threadHistory[tid];
-        DPRINTF(Tage, "BTB miss resets prediction: %lx\n", branch_pc);
-        assert(tHist.gHist == &tHist.globalHistory[tHist.ptGhist]);
-        tHist.gHist[0] = 0;
-        for (int i = 1; i <= nHistoryTables; i++) {
-            tHist.computeIndices[i].comp = bi->ci[i];
-            tHist.computeTags[0][i].comp = bi->ct0[i];
-            tHist.computeTags[1][i].comp = bi->ct1[i];
-            tHist.computeIndices[i].update(tHist.gHist);
-            tHist.computeTags[0][i].update(tHist.gHist);
-            tHist.computeTags[1][i].update(tHist.gHist);
-        }
     }
 }
 
@@ -319,21 +300,42 @@ TAGEBase::baseUpdate(Addr pc, bool taken, BranchInfo* bi)
 // shifting the global history:  we manage the history in a big table in order
 // to reduce simulation time
 void
-TAGEBase::updateGHist(uint8_t * &h, bool dir, uint8_t * tab, int &pt)
+TAGEBase::updateGHist(ThreadID tid, uint64_t bv, uint8_t n)
 {
-    if (pt == 0) {
+    if (n == 0) return;
+
+    // Handle rollovers first.
+    ThreadHistory& tHist = threadHistory[tid];
+    if (tHist.ptGhist < n) {
         DPRINTF(Tage, "Rolling over the histories\n");
          // Copy beginning of globalHistoryBuffer to end, such that
          // the last maxHist outcomes are still reachable
-         // through pt[0 .. maxHist - 1].
-         for (int i = 0; i < maxHist; i++)
-             tab[histBufferSize - maxHist + i] = tab[i];
-         pt =  histBufferSize - maxHist;
-         h = &tab[pt];
+         // through globalHistory[0 .. maxHist - 1].
+        for (int i = 0; i < maxHist; i++) {
+            tHist.globalHistory[histBufferSize - maxHist + i]
+                = tHist.globalHistory[tHist.ptGhist + i];
+        }
+
+        tHist.ptGhist = histBufferSize - maxHist;
+        tHist.gHist = &tHist.globalHistory[tHist.ptGhist];
     }
-    pt--;
-    h--;
-    h[0] = (dir) ? 1 : 0;
+
+    // Update the global history
+    for (int i = 0; i < n; i++) {
+
+        // Shift the next bit of the bit vector into the history
+        tHist.ptGhist--;
+        tHist.gHist--;
+        *(tHist.gHist) = (bv & 1) ? 1 : 0;
+        bv >>= 1;
+
+        // Update the folded histories with the new bit.
+        for (int i = 1; i <= nHistoryTables; i++) {
+            tHist.computeIndices[i].update(tHist.gHist);
+            tHist.computeTags[0][i].update(tHist.gHist);
+            tHist.computeTags[1][i].update(tHist.gHist);
+        }
+    }
 }
 
 void
@@ -347,6 +349,7 @@ TAGEBase::calculateIndicesAndTags(ThreadID tid, Addr branch_pc,
         tableTags[i] = gtag(tid, branch_pc, i);
         bi->tableTags[i] = tableTags[i];
     }
+    bi->valid = true;
 }
 
 unsigned
@@ -360,78 +363,75 @@ bool
 TAGEBase::tagePredict(ThreadID tid, Addr branch_pc,
               bool cond_branch, BranchInfo* bi)
 {
-    Addr pc = branch_pc;
-    bool pred_taken = true;
+    if (!cond_branch) {
+        // Unconditional branch, predict taken
+        assert(bi->branchPC == branch_pc);
+        return true;
+    }
 
-    if (cond_branch) {
         // TAGE prediction
 
-        calculateIndicesAndTags(tid, pc, bi);
+    calculateIndicesAndTags(tid, branch_pc, bi);
+    bi->bimodalIndex = bindex(branch_pc);
 
-        bi->bimodalIndex = bindex(pc);
-
-        bi->hitBank = 0;
-        bi->altBank = 0;
-        //Look for the bank with longest matching history
-        for (int i = nHistoryTables; i > 0; i--) {
-            if (noSkip[i] &&
-                gtable[i][tableIndices[i]].tag == tableTags[i]) {
-                bi->hitBank = i;
-                bi->hitBankIndex = tableIndices[bi->hitBank];
-                break;
-            }
+    bi->hitBank = 0;
+    bi->altBank = 0;
+    //Look for the bank with longest matching history
+    for (int i = nHistoryTables; i > 0; i--) {
+        if (noSkip[i] &&
+            gtable[i][tableIndices[i]].tag == tableTags[i]) {
+            bi->hitBank = i;
+            bi->hitBankIndex = tableIndices[bi->hitBank];
+            break;
         }
-        //Look for the alternate bank
-        for (int i = bi->hitBank - 1; i > 0; i--) {
-            if (noSkip[i] &&
-                gtable[i][tableIndices[i]].tag == tableTags[i]) {
-                bi->altBank = i;
-                bi->altBankIndex = tableIndices[bi->altBank];
-                break;
-            }
-        }
-        //computes the prediction and the alternate prediction
-        if (bi->hitBank > 0) {
-            if (bi->altBank > 0) {
-                bi->altTaken =
-                    gtable[bi->altBank][tableIndices[bi->altBank]].ctr >= 0;
-                extraAltCalc(bi);
-            }else {
-                bi->altTaken = getBimodePred(pc, bi);
-            }
-
-            bi->longestMatchPred =
-                gtable[bi->hitBank][tableIndices[bi->hitBank]].ctr >= 0;
-            bi->pseudoNewAlloc =
-                abs(2 * gtable[bi->hitBank][bi->hitBankIndex].ctr + 1) <= 1;
-
-            //if the entry is recognized as a newly allocated entry and
-            //useAltPredForNewlyAllocated is positive use the alternate
-            //prediction
-            if ((useAltPredForNewlyAllocated[getUseAltIdx(bi, branch_pc)] < 0)
-                || ! bi->pseudoNewAlloc) {
-                bi->tagePred = bi->longestMatchPred;
-                bi->provider = TAGE_LONGEST_MATCH;
-            } else {
-                bi->tagePred = bi->altTaken;
-                bi->provider = bi->altBank ? TAGE_ALT_MATCH
-                                           : BIMODAL_ALT_MATCH;
-            }
-        } else {
-            bi->altTaken = getBimodePred(pc, bi);
-            bi->tagePred = bi->altTaken;
-            bi->longestMatchPred = bi->altTaken;
-            bi->provider = BIMODAL_ONLY;
-        }
-        //end TAGE prediction
-
-        pred_taken = (bi->tagePred);
-        DPRINTF(Tage, "Predict for %lx: taken?:%d, tagePred:%d, altPred:%d\n",
-                branch_pc, pred_taken, bi->tagePred, bi->altTaken);
     }
-    bi->branchPC = branch_pc;
-    bi->condBranch = cond_branch;
-    return pred_taken;
+    //Look for the alternate bank
+    for (int i = bi->hitBank - 1; i > 0; i--) {
+        if (noSkip[i] &&
+            gtable[i][tableIndices[i]].tag == tableTags[i]) {
+            bi->altBank = i;
+            bi->altBankIndex = tableIndices[bi->altBank];
+            break;
+        }
+    }
+    //computes the prediction and the alternate prediction
+    if (bi->hitBank > 0) {
+        if (bi->altBank > 0) {
+            bi->altTaken =
+                gtable[bi->altBank][tableIndices[bi->altBank]].ctr >= 0;
+            extraAltCalc(bi);
+        } else {
+            bi->altTaken = getBimodePred(branch_pc, bi);
+        }
+
+        bi->longestMatchPred =
+            gtable[bi->hitBank][tableIndices[bi->hitBank]].ctr >= 0;
+        bi->pseudoNewAlloc =
+            abs(2 * gtable[bi->hitBank][bi->hitBankIndex].ctr + 1) <= 1;
+
+        //if the entry is recognized as a newly allocated entry and
+        //useAltPredForNewlyAllocated is positive use the alternate
+        //prediction
+        if ((useAltPredForNewlyAllocated[getUseAltIdx(bi, branch_pc)] < 0)
+            || ! bi->pseudoNewAlloc) {
+            bi->tagePred = bi->longestMatchPred;
+            bi->provider = TAGE_LONGEST_MATCH;
+        } else {
+            bi->tagePred = bi->altTaken;
+            bi->provider = bi->altBank ? TAGE_ALT_MATCH
+                                        : BIMODAL_ALT_MATCH;
+        }
+    } else {
+        bi->altTaken = getBimodePred(branch_pc, bi);
+        bi->tagePred = bi->altTaken;
+        bi->longestMatchPred = bi->altTaken;
+        bi->provider = BIMODAL_ONLY;
+    }
+
+    DPRINTF(Tage, "Predict for %lx: tagePred:%d, altPred:%d\n",
+            branch_pc, bi->tagePred, bi->altTaken);
+
+    return bi->tagePred;
 }
 
 void
@@ -585,70 +585,128 @@ TAGEBase::handleTAGEUpdate(Addr branch_pc, bool taken, BranchInfo* bi)
 }
 
 void
-TAGEBase::updateHistories(ThreadID tid, Addr branch_pc, bool taken,
-                          BranchInfo* bi, bool speculative,
-                          const StaticInstPtr &inst, Addr target)
+TAGEBase::updatePathAndGlobalHistory(ThreadID tid, int brtype, bool taken,
+                                Addr branch_pc, Addr target, BranchInfo* bi)
+{
+    ThreadHistory& tHist = threadHistory[tid];
+
+    // Update path history
+    bool pathbit = ((branch_pc >> instShiftAmt) & 1);
+    tHist.pathHist = (tHist.pathHist << 1) + pathbit;
+    tHist.pathHist = (tHist.pathHist & ((1ULL << pathHistBits) - 1));
+
+    // For normal direction history update the history by
+    // whether the branch was taken or not.
+    bi->ghist = taken ? 1 : 0;
+    bi->nGhist = 1;
+    // Update the global history
+    updateGHist(tid, bi->ghist, bi->nGhist);
+    bi->modified = true;
+}
+
+
+void
+TAGEBase::updateHistories(ThreadID tid, Addr branch_pc, bool speculative,
+                          bool taken, Addr target,
+                          const StaticInstPtr & inst, BranchInfo* bi)
 {
     if (speculative != speculativeHistUpdate) {
         return;
     }
-    ThreadHistory& tHist = threadHistory[tid];
-    //  UPDATE HISTORIES
-    bool pathbit = ((branch_pc >> instShiftAmt) & 1);
-    //on a squash, return pointers to this and recompute indices.
-    //update user history
-    updateGHist(tHist.gHist, taken, tHist.globalHistory, tHist.ptGhist);
-    tHist.pathHist = (tHist.pathHist << 1) + pathbit;
-    tHist.pathHist = (tHist.pathHist & ((1ULL << pathHistBits) - 1));
 
-    if (speculative) {
-        bi->ptGhist = tHist.ptGhist;
-        bi->pathHist = tHist.pathHist;
+    // If this is the first time we see this branch record the current
+    // state of the history to be able to recover.
+    if (speculativeHistUpdate && (!bi->modified)) {
+        recordHistState(tid, bi);
     }
 
-    //prepare next index and tag computations for user branchs
-    for (int i = 1; i <= nHistoryTables; i++)
-    {
-        if (speculative) {
-            bi->ci[i]  = tHist.computeIndices[i].comp;
-            bi->ct0[i] = tHist.computeTags[0][i].comp;
-            bi->ct1[i] = tHist.computeTags[1][i].comp;
-        }
-        tHist.computeIndices[i].update(tHist.gHist);
-        tHist.computeTags[0][i].update(tHist.gHist);
-        tHist.computeTags[1][i].update(tHist.gHist);
+    // In case the branch already updated the history
+    // we need to revert the previous update first.
+    if (bi->modified) {
+        restoreHistState(tid, bi);
     }
+
+    // Recalculate the tags and indices if needed. This can be the case
+    // as in the decoupled frontend branches can be inserted out of order
+    // (surprise branches). We can not compute the tags and indices
+    // at that point since the BPU might already speculated on other branches
+    // which updated the history. We can recalculate the tags and indices
+    // now since either the branch was correctly not taken and the history
+    // will not be updated or the branch was incorrect in which case the
+    // branches afterwards where squashed and the history was restored.
+    if (!bi->valid && bi->condBranch) {
+        calculateIndicesAndTags(tid, branch_pc, bi);
+    }
+
+    // We should have not already modified the history
+    // for this branch
+    assert(bi->nGhist == 0);
+
+    // Do the actual history update. Might be different for different
+    // TAGE implementations.
+    updatePathAndGlobalHistory(tid, branchTypeExtra(inst), taken,
+                               branch_pc, target, bi);
+
     DPRINTF(Tage, "Updating global histories with branch:%lx; taken?:%d, "
-            "path Hist: %x; pointer:%d\n", branch_pc, taken, tHist.pathHist,
-            tHist.ptGhist);
+            "path Hist: %x; pointer:%d\n", branch_pc, taken,
+            threadHistory[tid].pathHist, threadHistory[tid].ptGhist);
     assert(threadHistory[tid].gHist ==
             &threadHistory[tid].globalHistory[threadHistory[tid].ptGhist]);
 }
 
 void
-TAGEBase::squash(ThreadID tid, bool taken, TAGEBase::BranchInfo *bi,
-                 Addr target)
+TAGEBase::recordHistState(ThreadID tid, BranchInfo* bi)
+{
+    ThreadHistory& tHist = threadHistory[tid];
+    bi->ptGhist = tHist.ptGhist;
+    bi->pathHist = tHist.pathHist;
+
+    for (int i = 1; i <= nHistoryTables; i++) {
+        bi->ci[i]  = tHist.computeIndices[i].comp;
+        bi->ct0[i] = tHist.computeTags[0][i].comp;
+        bi->ct1[i] = tHist.computeTags[1][i].comp;
+    }
+}
+
+void
+TAGEBase::restoreHistState(ThreadID tid, BranchInfo* bi)
 {
     if (!speculativeHistUpdate) {
-        /* If there are no speculative updates, no actions are needed */
+        return;
+    }
+    if (!bi->modified) {
         return;
     }
 
     ThreadHistory& tHist = threadHistory[tid];
-    DPRINTF(Tage, "Restoring branch info: %lx; taken? %d; PathHistory:%x, "
-            "pointer:%d\n", bi->branchPC,taken, bi->pathHist, bi->ptGhist);
     tHist.pathHist = bi->pathHist;
-    tHist.ptGhist = bi->ptGhist;
-    tHist.gHist = &(tHist.globalHistory[tHist.ptGhist]);
-    tHist.gHist[0] = (taken ? 1 : 0);
-    for (int i = 1; i <= nHistoryTables; i++) {
-        tHist.computeIndices[i].comp = bi->ci[i];
-        tHist.computeTags[0][i].comp = bi->ct0[i];
-        tHist.computeTags[1][i].comp = bi->ct1[i];
-        tHist.computeIndices[i].update(tHist.gHist);
-        tHist.computeTags[0][i].update(tHist.gHist);
-        tHist.computeTags[1][i].update(tHist.gHist);
+
+    if (bi->nGhist == 0)
+        return;
+
+    //  RESTORE HISTORIES
+    // Shift out the inserted bits
+    // from the folded history and the global history vector
+    for (int n = 0; n < bi->nGhist; n++) {
+
+        // First revert the folded history
+        for (int i = 1; i <= nHistoryTables; i++) {
+            tHist.computeIndices[i].restore(tHist.gHist);
+            tHist.computeTags[0][i].restore(tHist.gHist);
+            tHist.computeTags[1][i].restore(tHist.gHist);
+        }
+        tHist.ptGhist++;
+        tHist.gHist++;
     }
+    bi->nGhist = 0;
+    bi->modified = false;
+}
+
+void
+TAGEBase::squash(ThreadID tid, bool taken, Addr target,
+                 const StaticInstPtr &inst, TAGEBase::BranchInfo *bi)
+{
+    updateHistories(tid, bi->branchPC, true, taken, target, inst, bi);
 }
 
 void
@@ -708,19 +766,19 @@ TAGEBase::updateStats(bool taken, BranchInfo* bi)
 }
 
 unsigned
-TAGEBase::getGHR(ThreadID tid, BranchInfo *bi) const
+TAGEBase::getGHR(ThreadID tid) const
 {
     unsigned val = 0;
-    for (unsigned i = 0; i < 32; i++) {
+    int gh_ptr = threadHistory[tid].ptGhist;
+    for (unsigned i = 0; i < 16; i++) {
         // Make sure we don't go out of bounds
-        int gh_offset = bi->ptGhist + i;
-        assert(&(threadHistory[tid].globalHistory[gh_offset]) <
+        assert(&(threadHistory[tid].globalHistory[gh_ptr + i]) <
                threadHistory[tid].globalHistory + histBufferSize);
-        val |= ((threadHistory[tid].globalHistory[gh_offset] & 0x1) << i);
+        val |= ((threadHistory[tid].globalHistory[gh_ptr + i] & 0x1) << i);
     }
-
     return val;
 }
+
 
 TAGEBase::TAGEBaseStats::TAGEBaseStats(
     statistics::Group *parent, unsigned nHistoryTables)

--- a/src/cpu/pred/tage_base.hh
+++ b/src/cpu/pred/tage_base.hh
@@ -110,6 +110,13 @@ class TAGEBase : public SimObject
             comp ^= (comp >> compLength);
             comp &= (1ULL << compLength) - 1;
         }
+
+        void restore(uint8_t * h)
+        {
+            comp ^= h[origLength] << outpoint;
+            auto tmp = (comp & 1) ^ h[0];
+            comp = (tmp << (compLength-1)) | (comp >> 1);
+        }
     };
 
   public:
@@ -127,6 +134,9 @@ class TAGEBase : public SimObject
     // Primary branch history entry
     struct BranchInfo
     {
+        const Addr branchPC;
+        const bool condBranch;
+
         int pathHist;
         int ptGhist;
         int hitBank;
@@ -137,10 +147,8 @@ class TAGEBase : public SimObject
 
         bool tagePred;
         bool altTaken;
-        bool condBranch;
         bool longestMatchPred;
         bool pseudoNewAlloc;
-        Addr branchPC;
 
         // Pointer to dynamically allocated storage
         // to save table indices and folded histories.
@@ -158,15 +166,29 @@ class TAGEBase : public SimObject
         // for stats purposes
         unsigned provider;
 
-        BranchInfo(const TAGEBase &tage)
-            : pathHist(0), ptGhist(0),
+        // The bit vector and the number of bits of global
+        // history used for this branch.
+        uint64_t ghist;
+        uint8_t nGhist;
+
+        // A flag to indicate if this history entry has
+        // modified the histories
+        bool modified;
+        // A flag to indicate if the indies and tags are valid.
+        bool valid;
+
+        BranchInfo(const TAGEBase &tage, Addr pc, bool conditional)
+            : branchPC(pc), condBranch(conditional),
               hitBank(0), hitBankIndex(0),
               altBank(0), altBankIndex(0),
               bimodalIndex(0),
               tagePred(false), altTaken(false),
-              condBranch(false), longestMatchPred(false),
-              pseudoNewAlloc(false), branchPC(0),
-              provider(-1)
+              longestMatchPred(false),
+              pseudoNewAlloc(false),
+              provider(-1),
+              ghist(0), nGhist(0),
+              modified(false),
+              valid(false)
         {
             int sz = tage.nHistoryTables + 1;
             storage = new int [sz * 5];
@@ -183,7 +205,8 @@ class TAGEBase : public SimObject
         }
     };
 
-    virtual BranchInfo *makeBranchInfo();
+    virtual BranchInfo *makeBranchInfo(Addr pc, bool conditional);
+
 
     /**
      * Computes the index used to access the
@@ -258,14 +281,16 @@ class TAGEBase : public SimObject
     void baseUpdate(Addr pc, bool taken, BranchInfo* bi);
 
    /**
-    * (Speculatively) updates the global branch history.
-    * @param h Reference to pointer to global branch history.
-    * @param dir (Predicted) outcome to update the histories
-    * with.
-    * @param tab
-    * @param PT Reference to path history.
+     * Internal history update function. This function shifts
+     * nBits into the global history vector. If the update
+     * is speculative the functions makes a copy of the
+     * GHR to rollback.
+     * @param tid The thread ID to select the histories to update.
+     * @param bv The bit vector with n bits that will be shifted
+     * into the global history vector.
+     * @param n The number of bits to be updated
     */
-    void updateGHist(uint8_t * &h, bool dir, uint8_t * tab, int &PT);
+    void updateGHist(ThreadID tid, uint64_t bv, uint8_t n);
 
     /**
      * Update TAGE. Called at execute to repair histories on a misprediction
@@ -279,23 +304,56 @@ class TAGEBase : public SimObject
      */
     void update(ThreadID tid, Addr branch_pc, bool taken, BranchInfo* bi);
 
-   /**
-    * (Speculatively) updates global histories (path and direction).
-    * Also recomputes compressed (folded) histories based on the
-    * branch direction.
-    * @param tid The thread ID to select the histories
-    * to update.
-    * @param branch_pc The unshifted branch PC.
-    * @param taken (Predicted) branch direction.
-    * @param b Wrapping pointer to BranchInfo (to allow
-    * storing derived class prediction information in the
-    * base class).
+    /**
+     * (Speculatively) updates global histories (path and direction).
+     * It manages squashing of histories in case of a mispredicted.
+     * In that case it also recomputes compressed (folded) histories based on
+     * the squashed state
+     * @param tid The thread ID to select the histories to update.
+     * @param branch_pc The unshifted branch PC.
+     * @param speculative Whether the update is speculative or not
+     * @param taken (Predicted) branch direction.
+     * @param target (Predicted) branch target.
+     * @param inst The branch instruction. Some predictors
+     * do different things depending on the branch type.
+     * @param bi Pointer to information on the prediction
+     * recorded at prediction time.
+     */
+    virtual void updateHistories(ThreadID tid, Addr branch_pc,
+                            bool speculative, bool taken, Addr target,
+                            const StaticInstPtr &inst, BranchInfo* bi);
+    /**
+     * Records the current state of the histories to be able to restore it
+     * in case of a mispredicted speculative update.
+     * @param tid The thread ID to select the histories to record.
+     * @param bi Pointer to the branch associated with the state
+     */
+    void recordHistState(ThreadID tid, BranchInfo* bi);
+
+    /**
+     * Restore the state of the histories in case of detecting
+     * a mispredicted speculative update.
+     * @param tid The thread ID to select the histories to restore.
+     * @param bi Pointer to the branch associated with the state
     */
-    virtual void updateHistories(
-        ThreadID tid, Addr branch_pc, bool taken, BranchInfo* b,
-        bool speculative,
-        const StaticInstPtr & inst = nullStaticInstPtr,
-        Addr target = MaxAddr);
+    void restoreHistState(ThreadID tid, BranchInfo* bi);
+
+    /** Does the actual update of path and global history. Different TAGE
+     * implementations may override this function to do extra work.
+     * @param tid The thread ID to select the histories to update.
+     * @param brtype The branch type
+     * @param taken Actual branch outcome.
+     * @param branch_pc The unshifted branch PC.
+     * @param target The branch target
+     * @param bi Pointer to information on the prediction
+     */
+    virtual void updatePathAndGlobalHistory(ThreadID tid, int brtype,
+                    bool taken, Addr branch_pc, Addr target, BranchInfo* bi);
+
+    /** This function acts as a hook for other TAGE implementations to
+     * adjust the branch type
+    */
+    virtual int branchTypeExtra(const StaticInstPtr & inst) { return 0; }
 
     /**
      * Restores speculatively updated path and direction histories.
@@ -304,14 +362,15 @@ class TAGEBase : public SimObject
      * This version of squash() is called once on a branch misprediction.
      * @param tid The Thread ID to select the histories to rollback.
      * @param taken The correct branch outcome.
-     * @param bp_history Wrapping pointer to BranchInfo (to allow
+     * @param target The correct branch target
+     * @param inst The branch instruction.
+     * @param bi Wrapping pointer to BranchInfo (to allow
      * storing derived class prediction information in the
      * base class).
-     * @param target The correct branch target
-     * @post bp_history points to valid memory.
+     * @post bi points to valid memory.
      */
-    virtual void squash(
-        ThreadID tid, bool taken, BranchInfo *bi, Addr target);
+    virtual void squash(ThreadID tid, bool taken, Addr target,
+                        const StaticInstPtr &inst, BranchInfo *bi);
 
     /**
      * Update TAGE for conditional branches.
@@ -412,8 +471,7 @@ class TAGEBase : public SimObject
         return false;
     }
 
-    void btbUpdate(ThreadID tid, Addr branch_addr, BranchInfo* &bi);
-    unsigned getGHR(ThreadID tid, BranchInfo *bi) const;
+    unsigned getGHR(ThreadID tid) const;
     int8_t getCtr(int hitBank, int hitBankIndex) const;
     unsigned getTageCtrBits() const;
     int getPathHist(ThreadID tid) const;

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -81,9 +81,9 @@ TAGE_SC_L::TAGE_SC_L(const TAGE_SC_LParams &p)
 }
 
 TAGEBase::BranchInfo*
-TAGE_SC_L_TAGE::makeBranchInfo()
+TAGE_SC_L_TAGE::makeBranchInfo(Addr pc, bool cond)
 {
-    return new BranchInfo(*this);
+    return new BranchInfo(*this, pc, cond);
 }
 void
 TAGE_SC_L_TAGE::calculateParameters()
@@ -239,8 +239,9 @@ TAGE_SC_L_TAGE::bindex(Addr pc) const
 
 void
 TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
-    ThreadHistory& tHist, int brtype, bool taken, Addr branch_pc, Addr target)
+    ThreadID tid, int brtype, bool taken, Addr branch_pc, Addr target)
 {
+    ThreadHistory& tHist = threadHistory[tid];
     // TAGE update
     int tmp = ((branch_pc ^ (branch_pc >> instShiftAmt))) ^ taken;
     int path = branch_pc ^ (branch_pc >> instShiftAmt)
@@ -254,28 +255,23 @@ TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
     int maxt = (brtype == 2) ? 3 : 2;
 
     for (int t = 0; t < maxt; t++) {
-        bool dir = (tmp & 1);
-        tmp >>= 1;
         int pathbit = (path & 127);
         path >>= 1;
-        updateGHist(tHist.gHist, dir, tHist.globalHistory, tHist.ptGhist);
         tHist.pathHist = (tHist.pathHist << 1) ^ pathbit;
         if (truncatePathHist) {
             // The 8KB implementation does not do this truncation
             tHist.pathHist = (tHist.pathHist & ((1ULL << pathHistBits) - 1));
         }
-        for (int i = 1; i <= nHistoryTables; i++) {
-            tHist.computeIndices[i].update(tHist.gHist);
-            tHist.computeTags[0][i].update(tHist.gHist);
-            tHist.computeTags[1][i].update(tHist.gHist);
-        }
     }
+
+    updateGHist(tid, tmp, maxt);
 }
 
 void
-TAGE_SC_L_TAGE::updateHistories(
-    ThreadID tid, Addr branch_pc, bool taken, TAGEBase::BranchInfo* b,
-    bool speculative, const StaticInstPtr &inst, Addr target)
+TAGE_SC_L_TAGE::updateHistories(ThreadID tid, Addr branch_pc,
+                                bool speculative, bool taken,
+                                Addr target, const StaticInstPtr &inst,
+                                TAGEBase::BranchInfo* bi)
 {
     if (speculative != speculativeHistUpdate) {
         return;
@@ -289,7 +285,7 @@ TAGE_SC_L_TAGE::updateHistories(
     if (! inst->isUncondCtrl()) {
         ++brtype;
     }
-    updatePathAndGlobalHistory(tHist, brtype, taken, branch_pc, target);
+    updatePathAndGlobalHistory(tid, brtype, taken, branch_pc, target);
 
     DPRINTF(TageSCL, "Updating global histories with branch:%lx; taken?:%d, "
             "path Hist: %x; pointer:%d\n", branch_pc, taken, tHist.pathHist,
@@ -297,8 +293,8 @@ TAGE_SC_L_TAGE::updateHistories(
 }
 
 void
-TAGE_SC_L_TAGE::squash(ThreadID tid, bool taken, TAGEBase::BranchInfo *bi,
-                       Addr target)
+TAGE_SC_L_TAGE::squash(ThreadID tid, bool taken, Addr target,
+                       const StaticInstPtr &inst, TAGEBase::BranchInfo *bi)
 {
     fatal("Speculation is not implemented");
 }
@@ -377,7 +373,8 @@ TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
 {
     TageSCLBranchInfo *bi = new TageSCLBranchInfo(*tage,
                                                   *statisticalCorrector,
-                                                  *loopPredictor);
+                                                  *loopPredictor,
+                                                  pc, cond_branch);
     b = (void*)(bi);
 
     bool pred_taken = tage->tagePredict(tid, pc, cond_branch,
@@ -422,7 +419,7 @@ TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
 
 void
 TAGE_SC_L::update(ThreadID tid, Addr pc, bool taken, void *&bp_history,
-        bool squashed, const StaticInstPtr & inst, Addr target)
+                  bool squashed, const StaticInstPtr & inst, Addr target)
 {
     assert(bp_history);
 
@@ -434,7 +431,7 @@ TAGE_SC_L::update(ThreadID tid, Addr pc, bool taken, void *&bp_history,
         if (tage->isSpeculativeUpdateEnabled()) {
             // This restores the global history, then update it
             // and recomputes the folded histories.
-            tage->squash(tid, taken, tage_bi, target);
+            tage->squash(tid, taken, target, inst, tage_bi);
             if (bi->tageBranchInfo->condBranch) {
                 loopPredictor->squashLoop(bi->lpBranchInfo);
             }
@@ -469,8 +466,8 @@ TAGE_SC_L::update(ThreadID tid, Addr pc, bool taken, void *&bp_history,
         statisticalCorrector->scHistoryUpdate(pc, inst, taken,
                                               bi->scBranchInfo, target);
 
-        tage->updateHistories(tid, pc, taken, bi->tageBranchInfo, false,
-                              inst, target);
+        tage->updateHistories(tid, pc, false, taken, target,
+                              inst, bi->tageBranchInfo);
     }
 
     delete bi;

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -91,14 +91,15 @@ class TAGE_SC_L_TAGE : public TAGEBase
         bool highConf;
         bool altConf;
         bool medConf;
-        BranchInfo(TAGEBase &tage) : TAGEBase::BranchInfo(tage),
+        BranchInfo(TAGEBase &tage, Addr pc, bool cond)
+          : TAGEBase::BranchInfo(tage, pc, cond),
             lowConf(false), highConf(false), altConf(false), medConf(false)
         {}
         virtual ~BranchInfo()
         {}
     };
 
-    virtual TAGEBase::BranchInfo *makeBranchInfo() override;
+    virtual TAGEBase::BranchInfo *makeBranchInfo(Addr pc, bool cond) override;
 
     TAGE_SC_L_TAGE(const TAGE_SC_L_TAGEParams &p)
       : TAGEBase(p),
@@ -120,10 +121,9 @@ class TAGE_SC_L_TAGE : public TAGEBase
 
     unsigned getUseAltIdx(TAGEBase::BranchInfo* bi, Addr branch_pc) override;
 
-    void updateHistories(
-        ThreadID tid, Addr branch_pc, bool taken, TAGEBase::BranchInfo* b,
-        bool speculative, const StaticInstPtr &inst,
-        Addr target) override;
+    void updateHistories(ThreadID tid, Addr branch_pc, bool speculative,
+                         bool taken, Addr target, const StaticInstPtr & inst,
+                         TAGEBase::BranchInfo* bi) override;
 
     int bindex(Addr pc_in) const override;
     int gindex(ThreadID tid, Addr pc, int bank) const override;
@@ -132,11 +132,11 @@ class TAGE_SC_L_TAGE : public TAGEBase
 
     virtual uint16_t gtag(ThreadID tid, Addr pc, int bank) const override = 0;
 
-    void squash(ThreadID tid, bool taken, TAGEBase::BranchInfo *bi,
-                Addr target) override;
+    void squash(ThreadID tid, bool taken, Addr target,
+                const StaticInstPtr &inst, TAGEBase::BranchInfo *bi) override;
 
     void updatePathAndGlobalHistory(
-        ThreadHistory & tHist, int brtype, bool taken,
+        ThreadID tid, int brtype, bool taken,
         Addr branch_pc, Addr target);
 
     void adjustAlloc(bool & alloc, bool taken, bool pred_taken) override;
@@ -175,11 +175,15 @@ class TAGE_SC_L: public LTAGE
   public:
     TAGE_SC_L(const TAGE_SC_LParams &params);
 
-    bool predict(ThreadID tid, Addr pc, bool cond_branch, void* &b) override;
+    bool predict(
+        ThreadID tid, Addr branch_pc, bool cond_branch, void* &b) override;
+    void update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
+                bool squashed, const StaticInstPtr & inst,
+                Addr target) override;
 
-    void update(ThreadID tid, Addr pc, bool taken,
-                void * &bp_history, bool squashed,
-                const StaticInstPtr & inst, Addr target) override;
+    void branchPlaceholder(ThreadID tid, Addr pc,
+                                bool uncond, void * &bp_history) override
+    { panic("Not implemented for this BP!\n"); }
 
   protected:
 
@@ -188,8 +192,9 @@ class TAGE_SC_L: public LTAGE
         StatisticalCorrector::BranchInfo *scBranchInfo;
 
         TageSCLBranchInfo(TAGEBase &tage, StatisticalCorrector &sc,
-                          LoopPredictor &lp)
-          : LTageBranchInfo(tage, lp), scBranchInfo(sc.makeBranchInfo())
+                          LoopPredictor &lp, Addr pc, bool cond_branch)
+          : LTageBranchInfo(tage, lp, pc, cond_branch),
+            scBranchInfo(sc.makeBranchInfo())
         {}
 
         virtual ~TageSCLBranchInfo()

--- a/src/cpu/pred/tournament.cc
+++ b/src/cpu/pred/tournament.cc
@@ -195,8 +195,9 @@ TournamentBP::lookup(ThreadID tid, Addr pc, void * &bp_history)
 }
 
 void
-TournamentBP::updateHistories(ThreadID tid, Addr pc, bool uncond,
-                         bool taken, Addr target, void * &bp_history)
+TournamentBP::updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
+                              Addr target, const StaticInstPtr &inst,
+                              void * &bp_history)
 {
     assert(uncond || bp_history);
     if (uncond) {

--- a/src/cpu/pred/tournament.hh
+++ b/src/cpu/pred/tournament.hh
@@ -74,10 +74,11 @@ class TournamentBP : public BPredUnit
     // Base class methods.
     bool lookup(ThreadID tid, Addr pc, void* &bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target,  void * &bp_history) override;
-    void update(ThreadID tid, Addr pc, bool taken,
-                void * &bp_history, bool squashed,
-                const StaticInstPtr & inst, Addr target) override;
+                         Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
+    void update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
+                bool squashed, const StaticInstPtr & inst,
+                Addr target) override;
     void squash(ThreadID tid, void * &bp_history) override;
 
   private:


### PR DESCRIPTION
To support the decoupled front-end the BPU must have the ability to add a placeholder for branches that are not in
the BTB (surprise branches). In this case the front-end cannot detect the branch and make a prediction. However,
to rollback in case of a misprediction the BPU needs a history element. This function allows generation of such elements to add it to the the speculative history buffer. It does NOT make a prediction or alter the BPU state.
