### PR TITLE
mem-cache: Fix possible crash in base prefetcher

### DIFF
--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, 2023 ARM Limited
+ * Copyright (c) 2013-2014, 2023-2024 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -65,7 +65,7 @@ Base::PrefetchInfo::PrefetchInfo(PacketPtr pkt, Addr addr, bool miss)
     paddress(pkt->req->getPaddr()), cacheMiss(miss)
 {
     unsigned int req_size = pkt->req->getSize();
-    if (!write && miss) {
+    if ((!write && miss) || !pkt->hasData()) {
         data = nullptr;
     } else {
         data = new uint8_t[req_size];


### PR DESCRIPTION
When processing memory Packets for prefetch, the `PrefetchInfo` class constructor will attempt to copy the `Packet` data. In cases where the `Packet` under consideration does not contain data, an assertion will be triggered in the Packet's `getConstPtr` method, causing the simulation to crash.

This problem was first exposed by Bug #580 when processing an `UpgradeReq` memory packet.

This patch addresses the problem by suppressing the copying of the `Packet` data during construction of a `PrefetchInfo` object in cases where the `Packet` has no data.

This patch addresses Bug #580 [1], which was exposed by PR #564 [2], subsequently reverted by PR #581 [3]

[1] https://github.com/gem5/gem5/issues/580
[2] https://github.com/gem5/gem5/pull/564
[3] https://github.com/gem5/gem5/pull/581

Change-Id: Ic1e828c0887f4003441b61647440c8e912bf0fbc
Reviewed-by: Andreas Sandberg <andreas.sandberg@arm.com>