### PR TITLE
arch-riscv: squash walks with tlb hits in startWalkWrapper

### DIFF
--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -134,11 +134,10 @@ class TLB : public BaseTLB
                               BaseMMU::Mode mode) override;
     Fault finalizePhysical(const RequestPtr &req, ThreadContext *tc,
                            BaseMMU::Mode mode) const override;
+    TlbEntry *lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden);
 
   private:
     uint64_t nextSeq() { return ++lruSeq; }
-
-    TlbEntry *lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden);
 
     void evictLRU();
     void remove(size_t idx);


### PR DESCRIPTION
Because each vector load is fragmented into 64 byte cache-aligned chunks, and one page-table walk is issued per fragment on tlb miss, walks start to accumulate on a pending queue, which is processed in a blocking way (no pending walks can be issued while one is being processed). This adds noticeable latency on vector loads when VLEN is sufficiently large.

This commit fixes the issue by allowing walks to be squashed if a TLB lookup hits just before starting the walk on `startWalkWrapper`. This idea was taken from the ARM walker.
