### PR TITLE
util-m5: Add default M5OP_ADDR to arm64

### DIFF
--- a/util/m5/src/abi/arm64/SConsopts
+++ b/util/m5/src/abi/arm64/SConsopts
@@ -32,3 +32,6 @@ get_abi_opt('QEMU_ARCH', 'aarch64')
 env['CALL_TYPE']['inst'].impl('m5op.S', 'verify_inst.cc', default=True)
 env['CALL_TYPE']['addr'].impl('m5op_addr.S')
 env['CALL_TYPE']['semi'].impl('m5op_semi.S', 'verify_semi.cc')
+
+env.Append(CXXFLAGS='-DM5OP_ADDR=0x10010000')
+env.Append(CCFLAGS='-DM5OP_ADDR=0x10010000')

--- a/util/m5/src/m5_mmap.c
+++ b/util/m5/src/m5_mmap.c
@@ -69,6 +69,10 @@ map_m5_mem()
         exit(1);
     }
 
+    if (m5op_addr == 0) {
+        fprintf(stdout, "Warn: m5op_addr is set to 0x0\n");
+    }
+
     fd = open(m5_mmap_dev, O_RDWR | O_SYNC);
     if (fd == -1) {
         fprintf(stderr, "Can't open %s: %s\n", m5_mmap_dev, strerror(errno));


### PR DESCRIPTION
As pointed out here [1], the expected M5OP_ADDR for arm64 arch is 0x10010000. This change reflects that.

[1] https://github.com/gem5/gem5/pull/725

Change-Id: I7e72f5ea20d4aacf3115a485ba7cd664d33d037e