### PR TITLE
Remove replacement_policy namespace

### DIFF
--- a/src/mem/cache/prefetch/associative_set.hh
+++ b/src/mem/cache/prefetch/associative_set.hh
@@ -58,7 +58,7 @@ class AssociativeSet
     /** Pointer to the indexing policy */
     BaseIndexingPolicy* const indexingPolicy;
     /** Pointer to the replacement policy */
-    replacement_policy::Base* const replacementPolicy;
+    BaseReplacementPolicy* const replacementPolicy;
     /** Vector containing the entries of the container */
     std::vector<Entry> entries;
 
@@ -73,7 +73,7 @@ class AssociativeSet
      * @param init_val initial value of the elements of the set
      */
     AssociativeSet(int assoc, int num_entries, BaseIndexingPolicy *idx_policy,
-        replacement_policy::Base *rpl_policy, Entry const &init_val = Entry());
+        BaseReplacementPolicy *rpl_policy, Entry const &init_val = Entry());
 
     /**
      * Find an entry within the set

--- a/src/mem/cache/prefetch/associative_set_impl.hh
+++ b/src/mem/cache/prefetch/associative_set_impl.hh
@@ -37,7 +37,7 @@ namespace gem5
 
 template<class Entry>
 AssociativeSet<Entry>::AssociativeSet(int assoc, int num_entries,
-        BaseIndexingPolicy *idx_policy, replacement_policy::Base *rpl_policy,
+        BaseIndexingPolicy *idx_policy, BaseReplacementPolicy *rpl_policy,
         Entry const &init_value)
   : associativity(assoc), numEntries(num_entries), indexingPolicy(idx_policy),
     replacementPolicy(rpl_policy), entries(numEntries, init_value)

--- a/src/mem/cache/prefetch/stride.hh
+++ b/src/mem/cache/prefetch/stride.hh
@@ -64,10 +64,7 @@ namespace gem5
 {
 
 class BaseIndexingPolicy;
-namespace replacement_policy
-{
-    class Base;
-}
+class BaseReplacementPolicy;
 struct StridePrefetcherParams;
 
 namespace prefetch
@@ -114,11 +111,11 @@ class Stride : public Queued
         const int numEntries;
 
         BaseIndexingPolicy* const indexingPolicy;
-        replacement_policy::Base* const replacementPolicy;
+        BaseReplacementPolicy* const replacementPolicy;
 
         PCTableInfo(int assoc, int num_entries,
             BaseIndexingPolicy* indexing_policy,
-            replacement_policy::Base* repl_policy)
+            BaseReplacementPolicy* repl_policy)
           : assoc(assoc), numEntries(num_entries),
             indexingPolicy(indexing_policy), replacementPolicy(repl_policy)
         {

--- a/src/mem/cache/replacement_policies/ReplacementPolicies.py
+++ b/src/mem/cache/replacement_policies/ReplacementPolicies.py
@@ -32,13 +32,13 @@ from m5.SimObject import SimObject
 class BaseReplacementPolicy(SimObject):
     type = "BaseReplacementPolicy"
     abstract = True
-    cxx_class = "gem5::replacement_policy::Base"
+    cxx_class = "gem5::BaseReplacementPolicy"
     cxx_header = "mem/cache/replacement_policies/base.hh"
 
 
 class DuelingRP(BaseReplacementPolicy):
     type = "DuelingRP"
-    cxx_class = "gem5::replacement_policy::Dueling"
+    cxx_class = "gem5::Dueling"
     cxx_header = "mem/cache/replacement_policies/dueling_rp.hh"
 
     constituency_size = Param.Unsigned(
@@ -57,31 +57,31 @@ class DuelingRP(BaseReplacementPolicy):
 
 class FIFORP(BaseReplacementPolicy):
     type = "FIFORP"
-    cxx_class = "gem5::replacement_policy::FIFO"
+    cxx_class = "gem5::FIFO"
     cxx_header = "mem/cache/replacement_policies/fifo_rp.hh"
 
 
 class SecondChanceRP(FIFORP):
     type = "SecondChanceRP"
-    cxx_class = "gem5::replacement_policy::SecondChance"
+    cxx_class = "gem5::SecondChance"
     cxx_header = "mem/cache/replacement_policies/second_chance_rp.hh"
 
 
 class LFURP(BaseReplacementPolicy):
     type = "LFURP"
-    cxx_class = "gem5::replacement_policy::LFU"
+    cxx_class = "gem5::LFU"
     cxx_header = "mem/cache/replacement_policies/lfu_rp.hh"
 
 
 class LRURP(BaseReplacementPolicy):
     type = "LRURP"
-    cxx_class = "gem5::replacement_policy::LRU"
+    cxx_class = "gem5::LRU"
     cxx_header = "mem/cache/replacement_policies/lru_rp.hh"
 
 
 class BIPRP(LRURP):
     type = "BIPRP"
-    cxx_class = "gem5::replacement_policy::BIP"
+    cxx_class = "gem5::BIP"
     cxx_header = "mem/cache/replacement_policies/bip_rp.hh"
     btp = Param.Percent(3, "Percentage of blocks to be inserted as MRU")
 
@@ -92,19 +92,19 @@ class LIPRP(BIPRP):
 
 class MRURP(BaseReplacementPolicy):
     type = "MRURP"
-    cxx_class = "gem5::replacement_policy::MRU"
+    cxx_class = "gem5::MRU"
     cxx_header = "mem/cache/replacement_policies/mru_rp.hh"
 
 
 class RandomRP(BaseReplacementPolicy):
     type = "RandomRP"
-    cxx_class = "gem5::replacement_policy::Random"
+    cxx_class = "gem5::RandomRP"
     cxx_header = "mem/cache/replacement_policies/random_rp.hh"
 
 
 class BRRIPRP(BaseReplacementPolicy):
     type = "BRRIPRP"
-    cxx_class = "gem5::replacement_policy::BRRIP"
+    cxx_class = "gem5::BRRIP"
     cxx_header = "mem/cache/replacement_policies/brrip_rp.hh"
     num_bits = Param.Int(2, "Number of bits per RRPV")
     hit_priority = Param.Bool(
@@ -138,7 +138,7 @@ class NRURP(BRRIPRP):
 class SHiPRP(BRRIPRP):
     type = "SHiPRP"
     abstract = True
-    cxx_class = "gem5::replacement_policy::SHiP"
+    cxx_class = "gem5::SHiP"
     cxx_header = "mem/cache/replacement_policies/ship_rp.hh"
 
     shct_size = Param.Unsigned(16384, "Number of SHCT entries")
@@ -154,24 +154,24 @@ class SHiPRP(BRRIPRP):
 
 class SHiPMemRP(SHiPRP):
     type = "SHiPMemRP"
-    cxx_class = "gem5::replacement_policy::SHiPMem"
+    cxx_class = "gem5::SHiPMem"
     cxx_header = "mem/cache/replacement_policies/ship_rp.hh"
 
 
 class SHiPPCRP(SHiPRP):
     type = "SHiPPCRP"
-    cxx_class = "gem5::replacement_policy::SHiPPC"
+    cxx_class = "gem5::SHiPPC"
     cxx_header = "mem/cache/replacement_policies/ship_rp.hh"
 
 
 class TreePLRURP(BaseReplacementPolicy):
     type = "TreePLRURP"
-    cxx_class = "gem5::replacement_policy::TreePLRU"
+    cxx_class = "gem5::TreePLRU"
     cxx_header = "mem/cache/replacement_policies/tree_plru_rp.hh"
     num_leaves = Param.Int(Parent.assoc, "Number of leaves in each tree")
 
 
 class WeightedLRURP(LRURP):
     type = "WeightedLRURP"
-    cxx_class = "gem5::replacement_policy::WeightedLRU"
+    cxx_class = "gem5::WeightedLRU"
     cxx_header = "mem/cache/replacement_policies/weighted_lru_rp.hh"

--- a/src/mem/cache/replacement_policies/base.hh
+++ b/src/mem/cache/replacement_policies/base.hh
@@ -45,18 +45,15 @@ namespace gem5
  */
 typedef std::vector<ReplaceableEntry*> ReplacementCandidates;
 
