### PR TITLE
misc: Make dockerfiles use gem5 source

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,34 +4,17 @@ name: Docker images build and push
 on:
     workflow_dispatch:
 jobs:
-    obtain-dockerfiles:
-        runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
-
-        steps:
-            - uses: actions/checkout@v3
-              with:
-          # Scheduled workflows run on the default branch by default. We
-          # therefore need to explicitly checkout the develop branch.
-                  ref: develop
-            - uses: actions/upload-artifact@v3
-              with:
-                  name: dockerfiles
-                  path: util/dockerfiles
-
   # This builds and pushes the docker image.
     build-and-push:
         runs-on: [self-hosted, linux, x64]
-        needs: obtain-dockerfiles
-        permissions:
-            packages: write
-            contents: read
-
         steps:
+            # Checkout gem5 so we can use `ADD` for building gem5
+            - uses: actions/checkout@v3
+
             - uses: actions/download-artifact@v3
               with:
                   name: dockerfiles
-                  path: dockerfiles-docker-build
+                  path: .
 
             - uses: docker/setup-qemu-action@v2
               name: Setup QEMU
@@ -49,6 +32,5 @@ jobs:
             - name: Build and push with bake
               uses: docker/bake-action@v4
               with:
-                  workdir: ./dockerfiles-docker-build
-                  files: docker-bake.hcl
+                  files: util/dockerfiles/docker-bake.hcl
                   push: true

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -64,58 +64,58 @@ target "common" {
 
 target "gcn-gpu" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "gcn-gpu"
+  dockerfile = "util/dockerfiles/gcn-gpu/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/gcn-gpu:${TAG}"]
 }
 
 target "gpu-fs" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "gpu-fs"
+  dockerfile = "util/dockerfiles/gpu-fs/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/gpu-fs:${TAG}"]
 }
 
 target "sst" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "sst-11.1.0"
+  dockerfile = "util/dockerfiles/sst-11.1.0/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/sst-env:${TAG}"]
 }
 
 target "systemc" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "systemc-2.3.3"
+  dockerfile = "util/dockerfiles/systemc-2.3.3/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/systemc-env:${TAG}"]
 }
 
 target "ubuntu-22-04_all-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "ubuntu-22.04_all-dependencies"
+  dockerfile = "util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/ubuntu-22.04_all-dependencies:${TAG}"]
 }
 
 target "ubuntu-20-04_all-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "ubuntu-20.04_all-dependencies"
+  dockerfile = "util/dockerfiles/ubuntu-20.04_all-dependenciesDockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/ubuntu-20.04_all-dependencies:${TAG}"]
 }
 
 target "ubuntu-22-04_min-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "ubuntu-22.04_min-dependencies"
+  dockerfile = "util/dockerfiles/ubuntu-22.04_min-dependencies/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/ubuntu-22.04_min-dependencies:${TAG}"]
 }
 
 target "gcc-compilers-base-20-04" {
   name = "gcc-compilers-${replace(ver, ".", "-")}"
   inherits = ["common"]
-  context = "ubuntu-20.04_gcc-version"
-  dockerfile = "Dockerfile"
+  context = "."
+  dockerfile = "util/dockerfiles/ubuntu-20.04_gcc-version/Dockerfile"
   matrix = {
     ver = ["8", "9", "10"]
   }
@@ -128,8 +128,8 @@ target "gcc-compilers-base-20-04" {
 target "gcc-compilers-base-22-04" {
   name = "gcc-compilers-${replace(ver, ".", "-")}"
   inherits = ["common"]
-  context = "ubuntu-22.04_gcc-version"
-  dockerfile = "Dockerfile"
+  context = "."
+  dockerfile = "util/dockerfiles/ubuntu-22.04_gcc-version/Dockerfile"
   matrix = {
     ver = ["11", "12"]
   }
@@ -142,8 +142,8 @@ target "gcc-compilers-base-22-04" {
 target "clang-compilers-base-20-04" {
   name = "clang-compilers-${replace(ver, ".", "-")}"
   inherits = ["common"]
-  context = "ubuntu-20.04_clang-version"
-  dockerfile = "Dockerfile"
+  context = "."
+  dockerfile = "util/dockerfiles/ubuntu-20.04_clang-version/Dockerfile"
   matrix = {
     ver = ["7", "8", "9", "10", "11", "12"]
   }
@@ -156,8 +156,8 @@ target "clang-compilers-base-20-04" {
 target "clang-compilers-base-22-04" {
   name = "clang-compilers-${replace(ver, ".", "-")}"
   inherits = ["common"]
-  context = "ubuntu-22.04_clang-version"
-  dockerfile = "Dockerfile"
+  context = "."
+  dockerfile = "util/dockerfiles/ubuntu-22.04_clang-version/Dockerfile"
   matrix = {
     ver = ["13", "14", "15"]
   }
@@ -169,21 +169,21 @@ target "clang-compilers-base-22-04" {
 
 target "clang-compilers-16" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "ubuntu-22.04_clang_16"
+  dockerfile = "util/dockerfiles/ubuntu-22.04_clang_16/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/clang-version-16:${TAG}"]
 }
 
 target "llvm-gnu-cross-compiler-riscv64" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "llvm-gnu-cross-compiler-riscv64"
+  dockerfile = "util/dockerfiles/llvm-gnu-cross-compiler-riscv64/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/llvm-gnu-cross-compiler-riscv64:${TAG}"]
 }
 
 target "gem5-all-min-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
-  context = "gem5-all-min-dependencies"
+  dockerfile = "util/dockerfiles/gem5-all-min-dependencies/Dockerfile"
+  context = "."
   tags = ["${IMAGE_URI}/gem5-all-min-dependencies:${TAG}"]
 }

--- a/util/dockerfiles/gem5-all-min-dependencies/Dockerfile
+++ b/util/dockerfiles/gem5-all-min-dependencies/Dockerfile
@@ -25,9 +25,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-22.04_min-dependencies:latest as source
-RUN apt -y update && apt -y install git
-RUN git clone -b develop https://github.com/gem5/gem5/ /gem5
+
+# Make sure to get the most recent code
+ADD . /gem5
 WORKDIR /gem5
+
 RUN scons -j`nproc` build/ALL/gem5.fast
 
 FROM ghcr.io/gem5/ubuntu-22.04_min-dependencies:latest


### PR DESCRIPTION
This is a draft to get feedback. It turns out that the gem5-all-min-dependencies image hasn't been updated since last march and doesn't work with `git clone` (I think) because docker doesn't see that the command has "changed."

I'm also not sure if this should be on stable or develop.