### PR TITLE
arch-riscv: Fix c.fsw source register

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -183,7 +183,7 @@ decode QUADRANT default Unknown::unknown() {
                         return std::make_shared<IllegalInstFault>("FPU is off",
                                                                    machInst);
 
-                    Mem_uw = unboxF32(boxF32(Fs2_bits));
+                    Mem_uw = unboxF32(boxF32(Fp2_bits));
                 }}, {{
                     EA = (uint32_t)(Rp1_uw + offset);
                 }});


### PR DESCRIPTION
RISC-V C.FSW format:

![image](https://github.com/gem5/gem5/assets/32214817/31f46525-23e1-4b36-91ee-968f18b9d32a)
Source register is bit 2-4, not bit 20-24
 
https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/bitfields.isa#L112

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/operands.isa#L88

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/bitfields.isa#L87

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/operands.isa#L80



