### PR TITLE
python,util: Fix SimObjectParams default constructor and destructor

### DIFF
--- a/build_tools/sim_object_param_struct_hh.py
+++ b/build_tools/sim_object_param_struct_hh.py
@@ -211,8 +211,7 @@ code.indent()
 if sim_object == SimObject:
     code(
         """
-SimObjectParams() {}
-virtual ~SimObjectParams() {}
+virtual ~SimObjectParams() = default;
 
 std::string name;
     """


### PR DESCRIPTION
The empty constructor prevent zero-initialization working correctly. In this change we fix the issue by removing the unwanted empty constructor. We also change the default destructor specification with c++11 style.

Change-Id: I869a93ca5283f811c2aa58406f1478459e0d7022