### PR TITLE
Increased packets sanity check limit to 1024

### DIFF
--- a/src/mem/packet_queue.cc
+++ b/src/mem/packet_queue.cc
@@ -118,8 +118,8 @@ PacketQueue::schedSendTiming(PacketPtr pkt, Tick when)
 
     // add a very basic sanity check on the port to ensure the
     // invisible buffer is not growing beyond reasonable limits
-    if (!_disableSanityCheck && transmitList.size() > 128) {
-        panic("Packet queue %s has grown beyond 128 packets\n",
+    if (!_disableSanityCheck && transmitList.size() > 1024) {
+        panic("Packet queue %s has grown beyond 1024 packets\n",
               name());
     }
 


### PR DESCRIPTION
For some simulations with big values for VLEN (e.g. 8k and 16k) there were more packets created on the fly and, as a consequence, failing the simulations. The sanity check has been increased in order to solve this high VLEN cases.

Supervised by [@aarmejach](https://github.com/aarmejach)
Change-Id: I137b0f3113687b3fc9c4154d19ca5e8017e6e992