### PR TITLE
arch-vega,arch-gcn3: Bugfix V_PERM_B32 and V_OR3_B32

### DIFF
--- a/src/arch/amdgpu/gcn3/insts/instructions.cc
+++ b/src/arch/amdgpu/gcn3/insts/instructions.cc
@@ -29692,7 +29692,7 @@ namespace Gcn3ISA
                 for (int i = 0; i < 4 ; ++i) {
                     VecElemU32 permuted_val = permute(selector, 0xFF
                         & ((VecElemU32)src2[lane] >> (8 * i)));
-                    vdst[lane] |= (permuted_val << i);
+                    vdst[lane] |= (permuted_val << (8 * i));
                 }
 
                 DPRINTF(GCN3, "v_perm result: 0x%08x\n", vdst[lane]);

--- a/src/arch/amdgpu/vega/decoder.cc
+++ b/src/arch/amdgpu/vega/decoder.cc
@@ -7020,7 +7020,7 @@ namespace VegaISA
     GPUStaticInst*
     Decoder::decode_OPU_VOP3__V_OR3_B32(MachInst iFmt)
     {
-        return new Inst_VOP3__V_OR_B32(&iFmt->iFmt_VOP3A);
+        return new Inst_VOP3__V_OR3_B32(&iFmt->iFmt_VOP3A);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/insts/instructions.cc
+++ b/src/arch/amdgpu/vega/insts/instructions.cc
@@ -32671,7 +32671,7 @@ namespace VegaISA
                 for (int i = 0; i < 4 ; ++i) {
                     VecElemU32 permuted_val = permute(selector, 0xFF
                         & ((VecElemU32)src2[lane] >> (8 * i)));
-                    vdst[lane] |= (permuted_val << i);
+                    vdst[lane] |= (permuted_val << (8 * i));
                 }
 
                 DPRINTF(VEGA, "v_perm result: 0x%08x\n", vdst[lane]);


### PR DESCRIPTION
The V_PERM_B32 instruction is selecting the correct byte, but is shifting into place moving by bits instead of bytes. The V_OR3_B32 instruction is calling the wrong instruction implementation in the decoder.

This patch fixes both issues plus a bonus fix for GCN3's V_PERM_B32. (GCN3 does not have V_OR3_B32).

Change-Id: Ied66c43981bc4236f680db42a9868f760becc284