### PR TITLE
mem-ruby: Fix compile error in chi-dvm-funcs

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-dvm-misc-node-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-dvm-misc-node-funcs.sm
@@ -137,15 +137,19 @@ Cycles dataLatency() {
   return intToCycles(0);
 }
 
-bool inCache(Addr txnId) {
+bool inCache(Addr txnId, bool is_secure) {
   return false;
 }
 
-bool hasBeenPrefetched(Addr txnId) {
+bool hasBeenPrefetched(Addr txnId, bool is_secure, RequestorID requestor) {
   return false;
 }
 
-bool inMissQueue(Addr txnId) {
+bool hasBeenPrefetched(Addr txnId, bool is_secure) {
+  return false;
+}
+
+bool inMissQueue(Addr txnId, bool is_secure) {
   return false;
 }
 


### PR DESCRIPTION
clang correctly found that the functions `inCache`, `hasBeenPrefetched`
and `inMissQueue` had the wrong signatures in the DVM funcs files. These
functions are unused, so this change just updates their signatures.

Change-Id: Id669ff661e1c6c46eaf04ea1f17cd9866a9e49ed
Signed-off-by: Jason Lowe-Power <jason@lowepower.com>