### PR TITLE
dev-amdgpu: Limit SDMA NOP count to wptr boundary

### DIFF
--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -389,7 +389,15 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
       case SDMA_OP_NOP: {
         uint32_t NOP_count = (header >> 16) & 0x3FFF;
         DPRINTF(SDMAEngine, "SDMA NOP packet with count %d\n", NOP_count);
-        if (NOP_count > 0) q->incRptr(NOP_count * 4);
+        if (NOP_count > 0) {
+            for (int i = 0; i < NOP_count; ++i) {
+                if (q->rptr() == q->wptr()) {
+                    warn("NOP count is beyond wptr, ignoring remaining NOPs");
+                    break;
+                }
+                q->incRptr(4);
+            }
+        }
         decodeNext(q);
         } break;
       case SDMA_OP_COPY: {


### PR DESCRIPTION
If the NOP count of an SDMA NOP packet goes beyond the wptr address, the queue decode method will loop infinitely. If a packet comes in with a bad count this causes gem5 to hang. This change advances the rptr one dword at a time until either reaching the NOP count or when rptr == wptr to prevent this issue.

Change-Id: Ib2c0f74a477bff27890c9c064bb4190e76e513bd