### PR TITLE
arch-riscv: Move trap handler status to RiscvISA

### DIFF
--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -65,40 +65,10 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
              name(), pc_state);
 
     if (FullSystem) {
+        auto isa = static_cast<RiscvISA::ISA*>(tc->getIsaPtr());
         PrivilegeMode pp = (PrivilegeMode)tc->readMiscReg(MISCREG_PRV);
-        PrivilegeMode prv = PRV_M;
-        MISA misa = tc->readMiscRegNoEffect(MISCREG_ISA);
-        STATUS status = tc->readMiscReg(MISCREG_STATUS);
-
-        // According to riscv-privileged-v1.11, if a NMI occurs at the middle
-        // of a M-mode trap handler, the state (epc/cause) will be overwritten
-        // and is not necessary recoverable. There's nothing we can do here so
-        // we'll just warn our user that the CPU state might be broken.
-        warn_if(isNonMaskableInterrupt() && pp == PRV_M && status.mie == 0,
-                "NMI overwriting M-mode trap handler state");
-
-        // Set fault handler privilege mode
-        if (isNonMaskableInterrupt()) {
-            prv = PRV_M;
-        } else if (isInterrupt()) {
-            if (pp != PRV_M &&
-                bits(tc->readMiscReg(MISCREG_MIDELEG), _code) != 0) {
-                prv = (misa.rvs) ? PRV_S : ((misa.rvn) ? PRV_U : PRV_M);
-            }
-            if (pp == PRV_U && misa.rvs && misa.rvn &&
-                bits(tc->readMiscReg(MISCREG_SIDELEG), _code) != 0) {
-                prv = PRV_U;
-            }
-        } else {
-            if (pp != PRV_M &&
-                bits(tc->readMiscReg(MISCREG_MEDELEG), _code) != 0) {
-                prv = (misa.rvs) ? PRV_S : ((misa.rvn) ? PRV_U : PRV_M);
-            }
-            if (pp == PRV_U && misa.rvs && misa.rvn &&
-                bits(tc->readMiscReg(MISCREG_SEDELEG), _code) != 0) {
-                prv = PRV_U;
-            }
-        }
+        PrivilegeMode prv = isa->getHandlerPriv(
+            pp, _code, isInterrupt(), isNonMaskableInterrupt());
 
         // Set fault registers and status
         MiscRegIndex cause, epc, tvec, tval;
@@ -108,29 +78,18 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
             epc = MISCREG_UEPC;
             tvec = MISCREG_UTVEC;
             tval = MISCREG_UTVAL;
-
-            status.upie = status.uie;
-            status.uie = 0;
             break;
           case PRV_S:
             cause = MISCREG_SCAUSE;
             epc = MISCREG_SEPC;
             tvec = MISCREG_STVEC;
             tval = MISCREG_STVAL;
-
-            status.spp = pp;
-            status.spie = status.sie;
-            status.sie = 0;
             break;
           case PRV_M:
             cause = MISCREG_MCAUSE;
             epc = MISCREG_MEPC;
             tvec = isNonMaskableInterrupt() ? MISCREG_NMIVEC : MISCREG_MTVEC;
             tval = MISCREG_MTVAL;
-
-            status.mpp = pp;
-            status.mpie = status.mie;
-            status.mie = 0;
             break;
           default:
             panic("Unknown privilege mode %d.", prv);
@@ -145,8 +104,7 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         tc->setMiscReg(cause, _cause);
         tc->setMiscReg(epc, tc->pcState().instAddr());
         tc->setMiscReg(tval, trap_value());
-        tc->setMiscReg(MISCREG_PRV, prv);
-        tc->setMiscReg(MISCREG_STATUS, status);
+        isa->updateEnterToTrapStatus(prv, pp, isNonMaskableInterrupt());
         // Temporarily mask NMI while we're in NMI handler. Otherweise, the
         // checkNonMaskableInterrupt will always return true and we'll be
         // stucked in an infinite loop.
@@ -155,7 +113,6 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         }
 
         // Clear load reservation address
-        auto isa = static_cast<RiscvISA::ISA*>(tc->getIsaPtr());
         isa->clearLoadReservation(tc->contextId());
 
         // Set PC to fault handler address

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -173,6 +173,26 @@ class ISA : public BaseISA
 
     virtual Addr getFaultHandlerAddr(
         RegIndex idx, uint64_t cause, bool intr) const;
