### PR TITLE
github: Update 'ubuntu-22.04' to 'ubuntu-latest'

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
     pre-commit:
     # runs on github hosted runner
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
   # ensures we have a change-id in every commit, needed for gerrit
     check-for-change-id:
         # runs on github hosted runner
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         needs: testlib-quick-execution
         steps:
             - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -61,7 +61,7 @@ jobs:
         # I.e., if we want to stop pull requests from being merged if the
         # compiler tests are failing, we can add this job as a required status
         # check.
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         needs:
             - latest-compilers-all-gem5-builds
             - all-compilers

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -304,7 +304,7 @@ jobs:
         # I.e., if we want to stop pull requests from being merged if the
         # daily tests are failing we can add this job as a required status
         # check.
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         needs:
             - unittests-fast-debug
             - testlib-long-tests

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -187,7 +187,7 @@ jobs:
         # I.e., if we want to stop pull requests from being merged if the
         # weekly tests are failing we can add this job as a required status
         # check.
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         needs:
             - testlib-very-long-tests
             - dramsys-tests


### PR DESCRIPTION
There was some inconsistency in the GitHub Workflow files on using 'ubuntu-latest' (which gets the latest Ubuntu version) or 'ubuntu-22.04'. To keep things consistent 'ubuntu-latest' is now used in all cases. This also saves us updating workloads upon release of a new Ubuntu version.
