### PR TITLE
misc: Tag checkpoints with the ISA of the CPUs

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -80,7 +80,7 @@ RegClass floatRegClass(FloatRegClass, FloatRegClassName, 0, debug::FloatRegs);
 
 } // anonymous namespace
 
-ISA::ISA(const Params &p) : BaseISA(p), system(NULL),
+ISA::ISA(const Params &p) : BaseISA(p, "arm"), system(NULL),
     _decoderFlavor(p.decoderFlavor), pmu(p.pmu), impdefAsNop(p.impdef_nop)
 {
     _regClasses.push_back(&flatIntRegClass);
@@ -1541,6 +1541,8 @@ ISA::getCurSmeVecLenInBits() const
 void
 ISA::serialize(CheckpointOut &cp) const
 {
+    BaseISA::serialize(cp);
+
     DPRINTF(Checkpoint, "Serializing Arm Misc Registers\n");
     SERIALIZE_MAPPING(miscRegs, miscRegName, NUM_PHYS_MISCREGS);
 }

--- a/src/arch/generic/isa.hh
+++ b/src/arch/generic/isa.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 ARM Limited
+ * Copyright (c) 2020, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -61,11 +61,15 @@ class BaseISA : public SimObject
     typedef std::vector<const RegClass *> RegClasses;
 
   protected:
-    using SimObject::SimObject;
+    BaseISA(const SimObjectParams &p, const std::string &name)
+      : SimObject(p), isaName(name)
+    {}
 
     ThreadContext *tc = nullptr;
 
     RegClasses _regClasses;
+
+    std::string isaName;
 
   public:
     virtual PCStateBase *newPCState(Addr new_inst_addr=0) const = 0;
@@ -125,6 +129,12 @@ class BaseISA : public SimObject
     globalClearExclusive(ExecContext *xc)
     {
         globalClearExclusive();
+    }
+
+    void
+    serialize(CheckpointOut &cp) const override
+    {
+        SERIALIZE_SCALAR(isaName);
     }
 };
 

--- a/src/arch/mips/isa.cc
+++ b/src/arch/mips/isa.cc
@@ -110,7 +110,7 @@ constexpr RegClass ccRegClass(CCRegClass, CCRegClassName, 0, debug::IntRegs);
 
 } // anonymous namespace
 
-ISA::ISA(const Params &p) : BaseISA(p), numThreads(p.num_threads),
+ISA::ISA(const Params &p) : BaseISA(p, "mips"), numThreads(p.num_threads),
     numVpes(p.num_vpes)
 {
     _regClasses.push_back(&intRegClass);

--- a/src/arch/power/isa.cc
+++ b/src/arch/power/isa.cc
@@ -62,7 +62,7 @@ RegClass ccRegClass(CCRegClass, CCRegClassName, 0, debug::IntRegs);
 
 } // anonymous namespace
 
-ISA::ISA(const Params &p) : BaseISA(p)
+ISA::ISA(const Params &p) : BaseISA(p, "power")
 {
     _regClasses.push_back(&intRegClass);
     _regClasses.push_back(&floatRegClass);

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -256,7 +256,7 @@ RegClass ccRegClass(CCRegClass, CCRegClassName, 0, debug::IntRegs);
 
 } // anonymous namespace
 
-ISA::ISA(const Params &p) : BaseISA(p),
+ISA::ISA(const Params &p) : BaseISA(p, "riscv"),
     _rvType(p.riscv_type), checkAlignment(p.check_alignment),
     enableRvv(p.enable_rvv), vlen(p.vlen), elen(p.elen),
     _privilegeModeSet(p.privilege_mode_set)
@@ -792,6 +792,8 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
 void
 ISA::serialize(CheckpointOut &cp) const
 {
+    BaseISA::serialize(cp);
+
     DPRINTF(Checkpoint, "Serializing Riscv Misc Registers\n");
     SERIALIZE_CONTAINER(miscRegFile);
 }

--- a/src/arch/sparc/isa.cc
+++ b/src/arch/sparc/isa.cc
@@ -79,7 +79,7 @@ RegClass ccRegClass(CCRegClass, CCRegClassName, 0, debug::IntRegs);
 
 } // anonymous namespace
 
