### PR TITLE
util-docker: Update docker-compose URLs to 'ghcr.io/gem5'

### DIFF
--- a/util/dockerfiles/docker-compose.yaml
+++ b/util/dockerfiles/docker-compose.yaml
@@ -6,145 +6,145 @@ services:
         build:
             context: gcn-gpu
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/gcn-gpu:latest
+        image: ghcr.io/gem5/gcn-gpu:latest
     gpu-fs:
         build:
             context: gpu-fs
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/gpu-fs:latest
+        image: ghcr.io/gem5/gpu-fs:latest
     sst:
         build:
             context: sst
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/sst-env:latest
+        image: ghcr.io/gem5/sst-env:latest
     systemc:
         build:
             context: systemc-2.3.3
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/systemc-env:latest
+        image: ghcr.io/gem5/systemc-env:latest
     ubuntu-20.04_all-dependencies:
         build:
             context: ubuntu-20.04_all-dependencies
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/ubuntu-20.04_all-dependencies:latest
+        image: ghcr.io/gem5/ubuntu-20.04_all-dependencies:latest
     ubuntu-22.04_all-dependencies:
         build:
             context: ubuntu-22.04_all-dependencies
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/ubuntu-22.04_all-dependencies:latest
+        image: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
     ubuntu-22.04_min-dependencies:
         build:
             context: ubuntu-22.04_min-dependencies
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/ubuntu-22.04_min-dependencies:latest
+        image: ghcr.io/gem5/ubuntu-22.04_min-dependencies:latest
     gcc-8:
         build:
             context: ubuntu-20.04_gcc-version
             dockerfile: Dockerfile
             args:
                 - version=8
-        image: gcr.io/gem5-test/gcc-version-8:latest
+        image: ghcr.io/gem5/gcc-version-8:latest
     gcc-10:
         build:
             context: ubuntu-20.04_gcc-version
             dockerfile: Dockerfile
             args:
                 - version=10
-        image: gcr.io/gem5-test/gcc-version-10:latest
+        image: ghcr.io/gem5/gcc-version-10:latest
     gcc-11:
         build:
             context: ubuntu-22.04_gcc-version
             dockerfile: Dockerfile
             args:
                 - version=11
-        image: gcr.io/gem5-test/gcc-version-11:latest
+        image: ghcr.io/gem5/gcc-version-11:latest
     gcc-12:
         build:
             context: ubuntu-22.04_gcc-version
             dockerfile: Dockerfile
             args:
                 - version=12
-        image: gcr.io/gem5-test/gcc-version-12:latest
+        image: ghcr.io/gem5/gcc-version-12:latest
     gcc-13:
         build:
             context: ubuntu-22.04_gcc_13-version
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/gcc-version-13:latest
+        image: ghcr.io/gem5/gcc-version-13:latest
     clang-7:
         build:
             context: ubuntu-20.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=7
-        image: gcr.io/gem5-test/clang-version-7:latest
+        image: ghcr.io/gem5/clang-version-7:latest
     clang-8:
         build:
             context: ubuntu-20.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=8
-        image: gcr.io/gem5-test/clang-version-8:latest
+        image: ghcr.io/gem5/clang-version-8:latest
     clang-9:
         build:
             context: ubuntu-20.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=9
-        image: gcr.io/gem5-test/clang-version-9:latest
+        image: ghcr.io/gem5/clang-version-9:latest
     clang-10:
         build:
             context: ubuntu-20.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=10
-        image: gcr.io/gem5-test/clang-version-10:latest
+        image: ghcr.io/gem5/clang-version-10:latest
     clang-11:
         build:
             context: ubuntu-20.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=11
-        image: gcr.io/gem5-test/clang-version-11:latest
+        image: ghcr.io/gem5/clang-version-11:latest
     clang-12:
         build:
             context: ubuntu-20.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=12
-        image: gcr.io/gem5-test/clang-version-12:latest
+        image: ghcr.io/gem5/clang-version-12:latest
     clang-13:
         build:
             context: ubuntu-22.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=13
-        image: gcr.io/gem5-test/clang-version-13:latest
+        image: ghcr.io/gem5/clang-version-13:latest
     clang-14:
         build:
             context: ubuntu-22.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=14
-        image: gcr.io/gem5-test/clang-version-14:latest
+        image: ghcr.io/gem5/clang-version-14:latest
     clang-15:
         build:
             context: ubuntu-22.04_clang-version
             dockerfile: Dockerfile
             args:
                 - version=15
-        image: gcr.io/gem5-test/clang-version-15:latest
+        image: ghcr.io/gem5/clang-version-15:latest
     clang-16:
         build:
             context: ubuntu-22.04_clang-16
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/clang-version-16:latest
+        image: ghcr.io/gem5/clang-version-16:latest
     llvm-gnu-cross-compiler-riscv64:
         build:
             context: llvm-gnu-cross-compiler-riscv64
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/llvm-gnu-cross-compiler-riscv64:latest
+        image: ghcr.io/gem5/llvm-gnu-cross-compiler-riscv64:latest
     gem5-all-min-dependencies:
         build:
             context: gem5-all-min-dependencies
             dockerfile: Dockerfile
-        image: gcr.io/gem5-test/gem5-all-min-dependencies:latest
+        image: ghcr.io/gem5/gem5-all-min-dependencies:latest


### PR DESCRIPTION
'gcr.io/test-gem5' was the registry we used when hosting them on Google Cloud services. We now use the GitHub container registries.