### PR TITLE
arch-x86: Fix TLB Assertion Error on CFLUSH

### DIFF
--- a/src/cpu/translation.hh
+++ b/src/cpu/translation.hh
@@ -254,7 +254,7 @@ class DataTranslation : public BaseMMU::Translation
            BaseMMU::Mode mode)
     {
         assert(state);
-        assert(mode == state->mode);
+        assert(mode == state->mode || req->isCacheClean());
         if (state->finish(fault, index)) {
             if (state->getFault() == NoFault) {
                 // Don't access the request if faulted (due to squash)


### PR DESCRIPTION
Fixed the assertion statement in the cpu's translation.hh file so that it doesn't fail the assertion if the cache is clean.

I compile this c code to `test`
```c
#include <stdio.h>

static inline void clflush(volatile void *p) {
    __asm__ volatile ("clflush (%0)" : : "r"(p) : "memory");
}

int main() {
    int data = 42;  // Example variable

    printf("Value before clflush: %d\n", data);

    clflush(&data);

    printf("Value after clflush: %d\n", data);

    return 0;
}
```
And run it with this script
`./build/X86/gem5.opt configs/learning_gem5/part1/two_level.py ./test`
In order to verify that it no longer fails the assertion check.

GitHub Issue: #862 
Change-Id: I6004662e7c99f637ba0ddb07d205d1657708e99f