### PR TITLE
arch-riscv: Fix control flow in VectorFloatMaskMacroConstructor

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1237,11 +1237,7 @@ template<typename ElemType>
     int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
     StaticInstPtr microop;
 
-    if (micro_vl == 0) {
-        microop = new VectorNopMicroInst(_machInst);
-        this->microops.push_back(microop);
-    }
-    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+    for (int i = 0; i < num_microops && micro_vl >= 0; ++i) {
         microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
         microop->setDelayedCommit();
         this->microops.push_back(microop);


### PR DESCRIPTION
This commit adjusts the logic in VectorFloatMaskMacroConstructor to ensure the %(copy_old_vd)s section is not skipped when vl = 0, ensuring correct values in destination vector register.

Change-Id: I2478722d6f003a0f2e4b3cd0ba3e845bed938ee6

This is the same problem as #715 .