### PR TITLE
tests,util-docker: Remove gcc 9 support

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -16,8 +16,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14,
-                    clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
+                image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13,
+                    clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
                     ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
                 opts: [.opt, .fast]
         runs-on: [self-hosted, linux, x64]

--- a/util/dockerfiles/docker-compose.yaml
+++ b/util/dockerfiles/docker-compose.yaml
@@ -44,13 +44,6 @@ services:
             args:
                 - version=8
         image: gcr.io/gem5-test/gcc-version-8:latest
-    gcc-9:
-        build:
-            context: ubuntu-20.04_gcc-version
-            dockerfile: Dockerfile
-            args:
-                - version=9
-        image: gcr.io/gem5-test/gcc-version-9:latest
     gcc-10:
         build:
             context: ubuntu-20.04_gcc-version

--- a/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
@@ -32,6 +32,15 @@ RUN apt -y update && apt -y upgrade && \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev python-is-python3 doxygen libboost-all-dev \
     libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config pip \
-    python3-venv black
+    python3-venv black gcc-10 g++-10
 
 RUN pip install mypy pre-commit
+
+RUN update-alternatives --install \
+    /usr/bin/g++ g++ /usr/bin/g++-10 100
+RUN update-alternatives --install \
+    /usr/bin/gcc gcc /usr/bin/gcc-10 100
+RUN update-alternatives --install \
+    /usr/bin/c++ c++ /usr/bin/g++-10 100
+RUN update-alternatives --install \
+    /usr/bin/cc cc /usr/bin/gcc-10 100

--- a/util/dockerfiles/ubuntu-20.04_gcc-version/Dockerfile
+++ b/util/dockerfiles/ubuntu-20.04_gcc-version/Dockerfile
@@ -28,7 +28,7 @@ FROM --platform=${BUILDPLATFORM} ubuntu:20.04
 # Valid version values:
 # 7
 # 8
-# 9
+# 9 # Not supported. See: https://github.com/gem5/gem5/issues/555.
 # 10
 ARG version
 


### PR DESCRIPTION
When compiling GCC-9 gem5 the gem5 object files are near double the size  than when compiling with other GCC versions. This increase in size means we need >16GB of memory available when linking. As we do not want to mandate >16GB systems for building gem5, we are going to drop GCC-9. The exact cause of this bug unknown. This is highlighted in Issue #555.