### PR TITLE
gpu-compute: WAX dependency detection

### DIFF
--- a/src/gpu-compute/vector_register_file.cc
+++ b/src/gpu-compute/vector_register_file.cc
@@ -58,14 +58,19 @@ VectorRegisterFile::VectorRegisterFile(const VectorRegisterFileParams &p)
 bool
 VectorRegisterFile::operandsReady(Wavefront *w, GPUDynInstPtr ii) const
 {
+    bool src_ready = true, dst_ready=true;
     for (const auto& srcVecOp : ii->srcVecRegOperands()) {
         for (const auto& physIdx : srcVecOp.physIndices()) {
             if (regBusy(physIdx)) {
                 DPRINTF(GPUVRF, "RAW stall: WV[%d]: %s: physReg[%d]\n",
                         w->wfDynId, ii->disassemble(), physIdx);
                 w->stats.numTimesBlockedDueRAWDependencies++;
-                return false;
+                src_ready = false;
+                break;
             }
+        }
+        if (!src_ready) {
+            break;
         }
     }
 
@@ -75,12 +80,16 @@ VectorRegisterFile::operandsReady(Wavefront *w, GPUDynInstPtr ii) const
                 DPRINTF(GPUVRF, "WAX stall: WV[%d]: %s: physReg[%d]\n",
                         w->wfDynId, ii->disassemble(), physIdx);
                 w->stats.numTimesBlockedDueWAXDependencies++;
-                return false;
+                dst_ready = false;
+                break;
             }
+        }
+        if (!dst_ready) {
+            break;
         }
     }
 
-    return true;
+    return src_ready && dst_ready;
 }
 
 void


### PR DESCRIPTION
WAX Dependencies would be missed if a RAW Dependency also existed.