### PR TITLE
sim-se,cpu-kvm: Fix SE workload setup on KVM CPUs

### DIFF
--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -120,6 +120,15 @@ class SEBinaryWorkload:
         if env_list is not None:
             process.env = env_list
 
+        if any(
+            core.is_kvm_core() for core in self.get_processor().get_cores()
+        ):
+            # Running KVM in SE mode requires special flags to be set for the
+            # process.
+            self.m5ops_base = max(0xFFFF0000, self.get_memory().get_size())
+            process.kvmInSE = True
+            process.useArchPT = True
+
         if isinstance(self.get_processor(), SwitchableProcessor):
             # This is a hack to get switchable processors working correctly in
             # SE mode. The "get_cores" API for processors only gets the current


### PR DESCRIPTION
This PR fixes #948 in which running KVM CPUs through the updated gem5 interface in SE mode causes an immediate crash.

To fix this, I added a check to set_se_binary_workload that checks if any of the cores are KVM, and if so, sets a couple of knobs for the board and process that are required to make KVM work. The depecated se.py script, which sets these knobs, is able to run KVM in SE mode just fine, so doing the same here fixed the bug.

Change-Id: I006de46310f96074dc5190646a403b3d280b5791
