### PR TITLE
arch-riscv: Add PCEvent for RISCV FS Workload kernel panic/oops

### DIFF
--- a/src/arch/riscv/RiscvFsWorkload.py
+++ b/src/arch/riscv/RiscvFsWorkload.py
@@ -55,6 +55,16 @@ class RiscvLinux(KernelWorkload):
     )
     dtb_addr = Param.Addr(0x87E00000, "DTB address")
 
+    # gem5 event upon guest's kernel panic
+    # Default to false because when the kernel is compiled into the bootloader
+    # it will not have symbols
+    exit_on_kernel_panic = Param.Bool(
+        False, "Generate gem5 panic upon the guest's kernel panic."
+    )
+    exit_on_kernel_oops = Param.Bool(
+        False, "Generate gem5 panic upon the guest's kernel oops."
+    )
+
 
 class RiscvBootloaderKernelWorkload(Workload):
     type = "RiscvBootloaderKernelWorkload"
@@ -84,5 +94,28 @@ class RiscvBootloaderKernelWorkload(Workload):
 
     # booting parameters
     command_line = Param.String(
-        "", "Booting arguments, to be passed to the kernel"
+        "", "Booting arguments, to be passed to the kernel."
+    )
+
+    # gem5 event upon guest's kernel panic
+    # Note that if the kernel doesn't have symbols there will be a warning and
+    # gem5 will not exit
+    exit_on_kernel_panic = Param.Bool(
+        True, "Generate gem5 exit upon the guest's kernel panic."
+    )
+    exit_on_kernel_oops = Param.Bool(
+        False, "Generate gem5 exit upon the guest's kernel oops."
+    )
+
+    # Note: Duplicated from KernelWorkload for now
+    on_panic = Param.KernelPanicOopsBehaviour(
+        "DumpDmesgAndExit",
+        "Define how gem5 should behave after a Linux Kernel Panic. "
+        "Handler might not be implemented for all architectures.",
+    )
+
+    on_oops = Param.KernelPanicOopsBehaviour(
+        "DumpDmesgAndExit",
+        "Define how gem5 should behave after a Linux Kernel Oops. "
+        "Handler might not be implemented for all architectures.",
     )

--- a/src/arch/riscv/linux/fs_workload.hh
+++ b/src/arch/riscv/linux/fs_workload.hh
@@ -44,11 +44,30 @@ namespace RiscvISA
 
 class FsLinux : public KernelWorkload
 {
+  private:
+    /**
+     * Event to halt the simulator if the kernel calls panic() or
+     * oops_exit()
+     **/
+    PCEvent *kernelPanicPcEvent = nullptr;
+    PCEvent *kernelOopsPcEvent = nullptr;
+    void addExitOnKernelPanicEvent();
+    void addExitOnKernelOopsEvent();
   public:
     PARAMS(RiscvLinux);
     FsLinux(const Params &p) : KernelWorkload(p) {}
+    ~FsLinux()
+    {
+        if (kernelPanicPcEvent != nullptr) {
+            delete kernelPanicPcEvent;
+        }
+        if (kernelOopsPcEvent != nullptr) {
+            delete kernelOopsPcEvent;
+        }
+    }
 
     void initState() override;
+    void startup() override;
 
     void
     setSystem(System *sys) override
@@ -71,12 +90,21 @@ class BootloaderKernelWorkload: public Workload
     loader::SymbolTable bootloaderSymbolTable;
     const std::string bootArgs;
 
+    /**
+     * Event to halt the simulator if the kernel calls panic() or
+     * oops_exit()
+     **/
+    PCEvent *kernelPanicPcEvent = nullptr;
+    PCEvent *kernelOopsPcEvent = nullptr;
+
   private:
     void loadBootloaderSymbolTable();
     void loadKernelSymbolTable();
     void loadBootloader();
     void loadKernel();
     void loadDtb();
+    void addExitOnKernelPanicEvent();
+    void addExitOnKernelOopsEvent();
 
   public:
     PARAMS(RiscvBootloaderKernelWorkload);
@@ -87,7 +115,18 @@ class BootloaderKernelWorkload: public Workload
         loadKernelSymbolTable();
     }
 
+    ~BootloaderKernelWorkload()
+    {
+        if (kernelPanicPcEvent != nullptr) {
+            delete kernelPanicPcEvent;
+        }
+        if (kernelOopsPcEvent != nullptr) {
+            delete kernelOopsPcEvent;
+        }
+    }
+
     void initState() override;
+    void startup() override;
 
     void
     setSystem(System *sys) override

--- a/src/python/gem5/simulate/exit_event.py
+++ b/src/python/gem5/simulate/exit_event.py
@@ -53,6 +53,8 @@ class ExitEvent(Enum):
     PERF_COUNTER_DISABLE = "performance counter disabled"
     PERF_COUNTER_RESET = "performance counter reset"
     PERF_COUNTER_INTERRUPT = "performance counter interrupt"
+    KERNEL_PANIC = "kernel panic in simulated system"
+    KERNEL_OOPS = "kernel oops in simulated system"
 
     @classmethod
     def translate_exit_status(cls, exit_string: str) -> "ExitEvent":
@@ -103,6 +105,10 @@ class ExitEvent(Enum):
             return ExitEvent.PERF_COUNTER_RESET
         elif exit_string == "performance counter interrupt":
             return ExitEvent.PERF_COUNTER_INTERRUPT
+        elif exit_string == "Kernel panic in simulated system.":
+            return ExitEvent.KERNEL_PANIC
+        elif exit_string == "Kernel oops in simulated system.":
+            return ExitEvent.KERNEL_OOPS
         elif exit_string.endswith("will terminate the simulation.\n"):
             # This is for the traffic generator exit event
             return ExitEvent.EXIT

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -308,6 +308,8 @@ class Simulator:
                 "max instructions",
                 "exiting the simulation",
             )(),
+            ExitEvent.KERNEL_PANIC: exit_generator(),
+            ExitEvent.KERNEL_OOPS: exit_generator(),
         }
 
         if on_exit_event:


### PR DESCRIPTION
Inspired by the similar feature in ARM's full system workload, this change adds
an option to halt gem5 simulation if the guest system encounter kernel panic
or kernel oops.

On RiscvISA::BootloaderKernelWorkload, by default, the simulation
will exit upon kernel panic, while kernel oops will not induce simulation halt.
This is because the system will essentially do nop after a kernel panic, while the
system might be still functional after a kernel oops.

Dumping kernel's dmesg is useful for diagonizing the cause of kernel panic, so
ideally, we want to dump the guest's dmesg to the host. However, due to a bug
described in [1], kernel v5.18+ dmesg might not be dumped properly. Hence, the
dmesg will not be dumped to the host.

On RiscvISA::FsLinux, this feature is turned off by default as the symbols from the
official RISC-V kernel resource are stripped from the binary. However, if this feature
is enable, the dmesg will be dumped to the host system.

[1] https://github.com/gem5/gem5/issues/550

Change-Id: I8f52257727a3a789ebf99fdd4dffe5b3d89f1ebf