### PR TITLE
base,sim: Add the SymbolType field to the Symbol object

### DIFF
--- a/src/arch/riscv/linux/fs_workload.cc
+++ b/src/arch/riscv/linux/fs_workload.cc
@@ -83,7 +83,9 @@ BootloaderKernelWorkload::loadBootloaderSymbolTable()
         bootloader = loader::createObjectFile(params().bootloader_filename);
         bootloaderSymbolTable = bootloader->symtab();
         auto renamedBootloaderSymbolTable = \
-            bootloaderSymbolTable.offset(bootloader_paddr_offset)->rename(
+            bootloaderSymbolTable.offset(
+                bootloader_paddr_offset
+            )->functionSymbols()->rename(
                 [](std::string &name) {
                     name = "bootloader." + name;
                 }
@@ -99,7 +101,7 @@ BootloaderKernelWorkload::loadKernelSymbolTable()
         kernel = loader::createObjectFile(params().kernel_filename);
         kernelSymbolTable = kernel->symtab();
         auto renamedKernelSymbolTable = \
-            kernelSymbolTable.rename(
+            kernelSymbolTable.functionSymbols()->rename(
                 [](std::string &name) {
                     name = "kernel." + name;
                 }

--- a/src/base/loader/elf_object.cc
+++ b/src/base/loader/elf_object.cc
@@ -196,6 +196,27 @@ ElfObject::ElfObject(ImageFileDataPtr ifd) : ObjectFile(ifd)
                     continue;
                 }
 
+                switch (GELF_ST_TYPE(sym.st_info)) {
+                  case STT_NOTYPE:
+                    symbol.type = loader::Symbol::SymbolType::NoType;
+                    break;
+                  case STT_OBJECT:
+                    symbol.type = loader::Symbol::SymbolType::Object;
+                    break;
+                  case STT_FUNC:
+                    symbol.type = loader::Symbol::SymbolType::Function;
+                    break;
+                  case STT_SECTION:
+                    symbol.type = loader::Symbol::SymbolType::Section;
+                    break;
+                  case STT_FILE:
+                    symbol.type = loader::Symbol::SymbolType::File;
+                    break;
+                  default:
+                    symbol.type = loader::Symbol::SymbolType::Other;
+                    break;
+                }
+
                 if (_symtab.insert(symbol)) {
                     DPRINTF(Loader, "Symbol: %-40s value %#x.\n",
                             symbol.name, symbol.address);

--- a/src/base/loader/symtab.cc
+++ b/src/base/loader/symtab.cc
@@ -101,6 +101,7 @@ SymbolTable::serialize(const std::string &base, CheckpointOut &cp) const
         paramOut(cp, csprintf("%s.addr_%d", base, i), symbol.address);
         paramOut(cp, csprintf("%s.symbol_%d", base, i), symbol.name);
         paramOut(cp, csprintf("%s.binding_%d", base, i), (int)symbol.binding);
+        paramOut(cp, csprintf("%s.type_%d", base, i), (int)symbol.type);
         i++;
     }
 }
@@ -116,12 +117,15 @@ SymbolTable::unserialize(const std::string &base, CheckpointIn &cp,
         Addr address;
         std::string name;
         Symbol::Binding binding = default_binding;
+        Symbol::SymbolType type = Symbol::SymbolType::Other;
 
         paramIn(cp, csprintf("%s.addr_%d", base, i), address);
         paramIn(cp, csprintf("%s.symbol_%d", base, i), name);
         if (!optParamIn(cp, csprintf("%s.binding_%d", base, i), binding))
             binding = default_binding;
-        insert({binding, name, address});
+        if (!optParamIn(cp, csprintf("%s.type_%d", base, i), type))
+            type = Symbol::SymbolType::Other;
+        insert({binding, type, name, address});
     }
 }
 

--- a/src/base/loader/symtab.hh
+++ b/src/base/loader/symtab.hh
@@ -176,6 +176,22 @@ class SymbolTable
         return filter(filt);
     }
 
+    /**
+     * Generate a new table by applying a filter that only accepts the symbols
+     * whose type matches the given symbol type.
+     *
+     * @param The type that must be matched.
+     * @return A new table, filtered by type.
+     */
+    SymbolTablePtr
+    filterBySymbolType(const Symbol::SymbolType& symbol_type) const
+    {
+        auto filt = [symbol_type](const Symbol &symbol) {
+            return symbol.type == symbol_type;
+        };
+        return filter(filt);
+    }
+
   public:
     typedef SymbolVector::iterator iterator;
     typedef SymbolVector::const_iterator const_iterator;
