### PR TITLE
arch-vega: Pass s_memtime through smem pipe

### DIFF
--- a/src/arch/amdgpu/common/tlb.cc
+++ b/src/arch/amdgpu/common/tlb.cc
@@ -379,7 +379,11 @@ namespace X86ISA
 
         assert(seg != segment_idx::Ms);
         Addr vaddr = req->getVaddr();
-        DPRINTF(GPUTLB, "TLB Lookup for vaddr %#x.\n", vaddr);
+        if (req->isMemtime()) {
+            return true;
+        } else {
+            DPRINTF(GPUTLB, "TLB Lookup for vaddr %#x.\n", vaddr);
+        }
         HandyM5Reg m5Reg = tc->readMiscRegNoEffect(misc_reg::M5Reg);
 
         if (m5Reg.prot) {
@@ -693,13 +697,19 @@ namespace X86ISA
         if (success) {
             lookup_outcome = TLB_HIT;
             // Put the entry in SenderState
-            TlbEntry *entry = lookup(tmp_req->getVaddr(), false);
-            assert(entry);
-
             auto p = sender_state->tc->getProcessPtr();
-            sender_state->tlbEntry =
-                new TlbEntry(p->pid(), entry->vaddr, entry->paddr,
-                             false, false);
+            if (pkt->req->isMemtime()) {
+                sender_state->tlbEntry =
+                    new TlbEntry(p->pid(), 0, 0,
+                                 false, false);
+            } else {
+                TlbEntry *entry = lookup(tmp_req->getVaddr(), false);
+                assert(entry);
+
+                sender_state->tlbEntry =
+                    new TlbEntry(p->pid(), entry->vaddr, entry->paddr,
+                                 false, false);
+            }
 
             if (update_stats) {
                 // the reqCnt has an entry per level, so its size tells us

--- a/src/arch/amdgpu/vega/gpu_mem_helpers.hh
+++ b/src/arch/amdgpu/vega/gpu_mem_helpers.hh
@@ -155,11 +155,17 @@ initMemReqScalarHelper(GPUDynInstPtr gpuDynInst, MemCmd mem_req_type)
      * than the address of the first byte then we have a misaligned
      * access.
      */
-    bool misaligned_acc = split_addr > vaddr;
+    bool misaligned_acc = split_addr > vaddr &&
+      !gpuDynInst->staticInstruction()->isMemtime();
 
-    RequestPtr req = std::make_shared<Request>(vaddr, req_size, 0,
-                                 gpuDynInst->computeUnit()->requestorId(), 0,
-                                 gpuDynInst->wfDynId);
+    Request::Flags flags;
+    if (gpuDynInst->staticInstruction()->isMemtime()) {
+        flags.set(Request::MEMTIME);
+    }
+    RequestPtr req = std::make_shared<Request>(
+        vaddr, req_size, std::move(flags),
+        gpuDynInst->computeUnit()->requestorId(), 0,
+        gpuDynInst->wfDynId);
 
     if (misaligned_acc) {
         RequestPtr req1, req2;

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -6103,6 +6103,8 @@ namespace VegaISA
             }
         } // getOperandSize
 
+        void initiateAcc(GPUDynInstPtr gpuDynInst) override;
+        void completeAcc(GPUDynInstPtr gpuDynInst) override;
         void execute(GPUDynInstPtr) override;
     }; // Inst_SMEM__S_MEMTIME
 

--- a/src/gpu-compute/GPUStaticInstFlags.py
+++ b/src/gpu-compute/GPUStaticInstFlags.py
@@ -105,4 +105,5 @@ class GPUStaticInstFlags(Enum):
         "FMA",  # FMA
         "MAC",  # MAC
         "MAD",  # MAD
+        "Memtime",  # MAD
     ]

--- a/src/gpu-compute/gpu_static_inst.hh
+++ b/src/gpu-compute/gpu_static_inst.hh
@@ -219,6 +219,8 @@ class GPUStaticInst : public GPUStaticInstFlags
     bool isMAC() const { return _flags[MAC]; }
     bool isMAD() const { return _flags[MAD]; }
 
+    bool isMemtime() const { return _flags[Memtime]; }
+
     virtual int instSize() const = 0;
 
     // only used for memory instructions

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -255,7 +255,8 @@ class Request : public Extensible<Request>
          * These flags are *not* cleared when a Request object is
          * reused (assigned a new address).
          */
