### PR TITLE
stdlib,resources: Fix obtaining gem5 Looppoint resources

### DIFF
--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -578,7 +578,9 @@ class LooppointCsvResource(FileResource, LooppointCsvLoader):
             resource_version=resource_version,
             downloader=downloader,
         )
-        LooppointCsvLoader.__init__(self, pinpoints_file=Path(local_path))
+        LooppointCsvLoader.__init__(
+            self, pinpoints_file=Path(self.get_local_path())
+        )
 
     def get_category_name(cls) -> str:
         return "LooppointCsvResource"
@@ -606,7 +608,7 @@ class LooppointJsonResource(FileResource, LooppointJsonLoader):
             downloader=downloader,
         )
         LooppointJsonLoader.__init__(
-            self, looppoint_file=local_path, region_id=region_id
+            self, looppoint_file=self.get_local_path(), region_id=region_id
         )
 
     def get_category_name(cls) -> str:

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -1098,7 +1098,6 @@ def obtain_resource(
             for key in resource_json["additional_params"].keys():
                 assert isinstance(key, str)
                 value = resource_json["additional_params"][key]
-                assert isinstance(value, str)
                 params[key] = value
         resource_json["parameters"] = params
     # Once we know what AbstractResource subclass we are using, we create it.


### PR DESCRIPTION
There were two small bugs preventing gem5 from obtaining Looppoint resources.

1. When obtained via a `WorkloadResource` there was an assert which assumed the values in the resource's DB entry's `additional_parameter` field were of type string. This is not the case. For Looppoint resources there are additional parameters which are arrays.
2. Due to changes introduced in https://github.com/gem5/gem5/pull/625, the Looppoint CSV and JSON files were not being downloaded when needed. This was fixed by replacing access to the `local_path` variable with a call to `get_local_path()`.