### PR TITLE
mem-cache: Remove power-of-2 requirement for TreePLRU num leaves

### DIFF
--- a/src/mem/cache/replacement_policies/tree_plru_rp.cc
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.cc
@@ -104,6 +104,7 @@ TreePLRU::TreePLRUReplData::TreePLRUReplData(
 TreePLRU::TreePLRU(const Params &p)
   : Base(p), numLeaves(p.num_leaves), count(0), treeInstance(nullptr)
 {
+    fatal_if(numLeaves < 2, "Number of leaves must be two or greater");
 }
 
 void

--- a/src/mem/cache/replacement_policies/tree_plru_rp.cc
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.cc
@@ -104,8 +104,6 @@ TreePLRU::TreePLRUReplData::TreePLRUReplData(
 TreePLRU::TreePLRU(const Params &p)
   : Base(p), numLeaves(p.num_leaves), count(0), treeInstance(nullptr)
 {
-    fatal_if(!isPowerOf2(numLeaves),
-             "Number of leaves must be non-zero and a power of 2");
 }
 
 void


### PR DESCRIPTION
Remove the requirement in TreePLRU's implementation that the number of leaves (i.e., the number of cache ways) be a power of two. Firstly, on some recent processors, this is not the case---for example, Intel Golden Cove's L1D has 12 ways. Secondly, The implementation of TreePLRU appears to work just fine as-is with a way count that's not a power of two.

Change-Id: If2a27dc5bbe7a8e96684f79ce791df5c0b582230