### PR TITLE
configs: Ensure m5ops base doesn't overlap physical mem in KVM

### DIFF
--- a/configs/deprecated/example/se.py
+++ b/configs/deprecated/example/se.py
@@ -224,7 +224,7 @@ for cpu in system.cpu:
 if ObjectList.is_kvm_cpu(CPUClass) or ObjectList.is_kvm_cpu(FutureClass):
     if buildEnv["USE_X86_ISA"]:
         system.kvm_vm = KvmVM()
-        system.m5ops_base = 0xFFFF0000
+        system.m5ops_base = max(0xFFFF0000, Addr(args.mem_size).getValue())
         for process in multiprocesses:
             process.useArchPT = True
             process.kvmInSE = True


### PR DESCRIPTION
Fix #874, in which running se.py with 4GB or more memory (via option --mem-size=4GB) causes all KVM programs to crash or hang. This occurred because the m5ops address range (set to 0xFFFF0000-0x100000000) overlapped with physical memory under such a configuration.

This patch fixes the bug by moving the m5ops address range if phyiscal memory is >=4GB.

Change-Id: Ic8a004517bc2be2c27860ed314460be749a11dc1