### PR TITLE
stdlib: Fix 'nozero' for Scalar SimStats

### DIFF
--- a/src/python/m5/stats/gem5stats.py
+++ b/src/python/m5/stats/gem5stats.py
@@ -118,13 +118,17 @@ def __get_statistic(statistic: _m5.stats.Info) -> Optional[Statistic]:
     :param statistic: The Info object to be translated to a Statistic object.
 
     :returns: The Statistic object of the Info object. Returns ``None`` if
-              Info object cannot be translated.
+              Info object cannot, or should not, be translated.
     """
 
     assert isinstance(statistic, _m5.stats.Info)
     statistic.prepare()
 
     if isinstance(statistic, _m5.stats.ScalarInfo):
+        if statistic.is_nozero and statistic.value == 0.0:
+            # In the case where the "nozero" flag is set, and the value is
+            # zero, we don't want to include this statistic so return None.
+            return None
         return __get_scaler(statistic)
     elif isinstance(statistic, _m5.stats.DistInfo):
         return __get_distribution(statistic)

--- a/src/python/pybind11/stats.cc
+++ b/src/python/pybind11/stats.cc
@@ -145,6 +145,9 @@ pybind_init_stats(py::module_ &m_native)
         .def_property_readonly("flags", [](const statistics::Info &info) {
                 return (statistics::FlagsType)info.flags;
             })
+        .def_property_readonly("is_nozero", [](const statistics::Info &info) {
+                return info.flags.isSet(statistics::nozero);
+            })
         .def("check", &statistics::Info::check)
         .def("baseCheck", &statistics::Info::baseCheck)
         .def("enable", &statistics::Info::enable)


### PR DESCRIPTION
When the `statistics::nozero` flag is set gem5 does not output that stat if its value is zero. This was not the case for SimStats which output in this case. This patch correct this behavior.