### PR TITLE
mem-ruby,configs: Enable Ruby with NULL build

### DIFF
--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -48,6 +48,7 @@ from m5.util import (
 )
 
 from gem5.isas import ISA
+from gem5.runtime import get_supported_isas
 
 addToPath("../")
 
@@ -330,6 +331,8 @@ def send_evicts(options):
     # 1. The O3 model must keep the LSQ coherent with the caches
     # 2. The x86 mwait instruction is built on top of coherence invalidations
     # 3. The local exclusive monitor in ARM systems
+    if get_supported_isas() == {ISA.NULL}:
+        return False
 
     if (
         hasattr(m5.objects, "DerivO3CPU")

--- a/tests/gem5/memory/test.py
+++ b/tests/gem5/memory/test.py
@@ -70,7 +70,7 @@ gem5_verify_config(
     length=constants.long_tag,
 )
 
-x86_tests = [
+null_tests = [
     ("garnet_synth_traffic", None, ["--sim-cycles", "5000000"]),
     ("memcheck", None, ["--maxtick", "2000000000", "--prefetchers"]),
     (
@@ -122,7 +122,7 @@ x86_tests = [
     ("ruby_direct_test", None, ["--requests", "50000"]),
 ]
 
-for test_name, basename_noext, args in x86_tests:
+for test_name, basename_noext, args in null_tests:
     if basename_noext == None:
         basename_noext = test_name
     gem5_verify_config(
@@ -133,8 +133,7 @@ for test_name, basename_noext, args in x86_tests:
             config.base_dir, "configs", "example", basename_noext + ".py"
         ),
         config_args=args,
-        valid_isas=(constants.x86_tag,),
-        protocol="MESI_Two_Level",
+        valid_isas=(constants.null_tag,),
         valid_hosts=constants.supported_hosts,
         length=constants.long_tag,
     )


### PR DESCRIPTION
After removing `get_runtime_isa`, the `send_evicts` function in the ruby configs assumes that there is an ISA built. This change short-circuits that logic if the current build is the NULL (none) ISA.

Change-Id: I75fefe3d70649b636b983c4d2145c63a9e1342f7