### PR TITLE
sim,python: Restore sigint handler in python

### DIFF
--- a/src/sim/init_signals.hh
+++ b/src/sim/init_signals.hh
@@ -38,6 +38,10 @@ void exitNowHandler(int sigtype);
 void abortHandler(int sigtype);
 void initSignals();
 
+// separate out sigint handler so that we can restore the python one
+void initSigInt();
+void restoreSigInt();
+
 } // namespace gem5
 
 #endif // __SIM_INIT_SIGNALS_HH__

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -50,6 +50,7 @@
 #include "base/types.hh"
 #include "sim/async.hh"
 #include "sim/eventq.hh"
+#include "sim/init_signals.hh"
 #include "sim/sim_events.hh"
 #include "sim/sim_exit.hh"
 #include "sim/stat_control.hh"
@@ -187,6 +188,10 @@ GlobalSimLoopExitEvent *global_exit_event= nullptr;
 GlobalSimLoopExitEvent *
 simulate(Tick num_cycles)
 {
+    // install the sigint handler to catch ctrl-c and exit the sim loop cleanly
+    // Note: This should be done before initializing the threads
+    initSigInt();
+
     if (global_exit_event)//cleaning last global exit event
         global_exit_event->clean();
     std::unique_ptr<GlobalSyncEvent, DescheduleDeleter> quantum_event;
@@ -228,6 +233,9 @@ simulate(Tick num_cycles)
     simulatorThreads->runUntilLocalExit();
     Event *local_event = doSimLoop(mainEventQueue[0]);
     assert(local_event);
+
+    // Restore normal ctrl-c operation as soon as the event queue is done
+    restoreSigInt();
 
     inParallelMode = false;
 


### PR DESCRIPTION
Currently, if you try to use ctrl-c while python code is running nothing
happens. This is not ideal. This change enables users to use ctrl-c
while python is running (e.g., when a large disk image is downloading).
To do this, we moved the `initSignals` function in gem5 from `main` to
the simulate loop. Thus, every time the simulate loop starts (i.e., is
called from python) gem5 will install its signal handlers. Also, when
the control is returned to python, we put python's default SIGINT
handler back.

Change-Id: I14490e48d931eb316e8c641217bf8d8ddaa340ed
Signed-off-by: Jason Lowe-Power <jason@lowepower.com>