-namespace replacement_policy
-{
-
 /**
  * A common base class of cache replacement policy objects.
  */
-class Base : public SimObject
+class BaseReplacementPolicy : public SimObject
 {
   public:
     typedef BaseReplacementPolicyParams Params;
-    Base(const Params &p) : SimObject(p) {}
-    virtual ~Base() = default;
+    BaseReplacementPolicy(const Params &p) : SimObject(p) {}
+    virtual ~BaseReplacementPolicy() = default;
 
     /**
      * Invalidate replacement data to set it as the next probable victim.
@@ -111,7 +108,6 @@ class Base : public SimObject
     virtual std::shared_ptr<ReplacementData> instantiateEntry() = 0;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_BASE_HH__

--- a/src/mem/cache/replacement_policies/bip_rp.cc
+++ b/src/mem/cache/replacement_policies/bip_rp.cc
@@ -37,9 +37,6 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 BIP::BIP(const Params &p)
   : LRU(p), btp(p.btp)
 {
@@ -60,5 +57,4 @@ BIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
     }
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/bip_rp.hh
+++ b/src/mem/cache/replacement_policies/bip_rp.hh
@@ -49,9 +49,6 @@ namespace gem5
 
 struct BIPRPParams;
 
-namespace replacement_policy
-{
-
 class BIP : public LRU
 {
   protected:
@@ -77,7 +74,6 @@ class BIP : public LRU
                                                                      override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_BIP_RP_HH__

--- a/src/mem/cache/replacement_policies/brrip_rp.cc
+++ b/src/mem/cache/replacement_policies/brrip_rp.cc
@@ -38,12 +38,9 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 BRRIP::BRRIP(const Params &p)
-  : Base(p), numRRPVBits(p.num_bits), hitPriority(p.hit_priority),
-    btp(p.btp)
+  : BaseReplacementPolicy(p), numRRPVBits(p.num_bits),
+    hitPriority(p.hit_priority), btp(p.btp)
 {
     fatal_if(numRRPVBits <= 0, "There should be at least one bit per RRPV.\n");
 }
@@ -147,5 +144,4 @@ BRRIP::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new BRRIPReplData(numRRPVBits));
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/brrip_rp.hh
+++ b/src/mem/cache/replacement_policies/brrip_rp.hh
@@ -60,10 +60,7 @@ namespace gem5
 
 struct BRRIPRPParams;
 
-namespace replacement_policy
-{
-
-class BRRIP : public Base
+class BRRIP : public BaseReplacementPolicy
 {
   protected:
     /** BRRIP-specific implementation of replacement data. */
@@ -159,7 +156,6 @@ class BRRIP : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_BRRIP_RP_HH__

--- a/src/mem/cache/replacement_policies/dueling_rp.cc
+++ b/src/mem/cache/replacement_policies/dueling_rp.cc
@@ -34,11 +34,8 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 Dueling::Dueling(const Params &p)
-  : Base(p), replPolicyA(p.replacement_policy_a),
+  : BaseReplacementPolicy(p), replPolicyA(p.replacement_policy_a),
     replPolicyB(p.replacement_policy_b),
     duelingMonitor(p.constituency_size, p.team_size),
     duelingStats(this)
@@ -189,5 +186,4 @@ Dueling::DuelingStats::DuelingStats(statistics::Group* parent)
 {
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/dueling_rp.hh
+++ b/src/mem/cache/replacement_policies/dueling_rp.hh
@@ -41,15 +41,12 @@ namespace gem5
 
 struct DuelingRPParams;
 
-namespace replacement_policy
-{
-
 /**
  * This replacement policy duels two replacement policies to find out which
  * one provides the best results. A policy is said to have the best results
  * when it has a lower number of misses.
  */
-class Dueling : public Base
+class Dueling : public BaseReplacementPolicy
 {
   protected:
     /**
@@ -71,9 +68,9 @@ class Dueling : public Base
     };
 
     /** Sub-replacement policy used in this multiple container. */
-    Base* const replPolicyA;
+    BaseReplacementPolicy* const replPolicyA;
     /** Sub-replacement policy used in this multiple container. */
-    Base* const replPolicyB;
+    BaseReplacementPolicy* const replPolicyB;
 
     /**
      * A dueling monitor that decides which is the best sub-policy based on
@@ -112,7 +109,6 @@ class Dueling : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_DUELING_RP_HH__

--- a/src/mem/cache/replacement_policies/fifo_rp.cc
+++ b/src/mem/cache/replacement_policies/fifo_rp.cc
@@ -37,11 +37,8 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 FIFO::FIFO(const Params &p)
-  : Base(p)
+  : BaseReplacementPolicy(p)
 {
 }
 
@@ -94,5 +91,4 @@ FIFO::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new FIFOReplData());
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/fifo_rp.hh
+++ b/src/mem/cache/replacement_policies/fifo_rp.hh
@@ -44,10 +44,7 @@ namespace gem5
 
 struct FIFORPParams;
 
-namespace replacement_policy
-{
-
-class FIFO : public Base
+class FIFO : public BaseReplacementPolicy
 {
   protected:
     /** FIFO-specific implementation of replacement data. */
@@ -117,7 +114,6 @@ class FIFO : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_FIFO_RP_HH__

--- a/src/mem/cache/replacement_policies/lfu_rp.cc
+++ b/src/mem/cache/replacement_policies/lfu_rp.cc
@@ -36,11 +36,8 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 LFU::LFU(const Params &p)
-  : Base(p)
+  : BaseReplacementPolicy(p)
 {
 }
 
@@ -92,5 +89,4 @@ LFU::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new LFUReplData());
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/lfu_rp.hh
+++ b/src/mem/cache/replacement_policies/lfu_rp.hh
@@ -44,10 +44,7 @@ namespace gem5
 
 struct LFURPParams;
 
-namespace replacement_policy
-{
-
-class LFU : public Base
+class LFU : public BaseReplacementPolicy
 {
   protected:
     /** LFU-specific implementation of replacement data. */
@@ -111,7 +108,6 @@ class LFU : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_LFU_RP_HH__

--- a/src/mem/cache/replacement_policies/lru_rp.cc
+++ b/src/mem/cache/replacement_policies/lru_rp.cc
@@ -37,11 +37,8 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 LRU::LRU(const Params &p)
-  : Base(p)
+  : BaseReplacementPolicy(p)
 {
 }
 
@@ -96,5 +93,4 @@ LRU::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new LRUReplData());
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/lru_rp.hh
+++ b/src/mem/cache/replacement_policies/lru_rp.hh
@@ -42,10 +42,7 @@ namespace gem5
 
 struct LRURPParams;
 
-namespace replacement_policy
-{
-
-class LRU : public Base
+class LRU : public BaseReplacementPolicy
 {
   protected:
     /** LRU-specific implementation of replacement data. */
@@ -109,7 +106,6 @@ class LRU : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_LRU_RP_HH__

--- a/src/mem/cache/replacement_policies/mru_rp.cc
+++ b/src/mem/cache/replacement_policies/mru_rp.cc
@@ -37,11 +37,8 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 MRU::MRU(const Params &p)
-  : Base(p)
+  : BaseReplacementPolicy(p)
 {
 }
 
@@ -101,5 +98,4 @@ MRU::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new MRUReplData());
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/mru_rp.hh
+++ b/src/mem/cache/replacement_policies/mru_rp.hh
@@ -44,10 +44,7 @@ namespace gem5
 
 struct MRURPParams;
 
-namespace replacement_policy
-{
-
-class MRU : public Base
+class MRU : public BaseReplacementPolicy
 {
   protected:
     /** MRU-specific implementation of replacement data. */
@@ -111,7 +108,6 @@ class MRU : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_MRU_RP_HH__

--- a/src/mem/cache/replacement_policies/random_rp.cc
+++ b/src/mem/cache/replacement_policies/random_rp.cc
@@ -37,16 +37,13 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
-Random::Random(const Params &p)
-  : Base(p)
+RandomRP::RandomRP(const Params &p)
+  : BaseReplacementPolicy(p)
 {
 }
 
 void
-Random::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+RandomRP::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 {
     // Unprioritize replacement data victimization
     std::static_pointer_cast<RandomReplData>(
@@ -54,12 +51,12 @@ Random::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-Random::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+RandomRP::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 {
 }
 
 void
-Random::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+RandomRP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
 {
     // Unprioritize replacement data victimization
     std::static_pointer_cast<RandomReplData>(
@@ -67,7 +64,7 @@ Random::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 ReplaceableEntry*
-Random::getVictim(const ReplacementCandidates& candidates) const
+RandomRP::getVictim(const ReplacementCandidates& candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);
@@ -90,10 +87,9 @@ Random::getVictim(const ReplacementCandidates& candidates) const
 }
 
 std::shared_ptr<ReplacementData>
-Random::instantiateEntry()
+RandomRP::instantiateEntry()
 {
     return std::shared_ptr<ReplacementData>(new RandomReplData());
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/random_rp.hh
+++ b/src/mem/cache/replacement_policies/random_rp.hh
@@ -42,10 +42,7 @@ namespace gem5
 
 struct RandomRPParams;
 
-namespace replacement_policy
-{
-
-class Random : public Base
+class RandomRP : public BaseReplacementPolicy
 {
   protected:
     /** Random-specific implementation of replacement data. */
@@ -65,8 +62,8 @@ class Random : public Base
 
   public:
     typedef RandomRPParams Params;
-    Random(const Params &p);
-    ~Random() = default;
+    RandomRP(const Params &p);
+    ~RandomRP() = default;
 
     /**
      * Invalidate replacement data to set it as the next probable victim.
@@ -112,7 +109,6 @@ class Random : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_RANDOM_RP_HH__

--- a/src/mem/cache/replacement_policies/replaceable_entry.hh
+++ b/src/mem/cache/replacement_policies/replaceable_entry.hh
@@ -38,16 +38,11 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 /**
  * The replacement data needed by replacement policies. Each replacement policy
  * should have its own implementation of replacement data.
  */
 struct ReplacementData {};
-
-} // namespace replacement_policy
 
 /**
  * A replaceable entry is a basic entry in a 2d table-like structure that needs
@@ -80,7 +75,7 @@ class ReplaceableEntry
      * Replacement data associated to this entry.
      * It must be instantiated by the replacement policy before being used.
      */
-    std::shared_ptr<replacement_policy::ReplacementData> replacementData;
+    std::shared_ptr<ReplacementData> replacementData;
 
     /**
      * Set both the set and way. Should be called only once.

--- a/src/mem/cache/replacement_policies/second_chance_rp.cc
+++ b/src/mem/cache/replacement_policies/second_chance_rp.cc
@@ -35,9 +35,6 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 SecondChance::SecondChance(const Params &p)
   : FIFO(p)
 {
@@ -137,5 +134,4 @@ SecondChance::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new SecondChanceReplData());
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/second_chance_rp.hh
+++ b/src/mem/cache/replacement_policies/second_chance_rp.hh
@@ -46,9 +46,6 @@ namespace gem5
 
 struct SecondChanceRPParams;
 
-namespace replacement_policy
-{
-
 class SecondChance : public FIFO
 {
   protected:
@@ -127,7 +124,6 @@ class SecondChance : public FIFO
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_SECOND_CHANCE_RP_HH__

--- a/src/mem/cache/replacement_policies/ship_rp.cc
+++ b/src/mem/cache/replacement_policies/ship_rp.cc
@@ -36,9 +36,6 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 SHiP::SHiPReplData::SHiPReplData(int num_bits)
   : BRRIPReplData(num_bits), signature(0), outcome(false)
 {
@@ -171,5 +168,4 @@ SHiPPC::getSignature(const PacketPtr pkt) const
     return signature % SHCT.size();
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/ship_rp.hh
+++ b/src/mem/cache/replacement_policies/ship_rp.hh
@@ -51,9 +51,6 @@ struct SHiPRPParams;
 struct SHiPMemRPParams;
 struct SHiPPCRPParams;
 
-namespace replacement_policy
-{
-
 class SHiP : public BRRIP
 {
   protected:
@@ -186,7 +183,6 @@ class SHiPPC : public SHiP
     ~SHiPPC() = default;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_SHIP_RP_HH__

--- a/src/mem/cache/replacement_policies/tree_plru_rp.cc
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.cc
@@ -43,9 +43,6 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 /**
  * Get the index of the parent of the given indexed subtree.
  *
@@ -102,7 +99,8 @@ TreePLRU::TreePLRUReplData::TreePLRUReplData(
 }
 
 TreePLRU::TreePLRU(const Params &p)
-  : Base(p), numLeaves(p.num_leaves), count(0), treeInstance(nullptr)
+  : BaseReplacementPolicy(p), numLeaves(p.num_leaves),
+    count(0), treeInstance(nullptr)
 {
     fatal_if(!isPowerOf2(numLeaves),
              "Number of leaves must be non-zero and a power of 2");
@@ -214,5 +212,4 @@ TreePLRU::instantiateEntry()
     return std::shared_ptr<ReplacementData>(treePLRUReplData);
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/tree_plru_rp.hh
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.hh
@@ -80,10 +80,7 @@ namespace gem5
 
 struct TreePLRURPParams;
 
-namespace replacement_policy
-{
-
-class TreePLRU : public Base
+class TreePLRU : public BaseReplacementPolicy
 {
   private:
     /**
@@ -209,7 +206,6 @@ class TreePLRU : public Base
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_TREE_PLRU_RP_HH__

--- a/src/mem/cache/replacement_policies/weighted_lru_rp.cc
+++ b/src/mem/cache/replacement_policies/weighted_lru_rp.cc
@@ -39,9 +39,6 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-
 WeightedLRU::WeightedLRU(const Params &p)
   : LRU(p)
 {
@@ -96,5 +93,4 @@ WeightedLRU::instantiateEntry()
     return std::shared_ptr<ReplacementData>(new WeightedLRUReplData);
 }
 
-} // namespace replacement_policy
 } // namespace gem5

--- a/src/mem/cache/replacement_policies/weighted_lru_rp.hh
+++ b/src/mem/cache/replacement_policies/weighted_lru_rp.hh
@@ -42,9 +42,6 @@ namespace gem5
 
 struct WeightedLRURPParams;
 
-namespace replacement_policy
-{
-
 class WeightedLRU : public LRU
 {
   protected:
@@ -64,7 +61,7 @@ class WeightedLRU : public LRU
     WeightedLRU(const Params &p);
     ~WeightedLRU() = default;
 
-    using Base::touch;
+    using BaseReplacementPolicy::touch;
     void touch(const std::shared_ptr<ReplacementData>& replacement_data,
                                         int occupancy) const;
 
@@ -85,7 +82,6 @@ class WeightedLRU : public LRU
                                               candidates) const override;
 };
 
-} // namespace replacement_policy
 } // namespace gem5
 
 #endif // __MEM_CACHE_REPLACEMENT_POLICIES_WEIGHTED_LRU_RP_HH__

--- a/src/mem/cache/tags/base_set_assoc.hh
+++ b/src/mem/cache/tags/base_set_assoc.hh
@@ -85,7 +85,7 @@ class BaseSetAssoc : public BaseTags
     const bool sequentialAccess;
 
     /** Replacement policy */
-    replacement_policy::Base *replacementPolicy;
+    BaseReplacementPolicy *replacementPolicy;
 
   public:
     /** Convenience typedef. */

--- a/src/mem/cache/tags/sector_tags.hh
+++ b/src/mem/cache/tags/sector_tags.hh
@@ -47,10 +47,7 @@
 namespace gem5
 {
 
-namespace replacement_policy
-{
-    class Base;
-}
+class BaseReplacementPolicy;
 class ReplaceableEntry;
 
 /**
@@ -77,7 +74,7 @@ class SectorTags : public BaseTags
     const bool sequentialAccess;
 
     /** Replacement policy */
-    replacement_policy::Base *replacementPolicy;
+    BaseReplacementPolicy *replacementPolicy;
 
     /** Number of data blocks per sector. */
     const unsigned numBlocksPerSector;

--- a/src/mem/ruby/structures/CacheMemory.cc
+++ b/src/mem/ruby/structures/CacheMemory.cc
@@ -84,7 +84,7 @@ CacheMemory::CacheMemory(const Params &p)
     m_is_instruction_only_cache = p.is_icache;
     m_resource_stalls = p.resourceStalls;
     m_block_size = p.block_size;  // may be 0 at this point. Updated in init()
-    m_use_occupancy = dynamic_cast<replacement_policy::WeightedLRU*>(
+    m_use_occupancy = dynamic_cast<WeightedLRU*>(
                                     m_replacementPolicy_ptr) ? true : false;
 }
 
@@ -400,9 +400,8 @@ CacheMemory::setMRU(Addr address, int occupancy)
         // replacement policy. Depending on different replacement policies,
         // use different touch() function.
         if (m_use_occupancy) {
-            static_cast<replacement_policy::WeightedLRU*>(
-                m_replacementPolicy_ptr)->touch(
-                entry->replacementData, occupancy);
+            static_cast<WeightedLRU*>(m_replacementPolicy_ptr)->touch(
+                                       entry->replacementData, occupancy);
         } else {
             m_replacementPolicy_ptr->touch(entry->replacementData);
         }

--- a/src/mem/ruby/structures/CacheMemory.hh
+++ b/src/mem/ruby/structures/CacheMemory.hh
@@ -71,7 +71,7 @@ class CacheMemory : public SimObject
 {
   public:
     typedef RubyCacheParams Params;
-    typedef std::shared_ptr<replacement_policy::ReplacementData> ReplData;
+    typedef std::shared_ptr<ReplacementData> ReplData;
     CacheMemory(const Params &p);
     ~CacheMemory();
 
@@ -183,7 +183,7 @@ class CacheMemory : public SimObject
     std::vector<std::vector<AbstractCacheEntry*> > m_cache;
 
     /** We use the replacement policies from the Classic memory system. */
-    replacement_policy::Base *m_replacementPolicy_ptr;
+    BaseReplacementPolicy *m_replacementPolicy_ptr;
 
     BankedArray dataArray;
     BankedArray tagArray;


### PR DESCRIPTION
When compared to indexing policies, replacement policies have an extra namespace layer making things a bit more verbose. I tried removing it and I feel it looks more consistent with the rest of the cache code-base. Please let me know if you have any comments. Thanks!