### PR TITLE
mem: allow comparison of addresses with ints in SLICC

### DIFF
--- a/src/mem/slicc/ast/OperatorExprAST.py
+++ b/src/mem/slicc/ast/OperatorExprAST.py
@@ -50,7 +50,10 @@ class InfixOperatorExprAST(ExprAST):
         # Figure out what the input and output types should be
         if self.op in ("==", "!=", ">=", "<=", ">", "<"):
             output = "bool"
-            if ltype != rtype:
+
+            if str(ltype) == "Addr" and str(rtype) == "int":
+                pass
+            elif ltype != rtype:
                 self.error(
                     "Type mismatch: left and right operands of "
                     + "operator '%s' must be the same type. "


### PR DESCRIPTION
allow comparing addresses to integers. can isolate specific addresses. useful for debugging coherence protocols