@@ -300,6 +316,17 @@ class SymbolTable
     weaks() const
     {
         return filterByBinding(Symbol::Binding::Weak);
+    }
+
+    /**
+     * Generates a new symbol table containing only function symbols.
+     *
+     * @return The new table.
+     */
+    SymbolTablePtr
+    functionSymbols() const
+    {
+        return filterBySymbolType(Symbol::SymbolType::Function);
     }
 
     /**

--- a/src/base/loader/symtab.hh
+++ b/src/base/loader/symtab.hh
@@ -56,7 +56,19 @@ struct Symbol
         Weak
     };
 
+    // The ELF64_ST_TYPE field of gelf's st_info
+    enum class SymbolType
+    {
+        NoType,
+        Object,
+        Function,
+        Section,
+        File,
+        Other
+    };
+
     Binding binding;
+    SymbolType type;
     std::string name;
     Addr address;
 };

--- a/src/base/loader/symtab.test.cc
+++ b/src/base/loader/symtab.test.cc
@@ -58,6 +58,12 @@ getSymbolError(const loader::Symbol& symbol, const loader::Symbol& expected)
             (int)expected.binding << "`.\n";
     }
 
+    if (symbol.type != expected.type) {
+        ss << "    symbols' types do not match: seen `" <<
+            (int)symbol.type << "`, expected `" <<
+            (int)expected.type << "`.\n";
+    }
+
     if (symbol.name != expected.name) {
         ss << "    symbols' names do not match: seen `" << symbol.name <<
             "`, expected `" << expected.name << "`.\n";
@@ -136,7 +142,9 @@ TEST(LoaderSymtabTest, InsertSymbolNoName)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "", 0x10};
     ASSERT_FALSE(symtab.insert(symbol));
     ASSERT_TRUE(checkTable(symtab, {}));
 }
@@ -146,7 +154,9 @@ TEST(LoaderSymtabTest, InsertOneSymbol)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "symbol", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10};
     ASSERT_TRUE(symtab.insert(symbol));
 
     ASSERT_FALSE(symtab.empty());
@@ -160,8 +170,10 @@ TEST(LoaderSymtabTest, InsertSymbolExistingName)
 
     const std::string name = "symbol";
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, name, 0x10},
-        {loader::Symbol::Binding::Local, name, 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            name, 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            name, 0x20},
     };
     ASSERT_TRUE(symtab.insert(symbols[0]));
     ASSERT_FALSE(symtab.insert(symbols[1]));
@@ -177,8 +189,10 @@ TEST(LoaderSymtabTest, InsertSymbolExistingAddress)
 
     const Addr addr = 0x10;
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", addr},
-        {loader::Symbol::Binding::Local, "symbol2", addr},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", addr},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", addr},
     };
     ASSERT_TRUE(symtab.insert(symbols[0]));
     ASSERT_TRUE(symtab.insert(symbols[1]));
@@ -193,9 +207,12 @@ TEST(LoaderSymtabTest, InsertMultipleSymbols)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -212,9 +229,12 @@ TEST(LoaderSymtabTest, ClearMultiple)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -234,9 +254,12 @@ TEST(LoaderSymtabTest, Offset)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -250,9 +273,12 @@ TEST(LoaderSymtabTest, Offset)
 
     // Check that the new table is offset
     loader::Symbol expected_symbols[] = {
-        {symbols[0].binding, symbols[0].name, symbols[0].address + offset},
-        {symbols[1].binding, symbols[1].name, symbols[1].address + offset},
-        {symbols[2].binding, symbols[2].name, symbols[2].address + offset},
+        {symbols[0].binding, symbols[0].type, symbols[0].name,
+            symbols[0].address + offset},
+        {symbols[1].binding, symbols[1].type, symbols[1].name,
+            symbols[1].address + offset},
+        {symbols[2].binding, symbols[2].type, symbols[2].name,
+            symbols[2].address + offset},
     };
     ASSERT_TRUE(checkTable(*symtab_new, {expected_symbols[0],
         expected_symbols[1], expected_symbols[2]}));
@@ -267,10 +293,14 @@ TEST(LoaderSymtabTest, Mask)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x1310},
-        {loader::Symbol::Binding::Local, "symbol2", 0x2810},
-        {loader::Symbol::Binding::Local, "symbol3", 0x2920},
-        {loader::Symbol::Binding::Local, "symbol4", 0x3C20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x1310},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x2810},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x2920},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x3C20},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -286,10 +316,14 @@ TEST(LoaderSymtabTest, Mask)
 
     // Check that the new table is masked
     loader::Symbol expected_symbols[] = {
-        {symbols[0].binding, symbols[0].name, symbols[0].address & mask},
-        {symbols[1].binding, symbols[1].name, symbols[1].address & mask},
-        {symbols[2].binding, symbols[2].name, symbols[2].address & mask},
-        {symbols[3].binding, symbols[3].name, symbols[3].address & mask},
+        {symbols[0].binding, symbols[0].type, symbols[0].name,
+            symbols[0].address & mask},
+        {symbols[1].binding, symbols[1].type, symbols[1].name,
+            symbols[1].address & mask},
+        {symbols[2].binding, symbols[2].type, symbols[2].name,
+            symbols[2].address & mask},
+        {symbols[3].binding, symbols[3].type, symbols[3].name,
+            symbols[3].address & mask},
     };
     ASSERT_TRUE(checkTable(*symtab_new, {expected_symbols[0],
         expected_symbols[1], expected_symbols[2], expected_symbols[3]}));
@@ -304,10 +338,14 @@ TEST(LoaderSymtabTest, Rename)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Local, "symbol4", 0x40},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -323,10 +361,14 @@ TEST(LoaderSymtabTest, Rename)
 
     // Check that the new table's symbols have been renamed
     loader::Symbol expected_symbols[] = {
-        {symbols[0].binding, symbols[0].name + "_suffix", symbols[0].address},
-        {symbols[1].binding, symbols[1].name + "_suffix", symbols[1].address},
-        {symbols[2].binding, symbols[2].name + "_suffix", symbols[2].address},
-        {symbols[3].binding, symbols[3].name + "_suffix", symbols[3].address},
+        {symbols[0].binding, symbols[0].type, symbols[0].name + "_suffix",
+            symbols[0].address},
+        {symbols[1].binding, symbols[1].type, symbols[1].name + "_suffix",
+            symbols[1].address},
+        {symbols[2].binding, symbols[2].type, symbols[2].name + "_suffix",
+            symbols[2].address},
+        {symbols[3].binding, symbols[3].type, symbols[3].name + "_suffix",
+            symbols[3].address},
     };
     ASSERT_TRUE(checkTable(*symtab_new, {expected_symbols[0],
         expected_symbols[1], expected_symbols[2], expected_symbols[3]}));
@@ -341,10 +383,14 @@ TEST(LoaderSymtabTest, RenameNonUnique)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Local, "symbol4", 0x40},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -366,9 +412,12 @@ TEST(LoaderSymtabTest, RenameNonUnique)
     // Check that the new table's symbols have been renamed, yet it does not
     // contain the symbols with duplicated names
     loader::Symbol expected_symbols[] = {
-        {symbols[0].binding, "NonUniqueName", symbols[0].address},
-        {symbols[1].binding, symbols[1].name, symbols[1].address},
-        {symbols[3].binding, symbols[3].name, symbols[3].address},
+        {symbols[0].binding, symbols[0].type, "NonUniqueName",
+            symbols[0].address},
+        {symbols[1].binding, symbols[1].type, symbols[1].name,
+            symbols[1].address},
+        {symbols[3].binding, symbols[3].type, symbols[3].name,
+            symbols[3].address},
     };
     ASSERT_TRUE(checkTable(*symtab_new, {expected_symbols[0],
         expected_symbols[1], expected_symbols[2]}));
@@ -383,11 +432,16 @@ TEST(LoaderSymtabTest, Globals)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Global, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Weak, "symbol4", 0x40},
-        {loader::Symbol::Binding::Weak, "symbol5", 0x50}
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol5", 0x50}
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -414,11 +468,16 @@ TEST(LoaderSymtabTest, Locals)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Global, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Weak, "symbol4", 0x40},
-        {loader::Symbol::Binding::Weak, "symbol5", 0x50}
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol5", 0x50}
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -445,11 +504,16 @@ TEST(LoaderSymtabTest, Weaks)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Global, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Weak, "symbol4", 0x40},
-        {loader::Symbol::Binding::Weak, "symbol5", 0x50}
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol5", 0x50}
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -467,12 +531,50 @@ TEST(LoaderSymtabTest, Weaks)
     ASSERT_TRUE(checkTable(*symtab_new, {symbols[3], symbols[4]}));
 }
 
+/**
+ * Test the creation of a new filtered table containing only function symbols
+ * of the original table. Also verifies if the original table is kept the same.
+ */
+TEST(LoaderSymtabTest, FunctionSymbols)
+{
+    loader::SymbolTable symtab;
+
+    loader::Symbol symbols[] = {
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::NoType,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::File,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Function,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Object,
+            "symbol4", 0x40},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Function,
+            "symbol5", 0x50}
+    };
+    EXPECT_TRUE(symtab.insert(symbols[0]));
+    EXPECT_TRUE(symtab.insert(symbols[1]));
+    EXPECT_TRUE(symtab.insert(symbols[2]));
+    EXPECT_TRUE(symtab.insert(symbols[3]));
+    EXPECT_TRUE(symtab.insert(symbols[4]));
+
+    const auto symtab_new = symtab.functionSymbols();
+
+    // Check that the original table is not modified
+    ASSERT_TRUE(checkTable(symtab, {symbols[0], symbols[1], symbols[2],
+        symbols[3], symbols[4]}));
+
+    // Check that the new table only contains function symbols
+    ASSERT_TRUE(checkTable(*symtab_new, {symbols[2], symbols[4]}));
+}
+
 /** Test searching for a non-existent address. */
 TEST(LoaderSymtabTest, FindNonExistentAddress)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "symbol", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10};
     EXPECT_TRUE(symtab.insert(symbol));
 
     ASSERT_EQ(symtab.find(0x0), symtab.end());