-        STICKY_FLAGS = INST_FETCH
+        STICKY_FLAGS = INST_FETCH,
+        MEMTIME                     = 0x0001000000000000,
     };
     static const FlagsType STORE_NO_DATA = CACHE_BLOCK_ZERO |
         CLEAN | INVALIDATE;
@@ -1013,6 +1014,7 @@ class Request : public Extensible<Request>
     bool isUncacheable() const { return _flags.isSet(UNCACHEABLE); }
     bool isStrictlyOrdered() const { return _flags.isSet(STRICT_ORDER); }
     bool isInstFetch() const { return _flags.isSet(INST_FETCH); }
+    bool isMemtime() const { return _flags.isSet(MEMTIME); }
     bool
     isPrefetch() const
     {

--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -243,12 +243,17 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     if (mandatoryQueue_in.isReady(clockEdge())) {
       peek(mandatoryQueue_in, RubyRequest, block_on="LineAddress") {
         Entry cache_entry := getCacheEntry(in_msg.LineAddress);
-        TBE tbe := TBEs.lookup(in_msg.LineAddress);
-        DPRINTF(RubySlicc, "%s\n", in_msg);
-        if (in_msg.Type == RubyRequestType:REPLACEMENT) {
-          trigger(Event:Evict, in_msg.LineAddress, cache_entry, tbe);
+        if (in_msg.Type == RubyRequestType:Memtime) {
+          sequencer.readCallback(in_msg.LineAddress, cache_entry.DataBlk, true, MachineType:L1Cache);
+          mandatoryQueue_in.dequeue(clockEdge());
         } else {
-          trigger(Event:Fetch, in_msg.LineAddress, cache_entry, tbe);
+          TBE tbe := TBEs.lookup(in_msg.LineAddress);
+          DPRINTF(RubySlicc, "%s\n", in_msg);
+          if (in_msg.Type == RubyRequestType:REPLACEMENT) {
+            trigger(Event:Evict, in_msg.LineAddress, cache_entry, tbe);
+          } else {
+            trigger(Event:Fetch, in_msg.LineAddress, cache_entry, tbe);
+          }
         }
       }
     }

--- a/src/mem/ruby/protocol/RubySlicc_Exports.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Exports.sm
@@ -193,6 +193,7 @@ enumeration(RubyRequestType, desc="...", default="RubyRequestType_NULL") {
   TLBI_SYNC,         desc="TLB Invalidation Sync operation - Potential initiation";
   TLBI_EXT_SYNC,      desc="TLB Invalidation Sync operation - External Sync has been requested";
   TLBI_EXT_SYNC_COMP, desc="TLB Invalidation Sync operation - External Sync has been completed";
+  Memtime,           desc="s_memtime msg";
 }
 
 bool isWriteRequest(RubyRequestType type);

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -268,7 +268,7 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
     }
     // Check for pio requests and directly send them to the dedicated
     // pio port.
-    if (pkt->cmd != MemCmd::MemSyncReq) {
+    if (pkt->cmd != MemCmd::MemSyncReq && !pkt->req->isMemtime()) {
         if (!pkt->req->isMemMgmt() && !isPhysMemAddress(pkt)) {
             assert(owner.memRequestPort.isConnected());
             DPRINTF(RubyPort, "Request address %#x assumed to be a "
@@ -456,7 +456,9 @@ RubyPort::ruby_hit_callback(PacketPtr pkt)
 
     // The packet was destined for memory and has not yet been turned
     // into a response
-    assert(system->isMemAddr(pkt->getAddr()) || system->isDeviceMemAddr(pkt));
+    assert(system->isMemAddr(pkt->getAddr()) ||
+        system->isDeviceMemAddr(pkt) ||
+        pkt->req->isMemtime());
     assert(pkt->isRequest());
 
     // First we must retrieve the request port from the sender State
@@ -613,7 +615,7 @@ RubyPort::MemResponsePort::hitCallback(PacketPtr pkt)
 
     // Flush, acquire, release requests don't access physical memory
     if (pkt->isFlush() || pkt->cmd == MemCmd::MemSyncReq
-        || pkt->cmd == MemCmd::WriteCompleteResp) {
+        || pkt->cmd == MemCmd::WriteCompleteResp || pkt->req->isMemtime()) {
         accessPhysMem = false;
     }
 


### PR DESCRIPTION
Previously, the cycle count was written with no
latency. Now, the cycle count is written when
the scalar memory pipeline executes s_memtime,
because a s_memtime should be treated like a
s_load_dwordx2. Through microbenchmarks, the
s_memtime latency has been set to 41 clock cycles.

Change-Id: I8860ab03e52d6dc9c80072cea99d6e0913201c45