### PR TITLE
misc: Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-22.04
         if: github.event.pull_request.draft == false
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: actions/setup-python@v3
             - uses: pre-commit/action@v3.0.0
 
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-22.04
         if: github.event.pull_request.draft == false
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
             - name: Check for Change-Id
@@ -54,7 +54,7 @@ jobs:
         needs: [pre-commit, check-for-change-id] # only runs if pre-commit and change-id passes
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: CI Unittests
               working-directory: ${{ github.workspace }}
               run: scons build/ALL/unittests.opt -j $(nproc)
@@ -68,7 +68,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
         needs: [pre-commit, check-for-change-id]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
       # Unfortunately the 'ubunutu-latest' image doesn't have jq installed.
       # We therefore need to install it as a step here.
@@ -100,7 +100,7 @@ jobs:
         needs: [pre-commit, check-for-change-id]
         timeout-minutes: 90
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Clang Compilation
               working-directory: ${{ github.workspace }}
               run: scons build/ALL/gem5.fast -j $(nproc)
@@ -114,7 +114,7 @@ jobs:
             matrix:
                 build-target: ${{ fromJson(needs.testlib-quick-matrix.outputs.build-matrix) }}
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Build gem5
               run: scons ${{ matrix.build-target }} -j $(nproc)
 
@@ -150,7 +150,7 @@ jobs:
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
 
         # Checkout the repository then download the gem5.opt artifact.
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: actions/download-artifact@v3
               with:
                   name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         timeout-minutes: 2880 # 48 hours
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
@@ -46,7 +46,7 @@ jobs:
         timeout-minutes: 2880 # 48 hours
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -46,7 +46,7 @@ jobs:
         needs: name-artifacts
         container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
@@ -75,7 +75,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
@@ -97,7 +97,7 @@ jobs:
         steps:
             - name: Clean runner
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
@@ -186,7 +186,7 @@ jobs:
         steps:
             - name: Clean runner
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
@@ -224,7 +224,7 @@ jobs:
         timeout-minutes: 180
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
@@ -249,7 +249,7 @@ jobs:
         timeout-minutes: 180
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
@@ -275,7 +275,7 @@ jobs:
         timeout-minutes: 720 # 12 hours
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -9,7 +9,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: [self-hosted, linux, x64]
         container: ghcr.io/gem5/gcn-gpu:latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
@@ -35,7 +35,7 @@ jobs:
         needs: build-gcn-gpu-gem5
         timeout-minutes: 480 # 8 hours
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
@@ -67,7 +67,7 @@ jobs:
         needs: build-gcn-gpu-gem5
         timeout-minutes: 120 # 2 hours
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
@@ -98,7 +98,7 @@ jobs:
         outputs:
             build-name: ${{ steps.artifact-name.outputs.name }}
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
@@ -128,12 +128,12 @@ jobs:
         steps:
             - name: Clean runner
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
                   ref: develop
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.build-gem5.outputs.build-name}}
                   path: build/ALL
@@ -162,7 +162,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
         timeout-minutes: 4320 # 3 days
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.


### PR DESCRIPTION
The `checkout` action now has a v4. v3 utilizes Node.js 16 which is now deprecated by GitHub actions. Migrating to v4 is therefore encouraged.