### PR TITLE
systemc: Fix two bugs in gem5-to-tlm bridge

### DIFF
--- a/src/systemc/tlm_bridge/gem5_to_tlm.cc
+++ b/src/systemc/tlm_bridge/gem5_to_tlm.cc
@@ -152,6 +152,7 @@ packet2payload(PacketPtr packet)
     trans->acquire();
 
     trans->set_address(packet->getAddr());
+    trans->set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 
     /* Check if this transaction was allocated by mm */
     sc_assert(trans->has_mm());
@@ -480,7 +481,8 @@ Gem5ToTlmBridge<BITWIDTH>::recvRespRetry()
 
     tlm::tlm_generic_payload *trans = blockingResponse;
     blockingResponse = nullptr;
-    PacketPtr packet = packetMap[blockingResponse];
+
+    PacketPtr packet = packetMap[trans];
     sc_assert(packet);
 
     bool need_retry = !bridgeResponsePort.sendTimingResp(packet);


### PR DESCRIPTION
This commit fixes a violation of the TLM2.0 protocol as well as a
bug regarding back-pressure:
- In the BEGIN_REQ phase, transaction objects are required to set
  their response status to TLM_INCOMPLETE_RESPONSE. This was not
  the case in the packet2payload function that converts gem5 packets
  to TLM2.0 generic payloads.
- When the target applies back-pressure to the initiator, an assert
  condition was triggered as soon as the response is retried. The
  cause of this was an unintentional nullptr-access into a map.