### PR TITLE
arch-x86: Fix two_byte_opcodes.isa `0x6` -> `0x0`

### DIFF
--- a/src/arch/x86/isa/decoder/two_byte_opcodes.isa
+++ b/src/arch/x86/isa/decoder/two_byte_opcodes.isa
@@ -291,7 +291,7 @@
                 0x0: decode LEGACY_DECODEVAL {
                     // no prefix
                     0x0: decode OPCODE_OP_BOTTOM3 {
-                        0x6: Cpl0CondInst::MOV(
+                        0x0: Cpl0CondInst::MOV(
                             {{misc_reg::isValid(misc_reg::cr(MODRM_REG))}},Rd,Cd);
                         0x1: Cpl0CondInst::MOV({{MODRM_REG < 8}},Rd,Dd);
                         0x2: Cpl0CondInst::MOV(


### PR DESCRIPTION
This bug was introduced by https://github.com/gem5/gem5/pull/593 and caused Issue https://github.com/gem5/gem5/issues/664.

Change-Id: Ia55de364ee8260e1fe315e37e1cffbc71ab229fb