### PR TITLE
cpu-o3: Clear thread state in time buffers on thread exit

### DIFF
--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -36,6 +36,7 @@ if env['CONF']['BUILD_ISA']:
     SimObject('BaseO3CPU.py', sim_objects=['BaseO3CPU'], enums=[
         'SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
 
+    Source('comm.cc')
     Source('commit.cc')
     Source('cpu.cc')
     Source('decode.cc')

--- a/src/cpu/o3/comm.cc
+++ b/src/cpu/o3/comm.cc
@@ -1,0 +1,74 @@
+#include "cpu/o3/comm.hh"
+
+#include <algorithm>
+
+#include "cpu/o3/dyn_inst.hh"
+
+namespace gem5
+{
+
+namespace o3
+{
+
+/**
+ * Remove instructions belonging to given thread from plain
+ * instruction array. Automatically updates the array size.
+ */
+static void
+removeThreadInsts(ThreadID tid, DynInstPtr *insts, int &size)
+{
+    auto has_tid = [tid] (const DynInstPtr &inst) -> bool {
+        return inst->threadNumber == tid;
+    };
+    DynInstPtr *last = std::remove_if(insts, insts + size, has_tid);
+    size = last - insts;
+}
+
+void
+FetchStruct::clearStates(ThreadID tid)
+{
+    removeThreadInsts(tid, insts, size);
+}
+
+void
+DecodeStruct::clearStates(ThreadID tid)
+{
+    removeThreadInsts(tid, insts, size);
+}
+
+void
+RenameStruct::clearStates(ThreadID tid)
+{
+    removeThreadInsts(tid, insts, size);
+}
+
+void
+IEWStruct::clearStates(ThreadID tid)
+{
+    removeThreadInsts(tid, insts, size);
+    mispredictInst[tid] = nullptr;
+    pc[tid] = nullptr;
+    squash[tid] = false;
+    branchMispredict[tid] = false;
+}
+
+void
+TimeStruct::clearStates(ThreadID tid)
+{
+    // Reset the thread's decode, rename, IEW, and commit structs to
+    // their default values.
+    decodeInfo[tid] = DecodeComm();
+    renameInfo[tid] = RenameComm();
+    iewInfo[tid] = IewComm();
+    commitInfo[tid] = CommitComm();
+
+    decodeBlock[tid] = false;
+    decodeUnblock[tid] = false;
+    renameBlock[tid] = false;
+    renameUnblock[tid] = false;
+    iewBlock[tid] = false;
+    iewUnblock[tid] = false;
+}
+
+}
+}

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -66,6 +66,9 @@ struct FetchStruct
     Fault fetchFault;
     InstSeqNum fetchFaultSN;
     bool clearFetchFault;
+
+    /** Remove any thread-specific state. */
+    void clearStates(ThreadID tid);
 };
 
 /** Struct that defines the information passed from decode to rename. */
@@ -74,6 +77,9 @@ struct DecodeStruct
     int size;
 
     DynInstPtr insts[MaxWidth];
+
+    /** Remove any thread-specific state. */
+    void clearStates(ThreadID tid);
 };
 
 /** Struct that defines the information passed from rename to IEW. */
@@ -82,6 +88,9 @@ struct RenameStruct
     int size;
 
     DynInstPtr insts[MaxWidth];
+
+    /** Remove any thread-specific state. */
+    void clearStates(ThreadID tid);
 };
 
 /** Struct that defines the information passed from IEW to commit. */
@@ -99,6 +108,9 @@ struct IEWStruct
     bool branchMispredict[MaxThreads];
     bool branchTaken[MaxThreads];
     bool includeSquashInst[MaxThreads];
+
+    /** Remove any thread-specific state. */
+    void clearStates(ThreadID tid);
 };
 
 struct IssueStruct
@@ -116,14 +128,14 @@ struct TimeStruct
         std::unique_ptr<PCStateBase> nextPC;
         DynInstPtr mispredictInst;
         DynInstPtr squashInst;
-        InstSeqNum doneSeqNum;
-        Addr mispredPC;
-        uint64_t branchAddr;
-        unsigned branchCount;
-        bool squash;
-        bool predIncorrect;
-        bool branchMispredict;
-        bool branchTaken;
+        InstSeqNum doneSeqNum = 0;
+        Addr mispredPC = 0;
+        uint64_t branchAddr = 0;
+        unsigned branchCount = 0;
+        bool squash = false;
+        bool predIncorrect = false;
+        bool branchMispredict = false;
+        bool branchTaken = false;
     };
 
     DecodeComm decodeInfo[MaxThreads];
