### PR TITLE
arch-riscv: Fix load and store to use EEW instead of SEW

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -172,11 +172,10 @@ Fault
         return fault;
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
-    const size_t micro_elems = vlen / width_EEW(machInst.width);
 
     size_t ei;
 
-    for (size_t i = 0; i < micro_elems; i++) {
+    for (size_t i = 0; i < micro_vlmax; i++) {
         ei = i + micro_vlmax * microIdx;
         %(memacc_code)s;
     }
@@ -244,10 +243,9 @@ Fault
     memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), pkt->getSize());
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
-    const size_t micro_elems = vlen / width_EEW(machInst.width);
 
     size_t ei;
-    for (size_t i = 0; i < micro_elems; i++) {
+    for (size_t i = 0; i < micro_vlmax; i++) {
         ei = i + micro_vlmax * microIdx;
         %(memacc_code)s;
     }

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -171,7 +171,7 @@ Fault
     if (fault != NoFault)
         return fault;
 
-    const size_t micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+    const size_t micro_vlmax = vlen / width_EEW(machInst.width);
     const size_t micro_elems = vlen / width_EEW(machInst.width);
 
     size_t ei;
@@ -243,7 +243,7 @@ Fault
 
     memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), pkt->getSize());
 
-    const size_t micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+    const size_t micro_vlmax = vlen / width_EEW(machInst.width);
     const size_t micro_elems = vlen / width_EEW(machInst.width);
 
     size_t ei;
@@ -360,7 +360,7 @@ Fault
     %(set_vlen)s;
     %(ea_code)s;
 
-    const size_t micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+    const size_t micro_vlmax = vlen / width_EEW(machInst.width);
     const size_t eewb = width_EEW(machInst.width) / 8;
     const size_t mem_size = eewb * microVl;
     std::vector<bool> byte_enable(mem_size, false);
@@ -411,7 +411,7 @@ Fault
     %(set_vlen)s;
     %(ea_code)s;
 
-    const size_t micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+    const size_t micro_vlmax = vlen / width_EEW(machInst.width);
     const size_t eewb = width_EEW(machInst.width) / 8;
     const size_t mem_size = eewb * microVl;
     std::vector<bool> byte_enable(mem_size, false);


### PR DESCRIPTION
Vector unit-stride instructions have an EEW encoded directly in the instruction, We should use that instead of SEW in vtype.

Change-Id: I282041ce8ed57fbcca899f7497ef6c6fb2dfcf85

Ref:
https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#73-vector-loadstore-width-encoding