### PR TITLE
configs: Add o3 --cpu choice to the starter_se.py script

### DIFF
--- a/configs/example/arm/starter_se.py
+++ b/configs/example/arm/starter_se.py
@@ -53,15 +53,24 @@ from common import (
     MemConfig,
     ObjectList,
 )
-from common.cores.arm import HPI
+from common.cores.arm import (
+    HPI,
+    O3_ARM_v7a,
+)
 
 # Pre-defined CPU configurations. Each tuple must be ordered as : (cpu_class,
-# l1_icache_class, l1_dcache_class, walk_cache_class, l2_Cache_class). Any of
+# l1_icache_class, l1_dcache_class, l2_Cache_class). Any of
 # the cache class may be 'None' if the particular cache is not present.
 cpu_types = {
     "atomic": (AtomicSimpleCPU, None, None, None),
     "minor": (MinorCPU, devices.L1I, devices.L1D, devices.L2),
     "hpi": (HPI.HPI, HPI.HPI_ICache, HPI.HPI_DCache, HPI.HPI_L2),
+    "o3": (
+        O3_ARM_v7a.O3_ARM_v7a_3,
+        O3_ARM_v7a.O3_ARM_v7a_ICache,
+        O3_ARM_v7a.O3_ARM_v7a_DCache,
+        O3_ARM_v7a.O3_ARM_v7aL2,
+    ),
 }
 
 


### PR DESCRIPTION
This is matching what we are already doing in the starter_fs.py script

Change-Id: I50239050be9bd151a607ec892f8dd9322b24040b