### PR TITLE
systemc: Bugfix in TlmToGem5Bridge

### DIFF
--- a/src/systemc/tlm_bridge/tlm_to_gem5.cc
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.cc
@@ -540,6 +540,7 @@ TlmToGem5Bridge<BITWIDTH>::recvReqRetry()
         trans.release();
 
         pendingRequest = nullptr;
+        pendingPacket = nullptr;
     }
 }
 


### PR DESCRIPTION
In handleBeginReq, a timing request is sent. If the receiver rejects the request, the bridge will save the pointers of the original transaction object and the generated gem5 packet. After a recvReqRetry-signal and a successful timing request, the variable for transaction object pointer, but not for the gem5 packet, is set to nullptr. When a new transaction with the phase BEGIN_REQ arrives, the assertion in handleBeginReq that there is no pending gem5 packet fails.
Therefore, the variable pendingPacket has to be set to nullptr in recvReqRetry after a successful timing request too.

Change-Id: I876f8f88e1893e8fdfa3441ed2ae5ddc39cef2ce