### PR TITLE
GPU Checkpointing Fix

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -24,6 +24,7 @@ jobs:
   # ensures we have a change-id in every commit, needed for gerrit
     check-for-change-id:
     # runs on github hosted runner
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
@@ -174,7 +175,7 @@ jobs:
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
-        runs-on: ubuntu-22.04
-        needs: testlib-quick-execution
-        steps:
-            - run: echo "This job's status is ${{ job.status }}."
+    runs-on: [self-hosted, linux, x64]
+    needs: testlib-quick-execution
+    steps:
+      - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -23,46 +23,45 @@ jobs:
 
   # ensures we have a change-id in every commit, needed for gerrit
     check-for-change-id:
-        # runs on github hosted runner
-        runs-on: ubuntu-22.04
-        if: github.event.pull_request.draft == false
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
-            - name: Check for Change-Id
-              run: |
-                  # loop through all the commits in the pull request
-                  for commit in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
-                      git checkout $commit
-                      if (git log -1 --pretty=format:"%B" | grep -q "Change-Id: ")
-                      then
-                        # passes as long as at least one change-id exists in the pull request
-                        exit 0
-                      fi
-                  done
-                  # if we reach this part, none of the commits had a change-id
-                  echo "None of the commits in this pull request contains a Change-ID, which we require for any changes made to gem5. "\
-                    "To automatically insert one, run the following:\n f=`git rev-parse --git-dir`/hooks/commit-msg ; mkdir -p $(dirname $f) ; "\
-                    "curl -Lo $f https://gerrit-review.googlesource.com/tools/hooks/commit-msg ; chmod +x $f\n Then amend the commit with git commit --amend --no-edit, and update your pull request."
-                  exit 1
+    # runs on github hosted runner
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check for Change-Id
+        run: |
+          # loop through all the commits in the pull request
+          for commit in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
+              git checkout $commit
+              if (git log -1 --pretty=format:"%B" | grep -q "Change-Id: ")
+              then
+                # passes as long as at least one change-id exists in the pull request
+                exit 0
+              fi
+          done
+          # if we reach this part, none of the commits had a change-id
+          echo "None of the commits in this pull request contains a Change-ID, which we require for any changes made to gem5. "\
+            "To automatically insert one, run the following:\n f=`git rev-parse --git-dir`/hooks/commit-msg ; mkdir -p $(dirname $f) ; "\
+            "curl -Lo $f https://gerrit-review.googlesource.com/tools/hooks/commit-msg ; chmod +x $f\n Then amend the commit with git commit --amend --no-edit, and update your pull request."
+          exit 1
 
-    unittests-all-opt:
-        runs-on: [self-hosted, linux, x64]
-        if: github.event.pull_request.draft == false
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
-        timeout-minutes: 60
-        steps:
-            - uses: actions/checkout@v3
-            - name: CI Unittests
-              working-directory: ${{ github.workspace }}
-              run: scons build/ALL/unittests.opt -j $(nproc)
-            - run: echo "This job's status is ${{ job.status }}."
+  unittests-all-opt:
+    runs-on: [self-hosted, linux, x64]
+    if: github.event.pull_request.draft == false
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+    needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: CI Unittests
+        working-directory: ${{ github.workspace }}
+        run: scons build/ALL/unittests.opt -j $(nproc)
+      - run: echo "This job's status is ${{ job.status }}."
 
-    testlib-quick-matrix:
-        runs-on: [self-hosted, linux, x64]
-        if: github.event.pull_request.draft == false
+  testlib-quick-matrix:
+    runs-on: [self-hosted, linux, x64]
+    if: github.event.pull_request.draft == false
     # In order to make sure the environment is exactly the same, we run in
     # the same container we use to build gem5 and run the testlib tests. This
         container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
@@ -72,51 +71,35 @@ jobs:
 
       # Unfortunately the 'ubunutu-latest' image doesn't have jq installed.
       # We therefore need to install it as a step here.
-            - name: Install jq
-              run: apt install -y jq
+      - name: Install jq
+        run: apt install -y jq
 
-            - name: Get directories for testlib-quick
-              working-directory: ${{ github.workspace }}/tests
-              id: dir-matrix
-              run: echo "test-dirs-matrix=$(find gem5/* -type d -maxdepth 0 | jq -ncR '[inputs]')" >>$GITHUB_OUTPUT
+      - name: Get directories for testlib-quick
+        working-directory: "${{ github.workspace }}/tests"
+        id: dir-matrix
+        run: echo "test-dirs-matrix=$(find gem5/* -type d -maxdepth 0 | jq -ncR '[inputs]')" >>$GITHUB_OUTPUT
 
-            - name: Get the build targets for testlib-quick-gem5-builds
-              working-directory: ${{ github.workspace }}/tests
-              id: build-matrix
-              run: echo "build-matrix=$(./main.py list --build-targets -q | jq -ncR '[inputs]')" >>$GITHUB_OUTPUT
+      - name: Get the build targets for testlib-quick-gem5-builds
+        working-directory: "${{ github.workspace }}/tests"
+        id: build-matrix
+        run: echo "build-matrix=$(./main.py list --build-targets -q | jq -ncR '[inputs]')" >>$GITHUB_OUTPUT
 
