### PR TITLE
arch-riscv: Move PMAChecker and PMP to RiscvISA namespace

### DIFF
--- a/src/arch/riscv/PMAChecker.py
+++ b/src/arch/riscv/PMAChecker.py
@@ -43,6 +43,6 @@ from m5.SimObject import SimObject
 class PMAChecker(SimObject):
     type = "PMAChecker"
     cxx_header = "arch/riscv/pma_checker.hh"
-    cxx_class = "gem5::PMAChecker"
+    cxx_class = "gem5::RiscvISA::PMAChecker"
 
     uncacheable = VectorParam.AddrRange([], "Uncacheable address ranges")

--- a/src/arch/riscv/PMP.py
+++ b/src/arch/riscv/PMP.py
@@ -32,6 +32,6 @@ from m5.SimObject import SimObject
 class PMP(SimObject):
     type = "PMP"
     cxx_header = "arch/riscv/pmp.hh"
-    cxx_class = "gem5::PMP"
+    cxx_class = "gem5::RiscvISA::PMP"
 
     pmp_entries = Param.Int(16, "Maximum PMP Entries Supported")

--- a/src/arch/riscv/pma_checker.cc
+++ b/src/arch/riscv/pma_checker.cc
@@ -47,6 +47,9 @@
 namespace gem5
 {
 
+namespace RiscvISA
+{
+
 PMAChecker::PMAChecker(const Params &params) :
 SimObject(params),
 uncacheable(params.uncacheable.begin(), params.uncacheable.end())
@@ -91,4 +94,5 @@ PMAChecker::takeOverFrom(PMAChecker *old)
     uncacheable = old->uncacheable;
 }
 
+} // namespace RiscvISA
 } // namespace gem5

