### PR TITLE
gpu-compute: Minor edits for atomic no returns and stores

### DIFF
--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -600,8 +600,8 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                 // data response is not needed.
                 case RubyRequestType_ATOMIC_NO_RETURN:
                     assert(pkt->isAtomicOp());
+                    break;
                 case RubyRequestType_ST:
-                    data.setData(pkt->getPtr<uint8_t>(), offset, pkt_size);
                     break;
                 case RubyRequestType_LD:
                     pkt->setData(data.getData(offset, pkt_size));


### PR DESCRIPTION
Since returned data is not needed for AtomicNoReturn and Store memory requests, the coalescer need not spend time writing in dummy data for packets of these types.

Change-Id: Ie669e8c2a3bf44b5b0c290f62c49c5d4876a9a6a