### PR TITLE
Fix callback of functional access in port wrapper

### DIFF
--- a/src/mem/port_wrapper.cc
+++ b/src/mem/port_wrapper.cc
@@ -120,7 +120,7 @@ void
 ResponsePortWrapper::recvFunctional(PacketPtr packet)
 {
     panic_if(!recvFunctionalCb, "RecvFunctionalCallback is empty.");
-    recvTimingReqCb(packet);
+    recvFunctionalCb(packet);
 }
 
 void


### PR DESCRIPTION
In previous implementation of port_wrapper, recvFunctional() will call timing request callback. This should be a typo and this change fix the typo.