### PR TITLE
mem-ruby: AtomicNoReturn should check comp_anr instead of comp_wu

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1039,7 +1039,7 @@ action(Initiate_AtomicNoReturn_LocalWrite, desc="") {
     // no one will send us data unless we explicitly ask
     tbe.actions.push(Event:SendSnpUniqueRetToSrc);
   }
-  if (comp_wu) {
+  if (comp_anr) {
     tbe.actions.push(Event:SendDBIDResp_ANR);
     tbe.actions.pushNB(Event:WriteFEPipe);
     tbe.actions.pushNB(Event:SendComp_ANR);
@@ -1072,7 +1072,7 @@ action(Initiate_AtomicNoReturn_Forward, desc="") {
      (tbe.dir_sharers.isElement(tbe.requestor))){
     tbe.dir_sharers.remove(tbe.requestor);
   }
-  if (comp_wu) {
+  if (comp_anr) {
     tbe.actions.push(Event:SendAtomicNoReturn);
     tbe.actions.push(Event:SendDBIDResp_ANR);
     tbe.actions.pushNB(Event:SendComp_ANR);
@@ -1103,7 +1103,7 @@ action(Initiate_AtomicReturn_Miss, desc="") {
 action(Initiate_AtomicNoReturn_Miss, desc="") {
   assert(is_HN);
   tbe.actions.push(Event:SendReadNoSnp);
-  if (comp_wu) {
+  if (comp_anr) {
     tbe.actions.push(Event:SendDBIDResp_ANR);
     tbe.actions.pushNB(Event:WriteFEPipe);
     tbe.actions.pushNB(Event:SendComp_ANR);


### PR DESCRIPTION
The comp_anr parameter is currently unused. Both parameters (comp_wu and comp_anr) are set to false by default

Change-Id: If09567504540dbee082191d46fcd53f1363d819f