### PR TITLE
scons: Add option to use libc++

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -117,6 +117,8 @@ AddOption('--no-compress-debug', action='store_true',
           help="Don't compress debug info in build files")
 AddOption('--with-lto', action='store_true',
           help='Enable Link-Time Optimization')
+AddOption('--with-libcxx', action='store_true',
+          help='Use libc++ as the C++ standard library (requires Clang)')
 AddOption('--verbose', action='store_true',
           help='Print full tool command lines')
 AddOption('--without-python', action='store_true',
@@ -567,6 +569,16 @@ for variant_path in variant_paths:
         with gem5_scons.Configure(env) as conf:
             conf.CheckLinkFlag('-Wl,--as-needed')
 
+        want_libcxx = GetOption('with_libcxx')
+        if want_libcxx:
+            with gem5_scons.Configure(env) as conf:
+                # Try using libc++ if it supports the <filesystem> library.
+                code = '#include <filesystem>\nint main() { return 0; }'
+                if (not conf.CheckCxxFlag('-stdlib=libc++') or
+                    not conf.CheckLinkFlag('-stdlib=libc++', code=code)
+                ):
+                    error('Requested libc++ but it is not usable')
+
         linker = GetOption('linker')
         if linker:
             with gem5_scons.Configure(env) as conf:
@@ -673,7 +685,7 @@ for variant_path in variant_paths:
 
         env.Append(TCMALLOC_CCFLAGS=['-fno-builtin'])
 
-        if compareVersions(env['CXXVERSION'], "11") < 0:
+        if not want_libcxx and compareVersions(env['CXXVERSION'], "11") < 0:
             # `libstdc++fs`` must be explicitly linked for `std::filesystem``
             # in clang versions 6 through 10.
             #
@@ -687,7 +699,7 @@ for variant_path in variant_paths:
 
         # On Mac OS X/Darwin we need to also use libc++ (part of XCode) as
         # opposed to libstdc++, as the later is dated.
-        if sys.platform == "darwin":
+        if not want_libcxx and sys.platform == "darwin":
             env.Append(CXXFLAGS=['-stdlib=libc++'])
             env.Append(LIBS=['c++'])
 

--- a/site_scons/gem5_scons/configure.py
+++ b/site_scons/gem5_scons/configure.py
@@ -59,13 +59,15 @@ def CheckCxxFlag(context, flag, autoadd=True):
     return ret
 
 
-def CheckLinkFlag(context, flag, autoadd=True, set_for_shared=True):
+def CheckLinkFlag(context, flag, autoadd=True, set_for_shared=True, code=None):
     context.Message(f"Checking for linker {flag} support... ")
     last_linkflags = context.env["LINKFLAGS"]
     context.env.Append(LINKFLAGS=[flag])
     pre_werror = context.env["LINKFLAGS"]
     context.env.Append(LINKFLAGS=["-Werror"])
-    ret = context.TryLink("int main(int, char *[]) { return 0; }", ".cc")
+    if not code:
+        code = "int main(int, char *[]) { return 0; }"
+    ret = context.TryLink(code, ".cc")
     context.env["LINKFLAGS"] = pre_werror
     if not (ret and autoadd):
         context.env["LINKFLAGS"] = last_linkflags


### PR DESCRIPTION
this adds an option --with-libcxx, that adds the -stdlib=libc++ flag to link against libc++ instead of libstdc++ on Linux. Currently this is only possible with clang and may not work with all build configurations (e.g. protobuf linked against libstdc++), so this needs to be opt-in rather than being on by default for clang whenever libc++ is detected.

Change-Id: Ib4022a58bb2dbd32417c58f01c7443a02ff710fe