### PR TITLE
cpu: Fix KVM false negative warning after Kconfig transition

### DIFF
--- a/src/cpu/kvm/Kconfig
+++ b/src/cpu/kvm/Kconfig
@@ -23,11 +23,16 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+config HAVE_KVM
+    bool
+    default "$(HAVE_KVM)"
+
 config KVM_ISA
     string
     default "$(KVM_ISA)"
 
 config USE_KVM
-    depends on KVM_ISA != ""
+    depends on KVM_ISA != "" && HAVE_KVM
     bool "Enable hardware virtualized (KVM) CPU models"
     default y

--- a/src/cpu/kvm/SConsopts
+++ b/src/cpu/kvm/SConsopts
@@ -61,5 +61,8 @@ with gem5_scons.Configure(main) as conf:
             warning("perf_event headers lack support for the exclude_host "
                     "attribute. KVM instruction counts will be inaccurate.")
 
-if not main['CONF']['KVM_ISA']:
-    warning("Can not enable KVM, host seems to lack KVM support")
+def create_use_kvm_var():
+    if not (main['CONF']['HAVE_KVM'] and main['CONF']['KVM_ISA']):
+        warning("Cannot enable KVM, host seems to lack KVM support")
+
+AfterSConsopts(create_use_kvm_var)


### PR DESCRIPTION
When we start to build gem5. We will read and process all of SConsopts files, and process the after_sconsopts_callbacks after all of SConsopts files read.

In the KVM_ISA env setting, the KVM_ISA env can be set in the different files, take x86 and arm as example:

KVM_ISA default value:
https://github.com/gem5/gem5/blob/bc39283451c6b563f8db6660ce694e838a3b38b0/src/cpu/kvm/SConsopts

x86 KVM_ISA:
https://github.com/gem5/gem5/blob/bc39283451c6b563f8db6660ce694e838a3b38b0/src/arch/x86/kvm/SConsopts#L39-L45

arm KVM_ISA:
https://github.com/gem5/gem5/blob/bc39283451c6b563f8db6660ce694e838a3b38b0/src/arch/arm/kvm/SConsopts#L35-L36

We should move the kvm warning after all of SConsopts env read

issue: https://github.com/gem5/gem5/issues/686

Change-Id: I096c6bebaaec18f9b2af93191d0dd23c65084eda