### PR TITLE
arch-riscv: Fix RVV instructions vmv.s.x/vfmv.s.f

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4019,8 +4019,10 @@ decode QUADRANT default Unknown::unknown() {
                         // The encodings corresponding to the masked versions
                         // (vm=0) of vfmv.s.f are reserved
                         0x1: VectorNonSplitFormat::vfmv_s_f({{
-                            auto fd = ftype_freg<et>(freg(Fs1_bits));
-                            Vd_vu[0] = fd.v;
+                            if (this->vl) {
+                                auto fd = ftype_freg<et>(freg(Fs1_bits));
+                                Vd_vu[0] = fd.v;
+                            }
                         }}, OPFVV, VectorMiscOp);
                     }
                 }
@@ -4296,7 +4298,9 @@ decode QUADRANT default Unknown::unknown() {
                         // The encodings corresponding to the masked versions
                         // (vm=0) of vmv.s.x are reserved.
                         0x1: VectorNonSplitFormat::vmv_s_x({{
-                            Vd_vu[0] = Rs1_vu;
+                            if (this->vl) {
+                                Vd_vu[0] = Rs1_vu;
+                            }
                         }}, OPMVX, VectorMiscOp);
                     }
                 }


### PR DESCRIPTION
This commit fixes the implementation of vmv.s.x and vfmv.s.f. 
When vl = 0, no elements are updated in the destination vector register group, regardless of vstart.

Change-Id: Ib21b3125da8009325743ec70ca0874704328356c

Reference:
[Integer Scalar Move Instructions](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#161-integer-scalar-move-instructions)
[Floating-Point Scalar Move Instructions](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#162-floating-point-scalar-move-instructions)