### PR TITLE
arch-riscv: Remove the check of bit 63 of the physical address

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -359,20 +359,6 @@ TLB::translate(const RequestPtr &req, ThreadContext *tc,
             fault = doTranslate(req, tc, translation, mode, delayed);
         }
 
-        // according to the RISC-V tests, negative physical addresses trigger
-        // an illegal address exception.
-        // TODO where is that written in the manual?
-        if (!delayed && fault == NoFault && bits(req->getPaddr(), 63)) {
-            ExceptionCode code;
-            if (mode == BaseMMU::Read)
-                code = ExceptionCode::LOAD_ACCESS;
-            else if (mode == BaseMMU::Write)
-                code = ExceptionCode::STORE_ACCESS;
-            else
-                code = ExceptionCode::INST_ACCESS;
-            fault = std::make_shared<AddressFault>(req->getVaddr(), code);
-        }
-
         if (!delayed && fault == NoFault) {
             pma->check(req);
 


### PR DESCRIPTION
Currently, the TLB enforces that the bit 63 of a physical address to be zero. This check stems from the riscv-tests that checks for the bit 63 of a physical address [1]. This is due to the fact that the ISA implicitly says that the physical address must be zero-extended on the most significant bits that are not translated [2]. More details on this issue is here [3].

The check for bit 63 of a physical address in the TLB is rather too specific, and I believe the check of invalid physical address is alread implemented in PMA. Thus, this change proposes to remove this check from RISC-V TLB.

[1] https://github.com/riscv-software-src/riscv-tests/blob/bd0a19c136927eaa3b7296a591a896c141affb6b/isa/rv64mi/access.S#L18
[2] https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/8kO7X0y4ubo
[3] https://github.com/gem5/gem5/issues/238

Change-Id: I247e4d4c75c1ef49a16882c431095f6e83f30383