### PR TITLE
tests,gpu-compute: Fix Lulesh 'Obtain LULESH' step

### DIFF
--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -53,7 +53,6 @@ jobs:
             - run: chmod u+x build/GCN3_X86/gem5.opt
 
             - name: Obtain LULESH
-              working-directory: ${{ github.workspace }}/lulesh
               # Obtains the latest LULESH compatible with this version of gem5 via
               # gem5 Resources.
               run: build/GCN3_X86/gem5.opt util/obtain-resource.py lulesh -p lulesh


### PR DESCRIPTION
The `working-directory: ${{ github.workspace }}` line was included by mistake and resulted in this step failing as the command was being executed in the wrong directory.

Example failure:
https://github.com/gem5/gem5/actions/runs/6832831307/job/18593080567