### PR TITLE
arch-x86, cpu-kvm: initialize x87 FCW

### DIFF
--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -398,6 +398,7 @@ X86_64Process::initState()
 
             tc->setMiscReg(misc_reg::Mxcsr, 0x1f80);
             tc->setMiscReg(misc_reg::Ftw, 0xffff);
+            tc->setMiscReg(misc_reg::Fcw, 0x037f);
 
             tc->setMiscReg(misc_reg::ApicBase, 0xfee00900);
 
@@ -617,6 +618,7 @@ X86_64Process::initState()
 
             tc->setMiscReg(misc_reg::Mxcsr, 0x1f80);
             tc->setMiscReg(misc_reg::Ftw, 0xffff);
+            tc->setMiscReg(misc_reg::Fcw, 0x037f);
 
             // Setting CR3 to the process pid so that concatinated
             // page addr with lower 12 bits of CR3 can be used in SE
@@ -752,6 +754,7 @@ I386Process::initState()
 
         tc->setMiscReg(misc_reg::Mxcsr, 0x1f80);
         tc->setMiscReg(misc_reg::Ftw, 0xffff);
+        tc->setMiscReg(misc_reg::Fcw, 0x037f);
     }
 }
 


### PR DESCRIPTION
Fix #876. The x87 floating-point control word (FCW) was not initialized at process startup in syscall emulation mode. This resulted in floating point exceptions in KVM mode when executing x87 floating-point instructions.

This patch fixes the bug by initializing FCW to its reset value, 0x37F.

Change-Id: Idd1573c6951524ef59466cc5c9f1e640ea7658ae