### PR TITLE
misc,github: Upgrade checkout and upload/download-artifact Actions to latest version

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -127,7 +127,7 @@ jobs:
         # stripping the "build" directory. By adding the "anchor.txt" file, we
         # ensure the "build" directory is preserved.
             - run: echo "anchor" > anchor.txt
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
                   path: |
@@ -151,7 +151,7 @@ jobs:
 
         # Checkout the repository then download the gem5.opt artifact.
             - uses: actions/checkout@v4
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
 
@@ -177,7 +177,7 @@ jobs:
         # Upload the tests/testing-results directory as an artifact.
             - name: Upload test results
               if: success() || failure()
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-quick-${{ steps.sanitize-test-dir.outputs.sanatized-test-dir
                       }}-status-${{ steps.run-tests.outcome }}-output

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -61,7 +61,7 @@ jobs:
               run: scons setconfig build/${{ matrix.image }} ${{ matrix.setconfig-option }}
             - name: Build gem5
               run: scons build/${{ matrix.image }}/gem5.opt -j $(nproc)
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: ${{ needs.name-artifacts.outputs.build-name }}${{ matrix.image }}
                   path: build/${{ matrix.image }}/gem5.opt
@@ -108,47 +108,47 @@ jobs:
     # since long tests can't start until the build matrix completes,
     # we download all artifacts from the build for each test
     # in this matrix
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ALL
                   path: build/ALL
             - run: chmod u+x build/ALL/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ALL_CHI
                   path: build/ALL_CHI
             - run: chmod u+x build/ALL_CHI/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ARM
                   path: build/ARM
             - run: chmod u+x build/ARM/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ALL_MSI
                   path: build/ALL_MSI
             - run: chmod u+x build/ALL_MSI/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ALL_MESI_Two_Level
                   path: build/ALL_MESI_Two_Level
             - run: chmod u+x build/ALL_MESI_Two_Level/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}NULL
                   path: build/NULL
             - run: chmod u+x build/NULL/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}NULL_MI_example
                   path: build/NULL_MI_example
             - run: chmod u+x build/NULL_MI_example/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}RISCV
                   path: build/RISCV
             - run: chmod u+x build/RISCV/gem5.opt
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}VEGA_X86
                   path: build/VEGA_X86
@@ -164,7 +164,7 @@ jobs:
                   zip -r output.zip tests/testing-results
             - name: upload zip
               if: success() || failure()
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               env:
                   MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
               with:
@@ -193,7 +193,7 @@ jobs:
         # Scheduled workflows run on the default branch by default. We
         # therefore need to explicitly checkout the develop branch.
                   ref: develop
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ALL
                   path: build/ALL
@@ -209,7 +209,7 @@ jobs:
                   zip -r output.zip tests/testing-results
             - name: upload zip
               if: success() || failure()
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               env:
                   MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
               with:

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -16,7 +16,7 @@ jobs:
         outputs:
             build-name: ${{ steps.artifact-name.outputs.name }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - id: artifact-name
               run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S-")" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -14,7 +14,7 @@ jobs:
           # Scheduled workflows run on the default branch by default. We
           # therefore need to explicitly checkout the develop branch.
                   ref: develop
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: dockerfiles
                   path: util/dockerfiles
@@ -28,7 +28,7 @@ jobs:
             contents: read
 
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: dockerfiles
                   path: dockerfiles-docker-build

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -22,7 +22,7 @@ jobs:
                   ref: develop
             - name: Build gem5
               run: scons build/VEGA_X86/gem5.opt -j $(nproc) --ignore-style
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-vega
                   path: build/VEGA_X86/gem5.opt
@@ -42,7 +42,7 @@ jobs:
                   ref: develop
 
             - name: Download build/VEGA_X86/gem5.opt
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-vega
                   path: build/VEGA_X86
@@ -72,7 +72,7 @@ jobs:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
                   ref: develop
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-vega
                   path: build/VEGA_X86
@@ -106,7 +106,7 @@ jobs:
             - name: Build gem5
               run: |
                   scons build/ALL/gem5.opt -j $(nproc)
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: ${{ steps.artifact-name.outputs.name }}
                   path: build/ALL/gem5.opt
@@ -131,7 +131,7 @@ jobs:
                   # Scheduled workflows run on the default branch by default. We
                   # therefore need to explicitly checkout the develop branch.
                   ref: develop
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.build-gem5.outputs.build-name}}
                   path: build/ALL
@@ -146,7 +146,7 @@ jobs:
                   zip -r output.zip tests/testing-results
             - name: upload zip
               if: success() || failure()
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               env:
                   MY_STEP_VAR: ${{ matrix.test-type }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
               with:


### PR DESCRIPTION
As can be seen from this Daily test log: https://github.com/gem5/gem5/actions/runs/8478384881, checkout@v2 and {upload/download}-artifact@v3 was causing warnings to be thrown. This fix upgrades all instances of these actions to the latest version (in both cases, v4).