### PR TITLE
arch-riscv: Add Integer Conditional operations extension (Zicond) instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1980,6 +1980,9 @@ decode QUADRANT default Unknown::unknown() {
                             Rd = divu<uint64_t>(Rs1, Rs2);
                         }
                     }}, IntDivOp);
+                    0x7: czero_eqz({{
+                        Rd = rvSext(Rs2) == 0 ? 0 : rvSext(Rs1);
+                    }});
                     0x20: sra({{
                         Rd = rvSext(Rs1_sd) >> rvSelect(Rs2<4:0>, Rs2<5:0>);
                     }});
@@ -2036,6 +2039,9 @@ decode QUADRANT default Unknown::unknown() {
                     }});
                     0x5: maxu({{
                         Rd = rvSext(std::max(rvZext(Rs1), rvZext(Rs2)));
+                    }});
+                    0x7: czero_nez({{
+                        Rd = rvSext(Rs2) != 0 ? 0 : rvSext(Rs1);
                     }});
                     0x20: andn({{
                         Rd = rvSext(Rs1 & (~Rs2));


### PR DESCRIPTION
This PR added RISC-V Integer Conditional Operations Extension, which is in the RVA23U64 Profile Mandatory Base. And the performance of conditional move instructions in micro-architecture is an interesting point to explore.

Zicond instructions added: czero.eqz, czero.nez

Changes based on spec:
https://github.com/riscvarchive/riscv-zicond/releases/download/v1.0.1/riscv-zicond_1.0.1.pdf