### PR TITLE
arch-riscv: Remove unnecessary assert

### DIFF
--- a/src/arch/riscv/interrupts.cc
+++ b/src/arch/riscv/interrupts.cc
@@ -44,7 +44,6 @@ Interrupts::Interrupts(const Params &p) : BaseInterrupts(p),
         i < p.port_local_interrupt_pins_connection_count;
         ++i) {
             uint8_t interruptID = p.local_interrupt_ids[i];
-            assert(interruptID >= 0);
             assert(interruptID <= 47);
             std::string pinName =
                 csprintf("%s.local_interrupt_pins[%d]", p.name, i);


### PR DESCRIPTION
`assert(interruptID >=0)` is always true as `interruptID` is an unsigned int.

This was causing compilation tests failures in GCC-8 with the following
error:

```sh
src/arch/riscv/interrupts.cc:47:32: error: comparison is always true due to limited range of data type [-Werror=type-limits]
             assert(interruptID >= 0);
```

Change-Id: I356be78d7f75ea5d20d34768fb8ece0f746be2fc