### PR TITLE
dev-arm: Handle translation aborts and add IRQ support to the SMMU

### DIFF
--- a/src/dev/arm/RealView.py
+++ b/src/dev/arm/RealView.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2022 Arm Limited
+# Copyright (c) 2009-2022, 2024 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -1283,6 +1283,7 @@ class VExpress_GEM5_Base(RealView):
              95    : HDLCD
              96- 98: GPU (reserved)
             100-103: PCI
+            106    : SMMU event queue
             130    : System Watchdog (SP805)
        256-319: MSI frame 0 (gem5-specific, SPIs)
        320-511: Unused
@@ -1508,7 +1509,10 @@ class VExpress_GEM5_Base(RealView):
         if hasattr(self, "smmu"):
             m5.fatal("A SMMU has already been instantiated\n")
 
-        self.smmu = SMMUv3(reg_map=AddrRange(0x2B400000, size=0x00020000))
+        self.smmu = SMMUv3(
+            reg_map=AddrRange(0x2B400000, size=0x00020000),
+            eventq_irq=ArmSPI(num=106),
+        )
 
         self.smmu.request = bus.cpu_side_ports
         self.smmu.control = bus.mem_side_ports

--- a/src/dev/arm/SConscript
+++ b/src/dev/arm/SConscript
@@ -87,6 +87,7 @@ Source('kmi.cc', tags='arm isa')
 Source('smmu_v3.cc', tags='arm isa');
 Source('smmu_v3_caches.cc', tags='arm isa');
 Source('smmu_v3_cmdexec.cc', tags='arm isa');
+Source('smmu_v3_defs.cc', tags='arm isa');
 Source('smmu_v3_events.cc', tags='arm isa');
 Source('smmu_v3_ports.cc', tags='arm isa');
 Source('smmu_v3_proc.cc', tags='arm isa');

--- a/src/dev/arm/SMMUv3.py
+++ b/src/dev/arm/SMMUv3.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, 2018-2020 ARM Limited
+# Copyright (c) 2013, 2018-2020, 2024 Arm Limited
 # All rights reserved
 #
 # The license below extends only to copyright in the software and shall
@@ -200,6 +200,13 @@ class SMMUv3(ClockedObject):
     # [7:0] (0 = SMMUv3.0) (1 = SMMUv3.1)
     smmu_aidr = Param.UInt32(0, "SMMU_AIDR register")
 
+    eventq_irq = Param.ArmSPI(
+        NULL,
+        "Event Queue Interrupt. If set to NULL it means a wired "
+        "implementation of the interrupt is not supported. "
+        "In that case MSIs should be used",
+    )
+
     def generateDeviceTree(self, state):
         reg_addr = self.reg_map.start
         reg_size = self.reg_map.size()
@@ -210,6 +217,22 @@ class SMMUv3(ClockedObject):
                 "reg", state.addrCells(reg_addr) + state.sizeCells(reg_size)
             )
         )
+
+        gic = self._parent.unproxy(self).gic
+
+        wired_interrupts = []
+        if self.eventq_irq != NULL:
+            wired_interrupts += self.eventq_irq.generateFdtProperty(gic)
+
+        if wired_interrupts:
+            node.append(FdtPropertyWords("interrupts", wired_interrupts))
+            node.append(
+                FdtPropertyWords(
+                    "interrupt-names",
+                    ["eventq"],
+                )
+            )
+
         node.append(FdtPropertyWords("#iommu-cells", [1]))
 
         node.appendPhandle(self)

--- a/src/dev/arm/SMMUv3.py
+++ b/src/dev/arm/SMMUv3.py
@@ -100,13 +100,6 @@ class SMMUv3(ClockedObject):
     reg_map = Param.AddrRange("Address range for control registers")
     system = Param.System(Parent.any, "System this device is part of")
 
-    irq_interface_enable = Param.Bool(
-        False,
-        "This flag enables software to program SMMU_IRQ_CTRL and "
-        "SMMU_IRQ_CTRLACK as if the model implemented architectural "
-        "interrupt sources",
-    )
-
     device_interfaces = VectorParam.SMMUv3DeviceInterface(
         [], "Responder interfaces"
     )

--- a/src/dev/arm/smmu_v3.cc
+++ b/src/dev/arm/smmu_v3.cc
@@ -64,7 +64,6 @@ SMMUv3::SMMUv3(const SMMUv3Params &params) :
     tableWalkPort(name() + ".walker", *this),
     controlPort(name() + ".control", *this, params.reg_map),
     eventqInterrupt(params.eventq_irq ? params.eventq_irq->get() : nullptr),
-    irqInterfaceEnable(params.irq_interface_enable),
     tlb(params.tlb_entries, params.tlb_assoc, params.tlb_policy, this),
     configCache(params.cfg_entries, params.cfg_assoc, params.cfg_policy, this),
     ipaCache(params.ipa_entries, params.ipa_assoc, params.ipa_policy, this),
