### PR TITLE
configs,ext: gem5 SST bridge calls m5.instantiate() in gem5

### DIFF
--- a/configs/example/sst/arm_fs.py
+++ b/configs/example/sst/arm_fs.py
@@ -185,3 +185,4 @@ for cpu in system.cpu:
     cpu.createInterruptController()
 
 root = Root(full_system=True, system=system)
+m5.instantiate()

--- a/configs/example/sst/riscv_fs.py
+++ b/configs/example/sst/riscv_fs.py
@@ -175,3 +175,4 @@ for cpu in system.cpu:
     cpu.createInterruptController()
 
 root = Root(full_system=True, system=system)
+m5.instantiate()

--- a/ext/sst/gem5.cc
+++ b/ext/sst/gem5.cc
@@ -204,13 +204,7 @@ gem5Component::init(unsigned phase)
 
     if (phase == 0) {
         initPython(args.size(), &args[0]);
-
-        const std::vector<std::string> m5_instantiate_commands = {
-            "import m5",
-            "m5.instantiate()"
-        };
-        execPythonCommands(m5_instantiate_commands);
-
+        // m5.instantiate() was moved to the gem5 script.
         // calling SimObject.startup()
         const std::vector<std::string> simobject_setup_commands = {
             "import atexit",

--- a/ext/sst/gem5.hh
+++ b/ext/sst/gem5.hh
@@ -80,7 +80,6 @@
 #include <sst/core/component.h>
 
 #include <sst/core/interfaces/stringEvent.h>
-#include <sst/core/interfaces/simpleMem.h>
 
 #include <sim/simulate.hh>
 


### PR DESCRIPTION
This change updates the gem5 SST bridge to call m5.instantiate() in the gem5 config script instead of in the SST component. This allows more flexibility for the gem5-SST setup, as we can now write traffic generators using the bridge.

Change-Id: I510a8c15f8fb00bdbdd60dafa2d9f5ad011e48f2