### PR TITLE
sim-se, arch-x86: initialize max stack size from parameter

### DIFF
--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -112,7 +112,7 @@ X86_64Process::X86_64Process(const ProcessParams &params,
 
     Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     Addr stack_base = 0x7FFFFFFFF000ULL;
-    Addr max_stack_size = 8 * 1024 * 1024;
+    Addr max_stack_size = params.maxStackSize;
     Addr next_thread_stack_base = stack_base - max_stack_size;
     Addr mmap_end = 0x7FFFF7FFF000ULL;
 


### PR DESCRIPTION
Initialize x86 process' max stack size to the value given in the process params, rather than hard-coding it to 8 MB, which made it impossible to run x86 programs requiring more than 8 MB of stack.

Change-Id: I0b17fe60b016b1e4a82d704ef7ad367974ea6a08