### PR TITLE
mem-ruby: Unused L3CacheCntrl freed

### DIFF
--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -338,6 +338,7 @@ class L3Cache(RubyCache):
         self.replacement_policy = TreePLRURP()
 
 
+# unused in GPU_VIPER; see git blame for discussion
 class L3Cntrl(L3Cache_Controller, CntrlBase):
     def create(self, options, ruby_system, system):
         self.version = self.versionCount()

--- a/src/mem/ruby/protocol/GPU_VIPER.slicc
+++ b/src/mem/ruby/protocol/GPU_VIPER.slicc
@@ -8,4 +8,4 @@ include "GPU_VIPER-msg.sm";
 include "GPU_VIPER-TCP.sm";
 include "GPU_VIPER-SQC.sm";
 include "GPU_VIPER-TCC.sm";
-include "MOESI_AMD_Base-L3cache.sm";
+include "MOESI_AMD_Base-L3cache.sm"; // unused in GPU_VIPER; see git blame for discussion


### PR DESCRIPTION
Seems like the MOESI_AMD_Base-L3Cache.sm file is unused in the VIPER protocol. It's confusing to have it in the GPU_VIPER.slicc file.