### PR TITLE
tests: Update tests to use specific resource versions

### DIFF
--- a/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
+++ b/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
@@ -205,14 +205,17 @@ board.set_kernel_disk_workload(
     kernel=obtain_resource(
         "arm64-linux-kernel-5.4.49",
         resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     bootloader=obtain_resource(
         "arm64-bootloader-foundation",
         resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     disk_image=obtain_resource(
         "arm64-ubuntu-20.04-img",
         resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
 )
 

--- a/tests/gem5/checkpoint_tests/configs/arm-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/arm-hello-restore-checkpoint.py
@@ -67,7 +67,7 @@ board = SimpleBoard(
 )
 
 board.set_se_binary_workload(
-    obtain_resource("arm-hello64-static"),
+    obtain_resource("arm-hello64-static", resource_version="1.0.0"),
     checkpoint=obtain_resource(
         "arm-hello-test-checkpoint", resource_version="1.0.0"
     ),

--- a/tests/gem5/checkpoint_tests/configs/arm-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/arm-hello-restore-checkpoint.py
@@ -68,7 +68,9 @@ board = SimpleBoard(
 
 board.set_se_binary_workload(
     obtain_resource("arm-hello64-static"),
-    checkpoint=obtain_resource("arm-hello-test-checkpoint"),
+    checkpoint=obtain_resource(
+        "arm-hello-test-checkpoint", resource_version="1.0.0"
+    ),
 )
 
 sim = Simulator(board=board, full_system=False)

--- a/tests/gem5/checkpoint_tests/configs/arm-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/arm-hello-save-checkpoint.py
@@ -63,7 +63,12 @@ board = SimpleBoard(
     memory=memory,
     cache_hierarchy=cache_hierarchy,
 )
-board.set_se_binary_workload(obtain_resource("arm-hello64-static"))
+board.set_se_binary_workload(
+    obtain_resource(
+        "arm-hello64-static",
+        resource_version="1.0.0",
+    )
+)
 
 sim = Simulator(board=board, full_system=False)
 max_ticks = 10**6

--- a/tests/gem5/checkpoint_tests/configs/power-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/power-hello-restore-checkpoint.py
@@ -61,7 +61,7 @@ board = SimpleBoard(
     cache_hierarchy=cache_hierarchy,
 )
 board.set_se_binary_workload(
-    obtain_resource("power-hello"),
+    obtain_resource("power-hello", resource_version="1.0.0"),
     checkpoint=obtain_resource(
         "power-hello-test-checkpoint-v24-0", resource_version="2.0.0"
     ),

--- a/tests/gem5/checkpoint_tests/configs/power-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/power-hello-restore-checkpoint.py
@@ -62,7 +62,9 @@ board = SimpleBoard(
 )
 board.set_se_binary_workload(
     obtain_resource("power-hello"),
-    checkpoint=obtain_resource("power-hello-test-checkpoint-v24-0"),
+    checkpoint=obtain_resource(
+        "power-hello-test-checkpoint-v24-0", resource_version="2.0.0"
+    ),
 )
 
 sim = Simulator(board=board, full_system=False)

--- a/tests/gem5/checkpoint_tests/configs/power-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/power-hello-save-checkpoint.py
@@ -69,7 +69,9 @@ board = SimpleBoard(
     memory=memory,
     cache_hierarchy=cache_hierarchy,
 )
-board.set_se_binary_workload(obtain_resource("power-hello"))
+board.set_se_binary_workload(
+    obtain_resource("power-hello", resource_version="1.0.0")
+)
 
 sim = Simulator(board=board, full_system=False)
 max_ticks = 10**6

--- a/tests/gem5/checkpoint_tests/configs/sparc-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/sparc-hello-save-checkpoint.py
@@ -69,7 +69,12 @@ board = SimpleBoard(
     memory=memory,
     cache_hierarchy=cache_hierarchy,
 )
-board.set_se_binary_workload(obtain_resource("sparc-hello"))
+board.set_se_binary_workload(
+    obtain_resource(
+        "sparc-hello",
+        resource_version="1.0.0",
+    )
+)
 
 sim = Simulator(board=board, full_system=False)
 max_ticks = 10**6

--- a/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
@@ -76,7 +76,9 @@ board = X86Board(
 board.set_kernel_disk_workload(
     kernel=obtain_resource("x86-linux-kernel-5.4.49"),
     disk_image=obtain_resource("x86-ubuntu-18.04-img"),
-    checkpoint=obtain_resource("x86-fs-test-checkpoint-v24-0"),
+    checkpoint=obtain_resource(
+        "x86-fs-test-checkpoint-v24-0", resource_version="2.0.0"
+    ),
 )
 
 sim = Simulator(board=board, full_system=True)

--- a/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
@@ -74,8 +74,12 @@ board = X86Board(
 
 # Set the Full System workload.
 board.set_kernel_disk_workload(
-    kernel=obtain_resource("x86-linux-kernel-5.4.49"),
-    disk_image=obtain_resource("x86-ubuntu-18.04-img"),
+    kernel=obtain_resource(
+        "x86-linux-kernel-5.4.49", resource_version="1.0.0"
+    ),
+    disk_image=obtain_resource(
+        "x86-ubuntu-18.04-img", resource_version="1.0.0"
+    ),
     checkpoint=obtain_resource(
         "x86-fs-test-checkpoint-v24-0", resource_version="2.0.0"
     ),

--- a/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
@@ -62,7 +62,9 @@ board = SimpleBoard(
 )
 board.set_se_binary_workload(
     obtain_resource("x86-hello64-static"),
-    checkpoint=obtain_resource("x86-hello-test-checkpoint-v24-0"),
+    checkpoint=obtain_resource(
+        "x86-hello-test-checkpoint-v24-0", resource_version="2.0.0"
+    ),
 )
 
 sim = Simulator(board=board, full_system=False)

--- a/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
@@ -61,7 +61,10 @@ board = SimpleBoard(
     cache_hierarchy=cache_hierarchy,
 )
 board.set_se_binary_workload(
-    obtain_resource("x86-hello64-static"),
+    obtain_resource(
+        "x86-hello64-static",
+        resource_version="1.0.0",
+    ),
     checkpoint=obtain_resource(
         "x86-hello-test-checkpoint-v24-0", resource_version="2.0.0"
     ),

--- a/tests/gem5/checkpoint_tests/configs/x86-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-hello-save-checkpoint.py
@@ -69,7 +69,12 @@ board = SimpleBoard(
     memory=memory,
     cache_hierarchy=cache_hierarchy,
 )
-board.set_se_binary_workload(obtain_resource("x86-hello64-static"))
+board.set_se_binary_workload(
+    obtain_resource(
+        "x86-hello64-static",
+        resource_version="1.0.0",
+    )
+)
 
 sim = Simulator(board=board, full_system=False)
 max_ticks = 10**6

--- a/tests/gem5/kvm_fork_tests/configs/boot_kvm_fork_run.py
+++ b/tests/gem5/kvm_fork_tests/configs/boot_kvm_fork_run.py
@@ -180,10 +180,14 @@ kernel_args = motherboard.get_default_kernel_args() + [args.kernel_args]
 # Set the Full System workload.
 motherboard.set_kernel_disk_workload(
     kernel=obtain_resource(
-        "x86-linux-kernel-5.4.49", resource_directory=args.resource_directory
+        "x86-linux-kernel-5.4.49",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     disk_image=obtain_resource(
-        "x86-ubuntu-18.04-img", resource_directory=args.resource_directory
+        "x86-ubuntu-18.04-img",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     readfile_contents=dedent(
         """

--- a/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
+++ b/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
@@ -166,10 +166,14 @@ kernal_args = motherboard.get_default_kernel_args() + [args.kernel_args]
 # Set the Full System workload.
 motherboard.set_kernel_disk_workload(
     kernel=obtain_resource(
-        "x86-linux-kernel-5.4.49", resource_directory=args.resource_directory
+        "x86-linux-kernel-5.4.49",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     disk_image=obtain_resource(
-        "x86-ubuntu-18.04-img", resource_directory=args.resource_directory
+        "x86-ubuntu-18.04-img",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     # The first exit signals to switch processors.
     readfile_contents="m5 exit\nm5 exit\n",

--- a/tests/gem5/parsec_benchmarks/configs/parsec_disk_run.py
+++ b/tests/gem5/parsec_benchmarks/configs/parsec_disk_run.py
@@ -204,10 +204,14 @@ command = (
 
 board.set_kernel_disk_workload(
     kernel=obtain_resource(
-        "x86-linux-kernel-5.4.49", resource_directory=args.resource_directory
+        "x86-linux-kernel-5.4.49",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     disk_image=obtain_resource(
-        "x86-parsec", resource_directory=args.resource_directory
+        "x86-parsec",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
     readfile_contents=command,
 )

--- a/tests/gem5/riscv_boot_tests/configs/riscv_boot_exit_run.py
+++ b/tests/gem5/riscv_boot_tests/configs/riscv_boot_exit_run.py
@@ -163,7 +163,9 @@ board = RiscvBoard(
 
 # Set the workload.
 workload = obtain_resource(
-    "riscv-ubuntu-20.04-boot", resource_directory=args.resource_directory
+    "riscv-ubuntu-20.04-boot",
+    resource_directory=args.resource_directory,
+    resource_version="3.0.0",
 )
 board.set_workload(workload)
 

--- a/tests/gem5/stdlib/configs/simulator_exit_event_run.py
+++ b/tests/gem5/stdlib/configs/simulator_exit_event_run.py
@@ -103,7 +103,9 @@ motherboard = SimpleBoard(
 # Note: Here we're using the "x86-m5-exit-repeat" resource. This calls an
 # `m5_exit(0)` command in an infinite while-loop.
 binary = obtain_resource(
-    "x86-m5-exit-repeat", resource_directory=args.resource_directory
+    "x86-m5-exit-repeat",
+    resource_directory=args.resource_directory,
+    resource_version="1.0.0",
 )
 motherboard.set_se_binary_workload(binary)
 

--- a/tests/gem5/suite_tests/test_suite.py
+++ b/tests/gem5/suite_tests/test_suite.py
@@ -97,6 +97,7 @@ test_suite(
     isa="riscv",
     to_tick=10000000000,
     is_fs=False,
+    version="1.0.0",
 )
 
 test_suite(
@@ -104,6 +105,7 @@ test_suite(
     isa="x86",
     to_tick=10000000000,
     is_fs=True,
+    version="1.0.0",
 )
 
 test_suite(
@@ -111,4 +113,5 @@ test_suite(
     isa="x86",
     to_tick=10000000000,
     is_fs=True,
+    version="1.0.0",
 )

--- a/tests/gem5/to_tick/configs/tick-exit.py
+++ b/tests/gem5/to_tick/configs/tick-exit.py
@@ -77,7 +77,9 @@ motherboard = SimpleBoard(
 
 # Set the workload
 binary = obtain_resource(
-    "x86-hello64-static", resource_directory=args.resource_directory
+    "x86-hello64-static",
+    resource_directory=args.resource_directory,
+    resource_version="1.0.0",
 )
 motherboard.set_se_binary_workload(binary)
 

--- a/tests/gem5/to_tick/configs/tick-to-max.py
+++ b/tests/gem5/to_tick/configs/tick-to-max.py
@@ -98,7 +98,9 @@ motherboard = SimpleBoard(
 
 # Set the workload
 binary = obtain_resource(
-    "x86-hello64-static", resource_directory=args.resource_directory
+    "x86-hello64-static",
+    resource_directory=args.resource_directory,
+    resource_version="1.0.0",
 )
 motherboard.set_se_binary_workload(binary)
 

--- a/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
+++ b/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
@@ -184,7 +184,9 @@ if args.boot_type == "init":
 
 # Set the workload.
 workload = obtain_resource(
-    "x86-ubuntu-18.04-boot", resource_directory=args.resource_directory
+    "x86-ubuntu-18.04-boot",
+    resource_directory=args.resource_directory,
+    resource_version="2.0.0",
 )
 workload.set_parameter("kernel_args", kernal_args)
 motherboard.set_workload(workload)


### PR DESCRIPTION
This update modifies the test configuration to specify the versions of resources used, rather than automatically using the latest versions. 
Previously, if a resource was updated for a change, it could potentially cause tests to fail if those tests were incompatible with the new version of the resource. 
Now, with this change, tests are tied to specific versions of resources, ensuring that any updates to resources will require corresponding updates to the tests to maintain compatibility.

Change-Id: I9633b1749f6c6c82af6aa6697b7e7656020f62fa