### PR TITLE
arch-riscv: Fix narrow datatypes in RVV isa files

### DIFF
--- a/.github/workflows/gpu-tests.yaml
+++ b/.github/workflows/gpu-tests.yaml
@@ -61,7 +61,7 @@ jobs:
               working-directory: ${{ github.workspace }}
               run: |
                   build/GCN3_X86/gem5.opt configs/example/apu_se.py -n3 --mem-size=8GB --reg-alloc-policy=dynamic --benchmark-root="lulesh" -c \
-                  lulesh 0.01 2
+                  lulesh --options="0.01 2"
 
     HACC-tests:
         runs-on: [self-hosted, linux, x64]

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -89,11 +89,7 @@ jobs:
 
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
-              run: |
-                  git clone https://github.com/tukl-msd/DRAMSys DRAMSys
-                  cd DRAMSys
-                  git checkout -b gem5 09f6dcbb91351e6ee7cadfc7bc8b29d97625db8f
-                  git submodule update --init --recursive
+              run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.0 --depth 1 DRAMSys
 
       # gem5 is built separately because it depends on the DRAMSys library
             - name: Build gem5

--- a/ext/dramsys/.gitignore
+++ b/ext/dramsys/.gitignore
@@ -1,0 +1,1 @@
+DRAMSys

--- a/ext/dramsys/SConscript
+++ b/ext/dramsys/SConscript
@@ -27,6 +27,10 @@
 import os
 import subprocess
 
+from shutil import which
+
+from gem5_scons import warning
+
 Import("env")
 
 build_root = Dir("../..").abspath
@@ -37,6 +41,16 @@ scons_root = Dir("#").abspath
 # See if we got a cloned DRAMSys repo as a subdirectory and set the
 # HAVE_DRAMSys flag accordingly
 if not os.path.exists(Dir(".").srcnode().abspath + "/DRAMSys"):
+    env["HAVE_DRAMSYS"] = False
+    Return()
+
+# DRAMSys requires CMake to build but this is is not a dependency for
+# gem5 outside of this DRAMSys integration. Therefore, we do not fail the
+# entire gem5 build if CMake is not found. Instead we just skip the building of
+# DRAMSys and print a warning.
+if which("cmake") is None:
+    warning("The DRAMSys repo is present but CMake cannot be found. "
+            "DRAMSys will not be built.")
     env["HAVE_DRAMSYS"] = False
     Return()
 

--- a/src/arch/amdgpu/gcn3/insts/instructions.cc
+++ b/src/arch/amdgpu/gcn3/insts/instructions.cc
@@ -29692,7 +29692,7 @@ namespace Gcn3ISA
                 for (int i = 0; i < 4 ; ++i) {
                     VecElemU32 permuted_val = permute(selector, 0xFF
                         & ((VecElemU32)src2[lane] >> (8 * i)));
-                    vdst[lane] |= (permuted_val << i);
+                    vdst[lane] |= (permuted_val << (8 * i));
                 }
 
                 DPRINTF(GCN3, "v_perm result: 0x%08x\n", vdst[lane]);

