### PR TITLE
arch-x86: Fixes page fault for CLFLUSH on write-protected pages

### DIFF
--- a/src/arch/x86/tlb.cc
+++ b/src/arch/x86/tlb.cc
@@ -509,6 +509,9 @@ TLB::translateAtomic(const RequestPtr &req, ThreadContext *tc,
     BaseMMU::Mode mode)
 {
     bool delayedResponse;
+    // CLFLUSHOPT/WB/FLUSH should be treated as read for protection checks
+    if (req->isCacheClean())
+        mode = BaseMMU::Read;
     return TLB::translate(req, tc, NULL, mode, delayedResponse, false);
 }
 
@@ -516,6 +519,9 @@ Fault
 TLB::translateFunctional(const RequestPtr &req, ThreadContext *tc,
     BaseMMU::Mode mode)
 {
+    // CLFLUSHOPT/WB/FLUSH should be treated as read for protection checks
+    if (req->isCacheClean())
+        mode = BaseMMU::Read;
     unsigned logBytes;
     const Addr vaddr = req->getVaddr();
     Addr addr = vaddr;
@@ -553,6 +559,9 @@ TLB::translateTiming(const RequestPtr &req, ThreadContext *tc,
 {
     bool delayedResponse;
     assert(translation);
+    // CLFLUSHOPT/WB/FLUSH should be treated as read for protection checks
+    if (req->isCacheClean())
+        mode = BaseMMU::Read;
     Fault fault =
         TLB::translate(req, tc, translation, mode, delayedResponse, true);
     if (!delayedResponse)


### PR DESCRIPTION
Converts CLFLUSHOPT/WB/FLUSH operations from Write to Read operations during address translation so that they don't trigger a page fault when done on write-protected pages.

Solves #226