### PR TITLE
cpu-o3: Fix discarded requests str-ld forwarding

### DIFF
--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -541,7 +541,7 @@ class LSQ
         {
             flags.set(Flag::WritebackDone);
             /* If the lsq resources are already free */
-            if (isReleased()) {
+            if (_numOutstandingPackets == 0 && isReleased()) {
                 delete this;
             }
         }


### PR DESCRIPTION
With the use of large RVV vectors (i.e., 8K or 16K bits) and a limited number of cacheLoadPorts, some loads take multiple cycles to execute. This triggered certain conditions when store-to-load forwarding happens in the middle of the execution of a load that already has outstanding packets.

First, after store-to-load forwarding the request is marked as discarded and the load is immediately writtenback, which triggers a writebackDone that tries to delete the request, triggering an assert as it still has outstanding packets. This patch avoid deleting the request leaving it self owned, it will be deleted when the last packet arrives in packetReplied.

Second, this patch avoid checking snoops on discarded requests by checking if the request exists.

Change-Id: Icea0add0327929d3a6af7e6dd0af9945cb0d0970