@@ -620,10 +619,9 @@ SMMUv3::writeControl(PacketPtr pkt)
             break;
         case offsetof(SMMURegs, irq_ctrl):
             assert(pkt->getSize() == sizeof(uint32_t));
-            if (irqInterfaceEnable) {
-                warn("SMMUv3::%s No support for interrupt sources", __func__);
-                regs.irq_ctrl = regs.irq_ctrlack = pkt->getLE<uint32_t>();
-            }
+            warn("SMMUv3::%s No support for GERROR and PRI interrupt sources",
+                 __func__);
+            regs.irq_ctrl = regs.irq_ctrlack = pkt->getLE<uint32_t>();
             break;
 
         case offsetof(SMMURegs, cr1):

--- a/src/dev/arm/smmu_v3.cc
+++ b/src/dev/arm/smmu_v3.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018-2020 ARM Limited
+ * Copyright (c) 2013, 2018-2020, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -48,6 +48,7 @@
 #include "base/types.hh"
 #include "debug/Checkpoint.hh"
 #include "debug/SMMUv3.hh"
+#include "dev/arm/base_gic.hh"
 #include "dev/arm/smmu_v3_transl.hh"
 #include "mem/packet_access.hh"
 #include "sim/system.hh"
@@ -62,6 +63,7 @@ SMMUv3::SMMUv3(const SMMUv3Params &params) :
     requestPort(name() + ".request", *this),
     tableWalkPort(name() + ".walker", *this),
     controlPort(name() + ".control", *this, params.reg_map),
+    eventqInterrupt(params.eventq_irq ? params.eventq_irq->get() : nullptr),
     irqInterfaceEnable(params.irq_interface_enable),
     tlb(params.tlb_entries, params.tlb_assoc, params.tlb_policy, this),
     configCache(params.cfg_entries, params.cfg_assoc, params.cfg_policy, this),

--- a/src/dev/arm/smmu_v3.hh
+++ b/src/dev/arm/smmu_v3.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018-2020 ARM Limited
+ * Copyright (c) 2013, 2018-2020, 2024 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -79,6 +79,8 @@
 namespace gem5
 {
 
+class ArmInterruptPin;
+
 class SMMUTranslationProcess;
 
 class SMMUv3 : public ClockedObject
@@ -96,6 +98,10 @@ class SMMUv3 : public ClockedObject
     SMMURequestPort    requestPort;
     SMMUTableWalkPort tableWalkPort;
     SMMUControlPort   controlPort;
+
+    // This could be nullptr if wired implementation of the
+    // event queue interrupt is not supported
+    ArmInterruptPin * const eventqInterrupt;
 
     const bool irqInterfaceEnable;
 

--- a/src/dev/arm/smmu_v3.hh
+++ b/src/dev/arm/smmu_v3.hh
@@ -103,8 +103,6 @@ class SMMUv3 : public ClockedObject
     // event queue interrupt is not supported
     ArmInterruptPin * const eventqInterrupt;
 
-    const bool irqInterfaceEnable;
-
     ARMArchTLB  tlb;
     ConfigCache configCache;
     IPACache    ipaCache;

--- a/src/dev/arm/smmu_v3_defs.cc
+++ b/src/dev/arm/smmu_v3_defs.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dev/arm/smmu_v3_defs.hh"
+
+namespace gem5
+{
+
+std::string
+SMMUEvent::print() const
+{
+    return csprintf("type=%#x sid=%#x ssid=%#x va=%#08x\n",
+        data.dw0.eventType, data.dw0.streamId, data.dw0.substreamId,
+        data.dw2.inputAddr);
+}
+
+} // namespace gem5

--- a/src/dev/arm/smmu_v3_defs.hh
+++ b/src/dev/arm/smmu_v3_defs.hh
@@ -384,25 +384,41 @@ struct SMMUCommand
     }
 };
 
-enum SMMUEventTypes
-{
-    EVT_FAULT = 0x0001,
-};
-
-enum SMMUEventFlags
-{
-    EVF_WRITE = 0x0001,
-};
-
 struct SMMUEvent
 {
-    uint16_t type;
-    uint16_t stag;
-    uint32_t flags;
-    uint32_t streamId;
-    uint32_t substreamId;
-    uint64_t va;
-    uint64_t ipa;
+    struct Data {
+        BitUnion64(DWORD0)
+            Bitfield<7, 0> eventType;
+            Bitfield<11> ssv;
+            Bitfield<31, 12> substreamId;
+            Bitfield<63, 32> streamId;
+        EndBitUnion(DWORD0)
+        DWORD0 dw0;
+
+        BitUnion64(DWORD1)
+            Bitfield<16, 0> stag;
+            Bitfield<33> pnu;
+            Bitfield<34> ind;
+            Bitfield<35> rnw;
+            Bitfield<38> nsipa;
+            Bitfield<39> s2;
+            Bitfield<41, 40> clss;
+        EndBitUnion(DWORD1)
+        DWORD1 dw1;
+
+        BitUnion64(DWORD2)
+            Bitfield<63, 0> inputAddr;
+        EndBitUnion(DWORD2)
+        DWORD2 dw2;
+
+        BitUnion64(DWORD3)
+            Bitfield<51, 3> fetchAddr;
+            Bitfield<51, 12> ipa;
+        EndBitUnion(DWORD3)
+        DWORD3 dw3;
+    } data;
+
+    std::string print() const;
 };
 
 enum

