### PR TITLE
misc: Add a DevContainer specification to the gem5 repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+    "name": "gem5 Development Container",
+    "image": "ghcr.io/gem5/devcontainer:latest",
+    "hostRequirements": {
+        "cpus": 8,
+        "memory": "16gb",
+        "storage": "32gb"
+     },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens",
+                "GitHub.copilot",
+                "GitHub.copilot-chat",
+                "GitHub.vscode-pull-request-github",
+                "ms-python.debugpy",
+                "ms-python.isort",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-vscode.cpptools",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-vscode.cpptools-themes",
+                "ms-vscode.makefile-tools",
+                "ms-vscode-remote.remote-containers",
+                "Tsinghua-Hexin-Joint-Institute.gem5-slicc",
+                "VisualStudioExptTeam.vscodeintellicode"
+            ]
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers-contrib/features/actionlint:1": {},
+        "ghcr.io/devcontainers-contrib/features/vscode-cli:1": {}
+    },
+    "onCreateCommand": "./.devcontainer/on-create.sh"
+}

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2024 The Regents of the University of California
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This script is run when the Docker container specified in devcontainer.json
+# is created.
+
+set -e
+
+# Refresh the git index.
+git update-index
+
+# Install the pre-commit checks.
+./util/pre-commit-install.sh

--- a/util/dockerfiles/devcontainer/Dockerfile
+++ b/util/dockerfiles/devcontainer/Dockerfile
@@ -1,0 +1,80 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This Dockerfile creates a devcontainer for gem5 development referenced in
+# ./devcontainer/devcontainer.json. The devcontainer is a multi-platform
+# container that can be built for x86, arm, and riscv and includes all
+# dependencies required for gem5 development.
+#
+# As this is a multi-platform image, we must build it using the
+# "docker-bake.hcl" specification via `docker buildx`. To do so, execute the
+# following:
+#
+# `docker buildx bake devcontainer --push`
+
+# Stage 1: We create the base image will all-dependencies.
+# Notes:
+# * This is an exact copy of the ubuntu-22.04_all-dependencies Dockerfile
+#   We do not use the image because it is not multi-platform right now. When
+#   the image utilizes multi-platform we can remove this duplication and
+#   replace it with
+#   `FROM ubuntu-22.04_all-dependencies:latest as all-dependenices`.
+# * The all-dependencies docker is all dependeices needed to build and run
+#   gem5. As there may be addition dependenices useful for development, we will
+#   add in the final stage of the Dockerfile.
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04 as all-dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt -y update && apt -y upgrade && \
+    apt -y install build-essential git m4 scons zlib1g zlib1g-dev \
+    libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
+    python3-dev doxygen libboost-all-dev libhdf5-serial-dev python3-pydot \
+    libpng-dev libelf-dev pkg-config pip python3-venv black python3-tk wget
+RUN pip install mypy pre-commit
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0.tar.gz \
+    && tar -xzf cmake-3.24.0.tar.gz \
+    && cd cmake-3.24.0 \
+    && ./bootstrap \
+    && make -j`nproc` \
+    && make install \
+    && cd .. \
+    && rm -rf cmake-3.24.0.tar.gz cmake-3.24.0
+
+# Stage 2: We build the stable version of gem5.
+# In the final stage this this is copied into /usr/local/bin/gem5. This ensures
+# there is a pre-built gem5 binary in each devcontainer. This can save time
+# if the container is used for education or demonstration purposes.
+FROM --platform=${BUILDPLATFORM} all-dependencies as builder
+RUN git clone --branch stable https://github.com/gem5/gem5
+WORKDIR /gem5
+RUN scons build/ALL/gem5.opt -j`nproc`
+
+# Stage 3: The final stage where we create the devcontainer image.
+# This includes all dependencies for building and running gem5, the
+# dependencies for developing gem5, and a pre-built gem5 binary.
+FROM --platform=${BUILDPLATFORM} all-dependencies
+RUN apt -y update  && \
+    apt -y install vim
+COPY --from=builder /gem5/build/ALL/gem5.opt /usr/local/bin/gem5

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -59,7 +59,7 @@ group "gcc-compilers" {
 target "common" {
   # Here we are enabling multi-platform builds. We are compiling to both ARM
   # amd X86.
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/riscv64"]
 }
 
 target "gcn-gpu" {
@@ -95,6 +95,14 @@ target "ubuntu-22-04_all-dependencies" {
   dockerfile = "Dockerfile"
   context = "ubuntu-22.04_all-dependencies"
   tags = ["${IMAGE_URI}/ubuntu-22.04_all-dependencies:${TAG}"]
+}
+
+target "devcontainer" {
+  inherits = ["common"]
+  dependencies = ["devcontainer"]
+  dockerfile = "Dockerfile"
+  context = "devcontainer"
+  tags = ["${IMAGE_URI}/devcontainer:${TAG}"]
 }
 
 target "ubuntu-20-04_all-dependencies" {


### PR DESCRIPTION
Speciftying a DevContainer in gem5 allows for users to quickly create an environment in which they can develop, build, and run gem5. The ".devcontainer/devcontainer.json" file specifies the properties of the container. In this commit they are as follows:

1. The Docker image ghcr.io/gem5/devcontainer. This is built from "util/dockerfiles/devcontainer". This Dockerfile provides all dependencies and a pre-built gem5 binary from the current main branch (added to "/usr/local/bin"). In order to support this Docker container on different platforms we use the Docker multi-platform feature. As such, this must be built using `docker buildx bake devcontainer --push` which reads the `docker-bake.hcl file for the specification of the multi-platform image.
2. Visual Studio extensions. This is a list of Visual Studio Code extensions useful when developing gem5. They are automatically added the Visual Studio dev container.
3. Features. Features are enhancemets that can be added to a DevContainer. Normally they are libraries and other commonly used tools to be included in the Container. As we have our dependencies specified in the Dockerfile here we select one to enable Docker inside the container, one to enable the Github CLI, one to improve Linting, and finally one to enable the vscode CLI.
4. The On Create Command : This command allows us to specify commands to be run after the DevContainer is created. In this case we execute ".devcontainer/on-create.sh" which, right now, refreshes the git index and installed the pre-commit checks.