--- a/src/arch/amdgpu/vega/decoder.cc
+++ b/src/arch/amdgpu/vega/decoder.cc
@@ -7020,7 +7020,7 @@ namespace VegaISA
     GPUStaticInst*
     Decoder::decode_OPU_VOP3__V_OR3_B32(MachInst iFmt)
     {
-        return new Inst_VOP3__V_OR_B32(&iFmt->iFmt_VOP3A);
+        return new Inst_VOP3__V_OR3_B32(&iFmt->iFmt_VOP3A);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/insts/instructions.cc
+++ b/src/arch/amdgpu/vega/insts/instructions.cc
@@ -32671,7 +32671,7 @@ namespace VegaISA
                 for (int i = 0; i < 4 ; ++i) {
                     VecElemU32 permuted_val = permute(selector, 0xFF
                         & ((VecElemU32)src2[lane] >> (8 * i)));
-                    vdst[lane] |= (permuted_val << i);
+                    vdst[lane] |= (permuted_val << (8 * i));
                 }
 
                 DPRINTF(VEGA, "v_perm result: 0x%08x\n", vdst[lane]);

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -203,7 +203,7 @@ class Interrupts : public BaseInterrupts
     getISR(HCR hcr, CPSR cpsr, SCR scr)
     {
         bool useHcrMux;
-        CPSR isr = 0; // ARM ARM states ISR reg uses same bit possitions as CPSR
+        ISR isr = 0;
 
         useHcrMux = (cpsr.mode != MODE_HYP) && !isSecure(tc);
         isr.i = (useHcrMux & hcr.imo) ? (interrupts[INT_VIRT_IRQ] || hcr.vi)

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -146,20 +146,15 @@ class Interrupts : public BaseInterrupts
         if (!(intStatus || hcr.va || hcr.vi || hcr.vf))
             return false;
 
-        bool take_irq = takeInt(INT_IRQ);
-        bool take_fiq = takeInt(INT_FIQ);
-        bool take_ea =  takeInt(INT_ABT);
-        bool take_virq = takeVirtualInt(INT_VIRT_IRQ);
-        bool take_vfiq = takeVirtualInt(INT_VIRT_FIQ);
-        bool take_vabt = takeVirtualInt(INT_VIRT_ABT);
-
-        return ((interrupts[INT_IRQ] && take_irq)                   ||
-                (interrupts[INT_FIQ] && take_fiq)                   ||
-                (interrupts[INT_ABT] && take_ea)                    ||
-                ((interrupts[INT_VIRT_IRQ] || hcr.vi) && take_virq) ||
-                ((interrupts[INT_VIRT_FIQ] || hcr.vf) && take_vfiq) ||
-                (hcr.va && take_vabt)                               ||
-                (interrupts[INT_RST])                               ||
+        return ((interrupts[INT_IRQ] && takeInt(INT_IRQ)) ||
+                (interrupts[INT_FIQ] && takeInt(INT_FIQ)) ||
+                (interrupts[INT_ABT] && takeInt(INT_ABT)) ||
+                ((interrupts[INT_VIRT_IRQ] || hcr.vi) &&
+                    takeVirtualInt(INT_VIRT_IRQ)) ||
+                ((interrupts[INT_VIRT_FIQ] || hcr.vf) &&
+                    takeVirtualInt(INT_VIRT_FIQ)) ||
+                (hcr.va && takeVirtualInt(INT_VIRT_ABT)) ||
+                (interrupts[INT_RST]) ||
                 (interrupts[INT_SEV])
                );
     }
@@ -224,24 +219,19 @@ class Interrupts : public BaseInterrupts
 
         HCR  hcr  = tc->readMiscReg(MISCREG_HCR_EL2);
 
-        bool take_irq = takeInt(INT_IRQ);
-        bool take_fiq = takeInt(INT_FIQ);
-        bool take_ea =  takeInt(INT_ABT);
-        bool take_virq = takeVirtualInt(INT_VIRT_IRQ);
-        bool take_vfiq = takeVirtualInt(INT_VIRT_FIQ);
-        bool take_vabt = takeVirtualInt(INT_VIRT_ABT);
-
-        if (interrupts[INT_IRQ] && take_irq)
+        if (interrupts[INT_IRQ] && takeInt(INT_IRQ))
             return std::make_shared<Interrupt>();
-        if ((interrupts[INT_VIRT_IRQ] || hcr.vi) && take_virq)
+        if ((interrupts[INT_VIRT_IRQ] || hcr.vi) &&
+            takeVirtualInt(INT_VIRT_IRQ))
             return std::make_shared<VirtualInterrupt>();
-        if (interrupts[INT_FIQ] && take_fiq)
+        if (interrupts[INT_FIQ] && takeInt(INT_FIQ))
             return std::make_shared<FastInterrupt>();
-        if ((interrupts[INT_VIRT_FIQ] || hcr.vf) && take_vfiq)
+        if ((interrupts[INT_VIRT_FIQ] || hcr.vf) &&
+            takeVirtualInt(INT_VIRT_FIQ))
             return std::make_shared<VirtualFastInterrupt>();
-        if (interrupts[INT_ABT] && take_ea)
+        if (interrupts[INT_ABT] && takeInt(INT_ABT))
             return std::make_shared<SystemError>();
-        if (hcr.va && take_vabt)
+        if (hcr.va && takeVirtualInt(INT_VIRT_ABT))
             return std::make_shared<VirtualDataAbort>(
                 0, TlbEntry::DomainType::NoAccess, false,
                 ArmFault::AsynchronousExternalAbort);

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -137,6 +137,8 @@ class Interrupts : public BaseInterrupts
     bool takeInt64(InterruptTypes int_type) const;
 
     bool takeVirtualInt(InterruptTypes int_type) const;
+    bool takeVirtualInt32(InterruptTypes int_type) const;
+    bool takeVirtualInt64(InterruptTypes int_type) const;
 
     bool
     checkInterrupts() const override

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012-2013, 2016 ARM Limited
+ * Copyright (c) 2010, 2012-2013, 2016, 2023 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -202,15 +202,14 @@ class Interrupts : public BaseInterrupts
     uint32_t
     getISR(HCR hcr, CPSR cpsr, SCR scr)
     {
-        bool useHcrMux;
+        bool use_hcr_mux = currEL(cpsr) < EL2 && EL2Enabled(tc);
         ISR isr = 0;
 
-        useHcrMux = (cpsr.mode != MODE_HYP) && !isSecure(tc);
-        isr.i = (useHcrMux & hcr.imo) ? (interrupts[INT_VIRT_IRQ] || hcr.vi)
-                                      :  interrupts[INT_IRQ];
-        isr.f = (useHcrMux & hcr.fmo) ? (interrupts[INT_VIRT_FIQ] || hcr.vf)
-                                      :  interrupts[INT_FIQ];
-        isr.a = (useHcrMux & hcr.amo) ?  hcr.va : interrupts[INT_ABT];
+        isr.i = (use_hcr_mux & hcr.imo) ? (interrupts[INT_VIRT_IRQ] || hcr.vi)
+                                        :  interrupts[INT_IRQ];
+        isr.f = (use_hcr_mux & hcr.fmo) ? (interrupts[INT_VIRT_FIQ] || hcr.vf)
+                                        :  interrupts[INT_FIQ];
+        isr.a = (use_hcr_mux & hcr.amo) ?  hcr.va : interrupts[INT_ABT];
         return isr;
     }
 

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -169,16 +169,16 @@ class Interrupts : public BaseInterrupts
     bool
     checkWfiWake(HCR hcr, CPSR cpsr, SCR scr) const
     {
-        uint64_t maskedIntStatus;
-        bool     virtWake;
+        uint64_t masked_int_status;
+        bool     virt_wake;
 
-        maskedIntStatus = intStatus & ~((1 << INT_VIRT_IRQ) |
-                                        (1 << INT_VIRT_FIQ));
-        virtWake  = (hcr.vi || interrupts[INT_VIRT_IRQ]) && hcr.imo;
-        virtWake |= (hcr.vf || interrupts[INT_VIRT_FIQ]) && hcr.fmo;
-        virtWake |=  hcr.va                              && hcr.amo;
-        virtWake &= (cpsr.mode != MODE_HYP) && !isSecure(tc);
-        return maskedIntStatus || virtWake;
+        masked_int_status = intStatus & ~((1 << INT_VIRT_IRQ) |
+                                          (1 << INT_VIRT_FIQ));
+        virt_wake  = (hcr.vi || interrupts[INT_VIRT_IRQ]) && hcr.imo;
+        virt_wake |= (hcr.vf || interrupts[INT_VIRT_FIQ]) && hcr.fmo;
+        virt_wake |=  hcr.va                              && hcr.amo;
+        virt_wake &= currEL(cpsr) < EL2 && EL2Enabled(tc);
+        return masked_int_status || virt_wake;
     }
 
     uint32_t

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -75,6 +75,12 @@ namespace ArmISA
         Bitfield<0> sp;         // AArch64
     EndBitUnion(CPSR)
 
+    BitUnion32(ISR)
+        Bitfield<8> a;
+        Bitfield<7> i;
+        Bitfield<6> f;
+    EndBitUnion(ISR)
+
     BitUnion32(ISAR5)
         Bitfield<31, 28> vcma;
         Bitfield<27, 24> rdm;

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -137,10 +137,10 @@ class VectorMicroInst : public RiscvMicroInst
 protected:
     uint32_t vlen;
     uint32_t microVl;
-    uint8_t microIdx;
+    uint32_t microIdx;
     uint8_t vtype;
     VectorMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
-      uint32_t _microVl, uint8_t _microIdx, uint32_t _vlen = 256)
+      uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen = 256)
         : RiscvMicroInst(mnem, _machInst, __opClass),
         vlen(_vlen),
         microVl(_microVl),
