### PR TITLE
arch-riscv: Fix narrow datatypes in RVV isa files

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -137,10 +137,10 @@ class VectorMicroInst : public RiscvMicroInst
 protected:
     uint32_t vlen;
     uint32_t microVl;
-    uint8_t microIdx;
+    uint32_t microIdx;
     uint8_t vtype;
     VectorMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
-      uint32_t _microVl, uint8_t _microIdx, uint32_t _vlen = 256)
+      uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen = 256)
         : RiscvMicroInst(mnem, _machInst, __opClass),
         vlen(_vlen),
         microVl(_microVl),
@@ -178,7 +178,7 @@ class VectorArithMicroInst : public VectorMicroInst
 protected:
     VectorArithMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx)
+                         uint32_t _microIdx)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
     {}
 
@@ -204,7 +204,7 @@ class VectorVMUNARY0MicroInst : public VectorMicroInst
 protected:
     VectorVMUNARY0MicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx)
+                         uint32_t _microIdx)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
     {}
 
@@ -243,11 +243,11 @@ class VectorSlideMacroInst : public VectorMacroInst
 class VectorSlideMicroInst : public VectorMicroInst
 {
   protected:
-    uint8_t vdIdx;
-    uint8_t vs2Idx;
+    uint32_t vdIdx;
+    uint32_t vs2Idx;
     VectorSlideMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx, uint8_t _vdIdx, uint8_t _vs2Idx)
+                         uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
         , vdIdx(_vdIdx), vs2Idx(_vs2Idx)
     {}
@@ -263,8 +263,8 @@ class VectorMemMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VectorMemMicroInst(const char* mnem, ExtMachInst _machInst,
-                       OpClass __opClass, uint32_t _microVl, uint8_t _microIdx,
-                       uint32_t _offset)
+                       OpClass __opClass, uint32_t _microVl,
+                       uint32_t _microIdx, uint32_t _offset)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
         , offset(_offset)
         , memAccessFlags(0)
@@ -310,7 +310,7 @@ class VleMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VleMicroInst(const char *mnem, ExtMachInst _machInst,OpClass __opClass,
-                  uint32_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+                  uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                             _microIdx, _vlen)
     {
@@ -327,7 +327,7 @@ class VseMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VseMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
-                  uint32_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+                  uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                             _microIdx, _vlen)
     {
@@ -356,7 +356,7 @@ class VlWholeMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VlWholeMicroInst(const char *mnem, ExtMachInst _machInst,
-          OpClass __opClass, uint32_t _microVl, uint8_t _microIdx,
+          OpClass __opClass, uint32_t _microVl, uint32_t _microIdx,
           uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                             _microIdx, _vlen)
@@ -385,7 +385,7 @@ class VsWholeMicroInst : public VectorMicroInst
 
     VsWholeMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint32_t _microVl,
-                      uint8_t _microIdx, uint32_t _vlen)
+                      uint32_t _microIdx, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass , _microVl,
                           _microIdx, _vlen)
     {}
@@ -409,10 +409,10 @@ class VlStrideMacroInst : public VectorMemMacroInst
 class VlStrideMicroInst : public VectorMemMicroInst
 {
   protected:
-  uint8_t regIdx;
+  uint32_t regIdx;
     VlStrideMicroInst(const char *mnem, ExtMachInst _machInst,
-                      OpClass __opClass, uint8_t _regIdx,
-                      uint8_t _microIdx, uint32_t _microVl)
+                      OpClass __opClass, uint32_t _regIdx,
+                      uint32_t _microIdx, uint32_t _microVl)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
                              _microIdx, 0)
         , regIdx(_regIdx)
@@ -437,10 +437,10 @@ class VsStrideMacroInst : public VectorMemMacroInst
 class VsStrideMicroInst : public VectorMemMicroInst
 {
   protected:
-    uint8_t regIdx;
+    uint32_t regIdx;
     VsStrideMicroInst(const char *mnem, ExtMachInst _machInst,
-                      OpClass __opClass, uint8_t _regIdx,
-                      uint8_t _microIdx, uint32_t _microVl)
+                      OpClass __opClass, uint32_t _regIdx,
+                      uint32_t _microIdx, uint32_t _microVl)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
                              _microIdx, 0)
         , regIdx(_regIdx)
