### PR TITLE
systemc: Reduce unnecessary backdoor request in atomic transaction

### DIFF
--- a/src/systemc/tlm_bridge/tlm_to_gem5.hh
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.hh
@@ -143,6 +143,8 @@ class TlmToGem5Bridge : public TlmToGem5BridgeBase
 
     void invalidateDmi(const gem5::MemBackdoor &backdoor);
 
+    void cacheBackdoor(gem5::MemBackdoorPtr backdoor);
+
   protected:
     // payload event call back
     void peq_cb(tlm::tlm_generic_payload &trans, const tlm::tlm_phase &phase);


### PR DESCRIPTION
The backdoor request in b_transport is only used for hinting the dmi capability. Since most of traffic patterns are continous, we can cache the previous backdoor request result to spare the backdoor inspect of next request.

Change-Id: I53c47226f949dd0be19d52cad0650fcfd62eebbc