### PR TITLE
arch-arm: Refactor PTW

### DIFF
--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -200,6 +200,26 @@ MMU::invalidateMiscReg()
 }
 
 Fault
+MMU::testAndFinalize(const RequestPtr &req,
+                     ThreadContext *tc, Mode mode,
+                     TlbEntry* te, CachedState &state) const
+{
+    // If we don't have a valid tlb entry it means virtual memory
+    // is not enabled
+    auto domain = te ? te-> domain : TlbEntry::DomainType::NoAccess;
+
+    // Check for a tester generated address fault
+    Fault fault = testTranslation(req, mode, domain, state);
+    if (fault != NoFault) {
+        return fault;
+    } else {
+        // Now that we checked no fault has been generated in the
+        // translation process, we can finalize the physical address
+        return finalizePhysical(req, tc, mode);
+    }
+}
+
+Fault
 MMU::finalizePhysical(const RequestPtr &req,
                       ThreadContext *tc, Mode mode) const
 {
@@ -848,12 +868,7 @@ MMU::translateMmuOff(ThreadContext *tc, const RequestPtr &req, Mode mode,
             state.isStage2);
     setAttr(temp_te.attributes);
 
-    Fault fault = testTranslation(req, mode, TlbEntry::DomainType::NoAccess, state);
-    if (fault == NoFault) {
-        return finalizePhysical(req, tc, mode);
-    } else {
-        return fault;
-    }
+    return testAndFinalize(req, tc, mode, nullptr, state);
 }
 
 Fault
@@ -914,18 +929,11 @@ MMU::translateMmuOn(ThreadContext* tc, const RequestPtr &req, Mode mode,
                     tranMethod);
         }
 
-        // Check for a trickbox generated address fault
         if (fault == NoFault)
-            fault = testTranslation(req, mode, te->domain, state);
+            fault = testAndFinalize(req, tc, mode, te, state);
     }
 
-    if (fault == NoFault) {
-        // Don't try to finalize a physical address unless the
-        // translation has completed (i.e., there is a table entry).
-        return te ? finalizePhysical(req, tc, mode) : NoFault;
-    } else {
-        return fault;
-    }
+    return fault;
 }
 
 Fault
@@ -1565,7 +1573,7 @@ MMU::setTestInterface(SimObject *_ti)
 
 Fault
 MMU::testTranslation(const RequestPtr &req, Mode mode,
-                     TlbEntry::DomainType domain, CachedState &state)
+                     TlbEntry::DomainType domain, CachedState &state) const
 {
     if (!test || !req->hasSize() || req->getSize() == 0 ||
         req->isCacheMaintenance()) {

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -848,7 +848,12 @@ MMU::translateMmuOff(ThreadContext *tc, const RequestPtr &req, Mode mode,
             state.isStage2);
     setAttr(temp_te.attributes);
 
-    return testTranslation(req, mode, TlbEntry::DomainType::NoAccess, state);
+    Fault fault = testTranslation(req, mode, TlbEntry::DomainType::NoAccess, state);
+    if (fault == NoFault) {
+        return finalizePhysical(req, tc, mode);
+    } else {
+        return fault;
+    }
 }
 
 Fault

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -1551,6 +1551,10 @@ MMU::setTestInterface(SimObject *_ti)
         TlbTestInterface *ti(dynamic_cast<TlbTestInterface *>(_ti));
         fatal_if(!ti, "%s is not a valid ARM TLB tester\n", _ti->name());
         test = ti;
+        itbWalker->setTestInterface(test);
+        dtbWalker->setTestInterface(test);
+        itbStage2Walker->setTestInterface(test);
+        dtbStage2Walker->setTestInterface(test);
     }
 }
 
@@ -1563,28 +1567,6 @@ MMU::testTranslation(const RequestPtr &req, Mode mode,
         return NoFault;
     } else {
         return test->translationCheck(req, state.isPriv, mode, domain);
-    }
-}
-
-Fault
-MMU::testWalk(Addr pa, Addr size, Addr va, bool is_secure, Mode mode,
-              TlbEntry::DomainType domain, LookupLevel lookup_level,
-              bool stage2)
-{
-    return testWalk(pa, size, va, is_secure, mode, domain, lookup_level,
-        stage2 ? s2State : s1State);
-}
-
-Fault
-MMU::testWalk(Addr pa, Addr size, Addr va, bool is_secure, Mode mode,
-              TlbEntry::DomainType domain, LookupLevel lookup_level,
-              CachedState &state)
-{
-    if (!test) {
-        return NoFault;
-    } else {
-        return test->walkCheck(pa, size, va, is_secure, state.isPriv, mode,
-                               domain, lookup_level);
     }
 }
 

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -460,7 +460,7 @@ class MMU : public BaseMMU
     void setTestInterface(SimObject *ti);
 
     Fault testTranslation(const RequestPtr &req, Mode mode,
-                          TlbEntry::DomainType domain, CachedState &state);
+                          TlbEntry::DomainType domain, CachedState &state) const;
 
   protected:
     bool checkWalkCache() const;
