### PR TITLE
systemc: remove if clause in Gem5ToTlmBridgeBase

### DIFF
--- a/src/systemc/tlm_bridge/gem5_to_tlm.cc
+++ b/src/systemc/tlm_bridge/gem5_to_tlm.cc
@@ -253,15 +253,13 @@ Gem5ToTlmBridge<BITWIDTH>::pec(
         if (need_retry) {
             blockingResponse = &trans;
         } else {
-            if (phase == tlm::BEGIN_RESP) {
-                // Send END_RESP and we're finished:
-                tlm::tlm_phase fw_phase = tlm::END_RESP;
-                sc_core::sc_time delay = sc_core::SC_ZERO_TIME;
-                socket->nb_transport_fw(trans, fw_phase, delay);
-                // Release the transaction with all the extensions.
-                packetMap.erase(&trans);
-                trans.release();
-            }
+            // Send END_RESP and we're finished:
+            tlm::tlm_phase fw_phase = tlm::END_RESP;
+            sc_core::sc_time delay = sc_core::SC_ZERO_TIME;
+            socket->nb_transport_fw(trans, fw_phase, delay);
+            // Release the transaction with all the extensions.
+            packetMap.erase(&trans);
+            trans.release();
         }
     }
 }


### PR DESCRIPTION
In the payload event queue in Gem5ToTlmBridgeBase, the phase is checked twice for BEGIN_RESP. This commit removes the second if clause since it is unnecessary.

Duplicate if clause in line 234 & line 256

https://github.com/gem5/gem5/blob/dd2689905fcb77a65f190705ba5f2b793535e28c/src/systemc/tlm_bridge/gem5_to_tlm.cc#L234-L267

please correct me if I am missing something important