### PR TITLE
arch-riscv: Fix vsadd_vi and vsaddu_vi to match v-spec

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3503,11 +3503,11 @@ decode QUADRANT default Unknown::unknown() {
                 }
                 format VectorIntVxsatFormat{
                     0x20: vsaddu_vi({{
-                        Vd_vu[i] = sat_addu<vu>(Vs2_vu[i], (vu)SIMM5,
+                        Vd_vu[i] = sat_addu<vu>(Vs2_vu[i], (vu)sext<5>(SIMM5),
                             vxsatptr);
                     }}, OPIVI, VectorIntegerArithOp);
                     0x21: vsadd_vi({{
-                        Vd_vu[i] = sat_add<vi>(Vs2_vu[i], (vu)SIMM5,
+                        Vd_vi[i] = sat_add<vi>(Vs2_vi[i], (vi)sext<5>(SIMM5),
                             vxsatptr);
                     }}, OPIVI, VectorIntegerArithOp);
                 }


### PR DESCRIPTION
This commit fixes the implementation of two instructions, vsadd_vi and vsaddu_vi, in the OPIVI category
to match the RISC-V vector specification.

According to [riscv-v-spec](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#101-vector-arithmetic-instruction-encoding), the immediate field of these two instructions should be sign extended.

> For integer operations, the scalar can be a 5-bit immediate, imm[4:0], encoded in the rs1 field. The value is sign-extended to SEW bits, unless otherwise specified.

There is an example in both [vsadd](https://github.com/QQeg/rvv_intrinsic_testcases/tree/master/vsadd_vi) and [vsaddu](https://github.com/QQeg/rvv_intrinsic_testcases/tree/master/vsaddu_vi).

Change-Id: Ib877627ba01c0868b2103d41613651df488fca13