@@ -470,6 +470,10 @@ class MMU : public BaseMMU
     CachedState& updateMiscReg(
         ThreadContext *tc, ArmTranslationType tran_type,
         bool stage2);
+
+    Fault testAndFinalize(const RequestPtr &req,
+                          ThreadContext *tc, Mode mode,
+                          TlbEntry *te, CachedState &state) const;
 
   protected:
     ContextID miscRegContext;

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2016, 2019-2023 Arm Limited
+ * Copyright (c) 2010-2013, 2016, 2019-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -461,12 +461,6 @@ class MMU : public BaseMMU
 
     Fault testTranslation(const RequestPtr &req, Mode mode,
                           TlbEntry::DomainType domain, CachedState &state);
-    Fault testWalk(Addr pa, Addr size, Addr va, bool is_secure, Mode mode,
-                   TlbEntry::DomainType domain,
-                   LookupLevel lookup_level, bool stage2);
-    Fault testWalk(Addr pa, Addr size, Addr va, bool is_secure, Mode mode,
-                   TlbEntry::DomainType domain,
-                   LookupLevel lookup_level, CachedState &state);
 
   protected:
     bool checkWalkCache() const;

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -62,7 +62,7 @@ using namespace ArmISA;
 TableWalker::TableWalker(const Params &p)
     : ClockedObject(p),
       requestorId(p.sys->getRequestorId(this)),
-      port(new Port(*this, requestorId)),
+      port(new Port(*this)),
       isStage2(p.is_stage2), tlb(NULL),
       currState(NULL), pending(false),
       numSquashable(p.num_squash_per_cycle),
@@ -140,25 +140,20 @@ TableWalker::WalkerState::WalkerState() :
 {
 }
 
-TableWalker::Port::Port(TableWalker& _walker, RequestorID id)
+TableWalker::Port::Port(TableWalker& _walker)
   : QueuedRequestPort(_walker.name() + ".port", reqQueue, snoopRespQueue),
     owner{_walker},
     reqQueue(_walker, *this),
