### PR TITLE
stdlib, resources: Update JSON data in workload

### DIFF
--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -964,10 +964,22 @@ def obtain_resource(
             for key in resource_json["resources"].keys():
                 assert isinstance(key, str)
                 value = resource_json["resources"][key]
-                assert isinstance(value, str)
-                params[key] = obtain_resource(
-                    value,
-                )
+
+                if isinstance(value, str):
+                    warn(
+                        "Deprecation warning: resources field in workloads has changed"
+                        "from { category: id } to"
+                        "{ category: { id: id, resource_version: resource_version } }"
+                        "Please update your resource.json file to reflect this change."
+                    )
+                    params[key] = obtain_resource(
+                        value,
+                    )
+                elif isinstance(value, dict):
+                    params[key] = obtain_resource(
+                        value["id"],
+                        resource_version=value["resource_version"],
+                    )
         if "additional_params" in resource_json:
             for key in resource_json["additional_params"].keys():
                 assert isinstance(key, str)

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -970,7 +970,8 @@ def obtain_resource(
                         "Deprecation warning: resources field in workloads has changed"
                         "from { category: id } to"
                         "{ category: { id: id, resource_version: resource_version } }"
-                        "Please update your resource.json file to reflect this change."
+                        "The current develop branch of gem5 supports both formats"
+                        "but this will be removed in the 23.1 release."
                     )
                     params[key] = obtain_resource(
                         value,


### PR DESCRIPTION
- resources field in workload now supports a dict with resources id and version.

- Older workload JSON are still supported but added a deprecation waring

Change-Id: I137dbb99799a5294e84ce7d5d914f05e4cfe9e00