-ISA::ISA(const Params &p) : BaseISA(p)
+ISA::ISA(const Params &p) : BaseISA(p, "sparc")
 {
     _regClasses.push_back(&flatIntRegClass);
     _regClasses.push_back(&floatRegClass);
@@ -844,6 +844,8 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
 void
 ISA::serialize(CheckpointOut &cp) const
 {
+    BaseISA::serialize(cp);
+
     SERIALIZE_SCALAR(asi);
     SERIALIZE_SCALAR(tick);
     SERIALIZE_SCALAR(fprs);

--- a/src/arch/x86/isa.cc
+++ b/src/arch/x86/isa.cc
@@ -152,7 +152,7 @@ RegClass matRegClass(MatRegClass, MatRegClassName, 0, debug::MatRegs);
 } // anonymous namespace
 
 ISA::ISA(const X86ISAParams &p)
-    : BaseISA(p), cpuid(new X86CPUID(p.vendor_string, p.name_string))
+    : BaseISA(p, "x86"), cpuid(new X86CPUID(p.vendor_string, p.name_string))
 {
     cpuid->addStandardFunc(FamilyModelStepping, p.FamilyModelStepping);
     cpuid->addStandardFunc(CacheParams, p.CacheParams);
@@ -491,6 +491,8 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
 void
 ISA::serialize(CheckpointOut &cp) const
 {
+    BaseISA::serialize(cp);
+
     SERIALIZE_ARRAY(regVal, misc_reg::NumRegs);
 }
 

--- a/util/cpt_upgraders/riscv-dyn-vlen.py
+++ b/util/cpt_upgraders/riscv-dyn-vlen.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 Arm Limited
+# All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2023 Barcelona Supercomputing Center (BSC)
 # All rights reserved.
 
@@ -35,12 +47,14 @@ def upgrader(cpt):
     VecRegContainer is always MaxVecLenInBytes.
     """
 
-    for sec in cpt.sections():
-        import re
+    import re
 
+    for sec in cpt.sections():
         # Search for all XC sections
 
-        if re.search(r".*processor.*\.core.*\.xc.*", sec):
+        res = re.search(r"(.*processor.*\.core.*)\.xc.*", sec)
+        if res and cpt.get(res.groups()[0] + ".isa", "isaName") == "riscv":
+            # Only update for RISCV XCs
             # Updating RVV vector registers (dummy values)
             mr = cpt.get(sec, "regs.vector").split()
             if len(mr) != 327680:

--- a/util/cpt_upgraders/riscv-pcstate.py
+++ b/util/cpt_upgraders/riscv-pcstate.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 Arm Limited
+# All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2023 Google LLC
 # All rights reserved.
 
@@ -29,10 +41,12 @@ def upgrader(cpt):
     # Update the RISC-V pcstate to match the new version of
     # PCState
 
-    for sec in cpt.sections():
-        import re
+    import re
 
-        if re.search(r".*processor.*\.core.*\.xc.*", sec):
+    for sec in cpt.sections():
+        res = re.search(r"(.*processor.*\.core.*)\.xc.*", sec)
+        if res and cpt.get(res.groups()[0] + ".isa", "isaName") == "riscv":
+            # Only update for RISCV XCs
             if cpt.get(sec, "_rvType", fallback="") == "":
                 cpt.set(sec, "_rvType", "1")
 

--- a/util/cpt_upgraders/riscv-vext.py
+++ b/util/cpt_upgraders/riscv-vext.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 Arm Limited
+# All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2023 Barcelona Supercomputing Center (BSC)
 # All rights reserved.
 
@@ -35,11 +47,13 @@ def upgrader(cpt):
     3) Add RVV misc registers in the checkpoint
     """
 
-    for sec in cpt.sections():
-        import re
+    import re
 
+    for sec in cpt.sections():
         # Search for all XC sections
-        if re.search(r".*processor.*\.core.*\.xc.*", sec):
+        res = re.search(r"(.*processor.*\.core.*)\.xc.*", sec)
+        if res and cpt.get(res.groups()[0] + ".isa", "isaName") == "riscv":
+            # Only update for RISCV XCs
             # Updating RVV vector registers (dummy values)
             # Assuming VLEN = 256 bits (32 bytes)
             mr = cpt.get(sec, "regs.vector").split()
@@ -56,7 +70,10 @@ def upgrader(cpt):
             cpt.set(sec, "regs.matrix", "")
 
         # Search for all ISA sections
-        if re.search(r".*processor.*\.core.*\.isa$", sec):
+        if (
+            re.search(r".*processor.*\.core.*\.isa$", sec)
+            and cpt.get(sec, "isaName") == "riscv"
+        ):
             # Updating RVV misc registers (dummy values)
             mr = cpt.get(sec, "miscRegFile").split()
             if len(mr) == 164:


### PR DESCRIPTION
With the introduction of multi-ISA gem5, we don't store the TARGET_ISA
anymore as a string in the root section of the checkpoint [1].  There is
therefore no way at the moment to asses the ISA of a CPU/ThreadContext.
This is a problem when it comes to checkpoint updates which are ISA
specific.

By explicitly serializing the ISA as a string under the cpu.isa section
we avoid this problem and we let cpt_upgraders be aware of the ISA in
use.

[1]: https://gem5-review.googlesource.com/c/public/gem5/+/48884