### PR TITLE
arch-riscv: Use TeX's escape seq in Python instead of Unicode 

### DIFF
--- a/src/arch/riscv/RiscvInterrupts.py
+++ b/src/arch/riscv/RiscvInterrupts.py
@@ -50,7 +50,7 @@ add_citation(
     r"""@inproceedings{Hauser:2024:LocalRiscvInterrupts,
     author = {Robert Hauser  and
               Lukas Steffen and
-              Florian Grützmacher and
+              Florian Gr{\"u}tzmacher and
               Christian Haubelt},
     title = {Analyzing Local RISC-V Interrupt Latencies with Virtual Prototyping},
     booktitle = {Workshop Methoden und Beschreibungssprachen zur Modellierung und Verifikation von Schaltungen und Systemen (MBMV24)},


### PR DESCRIPTION
Currently, the citation string has a Unicode character. This works well in gem5, but it breaks the gem5+SST simulation [1]. This change modifies the letter "u" with umlaut to use TeX's escape sequence for this letter instead of using the UTF-8 character.

[1] https://github.com/gem5/gem5/issues/982