### PR TITLE
arch-arm,kvm: Fix copy-paste error

### DIFF
--- a/src/arch/arm/kvm/arm_cpu.hh
+++ b/src/arch/arm/kvm/arm_cpu.hh
@@ -100,7 +100,7 @@ class ArmKvmCPU : public BaseKvmCPU
     void
     stutterPC(PCStateBase &pc) const
     {
-        pc.as<X86ISA::PCState>().setNPC(pc->instAddr());
+        pc.as<ArmISA::PCState>().setNPC(pc->instAddr());
     }
 
     /**


### PR DESCRIPTION
This was probably a copy paste error introduced by [1]. Luckily armv7 KVM mode has been superseeded by the armv8 one.

[1]: https://gem5-review.googlesource.com/c/public/gem5/+/52059

Change-Id: I260229c94077d856510976bda58383f0564fc15b