### PR TITLE
tests: Remove multiple suites per job for Weekly tests

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -59,7 +59,7 @@ jobs:
             - run: chmod u+x build/ALL/gem5.opt
             - name: very-long ${{ matrix.test-type }}
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run gem5/${{ matrix.test-type }} --length very-long --skip-build -vv -t $(nproc)
+              run: ./main.py run gem5/${{ matrix.test-type }} --length very-long --skip-build -vv
             - name: create zip of results
               if: success() || failure()
               run: |


### PR DESCRIPTION
I believe the weekly test failures (example:
https://github.com/gem5/gem5/actions/runs/6832805510/job/18592876184) are due to a container running out of memory when running the very-long x86 boot tests. I found that the `-t $(nproc)` flag meant, on our runners, 4 x86 full system gem5 simulations were being pawned. Locally I found these gem5 x86 boot sims can reach 4GB in size so I suspect they eventually grew big enough exceed the 16GB memory of the VM.

I have removed `-t $(nproc)` meaning each execution to see if this fixes the issue (we may want to use `-t 2` later if the Weeklies take too long running single-threaded).