### PR TITLE
python,util: Fix magic number check in decode_inst_dep_trace.py

### DIFF
--- a/util/decode_inst_dep_trace.py
+++ b/util/decode_inst_dep_trace.py
@@ -130,7 +130,7 @@ def main():
         exit(-1)
 
     # Read the magic number in 4-byte Little Endian
-    magic_number = proto_in.read(4)
+    magic_number = proto_in.read(4).decode()
 
     if magic_number != "gem5":
         print("Unrecognized file")


### PR DESCRIPTION
The decode_inst_dep_trace.py opens the trace file in read mode, and subsequently reads the magic number from the trace file. Once the number is read, it is compared against the string 'gem5' without decoding it first. This causes the comparison to fail.
The fix addresses this by calling the decode() routine on the output of the read() call. Please find the details in the associated issue #543 