### PR TITLE
arch-riscv: adding stats to show completed page walks

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -408,10 +408,12 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         doTLBInsert = true;
 
                         // Update statistics for completed page walks
-                        if (level == 1)
+                        if (level == 1) {
                             walker->pagewalkerstats.num_2mb_walks++;
-                        else if (level == 0)
+                        }
+                        if (level == 0) {
                             walker->pagewalkerstats.num_4kb_walks++;
+                        }
                         DPRINTF(PageTableWalker,
                                 "#1 leaf node at level %d, with vpn %#x\n",
                                 level, entry.vaddr);

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -391,6 +391,9 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                     }
                     // perform step 8 only if pmp checks pass
                     if (fault == NoFault) {
+                        DPRINTF(PageTableWalker,
+                                "#0 leaf node at level %d, with vpn %#x\n",
+                                 level, entry.vaddr);
 
                         // step 8
                         entry.logBytes = PageShift + (level * LEVEL_BITS);
@@ -403,6 +406,15 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         if (!pte.d && mode != BaseMMU::Write)
                             entry.pte.w = 0;
                         doTLBInsert = true;
+
+                        // Update statistics for completed page walks
+                        if (level == 1)
+                            walker->pagewalkerstats.num_2mb_walks++;
+                        else if (level == 0)
+                            walker->pagewalkerstats.num_4kb_walks++;
+                        DPRINTF(PageTableWalker,
+                                "#1 leaf node at level %d, with vpn %#x\n",
+                                level, entry.vaddr);
                     }
                 }
             } else {
@@ -647,6 +659,15 @@ Walker::WalkerState::pageFault(bool present)
 {
     DPRINTF(PageTableWalker, "Raising page fault.\n");
     return walker->tlb->createPagefault(entry.vaddr, mode);
+}
+
+Walker::PagewalkerStats::PagewalkerStats(statistics::Group *parent)
+  : statistics::Group(parent),
+    ADD_STAT(num_4kb_walks, statistics::units::Count::get(),
+             "Completed page walks with 4KB pages"),
+    ADD_STAT(num_2mb_walks, statistics::units::Count::get(),
+             "Completed page walks with 2MB pages")
+{
 }
 
 } // namespace RiscvISA

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -46,6 +46,7 @@
 #include "arch/riscv/pma_checker.hh"
 #include "arch/riscv/pmp.hh"
 #include "arch/riscv/tlb.hh"
+#include "base/statistics.hh"
 #include "base/types.hh"
 #include "mem/packet.hh"
 #include "params/RiscvPagetableWalker.hh"
@@ -193,6 +194,16 @@ namespace RiscvISA
         void recvReqRetry();
         bool sendTiming(WalkerState * sendingState, PacketPtr pkt);
 
+        struct PagewalkerStats : public statistics::Group
+        {
+            PagewalkerStats(statistics::Group *parent);
+
+            statistics::Scalar num_4kb_walks;
+            statistics::Scalar num_2mb_walks;
+
+        } pagewalkerstats;
+
+
       public:
 
         void setTLB(TLB * _tlb)
@@ -209,7 +220,8 @@ namespace RiscvISA
             pmp(params.pmp),
             requestorId(sys->getRequestorId(this)),
             numSquashable(params.num_squash_per_cycle),
-            startWalkWrapperEvent([this]{ startWalkWrapper(); }, name())
+            startWalkWrapperEvent([this]{ startWalkWrapper(); }, name()),
+            pagewalkerstats(this)
         {
         }
     };


### PR DESCRIPTION
This commit adds statistics showing completed page walks for 4KB and 2MB pages. This will add to stats.txt the variables num_4kb_walks, num_2mb_walks and the corresponding values. This is done based on the level of page table walk traversed specific to Sv39 Virtual Memory System.