### PR TITLE
mem-ruby: allow comparison of int and Addr in SLICC

### DIFF
--- a/src/mem/slicc/ast/OperatorExprAST.py
+++ b/src/mem/slicc/ast/OperatorExprAST.py
@@ -62,7 +62,15 @@ class InfixOperatorExprAST(ExprAST):
         # Figure out what the input and output types should be
         if self.op in ("==", "!=", ">=", "<=", ">", "<"):
             output = "bool"
-            if ltype != rtype:
+
+            if (
+                str(ltype) == "Addr"
+                and str(rtype) == "int"
+                or str(ltype) == "int"
+                and str(rtype) == "Addr"
+            ):
+                pass
+            elif ltype != rtype:
                 self.error(
                     "Type mismatch: left and right operands of "
                     + "operator '%s' must be the same type. "


### PR DESCRIPTION
allow easy isolation of specific addresses in coherence protocols. useful for debugging.

Change-Id: I93e07956b8e29837219d328dacfbd5c6067c1a62