-        outputs:
-            build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
-            test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}
+    outputs:
+        build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
+        test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}
 
-    clang-fast-compilation:
-        # gem5 binaries built in `quick-gem5-builds` always use GCC.
-        # Clang is more strict than GCC. This job checks that gem5 compiles
-        # with Clang. It compiles build/ALL/gem5.fast to maximize the change
-        # for compilation error to be exposed.
-        runs-on: [self-hosted, linux, x64]
-        if: github.event.pull_request.draft == false
-        container: ghcr.io/gem5/clang-version-16:latest
-        needs: [pre-commit, check-for-change-id]
-        timeout-minutes: 90
-        steps:
-            - uses: actions/checkout@v3
-            - name: Clang Compilation
-              working-directory: ${{ github.workspace }}
-              run: scons build/ALL/gem5.fast -j $(nproc)
-
-    testlib-quick-gem5-builds:
-        runs-on: [self-hosted, linux, x64]
-        if: github.event.pull_request.draft == false
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [pre-commit, check-for-change-id, testlib-quick-matrix]
-        strategy:
-            matrix:
-                build-target: ${{ fromJson(needs.testlib-quick-matrix.outputs.build-matrix) }}
-        steps:
-            - uses: actions/checkout@v3
-            - name: Build gem5
-              run: scons ${{ matrix.build-target }} -j $(nproc)
+  testlib-quick-gem5-builds:
+    runs-on: [self-hosted, linux, x64]
+    if: github.event.pull_request.draft == false
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+    needs: [pre-commit, check-for-change-id, testlib-quick-matrix]
+    strategy:
+      matrix:
+        build-target: ${{ fromJson(needs.testlib-quick-matrix.outputs.build-matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build gem5
+        run: scons ${{ matrix.build-target }} -j $(nproc)
 
         # Upload the gem5 binary as an artifact.
         # Note: the "achor.txt" file is a hack to make sure the paths are
@@ -126,29 +109,31 @@ jobs:
         # Then upload-artifact will upload "ARM/gem5.opt" and "RISCV/gem5.opt",
         # stripping the "build" directory. By adding the "anchor.txt" file, we
         # ensure the "build" directory is preserved.
-            - run: echo "anchor" > anchor.txt
-            - uses: actions/upload-artifact@v3
-              with:
-                  name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
-                  path: |
-                      build/*/gem5.*
-                      anchor.txt
-                  retention-days: 7
+      - run: echo "anchor" > anchor.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
+          path: |
+            build/*/gem5.*
+            anchor.txt
+          retention-days: 7
 
-    testlib-quick-execution:
-        runs-on: [self-hosted, linux, x64]
-        if: github.event.pull_request.draft == false
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [pre-commit, check-for-change-id, testlib-quick-matrix, testlib-quick-gem5-builds]
-        timeout-minutes: 360 # 6 hours
-        strategy:
-            fail-fast: false
-            matrix:
-                test-dir: ${{ fromJson(needs.testlib-quick-matrix.outputs.test-dirs-matrix) }}
-        steps:
-            - name: Clean runner
-              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-
+  testlib-quick-execution:
+    runs-on: [self-hosted, linux, x64]
+    if: github.event.pull_request.draft == false
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+    needs: [pre-commit, check-for-change-id, testlib-quick-matrix, testlib-quick-gem5-builds]
+    timeout-minutes: 360     # 6 hours
+    strategy:
+      fail-fast: false
+      matrix:
+        test-dir: ${{ fromJson(needs.testlib-quick-matrix.outputs.test-dirs-matrix) }}
+    steps:
+      - name: Clean runner
+        run:
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          rm -rf ~/.cache || true
         # Checkout the repository then download the gem5.opt artifact.
             - uses: actions/checkout@v3
             - uses: actions/download-artifact@v3
@@ -189,7 +174,7 @@ jobs:
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
-        runs-on: ubuntu-22.04
-        needs: testlib-quick-execution
-        steps:
-            - run: echo "This job's status is ${{ job.status }}."
+    runs-on: [self-hosted, linux, x64]
+    needs: testlib-quick-execution
+    steps:
+      - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -148,10 +148,10 @@ jobs:
                   find . -name "gem5.fast" -exec chmod u+x {} \;
 
         # Run the testlib quick tests in the given directory.
-            - name: Run "tests/${{ matrix.test-dir }}" TestLib quick tests
-              id: run-tests
-              working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --skip-build -vv -j$(nproc) ${{ matrix.test-dir }}
+      - name: Run "tests/${{ matrix.test-dir }}" TestLib quick tests
+        id: run-tests
+        working-directory: ${{ github.workspace }}/tests
+        run: ./main.py run --skip-build -t $(nproc) -vv ${{ matrix.test-dir }}
 
         # Get the basename of the matrix.test-dir path (to name the artifact).
             - name: Sanatize test-dir for artifact name

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -174,7 +174,7 @@ jobs:
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
-    runs-on: [self-hosted, linux, x64]
-    needs: testlib-quick-execution
-    steps:
-      - run: echo "This job's status is ${{ job.status }}."
+        runs-on: ubuntu-22.04
+        needs: testlib-quick-execution
+        steps:
+            - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -149,7 +149,6 @@ jobs:
                   find . -name "gem5.fast" -exec chmod u+x {} \;
 
         # Run the testlib quick tests in the given directory.
-      - name: Run "tests/${{ matrix.test-dir }}" TestLib quick tests
         id: run-tests
         working-directory: ${{ github.workspace }}/tests
         run: ./main.py run --skip-build -t $(nproc) -vv ${{ matrix.test-dir }}

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -12,20 +12,18 @@ on:
 
 jobs:
   # replication of compiler-tests.sh
-    all-compilers:
-        strategy:
-            fail-fast: false
-            matrix:
-                image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14,
-                    clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
-                    ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
-                opts: [.opt, .fast]
-        runs-on: [self-hosted, linux, x64]
-        timeout-minutes: 2880 # 48 hours
-        container: ghcr.io/gem5/${{ matrix.image }}:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  all-compilers:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
+        opts: [.opt, .fast]
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 2880     # 48 hours
+    container: gcr.io/gem5-test/${{ matrix.image }}:latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -34,21 +32,19 @@ jobs:
               timeout-minutes: 600 # 10 hours
 
   # Tests the two latest gcc and clang supported compilers against all gem5 compilations.
-    latest-compilers-all-gem5-builds:
-        strategy:
-            fail-fast: false
-            matrix:
-                gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level,
-                    NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86,
-                    GCN3_X86]
-                image: [gcc-version-12, clang-version-16]
-                opts: [.opt]
-        runs-on: [self-hosted, linux, x64]
-        timeout-minutes: 2880 # 48 hours
-        container: ghcr.io/gem5/${{ matrix.image }}:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  latest-compilers-all-gem5-builds:
+    strategy:
+      fail-fast: false
+      matrix:
+        gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
+        image: [gcc-version-12, clang-version-16]
+        opts: [.opt]
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 2880     # 48 hours
+    container: gcr.io/gem5-test/${{ matrix.image }}:latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -12,18 +12,20 @@ on:
 
 jobs:
   # replication of compiler-tests.sh
-  all-compilers:
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
-        opts: [.opt, .fast]
-    runs-on: [self-hosted, linux, x64]
-    timeout-minutes: 2880     # 48 hours
-    container: gcr.io/gem5-test/${{ matrix.image }}:latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
+    all-compilers:
+        strategy:
+            fail-fast: false
+            matrix:
+                image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14,
+                    clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
+                    ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
+                opts: [.opt, .fast]
+        runs-on: [self-hosted, linux, x64]
+        timeout-minutes: 2880 # 48 hours
+        container: ghcr.io/gem5/${{ matrix.image }}:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -32,19 +34,21 @@ jobs:
               timeout-minutes: 600 # 10 hours
 
   # Tests the two latest gcc and clang supported compilers against all gem5 compilations.
-  latest-compilers-all-gem5-builds:
-    strategy:
-      fail-fast: false
-      matrix:
-        gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
-        image: [gcc-version-12, clang-version-16]
-        opts: [.opt]
-    runs-on: [self-hosted, linux, x64]
-    timeout-minutes: 2880     # 48 hours
-    container: gcr.io/gem5-test/${{ matrix.image }}:latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
+    latest-compilers-all-gem5-builds:
+        strategy:
+            fail-fast: false
+            matrix:
+                gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level,
+                    NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86,
+                    GCN3_X86]
+                image: [gcc-version-12, clang-version-16]
+                opts: [.opt]
+        runs-on: [self-hosted, linux, x64]
+        timeout-minutes: 2880 # 48 hours
+        container: ghcr.io/gem5/${{ matrix.image }}:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -12,20 +12,18 @@ on:
 
 jobs:
   # replication of compiler-tests.sh
-    all-compilers:
-        strategy:
-            fail-fast: false
-            matrix:
-                image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13,
-                    clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
-                    ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
-                opts: [.opt, .fast]
-        runs-on: [self-hosted, linux, x64]
-        timeout-minutes: 2880 # 48 hours
-        container: ghcr.io/gem5/${{ matrix.image }}:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  all-compilers:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-9, gcc-version-8, clang-version-16, clang-version-15, clang-version-14, clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-22.04_min-dependencies]
+        opts: [.opt, .fast]
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 2880     # 48 hours
+    container: gcr.io/gem5-test/${{ matrix.image }}:latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -34,21 +32,19 @@ jobs:
               timeout-minutes: 600 # 10 hours
 
   # Tests the two latest gcc and clang supported compilers against all gem5 compilations.