@@ -178,7 +178,7 @@ class VectorArithMicroInst : public VectorMicroInst
 protected:
     VectorArithMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx)
+                         uint32_t _microIdx)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
     {}
 
@@ -204,7 +204,7 @@ class VectorVMUNARY0MicroInst : public VectorMicroInst
 protected:
     VectorVMUNARY0MicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx)
+                         uint32_t _microIdx)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
     {}
 
@@ -243,11 +243,11 @@ class VectorSlideMacroInst : public VectorMacroInst
 class VectorSlideMicroInst : public VectorMicroInst
 {
   protected:
-    uint8_t vdIdx;
-    uint8_t vs2Idx;
+    uint32_t vdIdx;
+    uint32_t vs2Idx;
     VectorSlideMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx, uint8_t _vdIdx, uint8_t _vs2Idx)
+                         uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
         , vdIdx(_vdIdx), vs2Idx(_vs2Idx)
     {}
@@ -263,8 +263,8 @@ class VectorMemMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VectorMemMicroInst(const char* mnem, ExtMachInst _machInst,
-                       OpClass __opClass, uint32_t _microVl, uint8_t _microIdx,
-                       uint32_t _offset)
+                       OpClass __opClass, uint32_t _microVl,
+                       uint32_t _microIdx, uint32_t _offset)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
         , offset(_offset)
         , memAccessFlags(0)
