### PR TITLE
arch-riscv: Fix fence.i instruction in O3 CPU

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -771,7 +771,8 @@ decode QUADRANT default Unknown::unknown() {
                 0x0: fence({{
                 }}, uint64_t, IsReadBarrier, IsWriteBarrier, No_OpClass);
                 0x1: fence_i({{
-                }}, uint64_t, IsNonSpeculative, IsSerializeAfter, No_OpClass);
+                }}, uint64_t, IsNonSpeculative, IsSerializeAfter,
+                    IsSquashAfter, No_OpClass);
             }
 
             0x2: decode FUNCT12 {


### PR DESCRIPTION
We should clean the instruction buffer after the fence.i is execute to avoid execute old instruction for self-modifying code

Change-Id: Iece0ee0d10631fcd9bd17ee67cf0c92f72acdbd8