### PR TITLE
mem-ruby: fix ruby startup() to reset exit event correctly when simulating for given ticks only

### DIFF
--- a/src/mem/ruby/system/RubySystem.cc
+++ b/src/mem/ruby/system/RubySystem.cc
@@ -454,6 +454,9 @@ RubySystem::startup()
         Tick curtick_original = curTick();
         // save the event queue head
         Event* eventq_head = eventq->replaceHead(NULL);
+        // save the exit event pointer
+        GlobalSimLoopExitEvent *simulate_limit_event_copy = nullptr;
+        simulate_limit_event_copy = simulate_limit_event;
         // set curTick to 0 and reset Ruby System's clock
         setCurTick(0);
         resetClock();
@@ -471,6 +474,8 @@ RubySystem::startup()
 
         // Restore eventq head
         eventq->replaceHead(eventq_head);
+        // Restore exit event pointer
+        simulate_limit_event = simulate_limit_event_copy;
         // Restore curTick and Ruby System's clock
         setCurTick(curtick_original);
         resetClock();

--- a/src/mem/ruby/system/RubySystem.cc
+++ b/src/mem/ruby/system/RubySystem.cc
@@ -475,7 +475,7 @@ RubySystem::startup()
         // Restore eventq head
         eventq->replaceHead(eventq_head);
         // Restore exit event pointer
-        simulate_limit_event = simulate_limit_event_copy;
+        simulate_limit_event = original_simulate_limit_event;
         // Restore curTick and Ruby System's clock
         setCurTick(curtick_original);
         resetClock();

--- a/src/mem/ruby/system/RubySystem.cc
+++ b/src/mem/ruby/system/RubySystem.cc
@@ -455,8 +455,8 @@ RubySystem::startup()
         // save the event queue head
         Event* eventq_head = eventq->replaceHead(NULL);
         // save the exit event pointer
-        GlobalSimLoopExitEvent *simulate_limit_event_copy = nullptr;
-        simulate_limit_event_copy = simulate_limit_event;
+        GlobalSimLoopExitEvent *original_simulate_limit_event = nullptr;
+        original_simulate_limit_event = simulate_limit_event;
         // set curTick to 0 and reset Ruby System's clock
         setCurTick(0);
         resetClock();


### PR DESCRIPTION
**Issue**: When you have a checkpoint made with ruby and you want to restore you simply call `m5.simulate()` in your config file which is basically a call to `src/sim/simulate.cc`. This runs fine and no issues occur. However, when you call the function `m5.simulate(some_tick)` - i.e. end the simulation after '_some_tick_', the simulations exits abnormally with a `"Panic: event not found!"`

**Cause**: Finding the cause was not direct but it became apparent that when restoring a simulation from a checkpoint, ruby tries to do a cache warmup by resetting the clock to 0 and playing requests which can re-generate the cache state as mentioned in `src/mem/ruby/system/RubySystem.cc: startup()`. For this, it stores the event queue head, runs a dry simulation and restores the head. Now `src/sim/simulate.cc: simulate()` checks for the exit event by checking the pointer to the exit event which is stored in `simulate_limit_event`. When ruby finishes warmup, everything is restored but the exit event pointer `simulate_limit_event` points to an exit event which was created in this warmup phase but no longer exists. So when the actual `simulate(some_tick)` is called, it tries to 'reschedule' the exit event pointed by the `simulate_limit_event` which is garbage value now and ends up in `"Panic: event not found!"`.

**Fix**: The commit in this PR does a very simple thing. It stores this `simulate_limit_event` pointer to `simulate_limit_event_copy` just how the event head is stored before the dry run and is restored after that. 

PS: There could be a better way to fix this but I preferred the minimal which does not break other things.