### PR TITLE
configs,ext,stdlib: Update DRAMSys integration

### DIFF
--- a/configs/example/dramsys.py
+++ b/configs/example/dramsys.py
@@ -37,9 +37,8 @@ system.mem_mode = "timing"
 system.cpu = traffic_gen
 
 dramsys = DRAMSys(
-    configuration="ext/dramsys/DRAMSys/DRAMSys/"
-    "library/resources/simulations/ddr4-example.json",
-    resource_directory="ext/dramsys/DRAMSys/DRAMSys/library/resources",
+    configuration="ext/dramsys/DRAMSys/configs/ddr4-example.json",
+    resource_directory="ext/dramsys/DRAMSys/configs",
 )
 
 system.target = dramsys

--- a/configs/example/gem5_library/dramsys/dramsys-traffic.py
+++ b/configs/example/gem5_library/dramsys/dramsys-traffic.py
@@ -31,16 +31,14 @@ DRAMSys simulator.
 DRRAMSys simulator. Please consult 'ext/dramsys/README' on how to compile
 correctly. If this is not done correctly this script will run with error.
 """
-import m5
-from gem5.components.memory import DRAMSysMem
+
+from gem5.components.memory.dramsys import DRAMSysMem
 from gem5.components.boards.test_board import TestBoard
 from gem5.components.processors.linear_generator import LinearGenerator
-from m5.objects import Root
+from gem5.simulate.simulator import Simulator
 
 memory = DRAMSysMem(
-    configuration="ext/dramsys/DRAMSys/DRAMSys/"
-    "library/resources/simulations/ddr4-example.json",
-    resource_directory="ext/dramsys/DRAMSys/DRAMSys/library/resources",
+    configuration="ext/dramsys/DRAMSys/configs/ddr4-example.json",
     recordable=True,
     size="4GB",
 )
@@ -51,12 +49,16 @@ generator = LinearGenerator(
     num_cores=1,
     max_addr=memory.get_size(),
 )
+
 board = TestBoard(
     clk_freq="3GHz", generator=generator, memory=memory, cache_hierarchy=None
 )
 
-root = Root(full_system=False, system=board)
-board._pre_instantiate()
-m5.instantiate()
-generator.start_traffic()
-exit_event = m5.simulate()
+simulator = Simulator(board=board)
+simulator.run()
+
+print(
+    "Exiting @ tick {} because {}.".format(
+        simulator.get_current_tick(), simulator.get_last_exit_event_cause()
+    )
+)

--- a/ext/dramsys/CMakeLists.txt
+++ b/ext/dramsys/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Fraunhofer IESE
+# Copyright (c) 2023 Fraunhofer IESE
 # All rights reserved
 #
 # Redistribution and use in source and binary forms, with or without
@@ -24,55 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import subprocess
+cmake_minimum_required(VERSION 3.22.0)
+project(DRAMSys)
 
-Import("env")
+set(BUILD_SHARED_LIBS OFF)
 
-build_root = Dir("../..").abspath
-build_current = Dir(".").abspath
-src_root = Dir(".").srcnode().abspath
-scons_root = Dir("#").abspath
+add_library(systemc INTERFACE)
 
-# See if we got a cloned DRAMSys repo as a subdirectory and set the
-# HAVE_DRAMSys flag accordingly
-if not os.path.exists(Dir(".").srcnode().abspath + "/DRAMSys"):
-    env["HAVE_DRAMSYS"] = False
-    Return()
+target_include_directories(systemc INTERFACE "${SCONS_SOURCE_DIR}/src/systemc/ext/systemc_home/include")
 
-env["HAVE_DRAMSYS"] = True
+add_library(SystemC::systemc ALIAS systemc)
 
-subprocess.run(
-    [
-        "cmake",
-        f"-S{src_root}",
-        f"-B{build_current}",
-        "-DCMAKE_BUILD_TYPE=Release",
-        f"-DSCONS_SOURCE_DIR:STRING={scons_root}",
-        "-DDRAMSYS_BUILD_CLI=OFF"
-    ],
-    check=True
-)
-
-subprocess.run(
-    ["cmake", "--build", build_current],
-    check=True
-)
-
-env.Append(LIBS="DRAMSys_libdramsys")
-env.Append(LIBPATH=Dir("./DRAMSys/src/libdramsys").abspath)
-
-env.Append(LIBS="DRAMSys_Configuration")
-env.Append(LIBPATH=Dir("./DRAMSys/src/configuration").abspath)
-
-env.Append(LIBS="sqlite3")
-env.Append(LIBPATH=Dir("./DRAMSys/lib/sqlite3").abspath)
-
-env.Append(CPPPATH=src_root + "/DRAMSys/src/libdramsys")
-env.Append(CPPPATH=src_root + "/DRAMSys/src/configuration")
-env.Append(CPPPATH=src_root + "/DRAMSys/src/util")
-env.Append(CPPPATH=src_root + "/DRAMSys/lib/nlohmann_json/include")
-
-env.Prepend(CPPDEFINES=[("SYSTEMC_VERSION", 20191203)])
-env.Prepend(CPPDEFINES=[("DRAMSYS_RESOURCE_DIR",
-                         '\\"' + os.getcwd() + '/DRAMSys/configs' + '\\"')])
+add_subdirectory(DRAMSys)

--- a/ext/dramsys/README
+++ b/ext/dramsys/README
@@ -1,11 +1,13 @@
-Follow these steps to get DRAMSys as part of gem5
+Follow these steps to build DRAMSys as part of gem5
 
 1. Go to ext/dramsys (this directory)
-2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys DRAMSys'
-3. Change directory to DRAMSys: 'cd DRAMSys'
-4. Checkout the correct commit: 'git checkout -b gem5 09f6dcbb91351e6ee7cadfc7bc8b29d97625db8f'
-5. Recursively obtain the submodules: 'git submodule update --init --recursive'
+2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys --branch v5.0 --depth 1 DRAMSys'
+
+The latest verified working version is v5.0, but later versions might work too.
+gem5 will automatically pick up DRAMSys as an external module when it is rebuilt.
 
 If you wish to run a simulation using the gem5 processor cores, make sure to enable the storage mode in DRAMSys.
 This is done by setting the value of the "StoreMode" key to "Store" in the base configuration file.
 Those configuration file can be found in 'DRAMSys/library/resources/configs/simulator'.
+
+Currently, DRAMSys is only supported in conjunction with a cache. Running DRAMSys in Release mode without caches will silently fail!

--- a/src/mem/SConscript
+++ b/src/mem/SConscript
@@ -127,6 +127,7 @@ if env['HAVE_DRAMSIM3']:
 if env['HAVE_DRAMSYS']:
     SimObject('DRAMSys.py', sim_objects=['DRAMSys'])
     Source('dramsys_wrapper.cc')
+    Source('dramsys.cc')
 
 SimObject('MemChecker.py', sim_objects=['MemChecker', 'MemCheckerMonitor'])
 Source('mem_checker.cc')

--- a/src/mem/dramsys.cc
+++ b/src/mem/dramsys.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023 Fraunhofer IESE
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dramsys.hh"
+
+namespace gem5
+{
+
+namespace memory
+{
+
+DRAMSys::DRAMSys(Params const& params) :
+    AbstractMemory(params),
+    tlmWrapper(dramSysWrapper.tSocket, params.name + ".tlm", InvalidPortID),
+    config(::DRAMSys::Config::from_path(params.configuration,
+                                        params.resource_directory)),
+    dramSysWrapper(
+        params.name.c_str(), config, params.recordable, params.range)
+{
+    dramSysWrapper.dramsys->registerIdleCallback(
+        [this]
+        {
+            if (dramSysWrapper.dramsys->idle())
+            {
+                signalDrainDone();
+            }
+        });
+}
+
+gem5::Port& DRAMSys::getPort(const std::string& if_name, PortID idx)
+{
+    if (if_name != "tlm")
+    {
+        return AbstractMemory::getPort(if_name, idx);
+    }
+
+    return tlmWrapper;
+}
+
+DrainState DRAMSys::drain()
+{
+    return dramSysWrapper.dramsys->idle() ? DrainState::Drained
+                                          : DrainState::Draining;
+}
+
+void DRAMSys::serialize(CheckpointOut& cp) const
+{
+    std::filesystem::path checkpointPath = CheckpointIn::dir();
+
+    auto topLevelObjects = sc_core::sc_get_top_level_objects();
+    for (auto const* object : topLevelObjects)
+    {
+        std::function<void(sc_core::sc_object const*)> serialize;
+        serialize =
+            [&serialize, &checkpointPath](sc_core::sc_object const* object)
+        {
+            auto const* serializableObject =
+                dynamic_cast<::DRAMSys::Serialize const*>(object);
+
+            if (serializableObject != nullptr)
+            {
+                std::string dumpFileName(object->name());
+                dumpFileName += ".pmem";
+                std::ofstream stream(checkpointPath / dumpFileName,
+                                     std::ios::binary);
+                serializableObject->serialize(stream);
+            }
+
+            for (auto const* childObject : object->get_child_objects())
+            {
+                serialize(childObject);
+            }
+        };
+
+        serialize(object);
+    }
+}
+
+void DRAMSys::unserialize(CheckpointIn& cp)
+{
+    std::filesystem::path checkpointPath = CheckpointIn::dir();
+
+    auto topLevelObjects = sc_core::sc_get_top_level_objects();
+    for (auto* object : topLevelObjects)
+    {
+        std::function<void(sc_core::sc_object*)> deserialize;
+        deserialize =
+            [&deserialize, &checkpointPath](sc_core::sc_object* object)
+        {
+            auto* deserializableObject =
+                dynamic_cast<::DRAMSys::Deserialize*>(object);
+
+            if (deserializableObject != nullptr)
+            {
+                std::string dumpFileName(object->name());
+                dumpFileName += ".pmem";
+                std::ifstream stream(checkpointPath / dumpFileName,
+                                     std::ios::binary);
+                deserializableObject->deserialize(stream);
+            }
+
+            for (auto* childObject : object->get_child_objects())
+            {
+                deserialize(childObject);
+            }
+        };
+
+        deserialize(object);
+    }
+}
+
+} // namespace memory
+} // namespace gem5

--- a/src/mem/dramsys.hh
+++ b/src/mem/dramsys.hh
@@ -29,7 +29,7 @@
 #ifndef __MEM_DRAMSYS_H__
 #define __MEM_DRAMSYS_H__
 
-#include "DRAMSysConfiguration.h"
+#include "DRAMSys/config/DRAMSysConfiguration.h"
 #include "mem/abstract_mem.hh"
 #include "mem/dramsys_wrapper.hh"
 #include "params/DRAMSys.hh"
@@ -43,36 +43,20 @@ namespace memory
 class DRAMSys : public AbstractMemory
 {
     PARAMS(DRAMSys);
-    sc_gem5::TlmTargetWrapper<32> tlmWrapper;
+    sc_gem5::TlmTargetWrapper<> tlmWrapper;
 
   public:
-    DRAMSys(Params const &params)
-        : AbstractMemory(params),
-          tlmWrapper(dramSysWrapper.tSocket,
-              params.name + ".tlm",
-              InvalidPortID),
-          config(DRAMSysConfiguration::from_path(
-              params.configuration,
-              params.resource_directory)),
-          dramSysWrapper(params.name.c_str(),
-            config,
-            params.recordable,
-            params.range)
-    {
-    }
+    DRAMSys(Params const& params);
 
-    gem5::Port &getPort(const std::string &if_name, PortID idx) override
-    {
-        if (if_name != "tlm")
-        {
-            return AbstractMemory::getPort(if_name, idx);
-        }
+    gem5::Port& getPort(const std::string& if_name, PortID idx) override;
 
-        return tlmWrapper;
-    }
+    DrainState drain() override;
+
+    void serialize(CheckpointOut& cp) const override;
+    void unserialize(CheckpointIn& cp) override;
 
   private:
-    DRAMSysConfiguration::Configuration config;
+    ::DRAMSys::Config::Configuration config;
     DRAMSysWrapper dramSysWrapper;
 };
 

--- a/src/mem/dramsys_wrapper.hh
+++ b/src/mem/dramsys_wrapper.hh
@@ -32,13 +32,14 @@
 #include <iostream>
 #include <memory>
 
-#include "DRAMSysConfiguration.h"
+#include "DRAMSys/config/DRAMSysConfiguration.h"
+#include "DRAMSys/simulation/DRAMSysRecordable.h"
 #include "mem/abstract_mem.hh"
 #include "params/DRAMSys.hh"
 #include "sim/core.hh"
-#include "simulation/DRAMSysRecordable.h"
 #include "systemc/core/kernel.hh"
 #include "systemc/ext/core/sc_module_name.hh"
+
 #include "systemc/ext/systemc"
 #include "systemc/ext/tlm"
 #include "systemc/ext/tlm_utils/simple_target_socket.h"
@@ -57,14 +58,14 @@ class DRAMSysWrapper : public sc_core::sc_module
   public:
     SC_HAS_PROCESS(DRAMSysWrapper);
     DRAMSysWrapper(sc_core::sc_module_name name,
-                   DRAMSysConfiguration::Configuration const &config,
+                   ::DRAMSys::Config::Configuration const &config,
                    bool recordable,
                    AddrRange range);
 
   private:
-    static std::shared_ptr<::DRAMSys>
+    static std::shared_ptr<::DRAMSys::DRAMSys>
     instantiateDRAMSys(bool recordable,
-        DRAMSysConfiguration::Configuration const &config);
+        ::DRAMSys::Config::Configuration const &config);
 
     tlm::tlm_sync_enum nb_transport_fw(tlm::tlm_generic_payload &payload,
                                        tlm::tlm_phase &phase,
@@ -74,12 +75,15 @@ class DRAMSysWrapper : public sc_core::sc_module
                                        tlm::tlm_phase &phase,
                                        sc_core::sc_time &bwDelay);
 
+    void b_transport(tlm::tlm_generic_payload &payload,
+                     sc_core::sc_time &delay);
+
     unsigned int transport_dbg(tlm::tlm_generic_payload &trans);
 
     tlm_utils::simple_initiator_socket<DRAMSysWrapper> iSocket;
     tlm_utils::simple_target_socket<DRAMSysWrapper> tSocket;
 
-    std::shared_ptr<::DRAMSys> dramsys;
+    std::shared_ptr<::DRAMSys::DRAMSys> dramsys;
 
     AddrRange range;
 };

--- a/src/python/gem5/components/memory/dramsys.py
+++ b/src/python/gem5/components/memory/dramsys.py
@@ -24,7 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import m5
+from typing import Tuple, Sequence, List, Optional
+from pathlib import Path
 
 from m5.objects import (
     DRAMSys,
@@ -40,27 +41,46 @@ from ...utils.override import overrides
 from ..boards.abstract_board import AbstractBoard
 from .abstract_memory_system import AbstractMemorySystem
 
-from typing import Tuple, Sequence, List
+
+DEFAULT_DRAMSYS_DIRECTORY = Path("ext/dramsys/DRAMSys")
 
 
 class DRAMSysMem(AbstractMemorySystem):
+    """
+    A DRAMSys memory controller.
+
+    This class requires gem5 to be built with DRAMSys (see ext/dramsys).
+    The specified memory size does not control the simulated memory size but it's sole purpose is
+    to notify gem5 of DRAMSys's memory size.
+    Therefore it has to match the DRAMSys configuration.
+    DRAMSys is configured using JSON files, whose base configuration has to be passed as a
+    parameter. Sub-configs are specified relative to the optional resource directory parameter.
+    """
+
     def __init__(
         self,
         configuration: str,
         size: str,
-        resource_directory: str,
         recordable: bool,
+        resource_directory: Optional[str] = None,
     ) -> None:
         """
         :param configuration: Path to the base configuration JSON for DRAMSys.
         :param size: Memory size of DRAMSys. Must match the size specified in JSON configuration.
