### PR TITLE
util: Enable m5term Apple Mac OS Compilation

### DIFF
--- a/util/term/term.c
+++ b/util/term/term.c
@@ -32,7 +32,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>
-#include <linux/limits.h>
+#ifdef __APPLE__
+    #include <sys/syslimits.h>
+#else
+    #include <linux/limits.h>
+#endif
 #include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>


### PR DESCRIPTION
The "linux/limits.h" equivalent on Apple systems is "sys/syslimits.h". By adding an include guard to include the correct header dependent on the host system, we can compile m5term on Mac OS systems.
