### PR TITLE
scons: Limit adding fastmodel files and libpath

### DIFF
--- a/src/arch/arm/fastmodel/CortexA76/SConscript
+++ b/src/arch/arm/fastmodel/CortexA76/SConscript
@@ -25,6 +25,9 @@
 
 Import('*')
 
+if not env['CONF']['USE_ARM_FASTMODEL']:
+    Return()
+
 protocol_dir = Dir('..').Dir('protocol')
 
 for name in ('x1', 'x2', 'x3', 'x4'):

--- a/src/arch/arm/fastmodel/CortexR52/SConscript
+++ b/src/arch/arm/fastmodel/CortexR52/SConscript
@@ -25,6 +25,9 @@
 
 Import('*')
 
+if not env['CONF']['USE_ARM_FASTMODEL']:
+    Return()
+
 protocol_dir = Dir('..').Dir('protocol')
 
 for name in ('x1', 'x2', 'x3', 'x4'):

--- a/src/arch/arm/fastmodel/GIC/SConscript
+++ b/src/arch/arm/fastmodel/GIC/SConscript
@@ -25,6 +25,9 @@
 
 Import('*')
 
+if not env['CONF']['USE_ARM_FASTMODEL']:
+    Return()
+
 protocol_dir = Dir('..').Dir('protocol')
 
 ArmFastModelComponent(File('GIC.sgproj'), File('GIC.lisa'),

--- a/src/arch/arm/fastmodel/PL330_DMAC/SConscript
+++ b/src/arch/arm/fastmodel/PL330_DMAC/SConscript
@@ -25,6 +25,9 @@
 
 Import('*')
 
+if not env['CONF']['USE_ARM_FASTMODEL']:
+    Return()
+
 protocol_dir = Dir('..').Dir('protocol')
 
 ArmFastModelComponent(File('PL330.sgproj'), File('PL330.lisa'),

--- a/src/arch/arm/fastmodel/SConscript
+++ b/src/arch/arm/fastmodel/SConscript
@@ -49,6 +49,8 @@ import os.path
 
 if env['CONF']['USE_ARM_FASTMODEL']:
     env.TagImplies('arm fastmodel', 'arm isa')
+else:
+    Return()
 
 def extract_var(name):
     val = env['CONF'].get(name, None)

--- a/src/arch/arm/fastmodel/iris/SConscript
+++ b/src/arch/arm/fastmodel/iris/SConscript
@@ -25,6 +25,9 @@
 
 Import('*')
 
+if not env['CONF']['USE_ARM_FASTMODEL']:
+    Return()
+
 SimObject('Iris.py', sim_objects=[
     'IrisTLB', 'IrisMMU', 'IrisInterrupts', 'IrisISA', 'IrisBaseCPU'],
     tags='arm fastmodel')

--- a/src/arch/arm/fastmodel/reset_controller/SConscript
+++ b/src/arch/arm/fastmodel/reset_controller/SConscript
@@ -25,6 +25,9 @@
 
 Import('*')
 
+if not env['CONF']['USE_ARM_FASTMODEL']:
+    Return()
+
 SimObject('FastModelResetControllerExample.py', sim_objects=[
     'FastModelResetControllerExample'], tags='arm fastmodel')
 


### PR DESCRIPTION
The change will only add include and library path if the fastmodel is required to build. The change will benefit for most of gem5 build.

Change-Id: I98c20bd1470b7227940036199e02bc001e307eac