### PR TITLE
arch-riscv: correctly pass arguments to kernel with new bootloader+kernel

### DIFF
--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -256,7 +256,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
             root.append(node)
 
         node = FdtNode(f"chosen")
-        bootargs = " ".join(self.get_default_kernel_args())
+        bootargs = self.workload.command_line
         node.append(FdtPropertyStrings("bootargs", [bootargs]))
         node.append(FdtPropertyStrings("stdout-path", ["/uart@10000000"]))
         root.append(node)


### PR DESCRIPTION
The [PR](https://github.com/gem5/gem5/pull/390) adds support for new bootloader and linux kernel. However after applying the changes the arguments are not passed correctly to the kernel resulting in kernel panic during simulations. This commit fixes the issue.