--- a/src/dev/arm/smmu_v3_defs.hh
+++ b/src/dev/arm/smmu_v3_defs.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018-2019 ARM Limited
+ * Copyright (c) 2013, 2018-2019, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -102,9 +102,41 @@ enum
     Q_BASE_ADDR_MASK   = 0x0000ffffffffffe0ULL,
     Q_BASE_SIZE_MASK   = 0x000000000000001fULL,
 
-    E_BASE_ENABLE_MASK = 0x8000000000000000ULL,
     E_BASE_ADDR_MASK   = 0x0000fffffffffffcULL,
 };
+
+BitUnion32(IDR0)
+    Bitfield<0> s2p;
+    Bitfield<1> s1p;
+    Bitfield<3, 2> ttf;
+    Bitfield<4> cohacc;
+    Bitfield<5> btm;
+    Bitfield<7, 6> httu;
+    Bitfield<8> dormhint;
+    Bitfield<9> hyp;
+    Bitfield<10> ats;
+    Bitfield<11> ns1ats;
+    Bitfield<12> asid16;
+    Bitfield<13> msi;
+    Bitfield<14> sev;
+    Bitfield<15> atos;
+    Bitfield<16> pri;
+    Bitfield<17> vmw;
+    Bitfield<18> vmid16;
+    Bitfield<19> cd2l;
+    Bitfield<20> vatos;
+    Bitfield<22, 21> ttEndian;
+    Bitfield<23> atsRecErr;
+    Bitfield<25, 24> stallModel;
+    Bitfield<26> termModel;
+    Bitfield<28, 27> stLevel;
+EndBitUnion(IDR0)
+
+BitUnion32(IRQCtrl)
+    Bitfield<0> gerrorIrqEn;
+    Bitfield<1> priqIrqEn;
+    Bitfield<2> eventqIrqEn;
+EndBitUnion(IRQCtrl)
 
 union SMMURegs
 {

--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -96,6 +96,8 @@ class SMMUTranslationProcess : public SMMUProcess
         Addr       addr;
         Addr       addrMask;
         bool       writable;
+
+        bool isFaulting() const { return fault != FAULT_NONE; }
     };
 
     SMMUv3DeviceInterface &ifc;

--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -83,21 +83,73 @@ class SMMUTranslationProcess : public SMMUProcess
         uint8_t s2t0sz;
     };
 
