### PR TITLE
util: Bump GPUFS build docker to 5.4.2

### DIFF
--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -44,12 +44,12 @@ RUN apt -y install wget gnupg2 rpm
 # Get the radeon gpg key for apt repository
 RUN wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
 
-# Modify apt sources to pull from ROCm 4.2 repository only
-RUN echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.2/ ubuntu main' | tee /etc/apt/sources.list.d/rocm.list
+# Modify apt sources to pull from ROCm 5.4.2 repository only
+RUN echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/5.4.2/ ubuntu main' | tee /etc/apt/sources.list.d/rocm.list
 
 RUN apt-get update
 RUN apt -y install libnuma-dev
 
 # Install the ROCm-dkms source
 RUN apt -y install initramfs-tools
-RUN apt -y install rocm-dkms
+RUN apt -y install rocm-dev


### PR DESCRIPTION
This dockerfile is used to *build* applications (e.g., from gem5-resources) which can be run using full system mode in a GPU build. The next releases disk image will use ROCm 5.4.2, therefore bump the version from 4.2 to that version.

Again this is used to *build* input applications only and is not needed to run or compile gem5 with GPUFS. For example:

$ docker build -t rocm54-build .
/some/gem5-resources/src/gpu/lulesh$ docker run --rm -u $UID:$GID -v \
    ${PWD}:${PWD} -w ${PWD} rocm54-build make

Change-Id: If169c8d433afb3044f9b88e883ff3bb2f4bc70d2