### PR TITLE
arch-riscv: Fix the RiscvBareMetal parameter reset_vect

### DIFF
--- a/src/arch/riscv/RiscvFsWorkload.py
+++ b/src/arch/riscv/RiscvFsWorkload.py
@@ -43,6 +43,11 @@ class RiscvBareMetal(Workload):
     bootloader = Param.String("File, that contains the bootloader code")
     bare_metal = Param.Bool(True, "Using Bare Metal Application?")
     reset_vect = Param.Addr(0x0, "Reset vector")
+    auto_reset_vect = Param.Bool(
+        True,
+        "Use bootloader entry point as reset vector. "
+        "If `auto_reset_vect` is true, the `reset_vect` parameter is ignored.",
+    )
 
 
 class RiscvLinux(KernelWorkload):

--- a/src/arch/riscv/bare_metal/fs_workload.cc
+++ b/src/arch/riscv/bare_metal/fs_workload.cc
@@ -41,12 +41,17 @@ namespace RiscvISA
 {
 
 BareMetal::BareMetal(const Params &p) : Workload(p),
-    _isBareMetal(p.bare_metal), _resetVect(p.reset_vect),
+    _isBareMetal(p.bare_metal),
     bootloader(loader::createObjectFile(p.bootloader))
 {
     fatal_if(!bootloader, "Could not load bootloader file %s.", p.bootloader);
-    _resetVect = bootloader->entryPoint();
     bootloaderSymtab = bootloader->symtab();
+
+    if (p.auto_reset_vect) {
+        _resetVect = bootloader->entryPoint();
+    } else {
+        _resetVect = p.reset_vect;
+    }
 
     loader::debugSymbolTable.insert(bootloaderSymtab);
 }


### PR DESCRIPTION
The `reset_vect` has exist for a long time and `reset_vect` will not effect if the user gonna to use customized reset_vect. The CL added the `auto_reset_vect` to let the config determine the `reset_vect` from workload entry point or user-specified

Ref: https://gem5-review.googlesource.com/c/public/gem5/+/42053

Change-Id: I928c0dc42aaa85ceabf8d75f9654486496e0ffee