### PR TITLE
mem-ruby, gpu-compute: fix GPU SQC/TCP Ruby formatting

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -75,7 +75,7 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
   }
 
   structure(TBE, desc="...") {
-    State TBEState,             desc="Transient state";
+    State TBEState,          desc="Transient state";
     DataBlock DataBlk,       desc="data for the block, required for concurrent writebacks";
     bool Dirty,              desc="Is the data dirty (different than memory)?";
     int NumPendingMsgs,      desc="Number of acks/data messages that this processor is waiting for";

--- a/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
@@ -52,30 +52,30 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
 
 {
   state_declaration(State, desc="TCP Cache States", default="TCP_State_I") {
-    I, AccessPermission:Invalid, desc="Invalid";
+    I, AccessPermission:Invalid,   desc="Invalid";
     V, AccessPermission:Read_Only, desc="Valid";
-    A, AccessPermission:Invalid, desc="Waiting on Atomic";
+    A, AccessPermission:Invalid,   desc="Waiting on Atomic";
 
     F, AccessPermission:Invalid, desc="Flushing; Waiting for Ack";
   }
 
   enumeration(Event, desc="TCP Events") {
     // Core initiated
-    Load,           desc="Load";
+    Load,            desc="Load";
     LoadBypassEvict, desc="Bypass L1 on a load. Evict if cache block already allocated";
-    Store,          desc="Store to L1 (L1 is dirty)";
-    StoreThrough,   desc="Store directly to L2(L1 is clean)";
-    Atomic,         desc="Atomic";
-    Flush,          desc="Flush if dirty(wbL1 for Store Release)";
-    Evict,          desc="Evict if clean(invL1 for Load Acquire)";
+    Store,           desc="Store to L1 (L1 is dirty)";
+    StoreThrough,    desc="Store directly to L2(L1 is clean)";
+    Atomic,          desc="Atomic";
+    Flush,           desc="Flush if dirty(wbL1 for Store Release)";
+    Evict,           desc="Evict if clean(invL1 for Load Acquire)";
     // Mem sys initiated
-    Repl,           desc="Replacing block from cache";
+    Repl,            desc="Replacing block from cache";
 
     // TCC initiated
-    TCC_Ack,        desc="TCC Ack to Core Request";
-    TCC_AckWB,      desc="TCC Ack for WB";
+    TCC_Ack,         desc="TCC Ack to Core Request";
+    TCC_AckWB,       desc="TCC Ack for WB";
     // Disable L1 cache
-    Bypass,         desc="Bypass the entire L1 cache";
+    Bypass,          desc="Bypass the entire L1 cache";
  }
 
   enumeration(RequestType,
@@ -612,7 +612,6 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
   action(uu_profileDataHit, "\udh", desc="Profile the demand hit"){
     L1cache.profileDemandHit();
   }
-
 
   // Transitions
   // ArrayRead/Write assumptions:


### PR DESCRIPTION
mem-ruby, gpu-compute: fix GPU SQC/TCP Ruby formatting

Fix several not properly indented prints and extraneous extra lines in the SLICC code for the GPU SQC (L1I$) and TCP (L1D$).

Change-Id: Ia1cf605a01ad20335553acad357d6976dc8ab465