### PR TITLE
cpu: Fix Ruby/x86 pio port connections

### DIFF
--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -302,20 +302,25 @@ class BaseCPU(ClockedObject):
 
         # Practically speaking, these ports will exist on the x86 interrupt
         # controller class.
+        # Note: _uncached_interrupt_response_ports is a *class* variable
+        # not a *instance* variable. Thus, we cannot use `extend` here.
         if "pio" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_response_ports.extend(
-                [f"interrupts[{i}].pio" for i in range(self.numThreads)]
+            self._uncached_interrupt_response_ports = (
+                self._uncached_interrupt_response_ports
+                + [f"interrupts[{i}].pio" for i in range(self.numThreads)]
             )
         if "int_responder" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_response_ports.extend(
-                [
+            self._uncached_interrupt_response_ports = (
+                self._uncached_interrupt_response_ports
+                + [
                     f"interrupts[{i}].int_responder"
                     for i in range(self.numThreads)
                 ]
             )
         if "int_requestor" in self.ArchInterrupts._ports:
-            self._uncached_interrupt_request_ports.extend(
-                [
+            self._uncached_interrupt_request_ports = (
+                self._uncached_interrupt_request_ports
+                + [
                     f"interrupts[{i}].int_requestor"
                     for i in range(self.numThreads)
                 ]


### PR DESCRIPTION
Fixes #1033

In the BaseCPU object _uncached_interrupt_response_ports is a class variable, not an instance variable. #1004 changed the explicit self._uncached_interrupt_response_ports to use extend. This caused the list of ports to be extended *for all cores*, which caused problems when using a system with more than 1 core.

This reverts the `extend` part of the change, but keeps the rest.

Change-Id: I6dc7d6da6763048d82960229d34933a3a2ac36e0