### PR TITLE
mem: QoS q_policy assertions fix

### DIFF
--- a/src/mem/qos/q_policy.cc
+++ b/src/mem/qos/q_policy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 ARM Limited
+ * Copyright (c) 2018,2024 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -91,10 +91,10 @@ LrgQueuePolicy::selectPacket(PacketQueue* q)
                      "from queue with id %d\n", requestor_id);
 
         // Check if this is a known requestor.
-        panic_if(memCtrl->hasRequestor(requestor_id),
+        panic_if(!memCtrl->hasRequestor(requestor_id),
                  "%s: Unrecognized Requestor\n", __func__);
 
-        panic_if(toServe.size() > 0,
+        panic_if(toServe.size() <= 0,
                  "%s: toServe list is empty\n", __func__);
 
         if (toServe.front() == requestor_id) {

--- a/src/mem/qos/q_policy.cc
+++ b/src/mem/qos/q_policy.cc
@@ -70,8 +70,26 @@ QueuePolicy::create(const QoSMemCtrlParams &p)
 }
 
 QueuePolicy::PacketQueue::iterator
+FifoQueuePolicy::selectPacket(PacketQueue* queue)
+{
+    panic_if(queue->empty(),
+             "Provided packet queue is not usable by queue policy");
+    return queue->begin();
+}
+
+QueuePolicy::PacketQueue::iterator
+LifoQueuePolicy::selectPacket(PacketQueue* queue)
+{
+    panic_if(queue->empty(),
+             "Provided packet queue is not usable by queue policy");
+    return std::prev(queue->end());
+}
+
+QueuePolicy::PacketQueue::iterator
 LrgQueuePolicy::selectPacket(PacketQueue* q)
 {
+    panic_if(q->empty(),
+             "Provided packet queue is not usable by queue policy");
     QueuePolicy::PacketQueue::iterator ret = q->end();
 
     // Tracks one packet per requestor in the queue
@@ -137,8 +155,7 @@ LrgQueuePolicy::selectPacket(PacketQueue* q)
 
     DPRINTF(QOS, "QoSQPolicy::lrg no packet was serviced\n");
 
-    // Ret will be : packet to serve if any found or queue begin
-    // (end if queue is empty)
+    // Ret will be : packet to serve
     return ret;
 }
 

--- a/src/mem/qos/q_policy.hh
+++ b/src/mem/qos/q_policy.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 ARM Limited
+ * Copyright (c) 2018, 2024 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -93,7 +93,7 @@ class QueuePolicy
      * The implementation of this virtual method selects the packet
      * to be serviced from the packet queue passed as an argument.
      *
-     * @param queue Packet queue
+     * @param queue Non-empty packet queue to select a packet from
      * @return Iterator pointing to the packet in the queue to be
      *         serviced
      */
@@ -127,14 +127,11 @@ class LifoQueuePolicy : public QueuePolicy
     /**
      * Implements LIFO packet select policy
      *
-     * @param queue The queue in which to select a packet
+     * @param queue The non-empty queue from which to select a packet
      * @return Iterator to the selected packet
      */
     PacketQueue::iterator
-    selectPacket(PacketQueue* queue) override
-    {
-        return queue->end();
-    }
+    selectPacket(PacketQueue* queue) override;
 };
 
 /** First In First Out Queue Policy */
@@ -148,14 +145,11 @@ class FifoQueuePolicy : public QueuePolicy
     /**
      * Implements FCFS packet select policy
      *
-     * @param queue The queue in which to select a packet
+     * @param queue The non-empty queue from which to select a packet
      * @return Iterator to the selected packet
      */
     PacketQueue::iterator
-    selectPacket(PacketQueue* queue) override
-    {
-        return queue->begin();
-    }
+    selectPacket(PacketQueue* queue) override;
 };
 
 /**
@@ -176,7 +170,7 @@ class LrgQueuePolicy : public QueuePolicy
     /**
      * Implements LRG packet select policy
      *
-     * @param queue The queue in which to select a packet
+     * @param queue The non-empty queue from which to select a packet
      * @return Iterator to the selected packet
      */
     PacketQueue::iterator


### PR DESCRIPTION
Fix QoS Memory Queue Policies

* Fix assertions in LRG policy to correctly assert requestor and list validity
* Fix `selectPacket()` in LIFO Queue Policy to correctly return the end of the `deque` backing store for its packet queue