### PR TITLE
scons: Add an option to reduce memory usage of ld

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -131,6 +131,8 @@ AddOption('--with-systemc-tests', action='store_true',
           help='Build systemc tests')
 AddOption('--install-hooks', action='store_true',
           help='Install revision control hooks non-interactively')
+AddOption('--limit-ld-memory-usage', action='store_true',
+          help='Tell ld, the linker, to reduce memory usage.')
 AddOption('--gprof', action='store_true',
           help='Enable support for the gprof profiler')
 AddOption('--pprof', action='store_true',
@@ -587,6 +589,14 @@ for variant_path in variant_paths:
                     conf.CheckLinkFlag('-Wl,--threads')
                     conf.CheckLinkFlag(
                             '-Wl,--thread-count=%d' % GetOption('num_jobs'))
+
+        with gem5_scons.Configure(env) as conf:
+            ld_optimize_memory_usage = GetOption('limit_ld_memory_usage')
+            if ld_optimize_memory_usage:
+                if conf.CheckLinkFlag('-Wl,--no-keep-memory'):
+                    env.Append(LINKFLAGS=['-Wl,--no-keep-memory'])
+                else:
+                    error("Unable to use --no-keep-memory with the linker")
 
         # Treat warnings as errors but white list some warnings that we
         # want to allow (e.g., deprecation warnings).


### PR DESCRIPTION
Linking the gem5 binary consists of linking numerous object files. By default, ld optimizes for speed over for memory consumption [1]. This leads to the huge memory consumption of gem5 at the linking stage.

This patch adds an option to add the `--no-keep-memory` flag to ld. According to the documentation [1], this flag optimizes the memory usage of ld.

[1] https://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_chapter/ld_2.html#IDX133