### PR TITLE
dev,mem,systemc: Revert the implementation of recvMemBackdoorReq CLs

### DIFF
--- a/src/mem/cfi_mem.cc
+++ b/src/mem/cfi_mem.cc
@@ -275,14 +275,6 @@ CfiMemory::recvFunctional(PacketPtr pkt)
     pkt->popLabel();
 }
 
-void
-CfiMemory::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &_backdoor)
-{
-    if (backdoor.ptr())
-        _backdoor = &backdoor;
-}
-
 bool
 CfiMemory::recvTimingReq(PacketPtr pkt)
 {
@@ -492,13 +484,6 @@ void
 CfiMemory::MemoryPort::recvFunctional(PacketPtr pkt)
 {
     mem.recvFunctional(pkt);
-}
-
-void
-CfiMemory::MemoryPort::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &_backdoor)
-{
-    mem.recvMemBackdoorReq(req, _backdoor);
 }
 
 bool

--- a/src/mem/cfi_mem.hh
+++ b/src/mem/cfi_mem.hh
@@ -248,8 +248,6 @@ class CfiMemory : public AbstractMemory
         Tick recvAtomicBackdoor(
                 PacketPtr pkt, MemBackdoorPtr &_backdoor) override;
         void recvFunctional(PacketPtr pkt) override;
-        void recvMemBackdoorReq(const MemBackdoorReq &req,
-                MemBackdoorPtr &_backdoor) override;
         bool recvTimingReq(PacketPtr pkt) override;
         void recvRespRetry() override;
         AddrRangeList getAddrRanges() const override;
@@ -363,8 +361,6 @@ class CfiMemory : public AbstractMemory
     Tick recvAtomic(PacketPtr pkt);
     Tick recvAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &_backdoor);
     void recvFunctional(PacketPtr pkt);
-    void recvMemBackdoorReq(const MemBackdoorReq &req,
-            MemBackdoorPtr &_backdoor);
     bool recvTimingReq(PacketPtr pkt);
     void recvRespRetry();
 

--- a/src/mem/coherent_xbar.cc
+++ b/src/mem/coherent_xbar.cc
@@ -998,14 +998,6 @@ CoherentXBar::forwardAtomic(PacketPtr pkt, PortID exclude_cpu_side_port_id,
 }
 
 void
-CoherentXBar::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    PortID dest_id = findPort(req.range());
-    memSidePorts[dest_id]->sendMemBackdoorReq(req, backdoor);
-}
-
-void
 CoherentXBar::recvFunctional(PacketPtr pkt, PortID cpu_side_port_id)
 {
     if (!pkt->isPrint()) {

--- a/src/mem/coherent_xbar.hh
+++ b/src/mem/coherent_xbar.hh
@@ -136,13 +136,6 @@ class CoherentXBar : public BaseXBar
             xbar.recvFunctional(pkt, id);
         }
 
-        void
-        recvMemBackdoorReq(const MemBackdoorReq &req,
-                MemBackdoorPtr &backdoor) override
-        {
-            xbar.recvMemBackdoorReq(req, backdoor);
-        }
-
         AddrRangeList
         getAddrRanges() const override
         {
@@ -380,11 +373,6 @@ class CoherentXBar : public BaseXBar
     /** Function called by the port when the crossbar is receiving a Functional
         transaction.*/
     void recvFunctional(PacketPtr pkt, PortID cpu_side_port_id);
-
-    /** Function called by the port when the crossbar receives a request for
-        a memory backdoor.*/
-    void recvMemBackdoorReq(const MemBackdoorReq &req,
-            MemBackdoorPtr &backdoor);
 
     /** Function called by the port when the crossbar is receiving a functional
         snoop transaction.*/

--- a/src/mem/hbm_ctrl.cc
+++ b/src/mem/hbm_ctrl.cc
@@ -140,21 +140,6 @@ HBMCtrl::recvAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &backdoor)
     return latency;
 }
 