@@ -484,9 +586,12 @@ TEST(LoaderSymtabTest, FindUniqueAddress)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -506,9 +611,12 @@ TEST(LoaderSymtabTest, FindNonUniqueAddress)
 
     const Addr addr = 0x20;
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", addr},
-        {loader::Symbol::Binding::Local, "symbol3", addr},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", addr},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", addr},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -524,7 +632,9 @@ TEST(LoaderSymtabTest, FindNonExistentName)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "symbol", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10};
     EXPECT_TRUE(symtab.insert(symbol));
 
     const auto it = symtab.find("symbol2");
@@ -537,9 +647,12 @@ TEST(LoaderSymtabTest, FindExistingName)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -556,8 +669,10 @@ TEST(LoaderSymtabTest, FindNearestExact)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -575,7 +690,9 @@ TEST(LoaderSymtabTest, FindNearestRound)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "symbol", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10};
     EXPECT_TRUE(symtab.insert(symbol));
 
     const auto it = symtab.findNearest(symbol.address + 0x1);
@@ -593,8 +710,10 @@ TEST(LoaderSymtabTest, FindNearestRoundWithNext)
     loader::SymbolTable symtab;
 
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -615,7 +734,9 @@ TEST(LoaderSymtabTest, FindNearestRoundWithNextNonExistent)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "symbol", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10};
     EXPECT_TRUE(symtab.insert(symbol));
 
     Addr next_addr;
