### PR TITLE
mem-ruby: Add missing transition for SLC writes to VIPER TCC

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -1106,7 +1106,7 @@ machine(MachineType:TCC, "TCC Cache")
     st_stallAndWaitRequest;
   }
 
-  transition(I, WrVicBlk) {TagArrayRead} {
+  transition(I, {WrVicBlk, WrVicBlkEvict}) {TagArrayRead} {
     p_profileMiss;
     wt_writeThrough;
     p_popRequestQueue;


### PR DESCRIPTION
Bypassed write though requests on invalid lines in the TCC should be written though to the directory. This transition was previously missing.

Change-Id: I16b117c4e085ce6be0ed5297aa0129d52cd35a51