### PR TITLE
mem-ruby, gpu-compute: fix formatting of TCC

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -258,8 +258,7 @@ machine(MachineType:TCC, "TCC Cache")
   // request queue going to NB
   //
 
-
-// ** IN_PORTS **
+  // ** IN_PORTS **
   in_port(triggerQueue_in, TriggerMsg, triggerQueue) {
     if (triggerQueue_in.isReady(clockEdge())) {
       peek(triggerQueue_in, TriggerMsg) {
@@ -283,8 +282,7 @@ machine(MachineType:TCC, "TCC Cache")
     }
   }
 
-
-
+  // handle responses from directory here
   in_port(responseFromNB_in, ResponseMsg, responseFromNB) {
     if (responseFromNB_in.isReady(clockEdge())) {
       peek(responseFromNB_in, ResponseMsg, block_on="addr") {
@@ -876,9 +874,9 @@ machine(MachineType:TCC, "TCC Cache")
     p_popRequestQueue;
   }
 
-// Transition to be called when a read request with SLC flag set arrives at
-// entry in state W. It evicts and invalidates the cache entry before
-// forwarding the request to global memory
+  // Transition to be called when a read request with SLC flag set arrives at
+  // entry in state W. It evicts and invalidates the cache entry before
+  // forwarding the request to global memory
   transition(W, RdBypassEvict, WIB) {TagArrayRead} {
     p_profileMiss;
     t_allocateTBE;
@@ -888,9 +886,9 @@ machine(MachineType:TCC, "TCC Cache")
     p_popRequestQueue;
   }
 
-// Transition to be called when a read request with SLC flag set arrives at
-// entry in state M. It evicts and invalidates the cache entry before
-// forwarding the request to global memory to main memory
+  // Transition to be called when a read request with SLC flag set arrives at
+  // entry in state M. It evicts and invalidates the cache entry before
+  // forwarding the request to global memory to main memory
   transition(M, RdBypassEvict, WIB) {TagArrayRead} {
     p_profileMiss;
     t_allocateTBE;
@@ -900,9 +898,9 @@ machine(MachineType:TCC, "TCC Cache")
     p_popRequestQueue;
   }
 
-// Transition to be called when a read request with SLC flag set arrives at
-// entry in state V. It invalidates the cache entry before forwarding the
-// request to global memory.
+  // Transition to be called when a read request with SLC flag set arrives at
+  // entry in state V. It invalidates the cache entry before forwarding the
+  // request to global memory.
   transition(V, RdBypassEvict, I) {TagArrayRead} {
     p_profileMiss;
     t_allocateTBE;
@@ -911,8 +909,8 @@ machine(MachineType:TCC, "TCC Cache")
     p_popRequestQueue;
   }
 
-// Transition to be called when a read request with SLC flag arrives at entry
-// in transient state. The request stalls until the pending transition is complete.
+  // Transition to be called when a read request with SLC flag arrives at entry
+  // in transient state. The request stalls until the pending transition is complete.
   transition({WI, WIB, IV}, RdBypassEvict)  {
     st_stallAndWaitRequest;
   }
@@ -955,7 +953,6 @@ machine(MachineType:TCC, "TCC Cache")
   // The following atomic pass on actions will send the request to the directory,
   // and are triggered when an atomic request is received that is not in TCC,
   // and/or if SLC is set.
-
   transition(V, AtomicPassOn, A) {TagArrayRead} {
     p_profileHit;
     i_invL2;
@@ -1032,9 +1029,9 @@ machine(MachineType:TCC, "TCC Cache")
     p_popRequestQueue;
   }
 
-// Transition to be called when a write request with SLC bit set arrives at an
-// entry with state V. The entry has to be evicted and invalidated before the
-// request is forwarded to global memory
+  // Transition to be called when a write request with SLC bit set arrives at an
+  // entry with state V. The entry has to be evicted and invalidated before the
+  // request is forwarded to global memory
   transition(V, WrVicBlkEvict, I) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     p_profileMiss;
     ut_updateTag;
@@ -1044,9 +1041,9 @@ machine(MachineType:TCC, "TCC Cache")
     p_popRequestQueue;
   }
 
-// Transition to be called when a write request with SLC bit set arrives at an
-// entry with state W. The entry has to be evicted and invalidated before the
-// request is forwarded to global memory.
+  // Transition to be called when a write request with SLC bit set arrives at an
+  // entry with state W. The entry has to be evicted and invalidated before the
+  // request is forwarded to global memory.
   transition(W, WrVicBlkEvict, I) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     p_profileMiss;
     ut_updateTag;
@@ -1091,9 +1088,9 @@ machine(MachineType:TCC, "TCC Cache")
     pp_popProbeQueue;
   }
 
-// Transition to be called when the response for a request with SLC bit set
-// arrives. The request has to be forwarded to the core that needs it while
-// making sure no entry is allocated.
+  // Transition to be called when the response for a request with SLC bit set
+  // arrives. The request has to be forwarded to the core that needs it while
+  // making sure no entry is allocated.
   transition(I, Bypass, I) {
     rb_bypassDone;
     pr_popResponseQueue;


### PR DESCRIPTION
mem-ruby, gpu-compute: fix formatting of TCC

Fix several not properly indented prints and extraneous extra lines in the SLICC code for the GPU TCC (L2 cache).

Change-Id: I6ef84960e7054ae4f91ae50df701dec7c74de8db
