### PR TITLE
sim-se: Catch None value if binary is not compatible with gem5

### DIFF
--- a/src/sim/Workload.py
+++ b/src/sim/Workload.py
@@ -147,6 +147,12 @@ class SEWorkload(Workload, metaclass=SEWorkloadMeta):
         from _m5 import object_file
 
         obj = object_file.create(path)
+
+        if obj is None:
+            raise ValueError(
+                f"{path}: the file is not an object file compatible with gem5."
+            )
+
         options = list(
             filter(
                 lambda wld: wld._is_compatible_with(obj),


### PR DESCRIPTION
Adding an error message in case the binary is not compatible with gem5.

This PR is addressing the comments in issue #807.

Change-Id: I66466ed6f657276c13d237fde3b1ec12c20cfe91