### PR TITLE
arch-riscv: Fix issue when vl=0 in VectorIntMaskMacroConstructor

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1097,11 +1097,7 @@ template<typename ElemType>
     int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
     StaticInstPtr microop;
 
-    if (micro_vl == 0) {
-        microop = new VectorNopMicroInst(_machInst);
-        this->microops.push_back(microop);
-    }
-    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+    for (int i = 0; i < num_microops && micro_vl >= 0; ++i) {
         microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
         microop->setDelayedCommit();
         this->microops.push_back(microop);


### PR DESCRIPTION
I’ve been working on a fix for the issue #759 where ‘vd’ incorrectly stores all zeros when ‘vl’ is set to 0 in VectorIntMaskMacroConstructor. My solution seems to work, but it behaves differently from other macros when ‘vl’ = 0. Instead of pushing a ‘nop’ to ‘microops’, it pushes a micro operation that remains ineffective due to ‘vl’ being 0. I’m wondering if anyone has thoughts on this? Is there a better way to tackle this problem?
Thanks in advance for your insights!