@@ -633,7 +754,9 @@ TEST(LoaderSymtabTest, FindNearestNonExistent)
 {
     loader::SymbolTable symtab;
 
-    loader::Symbol symbol = {loader::Symbol::Binding::Local, "symbol", 0x10};
+    loader::Symbol symbol = \
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10};
     EXPECT_TRUE(symtab.insert(symbol));
 
     const auto it = symtab.findNearest(symbol.address - 0x1);
@@ -648,12 +771,17 @@ TEST(LoaderSymtabTest, InsertTableConflicting)
 {
     const std::string name = "symbol";
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, name, 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Local, "symbol4", 0x40},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            name, 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
         // Introduce name conflict
-        {loader::Symbol::Binding::Local, name, 0x50},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            name, 0x50},
     };
 
     // Populate table 1
@@ -682,11 +810,16 @@ TEST(LoaderSymtabTest, InsertTableConflicting)
 TEST(LoaderSymtabTest, InsertTable)
 {
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
-        {loader::Symbol::Binding::Local, "symbol4", 0x40},
-        {loader::Symbol::Binding::Local, "symbol5", 0x50},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol4", 0x40},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol5", 0x50},
     };
 
     // Populate table 1
@@ -719,9 +852,12 @@ TEST_F(LoaderSymtabSerializationFixture, Serialization)
     // Populate the table
     loader::SymbolTable symtab;
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     EXPECT_TRUE(symtab.insert(symbols[0]));
     EXPECT_TRUE(symtab.insert(symbols[1]));
