### PR TITLE
arch-riscv: Fix narrowing/widening type-convert instructions

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -801,7 +801,7 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcWrapper(src3_reg_id)
     set_src_reg_idx += setSrcVm()
     code = maskCondWrapper(code)
-    code = eiDeclarePrefix(code)
+    code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
 
@@ -858,7 +858,7 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcWrapper(src3_reg_id)
     set_src_reg_idx += setSrcVm()
     code = maskCondWrapper(code)
-    code = eiDeclarePrefix(code)
+    code = eiDeclarePrefix(code, widening=True)
     code = loopWrapper(code)
     code = fflags_wrapper(code)
     code = narrowingOpRegisterConstraintChecks(code)


### PR DESCRIPTION
Correct ei calculation under VectorFloatWideningCvtFormat and VectorFloatNarrowingCvtFormat.

Change-Id: I08699ffe3b9f8a7d4543023437626cc054344053