@@ -465,13 +465,13 @@ class VlIndexMacroInst : public VectorMemMacroInst
 class VlIndexMicroInst : public VectorMemMicroInst
 {
   protected:
-    uint8_t vdRegIdx;
-    uint8_t vdElemIdx;
-    uint8_t vs2RegIdx;
-    uint8_t vs2ElemIdx;
+    uint32_t vdRegIdx;
+    uint32_t vdElemIdx;
+    uint32_t vs2RegIdx;
+    uint32_t vs2ElemIdx;
     VlIndexMicroInst(const char *mnem, ExtMachInst _machInst,
-                    OpClass __opClass, uint8_t _vdRegIdx, uint8_t _vdElemIdx,
-                    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+                    OpClass __opClass, uint32_t _vdRegIdx, uint32_t _vdElemIdx,
+                    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, 1,
                              0, 0)
         , vdRegIdx(_vdRegIdx), vdElemIdx(_vdElemIdx)
@@ -497,13 +497,14 @@ class VsIndexMacroInst : public VectorMemMacroInst
 class VsIndexMicroInst : public VectorMemMicroInst
 {
   protected:
-    uint8_t vs3RegIdx;
-    uint8_t vs3ElemIdx;
-    uint8_t vs2RegIdx;
-    uint8_t vs2ElemIdx;
+    uint32_t vs3RegIdx;
+    uint32_t vs3ElemIdx;
+    uint32_t vs2RegIdx;
+    uint32_t vs2ElemIdx;
     VsIndexMicroInst(const char *mnem, ExtMachInst _machInst,
-                    OpClass __opClass, uint8_t _vs3RegIdx, uint8_t _vs3ElemIdx,
-                    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+                    OpClass __opClass, uint32_t _vs3RegIdx,
+                    uint32_t _vs3ElemIdx, uint32_t _vs2RegIdx,
+                    uint32_t _vs2ElemIdx)
         : VectorMemMicroInst(mnem, _machInst, __opClass, 1, 0, 0),
           vs3RegIdx(_vs3RegIdx), vs3ElemIdx(_vs3ElemIdx),
           vs2RegIdx(_vs2RegIdx), vs2ElemIdx(_vs2ElemIdx)
@@ -530,7 +531,7 @@ class VMvWholeMicroInst : public VectorArithMicroInst
   protected:
     VMvWholeMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint8_t _microIdx)
+                         uint32_t _microIdx)
         : VectorArithMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
     {}
 

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2446,7 +2446,7 @@ decode QUADRANT default Unknown::unknown() {
                     for (uint32_t i = 0; i < microVl; i++) {
                         uint32_t ei = i + vs1_idx * vs1_elems + vs1_bias;
                         if (this->vm || elem_mask(v0, ei)) {
-                            const uint16_t idx = Vs1_uh[i + vs1_bias]
+                            const uint32_t idx = Vs1_uh[i + vs1_bias]
                                 - vs2_elems * vs2_idx;
                             auto res = (Vs1_uh[i + vs1_bias] >= vlmax) ? 0
                                 : (idx < vs2_elems) ? Vs2_vu[idx]

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -125,7 +125,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -136,7 +136,7 @@ def template VectorIntMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -216,7 +216,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override;
@@ -406,7 +406,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -417,7 +417,7 @@ def template VectorIntWideningMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx)
+        uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -596,7 +596,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx);
+        uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -606,7 +606,7 @@ public:
 def template VectorFloatMicroConstructor {{
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -704,7 +704,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx);
+        uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
@@ -886,7 +886,7 @@ private:
     int* cnt;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx, int* cnt);
+                   uint32_t _microIdx, int* cnt);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -897,7 +897,7 @@ def template ViotaMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint8_t _microIdx, int* cnt)
+    uint32_t _microVl, uint32_t _microIdx, int* cnt)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -1132,7 +1132,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1143,7 +1143,7 @@ def template VectorIntMaskMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1187,8 +1187,8 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
-    const uint16_t bit_offset = vlenb / sizeof(ElemType);
-    const uint16_t offset = bit_offset * microIdx;
+    const uint32_t bit_offset = vlenb / sizeof(ElemType);
+    const uint32_t offset = bit_offset * microIdx;
 
     %(code)s;
     %(op_wb)s;
