### PR TITLE
mem-ruby, gpu-compute: update GPU L1I$ MRU info

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012-2015 Advanced Micro Devices, Inc.
+ * Copyright (c) 2023 Matthew D. Sinclair
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -297,6 +298,10 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     }
   }
 
+  action(mru_updateMRU, "mru", desc="Touch block for replacement policy") {
+    L1cache.setMRU(address);
+  }
+
   // added for profiling
   action(uu_profileDataMiss, "\udm", desc="Profile SQC demand miss"){
     L1cache.profileDemandMiss();
@@ -332,6 +337,7 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
   // simple hit transitions
   transition(V, Fetch) {TagArrayRead, DataArrayRead} {
     l_loadDoneHit;
+    mru_updateMRU;
     uu_profileDataHit; // line was in SQC, so we hit
     p_popMandatoryQueue;
   }


### PR DESCRIPTION
Previously the GPU L1 I$ (SQC) was not updating the MRU information on hits in the SQC.  This commit resolves that by adding support to the appropriate Ruby transition.