### PR TITLE
arch-riscv: Add BasePMAChecker to support customized PMA

### DIFF
--- a/src/arch/riscv/PMAChecker.py
+++ b/src/arch/riscv/PMAChecker.py
@@ -40,7 +40,14 @@ from m5.proxy import *
 from m5.SimObject import SimObject
 
 
-class PMAChecker(SimObject):
+class BasePMAChecker(SimObject):
+    type = "BasePMAChecker"
+    cxx_header = "arch/riscv/pma_checker.hh"
+    cxx_class = "gem5::RiscvISA::BasePMAChecker"
+    abstract = True
+
+
+class PMAChecker(BasePMAChecker):
     type = "PMAChecker"
     cxx_header = "arch/riscv/pma_checker.hh"
     cxx_class = "gem5::RiscvISA::PMAChecker"

--- a/src/arch/riscv/RiscvMMU.py
+++ b/src/arch/riscv/RiscvMMU.py
@@ -49,7 +49,7 @@ class RiscvMMU(BaseMMU):
 
     itb = RiscvTLB(entry_type="instruction")
     dtb = RiscvTLB(entry_type="data")
-    pma_checker = Param.PMAChecker(PMAChecker(), "PMA Checker")
+    pma_checker = Param.BasePMAChecker(PMAChecker(), "PMA Checker")
     pmp = Param.PMP(PMP(), "Physical Memory Protection Unit")
 
     @classmethod

--- a/src/arch/riscv/RiscvTLB.py
+++ b/src/arch/riscv/RiscvTLB.py
@@ -45,7 +45,7 @@ class RiscvPagetableWalker(ClockedObject):
         4, "Number of outstanding walks that can be squashed per cycle"
     )
     # Grab the pma_checker from the MMU
-    pma_checker = Param.PMAChecker(Parent.any, "PMA Checker")
+    pma_checker = Param.BasePMAChecker(Parent.any, "PMA Checker")
     pmp = Param.PMP(Parent.any, "PMP")
 
 
@@ -59,5 +59,5 @@ class RiscvTLB(BaseTLB):
         RiscvPagetableWalker(), "page table walker"
     )
     # Grab the pma_checker from the MMU
-    pma_checker = Param.PMAChecker(Parent.any, "PMA Checker")
+    pma_checker = Param.BasePMAChecker(Parent.any, "PMA Checker")
     pmp = Param.PMP(Parent.any, "Physical Memory Protection Unit")

--- a/src/arch/riscv/SConscript
+++ b/src/arch/riscv/SConscript
@@ -63,7 +63,8 @@ Source('linux/fs_workload.cc', tags='riscv isa')
 
 Source('bare_metal/fs_workload.cc', tags='riscv isa')
 
-SimObject('PMAChecker.py', sim_objects=['PMAChecker'], tags='riscv isa')
+SimObject('PMAChecker.py', sim_objects=['PMAChecker', 'BasePMAChecker'],
+    tags='riscv isa')
 SimObject('PMP.py', sim_objects=['PMP'], tags='riscv isa')
 SimObject('RiscvDecoder.py', sim_objects=['RiscvDecoder'], tags='riscv isa')
 SimObject('RiscvFsWorkload.py',

--- a/src/arch/riscv/mmu.hh
+++ b/src/arch/riscv/mmu.hh
@@ -54,7 +54,7 @@ namespace RiscvISA {
 class MMU : public BaseMMU
 {
   public:
-    PMAChecker *pma;
+    BasePMAChecker *pma;
 
     MMU(const RiscvMMUParams &p)
       : BaseMMU(p), pma(p.pma_checker)

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -173,7 +173,7 @@ namespace RiscvISA
         // The TLB we're supposed to load.
         TLB * tlb;
         System * sys;
-        PMAChecker * pma;
+        BasePMAChecker * pma;
         PMP * pmp;
         RequestorID requestorId;
 

--- a/src/arch/riscv/pma_checker.cc
+++ b/src/arch/riscv/pma_checker.cc
@@ -51,7 +51,7 @@ namespace RiscvISA
 {
 
 PMAChecker::PMAChecker(const Params &params) :
-SimObject(params),
+BasePMAChecker(params),
 uncacheable(params.uncacheable.begin(), params.uncacheable.end())
 {
 }
@@ -89,9 +89,11 @@ PMAChecker::isUncacheable(PacketPtr pkt)
 }
 
 void
-PMAChecker::takeOverFrom(PMAChecker *old)
+PMAChecker::takeOverFrom(BasePMAChecker *old)
 {
-    uncacheable = old->uncacheable;
+    PMAChecker* derived_old = dynamic_cast<PMAChecker*>(old);
+    assert(derived_old != nullptr);
+    uncacheable = derived_old->uncacheable;
 }
 
 } // namespace RiscvISA

--- a/src/arch/riscv/pma_checker.hh
+++ b/src/arch/riscv/pma_checker.hh
@@ -41,6 +41,7 @@
 #include "base/addr_range.hh"
 #include "base/types.hh"
 #include "mem/packet.hh"
+#include "params/BasePMAChecker.hh"
 #include "params/PMAChecker.hh"
 #include "sim/sim_object.hh"
 
@@ -54,13 +55,23 @@ namespace RiscvISA
  * Based on the RISC-V ISA privileged specifications
  * V1.11, there is no implementation guidelines on the
  * Physical Memory Attributes.
- *
+ */
+
+class BasePMAChecker : public SimObject
+{
+  public:
+    BasePMAChecker(const BasePMACheckerParams &params) : SimObject(params) {};
+    virtual void check(const RequestPtr &req) = 0;
+    virtual void takeOverFrom(BasePMAChecker *old) = 0;
+};
+
+/**
  * This class provides an abstract PMAChecker for RISC-V
  * to provide PMA checking functionality. However,
  * hardware latencies are not modelled.
  */
 
-class PMAChecker : public SimObject
+class PMAChecker : public BasePMAChecker
 {
   public:
 
@@ -75,13 +86,13 @@ class PMAChecker : public SimObject
 
     AddrRangeList uncacheable;
 
-    void check(const RequestPtr &req);
+    void check(const RequestPtr &req) override;
 
     bool isUncacheable(const AddrRange &range);
     bool isUncacheable(const Addr &addr, const unsigned size);
     bool isUncacheable(PacketPtr pkt);
 
-    void takeOverFrom(PMAChecker *old);
+    void takeOverFrom(BasePMAChecker *old) override;
 };
 
 } // namespace RiscvISA

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -86,7 +86,7 @@ class TLB : public BaseTLB
     } stats;
 
   public:
-    PMAChecker *pma;
+    BasePMAChecker *pma;
     PMP *pmp;
 
   public:


### PR DESCRIPTION
The RISC-V privilege spec don't specify the implementation of PMA(physical memory attribute), which is addressed in the previous CL[1].

This CL creates the BasePMAChecker to support customized PMA so that we can only focus on the features wanted in the study. The CL also leaves the common methods `check` and `takeOverFrom` to make MMU easy to interact with PMA.

[1] https://gem5-review.googlesource.com/c/public/gem5/+/40596

Change-Id: I9725e3a8f7f9276e41f0d06988259456149d2a77