### PR TITLE
python: Handle unicode characters in config files

### DIFF
--- a/src/python/m5/main.py
+++ b/src/python/m5/main.py
@@ -632,7 +632,9 @@ def main():
             if not options.P:
                 sys.path = [os.path.dirname(sys.argv[0])] + sys.path
             filename = sys.argv[0]
-            filedata = open(filename).read()
+            with open(filename, "rb") as fd:
+                # Handle config files with unicode characters
+                filedata = fd.read().decode("utf-8")
             filecode = compile(filedata, filename, "exec")
             scope = {"__file__": filename, "__name__": "__m5_main__"}
 


### PR DESCRIPTION
Previously, opening a config file (such as `configs/example/hmc_hello.py`) containing non-ASCII characters causes UnicodeDecodeError.
Also switch to use more an more idiomatic context manager for handling files.

Change-Id: Ia39cbe2c420e9c94f3a84af459b7e5f4d9718d14