### PR TITLE
dev: Fix off-by-one in IDE controller PCI register allocation

### DIFF
--- a/src/dev/storage/ide_ctrl.hh
+++ b/src/dev/storage/ide_ctrl.hh
@@ -96,7 +96,8 @@ class IdeController : public PciDevice
         /* 0x48      */ Register8 udmaControl = {"udma control"};
         /* 0x49      */ RegisterRaz raz1 = {"raz1", 1};
         /* 0x4a-0x4b */ Register16 udmaTiming = {"udma timing"};
-        /* 0x4c-...  */ RegisterRaz raz2 = {"raz2", PCI_CONFIG_SIZE - 0x4c};
+        /* 0x4c-...  */ RegisterRaz raz2 =
+                            {"raz2", (PCI_CONFIG_SIZE + 1) - 0x4c};
 
         void serialize(CheckpointOut &cp) const;
         void unserialize(CheckpointIn &cp);


### PR DESCRIPTION
The PCI configuration space is 256 bytes, yet because the PCI_CONFIG_SIZE macro is 0xff, the final register allocation in the IDE controller only allocated up to byte 255.

Change-Id: I1aef2cad9df366ee8425edb410037061eb29ae33