-        :param resource_directory: Path to the base resource directory for DRAMSys.
         :param recordable: Whether the database recording feature of DRAMSys is enabled.
+        :param resource_directory: Path to the base resource directory for DRAMSys.
         """
         super().__init__()
+
+        resource_directory_path = (
+            DEFAULT_DRAMSYS_DIRECTORY / "configs"
+            if resource_directory is None
+            else Path(resource_directory)
+        )
+
         self.dramsys = DRAMSys(
             configuration=configuration,
-            resource_directory=resource_directory,
+            resource_directory=resource_directory_path.as_posix(),
             recordable=recordable,
         )
 
@@ -97,56 +117,72 @@ class DRAMSysMem(AbstractMemorySystem):
 
 
 class DRAMSysDDR4_1866(DRAMSysMem):
+    """
+    An example DDR4 1866 DRAMSys configuration.
+    """
+
     def __init__(self, recordable: bool):
         """
         :param recordable: Whether the database recording feature of DRAMSys is enabled.
         """
         super().__init__(
-            configuration="ext/dramsys/DRAMSys/DRAMSys/"
-            "library/resources/simulations/ddr4-example.json",
+            configuration=(
+                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr4-example.json"
+            ).as_posix(),
             size="4GB",
-            resource_directory="ext/dramsys/DRAMSys/DRAMSys/library/resources",
             recordable=recordable,
         )
 
 
 class DRAMSysDDR3_1600(DRAMSysMem):
+    """
+    An example DDR3 1600 DRAMSys configuration.
+    """
+
     def __init__(self, recordable: bool):
         """
         :param recordable: Whether the database recording feature of DRAMSys is enabled.
         """
         super().__init__(
-            configuration="ext/dramsys/DRAMSys/DRAMSys/"
-            "library/resources/simulations/ddr3-gem5-se.json",
-            size="4GB",
-            resource_directory="ext/dramsys/DRAMSys/DRAMSys/library/resources",
+            configuration=(
+                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr3-gem5-se.json"
+            ).as_posix(),
+            size="1GB",
             recordable=recordable,
         )
 
 
 class DRAMSysLPDDR4_3200(DRAMSysMem):
+    """
+    An example LPDDR4 3200 DRAMSys configuration.
+    """
+
     def __init__(self, recordable: bool):
         """
         :param recordable: Whether the database recording feature of DRAMSys is enabled.
         """
         super().__init__(
-            configuration="ext/dramsys/DRAMSys/DRAMSys/"
-            "library/resources/simulations/lpddr4-example.json",
-            size="4GB",
-            resource_directory="ext/dramsys/DRAMSys/DRAMSys/library/resources",
+            configuration=(
+                DEFAULT_DRAMSYS_DIRECTORY / "configs/lpddr4-example.json"
+            ).as_posix(),
+            size="1GB",
             recordable=recordable,
         )
 
 
 class DRAMSysHBM2(DRAMSysMem):
+    """
+    An example HBM2 DRAMSys configuration.
+    """
+
     def __init__(self, recordable: bool):
         """
         :param recordable: Whether the database recording feature of DRAMSys is enabled.
         """
         super().__init__(
-            configuration="ext/dramsys/DRAMSys/DRAMSys/"
-            "library/resources/simulations/hbm2-example.json",
-            size="4GB",
-            resource_directory="ext/dramsys/DRAMSys/DRAMSys/library/resources",
+            configuration=(
+                DEFAULT_DRAMSYS_DIRECTORY / "configs/hbm2-example.json"
+            ).as_posix(),
+            size="1GB",
             recordable=recordable,
         )


### PR DESCRIPTION
Recent breaking changes in the DRAMSys API require user code to be
updated. These updates have been applied to the gem5 integration.

Furthermore, as DRAMSys started to use CMake dependency management,
it is no longer sensible to maintain two separate build systems for
DRAMSys. The use of the DRAMSys integration in gem5 will therefore
from now on require that CMake is installed on the target machine.

Additionally, support for snapshots have been implemented into DRAMSys
and coupled with gem5's checkpointing API.


Open TODOs:
- [ ] Currently the CMAKE_BUILD_TYPE is hardcoded to Release. Ideally it should be changed to Debug or RelWithDebInfo depending on the set scons build type. Is there a way to get the current build type from Python?