### PR TITLE
tests: Allow pyunit tests to run on specific directories

### DIFF
--- a/tests/run_pyunit.py
+++ b/tests/run_pyunit.py
@@ -35,6 +35,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import argparse
 import sys
 
 if __name__ == "__main__":
@@ -44,8 +45,20 @@ if __name__ == "__main__":
 if __name__ == "__m5_main__":
     import unittest
 
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--directory",
+        default="pyunit",
+        help="directory to search for pyunit files",
+    )
+
+    args = parser.parse_args()
+
     loader = unittest.TestLoader()
-    tests = loader.discover("pyunit", pattern="pyunit*.py")
+    tests = loader.discover(args.directory, pattern="pyunit*.py")
 
     runner = unittest.runner.TextTestRunner(verbosity=2)
     result = runner.run(tests)


### PR DESCRIPTION
This change allows pyunit tests to be run on specific directories instead of the default `pyunit` directory.
You can pass in the directory as follows. I have built gem5.opt for RISCV however it should work the same with other builds
```
./build/RISCV/gem5.opt tests/run_pyunit.py --directory tests/pyunit/gem5/
```
The default path works as it is currently 
```
./build/RISCV/gem5.opt tests/run_pyunit.py
```

Change-Id: Id9cc17498fa01b489de0bc96a9c80fc6b639a43f