### PR TITLE
cpu-o3, arch-x86: Revert "initialize interrupts for all SMT ..."

### DIFF
--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -303,20 +303,16 @@ class BaseCPU(ClockedObject):
         # Practically speaking, these ports will exist on the x86 interrupt
         # controller class.
         if "pio" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_response_ports.extend(
-                [f"interrupts[{i}].pio" for i in range(self.numThreads)]
+            self._uncached_interrupt_response_ports = (
+                self._uncached_interrupt_response_ports + ["interrupts[0].pio"]
             )
         if "int_responder" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_response_ports.extend(
-                [
-                    f"interrupts[{i}].int_responder"
-                    for i in range(self.numThreads)
-                ]
+            self._uncached_interrupt_response_ports = (
+                self._uncached_interrupt_response_ports
+                + ["interrupts[0].int_responder"]
             )
         if "int_requestor" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_request_ports.extend(
-                [
-                    f"interrupts[{i}].int_requestor"
-                    for i in range(self.numThreads)
-                ]
+            self._uncached_interrupt_request_ports = (
+                self._uncached_interrupt_request_ports
+                + ["interrupts[0].int_requestor"]
             )


### PR DESCRIPTION
This reverts commit bc39283451c6b563f8db6660ce694e838a3b38b0.

Stops #1033 (but not a true fix for the issue).

This revert can be unreverted when a solution to #1033 is found.