@@ -735,22 +871,31 @@ TEST_F(LoaderSymtabSerializationFixture, Serialization)
     // Verify the output
     ASSERT_THAT(cp.str(), ::testing::StrEq("\n[Section1]\ntest.size=3\n"
         "test.addr_0=16\ntest.symbol_0=symbol\ntest.binding_0=1\n"
+        "test.type_0=5\n"
         "test.addr_1=32\ntest.symbol_1=symbol2\ntest.binding_1=1\n"
-        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n"));
+        "test.type_1=5\n"
+        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n"
+        "test.type_2=5\n"));
 }
 
 /** Test unserialization. */
 TEST_F(LoaderSymtabSerializationFixture, Unserialization)
 {
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Local, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     simulateSerialization("\n[Section1]\ntest.size=3\n"
         "test.addr_0=16\ntest.symbol_0=symbol\ntest.binding_0=1\n"
+        "test.type_0=5\n"
         "test.addr_1=32\ntest.symbol_1=symbol2\ntest.binding_1=1\n"
-        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n");
+        "test.type_1=5\n"
+        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n"
+        "test.type_2=5\n");
 
     loader::SymbolTable unserialized_symtab;
     CheckpointIn cp(getDirName());
@@ -771,14 +916,19 @@ TEST_F(LoaderSymtabSerializationFixture, Unserialization)
 TEST_F(LoaderSymtabSerializationFixture, UnserializationMissingBinding)
 {
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Global, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Global, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     simulateSerialization("\n[Section1]\ntest.size=3\n"
         "test.addr_0=16\ntest.symbol_0=symbol\ntest.binding_0=1\n"
-        "test.addr_1=32\ntest.symbol_1=symbol2\n"
-        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n");
+        "test.type_0=5\n"
+        "test.addr_1=32\ntest.symbol_1=symbol2\ntest.type_1=5\n"
+        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n"
+        "test.type_2=5\n");
 
     loader::SymbolTable unserialized_symtab;
     CheckpointIn cp(getDirName());
@@ -801,14 +951,20 @@ TEST_F(LoaderSymtabSerializationFixture,
     UnserializationMissingBindingChangeDefault)
 {
     loader::Symbol symbols[] = {
-        {loader::Symbol::Binding::Local, "symbol", 0x10},
-        {loader::Symbol::Binding::Weak, "symbol2", 0x20},
-        {loader::Symbol::Binding::Local, "symbol3", 0x30},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol", 0x10},
+        {loader::Symbol::Binding::Weak, loader::Symbol::SymbolType::Other,
+            "symbol2", 0x20},
+        {loader::Symbol::Binding::Local, loader::Symbol::SymbolType::Other,
+            "symbol3", 0x30},
     };
     simulateSerialization("\n[Section1]\ntest.size=3\n"
         "test.addr_0=16\ntest.symbol_0=symbol\ntest.binding_0=1\n"
+        "test.type_0=5\n"
         "test.addr_1=32\ntest.symbol_1=symbol2\n"
-        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n");
+        "test.type_1=5\n"
+        "test.addr_2=48\ntest.symbol_2=symbol3\ntest.binding_2=1\n"
+        "test.type_2=5\n");
 
     loader::SymbolTable unserialized_symtab;
     CheckpointIn cp(getDirName());

--- a/src/sim/pseudo_inst.cc
+++ b/src/sim/pseudo_inst.cc
@@ -244,9 +244,10 @@ loadsymbol(ThreadContext *tc)
             continue;
 
         if (!tc->getSystemPtr()->workload->insertSymbol(
-                    { loader::Symbol::Binding::Global, symbol, addr })) {
-            continue;
-        }
+            { loader::Symbol::Binding::Global,
+              loader::Symbol::SymbolType::Function, symbol, addr })) {
+                continue;
+              }
 
 
         DPRINTF(Loader, "Loaded symbol: %s @ %#llx\n", symbol, addr);
@@ -270,9 +271,13 @@ addsymbol(ThreadContext *tc, Addr addr, Addr symbolAddr)
     DPRINTF(Loader, "Loaded symbol: %s @ %#llx\n", symbol, addr);
 
     tc->getSystemPtr()->workload->insertSymbol(
-            { loader::Symbol::Binding::Global, symbol, addr });
+        { loader::Symbol::Binding::Global,
+          loader::Symbol::SymbolType::Function, symbol, addr }
+    );
     loader::debugSymbolTable.insert(
-            { loader::Symbol::Binding::Global, symbol, addr });
+        { loader::Symbol::Binding::Global,
+          loader::Symbol::SymbolType::Function, symbol, addr }
+    );
 }
 
 uint64_t


### PR DESCRIPTION
Symbol type is part of the info provided by an ELF object's symtab.
It indicates whether a symbol is a file symbol, or a function symbol, etc.

This chain of commits introduces a way to only load function symbols
to the gem5's symbol table. The RISC-V BootloaderKernelWorkload now
loads only function symbols from the bootloader and the kernel binaries
by default.