-    latest-compilers-all-gem5-builds:
-        strategy:
-            fail-fast: false
-            matrix:
-                gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level,
-                    NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86,
-                    GCN3_X86]
-                image: [gcc-version-12, clang-version-16]
-                opts: [.opt]
-        runs-on: [self-hosted, linux, x64]
-        timeout-minutes: 2880 # 48 hours
-        container: ghcr.io/gem5/${{ matrix.image }}:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  latest-compilers-all-gem5-builds:
+    strategy:
+      fail-fast: false
+      matrix:
+        gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, GCN3_X86, MIPS, 'NULL', NULL_MESI_Two_Level, NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86, GCN3_X86]
+        image: [gcc-version-12, clang-version-16]
+        opts: [.opt]
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 2880     # 48 hours
+    container: gcr.io/gem5-test/${{ matrix.image }}:latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -27,22 +27,22 @@ jobs:
         # this allows us to pass additional command line parameters
         # the default is to add -j $(nproc), but some images
         # require more specifications when built
-                include:
-                    - command-line: -j $(nproc)
-                    - image: ALL_CHI
-                      command-line: --default=ALL PROTOCOL=CHI -j $(nproc)
-                    - image: ALL_MSI
-                      command-line: --default=ALL PROTOCOL=MSI -j $(nproc)
-                    - image: ALL_MESI_Two_Level
-                      command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
-                    - image: NULL_MI_example
-                      command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
-        runs-on: [self-hosted, linux, x64]
-        needs: name-artifacts
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+        include:
+          - command-line: -j $(nproc)
+          - image: ALL_CHI
+            command-line: --default=ALL PROTOCOL=CHI -j $(nproc)
+          - image: ALL_MSI
+            command-line: --default=ALL PROTOCOL=MSI -j $(nproc)
+          - image: ALL_MESI_Two_Level
+            command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
+          - image: NULL_MI_example
+            command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
+    runs-on: [self-hosted, linux, x64]
+    needs: name-artifacts
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -56,16 +56,16 @@ jobs:
             - run: echo "This job's status is ${{ job.status }}."
 
   # this builds both unittests.fast and unittests.debug
