### PR TITLE
arch-riscv: Make c.flwsp destination register more maintainable

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -426,7 +426,7 @@ decode QUADRANT default Unknown::unknown() {
 
                     freg_t fd;
                     fd = freg(f32(Mem_uw));
-                    Fd_bits = fd.v;
+                    Fc1_bits = fd.v;
                 }}, {{
                     EA = (uint32_t)(sp_uw + offset);
                 }});


### PR DESCRIPTION
RISC-V C.FLWSP format:

![image](https://github.com/gem5/gem5/assets/32214817/f4c8d114-cd6b-4946-afff-fa752b31e337)
The name FC1 and FD share the same bits, change to FC1 to make it better

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/bitfields.isa#L110

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/operands.isa#L84

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/bitfields.isa#L85

https://github.com/gem5/gem5/blob/ee6f1377d7c54422137dfa47cd4d73407814867d/src/arch/riscv/isa/operands.isa#L76

