### PR TITLE
mem-cache: Add default values for args in tagged entry

### DIFF
--- a/src/mem/cache/tags/tagged_entry.hh
+++ b/src/mem/cache/tags/tagged_entry.hh
@@ -78,7 +78,7 @@ class TaggedEntry : public ReplaceableEntry
      * @return True if the tag information match this entry's.
      */
     virtual bool
-    matchTag(Addr tag, bool is_secure) const
+    matchTag(Addr tag, bool is_secure = false) const
     {
         return isValid() && (getTag() == tag) && (isSecure() == is_secure);
     }
@@ -90,7 +90,7 @@ class TaggedEntry : public ReplaceableEntry
      * @param tag The tag value.
      */
     virtual void
-    insert(const Addr tag, const bool is_secure)
+    insert(const Addr tag, const bool is_secure = false)
     {
         setValid();
         setTag(tag);


### PR DESCRIPTION
Add a default function arg so that we can easily invoke these functions from code that does not care about the 'is_secure' field for its entries.

Change-Id: Ib0fb985bffd52c3b2187e2f6eb90135871fd8ff5