### PR TITLE
mem-ruby: update RubyRequest print to include GPU fields

### DIFF
--- a/src/mem/ruby/slicc_interface/RubyRequest.cc
+++ b/src/mem/ruby/slicc_interface/RubyRequest.cc
@@ -61,7 +61,9 @@ RubyRequest::print(std::ostream& out) const
   out << " " << "AccessMode = " << m_AccessMode << " ";
   out << "Size = " << m_Size << " ";
   out << "Prefetch = " << m_Prefetch << " ";
-//  out << "Time = " << getTime() << " ";
+  out << "isGLCSet = " << m_isGLCSet << "";
+  out << "isSLCSet = " << m_isSLCSet << "";
+  //  out << "Time = " << getTime() << " ";
   out << "]";
 }
 


### PR DESCRIPTION
mem-ruby: update RubyRequest print to include GPU fields

The print function used for RubyRequests did not include the GPU specific fields (for the GLC and SLC bits, which are cache modifiers that specify what level of the memory hierarchy a request should be performed at).  This causes confusion when the GPU Ruby SLICC code prints out RubyRequest messages, since important fields are missing.

Thus this commit adds that support.  Since these fields are already part of the RubyRequest class, and are always 0 for non-GPU requests, it should not affect other components beyond slightly longer prints.

Change-Id: I31c9122b82dfa2c6415ce25d225ea82cb35c7333
