### PR TITLE
arch-vega: Implement accumulation offset

### DIFF
--- a/src/arch/amdgpu/vega/insts/vop3p.cc
+++ b/src/arch/amdgpu/vega/insts/vop3p.cc
@@ -596,10 +596,10 @@ void Inst_VOP3P__V_DOT8_U32_U4::execute(GPUDynInstPtr gpuDynInst)
 
 void Inst_VOP3P__V_ACCVGPR_READ::execute(GPUDynInstPtr gpuDynInst)
 {
-    // The Acc register file is not supported in gem5 and has been removed
-    // in MI200. Therefore this instruction becomes a mov.
     Wavefront *wf = gpuDynInst->wavefront();
-    ConstVecOperandU32 src(gpuDynInst, extData.SRC0);
+    unsigned accum_offset = wf->accumOffset;
+
+    ConstVecOperandU32 src(gpuDynInst, extData.SRC0+accum_offset);
     VecOperandU32 vdst(gpuDynInst, instData.VDST);
 
     src.readSrc();
@@ -615,11 +615,11 @@ void Inst_VOP3P__V_ACCVGPR_READ::execute(GPUDynInstPtr gpuDynInst)
 
 void Inst_VOP3P__V_ACCVGPR_WRITE::execute(GPUDynInstPtr gpuDynInst)
 {
-    // The Acc register file is not supported in gem5 and has been removed
-    // in MI200. Therefore this instruction becomes a mov.
     Wavefront *wf = gpuDynInst->wavefront();
+    unsigned accum_offset = wf->accumOffset;
+
     ConstVecOperandU32 src(gpuDynInst, extData.SRC0);
-    VecOperandU32 vdst(gpuDynInst, instData.VDST);
+    VecOperandU32 vdst(gpuDynInst, instData.VDST+accum_offset);
 
     src.readSrc();
 

--- a/src/gpu-compute/gpu_command_processor.cc
+++ b/src/gpu-compute/gpu_command_processor.cc
@@ -723,7 +723,6 @@ GPUCommandProcessor::sanityCheckAKC(AMDKernelCode *akc)
     warn_if(akc->kernarg_preload_spec_length ||
             akc->kernarg_preload_spec_offset,
             "Kernarg preload not implemented\n");
-    warn_if(akc->accum_offset, "ACC offset not implemented\n");
     warn_if(akc->tg_split, "TG split not implemented\n");
 }
 

--- a/src/gpu-compute/hsa_queue_entry.hh
+++ b/src/gpu-compute/hsa_queue_entry.hh
@@ -122,6 +122,11 @@ class HSAQueueEntry
         }
 
         parseKernelCode(akc);
+
+        // Offset of a first AccVGPR in the unified register file.
+        // Granularity 4. Value 0-63. 0 - accum-offset = 4,
+        // 1 - accum-offset = 8, ..., 63 - accum-offset = 256.
+        _accumOffset = (akc->accum_offset + 1) * 4;
     }
 
     const GfxVersion&
@@ -394,6 +399,12 @@ class HSAQueueEntry
         assert(_outstandingWbs >= 0);
     }
 
+    unsigned
+    accumOffset() const
+    {
+        return _accumOffset;
+    }
+
   private:
     void
     parseKernelCode(AMDKernelCode *akc)
@@ -489,6 +500,8 @@ class HSAQueueEntry
 
     std::bitset<NumVectorInitFields> initialVgprState;
     std::bitset<NumScalarInitFields> initialSgprState;
+
+    unsigned _accumOffset;
 };
 
 } // namespace gem5

--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -430,6 +430,9 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
         }
     }
 
+    // Save the offset to the first accumulation VGPR number from HSA task.
+    accumOffset = task->accumOffset();
+
     regInitIdx = 0;
 
     // VGPRs are initialized to the work item IDs for a given thread. There

--- a/src/gpu-compute/wavefront.hh
+++ b/src/gpu-compute/wavefront.hh
@@ -131,6 +131,8 @@ class Wavefront : public SimObject
     uint32_t maxVgprs;
     // number of SGPRs required by WF
     uint32_t maxSgprs;
+    // first accumulation vgpr number
+    uint32_t accumOffset;
     void freeResources();
     GPUDynInstPtr nextInstr();
     void setStatus(status_e newStatus);


### PR DESCRIPTION
This PR implements a few changes related to the accumulation offset which is new in MI200. Previously MI100 contained two vector register files: the architectural and accumulation register files. These have now been unified and the architectural register file is twice the size. As a result of this the dispatch packet set an offset into the unified vector register file for where the former accumulation registers would go. The changes are:

- Calculate the accumulation offset from dispatch packet and store in HSA task.
- Update the accumulation move instructions (v_accvgpr_read/write) to use it.
- Update the current MFMA instructions to use it.
- Make the MFMA examples more clean.