### PR TITLE
cpu: Indirect predictor track conditional indirect

### DIFF
--- a/src/cpu/pred/simple_indirect.hh
+++ b/src/cpu/pred/simple_indirect.hh
@@ -160,7 +160,8 @@ class SimpleIndirectPredictor : public IndirectPredictor
 
     inline bool isIndirectNoReturn(BranchType type) {
         return (type == BranchType::CallIndirect) ||
-               (type == BranchType::IndirectUncond);
+               (type == BranchType::IndirectUncond) ||
+               (type == BranchType::IndirectCond);
     }
 
   protected:


### PR DESCRIPTION
As discussed in https://github.com/orgs/gem5/discussions/954: 

In the refactor made by commit f65df9b959d8e2fc3b5 conditional indirect branches are no longer updated in the indirect predictor.
This kind of branches do not exist in x86 neither arm, but they are present in PowerPC.

This patch, enables the indirect predictor to track this kind of branches.