### PR TITLE
arch-vega: Fix upsize cast error in newer compilers

### DIFF
--- a/src/arch/amdgpu/vega/insts/instructions.cc
+++ b/src/arch/amdgpu/vega/insts/instructions.cc
@@ -46147,10 +46147,10 @@ namespace VegaISA
                                         *reinterpret_cast<float*>(&s1h),
                                         *reinterpret_cast<float*>(&s2h));
 
-                uint64_t result1 = *reinterpret_cast<uint64_t*>(&dword1);
-                uint64_t result2 = *reinterpret_cast<uint64_t*>(&dword2);
+                uint32_t result1 = *reinterpret_cast<uint32_t*>(&dword1);
+                uint32_t result2 = *reinterpret_cast<uint32_t*>(&dword2);
 
-                vdst[lane] = (result2 << 32) | result1;
+                vdst[lane] = (static_cast<uint64_t>(result2) << 32) | result1;
             }
         }
 
@@ -46206,10 +46206,10 @@ namespace VegaISA
                 float dword2 = *reinterpret_cast<float*>(&lower_dword)
                              * *reinterpret_cast<float*>(&upper_dword);
 
-                uint64_t result1 = *reinterpret_cast<uint64_t*>(&dword1);
-                uint64_t result2 = *reinterpret_cast<uint64_t*>(&dword2);
+                uint32_t result1 = *reinterpret_cast<uint32_t*>(&dword1);
+                uint32_t result2 = *reinterpret_cast<uint32_t*>(&dword2);
 
-                vdst[lane] = (result2 << 32) | result1;
+                vdst[lane] = (static_cast<uint64_t>(result2) << 32) | result1;
             }
         }
 
@@ -46265,10 +46265,10 @@ namespace VegaISA
                 float dword2 = *reinterpret_cast<float*>(&lower_dword)
                              + *reinterpret_cast<float*>(&upper_dword);
 
-                uint64_t result1 = *reinterpret_cast<uint64_t*>(&dword1);
-                uint64_t result2 = *reinterpret_cast<uint64_t*>(&dword2);
+                uint32_t result1 = *reinterpret_cast<uint32_t*>(&dword1);
+                uint32_t result2 = *reinterpret_cast<uint32_t*>(&dword2);
 
-                vdst[lane] = (result2 << 32) | result1;
+                vdst[lane] = (static_cast<uint64_t>(result2) << 32) | result1;
             }
         }
 


### PR DESCRIPTION
Newer compilers error on -Warray-length in the recent MI200 patches due to casting from a 32-bit data type to a 64-bit type. Change it to cast the 32-bit integer first then 64-bit integer latter to remove the warning.

Rerun of validation tests on the three instructions passed.

Change-Id: I0309e5f7b5b8cc8ce1651660ddddb120fa6e7666