-void
-HBMCtrl::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    auto &range = req.range();
-    if (pc0Int && pc0Int->getAddrRange().isSubset(range)) {
-        pc0Int->getBackdoor(backdoor);
-    } else if (pc1Int && pc1Int->getAddrRange().isSubset(range)) {
-        pc1Int->getBackdoor(backdoor);
-    }
-    else {
-        panic("Can't handle address range for range %s\n", range.to_string());
-    }
-}
-
 bool
 HBMCtrl::writeQueueFullPC0(unsigned int neededEntries) const
 {

--- a/src/mem/hbm_ctrl.hh
+++ b/src/mem/hbm_ctrl.hh
@@ -258,8 +258,6 @@ class HBMCtrl : public MemCtrl
     Tick recvAtomic(PacketPtr pkt) override;
     Tick recvAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &backdoor) override;
     void recvFunctional(PacketPtr pkt) override;
-    void recvMemBackdoorReq(const MemBackdoorReq &req,
-            MemBackdoorPtr &_backdoor) override;
     bool recvTimingReq(PacketPtr pkt) override;
 
 };

--- a/src/mem/mem_ctrl.cc
+++ b/src/mem/mem_ctrl.cc
@@ -1380,17 +1380,6 @@ MemCtrl::recvFunctional(PacketPtr pkt)
              pkt->print());
 }
 
-void
-MemCtrl::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    panic_if(!dram->getAddrRange().contains(req.range().start()),
-            "Can't handle address range for backdoor %s.",
-            req.range().to_string());
-
-    dram->getBackdoor(backdoor);
-}
-
 bool
 MemCtrl::recvFunctionalLogic(PacketPtr pkt, MemInterface* mem_intr)
 {
@@ -1504,13 +1493,6 @@ MemCtrl::MemoryPort::recvFunctional(PacketPtr pkt)
     }
 
     pkt->popLabel();
-}
-
-void
-MemCtrl::MemoryPort::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    ctrl.recvMemBackdoorReq(req, backdoor);
 }
 
 Tick

--- a/src/mem/mem_ctrl.hh
+++ b/src/mem/mem_ctrl.hh
@@ -267,8 +267,6 @@ class MemCtrl : public qos::MemCtrl
                 PacketPtr pkt, MemBackdoorPtr &backdoor) override;
 
         void recvFunctional(PacketPtr pkt) override;
-        void recvMemBackdoorReq(const MemBackdoorReq &req,
-                MemBackdoorPtr &backdoor) override;
 
         bool recvTimingReq(PacketPtr) override;
 
@@ -784,8 +782,6 @@ class MemCtrl : public qos::MemCtrl
     virtual Tick recvAtomic(PacketPtr pkt);
     virtual Tick recvAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &backdoor);
     virtual void recvFunctional(PacketPtr pkt);
-    virtual void recvMemBackdoorReq(const MemBackdoorReq &req,
-            MemBackdoorPtr &backdoor);
     virtual bool recvTimingReq(PacketPtr pkt);
 
     bool recvFunctionalLogic(PacketPtr pkt, MemInterface* mem_intr);

--- a/src/mem/noncoherent_xbar.cc
+++ b/src/mem/noncoherent_xbar.cc
@@ -285,14 +285,6 @@ NoncoherentXBar::recvAtomicBackdoor(PacketPtr pkt, PortID cpu_side_port_id,
 }
 
 void
