### PR TITLE
sim-se: Implement statx system call for Linux x86-64

### DIFF
--- a/src/arch/x86/linux/linux.hh
+++ b/src/arch/x86/linux/linux.hh
@@ -119,6 +119,49 @@ class X86Linux64 : public X86Linux, public OpenFlagTable<X86Linux64>
         int64_t unused0[3];
     };
 
+    struct tgt_statx
+    {
+        /* 0x00 */
+        uint32_t stx_mask;
+        uint32_t stx_blksize;
+        uint64_t stx_attributes;
+        /* 0x10 */
+        uint32_t stx_nlink;
+        uint32_t stx_uid;
+        uint32_t stx_gid;
+        uint16_t stx_mode;
+        uint16_t stx_spare0;
+        /* 0x20 */
+        uint64_t stx_ino;
+        uint64_t stx_size;
+        uint64_t stx_blocks;
+        uint64_t stx_attributes_mask;
+        /* 0x40 */
+        uint64_t stx_atimeX;
+        uint32_t stx_atime_nsec;
+        int32_t  stx_atime_reserved;
+        uint64_t stx_btimeX;
+        uint32_t stx_btime_nsec;
+        int32_t  stx_btime_reserved;
+        uint64_t stx_ctimeX;
+        uint32_t stx_ctime_nsec;
+        int32_t  stx_ctime_reserved;
+        uint64_t stx_mtimeX;
+        uint32_t stx_mtime_nsec;
+        int32_t  stx_mtime_reserved;
+        /* 0x80 */
+        uint32_t stx_rdev_major;
+        uint32_t stx_rdev_minor;
+        uint32_t stx_dev_major;
+        uint32_t stx_dev_minor;
+        /* 0x90 */
+        uint64_t stx_mnt_id;
+        uint64_t stx_spare2;
+        /* 0xa0 */
+        uint64_t stx_spare3[12];
+        /* 0x100 */
+    };
+
     struct tgt_fsid
     {
         long val[2];

--- a/src/arch/x86/linux/syscall_tbl64.cc
+++ b/src/arch/x86/linux/syscall_tbl64.cc
@@ -375,7 +375,7 @@ SyscallDescTable<EmuLinux::SyscallABI64> EmuLinux::syscallDescs64 = {
     { 329, "pkey_mprotect" },
     { 330, "pkey_alloc" },
     { 331, "pkey_free" },
-    { 332, "statx" },
+    { 332, "statx", statxFunc<X86Linux64> },
     { 333, "io_pgetevents" },
     { 334, "rseq", ignoreFunc },
     { 424, "pidfd_send_signal" },


### PR DESCRIPTION
Implement the statx Linux-specific system call for x86-64. statx is used by LLVM's libc.

Change-Id: Ic000a36a5e5c1399996f520fa357b9354c73c864