### PR TITLE
base: Fix 'doGzipLoad' str manipulation

### DIFF
--- a/src/base/loader/image_file_data.cc
+++ b/src/base/loader/image_file_data.cc
@@ -67,7 +67,7 @@ doGzipLoad(int fd)
     size_t tmp_len = strlen(P_tmpdir);
     char *tmpnam = (char*) malloc(tmp_len + 20);
     strcpy(tmpnam, P_tmpdir);
-    strcpy(tmpnam+tmp_len, "/gem5-gz-obj-XXXXXX"); // 19 chars
+    strcat(tmpnam, "/gem5-gz-obj-XXXXXX"); // concat 19 chars
     fd = mkstemp(tmpnam); // repurposing fd variable for output
     if (fd < 0) {
         free(tmpnam);

--- a/src/base/loader/image_file_data.cc
+++ b/src/base/loader/image_file_data.cc
@@ -64,21 +64,16 @@ doGzipLoad(int fd)
         return -1;
     }
 
-    size_t tmp_len = strlen(P_tmpdir);
-    char *tmpnam = (char*) malloc(tmp_len + 20);
-    strcpy(tmpnam, P_tmpdir);
-    strcat(tmpnam, "/gem5-gz-obj-XXXXXX"); // concat 19 chars
+    std::string tmpnam_str = std::string(P_tmpdir) + "/gem5-gz-obj-XXXXXX";
+    char *tmpnam = const_cast<char*>(tmpnam_str.c_str());
     fd = mkstemp(tmpnam); // repurposing fd variable for output
     if (fd < 0) {
-        free(tmpnam);
         gzclose(fdz);
         return fd;
     }
 
     if (unlink(tmpnam) != 0)
         warn("couldn't remove temporary file %s\n", tmpnam);
-
-    free(tmpnam);
 
     auto buf = new uint8_t[blk_sz];
     int r; // size of (r)emaining uncopied data in (buf)fer


### PR DESCRIPTION
When running `scons build/ALL/gem5.opt --with-ubsan`, with GCC, the following error was returned:

```
[     CXX] src/base/loader/image_file_data.cc -> ALL/base/loader/image_file_data.o
In file included from /usr/include/string.h:535,
                 from /usr/include/c++/11/cstring:42,
                 from src/base/cprintf_formats.hh:33,
                 from src/base/cprintf.hh:38,
                 from src/base/logging.hh:49,
                 from src/base/loader/image_file_data.cc:40:
In function ‘char* strcpy(char*, const char*)’,
    inlined from ‘int gem5::loader::doGzipLoad(int)’ at src/base/loader/image_file_data.cc:70:11,
    inlined from ‘gem5::loader::ImageFileData::ImageFileData(const string&)’ atsrc/base/loader/image_file_data.cc:116:24:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:79:33: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ offset [0, 19] is out of the bounds [0, 0] [-Werror=array-bounds]
   79 |   return __builtin___strcpy_chk (__dest, __src, __glibc_objsize (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
scons: *** [build/ALL/base/loader/image_file_data.o] Error 1
scons: building terminated because of errors.
```

I do not know the exact issue but using strcpy in this way (i.e. `strcpy(char_pointer + offset, string)`) appears to trigger this error with the undefined behavior sanitizer. The fix in this patch replaces this with `strcat`.

Change-Id: I1a0c50c9022adc841e175aad0fe2247bfcb29d71