### PR TITLE
arch-riscv,dev: Update the PLIC implementation

### DIFF
--- a/src/dev/riscv/HiFive.py
+++ b/src/dev/riscv/HiFive.py
@@ -221,10 +221,10 @@ class HiFive(HiFiveBase):
         self.plic.n_src = max(plic_srcs) + 1
 
     def setNumCores(self, num_cpu):
-        """Sets the PLIC and CLINT to have the right number of threads and
-        contexts. Assumes that the cores have a single hardware thread.
+        """Sets the CLINT to number of threads and the PLIC hartID/pmode for
+        each contexts. Assumes that the cores have a single hardware thread.
         """
-        self.plic.n_contexts = num_cpu * 2
+        self.plic.hart_config = ",".join(["MS" for _ in range(num_cpu)])
         self.clint.num_threads = num_cpu
 
     def generateDeviceTree(self, state):

--- a/src/dev/riscv/plic.hh
+++ b/src/dev/riscv/plic.hh
@@ -57,11 +57,9 @@ namespace gem5
 using namespace RiscvISA;
 /**
  * NOTE:
- * This implementation of CLINT is based on
- * the SiFive U54MC datasheet:
- * https://sifive.cdn.prismic.io/sifive/fab000f6-
- * 0e07-48d0-9602-e437d5367806_sifive_U54MC_rtl_
- * full_20G1.03.00_manual.pdf
+ * This implementation of PLIC is based on
+ * he riscv-plic-spec repository:
+ * https://github.com/riscv/riscv-plic-spec/releases/tag/1.0.0
  */
 
 /**
@@ -124,13 +122,9 @@ class Plic : public PlicBase
      */
     int nSrc32;
     /**
-     * Number of interrupt contexts
-     * = nThread * 2
-     * e.g. context 0 => thread 0 M mode
-     *      context 1 => thread 0 S mode
-     * This is based on SiFive U54MC datasheet
+     * PLIC hart/pmode address configs, stored in the format {hartID, pmode}
      */
-    int nContext;
+    std::vector<std::pair<uint32_t, ExceptionCode>> contextConfigs;
 
   public:
     typedef PlicParams Params;
@@ -260,6 +254,12 @@ class Plic : public PlicBase
     // per-context last-claimed id
     std::vector<uint32_t> lastID;
     PlicOutput output;
+
+    /**
+     * The function for handling context config from params
+     */
+    void initContextFromNContexts(int n_contexts);
+    void initContextFromHartConfig(const std::string& hart_config);
 
     /**
      * Trigger:

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -149,7 +149,9 @@ class RISCVMatchedBoard(
             # Contains a CLINT, PLIC, UART, and some functions for the dtb, etc.
             self.platform = HiFive()
             # Note: This only works with single threaded cores.
-            self.platform.plic.n_contexts = self.processor.get_num_cores() * 2
+            self.platform.plic.hart_config = ",".join(
+                ["MS" for _ in range(self.processor.get_num_cores())]
+            )
             self.platform.attachPlic()
             self.platform.clint.num_threads = self.processor.get_num_cores()
 
@@ -433,12 +435,19 @@ class RISCVMatchedBoard(
         plic_node.append(FdtPropertyWords("riscv,ndev", [plic.n_src - 1]))
 
         int_extended = list()
-        for i, core in enumerate(self.get_processor().get_cores()):
-            phandle = state.phandle(f"cpu@{i}.int_state")
-            int_extended.append(phandle)
-            int_extended.append(0xB)
-            int_extended.append(phandle)
-            int_extended.append(0x9)
+        cpu_id = 0
+        phandle = int_state.phandle(f"cpu@{cpu_id}.int_state")
+        for c in plic.hart_config:
+            if c == ",":
+                cpu_id += 1
+                assert cpu_id < self.get_processor().get_num_cores()
+                phandle = int_state.phandle(f"cpu@{cpu_id}.int_state")
+            elif c == "S":
+                int_extended.append(phandle)
+                int_extended.append(0x9)
+            elif c == "M":
+                int_extended.append(phandle)
+                int_extended.append(0xB)
 
         plic_node.append(FdtPropertyWords("interrupts-extended", int_extended))
         plic_node.append(FdtProperty("interrupt-controller"))


### PR DESCRIPTION
Update the PLIC based on the [riscv-plic-spec](https://github.com/riscv/riscv-plic-spec) in the PR:
- Support customized PLIC hardID and privilege mode configuration
- Backward compatable with the n_contexts parameter, will generate the config like {0,M}, {0,S}, {1,M} ...

Change-Id: Ibff736827edb7c97921e01fa27f503574a27a562