### PR TITLE
dev-arm: Fix SMMUv3 DTB autogen

### DIFF
--- a/src/dev/arm/SMMUv3.py
+++ b/src/dev/arm/SMMUv3.py
@@ -220,7 +220,7 @@ class SMMUv3(ClockedObject):
         if wired_interrupts:
             node.append(FdtPropertyWords("interrupts", wired_interrupts))
             node.append(
-                FdtPropertyWords(
+                FdtPropertyStrings(
                     "interrupt-names",
                     ["eventq"],
                 )


### PR DESCRIPTION
Replacing FdtProperyWords (expecting an integer) with FdtPropertyStrings

Change-Id: Icd1cf00704e253c88ac9b1d69c3cf946d2a8ca70