### PR TITLE
cpu-o3, arch-x86: initialize interrupts for all SMT threads

### DIFF
--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -303,16 +303,20 @@ class BaseCPU(ClockedObject):
         # Practically speaking, these ports will exist on the x86 interrupt
         # controller class.
         if "pio" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_response_ports = (
-                self._uncached_interrupt_response_ports + ["interrupts[0].pio"]
+            self._uncached_interrupt_response_ports.extend(
+                [f"interrupts[{i}].pio" for i in range(self.numThreads)]
             )
         if "int_responder" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_response_ports = (
-                self._uncached_interrupt_response_ports
-                + ["interrupts[0].int_responder"]
+            self._uncached_interrupt_response_ports.extend(
+                [
+                    f"interrupts[{i}].int_responder"
+                    for i in range(self.numThreads)
+                ]
             )
         if "int_requestor" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_request_ports = (
-                self._uncached_interrupt_request_ports
-                + ["interrupts[0].int_requestor"]
+            self._uncached_interrupt_request_ports.extend(
+                [
+                    f"interrupts[{i}].int_requestor"
+                    for i in range(self.numThreads)
+                ]
             )


### PR DESCRIPTION
Fix issue #1004. When enabling SMT with the O3 cpu, only the first interrupts object was getting initialized properly. This patch initializes all interrupts objects, one per SMT thread.

Change-Id: I300782b645bd8ea3ef2497278fb73125ab4bf495