### PR TITLE
arch-vega,gpu-compute,mem-ruby: SQC Invalidation Support

### DIFF
--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -434,6 +434,7 @@ print(
 # shader is the GPU
 shader = Shader(
     n_wf=args.wfs_per_simd,
+    cu_per_sqc=args.cu_per_sqc,
     clk_domain=SrcClockDomain(
         clock=args.gpu_clock,
         voltage_domain=VoltageDomain(voltage=args.gpu_voltage),

--- a/configs/example/gpufs/system/amdgpu.py
+++ b/configs/example/gpufs/system/amdgpu.py
@@ -33,7 +33,10 @@ from m5.objects import *
 
 def createGPU(system, args):
     shader = Shader(
-        n_wf=args.wfs_per_simd, timing=True, clk_domain=system.clk_domain
+        n_wf=args.wfs_per_simd,
+        cu_per_sqc=args.cu_per_sqc,
+        timing=True,
+        clk_domain=system.clk_domain,
     )
 
     # VIPER GPU protocol implements release consistency at GPU side. So,

--- a/src/gpu-compute/GPU.py
+++ b/src/gpu-compute/GPU.py
@@ -294,6 +294,7 @@ class Shader(ClockedObject):
     dispatcher = Param.GPUDispatcher("GPU workgroup dispatcher")
     system_hub = Param.AMDGPUSystemHub(NULL, "GPU System Hub (FS Mode only)")
     n_wf = Param.Int(10, "Number of wavefront slots per SIMD")
+    cu_per_sqc = Param.Int(4, "Number of CUs that share an SQC")
     impl_kern_launch_acq = Param.Bool(
         True,
         """Insert acq packet into

--- a/src/gpu-compute/compute_unit.cc
+++ b/src/gpu-compute/compute_unit.cc
@@ -1085,11 +1085,9 @@ ComputeUnit::SQCPort::MemReqEvent::process()
     SenderState *sender_state = safe_cast<SenderState*>(pkt->senderState);
     [[maybe_unused]] ComputeUnit *compute_unit = sqcPort.computeUnit;
 
-    if (pkt->req->systemReq()) {
-        assert(compute_unit->shader->systemHub);
-        SystemHubEvent *resp_event = new SystemHubEvent(pkt, &sqcPort);
-        compute_unit->shader->systemHub->sendRequest(pkt, resp_event);
-    } else if (!(sqcPort.sendTimingReq(pkt))) {
+    assert(!pkt->req->systemReq());
+
+    if (!(sqcPort.sendTimingReq(pkt))) {
         sqcPort.retries.push_back(std::pair<PacketPtr, Wavefront*>
                 (pkt, sender_state->wavefront));
     }

--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -680,6 +680,41 @@ class ComputeUnit : public ClockedObject
                 kernId(_kernId){ }
         };
 
+        class MemReqEvent : public Event
+        {
+          private:
+            SQCPort &sqcPort;
+            PacketPtr pkt;
+
+          public:
+            MemReqEvent(SQCPort &_sqc_port, PacketPtr _pkt)
+                : Event(), sqcPort(_sqc_port), pkt(_pkt)
+            {
+              setFlags(Event::AutoDelete);
+            }
+
+            void process();
+            const char *description() const;
+        };
+
+        class SystemHubEvent : public Event
+        {
+          SQCPort *sqcPort;
+          PacketPtr reqPkt;
+
+          public:
+            SystemHubEvent(PacketPtr pkt, SQCPort *_sqcPort)
+                : sqcPort(_sqcPort), reqPkt(pkt)
+            {
+                setFlags(Event::AutoDelete);
+            }
+
+            void
+            process()
+            {
+            }
+        };
+
         std::deque<std::pair<PacketPtr, Wavefront*>> retries;
 
       protected:

--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -698,24 +698,6 @@ class ComputeUnit : public ClockedObject
             const char *description() const;
         };
 
-        class SystemHubEvent : public Event
-        {
-          SQCPort *sqcPort;
-          PacketPtr reqPkt;
-
-          public:
-            SystemHubEvent(PacketPtr pkt, SQCPort *_sqcPort)
-                : sqcPort(_sqcPort), reqPkt(pkt)
-            {
-                setFlags(Event::AutoDelete);
-            }
-
-            void
-            process()
-            {
-            }
-        };
-
         std::deque<std::pair<PacketPtr, Wavefront*>> retries;
 
       protected:

--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -412,6 +412,7 @@ class ComputeUnit : public ClockedObject
 
     void doInvalidate(RequestPtr req, int kernId);
     void doFlush(GPUDynInstPtr gpuDynInst);
+    void doSQCInvalidate(RequestPtr req, int kernId);
 
     void dispWorkgroup(HSAQueueEntry *task, int num_wfs_in_wg);
     bool hasDispResources(HSAQueueEntry *task, int &num_wfs_in_wg);

--- a/src/gpu-compute/fetch_unit.cc
+++ b/src/gpu-compute/fetch_unit.cc
@@ -320,7 +320,7 @@ FetchUnit::processFetchReturn(PacketPtr pkt)
         assert(!fetchBuf.at(wavefront->wfSlotId).hasFetchDataToProcess());
         wavefront->dropFetch = false;
     } else {
-        fetchBuf.at(wavefront->wfSlotId).fetchDone(pkt->req->getVaddr());
+        fetchBuf.at(wavefront->wfSlotId).fetchDone(pkt);
     }
 
     wavefront->pendingFetch = false;
@@ -370,28 +370,6 @@ void
 FetchUnit::FetchBufDesc::flushBuf()
 {
     restartFromBranch = true;
-    /**
-     * free list may have some entries
-     * so we clear it here to avoid duplicates
-     */
-    freeList.clear();
-    bufferedPCs.clear();
-    reservedPCs.clear();
-    readPtr = bufStart;
-
-    for (int i = 0; i < fetchDepth; ++i) {
-        freeList.push_back(bufStart + i * cacheLineSize);
-    }
-
-    DPRINTF(GPUFetch, "WF[%d][%d]: Id%d Fetch dropped, flushing fetch "
-            "buffer\n", wavefront->simdId, wavefront->wfSlotId,
-            wavefront->wfDynId);
-}
-
-void
-FetchUnit::FetchBufDesc::invBuf()
-{
-    restartFromBranch = false;
     /**
      * free list may have some entries
      * so we clear it here to avoid duplicates
@@ -491,19 +469,22 @@ FetchUnit::FetchBufDesc::reserveBuf(Addr vaddr)
 }
 
 void
-FetchUnit::FetchBufDesc::fetchDone(Addr vaddr)
+FetchUnit::FetchBufDesc::fetchDone(PacketPtr pkt)
 {
-    // If the return vaddr is 0, then it belongs to an SQC invalidation
-    // request. This request calls incLGKMInstsIssued() function in its
-    // execution path. Since there is no valid memory return response
-    // associated with this instruction, decLGKMInstsIssued() is not
-    // executed. Do this here to decrement the counter and invalidate
-    // all buffers
-    if (vaddr == 0) {
+    // If the return command is MemSyncResp, then it belongs to
+    // an SQC invalidation request. This request calls
+    // incLGKMInstsIssued() function in its execution path.
+    // Since there is no valid memory return response associated with
+    // this instruction, decLGKMInstsIssued() is not executed. Do this
+    // here to decrement the counter and invalidate all buffers
+    if (pkt->cmd == MemCmd::MemSyncResp) {
         wavefront->decLGKMInstsIssued();
-        invBuf();
+        flushBuf();
+        restartFromBranch = false;
         return;
     }
+
+    Addr vaddr = pkt->req->getVaddr();
 
     assert(bufferedPCs.find(vaddr) == bufferedPCs.end());
     DPRINTF(GPUFetch, "WF[%d][%d]: Id%d done fetching for addr %#x\n",

--- a/src/gpu-compute/fetch_unit.cc
+++ b/src/gpu-compute/fetch_unit.cc
@@ -408,7 +408,6 @@ FetchUnit::FetchBufDesc::invBuf()
     DPRINTF(GPUFetch, "WF[%d][%d]: Id%d Fetch dropped, flushing fetch "
             "buffer\n", wavefront->simdId, wavefront->wfSlotId,
             wavefront->wfDynId);
-
 }
 
 Addr

--- a/src/gpu-compute/fetch_unit.cc
+++ b/src/gpu-compute/fetch_unit.cc
@@ -493,8 +493,13 @@ FetchUnit::FetchBufDesc::reserveBuf(Addr vaddr)
 void
 FetchUnit::FetchBufDesc::fetchDone(Addr vaddr)
 {
+    // If the return vaddr is 0, then it belongs to an SQC invalidation
+    // request. This request calls incLGKMInstsIssued() function in its
+    // execution path. Since there is no valid memory return response
+    // associated with this instruction, decLGKMInstsIssued() is not
+    // executed. Do this here to decrement the counter and invalidate
+    // all buffers
     if (vaddr == 0) {
-        // S_ICACHE_INV fetch done
         wavefront->decLGKMInstsIssued();
         invBuf();
         return;

--- a/src/gpu-compute/fetch_unit.hh
+++ b/src/gpu-compute/fetch_unit.hh
@@ -104,6 +104,7 @@ class FetchUnit
         int reservedLines() const { return reservedPCs.size(); }
         bool hasFreeSpace() const { return !freeList.empty(); }
         void flushBuf();
+        void invBuf();
         Addr nextFetchAddr();
 
         /**

--- a/src/gpu-compute/fetch_unit.hh
+++ b/src/gpu-compute/fetch_unit.hh
@@ -104,7 +104,6 @@ class FetchUnit
         int reservedLines() const { return reservedPCs.size(); }
         bool hasFreeSpace() const { return !freeList.empty(); }
         void flushBuf();
-        void invBuf();
         Addr nextFetchAddr();
 
         /**
@@ -139,7 +138,7 @@ class FetchUnit
             return is_reserved;
         }
 
-        void fetchDone(Addr vaddr);
+        void fetchDone(PacketPtr ptr);
 
         /**
          * checks if the buffer contains valid data. this essentially

--- a/src/gpu-compute/scalar_memory_pipeline.hh
+++ b/src/gpu-compute/scalar_memory_pipeline.hh
@@ -36,6 +36,7 @@
 #include <string>
 
 #include "gpu-compute/misc.hh"
+#include "mem/request.hh"
 #include "params/ComputeUnit.hh"
 #include "sim/stats.hh"
 
@@ -66,6 +67,9 @@ class ScalarMemPipeline
     std::queue<GPUDynInstPtr> &getGMLdRespFIFO() { return returnedLoads; }
 
     void issueRequest(GPUDynInstPtr gpuDynInst);
+
+    void injectScalarMemFence(
+            GPUDynInstPtr gpuDynInst, bool kernelMemSync, RequestPtr req);
 
     bool
     isGMLdRespFIFOWrRdy() const

--- a/src/gpu-compute/shader.cc
+++ b/src/gpu-compute/shader.cc
@@ -221,6 +221,11 @@ Shader::prepareInvalidate(HSAQueueEntry *task) {
         // all necessary INV flags are all set now, call cu to execute
         cuList[i_cu]->doInvalidate(req, task->dispatchId());
 
+
+        if ((i_cu % 4) == 0) {
+            cuList[i_cu]->doSQCInvalidate(req, task->dispatchId());
+        }
+
         // I don't like this. This is intrusive coding.
         cuList[i_cu]->resetRegisterPool();
     }

--- a/src/gpu-compute/shader.cc
+++ b/src/gpu-compute/shader.cc
@@ -64,6 +64,7 @@ Shader::Shader(const Params &p) : ClockedObject(p),
     impl_kern_end_rel(p.impl_kern_end_rel),
     coissue_return(1),
     trace_vgpr_all(1), n_cu((p.CUs).size()), n_wf(p.n_wf),
+    n_cu_per_sqc(p.cu_per_sqc),
     globalMemSize(p.globalmem),
     nextSchedCu(0), sa_n(0), gpuCmdProc(*p.gpu_cmd_proc),
     _dispatcher(*p.dispatcher), systemHub(p.system_hub),
@@ -222,7 +223,9 @@ Shader::prepareInvalidate(HSAQueueEntry *task) {
         cuList[i_cu]->doInvalidate(req, task->dispatchId());
 
 
-        if ((i_cu % 4) == 0) {
+        // A set of CUs share a single SQC cache. Send a single invalidate
+        // request to each SQC
+        if ((i_cu % n_cu_per_sqc) == 0) {
             cuList[i_cu]->doSQCInvalidate(req, task->dispatchId());
         }
 

--- a/src/gpu-compute/shader.hh
+++ b/src/gpu-compute/shader.hh
@@ -237,6 +237,8 @@ class Shader : public ClockedObject
     int n_cu;
     // Number of wavefront slots per SIMD per CU
     int n_wf;
+    //Number of cu units per sqc in the shader
+    int n_cu_per_sqc;
 
     // The size of global memory
     int globalMemSize;

--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -324,7 +324,6 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     sequencer.invL1Callback();
   }
 
-
   action(w_writeCache, "w", desc="write data to cache") {
     peek(responseToSQC_in, ResponseMsg) {
       assert(is_valid(cache_entry));

--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -60,6 +60,7 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     // Mem sys initiated
     Repl,           desc="Replacing block from cache";
     Data,           desc="Received Data";
+    Evict,          desc="Evict cache line";
   }
 
   enumeration(RequestType, desc="To communicate stats from transitions to recordStats") {
@@ -67,6 +68,7 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     DataArrayWrite,   desc="Write the data array";
     TagArrayRead,     desc="Read the data array";
     TagArrayWrite,    desc="Write the data array";
+    TagArrayFlash,    desc="Flash clear the data array";
   }
 
 
@@ -242,7 +244,12 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
       peek(mandatoryQueue_in, RubyRequest, block_on="LineAddress") {
         Entry cache_entry := getCacheEntry(in_msg.LineAddress);
         TBE tbe := TBEs.lookup(in_msg.LineAddress);
-        trigger(Event:Fetch, in_msg.LineAddress, cache_entry, tbe);
+        DPRINTF(RubySlicc, "%s\n", in_msg);
+        if (in_msg.Type == RubyRequestType:REPLACEMENT) {
+          trigger(Event:Evict, in_msg.LineAddress, cache_entry, tbe);
+        } else {
+          trigger(Event:Fetch, in_msg.LineAddress, cache_entry, tbe);
+        }
       }
     }
   }
@@ -313,6 +320,11 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     APPEND_TRANSITION_COMMENT(cache_entry.DataBlk);
   }
 
+  action(inv_invDone, "inv", desc="local inv done") {
+    sequencer.invL1Callback();
+  }
+
+
   action(w_writeCache, "w", desc="write data to cache") {
     peek(responseToSQC_in, ResponseMsg) {
       assert(is_valid(cache_entry));
@@ -348,6 +360,13 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
   transition({I, IV, V}, Repl, I) {TagArrayRead, TagArrayWrite} {
     // since we're evicting something, don't bother classifying as hit/miss
     ic_invCache;
+  }
+
+  transition({I, IV, V}, Evict, I) {TagArrayRead, TagArrayWrite} {
+    // since we're evicting something, don't bother classifying as hit/miss
+    ic_invCache;
+    inv_invDone;
+    p_popMandatoryQueue;
   }
 
   // if we got a response for a load where the line is in I, then

--- a/src/mem/ruby/protocol/RubySlicc_Types.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Types.sm
@@ -157,6 +157,9 @@ structure (Sequencer, external = "yes") {
   void llscClearLocalMonitor();
 
   void evictionCallback(Addr);
+
+  void invL1Callback();
+
   void recordRequestType(SequencerRequestType);
   bool checkResourceAvailable(CacheResourceType, Addr);
 }

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -350,6 +350,11 @@ Sequencer::insertRequest(PacketPtr pkt, RubyRequestType primary_type,
         return RequestStatus_Ready;
     }
 
+    // If command is MemSyncReq, it is used to invalidate the cache.
+    // As the cache invalidation requests are already issued in invL1(),
+    // there is no need to create a new request for the same here.
+    // Instead, return RequestStatus_Aliased, and make the sequencer skip
+    // an extra issueRequest
     if (pkt->cmd == MemCmd::MemSyncReq) {
         return RequestStatus_Aliased;
     }

--- a/src/mem/ruby/system/Sequencer.hh
+++ b/src/mem/ruby/system/Sequencer.hh
@@ -141,6 +141,10 @@ class Sequencer : public RubyPort
                              const Cycles forwardRequestTime = Cycles(0),
                              const Cycles firstResponseTime = Cycles(0));
 
+    void completeHitCallback(std::vector<PacketPtr>& list);
+    void invL1Callback();
+    void invL1();
+
     RequestStatus makeRequest(PacketPtr pkt) override;
     virtual bool empty() const;
     int outstandingCount() const override { return m_outstanding_count; }
@@ -242,6 +246,10 @@ class Sequencer : public RubyPort
 
   private:
     int m_max_outstanding_requests;
+
+    int m_num_pending_invs;
+
+    PacketPtr m_cache_inv_pkt;
 
     CacheMemory* m_dataCache_ptr;
 


### PR DESCRIPTION
This PR adds support for SQC (GPU I-cache) invalidation to the GPU model. It does this by updating the GPU-VIPER-SQC protocol to support flushes, the sequencer model to send out invalidates and the gpu compute model to send invalidates and handle responses. It also adds support for S_ICACHE_INV, a VEGA ISA instruction that invalidates the entire GPU I-cache. Additionally, the PR modifies the kernel start behavior to invalidate the I-cache too. It previously invalidated only the L1 D-cache.