### PR TITLE
mem-ruby: fix hex print in CacheMemory

### DIFF
--- a/src/mem/ruby/structures/CacheMemory.cc
+++ b/src/mem/ruby/structures/CacheMemory.cc
@@ -288,7 +288,7 @@ CacheMemory::allocate(Addr address, AbstractCacheEntry *entry)
             set[i] = entry;  // Init entry
             set[i]->m_Address = address;
             set[i]->m_Permission = AccessPermission_Invalid;
-            DPRINTF(RubyCache, "Allocate clearing lock for addr: %x\n",
+            DPRINTF(RubyCache, "Allocate clearing lock for addr: 0x%x\n",
                     address);
             set[i]->m_locked = -1;
             m_tag_index[address] = i;


### PR DESCRIPTION
Update print in CacheMemory about clearing the lock to properly print in hex.

Change-Id: I6607af4720d44d759725ae6c485a07e5a32a2448