### PR TITLE
mem-ruby: Fixes for new AtomicWait event in VIPER TCC

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -938,7 +938,7 @@ machine(MachineType:TCC, "TCC Cache")
       st_stallAndWaitRequest;
   }
 
-  transition({I, IV, V}, AtomicWait) {
+  transition({I, IV, V, WI}, AtomicWait) {
     // don't profile as hit or miss since it will be tried again
     /*
       By putting the stalled requests in a buffer, we reduce resource contention
@@ -1273,6 +1273,7 @@ machine(MachineType:TCC, "TCC Cache")
     wardb_writeAtomicResponseDirtyBytes;
     pa_performAtomic;
     baplr_sendBypassedAtomicPerformedLocallyResponse;
+    dt_deallocateTBE;
     pr_popResponseQueue;
   }
 


### PR DESCRIPTION
The AtomicWait event was not being woken up properly due to the numPending count in the TBE not being decremented. This patch decrements the count when Data is returned. Since that moves to a base state, the TBE should no longer be needed.

Additionally added a transition which stalls and wait when an AtomicWait occurs while in WI state so that it retries.

Change-Id: Ic8bfc700f9df3f95bea0799121898926a23d8163