### PR TITLE
stdlib: Integrate BootloaderKernelWorkload

### DIFF
--- a/src/arch/riscv/RiscvFsWorkload.py
+++ b/src/arch/riscv/RiscvFsWorkload.py
@@ -67,9 +67,7 @@ class RiscvBootloaderKernelWorkload(Workload):
     bootloader_addr = Param.Addr(
         0x0, "Where to place the bootloader in memory."
     )
-    kernel_filename = Param.String(
-        "", "vmlinux file. Don't use kernel if empty."
-    )
+    object_file = Param.String("", "vmlinux file. Don't use kernel if empty.")
     kernel_addr = Param.Addr(
         0x80200000,
         "Where to place the kernel in memory. Typically, after the first "
@@ -85,6 +83,6 @@ class RiscvBootloaderKernelWorkload(Workload):
     dtb_addr = Param.Addr(0x87E00000, "Where to place the DTB in memory.")
 
     # booting parameters
-    boot_args = Param.String(
+    command_line = Param.String(
         "", "Booting arguments, to be passed to the kernel"
     )

--- a/src/arch/riscv/linux/fs_workload.cc
+++ b/src/arch/riscv/linux/fs_workload.cc
@@ -97,8 +97,8 @@ BootloaderKernelWorkload::loadBootloaderSymbolTable()
 void
 BootloaderKernelWorkload::loadKernelSymbolTable()
 {
-    if (params().kernel_filename != "") {
-        kernel = loader::createObjectFile(params().kernel_filename);
+    if (params().object_file != "") {
+        kernel = loader::createObjectFile(params().object_file);
         kernelSymbolTable = kernel->symtab();
         auto renamedKernelSymbolTable = \
             kernelSymbolTable.functionSymbols()->rename(
@@ -131,7 +131,7 @@ BootloaderKernelWorkload::loadBootloader()
 void
 BootloaderKernelWorkload::loadKernel()
 {
-    if (params().kernel_filename != "") {
+    if (params().object_file != "") {
         Addr kernel_paddr_offset = params().kernel_addr;
         kernel->buildImage().offset(kernel_paddr_offset).write(
             system->physProxy
@@ -139,7 +139,7 @@ BootloaderKernelWorkload::loadKernel()
         delete kernel;
 
         inform("Loaded kernel \'%s\' at 0x%llx\n",
-                params().kernel_filename,
+                params().object_file,
                 kernel_paddr_offset);
     } else {
         inform("Kernel is not specified.\n");

--- a/src/arch/riscv/linux/fs_workload.hh
+++ b/src/arch/riscv/linux/fs_workload.hh
@@ -81,7 +81,7 @@ class BootloaderKernelWorkload: public Workload
   public:
     PARAMS(RiscvBootloaderKernelWorkload);
     BootloaderKernelWorkload(const Params &p)
-        : Workload(p), entryPoint(p.entry_point), bootArgs(p.boot_args)
+        : Workload(p), entryPoint(p.entry_point), bootArgs(p.command_line)
     {
         loadBootloaderSymbolTable();
         loadKernelSymbolTable();

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -201,8 +201,9 @@ class KernelDiskWorkload:
         # implementation of the ArmBoard class expects a boot loader file to be
         # provided along with the kernel and the disk image.
 
+        self._bootloader = []
         if bootloader is not None:
-            self._bootloader = [bootloader.get_local_path()]
+            self._bootloader.append(bootloader.get_local_path())
 
         # Set the readfile.
         if readfile:


### PR DESCRIPTION
This change does the following,

- Change the name of several python parameter names of the RiscvBootloaderKernelWorkload. This is done to conform the expectation from the stdlib, e.g., the kernel path must be `object_file`, and the boot parameter must be `command_line`.
- Use RiscvBootloaderKernelWorkload by default for all full system RISC-V simulations. RiscvBootloaderKernelWorkload is a superset of RiscvFsWorkload.