### PR TITLE
misc: Add 'workflow_dispatch' to daily tests

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -7,6 +7,8 @@ on:
   # Runs every day from 7AM UTC
     schedule:
         - cron: 0 7 * * *
+  # Allows us to manually start workflow for testing
+    workflow_dispatch:
 
 jobs:
     name-artifacts:


### PR DESCRIPTION
This allows us to manually trigger daily test runs rather than wait for the scheduled time. This can be useful in cases where a fix for a broken test is pushed and we wish to verify it works as intended ASAP.