### PR TITLE
mem-ruby: fix missing txnId for prefetch requests

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -236,6 +236,7 @@ action(AllocateTBE_PfRequest, desc="Allocate TBE for prefetch request") {
       assert(in_msg.Prefetch != PrefetchBit:No);
       out_msg.is_local_pf := true;
       out_msg.is_remote_pf := false;
+      out_msg.txnId := max_outstanding_transactions;
 
       if (in_msg.Type == RubyRequestType:LD) {
         out_msg.type := CHIRequestType:Load;


### PR DESCRIPTION
Internal prefetch message generation at AllocateTBE_PfRequest was missing the expected txnId value.

Change-Id: I7d1ead24db947a15133f6ec45b27a47c70096682