-    unittests-fast-debug:
-        strategy:
-            matrix:
-                type: [fast, debug]
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        timeout-minutes: 60
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  unittests-fast-debug:
+    strategy:
+      matrix:
+        type: [fast, debug]
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -73,21 +73,23 @@ jobs:
               run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
 
   # start running all of the long tests
-    testlib-long-tests:
-        strategy:
-            fail-fast: false
-            matrix:
-                test-type: [arm_boot_tests, fs, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests,
-                    stdlib, x86_boot_tests]
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [name-artifacts, build-gem5]
-        timeout-minutes: 1440 # 24 hours for entire matrix to run
-        steps:
-            - name: Clean runner
-              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
-              with:
+  testlib-long-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: [arm_boot_tests, fs, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests, stdlib, x86_boot_tests]
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    needs: [name-artifacts, build-gem5]
+    timeout-minutes: 1440 # 24 hours for entire matrix to run
+    steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -162,21 +164,23 @@ jobs:
 
   # split library example tests into runs based on Suite UID
   # so that they don't hog the runners for too long
-    testlib-long-gem5_library_example_tests:
-        runs-on: [self-hosted, linux, x64]
-        strategy:
-            fail-fast: false
-            matrix:
-                test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt,
-                    gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [name-artifacts, build-gem5]
-        timeout-minutes: 1440 # 24 hours
-        steps:
-            - name: Clean runner
-              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
-              with:
+  testlib-long-gem5_library_example_tests:
+    runs-on: [self-hosted, linux, x64]
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt, gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    needs: [name-artifacts, build-gem5]
+    timeout-minutes: 1440 # 24 hours
+    steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -207,10 +211,10 @@ jobs:
 
   # This runs the SST-gem5 integration compilation and tests it with
   # ext/sst/sst/example.py.
-    sst-test:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/sst-env:latest
-        timeout-minutes: 180
+  sst-test:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/sst-env:latest
+    timeout-minutes: 180
 
         steps:
             - uses: actions/checkout@v3
@@ -232,10 +236,10 @@ jobs:
 
   # This runs the gem5 within SystemC ingration and runs a simple hello-world
   # simulation with it.
-    systemc-test:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/systemc-env:latest
-        timeout-minutes: 180
+  systemc-test:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/systemc-env:latest
+    timeout-minutes: 180
 
         steps:
             - uses: actions/checkout@v3
@@ -256,10 +260,10 @@ jobs:
               run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
 
   # Runs the gem5 Nighyly GPU tests.
-    gpu-tests:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
-        timeout-minutes: 720 # 12 hours
+  gpu-tests:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/gcn-gpu:latest
+    timeout-minutes: 720 # 12 hours
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -27,22 +27,22 @@ jobs:
         # this allows us to pass additional command line parameters
         # the default is to add -j $(nproc), but some images
         # require more specifications when built
-        include:
-          - command-line: -j $(nproc)
-          - image: ALL_CHI
-            command-line: --default=ALL PROTOCOL=CHI -j $(nproc)
-          - image: ALL_MSI
-            command-line: --default=ALL PROTOCOL=MSI -j $(nproc)
-          - image: ALL_MESI_Two_Level
-            command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
-          - image: NULL_MI_example
-            command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
-    runs-on: [self-hosted, linux, x64]
-    needs: name-artifacts
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
+                include:
+                    - command-line: -j $(nproc)
+                    - image: ALL_CHI
+                      command-line: --default=ALL PROTOCOL=CHI -j $(nproc)
+                    - image: ALL_MSI
+                      command-line: --default=ALL PROTOCOL=MSI -j $(nproc)
+                    - image: ALL_MESI_Two_Level
+                      command-line: --default=ALL PROTOCOL=MESI_Two_Level -j $(nproc)
+                    - image: NULL_MI_example
+                      command-line: --default=NULL PROTOCOL=MI_example -j $(nproc)
+        runs-on: [self-hosted, linux, x64]
+        needs: name-artifacts
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -56,16 +56,16 @@ jobs:
             - run: echo "This job's status is ${{ job.status }}."
 
   # this builds both unittests.fast and unittests.debug