@@ -310,7 +310,7 @@ class VleMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VleMicroInst(const char *mnem, ExtMachInst _machInst,OpClass __opClass,
-                  uint32_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+                  uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                             _microIdx, _vlen)
     {
@@ -327,7 +327,7 @@ class VseMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VseMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
-                  uint32_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+                  uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                             _microIdx, _vlen)
     {
@@ -356,7 +356,7 @@ class VlWholeMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VlWholeMicroInst(const char *mnem, ExtMachInst _machInst,
-          OpClass __opClass, uint32_t _microVl, uint8_t _microIdx,
+          OpClass __opClass, uint32_t _microVl, uint32_t _microIdx,
           uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                             _microIdx, _vlen)
@@ -385,7 +385,7 @@ class VsWholeMicroInst : public VectorMicroInst
 
     VsWholeMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint32_t _microVl,
-                      uint8_t _microIdx, uint32_t _vlen)
+                      uint32_t _microIdx, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass , _microVl,
                           _microIdx, _vlen)
     {}
@@ -409,10 +409,10 @@ class VlStrideMacroInst : public VectorMemMacroInst
 class VlStrideMicroInst : public VectorMemMicroInst
 {
   protected:
-  uint8_t regIdx;
+  uint32_t regIdx;
     VlStrideMicroInst(const char *mnem, ExtMachInst _machInst,
-                      OpClass __opClass, uint8_t _regIdx,
-                      uint8_t _microIdx, uint32_t _microVl)
+                      OpClass __opClass, uint32_t _regIdx,
+                      uint32_t _microIdx, uint32_t _microVl)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
                              _microIdx, 0)
         , regIdx(_regIdx)
@@ -437,10 +437,10 @@ class VsStrideMacroInst : public VectorMemMacroInst
 class VsStrideMicroInst : public VectorMemMicroInst
 {
   protected:
-    uint8_t regIdx;
+    uint32_t regIdx;
     VsStrideMicroInst(const char *mnem, ExtMachInst _machInst,
-                      OpClass __opClass, uint8_t _regIdx,
-                      uint8_t _microIdx, uint32_t _microVl)
+                      OpClass __opClass, uint32_t _regIdx,
+                      uint32_t _microIdx, uint32_t _microVl)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
                              _microIdx, 0)
         , regIdx(_regIdx)
@@ -465,13 +465,13 @@ class VlIndexMacroInst : public VectorMemMacroInst
 class VlIndexMicroInst : public VectorMemMicroInst
 {
   protected:
-    uint8_t vdRegIdx;
-    uint8_t vdElemIdx;
-    uint8_t vs2RegIdx;
-    uint8_t vs2ElemIdx;
+    uint32_t vdRegIdx;
+    uint32_t vdElemIdx;
+    uint32_t vs2RegIdx;
+    uint32_t vs2ElemIdx;
     VlIndexMicroInst(const char *mnem, ExtMachInst _machInst,
-                    OpClass __opClass, uint8_t _vdRegIdx, uint8_t _vdElemIdx,
-                    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+                    OpClass __opClass, uint32_t _vdRegIdx, uint32_t _vdElemIdx,
+                    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, 1,
                              0, 0)
         , vdRegIdx(_vdRegIdx), vdElemIdx(_vdElemIdx)
@@ -497,13 +497,14 @@ class VsIndexMacroInst : public VectorMemMacroInst
 class VsIndexMicroInst : public VectorMemMicroInst
 {
   protected:
-    uint8_t vs3RegIdx;
-    uint8_t vs3ElemIdx;
-    uint8_t vs2RegIdx;
-    uint8_t vs2ElemIdx;
+    uint32_t vs3RegIdx;
+    uint32_t vs3ElemIdx;
+    uint32_t vs2RegIdx;
+    uint32_t vs2ElemIdx;
     VsIndexMicroInst(const char *mnem, ExtMachInst _machInst,
-                    OpClass __opClass, uint8_t _vs3RegIdx, uint8_t _vs3ElemIdx,
-                    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+                    OpClass __opClass, uint32_t _vs3RegIdx,
+                    uint32_t _vs3ElemIdx, uint32_t _vs2RegIdx,
+                    uint32_t _vs2ElemIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, 1, 0, 0),
           vs3RegIdx(_vs3RegIdx), vs3ElemIdx(_vs3ElemIdx),
           vs2RegIdx(_vs2RegIdx), vs2ElemIdx(_vs2ElemIdx)
@@ -530,7 +531,7 @@ class VMvWholeMicroInst : public VectorArithMicroInst
   protected:
     VMvWholeMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx)
+                         uint32_t _microIdx)
         : VectorArithMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
     {}
 

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2446,7 +2446,7 @@ decode QUADRANT default Unknown::unknown() {
                     for (uint32_t i = 0; i < microVl; i++) {
                         uint32_t ei = i + vs1_idx * vs1_elems + vs1_bias;
                         if (this->vm || elem_mask(v0, ei)) {
-                            const uint16_t idx = Vs1_uh[i + vs1_bias]
+                            const uint32_t idx = Vs1_uh[i + vs1_bias]
                                 - vs2_elems * vs2_idx;
                             auto res = (Vs1_uh[i + vs1_bias] >= vlmax) ? 0
                                 : (idx < vs2_elems) ? Vs2_vu[idx]

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -125,7 +125,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -136,7 +136,7 @@ def template VectorIntMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -216,7 +216,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override;
@@ -406,7 +406,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -417,7 +417,7 @@ def template VectorIntWideningMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx)
+        uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -596,7 +596,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx);
+        uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -606,7 +606,7 @@ public:
 def template VectorFloatMicroConstructor {{
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -704,7 +704,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx);
+        uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
@@ -886,7 +886,7 @@ private:
     int* cnt;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx, int* cnt);
+                   uint32_t _microIdx, int* cnt);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -897,7 +897,7 @@ def template ViotaMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint8_t _microIdx, int* cnt)
+    uint32_t _microVl, uint32_t _microIdx, int* cnt)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -1132,7 +1132,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1143,7 +1143,7 @@ def template VectorIntMaskMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1187,8 +1187,8 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
-    const uint16_t bit_offset = vlenb / sizeof(ElemType);
-    const uint16_t offset = bit_offset * microIdx;
+    const uint32_t bit_offset = vlenb / sizeof(ElemType);
+    const uint32_t offset = bit_offset * microIdx;
 
     %(code)s;
     %(op_wb)s;
