### PR TITLE
cpu: Remove SLC bit restraint for GPU tester

### DIFF
--- a/src/cpu/testers/gpu_ruby_test/gpu_wavefront.cc
+++ b/src/cpu/testers/gpu_ruby_test/gpu_wavefront.cc
@@ -189,7 +189,6 @@ GpuWavefront::issueAtomicOps()
                                              AtomicOpFunctorPtr(amo_op));
         req->setPaddr(address);
         req->setReqInstSeqNum(tester->getActionSeqNum());
-        req->setCacheCoherenceFlags(Request::SLC_BIT);
         // set protocol-specific flags
         setExtraRequestFlags(req);
 


### PR DESCRIPTION
This reverts gem5#133, the temporary work-around for gem5#131, allowing both SLC and GLC atomic requests to be made in the GPU tester.

The underlying issues behind gem5#131 have been resolved by gem5#367 and gem5#397.

Change-Id: Iab8817192a4aaae6a691e8ac442acaf1844f1aec