### PR TITLE
arch-x86: Add XCR0 register and add to X86KvmCPU

### DIFF
--- a/configs/example/gem5_library/checkpoints/simpoints-se-restore.py
+++ b/configs/example/gem5_library/checkpoints/simpoints-se-restore.py
@@ -125,7 +125,7 @@ board.set_se_simpoint_workload(
         weight_list=[0.1, 0.2, 0.4, 0.3],
         warmup_interval=1000000,
     ),
-    checkpoint=obtain_resource("simpoints-se-checkpoints-v24-0"),
+    checkpoint=obtain_resource("simpoints-se-checkpoints"),
 )
 
 

--- a/src/arch/x86/fs_workload.cc
+++ b/src/arch/x86/fs_workload.cc
@@ -302,6 +302,11 @@ FsWorkload::initState()
     // Point to the page tables.
     tc->setMiscReg(misc_reg::Cr3, PageMapLevel4);
 
+    // Only used if cr4.osxsave is set
+    XCR0 xcr0 = tc->readMiscRegNoEffect(misc_reg::Xcr0);
+    xcr0.x87 = 1; // Must be 1 according to x86 specification
+    tc->setMiscReg(misc_reg::Xcr0, xcr0);
+
     Efer efer = tc->readMiscRegNoEffect(misc_reg::Efer);
     // Enable long mode.
     efer.lme = 1;

--- a/src/arch/x86/isa.cc
+++ b/src/arch/x86/isa.cc
@@ -338,6 +338,8 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
         break;
       case misc_reg::Cr8:
         break;
+      case misc_reg::Xcr0:
+        break;
       case misc_reg::Rflags:
         {
             RFLAGS rflags = val;

--- a/src/arch/x86/kvm/x86_cpu.hh
+++ b/src/arch/x86/kvm/x86_cpu.hh
@@ -217,6 +217,8 @@ class X86KvmCPU : public BaseKvmCPU
     void updateKvmStateFPUXSave();
     /** Update MSR registers */
     void updateKvmStateMSRs();
+    /** Update XCR registers */
+    void updateKvmStateXCRs();
     /** @} */
 
     /**
@@ -236,6 +238,8 @@ class X86KvmCPU : public BaseKvmCPU
     void updateThreadContextXSave(const struct kvm_xsave &kxsave);
     /** Update MSR registers */
     void updateThreadContextMSRs();
+    /** Update XCR registers */
+    void updateThreadContextXCRs();
     /** @} */
 
     /** Transfer gem5's CPUID values into the virtual CPU. */

--- a/src/arch/x86/regs/misc.hh
+++ b/src/arch/x86/regs/misc.hh
@@ -405,6 +405,9 @@ enum : RegIndex
     // "Fake" MSRs for internally implemented devices
     PciConfigAddress,
 
+    XcrBase,
+    Xcr0 = XcrBase,
+
     NumRegs
 };
 
@@ -422,6 +425,13 @@ cr(int index)
 {
     assert(index >= 0 && index < NumCRegs);
     return CrBase + index;
+}
+
+static inline RegIndex
+xcr(int index)
+{
+    assert(index >= 0 && index < NumXCRegs);
+    return XcrBase + index;
 }
 
 static inline RegIndex
@@ -648,6 +658,24 @@ EndBitUnion(CR4)
 BitUnion64(CR8)
     Bitfield<3, 0> tpr; // Task Priority Register
 EndBitUnion(CR8)
