### PR TITLE
github,tests: Add Pyunit tests to CI GitHub Action Workflow

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -184,12 +184,49 @@ jobs:
                   path: tests/testing-results
                   retention-days: 30
 
+    pyunit:
+        runs-on: [self-hosted, linux, x64]
+        if: github.event.pull_request.draft == false
+        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        needs: [pre-commit, check-for-change-id, testlib-quick-gem5-builds]
+        timeout-minutes: 30
+        steps:
+
+            # Checkout the repository then download the builds.
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
+              with:
+                  name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds
+
+            # Check that the gem5 binaries exist and are executable.
+            - name: Chmod gem5.{opt,debug,fast} to be executable
+              run: |
+                  find . -name "gem5.opt" -exec chmod u+x {} \;
+                  find . -name "gem5.debug" -exec chmod u+x {} \;
+                  find . -name "gem5.fast" -exec chmod u+x {} \;
+
+            # Run the pyunit tests.
+            # Note: these are all quick tests.
+            - name: Run The pyunit tests
+              id: run-tests
+              working-directory: ${{ github.workspace }}/tests
+              run: ./main.py run --skip-build -vv -j$(nproc) pyunit
+
+            # Upload the tests/testing-results directory as an artifact.
+            - name: Upload pyunit test results
+              if: success() || failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-pyunit-status-${{ steps.run-tests.outcome }}-output
+                  path: tests/testing-results
+                  retention-days: 30
+
     testlib-quick:
     # It is 'testlib-quick' which needs to pass for the pull request to be
     # merged. The 'testlib-quick-execution' is a matrix job which runs all the
     # the testlib quick tests. This job is therefore a stub which will pass if
     # all the testlib-quick-execution jobs pass.
         runs-on: ubuntu-latest
-        needs: testlib-quick-execution
+        needs: [testlib-quick-execution, pyunit]
         steps:
             - run: echo "This job's status is ${{ job.status }}."

--- a/tests/pyunit/stdlib/resources/pyunit_client_wrapper_checks.py
+++ b/tests/pyunit/stdlib/resources/pyunit_client_wrapper_checks.py
@@ -76,7 +76,7 @@ with open(Path(__file__).parent / "refs/mongo-dup-mock.json") as f:
     duplicate_mock_json = json.load(f)
 
 
-def mocked_requests_post(*args):
+def mocked_requests_post(*args, **kwargs):
     # mokcing urllib.request.urlopen
     class MockResponse:
         def __init__(self, json_data, status_code):

--- a/tests/pyunit/stdlib/resources/pyunit_suite_checks.py
+++ b/tests/pyunit/stdlib/resources/pyunit_suite_checks.py
@@ -35,6 +35,7 @@ from unittest.mock import patch
 
 from gem5.resources.client_api.client_wrapper import ClientWrapper
 from gem5.resources.resource import (
+    ShadowResource,
     SuiteResource,
     WorkloadResource,
     obtain_resource,
@@ -112,7 +113,7 @@ class SuiteResourceTestSuite(unittest.TestCase):
         self.assertIsInstance(filtered_suite, SuiteResource)
         self.assertEqual(len(filtered_suite), 1)
         for workload in filtered_suite:
-            self.assertIsInstance(workload, WorkloadResource)
+            self.assertIsInstance(workload, ShadowResource)
 
     @patch(
         "gem5.resources.client.clientwrapper",
@@ -124,7 +125,7 @@ class SuiteResourceTestSuite(unittest.TestCase):
         self.assertIsInstance(filtered_suite, SuiteResource)
         self.assertEqual(len(filtered_suite), 2)
         for workload in filtered_suite:
-            self.assertIsInstance(workload, WorkloadResource)
+            self.assertIsInstance(workload, ShadowResource)
 
     @patch(
         "gem5.resources.client.clientwrapper",

--- a/tests/pyunit/stdlib/resources/refs/suite-checks.json
+++ b/tests/pyunit/stdlib/resources/refs/suite-checks.json
@@ -23,8 +23,14 @@
         "description": "Description of workload here",
         "function": "set_kernel_disk_workload",
         "resources": {
-            "kernel": "x86-linux-kernel-5.2.3-example",
-            "disk-image": "x86-ubuntu-18.04-img-example"
+            "kernel": {
+                "id": "x86-linux-kernel-5.2.3-example",
+                "resource_version": "1.0.0"
+            },
+            "disk-image": {
+                "id": "x86-ubuntu-18.04-img-example",
+                "resource_version": "1.0.0"
+            }
         },
         "additional_params": {
             "readfile_contents": "echo 'Boot successful'; m5 exit"
@@ -40,8 +46,14 @@
         "description": "Description of workload here",
         "function": "set_kernel_disk_workload",
         "resources": {
-            "kernel": "x86-linux-kernel-5.2.3-example",
-            "disk-image": "x86-ubuntu-18.04-img-example"
+            "kernel": {
+                "id": "x86-linux-kernel-5.2.3-example",
+                "resource_version": "1.0.0"
+            },
+            "disk-image": {
+                "id": "x86-ubuntu-18.04-img-example",
+                "resource_version": "1.0.0"
+            }
         },
         "additional_params": {
             "readfile_contents": "echo 'Boot successful'; m5 exit"

--- a/tests/pyunit/stdlib/resources/refs/workload-checks.json
+++ b/tests/pyunit/stdlib/resources/refs/workload-checks.json
@@ -34,8 +34,14 @@
         "description": "Description of workload here",
         "function": "set_kernel_disk_workload",
         "resources": {
-            "kernel": "x86-linux-kernel-5.2.3-example",
-            "disk-image": "x86-ubuntu-18.04-img-example"
+            "kernel": {
+                "id": "x86-linux-kernel-5.2.3-example",
+                "resource_version": "1.0.0"
+            },
+            "disk-image": {
+                "id": "x86-ubuntu-18.04-img-example",
+                "resource_version": "1.0.0"
+            }
         },
         "additional_params": {
             "readfile_contents": "echo 'Boot successful'; m5 exit"


### PR DESCRIPTION
Due to an oversight, the PyUnit tests were not being run as part of the gem5 CI tests. This was because they are located in "tests/pyunit" instead of "tests/gem5", where the CI GitHub Action workflow searched for tests to run and where all other tests reside.

This adds the Pyunit tests as a seperate job in the CI GitHub Action's workflow.
