### PR TITLE
arch-arm: Fix Virtual Interrupt logic in secure mode

### DIFF
--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -203,7 +203,7 @@ class Interrupts : public BaseInterrupts
     getISR(HCR hcr, CPSR cpsr, SCR scr)
     {
         bool useHcrMux;
-        CPSR isr = 0; // ARM ARM states ISR reg uses same bit possitions as CPSR
+        ISR isr = 0;
 
         useHcrMux = (cpsr.mode != MODE_HYP) && !isSecure(tc);
         isr.i = (useHcrMux & hcr.imo) ? (interrupts[INT_VIRT_IRQ] || hcr.vi)

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -146,20 +146,15 @@ class Interrupts : public BaseInterrupts
         if (!(intStatus || hcr.va || hcr.vi || hcr.vf))
             return false;
 
-        bool take_irq = takeInt(INT_IRQ);
-        bool take_fiq = takeInt(INT_FIQ);
-        bool take_ea =  takeInt(INT_ABT);
-        bool take_virq = takeVirtualInt(INT_VIRT_IRQ);
-        bool take_vfiq = takeVirtualInt(INT_VIRT_FIQ);
-        bool take_vabt = takeVirtualInt(INT_VIRT_ABT);
-
-        return ((interrupts[INT_IRQ] && take_irq)                   ||
-                (interrupts[INT_FIQ] && take_fiq)                   ||
-                (interrupts[INT_ABT] && take_ea)                    ||
-                ((interrupts[INT_VIRT_IRQ] || hcr.vi) && take_virq) ||
-                ((interrupts[INT_VIRT_FIQ] || hcr.vf) && take_vfiq) ||
-                (hcr.va && take_vabt)                               ||
-                (interrupts[INT_RST])                               ||
+        return ((interrupts[INT_IRQ] && takeInt(INT_IRQ)) ||
+                (interrupts[INT_FIQ] && takeInt(INT_FIQ)) ||
+                (interrupts[INT_ABT] && takeInt(INT_ABT)) ||
+                ((interrupts[INT_VIRT_IRQ] || hcr.vi) &&
+                    takeVirtualInt(INT_VIRT_IRQ)) ||
+                ((interrupts[INT_VIRT_FIQ] || hcr.vf) &&
+                    takeVirtualInt(INT_VIRT_FIQ)) ||
+                (hcr.va && takeVirtualInt(INT_VIRT_ABT)) ||
+                (interrupts[INT_RST]) ||
                 (interrupts[INT_SEV])
                );
     }
@@ -224,24 +219,19 @@ class Interrupts : public BaseInterrupts
 
         HCR  hcr  = tc->readMiscReg(MISCREG_HCR_EL2);
 
-        bool take_irq = takeInt(INT_IRQ);
-        bool take_fiq = takeInt(INT_FIQ);
-        bool take_ea =  takeInt(INT_ABT);
-        bool take_virq = takeVirtualInt(INT_VIRT_IRQ);
-        bool take_vfiq = takeVirtualInt(INT_VIRT_FIQ);
-        bool take_vabt = takeVirtualInt(INT_VIRT_ABT);
-
-        if (interrupts[INT_IRQ] && take_irq)
+        if (interrupts[INT_IRQ] && takeInt(INT_IRQ))
             return std::make_shared<Interrupt>();
-        if ((interrupts[INT_VIRT_IRQ] || hcr.vi) && take_virq)
+        if ((interrupts[INT_VIRT_IRQ] || hcr.vi) &&
+            takeVirtualInt(INT_VIRT_IRQ))
             return std::make_shared<VirtualInterrupt>();
-        if (interrupts[INT_FIQ] && take_fiq)
+        if (interrupts[INT_FIQ] && takeInt(INT_FIQ))
             return std::make_shared<FastInterrupt>();
-        if ((interrupts[INT_VIRT_FIQ] || hcr.vf) && take_vfiq)
+        if ((interrupts[INT_VIRT_FIQ] || hcr.vf) &&
+            takeVirtualInt(INT_VIRT_FIQ))
             return std::make_shared<VirtualFastInterrupt>();
-        if (interrupts[INT_ABT] && take_ea)
+        if (interrupts[INT_ABT] && takeInt(INT_ABT))
             return std::make_shared<SystemError>();
-        if (hcr.va && take_vabt)
+        if (hcr.va && takeVirtualInt(INT_VIRT_ABT))
             return std::make_shared<VirtualDataAbort>(
                 0, TlbEntry::DomainType::NoAccess, false,
                 ArmFault::AsynchronousExternalAbort);

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -137,6 +137,8 @@ class Interrupts : public BaseInterrupts
     bool takeInt64(InterruptTypes int_type) const;
 
     bool takeVirtualInt(InterruptTypes int_type) const;
+    bool takeVirtualInt32(InterruptTypes int_type) const;
+    bool takeVirtualInt64(InterruptTypes int_type) const;
 
     bool
     checkInterrupts() const override

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012-2013, 2016 ARM Limited
+ * Copyright (c) 2010, 2012-2013, 2016, 2023 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -202,15 +202,14 @@ class Interrupts : public BaseInterrupts
     uint32_t
     getISR(HCR hcr, CPSR cpsr, SCR scr)
     {
-        bool useHcrMux;
+        bool use_hcr_mux = currEL(cpsr) < EL2 && EL2Enabled(tc);
         ISR isr = 0;
 
-        useHcrMux = (cpsr.mode != MODE_HYP) && !isSecure(tc);
-        isr.i = (useHcrMux & hcr.imo) ? (interrupts[INT_VIRT_IRQ] || hcr.vi)
-                                      :  interrupts[INT_IRQ];
-        isr.f = (useHcrMux & hcr.fmo) ? (interrupts[INT_VIRT_FIQ] || hcr.vf)
-                                      :  interrupts[INT_FIQ];
-        isr.a = (useHcrMux & hcr.amo) ?  hcr.va : interrupts[INT_ABT];
+        isr.i = (use_hcr_mux & hcr.imo) ? (interrupts[INT_VIRT_IRQ] || hcr.vi)
+                                        :  interrupts[INT_IRQ];
+        isr.f = (use_hcr_mux & hcr.fmo) ? (interrupts[INT_VIRT_FIQ] || hcr.vf)
+                                        :  interrupts[INT_FIQ];
+        isr.a = (use_hcr_mux & hcr.amo) ?  hcr.va : interrupts[INT_ABT];
         return isr;
     }
 

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -169,16 +169,16 @@ class Interrupts : public BaseInterrupts
     bool
     checkWfiWake(HCR hcr, CPSR cpsr, SCR scr) const
     {
-        uint64_t maskedIntStatus;
-        bool     virtWake;
+        uint64_t masked_int_status;
+        bool     virt_wake;
 
-        maskedIntStatus = intStatus & ~((1 << INT_VIRT_IRQ) |
-                                        (1 << INT_VIRT_FIQ));
-        virtWake  = (hcr.vi || interrupts[INT_VIRT_IRQ]) && hcr.imo;
-        virtWake |= (hcr.vf || interrupts[INT_VIRT_FIQ]) && hcr.fmo;
-        virtWake |=  hcr.va                              && hcr.amo;
-        virtWake &= (cpsr.mode != MODE_HYP) && !isSecure(tc);
-        return maskedIntStatus || virtWake;
+        masked_int_status = intStatus & ~((1 << INT_VIRT_IRQ) |
+                                          (1 << INT_VIRT_FIQ));
+        virt_wake  = (hcr.vi || interrupts[INT_VIRT_IRQ]) && hcr.imo;
+        virt_wake |= (hcr.vf || interrupts[INT_VIRT_FIQ]) && hcr.fmo;
+        virt_wake |=  hcr.va                              && hcr.amo;
+        virt_wake &= currEL(cpsr) < EL2 && EL2Enabled(tc);
+        return masked_int_status || virt_wake;
     }
 
     uint32_t

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -75,6 +75,12 @@ namespace ArmISA
         Bitfield<0> sp;         // AArch64
     EndBitUnion(CPSR)
 
+    BitUnion32(ISR)
+        Bitfield<8> a;
+        Bitfield<7> i;
+        Bitfield<6> f;
+    EndBitUnion(ISR)
+
     BitUnion32(ISAR5)
         Bitfield<31, 28> vcma;
         Bitfield<27, 24> rdm;


### PR DESCRIPTION
This PR is fixing remaining issues in the ArmISA::Interrupt class; more specifically it is enabling
virtual interrupts in secure mode (when FEAT_SEL2 is present). Previous version was assuming no
virtual interrupt was possible in secure mode. We fix this assumption by replacing the security check
with the EL2Enabled helper which closely matches the Arm pseudocode