@@ -135,18 +147,18 @@ struct TimeStruct
     struct IewComm
     {
         // Also eventually include skid buffer space.
-        unsigned freeIQEntries;
-        unsigned freeLQEntries;
-        unsigned freeSQEntries;
-        unsigned dispatchedToLQ;
-        unsigned dispatchedToSQ;
+        unsigned freeIQEntries = 0;
+        unsigned freeLQEntries = 0;
+        unsigned freeSQEntries = 0;
+        unsigned dispatchedToLQ = 0;
+        unsigned dispatchedToSQ = 0;
 
-        unsigned iqCount;
-        unsigned ldstqCount;
+        unsigned iqCount = 0;
+        unsigned ldstqCount = 0;
 
-        unsigned dispatched;
-        bool usedIQ;
-        bool usedLSQ;
+        unsigned dispatched = 0;
+        bool usedIQ = false;
+        bool usedLSQ = false;
     };
 
     IewComm iewInfo[MaxThreads];
@@ -183,35 +195,35 @@ struct TimeStruct
 
         /// Communication specifically to the IQ to tell the IQ that it can
         /// schedule a non-speculative instruction.
-        InstSeqNum nonSpecSeqNum; // *I
+        InstSeqNum nonSpecSeqNum = 0; // *I
 
         /// Represents the instruction that has either been retired or
         /// squashed.  Similar to having a single bus that broadcasts the
         /// retired or squashed sequence number.
-        InstSeqNum doneSeqNum; // *F, I
+        InstSeqNum doneSeqNum = 0; // *F, I
 
         /// Tell Rename how many free entries it has in the ROB
-        unsigned freeROBEntries; // *R
+        unsigned freeROBEntries = 0; // *R
 
-        bool squash; // *F, D, R, I
-        bool robSquashing; // *F, D, R, I
+        bool squash = false; // *F, D, R, I
+        bool robSquashing = false; // *F, D, R, I
 
         /// Rename should re-read number of free rob entries
-        bool usedROB; // *R
+        bool usedROB = false; // *R
 
         /// Notify Rename that the ROB is empty
-        bool emptyROB; // *R
+        bool emptyROB = false; // *R
 
         /// Was the branch taken or not
-        bool branchTaken; // *F
+        bool branchTaken = false; // *F
         /// If an interrupt is pending and fetch should stall
-        bool interruptPending; // *F
+        bool interruptPending = false; // *F
         /// If the interrupt ended up being cleared before being handled
-        bool clearInterrupt; // *F
+        bool clearInterrupt = false; // *F
 
         /// Hack for now to send back an strictly ordered access to
         /// the IEW stage.
-        bool strictlyOrdered; // *I
+        bool strictlyOrdered = false; // *I
 
     };
 
@@ -223,6 +235,9 @@ struct TimeStruct
     bool renameUnblock[MaxThreads];
     bool iewBlock[MaxThreads];
     bool iewUnblock[MaxThreads];
+
+    /** Remove any thread-specific state. */
+    void clearStates(ThreadID tid);
 };
 
 } // namespace o3

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -651,14 +651,16 @@ CPU::removeThread(ThreadID tid)
     rename.clearStates(tid);
     iew.clearStates(tid);
 
-    // Flush out any old data from the time buffers.
-    for (int i = 0; i < timeBuffer.getSize(); ++i) {
-        timeBuffer.advance();
-        fetchQueue.advance();
-        decodeQueue.advance();
-        renameQueue.advance();
-        iewQueue.advance();
-    }
+    // Clear all thread-specific state from the time buffers.
+    auto clear_timebuf = [tid] (auto &buf) {
+        for (int i = -buf.getPast(); i <= buf.getFuture(); ++i)
+            buf[i].clearStates(tid);
+    };
+    clear_timebuf(timeBuffer);
+    clear_timebuf(fetchQueue);
+    clear_timebuf(decodeQueue);
+    clear_timebuf(renameQueue);
+    clear_timebuf(iewQueue);
 
     // at this step, all instructions in the pipeline should be already
     // either committed successfully or squashed. All thread-specific

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -245,6 +245,16 @@ class TimeBuffer
     {
         return size;
     }
+
+    int getPast() const
+    {
+        return past;
+    }
+
+    int getFuture() const
+    {
+        return future;
+    }
 };
 
 } // namespace gem5


### PR DESCRIPTION
Fix #1049. Clear only thread-specific state from the O3 CPU time buffers, rather than clearing *all* state for *all* threads.

Specifically, this patch adds a `clearStates()` method for all O3 time buffer structs in src/cpu/o3/comm.hh. Upon thread exit, `CPU::removeThread()` now invokes this method for all structs in each time buffer, rather than flushing out the time buffers (which nukes the states for all threads, not just the exiting one).

Change-Id: I48cd50e39b3cd5e0068ddfc19a03d9bbd3f31bd5