### PR TITLE
arch-riscv: Refactor the RISC-V multiplication utility

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1467,9 +1467,9 @@ decode QUADRANT default Unknown::unknown() {
                     }});
                     0x1: mulh({{
                         if (machInst.rv_type == RV32) {
-                            Rd_sd = mulh_32(Rs1_sd, Rs2_sd);
+                            Rd_sd = mulh<int32_t>(Rs1_sd, Rs2_sd);
                         } else {
-                            Rd_sd = mulh_64(Rs1_sd, Rs2_sd);
+                            Rd_sd = mulh<int64_t>(Rs1_sd, Rs2_sd);
                         }
                     }}, IntMultOp);
                     0x5: clmul({{
@@ -1506,9 +1506,9 @@ decode QUADRANT default Unknown::unknown() {
                     }});
                     0x1: mulhsu({{
                         if (machInst.rv_type == RV32) {
-                            Rd_sd = mulhsu_32(Rs1_sd, Rs2);
+                            Rd_sd = mulhsu<int32_t>(Rs1_sd, Rs2);
                         } else {
-                            Rd_sd = mulhsu_64(Rs1_sd, Rs2);
+                            Rd_sd = mulhsu<int64_t>(Rs1_sd, Rs2);
                         }
                     }}, IntMultOp);
                     0x5: clmulr({{
@@ -1539,9 +1539,9 @@ decode QUADRANT default Unknown::unknown() {
                     }});
                     0x1: mulhu({{
                         if (machInst.rv_type == RV32) {
-                            Rd = (int32_t)mulhu_32(Rs1, Rs2);
+                            Rd = (int32_t)mulhu<uint32_t>(Rs1, Rs2);
                         } else {
-                            Rd = mulhu_64(Rs1, Rs2);
+                            Rd = mulhu<uint64_t>(Rs1, Rs2);
                         }
                     }}, IntMultOp);
                     0x5: clmulh({{
@@ -3292,7 +3292,7 @@ decode QUADRANT default Unknown::unknown() {
                             Vd_vu[i] = ((uint64_t)Vs2_vu[i] * Vs1_vu[i])
                                         >> sew;
                         } else {
-                            Vd_vu[i] = mulhu_64(Vs2_vu[i], Vs1_vu[i]);
+                            Vd_vu[i] = mulhu<uint64_t>(Vs2_vu[i], Vs1_vu[i]);
                         }
                     }}, OPMVV, VectorIntegerArithOp);
                     0x25: vmul_vv({{
@@ -3304,7 +3304,7 @@ decode QUADRANT default Unknown::unknown() {
                                         (uint64_t)Vs1_vu[i])
                                         >> sew;
                         } else {
-                            Vd_vi[i] = mulhsu_64(Vs2_vi[i], Vs1_vu[i]);
+                            Vd_vi[i] = mulhsu<int64_t>(Vs2_vi[i], Vs1_vu[i]);
                         }
                     }}, OPMVV, VectorIntegerArithOp);
                     0x27: vmulh_vv({{
@@ -3312,7 +3312,7 @@ decode QUADRANT default Unknown::unknown() {
                             Vd_vi[i] = ((int64_t)Vs2_vi[i] * Vs1_vi[i])
                                         >> sew;
                         } else {
-                            Vd_vi[i] = mulh_64(Vs2_vi[i], Vs1_vi[i]);
+                            Vd_vi[i] = mulh<int64_t>(Vs2_vi[i], Vs1_vi[i]);
                         }
                     }}, OPMVV, VectorIntegerArithOp);
                     0x29: vmadd_vv({{
@@ -4384,7 +4384,7 @@ decode QUADRANT default Unknown::unknown() {
                             Vd_vu[i] = ((uint64_t)Vs2_vu[i] * Rs1_vu)
                                         >> sew;
                         else
-                            Vd_vu[i] = mulhu_64(Vs2_vu[i], Rs1_vu);
+                            Vd_vu[i] = mulhu<uint64_t>(Vs2_vu[i], Rs1_vu);
                     }}, OPMVX, VectorIntegerArithOp);
                     0x25: vmul_vx({{
                         Vd_vi[i] = Vs2_vi[i] * Rs1_vi;
@@ -4395,14 +4395,14 @@ decode QUADRANT default Unknown::unknown() {
                                         (uint64_t)Rs1_vu)
                                         >> sew;
                         else
-                            Vd_vi[i] = mulhsu_64(Vs2_vi[i], Rs1_vu);
+                            Vd_vi[i] = mulhsu<int64_t>(Vs2_vi[i], Rs1_vu);
                     }}, OPMVX, VectorIntegerArithOp);
                     0x27: vmulh_vx({{
                         if (sew < 64)
                             Vd_vi[i] = ((int64_t)Vs2_vi[i] * Rs1_vi)
                                         >> sew;
                         else
-                            Vd_vi[i] = mulh_64(Vs2_vi[i], Rs1_vi);
+                            Vd_vi[i] = mulh<int64_t>(Vs2_vi[i], Rs1_vi);
                     }}, OPMVX, VectorIntegerArithOp);
                     0x29: vmadd_vx({{
                         Vd_vi[i] = Vs3_vi[i] * Rs1_vi + Vs2_vi[i];


### PR DESCRIPTION
1. Add the new double width for int64_t and uint64_t
2. Use the wider type to get the upper result of multiplication

Change-Id: Id6cfa6f274c65592b2b3e2b70c00f82954b41f1a