### PR TITLE
arch-riscv: fix vl in mask load/store (i.e vlm.v/vsm.v)

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -452,8 +452,7 @@ def template VlmConstructor {{
     %(set_reg_idx_arr)s;
     %(constructor)s;
 
-    const uint32_t micro_vlmax = vlen / width_EEW(_machInst.width);
-    int32_t micro_vl = (std::min(this->vl, micro_vlmax) + 7) / 8;
+    int32_t micro_vl = (this->vl + 7) / 8;
     StaticInstPtr microop;
 
     if (micro_vl == 0) {
@@ -479,8 +478,7 @@ def template VsmConstructor {{
     %(set_reg_idx_arr)s;
     %(constructor)s;
 
-    const uint32_t micro_vlmax = vlen / width_EEW(_machInst.width);
-    int32_t micro_vl = (std::min(this->vl, micro_vlmax) + 7) / 8;
+    int32_t micro_vl = (this->vl + 7) / 8;
 
     StaticInstPtr microop;
     if (micro_vl == 0) {


### PR DESCRIPTION
The vlm.v and vsm.v unit-stride mask load/store instructions are constructed with an incorrect VL when the current one is larger than than VLEN/EEW  (i.e. when LMUL > 1). This commit fixes the issue for both instructions.

Change-Id: I05e29d327e52fa2a225c6b83b927b01f84b9d2db