--- a/src/arch/riscv/pma_checker.hh
+++ b/src/arch/riscv/pma_checker.hh
@@ -47,6 +47,9 @@
 namespace gem5
 {
 
+namespace RiscvISA
+{
+
 /**
  * Based on the RISC-V ISA privileged specifications
  * V1.11, there is no implementation guidelines on the
@@ -81,6 +84,7 @@ class PMAChecker : public SimObject
     void takeOverFrom(PMAChecker *old);
 };
 
+} // namespace RiscvISA
 } // namespace gem5
 
 #endif // __ARCH_RISCV_PMA_CHECKER_HH__

--- a/src/arch/riscv/pmp.cc
+++ b/src/arch/riscv/pmp.cc
@@ -44,6 +44,9 @@
 namespace gem5
 {
 
+namespace RiscvISA
+{
+
 PMP::PMP(const Params &params) :
     SimObject(params),
     pmpEntries(params.pmp_entries),
@@ -55,8 +58,7 @@ PMP::PMP(const Params &params) :
 
 Fault
 PMP::pmpCheck(const RequestPtr &req, BaseMMU::Mode mode,
-              RiscvISA::PrivilegeMode pmode, ThreadContext *tc,
-              Addr vaddr)
+              PrivilegeMode pmode, ThreadContext *tc, Addr vaddr)
 {
     // First determine if pmp table should be consulted
     if (!shouldCheckPMP(pmode, tc))
@@ -91,7 +93,7 @@ PMP::pmpCheck(const RequestPtr &req, BaseMMU::Mode mode,
             && (PMP_OFF != pmpGetAField(pmpTable[match_index].pmpCfg))) {
             uint8_t this_cfg = pmpTable[match_index].pmpCfg;
 
-            if ((pmode == RiscvISA::PrivilegeMode::PRV_M) &&
+            if ((pmode == PrivilegeMode::PRV_M) &&
                                     (PMP_LOCK & this_cfg) == 0) {
                 return NoFault;
             } else if ((mode == BaseMMU::Mode::Read) &&
@@ -113,7 +115,7 @@ PMP::pmpCheck(const RequestPtr &req, BaseMMU::Mode mode,
         }
     }
     // if no entry matched and we are not in M mode return fault
-    if (pmode == RiscvISA::PrivilegeMode::PRV_M) {
+    if (pmode == PrivilegeMode::PRV_M) {
         return NoFault;
     } else if (req->hasVaddr()) {
         return createAddrfault(req->getVaddr(), mode);
@@ -125,16 +127,16 @@ PMP::pmpCheck(const RequestPtr &req, BaseMMU::Mode mode,
 Fault
 PMP::createAddrfault(Addr vaddr, BaseMMU::Mode mode)
 {
-    RiscvISA::ExceptionCode code;
+    ExceptionCode code;
     if (mode == BaseMMU::Read) {
-        code = RiscvISA::ExceptionCode::LOAD_ACCESS;
+        code = ExceptionCode::LOAD_ACCESS;
     } else if (mode == BaseMMU::Write) {
-        code = RiscvISA::ExceptionCode::STORE_ACCESS;
+        code = ExceptionCode::STORE_ACCESS;
     } else {
-        code = RiscvISA::ExceptionCode::INST_ACCESS;
+        code = ExceptionCode::INST_ACCESS;
     }
     warn("pmp access fault.\n");
-    return std::make_shared<RiscvISA::AddressFault>(vaddr, code);
+    return std::make_shared<AddressFault>(vaddr, code);
 }
 
 inline uint8_t
@@ -270,14 +272,13 @@ PMP::pmpUpdateAddr(uint32_t pmp_index, Addr this_addr)
 }
 
 bool
-PMP::shouldCheckPMP(RiscvISA::PrivilegeMode pmode, ThreadContext *tc)
+PMP::shouldCheckPMP(PrivilegeMode pmode, ThreadContext *tc)
 {
     // The privilege mode of memory read and write
     // is modified by TLB. It can just simply check if
     // the numRule is not zero, then return true if
     // privilege mode is not M or has any lock entry
-    return numRules != 0 && (
-        pmode != RiscvISA::PrivilegeMode::PRV_M || hasLockEntry);
+    return numRules != 0 && (pmode != PrivilegeMode::PRV_M || hasLockEntry);
 }
 
 AddrRange
@@ -298,4 +299,5 @@ PMP::pmpDecodeNapot(Addr pmpaddr)
     }
 }
 
+} // namespace RiscvISA
 } // namespace gem5

--- a/src/arch/riscv/pmp.hh
+++ b/src/arch/riscv/pmp.hh
@@ -46,6 +46,9 @@
 namespace gem5
 {
 
+namespace RiscvISA
+{
+
 /**
  * This class helps to implement RISCV's physical memory
  * protection (pmp) primitive.
@@ -125,7 +128,7 @@ class PMP : public SimObject
      * @return Fault.
      */
     Fault pmpCheck(const RequestPtr &req, BaseMMU::Mode mode,
-                  RiscvISA::PrivilegeMode pmode, ThreadContext *tc,
+                  PrivilegeMode pmode, ThreadContext *tc,
                   Addr vaddr = 0);
 
     /**
@@ -163,7 +166,7 @@ class PMP : public SimObject
      * @param tc thread context.
      * @return true or false.
      */
-    bool shouldCheckPMP(RiscvISA::PrivilegeMode pmode, ThreadContext *tc);
+    bool shouldCheckPMP(PrivilegeMode pmode, ThreadContext *tc);
 
     /**
      * createAddrfault creates an address fault
@@ -205,6 +208,7 @@ class PMP : public SimObject
 
 };
 
+} // namespace RiscvISA
 } // namespace gem5
 
 #endif // __ARCH_RISCV_PMP_HH__


### PR DESCRIPTION
The PMAChecker and PMP are only used in the RisvISA and it should be in the RiscvISA to simply the implementation

Change-Id: I4968e2de4c028cb2dceed977f2173fc8b1efd175