### PR TITLE
dev-arm: Remove the dependency of Platform for ArmSigInterruptPin

### DIFF
--- a/src/dev/arm/Gic.py
+++ b/src/dev/arm/Gic.py
@@ -155,6 +155,7 @@ class ArmSigInterruptPin(ArmInterruptPin):
     cxx_class = "gem5::ArmSigInterruptPinGen"
 
     irq = IntSourcePin("Interrupt pin")
+    platform = NULL
 
 
 class GicV2(BaseGic):

--- a/src/dev/arm/base_gic.cc
+++ b/src/dev/arm/base_gic.cc
@@ -154,7 +154,6 @@ ArmInterruptPin::ArmInterruptPin(
       : threadContext(tc), platform(dynamic_cast<RealView*>(p.platform)),
         intNum(p.num), triggerType(p.int_type), _active(false)
 {
-    fatal_if(!platform, "Interrupt not connected to a RealView platform");
 }
 
 void
@@ -190,6 +189,7 @@ ArmSPI::ArmSPI(
     const ArmSPIParams &p)
       : ArmInterruptPin(p, nullptr)
 {
+    fatal_if(!platform, "Interrupt not connected to a RealView platform");
 }
 
 void
@@ -210,6 +210,7 @@ ArmPPI::ArmPPI(
     const ArmPPIParams &p, ThreadContext *tc)
       : ArmInterruptPin(p, tc)
 {
+    fatal_if(!platform, "Interrupt not connected to a RealView platform");
 }
 
 void


### PR DESCRIPTION
ArmSigInterruptPin don't send the interrupt to GIC. Instead it sends the interrupt to the irq specified in Param. When using ArmSigInterruptPin, we shouldn't ask users to provide "Platform" since it doesn't need it. To reduce the confusion, this change removes the dependency of Platform for ArmSigInterruptPin.

Change-Id: I0ee507ed1c08b4fa6d3e384e28732f3acb4f6892