### PR TITLE
mem-ruby: Fix typo in CHI's Send_CompI

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -2949,7 +2949,6 @@ action(Send_CompI, desc="") {
     out_msg.type := CHIResponseType:Comp_I;
     out_msg.responder := machineID;
     out_msg.Destination.add(tbe.requestor);
-    out_msg.Destination.add(tbe.requestor);
     out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
   }


### PR DESCRIPTION
The destination for the response is set twice.

Change-Id: Ia02ccb4bcf312fa4f39d69a46af26c2e2377ef41