### PR TITLE
misc: Fix weekly tests

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -133,7 +133,7 @@ jobs:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
                   ref: develop
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v3
               with:
                   name: ${{needs.build-gem5.outputs.build-name}}
                   path: build/ALL

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -85,10 +85,8 @@ jobs:
                   export TERM=xterm-256color
                   scons build/x86/out/m5
             - name: Download tests
-              working-directory: ${{ github.workspace }}/hip
-              run: build/VEGA_X86/gem5.opt util/obtain-resource.py hacc-force-tree -p ForceTreeTest
+              run: build/VEGA_X86/gem5.opt util/obtain-resource.py hacc-force-tree -p hip/ForceTreeTest
             - name: Run HACC tests
-              working-directory: ${{ github.workspace }}
               run: |
                   build/VEGA_X86/gem5.opt configs/example/apu_se.py -n3 --reg-alloc-policy=dynamic --benchmark-root=hip -c ForceTreeTest --options="0.5 0.1 64 0.1 1 N 12 rcb"
 


### PR DESCRIPTION
There were two errors causing the Weekly tests to fail. Each has a patch in this PR:

1. Fixed incorrect version for the `artifact-downloader` (v4 instead of v3).
2. Fixed incorrect use of `working-directory` which use of `build/VEGA_X86/gem5.opt` to fail (not accessible in set `working-directory`. The default `${github.workspace}` is sufficient.