### PR TITLE
misc: Turn off 'maybe-uninitialized' warn for regex include

### DIFF
--- a/src/kern/linux/helpers.cc
+++ b/src/kern/linux/helpers.cc
@@ -37,7 +37,27 @@
 
 #include "kern/linux/helpers.hh"
 
+/* The following pragmas are to fix a bug in GCC \w the CPP standard library,
+ * outlined here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562.
+ * This ignores the 'maybe-unitialized' warning when importing regex for
+ * GCC 12.1.
+ */
+
+// ignore 'maybe-uniitialized' warnings for GCC 12.1.
+#if __GNUC__ &&  __GNUC__ == 12 && __GNUC_MINOR__ == 1
+    #if __has_warning( "-Wmaybe-uninitialized" )
+        #define SUPPRESSING_MAYBE_UNINITIALIZED_WARNING
+        // save diagnostic state.
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    #endif
+#endif
 #include <regex>
+#ifdef SUPPRESSING_MAYBE_UNINITIALIZED_WARNING
+    // restore the diagnostic state.
+    #pragma GCC diagnostic pop
+#endif
+
 #include <string>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
 https://github.com/gem5/gem5/pull/636 triggered a bug with the GCC
compiler and its interaction with the CPP stdlib regex library, outlined here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562.

This was causing the gem5 Compiler tests to fail for GCC-12: https://github.com/gem5/gem5/actions/runs/7219055796

This fix turns off the 'maybe-unitialized' warning when we include the regex headers in "src/kern/linux/helpers.cc".