### PR TITLE
configs: Fix apu_se.py CPU type checks

### DIFF
--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -129,7 +129,7 @@ class CPCntrl(CorePair_Controller, CntrlBase):
         self.sequencer1.is_cpu_sequencer = True
 
         self.issue_latency = options.cpu_to_dir_latency
-        self.send_evictions = send_evicts(options)
+        self.send_evictions = True if options.cpu_type == "X86O3CPU" else False
 
         self.ruby_system = ruby_system
 


### PR DESCRIPTION
The current checks do not work. Correct the CPU type names

Change-Id: I81778873df0567c4a8dabbbe659c4c7a39326f98