### PR TITLE
arch-arm,stdlib: ARM release for_kvm is moved to configs

### DIFF
--- a/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
@@ -87,9 +87,9 @@ processor = SimpleSwitchableProcessor(
 )
 
 # The ArmBoard requires a `release` to be specified. This adds all the
-# extensions or features to the system. We are setting this to Armv8
-# (ArmDefaultRelease) in this example config script.
-release = ArmDefaultRelease()
+# extensions or features to the system. We are setting this to for_kvm()
+# to enable KVM simulation.
+release = ArmDefaultRelease.for_kvm()
 
 # The platform sets up the memory ranges of all the on-chip and off-chip
 # devices present on the ARM system. ARM KVM only works with VExpress_GEM5_V1

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -113,13 +113,8 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         requires(isa_required=ISA.ARM)
 
         # Setting up ARM release here. We use the ARM default release, which
-        # corresponds to an ARMv8 system. The default release is updated if
-        # the user is using any KVM cores.
+        # corresponds to an ARMv8 system.
         self.release = release
-        if any(core.is_kvm_core() for core in processor.get_cores()):
-            # KVM cores only work with VExpress_GEM5_V1()
-            if isinstance(platform, VExpress_GEM5_V1):
-                self.release = ArmDefaultRelease.for_kvm()
 
         # Setting multi_proc of ArmSystem by counting the number of processors.
         if processor.get_num_cores() == 1:


### PR DESCRIPTION
This change sets the `release` of the ARM board at the config file instead of overriding the release on the ArmBoard. This change partially solves issue 932 as the system taking and restoring the checkpoint is consistent across KVM and timing CPUs respectively.