### PR TITLE
configs: Fix SMT cpu type checking

### DIFF
--- a/configs/common/ObjectList.py
+++ b/configs/common/ObjectList.py
@@ -228,3 +228,4 @@ def _subclass_tester(name):
 
 is_kvm_cpu = _subclass_tester("BaseKvmCPU")
 is_noncaching_cpu = _subclass_tester("NonCachingSimpleCPU")
+is_o3_cpu = _subclass_tester("BaseO3CPU")

--- a/configs/deprecated/example/se.py
+++ b/configs/deprecated/example/se.py
@@ -118,7 +118,8 @@ def get_processes(args):
         idx += 1
 
     if args.smt:
-        assert isinstance(args.cpu_type, DerivO3CPU)
+        cpu_type = ObjectList.cpu_list.get(args.cpu_type)
+        assert ObjectList.is_o3_cpu(cpu_type), "SMT requires an O3CPU"
         return multiprocesses, idx
     else:
         return multiprocesses, 1


### PR DESCRIPTION
The args.cpu_type is not a type but a string so the isinstance checking will always fail and an assertion will always be thrown

Change-Id: I6a88d1a514bb323c517949632f4e76be40e87e8c