### PR TITLE
misc: Fix precommit install

### DIFF
--- a/site_scons/site_tools/git.py
+++ b/site_scons/site_tools/git.py
@@ -41,7 +41,6 @@
 import os
 import subprocess
 import sys
-from asyncio import subprocess
 
 import gem5_scons.util
 import SCons.Script


### PR DESCRIPTION
Previously, the `subprocess` module was used to execute shell command installing precommit hook. However, after #431 [1], the import of the `subprocess` module was overriden by `asyncio.subprocess`, which has a different API to execute the shell command. This change removes the `asyncio.subprocess` import.

[1] https://github.com/gem5/gem5/pull/431

Change-Id: I9a7d51f85518089d258ab57c5d849a36dcf128e9