### PR TITLE
mem-cache: Fix circular dependency in QoS mem

### DIFF
--- a/src/mem/qos/QoSMemSinkCtrl.py
+++ b/src/mem/qos/QoSMemSinkCtrl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 ARM Limited
+# Copyright (c) 2018-2020,2024 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -36,7 +36,6 @@
 # Author: Matteo Andreozzi
 
 from m5.objects.QoSMemCtrl import *
-from m5.objects.QoSMemSinkInterface import *
 from m5.params import *
 
 
@@ -46,9 +45,7 @@ class QoSMemSinkCtrl(QoSMemCtrl):
     cxx_class = "gem5::memory::qos::MemSinkCtrl"
     port = ResponsePort("Response ports")
 
-    interface = Param.QoSMemSinkInterface(
-        QoSMemSinkInterface(), "Interface to memory"
-    )
+    interface = Param.QoSMemSinkInterface("Interface to memory")
 
     # the basic configuration of the controller architecture, note
     # that each entry corresponds to a burst for the specific DRAM

--- a/src/mem/qos/QoSMemSinkInterface.py
+++ b/src/mem/qos/QoSMemSinkInterface.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2021,2024 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -34,6 +34,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.AbstractMemory import AbstractMemory
+from m5.objects.QoSMemSinkCtrl import QoSMemSinkCtrl
 
 
 class QoSMemSinkInterface(AbstractMemory):


### PR DESCRIPTION
This PR removes a circular dependency between `QoSMemSinkCtrl` and `QoSMemSinkInterface` that prevented the `controller()` function of `QoSMemSinkInterface` from being used by removing the default value for `QoSMemSinkCtrl.interface`.

Change-Id: I4ecc39b974e239be1a2e9285e1f6f8ea873c018d