### PR TITLE
arch-arm: Only build ArmCapstoneDisassembler when ISA is arm

### DIFF
--- a/src/arch/arm/tracers/SConscript
+++ b/src/arch/arm/tracers/SConscript
@@ -43,7 +43,7 @@ Source('tarmac_tracer.cc', tags='arm isa')
 Source('tarmac_record.cc', tags='arm isa')
 Source('tarmac_record_v8.cc', tags='arm isa')
 
-if env['CONF']['HAVE_CAPSTONE']:
+if env['CONF']['USE_CAPSTONE']:
     SimObject('ArmCapstone.py', sim_objects=['ArmCapstoneDisassembler'],
-              tags=['capstone', 'arm isa'])
-    Source('capstone.cc', tags=['capstone', 'arm isa'])
+              tags=['arm isa'])
+    Source('capstone.cc', tags=['arm isa'])

--- a/src/cpu/Kconfig
+++ b/src/cpu/Kconfig
@@ -27,3 +27,9 @@ config HAVE_CAPSTONE
     def_bool $(HAVE_CAPSTONE)
 
 rsource "kvm/Kconfig"
+
+config USE_CAPSTONE
+    depends on HAVE_CAPSTONE
+    depends on USE_ARM_ISA
+    bool "Use CapstoneDisassembler"
+    default y

--- a/src/cpu/SConscript
+++ b/src/cpu/SConscript
@@ -115,9 +115,11 @@ Source('simple_thread.cc')
 Source('thread_context.cc')
 Source('thread_state.cc')
 Source('timing_expr.cc')
-SourceLib('capstone', tags='capstone')
-Source('capstone.cc', tags='capstone')
-SimObject('Capstone.py', sim_objects=['CapstoneDisassembler'], tags='capstone')
+
+if env['CONF']['USE_CAPSTONE']:
+    SourceLib('capstone')
+    Source('capstone.cc')
+    SimObject('Capstone.py', sim_objects=['CapstoneDisassembler'])
 
 SimObject('DummyChecker.py', sim_objects=['DummyChecker'])
 Source('checker/cpu.cc')


### PR DESCRIPTION
Currently, if the Capstone header file is found in the host system, scons will try to build the ArmCapstoneDisassembler regardless of the gem5 target ISA. This is causing problem when the host has Capstone, but the gem5 target ISA is not arm. Compiling gem5 in this case will cause errors, e.g., ArmISA and ArmSystem is not found.

This change aims to prevent building the ArmCapstoneDisassembler when the gem5 target ISA is not arm.

Ref:
[1] The Arm Capstone PR https://github.com/gem5/gem5/pull/494

Change-Id: I1e714d34aec8fe2a2af8cd351536951053a4d8a5