### PR TITLE
tests: Silence Clang 16 warnings

### DIFF
--- a/src/base/bitunion.test.cc
+++ b/src/base/bitunion.test.cc
@@ -129,7 +129,7 @@ containingFunc(uint64_t init_val, uint64_t fieldVal)
 // Declare these as global so g++ doesn't ignore them. Initialize them in
 // various ways.
 EmptySixtyFour emptySixtyFour = 0;
-EmptyThirtyTwo emptyThirtyTwo{};
+[[maybe_unused]] EmptyThirtyTwo emptyThirtyTwo{};
 [[maybe_unused]] EmptySixteen emptySixteen;
 EmptyEight emptyEight(0);
 

--- a/src/base/compiler.hh
+++ b/src/base/compiler.hh
@@ -90,7 +90,7 @@
 // This version is for macros which are statement-like, which frequently use
 // "do {} while (0)" to make their syntax look more like normal c++ statements.
 #  define GEM5_DEPRECATED_MACRO_STMT(name, definition, message) \
-     do {{definition;} GEM5_DEPRECATED_MACRO(name, {}, message);} while (0)
+     do {{definition;} GEM5_DEPRECATED_MACRO(name, ({}), message);} while (0)
 
 // To mark a class as deprecated in favor of a new name, add a respective
 // instance of this macro to the file that used to declare the old name.


### PR DESCRIPTION
I was trying to build with clang 16 and ran into these -Werror warnings

Change-Id: I9207990fcfe9c1a5485945294969f21d1d812a7c