### PR TITLE
gpu-compute: Fix typo with GPUTLB print

### DIFF
--- a/src/arch/amdgpu/common/tlb_coalescer.cc
+++ b/src/arch/amdgpu/common/tlb_coalescer.cc
@@ -482,7 +482,7 @@ TLBCoalescer::processProbeTLBEvent()
                     stats.localqueuingCycles += (curTick() * pkt_cnt);
                 }
 
-                DPRINTF(GPUTLB, "Successfully sent TLB request for page %#x",
+                DPRINTF(GPUTLB, "Successfully sent TLB request for page %#x\n",
                        virt_page_addr);
 
                 //copy coalescedReq to issuedTranslationsTable


### PR DESCRIPTION
gpu-compute: Fix typo with GPUTLB print

Print was not properly ending in a newline, which caused confusion when looking a trace with GPUTLB enabled. This fixes that.

Change-Id: I1e0d93e2f555bfbeb7c02b281bdce4ffe5398e31