### PR TITLE
stdlib: Fix initialization for self.pic.hart_config in lupv_board

### DIFF
--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -186,7 +186,7 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         # remain unused during the simulation
         self.pic.n_src = 0
         self.pic.hart_config = ",".join(
-            ["MS" for _ in range(self.processor.get_num_cores())]
+            ["M" for _ in range(self.processor.get_num_cores())]
         )
         self.lupio_pic.n_src = max(pic_srcs) + 1
         self.lupio_pic.num_threads = self.processor.get_num_cores()

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -185,7 +185,9 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
         # point for our bbl to use upon startup, and will
         # remain unused during the simulation
         self.pic.n_src = 0
-        self.pic.hart_config = ""
+        self.pic.hart_config = ",".join(
+            ["MS" for _ in range(self.processor.get_num_cores())]
+        )
         self.lupio_pic.n_src = max(pic_srcs) + 1
         self.lupio_pic.num_threads = self.processor.get_num_cores()
 


### PR DESCRIPTION
Previously merged PR #886 created pic.hart_config, but it was not initialized properly in lupv_board.py.  This issue is causing daily tests to fail.

Change-Id: I193ff4a3e5ef787eefcf066404e762f024fa6603