### PR TITLE
arch-riscv: fix c.fswsp source register

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5,6 +5,7 @@
 // Copyright (c) 2020 Barkhausen Institut
 // Copyright (c) 2021 StreamComputing Corp
 // Copyright (c) 2022 Google LLC
+// Copyright (c) 2024 University of Rostock
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -508,7 +509,7 @@ decode QUADRANT default Unknown::unknown() {
                         return std::make_shared<IllegalInstFault>("FPU is off",
                                                                    machInst);
 
-                    Mem_uw = unboxF32(boxF32(Fs2_bits));
+                    Mem_uw = unboxF32(boxF32(Fc2_bits));
                 }}, {{
                     EA = (uint32_t)(sp_uw + offset);
                 }});


### PR DESCRIPTION
RISC-V C.FSWSP format (RISC-V Unprivileged ISA V20191213, page 102):
 
|15-13|12-7|6-2|1-0|
|-------|----|----|----|
|funct3|imm|rs2|op|

Source register is bit 2-6, not bit 20-24

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/bitfields.isa#L111

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/operands.isa#L86

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/bitfields.isa#L87

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/operands.isa#L80