### PR TITLE
dev: Fix `std::min` type mismatch in reg_bank.hh

### DIFF
--- a/src/dev/reg_bank.hh
+++ b/src/dev/reg_bank.hh
@@ -979,9 +979,9 @@ class RegisterBank : public RegisterBankBase
         std::ostringstream ss;
         while (done != bytes) {
           RegisterBase &reg = it->second.get();
-          const size_t reg_off = addr - it->first;
-          const size_t reg_size = reg.size() - reg_off;
-          const size_t reg_bytes = std::min(reg_size, bytes - done);
+          const Addr reg_off = addr - it->first;
+          const Addr reg_size = reg.size() - reg_off;
+          const Addr reg_bytes = std::min(reg_size, bytes - done);
 
           if (reg_bytes != reg.size()) {
               if (_debug_flag) {
@@ -1025,9 +1025,9 @@ class RegisterBank : public RegisterBankBase
         std::ostringstream ss;
         while (done != bytes) {
             RegisterBase &reg = it->second.get();
-            const size_t reg_off = addr - it->first;
-            const size_t reg_size = reg.size() - reg_off;
-            const size_t reg_bytes = std::min(reg_size, bytes - done);
+            const Addr reg_off = addr - it->first;
+            const Addr reg_size = reg.size() - reg_off;
+            const Addr reg_bytes = std::min(reg_size, bytes - done);
 
             if (reg_bytes != reg.size()) {
                 if (_debug_flag) {


### PR DESCRIPTION
https://github.com/gem5/gem5/pull/386 included two cases in "src/dev/reg_bank.hh" where `std:: min` was used to compare a an integer of type `size_t` and another of type `Addr`. This causes an error on my Apple Silicon Mac as the comparison between an "unsigned long" and an "unsigned long long" is not permitted. To fix this issue this patch changes `reg_size`  from `size_t` to `Addr`, as well as it the types of the values it was derived from and the variable used to hold the return from the `std::min` calls. While not completely correct typing from a labelling perspective (`reg_bytes` is not an address), functions in "src/dev/reg_bank.hh" already abuse `Addr` in this way frequently (for example,  `bytes` in the `write` function).