### PR TITLE
Fix calculation of compressed size in bytes

### DIFF
--- a/src/mem/cache/compressors/base.cc
+++ b/src/mem/cache/compressors/base.cc
@@ -78,7 +78,7 @@ Base::CompressionData::getSizeBits() const
 std::size_t
 Base::CompressionData::getSize() const
 {
-    return std::ceil(_size/8);
+    return std::ceil(_size/(float)CHAR_BIT);
 }
 
 Base::Base(const Params &p)


### PR DESCRIPTION
An integer division in the compression:Base:getSize() was being done, which led to rounding down instead of up.