### PR TITLE
mem-ruby: Implement WriteUniqueZero CHI transaction

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -927,6 +927,25 @@ action(Initiate_StoreUpgrade, desc="") {
   tbe.actions.push(Event:TagArrayWrite);
 }
 
+action(Initiate_WriteUnique_Zero, desc="") {
+  assert(is_HN);
+  tbe.dataUnique := true;
+  if (tbe.dir_sharers.count() > 0) {
+    tbe.actions.push(Event:SendSnpCleanInvalid);
+  }
+  tbe.actions.push(Event:WriteZero);
+  if (comp_wu) {
+    tbe.actions.push(Event:SendDBIDResp_WUZ);
+    tbe.actions.pushNB(Event:WriteFEPipe);
+    tbe.actions.pushNB(Event:SendComp_WU);
+  } else {
+    tbe.actions.push(Event:SendCompDBIDResp);
+    tbe.actions.pushNB(Event:WriteFEPipe);
+  }
+  tbe.actions.push(Event:CheckCacheFill);
+  tbe.actions.push(Event:TagArrayWrite);
+}
+
 action(Initiate_WriteUnique_LocalWrite, desc="") {
   // auto-upgrade if hn but state was not unique
   assert(is_HN || tbe.dataUnique);
@@ -1953,6 +1972,11 @@ action(ExpectComp, desc="") {
   assert(is_valid(tbe));
   tbe.expected_req_resp.addExpectedRespType(CHIResponseType:Comp);
   tbe.expected_req_resp.addExpectedCount(1);
+}
+
+action(WriteZero, desc="") {
+  tbe.dataBlkValid.fillMask();
+  tbe.dataBlk.clear();
 }
 
 action(Receive_ReqDataResp, desc="") {

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1194,6 +1194,7 @@ bool isWriteReqType(CHIRequestType type) {
       type == CHIRequestType:StoreLine ||
       type == CHIRequestType:WriteUniquePtl ||
       type == CHIRequestType:WriteUniqueFull ||
+      type == CHIRequestType:WriteUniqueZero ||
       type == CHIRequestType:ReadUnique) {
     return true;
   }
@@ -1262,6 +1263,8 @@ Event reqToEvent(CHIRequestType type, bool is_prefetch) {
     } else {
       return Event:WriteUnique; // all WriteUnique handled the same when ~PoC
     }
+  } else if (type == CHIRequestType:WriteUniqueZero) {
+      return Event:WriteUniqueZero;
   } else if (type == CHIRequestType:StashOnceShared) {
       return Event:StashOnceShared;
   } else if (type == CHIRequestType:StashOnceUnique) {

--- a/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
@@ -351,6 +351,28 @@ transition({I, SC, UC, SD, UD, RU, RSC, RSD, RUSD, RUSC,
   ProcessNextState;
 }
 
+// WriteUniqueZero cacheline not present
+transition({I,RU,RSC,RSD,RUSD,RUSC},
+           WriteUniqueZero,
+           BUSY_BLKD) {
+  Initiate_Request;
+  Initiate_WriteUnique_Zero;
+  Profile_Miss;
+  Pop_ReqRdyQueue;
+  ProcessNextState;
+}
+
+// WriteUniqueZero cacheline available
+transition({SC,UC,SD,UD,SC_RSC,UC_RSC,SD_RSC,UD_RSC,UC_RU,UD_RU,UD_RSD,SD_RSD},
+           WriteUniqueZero,
+           BUSY_BLKD) {
+  Initiate_Request;
+  Initiate_WriteUnique_Zero;
+  Profile_Hit;
+  Pop_ReqRdyQueue;
+  ProcessNextState;
+}
+
 // WriteUniquePtl
 
 transition({UD,UD_RSD,UD_RSC,UC,UC_RSC},
@@ -856,7 +878,8 @@ transition({BUSY_BLKD,BUSY_INTR},
             WriteCleanFull, WriteCleanFull_Stale,
             Evict, Evict_Stale,
             WriteUnique,WriteUniquePtl_PoC,
-            WriteUniqueFull_PoC,WriteUniqueFull_PoC_Alloc
+            WriteUniqueFull_PoC,WriteUniqueFull_PoC_Alloc,
+            WriteUniqueZero,
             AtomicReturn,AtomicReturn_PoC,
             AtomicNoReturn,AtomicNoReturn_PoC,
             StashOnceShared,StashOnceUnique}) {
@@ -1212,6 +1235,12 @@ transition(BUSY_BLKD, SendCompDBIDResp_WU) {
   ProcessNextState_ClearPending;
 }
 
+transition(BUSY_BLKD, SendDBIDResp_WUZ) {
+  Pop_TriggerQueue;
+  Send_DBIDResp;
+  ProcessNextState_ClearPending;
+}
+
 transition(BUSY_BLKD, SendDBIDResp_WU) {
   Pop_TriggerQueue;
   ExpectNCBWrData;
@@ -1477,6 +1506,12 @@ transition(BUSY_BLKD, Comp) {
 transition(BUSY_BLKD, TX_Data) {
   Pop_TriggerQueue;
   Send_Data;
+  ProcessNextState_ClearPending;
+}
+
+transition(BUSY_INTR, WriteZero) {
+  Pop_TriggerQueue;
+  WriteZero;
   ProcessNextState_ClearPending;
 }
 

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -321,6 +321,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     WriteUniquePtl_PoC,          desc="", in_trans="yes";
     WriteUniqueFull_PoC,         desc="", in_trans="yes";
     WriteUniqueFull_PoC_Alloc,   desc="", in_trans="yes";
+    WriteUniqueZero,             desc="", in_trans="yes";
     AtomicReturn,                desc="", in_trans="yes";
     AtomicNoReturn,              desc="", in_trans="yes";
     AtomicReturn_PoC,            desc="", in_trans="yes";
@@ -482,6 +483,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     SendCompDBIDResp_WU,       desc="Ack WU with CompDBIDResp and set expected data";
     SendDBIDResp_WU,           desc="Ack WU with DBIDResp and set expected data";
     SendComp_WU,               desc="Ack WU completion";
+    SendDBIDResp_WUZ,          desc="Ack WUZ with DBIDResp and set expected data";
 
     // Send an atomic request downstream.
     SendAtomicReturn,          out_trans="yes", desc="Send atomic request with return";
@@ -495,7 +497,6 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     SendCompDBIDResp_ANR,  desc="Ack ANR with CompDBIDResp and set expected data";
     SendDBIDResp_ANR,      desc="Ack ANR with DBIDResp and set expected data";
     SendComp_ANR,          desc="Ack ANR completion";
-
 
     // Dataless requests
     SendEvict,      out_trans="yes", desc="Send a Evict";
@@ -552,6 +553,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     FinishCleanUnique, desc="Sends acks and perform any writeback after a CleanUnique";
     FinishCopyBack_Stale, desc="Check if a Evict needs to be sent";
     ActionStalledOnHazard, desc="Stall a trigger action because until finish handling snoop hazard";
+    WriteZero, desc="Stall a trigger action because until finish handling snoop hazard";
 
     // This is triggered once a transaction doesn't have
     // any queued action and is not expecting responses/data. The transaction

--- a/src/mem/ruby/protocol/chi/CHI-msg.sm
+++ b/src/mem/ruby/protocol/chi/CHI-msg.sm
@@ -67,6 +67,7 @@ enumeration(CHIRequestType, desc="") {
   WriteEvictFull;
   WriteUniquePtl;
   WriteUniqueFull;
+  WriteUniqueZero;
 
   AtomicReturn;
   AtomicNoReturn;


### PR DESCRIPTION
The WriteUniqueZero is an immediate write to a Snoopable address region that does not require any data transfer (cacheline is zeroed)

Change-Id: Ia8c9b40e08a3b7d613f0b62ce0ac4b0547860871

Reviewed-by: Tiago Muck <tiago.muck@arm.com>