### PR TITLE
ext,github,tests: Update DRAMSys tests to v5.0 and handle new dependencies

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -89,11 +89,7 @@ jobs:
 
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
-              run: |
-                  git clone https://github.com/tukl-msd/DRAMSys DRAMSys
-                  cd DRAMSys
-                  git checkout -b gem5 09f6dcbb91351e6ee7cadfc7bc8b29d97625db8f
-                  git submodule update --init --recursive
+              run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.0 --depth 1 DRAMSys
 
       # gem5 is built separately because it depends on the DRAMSys library
             - name: Build gem5

--- a/ext/dramsys/.gitignore
+++ b/ext/dramsys/.gitignore
@@ -1,0 +1,1 @@
+DRAMSys

--- a/ext/dramsys/SConscript
+++ b/ext/dramsys/SConscript
@@ -27,6 +27,10 @@
 import os
 import subprocess
 
+from shutil import which
+
+from gem5_scons import warning
+
 Import("env")
 
 build_root = Dir("../..").abspath
@@ -37,6 +41,16 @@ scons_root = Dir("#").abspath
 # See if we got a cloned DRAMSys repo as a subdirectory and set the
 # HAVE_DRAMSys flag accordingly
 if not os.path.exists(Dir(".").srcnode().abspath + "/DRAMSys"):
+    env["HAVE_DRAMSYS"] = False
+    Return()
+
+# DRAMSys requires CMake to build but this is is not a dependency for
+# gem5 outside of this DRAMSys integration. Therefore, we do not fail the
+# entire gem5 build if CMake is not found. Instead we just skip the building of
+# DRAMSys and print a warning.
+if which("cmake") is None:
+    warning("The DRAMSys repo is present but CMake cannot be found. "
+            "DRAMSys will not be built.")
     env["HAVE_DRAMSYS"] = False
     Return()
 

--- a/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
@@ -32,7 +32,7 @@ RUN apt -y update && apt -y upgrade && \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev python-is-python3 doxygen libboost-all-dev \
     libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config pip \
-    python3-venv black gcc-10 g++-10
+    python3-venv black gcc-10 g++-10 cmake
 
 RUN pip install mypy pre-commit
 

--- a/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
@@ -31,6 +31,6 @@ RUN apt -y update && apt -y upgrade && \
     apt -y install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev doxygen libboost-all-dev libhdf5-serial-dev python3-pydot \
-    libpng-dev libelf-dev pkg-config pip python3-venv black
+    libpng-dev libelf-dev pkg-config pip python3-venv black cmake
 
 RUN pip install mypy pre-commit


### PR DESCRIPTION
#525 Updated DRAMSys to v5.0. This PR further improves v5.0 inforporation into gem5 by better managing its new dependencies and updating the DRAMSys tests to use v5.0.

This PR:

1. Adds a check which throws warning if DRAMSys cannot be build due to a missing `cmake` instead of failing with a build error. `cmake` is not a hard gem5 requirement. It is only required to build DRAMSys in the cases it is required. It is therefore prudent to not fail a build in cases `cmake` is not present on the host system.
2. Updates the "all-dependency" Docker images to include the optional dependencies `git-lfs` (needed to clone the DRAMSys repo when running the command outlined in ext/dramsys/README -- introduced in #525) and `cmake` (needed to build DRAMSys).
3. Updates the Weekly workflow's `dramsys-tests`' `Checkout DRAMSys` job to clone DRAMSys in the same manner as outlined in ext/dramsys/README. This ensures the `dram-systests` test the instructions we give users.
4. `.gitignore` is added to ext/dramsys to ignore the ext/dramsys/DRAMSys directory when cloned for building and integration into gem5.

(2.) Should fix our failing weekly tests: https://github.com/gem5/gem5/actions/runs/6912511984/job/18808339821 and (3.) will ensure the changes introduced in #525 are tested.