### PR TITLE
configs: GPUFS: Turn off SSE4 and fancy XSAVEs

### DIFF
--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -263,7 +263,7 @@ def makeGpuFSSystem(args):
         0x00000340,
         0x00000000,
         0x00000340,
-        0x0000000F,
+        0x00000000,
         0x00000340,
         0x00000000,
         0x00000000,
@@ -281,7 +281,7 @@ def makeGpuFSSystem(args):
     # See: https://sandpile.org/x86/cpuid.htm#level_0000_0001h
     # Enables AVX, OSXSAVE, XSAVE, POPCNT, SSE4.2, SSE4.1, CMPXCHG16B,
     # and FMA.
-    avx_cpu_features = [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x1C983209]
+    avx_cpu_features = [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x1C803209]
 
     for i, cpu in enumerate(system.cpu):
         # Break once we reach the shader "CPU"


### PR DESCRIPTION
A user reported a bug with the SSE4.1 version of memcmp in libc. When enabled the simulated program crashes with SIGILL. After attempting all fixes recommended by Intel SDM and still not working, turning the bit off instead.

Similar, the default XSAVE functionality is not completely implemented for AVX and newer ISA extensions. Therefore, there is not much point to claiming to support the more advanced versions of XSAVE (XSAVEOPT, XSAVEC, XSAVES, and XGETBV with ECX=1).

Note that none of these bits are enabled for non-GPU full system simulations (see src/arch/x86/X86ISA.py). This only impacts GPUFS simulations.

Change-Id: I8eb7bf0f2a0a29226095e7889fec9c1e8a65f88f