-  unittests-fast-debug:
-    strategy:
-      matrix:
-        type: [fast, debug]
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    unittests-fast-debug:
+        strategy:
+            matrix:
+                type: [fast, debug]
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        timeout-minutes: 60
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -73,23 +73,21 @@ jobs:
               run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
 
   # start running all of the long tests
-  testlib-long-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [arm_boot_tests, fs, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests, stdlib, x86_boot_tests]
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [name-artifacts, build-gem5]
-    timeout-minutes: 1440 # 24 hours for entire matrix to run
-    steps:
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
-    - uses: actions/checkout@v3
-      with:
+    testlib-long-tests:
+        strategy:
+            fail-fast: false
+            matrix:
+                test-type: [arm_boot_tests, fs, gpu, insttest_se, learning_gem5, m5threads_test_atomic, memory, multi_isa, replacement_policies, riscv_boot_tests,
+                    stdlib, x86_boot_tests]
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [name-artifacts, build-gem5]
+        timeout-minutes: 1440 # 24 hours for entire matrix to run
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -164,23 +162,21 @@ jobs:
 
   # split library example tests into runs based on Suite UID
   # so that they don't hog the runners for too long
-  testlib-long-gem5_library_example_tests:
-    runs-on: [self-hosted, linux, x64]
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt, gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [name-artifacts, build-gem5]
-    timeout-minutes: 1440 # 24 hours
-    steps:
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
-    - uses: actions/checkout@v3
-      with:
+    testlib-long-gem5_library_example_tests:
+        runs-on: [self-hosted, linux, x64]
+        strategy:
+            fail-fast: false
+            matrix:
+                test-type: [gem5-library-example-x86-ubuntu-run-ALL-x86_64-opt, gem5-library-example-riscv-ubuntu-run-ALL-x86_64-opt, lupv-example-ALL-x86_64-opt,
+                    gem5-library-example-arm-ubuntu-run-test-ALL-x86_64-opt, gem5-library-example-riscvmatched-hello-ALL-x86_64-opt]
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [name-artifacts, build-gem5]
+        timeout-minutes: 1440 # 24 hours
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -211,10 +207,10 @@ jobs:
 
   # This runs the SST-gem5 integration compilation and tests it with
   # ext/sst/sst/example.py.
-  sst-test:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/sst-env:latest
-    timeout-minutes: 180
+    sst-test:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/sst-env:latest
+        timeout-minutes: 180
 
         steps:
             - uses: actions/checkout@v3
@@ -236,10 +232,10 @@ jobs:
 
   # This runs the gem5 within SystemC ingration and runs a simple hello-world
   # simulation with it.
-  systemc-test:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/systemc-env:latest
-    timeout-minutes: 180
+    systemc-test:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/systemc-env:latest
+        timeout-minutes: 180
 
         steps:
             - uses: actions/checkout@v3
@@ -260,10 +256,10 @@ jobs:
               run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
 
   # Runs the gem5 Nighyly GPU tests.
-  gpu-tests:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/gcn-gpu:latest
-    timeout-minutes: 720 # 12 hours
+    gpu-tests:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/gcn-gpu:latest
+        timeout-minutes: 720 # 12 hours
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,9 +4,9 @@ name: Docker images build and push
 on:
     workflow_dispatch:
 jobs:
-    obtain-dockerfiles:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+  obtain-dockerfiles:
+    runs-on: [self-hosted, linux, x64]
+    container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
 
         steps:
             - uses: actions/checkout@v3
@@ -20,35 +20,35 @@ jobs:
                   path: util/dockerfiles
 
   # This builds and pushes the docker image.
-    build-and-push:
-        runs-on: [self-hosted, linux, x64]
-        needs: obtain-dockerfiles
-        permissions:
-            packages: write
-            contents: read
+  build-and-push:
+    runs-on: [self-hosted, linux, x64]
+    needs: obtain-dockerfiles
+    permissions:
+      packages: write
+      contents: read
 
-        steps:
-            - uses: actions/download-artifact@v3
-              with:
-                  name: dockerfiles
-                  path: dockerfiles-docker-build
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dockerfiles
+          path: dockerfiles-docker-build
 
-            - uses: docker/setup-qemu-action@v2
-              name: Setup QEMU
+      - uses: docker/setup-qemu-action@v2
+        name: Setup QEMU
 
-            - uses: docker/setup-buildx-action@v2
-              name: Set up Docker Buildx
+      - uses: docker/setup-buildx-action@v2
+        name: Set up Docker Buildx
 
-            - uses: docker/login-action@v2
-              name: Login to the GitHub Container Registry
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v2
+        name: Login to the GitHub Container Registry
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Build and push with bake
-              uses: docker/bake-action@v4
-              with:
-                  workdir: ./dockerfiles-docker-build
-                  files: docker-bake.hcl
-                  push: true
+      - name: Build and push with bake
+        uses: docker/bake-action@v4
+        with:
+          workdir: ./dockerfiles-docker-build
+          files: docker-bake.hcl
+          push: true

