### PR TITLE
arch-riscv: Move fault handler addr logic to ISA

### DIFF
--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -158,9 +158,7 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         isa->clearLoadReservation(tc->contextId());
 
         // Set PC to fault handler address
-        Addr addr = mbits(tc->readMiscReg(tvec), 63, 2);
-        if (isInterrupt() && bits(tc->readMiscReg(tvec), 1, 0) == 1)
-            addr += 4 * _code;
+        Addr addr = isa->getFaultHandlerAddr(tvec, _code, isInterrupt());
         pc_state.set(addr);
         tc->pcState(pc_state);
     } else {

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -837,6 +837,16 @@ ISA::resetThread()
     Reset().invoke(tc);
 }
 
+Addr
+ISA::getFaultHandlerAddr(RegIndex idx, uint64_t cause, bool intr) const
+{
+    auto vec = tc->readMiscRegNoEffect(idx);
+    Addr addr = mbits(vec, 63, 2);
+    if (intr && bits(vec, 1, 0) == 1)
+        addr += 4 * cause;
+    return addr;
+}
+
 } // namespace RiscvISA
 } // namespace gem5
 

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -158,10 +158,14 @@ class ISA : public BaseISA
         Addr& load_reservation_addr = load_reservation_addrs[cid];
         load_reservation_addr = INVALID_RESERVATION_ADDR;
     }
+
     /** Methods for getting VLEN, VLENB and ELEN values */
     unsigned getVecLenInBits() { return vlen; }
     unsigned getVecLenInBytes() { return vlen >> 3; }
     unsigned getVecElemLenInBits() { return elen; }
+
+    virtual Addr getFaultHandlerAddr(
+        RegIndex idx, uint64_t cause, bool intr) const;
 };
 
 } // namespace RiscvISA


### PR DESCRIPTION
mtvec.mode is extended in the new riscv proposal, like fast interrupt. This change moves that part from Fault class to ISA class for extendable.

Ref: https://github.com/riscv/riscv-fast-interrupt

Change-Id: Ifcfd6f4ce011149b5982dabfd2421f48c9a10b75