### PR TITLE
arch-arm: Handle invalid case for encodeAArch64SysReg

### DIFF
--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -61,8 +61,8 @@ SysDC64::generateDisassembly(Addr pc, const loader::SymbolTable *symtab) const
 uint32_t
 SysDC64::iss() const
 {
-    const MiscRegNum64 &misc_reg = encodeAArch64SysReg(dest);
-    return _iss(misc_reg, base);
+    const auto misc_reg = encodeAArch64SysReg(dest);
+    return _iss(misc_reg.value(), base);
 }
 
 void

--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -186,8 +186,9 @@ MiscRegRegImmOp64::generateDisassembly(
 uint32_t
 MiscRegRegImmOp64::iss() const
 {
-    const MiscRegNum64 &misc_reg = encodeAArch64SysReg(dest);
-    return _iss(misc_reg, op1);
+    const auto misc_reg = encodeAArch64SysReg(dest);
+    assert(misc_reg.has_value());
+    return _iss(misc_reg.value(), op1);
 }
 
 std::string
@@ -205,8 +206,9 @@ RegMiscRegImmOp64::generateDisassembly(
 uint32_t
 RegMiscRegImmOp64::iss() const
 {
-    const MiscRegNum64 &misc_reg = encodeAArch64SysReg(op1);
-    return _iss(misc_reg, dest);
+    const auto misc_reg = encodeAArch64SysReg(op1);
+    assert(misc_reg.has_value());
+    return _iss(misc_reg.value(), dest);
 }
 
 Fault

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -2572,14 +2572,14 @@ decodeAArch64SysReg(const MiscRegNum64 &sys_reg)
     }
 }
 
-MiscRegNum64
+std::optional<MiscRegNum64>
 encodeAArch64SysReg(MiscRegIndex misc_reg)
 {
     if (auto it = idxToMiscRegNum.find(misc_reg);
         it != idxToMiscRegNum.end()) {
         return it->second;
     } else {
-        panic("Invalid MiscRegIndex: %d\n", misc_reg);
+        return std::nullopt;
     }
 }
 

--- a/src/arch/arm/regs/misc.hh
+++ b/src/arch/arm/regs/misc.hh
@@ -43,6 +43,7 @@
 
 #include <array>
 #include <bitset>
+#include <optional>
 #include <tuple>
 
 #include "arch/arm/regs/misc_types.hh"
@@ -1778,7 +1779,7 @@ namespace ArmISA
                                      unsigned crn, unsigned crm,
                                      unsigned op2);
     MiscRegIndex decodeAArch64SysReg(const MiscRegNum64 &misc_reg);
-    MiscRegNum64 encodeAArch64SysReg(MiscRegIndex misc_reg);
+    std::optional<MiscRegNum64> encodeAArch64SysReg(MiscRegIndex misc_reg);
 
     // Whether a particular AArch64 system register is -always- read only.
     bool aarch64SysRegReadOnly(MiscRegIndex miscReg);


### PR DESCRIPTION
This patch is amending encodeAArch64SysReg so that it covers the case where there are no arch numbers available for the misc index passed as an argument.

This could happen if the register ID is a gem5 pseudo register which is not associated with any architected op1/op2/crn/crm tuple.

Rather than panicking we return a nullopt.

Change-Id: I7ab70467105ef93c0c78ac4e999c7dc8e5e09925