### PR TITLE
cpu: Don't change to suspend if the thread status is halted

### DIFF
--- a/src/cpu/o3/thread_context.cc
+++ b/src/cpu/o3/thread_context.cc
@@ -86,7 +86,9 @@ ThreadContext::suspend()
     DPRINTF(O3CPU, "Calling suspend on Thread Context %d\n",
             threadId());
 
-    if (thread->status() == gem5::ThreadContext::Suspended)
+    if (thread->status() == gem5::ThreadContext::Suspended ||
+        thread->status() == gem5::ThreadContext::Halting ||
+        thread->status() == gem5::ThreadContext::Halted)
         return;
 
     if (cpu->isDraining()) {

--- a/src/cpu/simple_thread.cc
+++ b/src/cpu/simple_thread.cc
@@ -143,7 +143,8 @@ SimpleThread::activate()
 void
 SimpleThread::suspend()
 {
-    if (status() == ThreadContext::Suspended)
+    if (status() == ThreadContext::Suspended ||
+        status() == ThreadContext::Halted)
         return;
 
     lastActivate = curTick();


### PR DESCRIPTION
In our gem5 model, there are four types represent thread context: Active, Suspend, Halting and Halted

https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/thread_context.hh#L99-L117

When initializing the gem5 instance, all of the thread contexts are set Halted. The status of thread context will not be active until the Workload initializes start up, except the StubWorkload. So if the user uses the StubWorkload, and the CPU is connected with the model_reset port. The thread context of the CPU will be activated possibly.

The following is the steps of activating thread context of the CPU without Workload[1] initialization or lower model_reset port[2].

1. Raise the model_reset port (Change the state from Halted to Suspend) https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/base.cc#L671-L673

2. Post the interrupt to CPU (Change the state from Suspend to Active) https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/base.cc#L231-L239

Implementation of wakeup

SimpleCPU:
https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/simple/base.cc#L251-L259

MinorCPU:
https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/minor/cpu.cc#L143-L151

O3CPU:
https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/o3/cpu.cc#L1337-L1346

This CL fixed the issue when raising the model reset port to CPU(let CPU sleep) if the CPU is not activated by workload. If the CPU status is halted, it's should not change to Suspend to avoid wake up

Reference

The model_reset is introduced in the CL:
https://gem5-review.googlesource.com/c/public/gem5/+/67574/4

[1] Activate by workload (ARM example):
https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/arch/arm/fs_workload.cc#L101-L114

[2] Lower the model_reset:
https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/base.cc#L191-L192 https://github.com/gem5/gem5/blob/5641c5e4642f7d44651f783bdb018d3cf8ba01b5/src/cpu/base.cc#L674-L685

Change-Id: I5bfc0b7491d14369fff77b98b71c0ac763fb7c42