### PR TITLE
mem-ruby: Implement a dummy StashOnceShared/Unique

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -2938,11 +2938,13 @@ action(Send_RespSepData, desc="") {
 action(Send_CompI, desc="") {
   assert(is_valid(tbe));
 
-  // Used to ack Evict request
-  assert(tbe.dir_sharers.isElement(tbe.requestor));
-  assert((tbe.dir_ownerExists == false) || (tbe.dir_owner != tbe.requestor));
+  if (!isStashReqType(tbe.reqType)) {
+    // Used to ack Evict request
+    assert(tbe.dir_sharers.isElement(tbe.requestor));
+    assert((tbe.dir_ownerExists == false) || (tbe.dir_owner != tbe.requestor));
 
-  tbe.dir_sharers.remove(tbe.requestor);
+    tbe.dir_sharers.remove(tbe.requestor);
+  }
 
   enqueue(rspOutPort, CHIResponseMsg, response_latency) {
     out_msg.addr := address;

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1200,6 +1200,14 @@ bool isWriteReqType(CHIRequestType type) {
   return false;
 }
 
+bool isStashReqType(CHIRequestType type) {
+  if (type == CHIRequestType:StashOnceShared ||
+      type == CHIRequestType:StashOnceUnique) {
+    return true;
+  }
+  return false;
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // State->Event converters
 
@@ -1254,6 +1262,10 @@ Event reqToEvent(CHIRequestType type, bool is_prefetch) {
     } else {
       return Event:WriteUnique; // all WriteUnique handled the same when ~PoC
     }
+  } else if (type == CHIRequestType:StashOnceShared) {
+      return Event:StashOnceShared;
+  } else if (type == CHIRequestType:StashOnceUnique) {
+      return Event:StashOnceUnique;
   } else if (type == CHIRequestType:DvmTlbi_Initiate) {
     return Event:DvmTlbi_Initiate;
   } else if (type == CHIRequestType:DvmSync_Initiate) {

--- a/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
@@ -836,6 +836,14 @@ transition(BUSY_INTR, {SnpOnce,SnpOnceFwd}, BUSY_BLKD) {
   ProcessNextState;
 }
 
+// Stash
+transition({I,SC,UC,SD,UD,RU,RSC,RSD,RUSD,SC_RSC,UC_RSC,SD_RSC,UD_RSC,UC_RU,UD_RU,UD_RSD,SD_RSD,RUSC},
+           {StashOnceShared,StashOnceUnique}, BUSY_BLKD) {
+  Initiate_Request;
+  Send_CompI;
+  Pop_ReqRdyQueue;
+  ProcessNextState;
+}
 
 // Stalls
 
@@ -850,7 +858,8 @@ transition({BUSY_BLKD,BUSY_INTR},
             WriteUnique,WriteUniquePtl_PoC,
             WriteUniqueFull_PoC,WriteUniqueFull_PoC_Alloc
             AtomicReturn,AtomicReturn_PoC,
-            AtomicNoReturn,AtomicNoReturn_PoC}) {
+            AtomicNoReturn,AtomicNoReturn_PoC,
+            StashOnceShared,StashOnceUnique}) {
   StallRequest;
 }
 

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -334,6 +334,8 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     SnpOnce,                     desc="", in_trans="yes";
     SnpOnceFwd,                  desc="", in_trans="yes";
     SnpStalled, desc="", in_trans="yes"; // A snoop stall triggered from the inport
+    StashOnceShared,             desc="", in_trans="yes"; // Just discarding the hint
+    StashOnceUnique,             desc="", in_trans="yes"; // Just discarding the hint
 
     // DVM sequencer requests
     DvmTlbi_Initiate, desc="", out_trans="yes", in_trans="yes"; // triggered when a CPU core wants to send a TLBI

--- a/src/mem/ruby/protocol/chi/CHI-msg.sm
+++ b/src/mem/ruby/protocol/chi/CHI-msg.sm
@@ -89,6 +89,9 @@ enumeration(CHIRequestType, desc="") {
   ReadNoSnp;
   ReadNoSnpSep;
 
+  StashOnceShared;
+  StashOnceUnique;
+
   DvmOpNonSync;
   DvmOpSync;
 


### PR DESCRIPTION
Stash requests will simply be discarded by the Home Node This will return a CompI response to the RNF

Change-Id: I9c2ce5d4d42f380d1a554933d381cf8a8590ba22

Reviewed-by: Tiago Muck <tiago.muck@arm.com>