-NoncoherentXBar::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    PortID dest_id = findPort(req.range());
-    memSidePorts[dest_id]->sendMemBackdoorReq(req, backdoor);
-}
-
-void
 NoncoherentXBar::recvFunctional(PacketPtr pkt, PortID cpu_side_port_id)
 {
     if (!pkt->isPrint()) {

--- a/src/mem/noncoherent_xbar.hh
+++ b/src/mem/noncoherent_xbar.hh
@@ -126,13 +126,6 @@ class NoncoherentXBar : public BaseXBar
             xbar.recvFunctional(pkt, id);
         }
 
-        void
-        recvMemBackdoorReq(const MemBackdoorReq &req,
-                MemBackdoorPtr &backdoor) override
-        {
-            xbar.recvMemBackdoorReq(req, backdoor);
-        }
-
         AddrRangeList
         getAddrRanges() const override
         {
@@ -186,8 +179,6 @@ class NoncoherentXBar : public BaseXBar
     Tick recvAtomicBackdoor(PacketPtr pkt, PortID cpu_side_port_id,
                             MemBackdoorPtr *backdoor=nullptr);
     void recvFunctional(PacketPtr pkt, PortID cpu_side_port_id);
-    void recvMemBackdoorReq(const MemBackdoorReq &req,
-            MemBackdoorPtr &backdoor);
 
   public:
 

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -108,13 +108,6 @@ SimpleMemory::recvFunctional(PacketPtr pkt)
     pkt->popLabel();
 }
 
-void
-SimpleMemory::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &_backdoor)
-{
-    getBackdoor(_backdoor);
-}
-
 bool
 SimpleMemory::recvTimingReq(PacketPtr pkt)
 {
@@ -299,13 +292,6 @@ void
 SimpleMemory::MemoryPort::recvFunctional(PacketPtr pkt)
 {
     mem.recvFunctional(pkt);
-}
-
-void
-SimpleMemory::MemoryPort::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    mem.recvMemBackdoorReq(req, backdoor);
 }
 
 bool

--- a/src/mem/simple_mem.hh
+++ b/src/mem/simple_mem.hh
@@ -98,8 +98,6 @@ class SimpleMemory : public AbstractMemory
         Tick recvAtomicBackdoor(
                 PacketPtr pkt, MemBackdoorPtr &_backdoor) override;
         void recvFunctional(PacketPtr pkt) override;
-        void recvMemBackdoorReq(const MemBackdoorReq &req,
-                MemBackdoorPtr &backdoor) override;
         bool recvTimingReq(PacketPtr pkt) override;
         void recvRespRetry() override;
         AddrRangeList getAddrRanges() const override;
@@ -193,8 +191,6 @@ class SimpleMemory : public AbstractMemory
     Tick recvAtomic(PacketPtr pkt);
     Tick recvAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &_backdoor);
     void recvFunctional(PacketPtr pkt);
-    void recvMemBackdoorReq(const MemBackdoorReq &req,
-            MemBackdoorPtr &backdoor);
     bool recvTimingReq(PacketPtr pkt);
     void recvRespRetry();
 };

--- a/src/mem/sys_bridge.hh
+++ b/src/mem/sys_bridge.hh
@@ -331,13 +331,6 @@ class SysBridge : public SimObject
                     pkt->requestorId());
         }
 
-        void
-        recvMemBackdoorReq(const MemBackdoorReq &req,
-                MemBackdoorPtr &backdoor) override
-        {
-            targetPort->sendMemBackdoorReq(req, backdoor);
-        }
-
         AddrRangeList
         getAddrRanges() const override
         {

--- a/src/mem/thread_bridge.cc
+++ b/src/mem/thread_bridge.cc
@@ -84,14 +84,6 @@ ThreadBridge::IncomingPort::recvFunctional(PacketPtr pkt)
     device_.out_port_.sendFunctional(pkt);
 }
 
-void
-ThreadBridge::IncomingPort::recvMemBackdoorReq(const MemBackdoorReq &req,
-                                               MemBackdoorPtr &backdoor)
-{
-    EventQueue::ScopedMigration migrate(device_.eventQueue());
-    device_.out_port_.sendMemBackdoorReq(req, backdoor);
-}
-
 ThreadBridge::OutgoingPort::OutgoingPort(const std::string &name,
                                          ThreadBridge &device)
     : RequestPort(name), device_(device)

