### PR TITLE
arch-riscv: Correct BootloaderKernelWorkload symbol table

### DIFF
--- a/src/arch/riscv/linux/fs_workload.cc
+++ b/src/arch/riscv/linux/fs_workload.cc
@@ -96,11 +96,10 @@ void
 BootloaderKernelWorkload::loadKernelSymbolTable()
 {
     if (params().kernel_filename != "") {
-        Addr kernel_paddr_offset = params().kernel_addr;
         kernel = loader::createObjectFile(params().kernel_filename);
         kernelSymbolTable = kernel->symtab();
         auto renamedKernelSymbolTable = \
-            kernelSymbolTable.offset(kernel_paddr_offset)->rename(
+            kernelSymbolTable.rename(
                 [](std::string &name) {
                     name = "kernel." + name;
                 }


### PR DESCRIPTION
Currently, the kernel's symbols are shifted by `kernel_paddr_offset`, which is where the kernel is located in the physcial address space. However, the symbols are mapped to virtual addresses, which stay the same even though the physical address space is shifted.

This patch removes the offset for the kernel's symbols virtual addresses.

Change-Id: I7c35f925777220f56bd8c69bba14c267d2048ade