### PR TITLE
util-docker: Bump gpu-fs build docker to ROCm 6.0.2

### DIFF
--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 Advanced Micro Devices, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,29 +27,38 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-FROM --platform=${BUILDPLATFORM} ubuntu:20.04
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \
     apt -y install build-essential git m4 scons zlib1g zlib1g-dev \
     libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
     python3-dev python-is-python3 doxygen libboost-all-dev \
     libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config
+RUN apt -y install wget
 
-# Requirements for ROCm
-RUN apt -y install cmake mesa-common-dev libgflags-dev libgoogle-glog-dev
+# The follow were adapted from instructions at the URL below, accessed 4/12/24:
+# https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/
+#             native-install/ubuntu.html
 
-# Needed to get ROCm repo, build packages
-RUN apt -y install wget gnupg2 rpm
+# Make the directory if it doesn't exist yet.
+# This location is recommended by the distribution maintainers.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings
 
-# Get the radeon gpg key for apt repository
-RUN wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
+# Download the key, convert the signing-key to a full
+# keyring required by apt and store in the keyring directory
+RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+    gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-# Modify apt sources to pull from ROCm 5.4.2 repository only
-RUN echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/5.4.2/ ubuntu main' | tee /etc/apt/sources.list.d/rocm.list
+RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/6.0.2/ubuntu jammy main" \
+    | tee /etc/apt/sources.list.d/amdgpu.list
+RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.0.2 jammy main" \
+    | tee --append /etc/apt/sources.list.d/rocm.list
+# Note: Need to remove 'echo -e' in docker.
+RUN echo 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+    | tee /etc/apt/preferences.d/rocm-pin-600
 
-RUN apt-get update
-RUN apt -y install libnuma-dev
+RUN apt update
 
-# Install the ROCm-dkms source
-RUN apt -y install initramfs-tools
+# This package should be the minimum needed to build and is significantly
+# smaller than the full `rocm` package.
 RUN apt -y install rocm-dev

--- a/util/dockerfiles/gpu-fs/README.md
+++ b/util/dockerfiles/gpu-fs/README.md
@@ -1,0 +1,33 @@
+## rocm-build Dockerfile
+The Dockerfile in this directory is used to build applications to be run with GPU full system.
+Applications targeting AMD's ROCm GPU framework can be built using this docker (e.g., HIP, HSA, OpenCL, etc.).
+The current major ROCm version targeted is 6.0.2.
+This version matches the disk image provided in gem5-resources.
+
+The purpose of this docker image is to allow building applications without requiring ROCm to be installed on the host machine.
+If you have ROCm installed locally and the version matches the disk image of the simulated system, this docker is not required and you may build on the host normally.
+This docker is also not the disk image used to simulated GPU full system applications (i.e., not an input to gem5 itself).
+
+### Building the docker image
+```sh
+docker build -t <image_name> .
+```
+
+For example:
+
+```sh
+docker build -t rocm6-build .
+```
+
+### Building an application
+Building an application requires that docker run in a directory which has access to all files needed to build.
+The simplest example would be `square` in the `gem5-resources` repository.
+Square provides a Makefile and has only one input file:
+
+```sh
+cd gem5-resources/src/gpu/square
+docker run --rm -u $UID:$GID -v $PWD:$PWD -w $PWD rocm6-build make
+```
+
+More complex applications, such as applications requiring m5ops, applications with multiple build steps, or paths with symlinks require more complex --volume command line options.
+See the docker documentation to figure out how to set the volumes to build your application.


### PR DESCRIPTION
This bumps the docker image used to build GPU applications for input to GPUFS simulations from ROCm 5.4.2 to ROCm 6.0.2 and Ubuntu from 20.04 to 22.04. This matches the versions in gem5-resources#29 .

Several notes were added to the Dockerfile to describe where the RUN commands come from. A README.md is also added to clarify that this is not a disk image for GPUFS and is only used to build applications.

Change-Id: I9ada99e2ed1854cb7adb76f2a1fa662bab398f86