-    snoopRespQueue(_walker, *this),
-    requestorId(id)
+    snoopRespQueue(_walker, *this)
 {
 }
 
 PacketPtr
 TableWalker::Port::createPacket(
-    Addr desc_addr, int size,
-    uint8_t *data, Request::Flags flags, Tick delay,
+    const RequestPtr &req,
+    uint8_t *data, Tick delay,
     Event *event)
 {
-    RequestPtr req = std::make_shared<Request>(
-        desc_addr, size, flags, requestorId);
-    req->taskId(context_switch_task_id::DMA);
-
     PacketPtr pkt = new Packet(req, MemCmd::ReadReq);
     pkt->dataStatic(data);
 
@@ -172,10 +167,9 @@ TableWalker::Port::createPacket(
 
 void
 TableWalker::Port::sendFunctionalReq(
-    Addr desc_addr, int size,
-    uint8_t *data, Request::Flags flags)
+    const RequestPtr &req, uint8_t *data)
 {
-    auto pkt = createPacket(desc_addr, size, data, flags, 0, nullptr);
+    auto pkt = createPacket(req, data, 0, nullptr);
 
     sendFunctional(pkt);
 
@@ -184,10 +178,10 @@ TableWalker::Port::sendFunctionalReq(
 
 void
 TableWalker::Port::sendAtomicReq(
-    Addr desc_addr, int size,
-    uint8_t *data, Request::Flags flags, Tick delay)
+    const RequestPtr &req,
+    uint8_t *data, Tick delay)
 {
-    auto pkt = createPacket(desc_addr, size, data, flags, delay, nullptr);
+    auto pkt = createPacket(req, data, delay, nullptr);
 
     Tick lat = sendAtomic(pkt);
 
@@ -196,11 +190,11 @@ TableWalker::Port::sendAtomicReq(
 
 void
 TableWalker::Port::sendTimingReq(
-    Addr desc_addr, int size,
-    uint8_t *data, Request::Flags flags, Tick delay,
+    const RequestPtr &req,
+    uint8_t *data, Tick delay,
     Event *event)
 {
-    auto pkt = createPacket(desc_addr, size, data, flags, delay, event);
+    auto pkt = createPacket(req, data, delay, event);
 
     schedTimingReq(pkt, curTick());
 }
@@ -2115,7 +2109,7 @@ TableWalker::nextWalk(ThreadContext *tc)
 }
 
 bool
-TableWalker::fetchDescriptor(Addr descAddr, uint8_t *data, int numBytes,
+TableWalker::fetchDescriptor(Addr desc_addr, uint8_t *data, int num_bytes,
     Request::Flags flags, int queueIndex, Event *event,
     void (TableWalker::*doDescriptor)())
 {
@@ -2123,9 +2117,9 @@ TableWalker::fetchDescriptor(Addr descAddr, uint8_t *data, int numBytes,
 
     DPRINTF(PageTableWalker,
             "Fetching descriptor at address: 0x%x stage2Req: %d\n",
-            descAddr, currState->stage2Req);
+            desc_addr, currState->stage2Req);
 
-    // If this translation has a stage 2 then we know descAddr is an IPA and
+    // If this translation has a stage 2 then we know desc_addr is an IPA and
     // needs to be translated before we can access the page table. Do that
     // check here.
     if (currState->stage2Req) {
@@ -2136,11 +2130,11 @@ TableWalker::fetchDescriptor(Addr descAddr, uint8_t *data, int numBytes,
                 Stage2Walk(*this, data, event, currState->vaddr,
                     currState->mode, currState->tranType);
             currState->stage2Tran = tran;
-            readDataTimed(currState->tc, descAddr, tran, numBytes, flags);
+            readDataTimed(currState->tc, desc_addr, tran, num_bytes, flags);
             fault = tran->fault;
         } else {
             fault = readDataUntimed(currState->tc,
-                currState->vaddr, descAddr, data, numBytes, flags,
+                currState->vaddr, desc_addr, data, num_bytes, flags,
                 currState->mode,
                 currState->tranType,
                 currState->functional);
@@ -2160,8 +2154,13 @@ TableWalker::fetchDescriptor(Addr descAddr, uint8_t *data, int numBytes,
             (this->*doDescriptor)();
         }
     } else {
-        if (isTiming) {
-            port->sendTimingReq(descAddr, numBytes, data, flags,
+
+        RequestPtr req = std::make_shared<Request>(
+            desc_addr, num_bytes, flags, requestorId);
+        req->taskId(context_switch_task_id::DMA);
+
+        if (currState->timing) {
+            port->sendTimingReq(req, data,
                 currState->tc->getCpuPtr()->clockPeriod(), event);
 
             if (queueIndex >= 0) {
@@ -2171,12 +2170,12 @@ TableWalker::fetchDescriptor(Addr descAddr, uint8_t *data, int numBytes,
                 stateQueues[queueIndex].push_back(currState);
             }
         } else if (!currState->functional) {
-            port->sendAtomicReq(descAddr, numBytes, data, flags,
+            port->sendAtomicReq(req, data,
                 currState->tc->getCpuPtr()->clockPeriod());
 
             (this->*doDescriptor)();
         } else {
-            port->sendFunctionalReq(descAddr, numBytes, data, flags);
+            port->sendFunctionalReq(req, data);
             (this->*doDescriptor)();
         }
     }
@@ -2458,8 +2457,7 @@ TableWalker::Stage2Walk::finish(const Fault &_fault,
     }
 
     if (_fault == NoFault && !req->getFlags().isSet(Request::NO_ACCESS)) {
-        parent.getTableWalkerPort().sendTimingReq(
-            req->getPaddr(), numBytes, data, req->getFlags(),
+        parent.getTableWalkerPort().sendTimingReq(req, data,
             tc->getCpuPtr()->clockPeriod(), event);
     } else {
         // We can't do the DMA access as there's been a problem, so tell the

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -2114,7 +2114,7 @@ TableWalker::fetchDescriptor(Addr desc_addr,
             desc_addr, num_bytes, flags, requestorId);
         req->taskId(context_switch_task_id::DMA);
 
-        Fault fault = testWalk(desc_addr, num_bytes, descriptor.domain(),
+        Fault fault = testWalk(req, descriptor.domain(),
             lookup_level);
 
         if (fault != NoFault) {
@@ -2306,13 +2306,13 @@ TableWalker::pendingChange()
 }
 
 Fault
-TableWalker::testWalk(Addr pa, Addr size, TlbEntry::DomainType domain,
+TableWalker::testWalk(const RequestPtr &walk_req, TlbEntry::DomainType domain,
                       LookupLevel lookup_level)
 {
     if (!test) {
         return NoFault;
     } else {
-        return test->walkCheck(pa, size, currState->vaddr, currState->isSecure,
+        return test->walkCheck(walk_req, currState->vaddr, currState->isSecure,
                                currState->el != EL0,
                                currState->mode, domain, lookup_level);
     }

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -332,18 +332,15 @@ TableWalker::walk(const RequestPtr &_req, ThreadContext *_tc, uint16_t _asid,
 
     currState->startTime = curTick();
     currState->tc = _tc;
-    // ARM DDI 0487A.f (ARMv8 ARM) pg J8-5672
-    // aarch32/translation/translation/AArch32.TranslateAddress dictates
-    // even AArch32 EL0 will use AArch64 translation if EL1 is in AArch64.
+    currState->el =
+        MMU::tranTypeEL(_tc->readMiscReg(MISCREG_CPSR),
+            _tc->readMiscReg(MISCREG_SCR_EL3),
+            tranType);
+
     if (isStage2) {
-        currState->el = EL1;
         currState->regime = TranslationRegime::EL10;
         currState->aarch64 = ELIs64(_tc, EL2);
     } else {
-        currState->el =
-            MMU::tranTypeEL(_tc->readMiscReg(MISCREG_CPSR),
-                _tc->readMiscReg(MISCREG_SCR_EL3),
-                tranType);
         currState->regime =
             translationRegime(_tc, currState->el);
         currState->aarch64 =

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -943,14 +943,11 @@ class TableWalker : public ClockedObject
     class Port : public QueuedRequestPort
     {
       public:
-        Port(TableWalker& _walker, RequestorID id);
+        Port(TableWalker& _walker);
 
-        void sendFunctionalReq(Addr desc_addr, int size,
-            uint8_t *data, Request::Flags flag);
-        void sendAtomicReq(Addr desc_addr, int size,
-            uint8_t *data, Request::Flags flag, Tick delay);
-        void sendTimingReq(Addr desc_addr, int size,
-            uint8_t *data, Request::Flags flag, Tick delay,
+        void sendFunctionalReq(const RequestPtr &req, uint8_t *data);
+        void sendAtomicReq(const RequestPtr &req, uint8_t *data, Tick delay);
+        void sendTimingReq(const RequestPtr &req, uint8_t *data, Tick delay,
             Event *event);
 
         bool recvTimingResp(PacketPtr pkt) override;
@@ -960,8 +957,7 @@ class TableWalker : public ClockedObject
         void handleResp(TableWalkerState *state, Addr addr,
                         Addr size, Tick delay=0);
 
-        PacketPtr createPacket(Addr desc_addr, int size,
-                               uint8_t *data, Request::Flags flag,
+        PacketPtr createPacket(const RequestPtr &req, uint8_t *data,
                                Tick delay, Event *event);
 
       private:
@@ -972,9 +968,6 @@ class TableWalker : public ClockedObject
 
         /** Packet queue used to store outgoing snoop responses. */
         SnoopRespPacketQueue snoopRespQueue;
-
-        /** Cached requestorId of the table walker */
-        RequestorID requestorId;
     };
 
     /** This translation class is used to trigger the data fetch once a timing

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016, 2019, 2021-2023 Arm Limited
+ * Copyright (c) 2010-2016, 2019, 2021-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1185,8 +1185,13 @@ class TableWalker : public ClockedObject
 
     static uint8_t pageSizeNtoStatBin(uint8_t N);
 
+  public: /* Testing */
+    TlbTestInterface *test;
+
+    void setTestInterface(TlbTestInterface *ti);
+
     Fault testWalk(Addr pa, Addr size, TlbEntry::DomainType domain,
-                   LookupLevel lookup_level, bool stage2);
+                   LookupLevel lookup_level);
 };
 
 } // namespace ArmISA

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1206,7 +1206,7 @@ class TableWalker : public ClockedObject
 
     void setTestInterface(TlbTestInterface *ti);
 
-    Fault testWalk(Addr pa, Addr size, TlbEntry::DomainType domain,
+    Fault testWalk(const RequestPtr &walk_req, TlbEntry::DomainType domain,
                    LookupLevel lookup_level);
 };
 

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2016, 2019-2022 Arm Limited
+ * Copyright (c) 2010-2013, 2016, 2019-2022, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -84,8 +84,7 @@ class TlbTestInterface
     /**
      * Check if a page table walker access should be forced to fail.
      *
-     * @param pa Physical address the walker is accessing
-     * @param size Walker access size
+     * @param req walk request bearing a valid phys address
      * @param va Virtual address that initiated the walk
      * @param is_secure Access from secure state
      * @param is_priv Access from a privileged mode (i.e., not EL0)
@@ -93,7 +92,8 @@ class TlbTestInterface
      * @param domain Domain type
      * @param lookup_level Page table walker level
      */
-    virtual Fault walkCheck(Addr pa, Addr size, Addr va, bool is_secure,
+    virtual Fault walkCheck(const RequestPtr &walk_req,
+                            Addr va, bool is_secure,
                             Addr is_priv, BaseMMU::Mode mode,
                             TlbEntry::DomainType domain,
                             enums::ArmLookupLevel lookup_level) = 0;


### PR DESCRIPTION
This PR is refactoring the Arm PageTableWalker in the following way:

1) Simplifying the currState handling logic (mainly the tear down)
2) Amending the TlbTestInterface APIs to use a RequestPtr reference
3) Use finalizePhysical even when MMU is off, which means allowing memory mapped m5ops to work also in that circumstance