### PR TITLE
gpu-compute: Fix for failing assertion in GPUCoalescer

### DIFF
--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -599,6 +599,8 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                 // data response is not needed.
                 case RubyRequestType_ATOMIC_NO_RETURN:
                     assert(pkt->isAtomicOp());
+                    data.popAtomicLogEntryFront();
+                    break;
                 case RubyRequestType_ST:
                     data.setData(pkt->getPtr<uint8_t>(), offset, pkt_size);
                     break;

--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -599,7 +599,8 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                 // data response is not needed.
                 case RubyRequestType_ATOMIC_NO_RETURN:
                     assert(pkt->isAtomicOp());
-                    data.popAtomicLogEntryFront();
+                    log = data.popAtomicLogEntryFront();
+                    delete [] log;
                     data.setData(pkt->getPtr<uint8_t>(), offset, pkt_size);
                     break;
                 case RubyRequestType_ST:

--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -600,6 +600,7 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                 case RubyRequestType_ATOMIC_NO_RETURN:
                     assert(pkt->isAtomicOp());
                     data.popAtomicLogEntryFront();
+                    data.setData(pkt->getPtr<uint8_t>(), offset, pkt_size);
                     break;
                 case RubyRequestType_ST:
                     data.setData(pkt->getPtr<uint8_t>(), offset, pkt_size);


### PR DESCRIPTION
Commit #200 introduces colaesced atomics to same addr from within a WF; atomicLog was part of it to record the changes on datablock sequentially; However, for non-returning atomics, this log isn't cleared, which manifests as a failing assertion.

Fixes issue #508, adds to PR #397 

Change-Id: Ib2aa470120163552488c3e69913d87b70b293c6e