### PR TITLE
stdlib: fix typo in error message

### DIFF
--- a/src/python/gem5/components/memory/memory.py
+++ b/src/python/gem5/components/memory/memory.py
@@ -198,7 +198,7 @@ class ChanneledMemory(AbstractMemorySystem):
             raise Exception(
                 "Multi channel memory controller requires a single range "
                 "which matches the memory's size.\n"
-                f"The range size: {range[0].size()}\n"
+                f"The range size: {ranges[0].size()}\n"
                 f"This memory's size: {self._size}"
             )
         self._mem_range = ranges[0]


### PR DESCRIPTION
Change-Id: I28f1881d207caa36c6101eef221ef4cdd229da57