### PR TITLE
arch-vega: Operand selectors for accumulation registers

### DIFF
--- a/src/arch/amdgpu/vega/gpu_registers.hh
+++ b/src/arch/amdgpu/vega/gpu_registers.hh
@@ -129,7 +129,7 @@ namespace VegaISA
         REG_LDS_DIRECT = 254,
         REG_SRC_LITERAL = 255,
         REG_VGPR_MIN = 256,
-        REG_VGPR_MAX = 511
+        REG_VGPR_MAX = 767
     };
 
     constexpr size_t MaxOperandDwords(16);


### PR DESCRIPTION
AMD's MI100 introduced a new register file called accumulation registers for the matrix cores. In MI200 these were recombined into the same register file according to the documentation. The accumulation register file is the same size as the architectural register file, hence the size is doubled.

The ISA spec does not explicitly state the register selector values, however it does say that the accumulation offset from the kernel dispatch packet should be added to the architecture register file selector number when an instruction sets the ACC bit. Therefore we can infer that the value must simply be an extension beyond the architectural VGPRs.

This fixes errors of the form "invalid register selector: 512" (or higher value). This was tested with the Learn the Basics tutorial example on pytorch.org

Change-Id: I48ced1532fc166d2f5032fe21fbeba70ac77f258