--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -13,12 +13,12 @@ on:
     workflow_dispatch:
 
 jobs:
-    build-gem5:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  build-gem5:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/gcn-gpu:latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -31,14 +31,14 @@ jobs:
                   retention-days: 5
             - run: echo "This job's status is ${{ job.status }}."
 
-    HACC-tests:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
-        needs: build-gem5
-        timeout-minutes: 120 # 2 hours
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  HACC-tests:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/gcn-gpu:latest
+    needs: build-gem5
+    timeout-minutes: 120 # 2 hours
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -13,12 +13,12 @@ on:
     workflow_dispatch:
 
 jobs:
-    build-gem5:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  build-gem5:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/gcn-gpu:latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -31,46 +31,14 @@ jobs:
                   retention-days: 5
             - run: echo "This job's status is ${{ job.status }}."
 
-    LULESH-tests:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
-        needs: build-gem5
-        timeout-minutes: 480 # 8 hours
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                # Scheduled workflows run on the default branch by default. We
-                # therefore need to explicitly checkout the develop branch.
-                  ref: develop
-
-            - name: Download build/GCN3_X86/gem5.opt
-              uses: actions/download-artifact@v3
-              with:
-                  name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-gcn3
-                  path: build/GCN3_X86
-                # `download-artifact` does not preserve permissions so we need to set
-                # them again.
-            - run: chmod u+x build/GCN3_X86/gem5.opt
-
-            - name: Obtain LULESH
-              # Obtains the latest LULESH compatible with this version of gem5 via
-              # gem5 Resources.
-              run: build/GCN3_X86/gem5.opt util/obtain-resource.py lulesh -p lulesh
-
-            - name: Run LULUESH tests
-              working-directory: ${{ github.workspace }}
-              run: |
-                  build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --mem-size=8GB --reg-alloc-policy=dynamic --benchmark-root="lulesh" -c \
-                  lulesh 0.01 2
-
-    HACC-tests:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
-        needs: build-gem5
-        timeout-minutes: 120 # 2 hours
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  HACC-tests:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/gcn-gpu:latest
+    needs: build-gem5
+    timeout-minutes: 120 # 2 hours
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -13,12 +13,12 @@ on:
     workflow_dispatch:
 
 jobs:
-  build-gem5:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/gcn-gpu:latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    build-gem5:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/gcn-gpu:latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -31,14 +31,14 @@ jobs:
                   retention-days: 5
             - run: echo "This job's status is ${{ job.status }}."
 
-  HACC-tests:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/gcn-gpu:latest
-    needs: build-gem5
-    timeout-minutes: 120 # 2 hours
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    HACC-tests:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/gcn-gpu:latest
+        needs: build-gem5
+        timeout-minutes: 120 # 2 hours
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -11,14 +11,14 @@ on:
     workflow_dispatch:
 
 jobs:
