### PR TITLE
arch-arm: Add FEAT_FGT trapping for debug registers

### DIFF
--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -1162,6 +1162,8 @@ std::unordered_map<MiscRegNum64, MiscRegIndex> miscRegNumToIdx{
     { MiscRegNum64(3, 4, 2, 6, 0), MISCREG_VSTTBR_EL2 },
     { MiscRegNum64(3, 4, 2, 6, 2), MISCREG_VSTCR_EL2 },
     { MiscRegNum64(3, 4, 3, 0, 0), MISCREG_DACR32_EL2 },
+    { MiscRegNum64(3, 4, 3, 1, 4), MISCREG_HDFGRTR_EL2 },
+    { MiscRegNum64(3, 4, 3, 1, 5), MISCREG_HDFGWTR_EL2 },
     { MiscRegNum64(3, 4, 4, 0, 0), MISCREG_SPSR_EL2 },
     { MiscRegNum64(3, 4, 4, 0, 1), MISCREG_ELR_EL2 },
     { MiscRegNum64(3, 4, 4, 1, 0), MISCREG_SP_EL1 },
@@ -6174,6 +6176,12 @@ ISA::initializeMiscRegMetadata()
       .fault(EL2, faultFgtCtrlRegs)
       .hyp().mon(release->has(ArmExtension::FEAT_FGT));
     InitReg(MISCREG_HFGITR_EL2)
+      .fault(EL2, faultFgtCtrlRegs)
+      .hyp().mon(release->has(ArmExtension::FEAT_FGT));
+    InitReg(MISCREG_HDFGRTR_EL2)
+      .fault(EL2, faultFgtCtrlRegs)
+      .hyp().mon(release->has(ArmExtension::FEAT_FGT));
+    InitReg(MISCREG_HDFGWTR_EL2)
       .fault(EL2, faultFgtCtrlRegs)
       .hyp().mon(release->has(ArmExtension::FEAT_FGT));
 

--- a/src/arch/arm/regs/misc.hh
+++ b/src/arch/arm/regs/misc.hh
@@ -1139,6 +1139,8 @@ namespace ArmISA
         MISCREG_HFGITR_EL2,
         MISCREG_HFGRTR_EL2,
         MISCREG_HFGWTR_EL2,
+        MISCREG_HDFGRTR_EL2,
+        MISCREG_HDFGWTR_EL2,
 
         // NUM_PHYS_MISCREGS specifies the number of actual physical
         // registers, not considering the following pseudo-registers
@@ -2854,6 +2856,8 @@ namespace ArmISA
         "hfgitr_el2",
         "hfgrtr_el2",
         "hfgwtr_el2",
+        "hdfgrtr_el2",
+        "hdfgwtr_el2",
 
         "num_phys_regs",
 

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -1064,6 +1064,22 @@ namespace ArmISA
         Bitfield<0> afsr0EL1;
     EndBitUnion(HFGTR)
 
+    // HDFGRTR and HDFGWTR
+    BitUnion64(HDFGTR)
+        Bitfield<11> osdlrEL1;
+        Bitfield<10> oseccrEL1;
+        Bitfield<9> oslsrEL1;
+        Bitfield<8> oslarEL1;
+        Bitfield<7> dbgprcrEL1;
+        Bitfield<6> dbgauthstatusEL1;
+        Bitfield<5> dbgclaim;
+        Bitfield<4> mdscrEL1;
+        Bitfield<3> dbgwvrnEL1;
+        Bitfield<2> dbgwcrnEL1;
+        Bitfield<1> dbgbvrnEL1;
+        Bitfield<0> dbgbcrnEL1;
+    EndBitUnion(HDFGTR)
+
     BitUnion64(HCRX)
         Bitfield<15> sctlr2En;
         Bitfield<14> tcr2En;


### PR DESCRIPTION
We already implemented FEAT_FGT but we were missing trapping capabilities for trapping debug registers accesses