### PR TITLE
misc: Add gem5_build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+gem5_build
 parser.out
 parsetab.py
 cscope.files


### PR DESCRIPTION
The website's documentation on building gem5 now references
<gem5_base>/gem5_build in addition to <gem5_base>/build. So, we should
ignore files in that directory as well as the build directory.

Change-Id: Ie226545e04b885ce81b3c17e18b5052ed64af328
Signed-off-by: Jason Lowe-Power <jason@lowepower.com>