### PR TITLE
 mem-ruby, gpu-compute: fix typo in GPU coalescer deadlock print 

### DIFF
--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -344,7 +344,8 @@ GPUCoalescer::printRequestTable(std::stringstream& ss)
                << "\t\tIssue time: "
                << request->getIssueTime() * clockPeriod() << "\n"
                << "\t\tDifference from current tick: "
-               << (curCycle() - request->getIssueTime()) * clockPeriod();
+               << (curCycle() - request->getIssueTime()) * clockPeriod()
+               << "\n";
         }
     }
 


### PR DESCRIPTION
mem-ruby, gpu-compute: fix typo in GPU coalescer deadlock print 
 
The GPU Coalescer's deadlock print did not previously print a newline at the end of each deadlock, which caused confusion when there were multiple deadlocks as each deadlock print would appear to go with the address after it.  This patch fixes this issue.

Change-Id: Ic49a10e7cca3c9bb7cb247c4fea2f704588c68d0