+
+BitUnion64(XCR0)
+    Bitfield<0> x87; // x87 FPU/MMX support (must be 1)
+    Bitfield<1> sse; // XSAVE support for MXCSR and XMM registers
+    Bitfield<2> avx; // AVX enabled and XSAVE support for upper halves of YMM
+                     // registers
+    Bitfield<3> bndreg; // MPX enabled and XSAVE support for BND0-BND3
+                        // registers
+    Bitfield<4> bndsrc; // MPX enabled and XSAVE support for BNDCFGU and
+                        // BNDSTATUS registers
+    Bitfield<5> opmask; // AVX-512 enabled and XSAVE support for opmask
+                        // registers k0-k7
+    Bitfield<6> zmm_hi256; // AVX-512 enabled and XSAVE support for upper
+                           // halves of lower ZMM registers
+    Bitfield<7> hi16_zmm; // AVX-512 enabled and XSAVE support for upper ZMM
+                          // registers
+    Bitfield<9> pkru; // XSAVE support for PKRU register
+EndBitUnion(XCR0)
 
 BitUnion64(DR6)
     Bitfield<0> b0;

--- a/src/arch/x86/x86_traits.hh
+++ b/src/arch/x86/x86_traits.hh
@@ -55,6 +55,7 @@ namespace X86ISA
 
     const int NumCRegs = 16;
     const int NumDRegs = 8;
+    const int NumXCRegs = 1;
 
     const int NumSegments = 6;
     const int NumSysSegments = 4;

--- a/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
@@ -81,7 +81,7 @@ board.set_kernel_disk_workload(
         "x86-ubuntu-18.04-img", resource_version="1.0.0"
     ),
     checkpoint=obtain_resource(
-        "x86-fs-test-checkpoint-v24-0", resource_version="2.0.0"
+        "x86-fs-test-checkpoint-v24-0", resource_version="3.0.0"
     ),
 )
 

--- a/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
@@ -66,7 +66,7 @@ board.set_se_binary_workload(
         resource_version="1.0.0",
     ),
     checkpoint=obtain_resource(
-        "x86-hello-test-checkpoint-v24-0", resource_version="2.0.0"
+        "x86-hello-test-checkpoint-v24-0", resource_version="3.0.0"
     ),
 )
 

--- a/util/cpt_upgraders/x86-add-xcr0.py
+++ b/util/cpt_upgraders/x86-add-xcr0.py
@@ -44,3 +44,11 @@ def upgrader(cpt):
                 # Add the default value of XCR0 (1) if missing
                 regVals = f"{regVals} 1"
                 cpt.set(sec, "regVal", regVals)
+        elif re.search(rf"board\.processor\.cores.*isa$", sec):
+            # ISA name doesn't appear to be anywhere in the checkpoint.
+            # Assume it is X86.
+            regVals = cpt.get(sec, "regVal")
+
+            # Add the default value of XCR0 (1) if missing
+            regVals = f"{regVals} 1"
+            cpt.set(sec, "regVal", regVals)

--- a/util/cpt_upgraders/x86-add-xcr0.py
+++ b/util/cpt_upgraders/x86-add-xcr0.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2024 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+def upgrader(cpt):
+    """
+    Update the checkpoint to include the XCR0 register if X86 checkpoint.
+    The value is set to the default of 1.
+    """
+
+    import re
+
+    for sec in cpt.sections():
+        if re.search(r".*sys.*\.cpu.*\.isa$", sec):
+            if cpt.get(sec, "isaName") == "x86":
+                regVals = cpt.get(sec, "regVal")
+
+                # Add the default value of XCR0 (1) if missing
+                regVals = f"{regVals} 1"
+                cpt.set(sec, "regVal", regVals)


### PR DESCRIPTION
The extended control registers were not being updated in the KVM thread context nor updated in the KVM state. This was causing issues when checkpointing since the XCR0 value was reverting to the default value rather than what it was previously before the checkpoint. THis was causing multiple applications to crash due to executing instructions which are now illegal instructions due to XCR0 being incorrect.

This commit adds the XCR0 as a misc register similar to the exiting x86 control registers and adds all of the helper functions to access and set the register value. It also adds support for updating the KVM CPU's state with the register value and updating the thread context's misc reg value so that it is checkpointed along with the other misc regs.

Note that this does *not* add support for XSAVE of the AVX state (i.e., the upper 128 bits of YMM registers). It does however fix the immediate problem in issue #958 .

Change-Id: I97456c8b57cbc7b381bd4be94944ce6567a43c76