### PR TITLE
cpu-o3: Clear current macro-op in fetch if squashing after last micro-op

### DIFF
--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -691,7 +691,8 @@ Fetch::doSquash(const PCStateBase &new_pc, const DynInstPtr squashInst,
 
     set(pc[tid], new_pc);
     fetchOffset[tid] = 0;
-    if (squashInst && squashInst->pcState().instAddr() == new_pc.instAddr())
+    if (squashInst && squashInst->pcState().instAddr() == new_pc.instAddr() &&
+        !squashInst->isLastMicroop())
         macroop[tid] = squashInst->macroop;
     else
         macroop[tid] = NULL;


### PR DESCRIPTION
Fix #1042. Clear the current fetch macro-op if the instruction initiating the squash is the last micro-op in its macro-op.

Change-Id: I77f60334771277e47f19573d4067b3a7bc5488b2