### PR TITLE
sim: Updating Process::Map

### DIFF
--- a/src/sim/process.cc
+++ b/src/sim/process.cc
@@ -401,7 +401,7 @@ Process::unserialize(CheckpointIn &cp)
 }
 
 bool
-Process::map(Addr vaddr, Addr paddr, int size, bool cacheable)
+Process::map(Addr vaddr, Addr paddr, int64_t size, bool cacheable)
 {
     pTable->map(vaddr, paddr, size,
                 cacheable ? EmulationPageTable::MappingFlags(0) :

--- a/src/sim/process.hh
+++ b/src/sim/process.hh
@@ -158,7 +158,7 @@ class Process : public SimObject
      * @return True if the map operation was successful.  (At this
      *           point in time, the map operation always succeeds.)
      */
-    bool map(Addr vaddr, Addr paddr, int size, bool cacheable = true);
+    bool map(Addr vaddr, Addr paddr, int64_t size, bool cacheable = true);
 
     void replicatePage(Addr vaddr, Addr new_paddr, ThreadContext *old_tc,
                        ThreadContext *new_tc, bool alloc_page);


### PR DESCRIPTION
Changing size from int to int64_t to allow for mapping regions bigger than 2GB.
