### PR TITLE
mem-cache: Add a tag mask to indexing policies

### DIFF
--- a/src/mem/cache/tags/indexing_policies/IndexingPolicies.py
+++ b/src/mem/cache/tags/indexing_policies/IndexingPolicies.py
@@ -44,6 +44,11 @@ class BaseIndexingPolicy(SimObject):
     # Get the associativity
     assoc = Param.Int(Parent.assoc, "associativity")
 
+    # number of bits in the tag above the index and offset bit
+    # If this is less than 64, the other bits are ignored
+    # ignored_bits: (64 - tag_bits - index_bits - offset_bits)
+    tag_bits = Param.Unsigned(64, "number of bits in the tag")
+
 
 class SetAssociative(BaseIndexingPolicy):
     type = "SetAssociative"

--- a/src/mem/cache/tags/indexing_policies/base.cc
+++ b/src/mem/cache/tags/indexing_policies/base.cc
@@ -59,7 +59,8 @@ BaseIndexingPolicy::BaseIndexingPolicy(const Params &p)
     : SimObject(p), assoc(p.assoc),
       numSets(p.size / (p.entry_size * assoc)),
       setShift(floorLog2(p.entry_size)), setMask(numSets - 1), sets(numSets),
-      tagShift(setShift + floorLog2(numSets))
+      tagShift(setShift + floorLog2(numSets)),
+      tagMask(mask(p.tag_bits))
 {
     fatal_if(!isPowerOf2(numSets), "# of sets must be non-zero and a power " \
              "of 2");
@@ -98,7 +99,7 @@ BaseIndexingPolicy::setEntry(ReplaceableEntry* entry, const uint64_t index)
 Addr
 BaseIndexingPolicy::extractTag(const Addr addr) const
 {
-    return (addr >> tagShift);
+    return (addr >> tagShift) & tagMask;
 }
 
 } // namespace gem5

--- a/src/mem/cache/tags/indexing_policies/base.hh
+++ b/src/mem/cache/tags/indexing_policies/base.hh
@@ -96,6 +96,12 @@ class BaseIndexingPolicy : public SimObject
      */
     const int tagShift;
 
+    /**
+     * The mask to be applied to the address to generate a tag.
+     * If this masks out unique bits, we can have aliases.
+     */
+    const uint64_t tagMask;
+
   public:
     /**
      * Convenience typedef.


### PR DESCRIPTION
In some internal structures, a shorter tag is preferred to save storage. This can be achieved by techniques like hashing the full tag to generate the shortened tag or just ignoring the upper bits of the tag.

Adding a tag mask allows us to implement such techniques in gem5.

Change-Id: Ib339efd97bf33b706f93eb7f0eb5851ceb51afb6