### PR TITLE
arch-riscv: Fix VCSR read behavoir

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -568,7 +568,7 @@ ISA::readMiscReg(RegIndex idx)
         }
       case MISCREG_VCSR:
         {
-            return readMiscRegNoEffect(MISCREG_VXSAT) &
+            return readMiscRegNoEffect(MISCREG_VXSAT) |
                   (readMiscRegNoEffect(MISCREG_VXRM) << 1);
         }
         break;


### PR DESCRIPTION
The VCSR should read the value with VXSAT and VXRM

<table class="tableblock frame-all grid-all fit-content center">
<caption class="title">Table 40. vcsr layout</caption>
<colgroup>
<col>
<col>
<col>
</colgroup>
<thead>
<tr>
<th class="tableblock halign-right valign-top">Bits</th>
<th class="tableblock halign-left valign-top">Name</th>
<th class="tableblock halign-left valign-top">Description</th>
</tr>
</thead>
<tbody>
<tr>
<td class="tableblock halign-right valign-top"><p class="tableblock">XLEN-1:3</p></td>
<td class="tableblock halign-left valign-top"></td>
<td class="tableblock halign-left valign-top"><p class="tableblock">Reserved</p></td>
</tr>
<tr>
<td class="tableblock halign-right valign-top"><p class="tableblock">2:1</p></td>
<td class="tableblock halign-left valign-top"><p class="tableblock">vxrm[1:0]</p></td>
<td class="tableblock halign-left valign-top"><p class="tableblock">Fixed-point rounding mode</p></td>
</tr>
<tr>
<td class="tableblock halign-right valign-top"><p class="tableblock">0</p></td>
<td class="tableblock halign-left valign-top"><p class="tableblock">vxsat</p></td>
<td class="tableblock halign-left valign-top"><p class="tableblock">Fixed-point accrued saturation flag</p></td>
</tr>
</tbody>
</table>

Change-Id: I1227b920da78026951dfa548e41c8cc56da6caac