+
+    /** Update the RISC-V xpie, xie and xpp bits and privilege mode when
+     *  executing xret instruction
+     */
+    virtual void updateReturnFromTrapStatus(PrivilegeMode prv);
+
+    /** Update the RISC-V xpie, xie and xpp bits and privilege mode when
+     *  entering exception & interrupt handler
+     */
+    virtual void updateEnterToTrapStatus(
+        PrivilegeMode prv, PrivilegeMode pp, bool isNonMaskIntr);
+
+    /**
+     * Get the privilege mode of trap execution
+     */
+    virtual PrivilegeMode getHandlerPriv(
+        PrivilegeMode pp, uint64_t cause, bool intr, bool isNonMaskIntr);
+
+    /** Get mpp bits from CSR */
+    virtual PrivilegeMode getMpp();
 };
 
 } // namespace RiscvISA

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4595,29 +4595,32 @@ decode QUADRANT default Unknown::unknown() {
                                 xc->pcState());
                         }}, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                         0x2: uret({{
-                           MISA misa = xc->readMiscReg(MISCREG_ISA);
+                            auto* isa = dynamic_cast<RiscvISA::ISA*>(
+                                    xc->tcBase()->getIsaPtr());
+                            panic_if(!isa, "Invalid ISA specify.");
+                            MISA misa = isa->readMiscRegNoEffect(MISCREG_ISA);
                             if (!misa.rvn) {
                                 return std::make_shared<IllegalInstFault>(
                                     "sret can't execute without N systems",
                                     machInst);
                             }
-                            STATUS status = xc->readMiscReg(MISCREG_STATUS);
-                            status.uie = status.upie;
-                            status.upie = 1;
-                            xc->setMiscReg(MISCREG_STATUS, status);
+                            isa->updateReturnFromTrapStatus(PRV_U);
                             NPC = xc->readMiscReg(MISCREG_UEPC);
                         }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
                     }
                     0x8: decode RS2 {
                         0x2: sret({{
-                            MISA misa = xc->readMiscReg(MISCREG_ISA);
+                            auto* isa = dynamic_cast<RiscvISA::ISA*>(
+                                xc->tcBase()->getIsaPtr());
+                            panic_if(!isa, "Invalid ISA specify.");
+                            MISA misa = isa->readMiscRegNoEffect(MISCREG_ISA);
                             if (!misa.rvs) {
                                 return std::make_shared<IllegalInstFault>(
                                             "sret can't execute without RVS",
                                             machInst);
                             }
-                            STATUS status = xc->readMiscReg(MISCREG_STATUS);
-                            auto pm = (PrivilegeMode)xc->readMiscReg(
+                            STATUS status = isa->readMiscReg(MISCREG_STATUS);
+                            auto pm = (PrivilegeMode)isa->readMiscRegNoEffect(
                                 MISCREG_PRV);
                             if (pm == PRV_U ||
                                 (pm == PRV_S && status.tsr == 1)) {
@@ -4626,11 +4629,7 @@ decode QUADRANT default Unknown::unknown() {
                                             machInst);
                                 NPC = NPC;
                             } else {
-                                xc->setMiscReg(MISCREG_PRV, status.spp);
-                                status.sie = status.spie;
-                                status.spie = 1;
-                                status.spp = PRV_U;
-                                xc->setMiscReg(MISCREG_STATUS, status);
+                                isa->updateReturnFromTrapStatus(PRV_S);
                                 NPC = xc->readMiscReg(MISCREG_SEPC);
                             }
                         }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
@@ -4676,18 +4675,16 @@ decode QUADRANT default Unknown::unknown() {
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
                     }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
                     0x18: mret({{
-                        if (xc->readMiscReg(MISCREG_PRV) != PRV_M) {
+                        auto* isa = dynamic_cast<RiscvISA::ISA*>(
+                            xc->tcBase()->getIsaPtr());
+                        panic_if(!isa, "Invalid ISA specify.");
+                        if (isa->readMiscRegNoEffect(MISCREG_PRV) != PRV_M) {
                             return std::make_shared<IllegalInstFault>(
                                         "mret at lower privilege", machInst);
                             NPC = NPC;
                         } else {
-                            STATUS status = xc->readMiscReg(MISCREG_STATUS);
-                            xc->setMiscReg(MISCREG_PRV, status.mpp);
                             xc->setMiscReg(MISCREG_NMIE, 1);
-                            status.mie = status.mpie;
-                            status.mpie = 1;
-                            status.mpp = PRV_U;
-                            xc->setMiscReg(MISCREG_STATUS, status);
+                            isa->updateReturnFromTrapStatus(PRV_M);
                             NPC = xc->readMiscReg(MISCREG_MEPC);
                         }
                     }}, IsSerializeAfter, IsNonSpeculative, IsReturn);

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -327,8 +327,10 @@ TLB::getMemPriv(ThreadContext *tc, BaseMMU::Mode mode)
 {
     STATUS status = (STATUS)tc->readMiscReg(MISCREG_STATUS);
     PrivilegeMode pmode = (PrivilegeMode)tc->readMiscReg(MISCREG_PRV);
-    if (mode != BaseMMU::Execute && status.mprv == 1)
-        pmode = (PrivilegeMode)(RegVal)status.mpp;
+    if (mode != BaseMMU::Execute && status.mprv == 1) {
+        ISA* isa = dynamic_cast<ISA*>(tc->getIsaPtr());
+        pmode = isa->getMpp();
+    }
     return pmode;
 }
 


### PR DESCRIPTION
The change will enable customize the xpie, xie and xpp bits, privilege mode configuration and delegation. Some of CPUs handle xpie, xie and xpp bits in the other CSR. For example, if the CPU support CLIC mode, the xpie and xpp will handle in the xcause rather than xstatus.

Reference: https://github.com/riscv/riscv-fast-interrupt
Change-Id: I03159a4b5093dc0aa1b36df8729e9610b1d3bd7f