### PR TITLE
util: Remove action runner add-apt-repo git-core/ppa

### DIFF
--- a/util/github-runners-vagrant/provision_root.sh
+++ b/util/github-runners-vagrant/provision_root.sh
@@ -31,7 +31,6 @@ set -eu -o pipefail # -x: is for debugging
 
 apt-get update
 apt-get upgrade -y
-add-apt-repository --yes --update ppa:git-core/ppa
 apt-get install -y \
   software-properties-common \
   bash \


### PR DESCRIPTION
We were having some difficulty on a server running this `apt-apt-repository` command due to suspected firewall issues. On further inspection is appear to be superfluous as git can be obtained easily through `apt-get` without adding this repository.

Change-Id: I60d0015651a53ce13dccb3d4ad223fdeca597de9