@@ -1260,7 +1260,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1271,7 +1271,7 @@ def template VectorFloatMaskMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1315,8 +1315,8 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
-    const uint16_t bit_offset = vlenb / sizeof(ElemType);
-    const uint16_t offset = bit_offset * microIdx;
+    const uint32_t bit_offset = vlenb / sizeof(ElemType);
+    const uint32_t offset = bit_offset * microIdx;
 
     %(code)s;
     %(op_wb)s;
@@ -1371,7 +1371,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1381,7 +1381,7 @@ public:
 def template VMvWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-                               uint32_t _microVl, uint8_t _microIdx)
+                               uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -1674,7 +1674,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1685,7 +1685,7 @@ def template VectorReduceMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1899,7 +1899,7 @@ template<typename ElemType, typename IndexType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
-    for (uint8_t i = 0; i < std::max(vs1_vregs, vd_vregs) && micro_vl > 0;
+    for (uint32_t i = 0; i < std::max(vs1_vregs, vd_vregs) && micro_vl > 0;
             i++) {
         for (uint8_t j = 0; j < vs2_vregs; j++) {
             microop = new %(class_name)sMicro<ElemType, IndexType>(
@@ -1930,7 +1930,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1941,7 +1941,7 @@ def template VectorGatherMicroConstructor {{
 
 template<typename ElemType, typename IndexType>
 %(class_name)s<ElemType, IndexType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint8_t _microIdx)
+    uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1952,14 +1952,14 @@ template<typename ElemType, typename IndexType>
     [[maybe_unused]] constexpr uint32_t vd_eewb = sizeof(ElemType);
     [[maybe_unused]] constexpr uint32_t vs2_eewb = sizeof(ElemType);
     [[maybe_unused]] constexpr uint32_t vs1_eewb = sizeof(IndexType);
-    constexpr uint8_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
-    constexpr uint8_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
+    constexpr uint32_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
+    constexpr uint32_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
     const int8_t lmul = vtype_vlmul(vtype);
     const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    [[maybe_unused]] const uint8_t vs2_idx = _microIdx % vs2_vregs;
-    [[maybe_unused]] const uint8_t vs1_idx =
+    [[maybe_unused]] const uint32_t vs2_idx = _microIdx % vs2_vregs;
+    [[maybe_unused]] const uint32_t vs1_idx =
         _microIdx / vs2_vregs / vs1_split_num;
-    [[maybe_unused]] const uint8_t vd_idx =
+    [[maybe_unused]] const uint32_t vd_idx =
         _microIdx / vs2_vregs / vd_split_num;
     %(set_dest_reg_idx)s;
     %(set_src_reg_idx)s;
@@ -1998,24 +1998,24 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
     const uint32_t vlmax = vtype_VLMAX(vtype,vlen);
-    constexpr uint8_t vd_eewb = sizeof(ElemType);
-    constexpr uint8_t vs1_eewb = sizeof(IndexType);
-    constexpr uint8_t vs2_eewb = sizeof(ElemType);
-    constexpr uint8_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
-    constexpr uint8_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
-    [[maybe_unused]] const uint16_t vd_elems = vlenb / vd_eewb;
-    [[maybe_unused]] const uint16_t vs1_elems = vlenb / vs1_eewb;
-    [[maybe_unused]] const uint16_t vs2_elems = vlenb / vs2_eewb;
+    constexpr uint32_t vd_eewb = sizeof(ElemType);
+    constexpr uint32_t vs1_eewb = sizeof(IndexType);
+    constexpr uint32_t vs2_eewb = sizeof(ElemType);
+    constexpr uint32_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
+    constexpr uint32_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
+    [[maybe_unused]] const uint32_t vd_elems = vlenb / vd_eewb;
+    [[maybe_unused]] const uint32_t vs1_elems = vlenb / vs1_eewb;
+    [[maybe_unused]] const uint32_t vs2_elems = vlenb / vs2_eewb;
     [[maybe_unused]] const int8_t lmul = vtype_vlmul(vtype);
     [[maybe_unused]] const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    [[maybe_unused]] const uint8_t vs2_idx = microIdx % vs2_vregs;
-    [[maybe_unused]] const uint8_t vs1_idx =
+    [[maybe_unused]] const uint32_t vs2_idx = microIdx % vs2_vregs;
+    [[maybe_unused]] const uint32_t vs1_idx =
         microIdx / vs2_vregs / vs1_split_num;
-    [[maybe_unused]] const uint8_t vd_idx =
+    [[maybe_unused]] const uint32_t vd_idx =
         microIdx / vs2_vregs / vd_split_num;
-    [[maybe_unused]] const uint16_t vs1_bias =
+    [[maybe_unused]] const uint32_t vs1_bias =
         vs1_elems * (vd_idx % vs1_split_num) / vs1_split_num;
-    [[maybe_unused]] const uint16_t vd_bias =
+    [[maybe_unused]] const uint32_t vd_bias =
         vd_elems * (vs1_idx % vd_split_num) / vd_split_num;
 
     %(code)s;
@@ -2116,7 +2116,7 @@ private:
     bool* vxsatptr;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx, bool* vxsatptr);
+                   uint32_t _microIdx, bool* vxsatptr);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2127,7 +2127,7 @@ def template VectorIntVxsatMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint8_t _microIdx, bool* vxsatptr)
+    uint32_t _microVl, uint32_t _microIdx, bool* vxsatptr)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -2299,7 +2299,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-        uint8_t _microIdx, uint8_t _vdIdx, uint8_t _vs2Idx);
+        uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2310,7 +2310,8 @@ def template VectorSlideMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx, uint8_t _vdIdx, uint8_t _vs2Idx)
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vdIdx,
+        uint32_t _vs2Idx)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
         _microIdx, _vdIdx, _vs2Idx)
 {

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -96,8 +96,8 @@ private:
     RegId srcRegIdxArr[3];
     RegId destRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst, uint8_t _microVl,
-        uint8_t _microIdx, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+        uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -111,8 +111,8 @@ public:
 
 def template VleMicroConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint8_t _microVl,
-    uint8_t _microIdx, uint32_t _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+    uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s(
         "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
 {
@@ -300,7 +300,7 @@ private:
     RegId destRegIdxArr[0];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -314,7 +314,7 @@ public:
 def template VseMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s(
         "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
 {
@@ -532,7 +532,7 @@ private:
     RegId srcRegIdxArr[2];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -546,7 +546,7 @@ public:
 def template VsWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s(
         "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
 {
@@ -666,7 +666,7 @@ private:
     RegId srcRegIdxArr[1];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -680,7 +680,7 @@ public:
 def template VlWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s("%(mnemonic)s_micro", _machInst, %(op_class)s, _microVl,
       _microIdx, _vlen)
 {
@@ -832,7 +832,7 @@ private:
     RegId srcRegIdxArr[4];
     RegId destRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
         uint32_t _microVl);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
@@ -847,7 +847,7 @@ public:
 def template VlStrideMicroConstructor {{
 
 %(class_name)s::%(class_name)s(
-    ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
     uint32_t _microVl)
   : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
         _regIdx, _microIdx, _microVl)
@@ -1056,7 +1056,7 @@ private:
     RegId srcRegIdxArr[4];
     RegId destRegIdxArr[0];
 public:
-    %(class_name)s(ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
             uint32_t _microVl);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
@@ -1071,7 +1071,7 @@ public:
 def template VsStrideMicroConstructor {{
 
 %(class_name)s::%(class_name)s(
-    ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
     uint32_t _microVl)
   : %(base_class)s("%(mnemonic)s""_micro", _machInst, %(op_class)s,
       _regIdx, _microIdx, _microVl)
@@ -1210,12 +1210,12 @@ template<typename ElemType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
-    for (uint8_t i = 0; micro_vl > 0; i++) {
-        for (uint8_t j = 0; j < micro_vl; ++j) {
-            uint8_t vdRegIdx = i / vd_split_num;
-            uint8_t vs2RegIdx = i / vs2_split_num;
-            uint8_t vdElemIdx = j + micro_vlmax * (i % vd_split_num);
-            uint8_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
+    for (uint32_t i = 0; micro_vl > 0; i++) {
+        for (uint32_t j = 0; j < micro_vl; ++j) {
+            uint32_t vdRegIdx = i / vd_split_num;
+            uint32_t vs2RegIdx = i / vs2_split_num;
+            uint32_t vdElemIdx = j + micro_vlmax * (i % vd_split_num);
+            uint32_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
             microop = new %(class_name)sMicro<ElemType>(machInst,
                 vdRegIdx, vdElemIdx, vs2RegIdx, vs2ElemIdx);
             microop->setFlag(IsDelayedCommit);
@@ -1246,8 +1246,8 @@ private:
     RegId destRegIdxArr[1];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _vdRegIdx, uint8_t _vdElemIdx,
-        uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx);
+        uint32_t _vdRegIdx, uint32_t _vdElemIdx,
+        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -1262,8 +1262,8 @@ def template VlIndexMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(
-    ExtMachInst _machInst,uint8_t _vdRegIdx, uint8_t _vdElemIdx,
-    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+    ExtMachInst _machInst,uint32_t _vdRegIdx, uint32_t _vdElemIdx,
+    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
   : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
       _vdRegIdx, _vdElemIdx, _vs2RegIdx, _vs2ElemIdx)
 {
@@ -1450,12 +1450,12 @@ template<typename ElemType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
-    for (uint8_t i = 0; micro_vl > 0; i++) {
-        for (uint8_t j = 0; j < micro_vl; ++j) {
-            uint8_t vs3RegIdx = i / vs3_split_num;
-            uint8_t vs2RegIdx = i / vs2_split_num;
-            uint8_t vs3ElemIdx = j + micro_vlmax * (i % vs3_split_num);
-            uint8_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
+    for (uint32_t i = 0; micro_vl > 0; i++) {
+        for (uint32_t j = 0; j < micro_vl; ++j) {
+            uint32_t vs3RegIdx = i / vs3_split_num;
+            uint32_t vs2RegIdx = i / vs2_split_num;
+            uint32_t vs3ElemIdx = j + micro_vlmax * (i % vs3_split_num);
+            uint32_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
             microop = new %(class_name)sMicro<ElemType>(machInst,
                 vs3RegIdx, vs3ElemIdx, vs2RegIdx, vs2ElemIdx);
             microop->setFlag(IsDelayedCommit);
@@ -1486,8 +1486,8 @@ private:
     RegId destRegIdxArr[0];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _vs3RegIdx, uint8_t _vs3ElemIdx,
-        uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx);
+        uint32_t _vs3RegIdx, uint32_t _vs3ElemIdx,
+        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -1502,8 +1502,8 @@ def template VsIndexMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _vs3RegIdx, uint8_t _vs3ElemIdx,
-    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+    uint32_t _vs3RegIdx, uint32_t _vs3ElemIdx,
+    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
   : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
       _vs3RegIdx, _vs3ElemIdx, _vs2RegIdx, _vs2ElemIdx)
 {

--- a/src/mem/cache/Cache.py
+++ b/src/mem/cache/Cache.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2013, 2015, 2018, 2022 Arm Limited
+# Copyright (c) 2012-2013, 2015, 2018 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -112,7 +112,7 @@ class BaseCache(ClockedObject):
         "Notify the hardware prefetcher on every access (not just misses)",
     )
     prefetch_on_pf_hit = Param.Bool(
-        True, "Notify the hardware prefetcher on hit on prefetched lines"
+        False, "Notify the hardware prefetcher on hit on prefetched lines"
     )
 
     tags = Param.BaseTags(BaseSetAssoc(), "Tag store")

--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012, 2014, 2019, 2022 Arm Limited
+# Copyright (c) 2012, 2014, 2019 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -192,13 +192,6 @@ class StridePrefetcher(QueuedPrefetcher):
     use_requestor_id = Param.Bool(True, "Use requestor id based history")
 
     degree = Param.Int(4, "Number of prefetches to generate")
-    distance = Param.Unsigned(
-        0,
-        "How far ahead of the demand stream to start prefetching. "
-        "Skip this number of strides ahead of the first identified prefetch, "
-        "then generate `degree` prefetches at `stride` intervals. "
-        "A value of zero indicates no skip.",
-    )
 
     table_assoc = Param.Int(4, "Associativity of the PC table")
     table_entries = Param.MemorySize("64", "Number of entries of the PC table")

--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, 2022 Arm Limited
+ * Copyright (c) 2013-2014 ARM Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -245,7 +245,6 @@ Base::probeNotify(const PacketPtr &pkt, bool miss)
     // operations or for writes that we are coaslescing.
     if (pkt->cmd.isSWPrefetch()) return;
     if (pkt->req->isCacheMaintenance()) return;
-    if (pkt->isCleanEviction()) return;
     if (pkt->isWrite() && cache != nullptr && cache->coalesce()) return;
     if (!pkt->req->hasPaddr()) {
         panic("Request must have a physical address");

--- a/src/mem/cache/prefetch/queued.cc
+++ b/src/mem/cache/prefetch/queued.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, 2022 Arm Limited
+ * Copyright (c) 2014-2015 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -178,7 +178,7 @@ Queued::notify(const PacketPtr &pkt, const PrefetchInfo &pfi)
     if (queueSquash) {
         auto itr = pfq.begin();
         while (itr != pfq.end()) {
-            if (blockAddress(itr->pfInfo.getAddr()) == blk_addr &&
+            if (itr->pfInfo.getAddr() == blk_addr &&
                 itr->pfInfo.isSecure() == is_secure) {
                 DPRINTF(HWPrefetch, "Removing pf candidate addr: %#x "
                         "(cl: %#x), demand request going to the same addr\n",

--- a/src/mem/cache/prefetch/stride.cc
+++ b/src/mem/cache/prefetch/stride.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Inria
- * Copyright (c) 2012-2013, 2015, 2022-2023 Arm Limited
+ * Copyright (c) 2012-2013, 2015 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -84,7 +84,6 @@ Stride::Stride(const StridePrefetcherParams &p)
     threshConf(p.confidence_threshold/100.0),
     useRequestorId(p.use_requestor_id),
     degree(p.degree),
-    distance(p.distance),
     pcTableInfo(p.table_assoc, p.table_entries, p.table_indexing_policy,
         p.table_replacement_policy)
 {
@@ -168,16 +167,16 @@ Stride::calculatePrefetch(const PrefetchInfo &pfi,
             return;
         }
 
-        // Round strides up to atleast 1 cacheline
-        int prefetch_stride = new_stride;
-        if (abs(new_stride) < blkSize) {
-            prefetch_stride = (new_stride < 0) ? -blkSize : blkSize;
-        }
-
-        Addr new_addr = pf_addr + distance * prefetch_stride;
         // Generate up to degree prefetches
         for (int d = 1; d <= degree; d++) {
-            addresses.push_back(AddrPriority(new_addr += prefetch_stride, 0));
+            // Round strides up to atleast 1 cacheline
+            int prefetch_stride = new_stride;
+            if (abs(new_stride) < blkSize) {
+                prefetch_stride = (new_stride < 0) ? -blkSize : blkSize;
+            }
+
+            Addr new_addr = pf_addr + d * prefetch_stride;
+            addresses.push_back(AddrPriority(new_addr, 0));
         }
     } else {
         // Miss in table

--- a/src/mem/cache/prefetch/stride.hh
+++ b/src/mem/cache/prefetch/stride.hh
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Inria
- * Copyright (c) 2012-2013, 2015, 2022 Arm Limited
+ * Copyright (c) 2012-2013, 2015 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -104,8 +104,6 @@ class Stride : public Queued
     const bool useRequestorId;
 
     const int degree;
-
-    const int distance;
 
     /**
      * Information used to create a new PC table. All of them behave equally.

--- a/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
@@ -32,7 +32,7 @@ RUN apt -y update && apt -y upgrade && \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev python-is-python3 doxygen libboost-all-dev \
     libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config pip \
-    python3-venv black gcc-10 g++-10
+    python3-venv black gcc-10 g++-10 cmake
 
 RUN pip install mypy pre-commit
 

--- a/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
@@ -31,6 +31,6 @@ RUN apt -y update && apt -y upgrade && \
     apt -y install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev doxygen libboost-all-dev libhdf5-serial-dev python3-pydot \
-    libpng-dev libelf-dev pkg-config pip python3-venv black
+    libpng-dev libelf-dev pkg-config pip python3-venv black cmake
 
 RUN pip install mypy pre-commit


### PR DESCRIPTION
Some variables hava narrow datatypes that overflow on large VLEN values. For example, the maximum number of microops for LMUL=8 SEW=8 and VLEN=64K is 2^16.

Change-Id: I5cce759f040884e09ce83bee7e54a62c4b42c5aa