### PR TITLE
Fix for gem5 Issue #550

### DIFF
--- a/src/arch/arm/insts/static_inst.cc
+++ b/src/arch/arm/insts/static_inst.cc
@@ -401,8 +401,8 @@ ArmStaticInst::printTarget(std::ostream &os, Addr target,
     if (symtab) {
         auto it = symtab->findNearest(target);
         if (it != symtab->end()) {
-            ccprintf(os, "<%s", it->name);
-            Addr delta = target - it->address;
+            ccprintf(os, "<%s", it->name());
+            Addr delta = target - it->address();
             if (delta)
                 ccprintf(os, "+%d>", delta);
             else
@@ -486,9 +486,9 @@ ArmStaticInst::printMemSymbol(std::ostream &os,
     if (symtab) {
         auto it = symtab->findNearest(addr);
         if (it != symtab->end()) {
-            ccprintf(os, "%s%s", prefix, it->name);
-            if (it->address != addr)
-                ccprintf(os, "+%d", addr - it->address);
+            ccprintf(os, "%s%s", prefix, it->name());
+            if (it->address() != addr)
+                ccprintf(os, "+%d", addr - it->address());
             ccprintf(os, suffix);
         }
     }

--- a/src/arch/generic/linux/threadinfo.hh
+++ b/src/arch/generic/linux/threadinfo.hh
@@ -60,7 +60,7 @@ class ThreadInfo
             return false;
         }
 
-        data = TranslatingPortProxy(tc).read<T>(it->address, byteOrder);
+        data = TranslatingPortProxy(tc).read<T>(it->address(), byteOrder);
 
         return true;
     }

--- a/src/arch/mips/isa/formats/branch.isa
+++ b/src/arch/mips/isa/formats/branch.isa
@@ -194,7 +194,7 @@ output decoder {{
 
         loader::SymbolTable::const_iterator it;
         if (symtab && (it = symtab->find(target)) != symtab->end())
-            ss << it->name;
+            ss << it->name();
         else
             ccprintf(ss, "%#x", target);
 
@@ -214,7 +214,7 @@ output decoder {{
         } else if (_numSrcRegs == 0) {
             loader::SymbolTable::const_iterator it;
             if (symtab && (it = symtab->find(disp)) != symtab->end())
-                ss << it->name;
+                ss << it->name();
             else
                 ccprintf(ss, "0x%x", disp);
         } else if (_numSrcRegs == 1) {

--- a/src/arch/power/insts/branch.cc
+++ b/src/arch/power/insts/branch.cc
@@ -97,7 +97,7 @@ BranchOp::generateDisassembly(
 
     loader::SymbolTable::const_iterator it;
     if (symtab && (it = symtab->find(target)) != symtab->end())
-        ss << it->name;
+        ss << it->name();
     else
         ccprintf(ss, "%#x", target);
 
@@ -149,7 +149,7 @@ BranchDispCondOp::generateDisassembly(
 
     loader::SymbolTable::const_iterator it;
     if (symtab && (it = symtab->find(target)) != symtab->end())
-        ss << it->name;
+        ss << it->name();
     else
         ccprintf(ss, "%#x", target);
 

--- a/src/arch/power/process.cc
+++ b/src/arch/power/process.cc
@@ -122,8 +122,8 @@ PowerProcess::initState()
         loader::Symbol symbol = sym;
 
         // Try to read entry point from function descriptor
-        if (initVirtMem->tryReadBlob(sym.address, &entry, sizeof(Addr)))
-            symbol.address = gtoh(entry, byteOrder);
+        if (initVirtMem->tryReadBlob(sym.address(), &entry, sizeof(Addr)))
+            symbol.relocate(gtoh(entry, byteOrder));
 
         symbolTable->insert(symbol);
     }

--- a/src/arch/riscv/linux/fs_workload.cc
+++ b/src/arch/riscv/linux/fs_workload.cc
@@ -86,8 +86,8 @@ BootloaderKernelWorkload::loadBootloaderSymbolTable()
             bootloaderSymbolTable.offset(
                 bootloader_paddr_offset
             )->functionSymbols()->rename(
-                [](std::string &name) {
-                    name = "bootloader." + name;
+                [](const std::string &name) {
+                    return "bootloader." + name;
                 }
             );
         loader::debugSymbolTable.insert(*renamedBootloaderSymbolTable);
@@ -102,8 +102,8 @@ BootloaderKernelWorkload::loadKernelSymbolTable()
         kernelSymbolTable = kernel->symtab();
         auto renamedKernelSymbolTable = \
             kernelSymbolTable.functionSymbols()->rename(
-                [](std::string &name) {
-                    name = "kernel." + name;
+                [](const std::string &name) {
+                    return "kernel." + name;
                 }
             );
         loader::debugSymbolTable.insert(*renamedKernelSymbolTable);

--- a/src/arch/sparc/insts/branch.cc
+++ b/src/arch/sparc/insts/branch.cc
@@ -88,9 +88,9 @@ BranchDisp::generateDisassembly(
 
     loader::SymbolTable::const_iterator it;
     if (symtab && (it = symtab->findNearest(target)) != symtab->end()) {
-        ccprintf(response, " <%s", it->name);
-        if (it->address != target)
-            ccprintf(response, "+%d>", target - it->address);
+        ccprintf(response, " <%s", it->name());
+        if (it->address() != target)
+            ccprintf(response, "+%d>", target - it->address());
         else
             ccprintf(response, ">");
     }

--- a/src/base/loader/elf_object.cc
+++ b/src/base/loader/elf_object.cc
@@ -218,7 +218,8 @@ ElfObject::ElfObject(ImageFileDataPtr ifd) : ObjectFile(ifd)
                 }
 
                 loader::Symbol symbol(
-                    binding, symbol_type, sym_name, sym.st_value);
+                    binding, symbol_type, sym_name, sym.st_value,
+                    sym.st_size);
 
                 if (_symtab.insert(symbol)) {
                     DPRINTF(Loader, "Symbol: %-40s value %#x.\n",

--- a/src/base/loader/symtab.hh
+++ b/src/base/loader/symtab.hh
@@ -81,8 +81,15 @@ class Symbol
     };
 
     Symbol(const Binding binding, const SymbolType type,
+           const std::string & name, const Addr addr, const size_t size)
+        : _binding(binding), _type(type), _name(name), _address(addr),
+          _size(size), _sizeIsValid(true)
+    {}
+
+    Symbol(const Binding binding, const SymbolType type,
            const std::string & name, const Addr addr)
-        : _binding(binding), _type(type), _name(name), _address(addr)
+        : _binding(binding), _type(type), _name(name), _address(addr),
+          _size(0x0), _sizeIsValid(false)
     {}
 
     Symbol(const Symbol & other) = default;
@@ -112,11 +119,32 @@ class Symbol
         _address = new_addr;
     }
 
+    /**
+     * Return the Symbol size if it is valid, otherwise return the
+     * default value supplied.
+     *
+     * This method forces the client code to consider the possibility
+     * that the `SymbolTable` may contain `Symbol`s that do not have
+     * valid sizes.
+     */
+    size_t sizeOrDefault(const size_t default_size) const {
+        return _sizeIsValid ? _size : default_size;
+    }
+
+    /**
+     * Return whether the Symbol size is valid or not.
+     */
+    bool sizeIsValid() const {
+        return _sizeIsValid;
+    }
+
   private:
     Binding _binding;
     SymbolType _type;
     std::string _name;
     Addr _address;
+    size_t _size;
+    bool _sizeIsValid;
 };
 
 

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012,2016-2017, 2019-2020 ARM Limited
+ * Copyright (c) 2011-2012,2016-2017, 2019-2020 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -795,8 +795,8 @@ BaseCPU::traceFunctionsInternal(Addr pc)
             currentFunctionStart = pc;
             currentFunctionEnd = pc + 1;
         } else {
-            sym_str = it->name;
-            currentFunctionStart = it->address;
+            sym_str = it->name();
+            currentFunctionStart = it->address();
         }
 
         ccprintf(*functionTraceStream, " (%d)\n%d: %s",

--- a/src/cpu/exetrace.cc
+++ b/src/cpu/exetrace.cc
@@ -81,11 +81,11 @@ ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
     if (debug::ExecSymbol && (!FullSystem || !in_user_mode) &&
             (it = loader::debugSymbolTable.findNearest(cur_pc)) !=
                 loader::debugSymbolTable.end()) {
-        Addr delta = cur_pc - it->address;
+        Addr delta = cur_pc - it->address();
         if (delta)
-            ccprintf(outs, " @%s+%d", it->name, delta);
+            ccprintf(outs, " @%s+%d", it->name(), delta);
         else
-            ccprintf(outs, " @%s", it->name);
+            ccprintf(outs, " @%s", it->name());
     }
 
     if (inst->isMicroop()) {

--- a/src/cpu/profile.cc
+++ b/src/cpu/profile.cc
@@ -63,7 +63,7 @@ BaseStackTrace::tryGetSymbol(std::string &symbol, Addr addr,
     const auto it = symtab->find(addr);
     if (it == symtab->end())
         return false;
-    symbol = it->name;
+    symbol = it->name();
     return true;
 }
 
@@ -151,7 +151,7 @@ FunctionProfile::sample(ProfileNode *node, Addr pc)
 
     auto it = symtab.findNearest(pc);
     if (it != symtab.end()) {
-        pc_count[it->address]++;
+        pc_count[it->address()]++;
     } else {
         // record PC even if we don't have a symbol to avoid
         // silently biasing the histogram

--- a/src/sim/kernel_workload.cc
+++ b/src/sim/kernel_workload.cc
@@ -66,8 +66,8 @@ KernelWorkload::KernelWorkload(const Params &p) : Workload(p),
         kernelSymtab = kernelObj->symtab();
         auto initKernelSymtab = kernelSymtab.mask(_loadAddrMask)
             ->offset(_loadAddrOffset)
-            ->rename([](std::string &name) {
-                name = "kernel_init." + name;
+            ->rename([](const std::string &name) {
+                return "kernel_init." + name;
             });
 
         loader::debugSymbolTable.insert(*initKernelSymtab);

--- a/src/sim/workload.hh
+++ b/src/sim/workload.hh
@@ -141,7 +141,7 @@ class Workload : public SimObject
         if (it == symtab.end())
             return nullptr;
 
-        return new T(system, desc, fixFuncEventAddr(it->address),
+        return new T(system, desc, fixFuncEventAddr(it->address()),
                       std::forward<Args>(args)...);
     }
 


### PR DESCRIPTION
This Pull-Request addresses gem5 Issue #550. The code that dumps the Dmesg buffer is now templated on the two variants of the `Metadata` structure, and the correct one is chosen based on the detected Kernel version.

To support this functionality, the pull request also adds Symbol Size data to the loader Symbol Table, and adds a method to query the Kernel Version from the image in guest memory. The new attributes in the Symbol class are de-serialized speculatively, so no checkpoint upgrader is required to support this change.