### PR TITLE
tests: Revert "tests: Move the arm+ruby tests to not use ALL"

### DIFF
--- a/tests/gem5/fs/linux/arm/test.py
+++ b/tests/gem5/fs/linux/arm/test.py
@@ -72,6 +72,10 @@ arm_fs_long_tests = [
     "realview64-minor-dual",
     "realview64-switcheroo-o3",
     "realview64-switcheroo-full",
+    "realview-simple-timing-ruby",
+    "realview64-simple-timing-ruby",
+    "realview64-simple-timing-dual-ruby",
+    "realview64-o3-dual-ruby",
     # The following tests fail. These are recorded in the GEM5-640
     # Jira issue.
     #
@@ -81,14 +85,6 @@ arm_fs_long_tests = [
     #'realview-o3-dual',
     #'realview-minor-dual',
     #'realview-simple-timing-dual-ruby',
-]
-
-# These tests are Ruby-based and Ruby does not support multiple ISAs
-arm_fs_long_tests_arm_target = [
-    "realview-simple-timing-ruby",
-    "realview64-simple-timing-ruby",
-    "realview64-simple-timing-dual-ruby",
-    "realview64-o3-dual-ruby",
 ]
 
 tarball = "aarch-system-20220707.tar.bz2"
@@ -174,32 +170,6 @@ for name in arm_fs_long_tests:
         config=joinpath(filepath, "run.py"),
         config_args=args,
         valid_isas=(constants.all_compiled_tag,),
-        length=constants.long_tag,
-        fixtures=(arm_fs_binaries,),
-        uses_kvm=name in arm_fs_kvm_tests,
-    )
-
-for name in arm_fs_long_tests_arm_target:
-    args = [
-        joinpath(
-            config.base_dir,
-            "tests",
-            "gem5",
-            "fs",
-            "linux",
-            "arm",
-            "configs",
-            name + ".py",
-        ),
-        path,
-        config.base_dir,
-    ]
-    gem5_verify_config(
-        name=name,
-        verifiers=verifier_list(name),  # TODO: Add basic stat verifiers
-        config=joinpath(filepath, "run.py"),
-        config_args=args,
-        valid_isas=(constants.arm_tag,),
         length=constants.long_tag,
         fixtures=(arm_fs_binaries,),
         uses_kvm=name in arm_fs_kvm_tests,


### PR DESCRIPTION
This reverts commit c1de2b876229bd0c6431d4af8804c58c2fd4fdeb. We revert the commit as Ruby does not use get_runtime_isa anymore after [1]

[1]: https://github.com/gem5/gem5/pull/241

Change-Id: Iaac8d64194bbd53a9b1a57a796ff92f763c75a87