@@ -1260,7 +1260,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1271,7 +1271,7 @@ def template VectorFloatMaskMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1315,8 +1315,8 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
-    const uint16_t bit_offset = vlenb / sizeof(ElemType);
-    const uint16_t offset = bit_offset * microIdx;
+    const uint32_t bit_offset = vlenb / sizeof(ElemType);
+    const uint32_t offset = bit_offset * microIdx;
 
     %(code)s;
     %(op_wb)s;
@@ -1371,7 +1371,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx);
+                   uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1381,7 +1381,7 @@ public:
 def template VMvWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-                               uint32_t _microVl, uint8_t _microIdx)
+                               uint32_t _microVl, uint32_t _microIdx)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -1674,7 +1674,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1685,7 +1685,7 @@ def template VectorReduceMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint8_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1899,7 +1899,7 @@ template<typename ElemType, typename IndexType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
-    for (uint8_t i = 0; i < std::max(vs1_vregs, vd_vregs) && micro_vl > 0;
+    for (uint32_t i = 0; i < std::max(vs1_vregs, vd_vregs) && micro_vl > 0;
             i++) {
         for (uint8_t j = 0; j < vs2_vregs; j++) {
             microop = new %(class_name)sMicro<ElemType, IndexType>(
@@ -1930,7 +1930,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint8_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1941,7 +1941,7 @@ def template VectorGatherMicroConstructor {{
 
 template<typename ElemType, typename IndexType>
 %(class_name)s<ElemType, IndexType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint8_t _microIdx)
+    uint32_t _microVl, uint32_t _microIdx)
 : %(base_class)s("%(mnemonic)s", _machInst,
                  %(op_class)s, _microVl, _microIdx)
 {
@@ -1952,14 +1952,14 @@ template<typename ElemType, typename IndexType>
     [[maybe_unused]] constexpr uint32_t vd_eewb = sizeof(ElemType);
     [[maybe_unused]] constexpr uint32_t vs2_eewb = sizeof(ElemType);
     [[maybe_unused]] constexpr uint32_t vs1_eewb = sizeof(IndexType);
-    constexpr uint8_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
-    constexpr uint8_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
+    constexpr uint32_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
+    constexpr uint32_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
     const int8_t lmul = vtype_vlmul(vtype);
     const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    [[maybe_unused]] const uint8_t vs2_idx = _microIdx % vs2_vregs;
-    [[maybe_unused]] const uint8_t vs1_idx =
+    [[maybe_unused]] const uint32_t vs2_idx = _microIdx % vs2_vregs;
+    [[maybe_unused]] const uint32_t vs1_idx =
         _microIdx / vs2_vregs / vs1_split_num;
-    [[maybe_unused]] const uint8_t vd_idx =
+    [[maybe_unused]] const uint32_t vd_idx =
         _microIdx / vs2_vregs / vd_split_num;
     %(set_dest_reg_idx)s;
     %(set_src_reg_idx)s;
@@ -1998,24 +1998,24 @@ Fault
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
     const uint32_t vlmax = vtype_VLMAX(vtype,vlen);
-    constexpr uint8_t vd_eewb = sizeof(ElemType);
-    constexpr uint8_t vs1_eewb = sizeof(IndexType);
-    constexpr uint8_t vs2_eewb = sizeof(ElemType);
-    constexpr uint8_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
-    constexpr uint8_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
-    [[maybe_unused]] const uint16_t vd_elems = vlenb / vd_eewb;
-    [[maybe_unused]] const uint16_t vs1_elems = vlenb / vs1_eewb;
-    [[maybe_unused]] const uint16_t vs2_elems = vlenb / vs2_eewb;
+    constexpr uint32_t vd_eewb = sizeof(ElemType);
+    constexpr uint32_t vs1_eewb = sizeof(IndexType);
+    constexpr uint32_t vs2_eewb = sizeof(ElemType);
+    constexpr uint32_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
+    constexpr uint32_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
+    [[maybe_unused]] const uint32_t vd_elems = vlenb / vd_eewb;
+    [[maybe_unused]] const uint32_t vs1_elems = vlenb / vs1_eewb;
+    [[maybe_unused]] const uint32_t vs2_elems = vlenb / vs2_eewb;
     [[maybe_unused]] const int8_t lmul = vtype_vlmul(vtype);
     [[maybe_unused]] const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    [[maybe_unused]] const uint8_t vs2_idx = microIdx % vs2_vregs;
-    [[maybe_unused]] const uint8_t vs1_idx =
+    [[maybe_unused]] const uint32_t vs2_idx = microIdx % vs2_vregs;
+    [[maybe_unused]] const uint32_t vs1_idx =
         microIdx / vs2_vregs / vs1_split_num;
-    [[maybe_unused]] const uint8_t vd_idx =
+    [[maybe_unused]] const uint32_t vd_idx =
         microIdx / vs2_vregs / vd_split_num;
-    [[maybe_unused]] const uint16_t vs1_bias =
+    [[maybe_unused]] const uint32_t vs1_bias =
         vs1_elems * (vd_idx % vs1_split_num) / vs1_split_num;
-    [[maybe_unused]] const uint16_t vd_bias =
+    [[maybe_unused]] const uint32_t vd_bias =
         vd_elems * (vs1_idx % vd_split_num) / vd_split_num;
 
     %(code)s;
@@ -2116,7 +2116,7 @@ private:
     bool* vxsatptr;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint8_t _microIdx, bool* vxsatptr);
+                   uint32_t _microIdx, bool* vxsatptr);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2127,7 +2127,7 @@ def template VectorIntVxsatMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint8_t _microIdx, bool* vxsatptr)
+    uint32_t _microVl, uint32_t _microIdx, bool* vxsatptr)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx)
 {
@@ -2299,7 +2299,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-        uint8_t _microIdx, uint8_t _vdIdx, uint8_t _vs2Idx);
+        uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2310,7 +2310,8 @@ def template VectorSlideMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint8_t _microIdx, uint8_t _vdIdx, uint8_t _vs2Idx)
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vdIdx,
+        uint32_t _vs2Idx)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
         _microIdx, _vdIdx, _vs2Idx)
 {

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -96,8 +96,8 @@ private:
     RegId srcRegIdxArr[3];
     RegId destRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst, uint8_t _microVl,
-        uint8_t _microIdx, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+        uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -111,8 +111,8 @@ public:
 
 def template VleMicroConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint8_t _microVl,
-    uint8_t _microIdx, uint32_t _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+    uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s(
         "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
 {
@@ -300,7 +300,7 @@ private:
     RegId destRegIdxArr[0];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -314,7 +314,7 @@ public:
 def template VseMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s(
         "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
 {
@@ -532,7 +532,7 @@ private:
     RegId srcRegIdxArr[2];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -546,7 +546,7 @@ public:
 def template VsWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s(
         "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
 {
@@ -666,7 +666,7 @@ private:
     RegId srcRegIdxArr[1];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -680,7 +680,7 @@ public:
 def template VlWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _microVl, uint8_t _microIdx, uint32_t _vlen)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
   : %(base_class)s("%(mnemonic)s_micro", _machInst, %(op_class)s, _microVl,
       _microIdx, _vlen)
 {
@@ -832,7 +832,7 @@ private:
     RegId srcRegIdxArr[4];
     RegId destRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
         uint32_t _microVl);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
@@ -847,7 +847,7 @@ public:
 def template VlStrideMicroConstructor {{
 
 %(class_name)s::%(class_name)s(
-    ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
     uint32_t _microVl)
   : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
         _regIdx, _microIdx, _microVl)
@@ -1056,7 +1056,7 @@ private:
     RegId srcRegIdxArr[4];
     RegId destRegIdxArr[0];
 public:
-    %(class_name)s(ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
             uint32_t _microVl);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
@@ -1071,7 +1071,7 @@ public:
 def template VsStrideMicroConstructor {{
 
 %(class_name)s::%(class_name)s(
-    ExtMachInst _machInst, uint8_t _regIdx, uint8_t _microIdx,
+    ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
     uint32_t _microVl)
   : %(base_class)s("%(mnemonic)s""_micro", _machInst, %(op_class)s,
       _regIdx, _microIdx, _microVl)
@@ -1210,12 +1210,12 @@ template<typename ElemType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
-    for (uint8_t i = 0; micro_vl > 0; i++) {
-        for (uint8_t j = 0; j < micro_vl; ++j) {
-            uint8_t vdRegIdx = i / vd_split_num;
-            uint8_t vs2RegIdx = i / vs2_split_num;
-            uint8_t vdElemIdx = j + micro_vlmax * (i % vd_split_num);
-            uint8_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
+    for (uint32_t i = 0; micro_vl > 0; i++) {
+        for (uint32_t j = 0; j < micro_vl; ++j) {
+            uint32_t vdRegIdx = i / vd_split_num;
+            uint32_t vs2RegIdx = i / vs2_split_num;
+            uint32_t vdElemIdx = j + micro_vlmax * (i % vd_split_num);
+            uint32_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
             microop = new %(class_name)sMicro<ElemType>(machInst,
                 vdRegIdx, vdElemIdx, vs2RegIdx, vs2ElemIdx);
             microop->setFlag(IsDelayedCommit);
@@ -1246,8 +1246,8 @@ private:
     RegId destRegIdxArr[1];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _vdRegIdx, uint8_t _vdElemIdx,
-        uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx);
+        uint32_t _vdRegIdx, uint32_t _vdElemIdx,
+        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -1262,8 +1262,8 @@ def template VlIndexMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(
-    ExtMachInst _machInst,uint8_t _vdRegIdx, uint8_t _vdElemIdx,
-    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+    ExtMachInst _machInst,uint32_t _vdRegIdx, uint32_t _vdElemIdx,
+    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
   : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
       _vdRegIdx, _vdElemIdx, _vs2RegIdx, _vs2ElemIdx)
 {
@@ -1450,12 +1450,12 @@ template<typename ElemType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
-    for (uint8_t i = 0; micro_vl > 0; i++) {
-        for (uint8_t j = 0; j < micro_vl; ++j) {
-            uint8_t vs3RegIdx = i / vs3_split_num;
-            uint8_t vs2RegIdx = i / vs2_split_num;
-            uint8_t vs3ElemIdx = j + micro_vlmax * (i % vs3_split_num);
-            uint8_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
+    for (uint32_t i = 0; micro_vl > 0; i++) {
+        for (uint32_t j = 0; j < micro_vl; ++j) {
+            uint32_t vs3RegIdx = i / vs3_split_num;
+            uint32_t vs2RegIdx = i / vs2_split_num;
+            uint32_t vs3ElemIdx = j + micro_vlmax * (i % vs3_split_num);
+            uint32_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
             microop = new %(class_name)sMicro<ElemType>(machInst,
                 vs3RegIdx, vs3ElemIdx, vs2RegIdx, vs2ElemIdx);
             microop->setFlag(IsDelayedCommit);
@@ -1486,8 +1486,8 @@ private:
     RegId destRegIdxArr[0];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint8_t _vs3RegIdx, uint8_t _vs3ElemIdx,
-        uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx);
+        uint32_t _vs3RegIdx, uint32_t _vs3ElemIdx,
+        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -1502,8 +1502,8 @@ def template VsIndexMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint8_t _vs3RegIdx, uint8_t _vs3ElemIdx,
-    uint8_t _vs2RegIdx, uint8_t _vs2ElemIdx)
+    uint32_t _vs3RegIdx, uint32_t _vs3ElemIdx,
+    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
   : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
       _vs3RegIdx, _vs3ElemIdx, _vs2RegIdx, _vs2ElemIdx)
 {


### PR DESCRIPTION
Some variables hava narrow datatypes that overflow on large VLEN values. For example, the maximum number of microops for LMUL=8 SEW=8 and VLEN=64K is 2^16.

Change-Id: I5cce759f040884e09ce83bee7e54a62c4b42c5aa