### PR TITLE
arch,arch-riscv: Fix inst flag of RISC-V vector store macro instructions

### DIFF
--- a/src/arch/isa_parser/util.py
+++ b/src/arch/isa_parser/util.py
@@ -69,7 +69,9 @@ commentRE = re.compile(
 # destination.  basically we're looking for an '=' that's not '=='.
 # The heinous tangle before that handles the case where the operand
 # has an array subscript.
-assignRE = re.compile(r"(\[[^\]]+\])?\s*=(?!=)", re.MULTILINE)
+assignRE = re.compile(
+    r"((\.as<[^>]+>\(\s*\))?\[[^\]]+\])?\s*=(?!=)", re.MULTILINE
+)
 
 #
 # Munge a somewhat arbitrarily formatted piece of Python code

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1586,7 +1586,7 @@ Fault
     }
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
-    %(op_src_decl)s;
+    %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
     %(ea_code)s;


### PR DESCRIPTION
Correct the instruction flags of RISC-V vector store instructions, such as `vse64_v`, `vse32_v`. The `vse64_v`  in `decoder.isa` is `Mem_vc.as<uint64_t>()[i] = Vs3_ud[i];` and it will generate the code `Mem.as<uint64_t>()[i] = Vs3[i];`. The current regex of assignRE only mark the operand `Mem` as `dest` only if meet the formats like `Mem = Rd` or `Mem[i] = Rd` because the code ` = Rd` or `[i] = Rd` match the `assignRE` respectively. For the expression `Mem.as<uint64_t>()[i]`, the operand `Mem` will falsely mark the operand as `src` because the code `.as<uint64_t>()[i]` is not match the  `assignRE`.

The PR will ensure the operand `Mem` is dest for the format like `Mem.as<xxx>()[i] = yyy`.
    
Change-Id: I9c57986a64f1efb81eb9c7ade90712b118e0788d