--- a/src/mem/thread_bridge.cc
+++ b/src/mem/thread_bridge.cc
@@ -64,6 +64,12 @@ ThreadBridge::IncomingPort::recvRespRetry()
 
 // AtomicResponseProtocol
 Tick
+ThreadBridge::IncomingPort::recvAtomicBackdoor(PacketPtr pkt,
+                                               MemBackdoorPtr &backdoor)
+{
+    panic("ThreadBridge only supports atomic/functional access.");
+}
+Tick
 ThreadBridge::IncomingPort::recvAtomic(PacketPtr pkt)
 {
     EventQueue::ScopedMigration migrate(device_.eventQueue());
@@ -76,6 +82,14 @@ ThreadBridge::IncomingPort::recvFunctional(PacketPtr pkt)
 {
     EventQueue::ScopedMigration migrate(device_.eventQueue());
     device_.out_port_.sendFunctional(pkt);
+}
+
+void
+ThreadBridge::IncomingPort::recvMemBackdoorReq(const MemBackdoorReq &req,
+                                               MemBackdoorPtr &backdoor)
+{
+    EventQueue::ScopedMigration migrate(device_.eventQueue());
+    device_.out_port_.sendMemBackdoorReq(req, backdoor);
 }
 
 ThreadBridge::OutgoingPort::OutgoingPort(const std::string &name,

--- a/src/mem/thread_bridge.hh
+++ b/src/mem/thread_bridge.hh
@@ -55,10 +55,14 @@ class ThreadBridge : public SimObject
         void recvRespRetry() override;
 
         // AtomicResponseProtocol
+        Tick recvAtomicBackdoor(PacketPtr pkt,
+                                MemBackdoorPtr &backdoor) override;
         Tick recvAtomic(PacketPtr pkt) override;
 
         // FunctionalResponseProtocol
         void recvFunctional(PacketPtr pkt) override;
+        void recvMemBackdoorReq(const MemBackdoorReq &req,
+                                MemBackdoorPtr &backdoor) override;
 
       private:
         ThreadBridge &device_;

--- a/src/mem/thread_bridge.hh
+++ b/src/mem/thread_bridge.hh
@@ -61,8 +61,6 @@ class ThreadBridge : public SimObject
 
         // FunctionalResponseProtocol
         void recvFunctional(PacketPtr pkt) override;
-        void recvMemBackdoorReq(const MemBackdoorReq &req,
-                                MemBackdoorPtr &backdoor) override;
 
       private:
         ThreadBridge &device_;

--- a/src/systemc/tlm_bridge/gem5_to_tlm.cc
+++ b/src/systemc/tlm_bridge/gem5_to_tlm.cc
@@ -516,31 +516,6 @@ Gem5ToTlmBridge<BITWIDTH>::recvFunctional(PacketPtr packet)
 }
 
 template <unsigned int BITWIDTH>
-void
-Gem5ToTlmBridge<BITWIDTH>::recvMemBackdoorReq(const MemBackdoorReq &req,
-        MemBackdoorPtr &backdoor)
-{
-    // Create a transaction to send along to TLM's get_direct_mem_ptr.
-    tlm::tlm_generic_payload *trans = mm.allocate();
-    trans->acquire();
-    trans->set_address(req.range().start());
-    trans->set_data_length(req.range().size());
-    trans->set_streaming_width(req.range().size());
-    trans->set_data_ptr(nullptr);
-
-    if (req.writeable())
-        trans->set_command(tlm::TLM_WRITE_COMMAND);
-    else if (req.readable())
-        trans->set_command(tlm::TLM_READ_COMMAND);
-    else
-        trans->set_command(tlm::TLM_IGNORE_COMMAND);
-
-    backdoor = getBackdoor(*trans);
-
-    trans->release();
-}
-
-template <unsigned int BITWIDTH>
 tlm::tlm_sync_enum
 Gem5ToTlmBridge<BITWIDTH>::nb_transport_bw(tlm::tlm_generic_payload &trans,
     tlm::tlm_phase &phase, sc_core::sc_time &delay)

--- a/src/systemc/tlm_bridge/gem5_to_tlm.hh
+++ b/src/systemc/tlm_bridge/gem5_to_tlm.hh
@@ -63,7 +63,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "mem/backdoor.hh"
 #include "mem/port.hh"
 #include "params/Gem5ToTlmBridgeBase.hh"
 #include "sim/system.hh"
@@ -118,12 +117,6 @@ class Gem5ToTlmBridge : public Gem5ToTlmBridgeBase
         recvFunctional(gem5::PacketPtr pkt) override
         {
             return bridge.recvFunctional(pkt);
-        }
-        void
-        recvMemBackdoorReq(const gem5::MemBackdoorReq &req,
-                gem5::MemBackdoorPtr &backdoor) override
-        {
-            bridge.recvMemBackdoorReq(req, backdoor);
         }
         bool
         recvTimingReq(gem5::PacketPtr pkt) override
@@ -193,8 +186,6 @@ class Gem5ToTlmBridge : public Gem5ToTlmBridgeBase
     gem5::Tick recvAtomicBackdoor(gem5::PacketPtr pkt,
         gem5::MemBackdoorPtr &backdoor);
     void recvFunctional(gem5::PacketPtr packet);
-    void recvMemBackdoorReq(const gem5::MemBackdoorReq &req,
-            gem5::MemBackdoorPtr &backdoor);
     bool recvTimingReq(gem5::PacketPtr packet);
     bool tryTiming(gem5::PacketPtr packet);
     bool recvTimingSnoopResp(gem5::PacketPtr packet);

--- a/src/systemc/tlm_bridge/tlm_to_gem5.cc
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.cc
@@ -207,29 +207,6 @@ void
 TlmToGem5Bridge<BITWIDTH>::sendBeginResp(tlm::tlm_generic_payload &trans,
                                          sc_core::sc_time &delay)
 {
-    MemBackdoor::Flags flags;
-    switch (trans.get_command()) {
-      case tlm::TLM_READ_COMMAND:
-        flags = MemBackdoor::Readable;
-        break;
-      case tlm::TLM_WRITE_COMMAND:
-        flags = MemBackdoor::Writeable;
-        break;
-      default:
-        panic("TlmToGem5Bridge: "
-                "received transaction with unsupported command");
-    }
-    Addr start_addr = trans.get_address();
-    Addr length = trans.get_data_length();
-
-    MemBackdoorReq req({start_addr, start_addr + length}, flags);
-    MemBackdoorPtr backdoor = nullptr;
-
-    bmp.sendMemBackdoorReq(req, backdoor);
-
-    if (backdoor)
-        trans.set_dmi_allowed(true);
-
     tlm::tlm_phase phase = tlm::BEGIN_RESP;
 
     auto status = socket->nb_transport_bw(trans, phase, delay);
@@ -598,12 +575,12 @@ TlmToGem5Bridge<BITWIDTH>::before_end_of_elaboration()
         DPRINTF(TlmBridge, "register blocking interface");
         socket.register_b_transport(
                 this, &TlmToGem5Bridge<BITWIDTH>::b_transport);
+        socket.register_get_direct_mem_ptr(
+                this, &TlmToGem5Bridge<BITWIDTH>::get_direct_mem_ptr);
     } else {
         panic("gem5 operates neither in Timing nor in Atomic mode");
     }
 
-    socket.register_get_direct_mem_ptr(
-            this, &TlmToGem5Bridge<BITWIDTH>::get_direct_mem_ptr);
     socket.register_transport_dbg(
             this, &TlmToGem5Bridge<BITWIDTH>::transport_dbg);
 


### PR DESCRIPTION
Revert these CLs to make the fastmodel 11.21 works well