-    enum FaultType
+    enum FaultType : uint8_t
     {
         FAULT_NONE,
-        FAULT_TRANSLATION, // F_TRANSLATION
-        FAULT_PERMISSION,  // F_PERMISSION
+        FAULT_UUT = 0x1, // F_UUT = Unsupported Upstream Transaction
+        FAULT_BAD_STREAMID = 0x2, // C_BAD_STREAMID = Transaction streamID out of range
+        FAULT_STE_FETCH = 0x3, // F_STE_FETCH = Fetch of STE caused external abort
+        FAULT_BAD_STE = 0x4, // C_BAD_STE = Invalid STE
+        FAULT_BAD_ATS_TREQ = 0x5, // F_BAD_ATS_TREQ
+        FAULT_STREAM_DISABLED = 0x6, // F_STREAM_DISABLED = Non-substream trans disabled
+        FAULT_TRANSL_FORBIDDEN = 0x7, // F_TRANSL_FORBIDDEN = SMMU bypass not allowed
+        FAULT_BAD_SUBSTREAMID = 0x8, // F_BAD_SUBSTREAMID = Bad substreamID
+        FAULT_CD_FETCH = 0x9, // F_CD_FETCH = Fetch of CD caused external abort
+        FAULT_BAD_CD = 0xa, // C_BAD_CD = Invalid CD
+        FAULT_WALK_EABT = 0xb, // F_WALK_EABT = Table walk/update caused external abort
+        FAULT_TRANSLATION = 0x10, // F_TRANSLATION = Translation Fault
+        FAULT_ADDR_SIZE = 0x11, // F_ADDR_SIZE = Address Size fault
+        FAULT_ACCESS = 0x12, // F_ACCESS = Access flag fault
+        FAULT_PERMISSION = 0x13, // F_PERMISSION = Permission fault
+        FAULT_TLB_CONFLICT = 0x20, // F_TLB_CONFLICT = TLB conflict
+        FAULT_CFG_CONFLICT = 0x21, // F_CFG_CONFLICT = Config cache conflict
+        FAULT_PAGE_REQUEST = 0x24, // E_PAGE_REQUEST
+        FAULT_VMS_FETCH = 0x25, // F_VMS_FETCH
+    };
+
+    /* The class of the operation that caused the fault */
+    enum FaultClass
+    {
+        CD = 0x0, // CD fetch
+        TT = 0x1, // Stage1 translation table fetch
+        IN = 0x2, // Input address caused fault
+        RESERVED = 0x3
+    };
+
+    struct Fault
+    {
+        explicit Fault(FaultType _type,
+                       FaultClass _clss=FaultClass::RESERVED,
+                       bool _stage2=false, Addr _ipa=0)
+          : type(_type), clss(_clss), stage2(_stage2), ipa(_ipa)
+        {}
+
+        Fault(const Fault &rhs) = default;
+        Fault& operator=(const Fault &rhs) = default;
+
+        bool isFaulting() const { return type != FAULT_NONE; }
+
+        FaultType type;
+        FaultClass clss;
+        bool stage2;
+        Addr ipa;
     };
 
     struct TranslResult
     {
-        FaultType  fault;
-        Addr       addr;
-        Addr       addrMask;
-        bool       writable;
+        TranslResult()
+          : fault(FaultType::FAULT_NONE),
+            addr(0), addrMask(0), writable(false)
+        {}
 
-        bool isFaulting() const { return fault != FAULT_NONE; }
+        TranslResult& operator=(const TranslResult &rhs) = default;
+
+        bool isFaulting() const { return fault.isFaulting(); }
+
+        Fault fault;
+        Addr  addr;
+        Addr  addrMask;
+        bool  writable;
     };
 
     SMMUv3DeviceInterface &ifc;

--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -223,6 +223,7 @@ class SMMUTranslationProcess : public SMMUProcess
     void completeTransaction(Yield &yield, const TranslResult &tr);
     void completePrefetch(Yield &yield);
 
+    SMMUEvent generateEvent(const TranslResult &tr);
     void sendEvent(Yield &yield, const SMMUEvent &ev);
 
     void doReadSTE(Yield &yield, StreamTableEntry &ste, uint32_t sid);

--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -226,6 +226,7 @@ class SMMUTranslationProcess : public SMMUProcess
 
     SMMUEvent generateEvent(const TranslResult &tr);
     void sendEvent(Yield &yield, const SMMUEvent &ev);
+    void sendEventInterrupt(Yield &yield);
 
     void doReadSTE(Yield &yield, StreamTableEntry &ste, uint32_t sid);
     TranslResult doReadCD(Yield &yield, ContextDescriptor &cd,

--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -220,6 +220,7 @@ class SMMUTranslationProcess : public SMMUProcess
 
     void issuePrefetch(Addr addr);
 
+    void abortTransaction(Yield &yield, const TranslResult &tr);
     void completeTransaction(Yield &yield, const TranslResult &tr);
     void completePrefetch(Yield &yield);
 

--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018-2019 ARM Limited
+ * Copyright (c) 2013, 2018-2019, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -174,8 +174,8 @@ class SMMUTranslationProcess : public SMMUProcess
     void sendEvent(Yield &yield, const SMMUEvent &ev);
 
     void doReadSTE(Yield &yield, StreamTableEntry &ste, uint32_t sid);
-    void doReadCD(Yield &yield, ContextDescriptor &cd,
-                  const StreamTableEntry &ste, uint32_t sid, uint32_t ssid);
+    TranslResult doReadCD(Yield &yield, ContextDescriptor &cd,
+                          const StreamTableEntry &ste, uint32_t sid, uint32_t ssid);
     void doReadConfig(Yield &yield, Addr addr, void *ptr, size_t size,
                       uint32_t sid, uint32_t ssid);
     void doReadPTE(Yield &yield, Addr va, Addr addr, void *ptr,


### PR DESCRIPTION
At the moment the SMMU is not handling translation errors gracefully the way it is described by the SMMUv3 spec: whenever a translation fault arises, simulation aborts as a whole. With this PR we add minimal support for
translation fault handling, which means:

1) Not aborting simulation, but rather:
2) Writing an event entry to the SMMU_EVENTQ (event queue)
3) Signaling the PE an error arose and there is an event entry to be consumed. The signaling is achieved
with the addition of the eventq SPI. Using an MSI is also possible though it is currently disabled by the SMMU_IDR0.MSI being set to zero.

The PR is addressing issues reported by https://github.com/orgs/gem5/discussions/898