### PR TITLE
util-docker: Enforce cmake version >=3.24 for DRAMSys

### DIFF
--- a/ext/dramsys/README
+++ b/ext/dramsys/README
@@ -11,3 +11,6 @@ This is done by setting the value of the "StoreMode" key to "Store" in the base 
 Those configuration file can be found in 'DRAMSys/library/resources/configs/simulator'.
 
 Currently, DRAMSys is only supported in conjunction with a cache. Running DRAMSys in Release mode without caches will silently fail!
+
+Note: DRAMSys requires cmake version >= 3.24. This is not available via apt on Ubuntu 20.04 or 22.04. 
+See `util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile` for an example of how to install cmake 3.24.

--- a/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile
@@ -32,7 +32,7 @@ RUN apt -y update && apt -y upgrade && \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev python-is-python3 doxygen libboost-all-dev \
     libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config pip \
-    python3-venv black gcc-10 g++-10 cmake python3-tk
+    python3-venv black gcc-10 g++-10 cmake python3-tk wget libssl-dev
 
 RUN pip install mypy pre-commit
 
@@ -44,3 +44,14 @@ RUN update-alternatives --install \
     /usr/bin/c++ c++ /usr/bin/g++-10 100
 RUN update-alternatives --install \
     /usr/bin/cc cc /usr/bin/gcc-10 100
+
+
+# DRAMSys requires cmake >= 3.24.0.
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0.tar.gz \
+    && tar -xzf cmake-3.24.0.tar.gz \
+    && cd cmake-3.24.0 \
+    && ./bootstrap \
+    && make -j`nproc` \
+    && make install \
+    && cd .. \
+    && rm -rf cmake-3.24.0.tar.gz cmake-3.24.0

--- a/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
@@ -31,6 +31,17 @@ RUN apt -y update && apt -y upgrade && \
     apt -y install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev doxygen libboost-all-dev libhdf5-serial-dev python3-pydot \
-    libpng-dev libelf-dev pkg-config pip python3-venv black cmake python3-tk
+    libpng-dev libelf-dev pkg-config pip python3-venv black python3-tk wget
 
 RUN pip install mypy pre-commit
+
+# DRAMSys requires cmake >= 3.24.0. APT only provides 3.22.1 for Ubuntu 22.04.
+# Therefore, we install cmake from source.
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0.tar.gz \
+    && tar -xzf cmake-3.24.0.tar.gz \
+    && cd cmake-3.24.0 \
+    && ./bootstrap \
+    && make -j`nproc` \
+    && make install \
+    && cd .. \
+    && rm -rf cmake-3.24.0.tar.gz cmake-3.24.0


### PR DESCRIPTION
DRAMSys requires cmake 3.24 or greater. By default neither Ubuntu 22.04 or 20.04 delevery this by APT.

In both cases wget is required. In 20.04 OpenSSL is required.