### PR TITLE
mem-cache: Revert "Remove power-of-2 requirement for..."

### DIFF
--- a/src/mem/cache/replacement_policies/tree_plru_rp.cc
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.cc
@@ -104,7 +104,8 @@ TreePLRU::TreePLRUReplData::TreePLRUReplData(
 TreePLRU::TreePLRU(const Params &p)
   : Base(p), numLeaves(p.num_leaves), count(0), treeInstance(nullptr)
 {
-    fatal_if(numLeaves < 2, "Number of leaves must be two or greater");
+    fatal_if(!isPowerOf2(numLeaves),
+             "Number of leaves must be non-zero and a power of 2");
 }
 
 void


### PR DESCRIPTION
Reverts gem5/gem5#1061. Caused error https://github.com/gem5/gem5/actions/runs/8828536310/job/24242396632#step:23:42.

```
src/mem/dram_interface.cc:690: warn: DRAM device capacity (16384 Mbytes) does not match the address range assigned (2048 Mbytes)
src/mem/dram_interface.cc:690: warn: DRAM device capacity (16384 Mbytes) does not match the address range assigned (2048 Mbytes)
src/sim/kernel_workload.cc:46: info: kernel located at: /__w/gem5/gem5/tests/gem5/resources/arm64-linux-kernel-5.4.49
src/base/loader/symtab.cc:95: warn: Cannot insert a new symbol table due to name collisions. Adding prefix to each symbol's name can resolve this issue.
src/mem/cache/replacement_policies/tree_plru_rp.cc:107: fatal: fatal condition numLeaves < 2 occurred: Number of leaves must be two or greater
Memory Usage: 4934480 KBytes
```