### PR TITLE
mem-ruby: Fix functional reads for MESI Three-Level messages

### DIFF
--- a/src/mem/ruby/protocol/MESI_Three_Level-msg.sm
+++ b/src/mem/ruby/protocol/MESI_Three_Level-msg.sm
@@ -81,8 +81,9 @@ structure(CoherenceMsg, desc="...", interface="Message") {
   PrefetchBit Prefetch,         desc="Is this a prefetch request";
 
   bool functionalRead(Packet *pkt) {
-    // Only PUTX messages contains the data block
-    if (Class == CoherenceClass:PUTX) {
+    // Valid data block is only present in message with following types
+    if (Class == CoherenceClass:PUTX ||
+        Class == CoherenceClass:DATA_EXCLUSIVE) {
         return testAndRead(addr, DataBlk, pkt);
     }
 


### PR DESCRIPTION
Fix #1044. This patch adds checks for message types (PUTX_COPY, DATA, DATA_EXCLUSIVE) that contain data blocks but were missing from the original `functionalRead` method in MESI Three-Level messages.

Change-Id: I0cedc314166c9cc037bf20f5b7fef5552dd1253c