### PR TITLE
arch-x86: Movfp account for dataSize=4

### DIFF
--- a/src/arch/x86/isa/microops/fpop.isa
+++ b/src/arch/x86/isa/microops/fpop.isa
@@ -257,7 +257,14 @@ let {{
             super().__init__(reg1, reg2, reg3, **kwargs)
 
     class Movfp(Fp2Op):
-        code = 'FpDestReg_uqw = FpSrcReg1_uqw;'
+        code = '''
+        if(dataSize == 4) {
+            FpDestReg_uqw = (0xFFFFFFFF00000000 & FpDestReg_uqw) |
+            (0x00000000FFFFFFFF & FpSrcReg1_uqw);
+        } else {
+            FpDestReg_uqw = FpSrcReg1_uqw;
+        }
+        '''
         else_code = 'FpDestReg_uqw = FpDestReg_uqw;'
         cond_check = "checkCondition(ccFlagBits | cfofBits | dfBit | \
                                      ecfBit | ezfBit, src1)"

--- a/src/arch/x86/isa/microops/fpop.isa
+++ b/src/arch/x86/isa/microops/fpop.isa
@@ -258,9 +258,9 @@ let {{
 
     class Movfp(Fp2Op):
         code = '''
-        if(dataSize == 4) {
-            FpDestReg_uqw = (0xFFFFFFFF00000000 & FpDestReg_uqw) |
-            (0x00000000FFFFFFFF & FpSrcReg1_uqw);
+        if (dataSize == 4) {
+            FpDestReg_uqw = mbits(FpDestReg_uqw, 63, 32) |
+                            mbits(FpSrcReg1_uqw, 31, 0);
         } else {
             FpDestReg_uqw = FpSrcReg1_uqw;
         }


### PR DESCRIPTION
Movfp instruction did not account for only copying the lower half of src register if dataSize is 4.
GitHub Issue: #893 
I used the test code in issue #893 to verify the fix is working.