### PR TITLE
sim: Remove trailing / from proc/meminfo special path

### DIFF
--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013, 2015, 2019-2021 Arm Limited
+ * Copyright (c) 2012-2013, 2015, 2019-2021, 2023 Arm Limited
  * Copyright (c) 2015 Advanced Micro Devices, Inc.
  * All rights reserved
  *
@@ -866,7 +866,7 @@ openatFunc(SyscallDesc *desc, ThreadContext *tc,
     int sim_fd = -1;
     std::string used_path;
     std::vector<std::string> special_paths =
-            { "/proc/meminfo/", "/system/", "/platform/", "/etc/passwd",
+            { "/proc/meminfo", "/system/", "/platform/", "/etc/passwd",
               "/proc/self/maps", "/dev/urandom",
               "/sys/devices/system/cpu/online" };
     for (auto entry : special_paths) {


### PR DESCRIPTION
Note: A bug was identified in that the one of the special file paths, namely /proc/meminfo contained an extra trailing /, implicitly making the incorrect assumption that meminfo was a directory, when it is, in fact, a (pseudo-)file. This was causing application in SE mode to fail opening the meminfo pseudo-file with errno 13. This commit fixes this issue.

Change-Id: I93fa81cab49645d70775088f1e634f067b300698
Reviewed-by: Richard Cooper <richard.cooper@arm.com>