-  build-gem5:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    outputs:
-      build-name: ${{ steps.artifact-name.outputs.name }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    build-gem5:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        outputs:
+            build-name: ${{ steps.artifact-name.outputs.name }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -35,23 +35,20 @@ jobs:
             - run: echo "This job's status is ${{ job.status }}."
 
   # start running the very-long tests
-  testlib-very-long-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    needs: [build-gem5]
-    timeout-minutes: 4320 # 3 days
-    steps:
-    - name: Clean runner
-      run:
-        rm -rf ./* || true
-        rm -rf ./.??* || true
-        rm -rf ~/.cache || true
-    - uses: actions/checkout@v3
-      with:
+    testlib-very-long-tests:
+        strategy:
+            fail-fast: false
+            matrix:
+                test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        needs: [build-gem5]
+        timeout-minutes: 4320 # 3 days
+        steps:
+            - name: Clean runner
+              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
+            - uses: actions/checkout@v3
+              with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -79,13 +76,13 @@ jobs:
                   retention-days: 7
             - run: echo "This job's status is ${{ job.status }}."
 
-  dramsys-tests:
-    runs-on: [self-hosted, linux, x64]
-    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-    timeout-minutes: 4320 # 3 days
-    steps:
-      - uses: actions/checkout@v3
-        with:
+    dramsys-tests:
+        runs-on: [self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        timeout-minutes: 4320 # 3 days
+        steps:
+            - uses: actions/checkout@v3
+              with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -11,14 +11,14 @@ on:
     workflow_dispatch:
 
 jobs:
-    build-gem5:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
-        outputs:
-            build-name: ${{ steps.artifact-name.outputs.name }}
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  build-gem5:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    outputs:
+      build-name: ${{ steps.artifact-name.outputs.name }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -35,20 +35,23 @@ jobs:
             - run: echo "This job's status is ${{ job.status }}."
 
   # start running the very-long tests
-    testlib-very-long-tests:
-        strategy:
-            fail-fast: false
-            matrix:
-                test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [build-gem5]
-        timeout-minutes: 4320 # 3 days
-        steps:
-            - name: Clean runner
-              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
-              with:
+  testlib-very-long-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    needs: [build-gem5]
+    timeout-minutes: 4320 # 3 days
+    steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -76,13 +79,13 @@ jobs:
                   retention-days: 7
             - run: echo "This job's status is ${{ job.status }}."
 
-    dramsys-tests:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        timeout-minutes: 4320 # 3 days
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  dramsys-tests:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    timeout-minutes: 4320 # 3 days
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -11,14 +11,14 @@ on:
     workflow_dispatch:
 
 jobs:
-    build-gem5:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        outputs:
-            build-name: ${{ steps.artifact-name.outputs.name }}
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  build-gem5:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    outputs:
+      build-name: ${{ steps.artifact-name.outputs.name }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -35,20 +35,23 @@ jobs:
             - run: echo "This job's status is ${{ job.status }}."
 
   # start running the very-long tests
-    testlib-very-long-tests:
-        strategy:
-            fail-fast: false
-            matrix:
-                test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        needs: [build-gem5]
-        timeout-minutes: 4320 # 3 days
-        steps:
-            - name: Clean runner
-              run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
-              with:
+  testlib-very-long-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: [gem5_library_example_tests, gem5_resources, parsec_benchmarks, x86_boot_tests]
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    needs: [build-gem5]
+    timeout-minutes: 4320 # 3 days
+    steps:
+    - name: Clean runner
+      run:
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        rm -rf ~/.cache || true
+    - uses: actions/checkout@v3
+      with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
@@ -76,13 +79,13 @@ jobs:
                   retention-days: 7
             - run: echo "This job's status is ${{ job.status }}."
 
-    dramsys-tests:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-        timeout-minutes: 4320 # 3 days
-        steps:
-            - uses: actions/checkout@v3
-              with:
+  dramsys-tests:
+    runs-on: [self-hosted, linux, x64]
+    container: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+    timeout-minutes: 4320 # 3 days
+    steps:
+      - uses: actions/checkout@v3
+        with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,8 @@ repos:
             args: [--fix=lf]
           - id: check-ast
           - id: check-case-conflict
+          - id: check-merge-conflict
+          - id: requirements-txt-fixer
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,55 +52,40 @@ exclude: |
 default_stages: [commit]
 
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-json
-          - id: check-yaml
-          - id: check-added-large-files
-          - id: mixed-line-ending
-            args: [--fix=lf]
-          - id: check-ast
-          - id: check-case-conflict
-          - id: check-merge-conflict
-          - id: check-symlinks
-          - id: destroyed-symlinks
-          - id: requirements-txt-fixer
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.2.3
-      hooks:
-          - id: yamlfmt
-    - repo: https://github.com/psf/black
-      rev: 23.9.1
-      hooks:
-          - id: black
-    - repo: https://github.com/asottile/pyupgrade
-      rev: v3.14.0
-      hooks:
-          - id: pyupgrade
-            # Python 3.8 is the earliest version supported.
-            # We therefore conform to the standards compatible with 3.8+.
-            args: [--py38-plus]
-    - repo: local
-      hooks:
-          - id: gem5-style-checker
-            name: gem5 style checker
-            entry: util/git-pre-commit.py
-            always_run: true
-            exclude: .*
-            language: system
-            description: The gem5 style checker hook.
-          - id: gem5-commit-msg-checker
-            name: gem5 commit msg checker
-            entry: ext/git-commit-msg
-            language: system
-            stages: [commit-msg]
-            description: The gem5 commit message checker hook.
-          - id: gerrit-commit-msg-job
-            name: gerrit commit message job
-            entry: util/gerrit-commit-msg-hook
-            language: system
-            stages: [commit-msg]
-            description: Adds Change-ID to the commit message. Needed by Gerrit.
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-json
+  - id: check-yaml
+  - id: check-added-large-files
+  - id: mixed-line-ending
+    args: [--fix=lf]
+  - id: requirements-txt-fixer
+  - id: check-case-conflict
+- repo: https://github.com/psf/black
+  rev: 22.6.0
+  hooks:
+    - id: black
+- repo: local
+  hooks:
+  - id: gem5-style-checker
+    name: gem5 style checker
+    entry: util/git-pre-commit.py
+    always_run: true
+    exclude: ".*"
+    language: system
+    description: 'The gem5 style checker hook.'
+  - id: gem5-commit-msg-checker
+    name: gem5 commit msg checker
+    entry: ext/git-commit-msg
+    language: system
+    stages: [commit-msg]
+    description: 'The gem5 commit message checker hook.'
+  - id: gerrit-commit-msg-job
+    name: gerrit commit message job
+    entry: util/gerrit-commit-msg-hook
+    language: system
+    stages: [commit-msg]
+    description: 'Adds Change-ID to the commit message. Needed by Gerrit.'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
           - id: check-added-large-files
           - id: mixed-line-ending
             args: [--fix=lf]
+          - id: check-ast
           - id: check-case-conflict
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,40 +52,43 @@ exclude: |
 default_stages: [commit]
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
-  hooks:
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-json
-  - id: check-yaml
-  - id: check-added-large-files
-  - id: mixed-line-ending
-    args: [--fix=lf]
-  - id: requirements-txt-fixer
-  - id: check-case-conflict
-- repo: https://github.com/psf/black
-  rev: 22.6.0
-  hooks:
-    - id: black
-- repo: local
-  hooks:
-  - id: gem5-style-checker
-    name: gem5 style checker
-    entry: util/git-pre-commit.py
-    always_run: true
-    exclude: ".*"
-    language: system
-    description: 'The gem5 style checker hook.'
-  - id: gem5-commit-msg-checker
-    name: gem5 commit msg checker
-    entry: ext/git-commit-msg
-    language: system
-    stages: [commit-msg]
-    description: 'The gem5 commit message checker hook.'
-  - id: gerrit-commit-msg-job
-    name: gerrit commit message job
-    entry: util/gerrit-commit-msg-hook
-    language: system
-    stages: [commit-msg]
-    description: 'Adds Change-ID to the commit message. Needed by Gerrit.'
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.5.0
+      hooks:
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+          - id: check-json
+          - id: check-yaml
+          - id: check-added-large-files
+          - id: mixed-line-ending
+            args: [--fix=lf]
+          - id: check-case-conflict
+    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+      rev: 0.2.3
+      hooks:
+          - id: yamlfmt
+    - repo: https://github.com/psf/black
+      rev: 23.9.1
+      hooks:
+          - id: black
+    - repo: local
+      hooks:
+          - id: gem5-style-checker
+            name: gem5 style checker
+            entry: util/git-pre-commit.py
+            always_run: true
+            exclude: .*
+            language: system
+            description: The gem5 style checker hook.
+          - id: gem5-commit-msg-checker
+            name: gem5 commit msg checker
+            entry: ext/git-commit-msg
+            language: system
+            stages: [commit-msg]
+            description: The gem5 commit message checker hook.
+          - id: gerrit-commit-msg-job
+            name: gerrit commit message job
+            entry: util/gerrit-commit-msg-hook
+            language: system
+            stages: [commit-msg]
+            description: Adds Change-ID to the commit message. Needed by Gerrit.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,46 +52,40 @@ exclude: |
 default_stages: [commit]
 
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-json
-          - id: check-yaml
-          - id: check-added-large-files
-          - id: mixed-line-ending
-            args: [--fix=lf]
-          - id: check-ast
-          - id: check-case-conflict
-          - id: check-merge-conflict
-          - id: requirements-txt-fixer
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.2.3
-      hooks:
-          - id: yamlfmt
-    - repo: https://github.com/psf/black
-      rev: 23.9.1
-      hooks:
-          - id: black
-    - repo: local
-      hooks:
-          - id: gem5-style-checker
-            name: gem5 style checker
-            entry: util/git-pre-commit.py
-            always_run: true
-            exclude: .*
-            language: system
-            description: The gem5 style checker hook.
-          - id: gem5-commit-msg-checker
-            name: gem5 commit msg checker
-            entry: ext/git-commit-msg
-            language: system
-            stages: [commit-msg]
-            description: The gem5 commit message checker hook.
-          - id: gerrit-commit-msg-job
-            name: gerrit commit message job
-            entry: util/gerrit-commit-msg-hook
-            language: system
-            stages: [commit-msg]
-            description: Adds Change-ID to the commit message. Needed by Gerrit.
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-json
+  - id: check-yaml
+  - id: check-added-large-files
+  - id: mixed-line-ending
+    args: [--fix=lf]
+  - id: requirements-txt-fixer
+  - id: check-case-conflict
+- repo: https://github.com/psf/black
+  rev: 22.6.0
+  hooks:
+    - id: black
+- repo: local
+  hooks:
+  - id: gem5-style-checker
+    name: gem5 style checker
+    entry: util/git-pre-commit.py
+    always_run: true
+    exclude: ".*"
+    language: system
+    description: 'The gem5 style checker hook.'
+  - id: gem5-commit-msg-checker
+    name: gem5 commit msg checker
+    entry: ext/git-commit-msg
+    language: system
+    stages: [commit-msg]
+    description: 'The gem5 commit message checker hook.'
+  - id: gerrit-commit-msg-job
+    name: gerrit commit message job
+    entry: util/gerrit-commit-msg-hook
+    language: system
+    stages: [commit-msg]
+    description: 'Adds Change-ID to the commit message. Needed by Gerrit.'

--- a/src/dev/amdgpu/pm4_packet_processor.cc
+++ b/src/dev/amdgpu/pm4_packet_processor.cc
@@ -1197,6 +1197,8 @@ PM4PacketProcessor::unserialize(CheckpointIn &cp)
         PM4MapQueues* pkt = new PM4MapQueues;
         memset(pkt, 0, sizeof(PM4MapQueues));
         newQueue(mqd, offset[i], pkt, id[i]);
+        PM4Queue *new_q = queuesMap[offset[i]];
+        gpuDevice->insertQId(gpuDevice->lastVMID(), new_q->id());
 
         if (ib[i]) {
             queues[id[i]]->wptr(ib_wptr[i]);


### PR DESCRIPTION
dev-amdgpu: Add PM4 queue ID to GPU used VMID map
    
When restoring checkpoints for certain applications, gem5 tries to create new doorbells with a pre-existing queue ID and simulation crashes shortly after. This commit adds existing IDs to the GPU device's used VMID map so that new doorbells are aware of existing queue IDs and use a new ID. This ensures that queue IDs are unique after checkpoint restoration