### PR TITLE
dev: Fix interrupt logic in uart8250

### DIFF
--- a/src/dev/serial/uart8250.hh
+++ b/src/dev/serial/uart8250.hh
@@ -215,6 +215,7 @@ class Uart8250 : public Uart
 
     void processIntrEvent(int intrBit);
     void scheduleIntr(Event *event);
+    void clearIntr(int intrBit);
 
     EventFunctionWrapper txIntrEvent;
     EventFunctionWrapper rxIntrEvent;


### PR DESCRIPTION
Hi, we've noticed some issues with the Uart8250 device when using it as the Linux console. Sometimes the Uart interrupt would remain constantly posted, so Linux would continue to try and handle it, effectively resulting in an infinite loop. With this patch, I'm no longer seeing any issues, but my testing has been limited to configurations and workloads we're interested in at Imagination, so please let me know if there's some other tests I should run or if you notice any other issues.

This patch fixes several issues with interrupt posting and clearing in the uart8250 device.

The "status" member variable and the console interrupt should be kept in sync. However, in one code path in readIir, the interrupt bit was being cleared in the status variable but not in the platform controller.

Additionally, in some code paths, the interrupts would be cleared in the status variable and in the interrupt controller, but a future interrupt would remain scheduled, causing a spurious interrupt and setting a bit in status to 1.

These issues can confuse the kernel and result in an ininite interrupt handling loop.

Another issue is related to the fact that there are two interrupt causes (TX and RX) and both of them can be valid at the same time. When one of them becomes no longer valid, we should check the status of the other one before clearing the interrupt.

This patch addresses the issues listed above and refactors the interrupt clearing logic to reduce repetition.