### PR TITLE
arch-riscv: fix tlb bug

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -292,7 +292,7 @@ TLB::doTranslate(const RequestPtr &req, ThreadContext *tc,
             delayed = true;
             return fault;
         }
-        e = lookup(vaddr, satp.asid, mode, false);
+        e = lookup(vaddr, satp.asid, mode, true);
         assert(e != nullptr);
     }
 


### PR DESCRIPTION
- one tlb miss was getting counted twice by the lookup function.

Change-Id: I5fee08bd6e936896704e7dbbd242720b8d23b547