### PR TITLE
gpu-compute: Fix typo with GPUTLB print

### DIFF
--- a/src/arch/amdgpu/common/tlb_coalescer.cc
+++ b/src/arch/amdgpu/common/tlb_coalescer.cc
@@ -482,7 +482,7 @@ TLBCoalescer::processProbeTLBEvent()
                     stats.localqueuingCycles += (curTick() * pkt_cnt);
                 }
 
-                DPRINTF(GPUTLB, "Successfully sent TLB request for page %#x",
+                DPRINTF(GPUTLB, "Successfully sent TLB request for page %#x\n",
                        virt_page_addr);
 
                 //copy coalescedReq to issuedTranslationsTable

--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012-2015 Advanced Micro Devices, Inc.
+ * Copyright (c) 2023 Matthew D. Sinclair
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -297,6 +298,10 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     }
   }
 
+  action(mru_updateMRU, "mru", desc="Touch block for replacement policy") {
+    L1cache.setMRU(address);
+  }
+
   // added for profiling
   action(uu_profileDataMiss, "\udm", desc="Profile SQC demand miss"){
     L1cache.profileDemandMiss();
@@ -332,6 +337,7 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
   // simple hit transitions
   transition(V, Fetch) {TagArrayRead, DataArrayRead} {
     l_loadDoneHit;
+    mru_updateMRU;
     uu_profileDataHit; // line was in SQC, so we hit
     p_popMandatoryQueue;
   }


### PR DESCRIPTION
Print was not properly ending in a newline, which caused confusion when looking a trace with GPUTLB enabled.  This fixes that.