### PR TITLE
mem-ruby, configs: Add a CHI-TLM controller + testing

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1950,6 +1950,7 @@ action(Send_SnpSharedFwd_ToOwner, desc="") {
     if (retToSrc) {
       tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_SC_Fwded_SC);
       tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_SC_Fwded_SD_PD);
+      tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_SD_Fwded_SC);
       tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_I_Fwded_SC);
       tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_I_Fwded_SD_PD);
     } else {
@@ -1964,6 +1965,7 @@ action(Send_SnpSharedFwd_ToOwner, desc="") {
       tbe.expected_snp_resp.addExpectedRespType(CHIResponseType:SnpResp_SC_Fwded_SC);
     }
     tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_SC_PD_Fwded_SC);
+    tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_SD_Fwded_SC);
     tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_I_PD_Fwded_SC);
   }
   tbe.expected_snp_resp.addExpectedCount(1);
@@ -2304,7 +2306,8 @@ action(UpdateDirState_FromSnpDataResp, desc="") {
                  (in_msg.type == CHIDataType:SnpRespData_SC) ||
                  (in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SC) ||
                  (in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SD_PD) ||
-                 (in_msg.type == CHIDataType:SnpRespData_SC_PD_Fwded_SC)) {
+                 (in_msg.type == CHIDataType:SnpRespData_SC_PD_Fwded_SC) ||
+                 (in_msg.type == CHIDataType:SnpRespData_SD_Fwded_SC)) {
         // the owner must have been the responder, if there was one
         assert((tbe.dir_ownerExists == false) ||
              (tbe.dir_ownerExists && (tbe.dir_owner == in_msg.responder)));
@@ -2313,12 +2316,16 @@ action(UpdateDirState_FromSnpDataResp, desc="") {
         tbe.dir_ownerIsExcl := false;
         if ((in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SC) ||
             (in_msg.type == CHIDataType:SnpRespData_SC_PD_Fwded_SC) ||
-            (in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SD_PD)) {
+            (in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SD_PD) ||
+            (in_msg.type == CHIDataType:SnpRespData_SD_Fwded_SC)) {
           tbe.dir_sharers.add(tbe.requestor);
         }
         if (in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SD_PD) {
           tbe.dir_ownerExists := true;
           tbe.dir_owner := tbe.requestor;
+        } else if (in_msg.type == CHIDataType:SnpRespData_SD_Fwded_SC) {
+          tbe.dir_ownerExists := true;
+          tbe.dir_owner := in_msg.responder;
         }
 
       } else if ((in_msg.type == CHIDataType:SnpRespData_I_Fwded_SD_PD) ||
@@ -2507,7 +2514,8 @@ action(UpdateDataState_FromSnpDataResp, desc="") {
 
       } else if ((in_msg.type == CHIDataType:SnpRespData_SD) ||
                  (in_msg.type == CHIDataType:SnpRespData_SC_Fwded_SD_PD) ||
-                 (in_msg.type == CHIDataType:SnpRespData_I_Fwded_SD_PD)) {
+                 (in_msg.type == CHIDataType:SnpRespData_I_Fwded_SD_PD) ||
+                 (in_msg.type == CHIDataType:SnpRespData_SD_Fwded_SC)) {
         tbe.dataDirty := true;
         tbe.dataValid := true;
         tbe.dataMaybeDirtyUpstream := true;

--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1996,6 +1996,7 @@ action(Send_SnpSharedFwd_ToSharer, desc="") {
   bool retToSrc := tbe.doCacheFill;
   if (retToSrc) {
     tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_SC_Fwded_SC);
+    tbe.expected_snp_resp.addExpectedDataType(CHIDataType:SnpRespData_I_Fwded_SC);
   } else {
     tbe.expected_snp_resp.addExpectedRespType(CHIResponseType:SnpResp_SC_Fwded_SC);
   }

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -229,6 +229,7 @@ void functionalRead(Addr addr, Packet *pkt, WriteMask &mask) {
             tbe.expected_snp_resp.receivedDataType(CHIDataType:SnpRespData_UD) ||
             tbe.expected_snp_resp.receivedDataType(CHIDataType:SnpRespData_SC_Fwded_SD_PD) ||
             tbe.expected_snp_resp.receivedDataType(CHIDataType:SnpRespData_SC_PD_Fwded_SC) ||
+            tbe.expected_snp_resp.receivedDataType(CHIDataType:SnpRespData_SD_Fwded_SC) ||
             tbe.expected_snp_resp.receivedDataType(CHIDataType:SnpRespData_I_Fwded_SD_PD) ||
             tbe.expected_snp_resp.receivedDataType(CHIDataType:SnpRespData_I_PD_Fwded_SC);
     }
@@ -1420,6 +1421,8 @@ Event dataToEvent (CHIDataType type) {
     return Event:SnpRespData_SC_Fwded_SC;
   } else if (type == CHIDataType:SnpRespData_SC_Fwded_SD_PD) {
     return Event:SnpRespData_SC_Fwded_SD_PD;
+  } else if (type == CHIDataType:SnpRespData_SD_Fwded_SC) {
+    return Event:SnpRespData_SD_Fwded_SC;
   } else if (type == CHIDataType:SnpRespData_SC_PD_Fwded_SC) {
     return Event:SnpRespData_SC_PD_Fwded_SC;
   } else if (type == CHIDataType:SnpRespData_I_Fwded_SD_PD) {

--- a/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
@@ -1426,6 +1426,7 @@ transition(BUSY_BLKD,
            {SnpRespData_I_PD,SnpRespData_I,SnpRespData_SC_PD,
             SnpRespData_SC,SnpRespData_SD,SnpRespData_UC,SnpRespData_UD,
             SnpRespData_SC_Fwded_SC,SnpRespData_SC_Fwded_SD_PD,
+            SnpRespData_SD_Fwded_SC,
             SnpRespData_SC_PD_Fwded_SC,SnpRespData_I_Fwded_SD_PD,
             SnpRespData_I_PD_Fwded_SC,SnpRespData_I_Fwded_SC}) {
   Receive_SnpDataResp;

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -406,6 +406,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     SnpRespData_UD,                desc="";
     SnpRespData_SC_Fwded_SC,       desc="";
     SnpRespData_SC_Fwded_SD_PD,    desc="";
+    SnpRespData_SD_Fwded_SC,       desc="";
     SnpRespData_SC_PD_Fwded_SC,    desc="";
     SnpRespData_I_Fwded_SD_PD,     desc="";
     SnpRespData_I_PD_Fwded_SC,     desc="";

--- a/src/mem/ruby/protocol/chi/CHI-msg.sm
+++ b/src/mem/ruby/protocol/chi/CHI-msg.sm
@@ -205,6 +205,7 @@ enumeration(CHIDataType, desc="...") {
   SnpRespData_SC_Fwded_SC;
   SnpRespData_SC_Fwded_SD_PD;
   SnpRespData_SC_PD_Fwded_SC;
+  SnpRespData_SD_Fwded_SC;
   SnpRespData_I_Fwded_SD_PD;
   SnpRespData_I_PD_Fwded_SC;
   SnpRespData_I_Fwded_SC;
@@ -243,6 +244,7 @@ structure(CHIDataMsg, desc="", interface="Message") {
                     (type == CHIDataType:SnpRespData_SD) ||
                     (type == CHIDataType:SnpRespData_UD) ||
                     (type == CHIDataType:SnpRespData_SC_Fwded_SD_PD) ||
+                    (type == CHIDataType:SnpRespData_SD_Fwded_SC) ||
                     (type == CHIDataType:SnpRespData_SC_PD_Fwded_SC) ||
                     (type == CHIDataType:SnpRespData_I_Fwded_SD_PD) ||
                     (type == CHIDataType:SnpRespData_I_PD_Fwded_SC);

--- a/src/mem/ruby/protocol/chi/generic/CHIGeneric.py
+++ b/src/mem/ruby/protocol/chi/generic/CHIGeneric.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects.Controller import RubyController
+from m5.params import *
+
+
+class CHIGenericController(RubyController):
+    type = "CHIGenericController"
+    cxx_header = "mem/ruby/protocol/chi/generic/CHIGenericController.hh"
+    cxx_class = "gem5::ruby::CHIGenericController"
+    abstract = True
+
+    data_channel_size = Param.Int("")
+
+    reqOut = Param.MessageBuffer("")
+    snpOut = Param.MessageBuffer("")
+    rspOut = Param.MessageBuffer("")
+    datOut = Param.MessageBuffer("")
+    reqIn = Param.MessageBuffer("")
+    snpIn = Param.MessageBuffer("")
+    rspIn = Param.MessageBuffer("")
+    datIn = Param.MessageBuffer("")

--- a/src/mem/ruby/protocol/chi/generic/CHIGenericController.cc
+++ b/src/mem/ruby/protocol/chi/generic/CHIGenericController.cc
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2023 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/generic/CHIGenericController.hh"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+
+#include "debug/RubyCHIGeneric.hh"
+#include "mem/ruby/network/Network.hh"
+#include "mem/ruby/protocol/MemoryMsg.hh"
+#include "mem/ruby/system/RubySystem.hh"
+#include "mem/ruby/system/Sequencer.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+CHIGenericController::CHIGenericController(const Params &p)
+  : AbstractController(p),
+    reqOut(p.reqOut), snpOut(p.snpOut),
+    rspOut(p.rspOut), datOut(p.datOut),
+    reqIn(p.reqIn), snpIn(p.snpIn),
+    rspIn(p.rspIn), datIn(p.datIn),
+    cacheLineSize(p.ruby_system->getBlockSizeBytes()),
+    cacheLineBits(floorLog2(cacheLineSize)),
+    dataChannelSize(p.data_channel_size),
+    dataMsgsPerLine(cacheLineSize / p.data_channel_size)
+{
+    m_machineID.type = MachineType_Cache;
+    m_machineID.num = m_version;
+    p.ruby_system->registerAbstractController(this);
+    p.ruby_system->m_num_controllers[m_machineID.type]++;
+    m_ruby_system = p.ruby_system;
+}
+
+void
+CHIGenericController::initNetQueues()
+{
+    int base = m_ruby_system->MachineType_base_number(m_machineID.type);
+
+    assert(m_net_ptr != nullptr);
+
+    m_net_ptr->setToNetQueue(m_version + base, reqOut->getOrdered(),
+                             CHI_REQ, "none", reqOut);
+    m_net_ptr->setToNetQueue(m_version + base, snpOut->getOrdered(),
+                             CHI_SNP, "none", snpOut);
+    m_net_ptr->setToNetQueue(m_version + base, rspOut->getOrdered(),
+                             CHI_RSP, "none", rspOut);
+    m_net_ptr->setToNetQueue(m_version + base, datOut->getOrdered(),
+                             CHI_DAT, "response", datOut);
+
+    m_net_ptr->setFromNetQueue(m_version + base, reqIn->getOrdered(),
+                               CHI_REQ, "none", reqIn);
+    m_net_ptr->setFromNetQueue(m_version + base, snpIn->getOrdered(),
+                               CHI_SNP, "none", snpIn);
+    m_net_ptr->setFromNetQueue(m_version + base, rspIn->getOrdered(),
+                               CHI_RSP, "none", rspIn);
+    m_net_ptr->setFromNetQueue(m_version + base, datIn->getOrdered(),
+                               CHI_DAT, "response", datIn);
+}
+
+void
+CHIGenericController::init()
+{
+    AbstractController::init();
+
+    rspIn->setConsumer(this);
+    datIn->setConsumer(this);
+    snpIn->setConsumer(this);
+    reqIn->setConsumer(this);
+
+    resetStats();
+}
+
+void
+CHIGenericController::addSequencer(RubyPort *seq)
+{
+    assert(seq != nullptr);
+    sequencers.emplace_back(seq);
+}
+
+void
+CHIGenericController::print(std::ostream& out) const
+{
+    out << "[CHIGenericController " << m_version << "]";
+}
+
+Sequencer*
+CHIGenericController::getCPUSequencer() const
+{
+    // CHIGenericController doesn't have a CPUSequencer
+    return nullptr;
+}
+
+DMASequencer*
+CHIGenericController::getDMASequencer() const
+{
+    // CHIGenericController doesn't have a DMASequencer
+    return nullptr;
+}
+
+GPUCoalescer*
+CHIGenericController::getGPUCoalescer() const
+{
+    // CHIGenericController doesn't have a GPUCoalescer
+    return nullptr;
+}
+
+MessageBuffer*
+CHIGenericController::getMandatoryQueue() const
+{
+    // CHIGenericController doesn't have a MandatoryQueue
+    return nullptr;
+}
+
+MessageBuffer*
+CHIGenericController::getMemReqQueue() const
+{
+    // CHIGenericController doesn't have a MemReqQueue
+    return nullptr;
+}
+
+MessageBuffer*
+CHIGenericController::getMemRespQueue() const
+{
+    // CHIGenericController doesn't have a MemRespQueue
+    return nullptr;
+}
+
+void
+CHIGenericController::regStats()
+{
+    AbstractController::regStats();
+}
+
+void
+CHIGenericController::collateStats()
+{
+
+}
+
+void
+CHIGenericController::resetStats()
+{
+    AbstractController::resetStats();
+}
+
+
+void
+CHIGenericController::wakeup()
+{
+    bool pending = false;
+
+    DPRINTF(RubyCHIGeneric, "wakeup: checking incoming rsp messages\n");
+    pending = pending || receiveAllRdyMessages<CHIResponseMsg>(rspIn,
+         [this](const CHIResponseMsg* msg){ return recvResponseMsg(msg); });
+
+    DPRINTF(RubyCHIGeneric, "wakeup: checking incoming dat messages\n");
+    pending = pending || receiveAllRdyMessages<CHIDataMsg>(datIn,
+         [this](const CHIDataMsg* msg){ return recvDataMsg(msg); });
+
+    DPRINTF(RubyCHIGeneric, "wakeup: checking incoming snp messages\n");
+    pending = pending || receiveAllRdyMessages<CHIRequestMsg>(snpIn,
+         [this](const CHIRequestMsg* msg){ return recvSnoopMsg(msg); });
+
+    DPRINTF(RubyCHIGeneric, "wakeup: checking incoming req messages\n");
+    pending = pending || receiveAllRdyMessages<CHIRequestMsg>(reqIn,
+         [this](const CHIRequestMsg* msg){ return recvRequestMsg(msg); });
+
+    if (pending) {
+        DPRINTF(RubyCHIGeneric, "wakeup: messages pending\n");
+        scheduleEvent(Cycles(1));
+    }
+}
+
+void
+CHIGenericController::recordCacheTrace(int cntrl, CacheRecorder* tr)
+{
+    panic("CHIGenericController doesn't implement recordCacheTrace");
+}
+
+AccessPermission
+CHIGenericController::getAccessPermission(const Addr& param_addr)
+{
+    return AccessPermission_NotPresent;
+}
+
+void
+CHIGenericController::functionalRead(
+    const Addr& param_addr, Packet* param_pkt, WriteMask& param_mask)
+{
+    panic("CHIGenericController doesn't expect functionalRead");
+}
+
+int
+CHIGenericController::functionalWrite(
+    const Addr& param_addr, Packet* param_pkt)
+{
+    panic("CHIGenericController doesn't expect functionalRead");
+    return 0;
+}
+
+int
+CHIGenericController::functionalWriteBuffers(PacketPtr& pkt)
+{
+    int num_functional_writes = 0;
+    num_functional_writes += reqOut->functionalWrite(pkt);
+    num_functional_writes += snpOut->functionalWrite(pkt);
+    num_functional_writes += rspOut->functionalWrite(pkt);
+    num_functional_writes += datOut->functionalWrite(pkt);
+    num_functional_writes += reqIn->functionalWrite(pkt);
+    num_functional_writes += snpIn->functionalWrite(pkt);
+    num_functional_writes += rspIn->functionalWrite(pkt);
+    num_functional_writes += datIn->functionalWrite(pkt);
+    return num_functional_writes;
+}
+
+bool
+CHIGenericController::functionalReadBuffers(PacketPtr& pkt)
+{
+    if (reqOut->functionalRead(pkt)) return true;
+    if (snpOut->functionalRead(pkt)) return true;
+    if (rspOut->functionalRead(pkt)) return true;
+    if (datOut->functionalRead(pkt)) return true;
+    if (reqIn->functionalRead(pkt)) return true;
+    if (snpIn->functionalRead(pkt)) return true;
+    if (rspIn->functionalRead(pkt)) return true;
+    if (datIn->functionalRead(pkt)) return true;
+    return false;
+}
+
+bool
+CHIGenericController::functionalReadBuffers(PacketPtr& pkt, WriteMask &mask)
+{
+    bool read = false;
+    if (reqOut->functionalRead(pkt, mask)) read = true;
+    if (snpOut->functionalRead(pkt, mask)) read = true;
+    if (rspOut->functionalRead(pkt, mask)) read = true;
+    if (datOut->functionalRead(pkt, mask)) read = true;
+    if (reqIn->functionalRead(pkt, mask)) read = true;
+    if (snpIn->functionalRead(pkt, mask)) read = true;
+    if (rspIn->functionalRead(pkt, mask)) read = true;
+    if (datIn->functionalRead(pkt, mask)) read = true;
+    return read;
+}
+
+} // namespace ruby
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/generic/CHIGenericController.hh
+++ b/src/mem/ruby/protocol/chi/generic/CHIGenericController.hh
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2023 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_CHIGenericController_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_CHIGenericController_HH__
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "mem/ruby/common/Consumer.hh"
+#include "mem/ruby/network/MessageBuffer.hh"
+#include "mem/ruby/protocol/AccessPermission.hh"
+#include "mem/ruby/slicc_interface/AbstractController.hh"
+#include "mem/ruby/system/CacheRecorder.hh"
+#include "params/CHIGenericController.hh"
+
+// Generated from SLICC
+#include "mem/ruby/protocol/CHIDataMsg.hh"
+#include "mem/ruby/protocol/CHIRequestMsg.hh"
+#include "mem/ruby/protocol/CHIResponseMsg.hh"
+#include "mem/ruby/protocol/Cache_Controller.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+class CHIGenericController : public AbstractController
+{
+  public:
+    PARAMS(CHIGenericController);
+    CHIGenericController(const Params &p);
+
+    void init() override;
+
+    MessageBuffer *getMandatoryQueue() const override;
+    MessageBuffer *getMemReqQueue() const override;
+    MessageBuffer *getMemRespQueue() const override;
+    void initNetQueues() override;
+
+    void print(std::ostream& out) const override;
+    void wakeup() override;
+    void resetStats() override;
+    void regStats() override;
+    void collateStats() override;
+
+    void recordCacheTrace(int cntrl, CacheRecorder* tr) override;
+    Sequencer* getCPUSequencer() const override;
+    DMASequencer* getDMASequencer() const override;
+    GPUCoalescer* getGPUCoalescer() const override;
+
+    void addSequencer(RubyPort* seq);
+
+    bool functionalReadBuffers(PacketPtr&) override;
+    bool functionalReadBuffers(PacketPtr&, WriteMask&) override;
+    int functionalWriteBuffers(PacketPtr&) override;
+
+    AccessPermission getAccessPermission(const Addr& param_addr) override;
+
+    void functionalRead(const Addr& param_addr, Packet* param_pkt,
+                        WriteMask& param_mask) override;
+    int functionalWrite(const Addr& param_addr, Packet* param_pkt) override;
+
+  protected:
+    MessageBuffer* const reqOut;
+    MessageBuffer* const snpOut;
+    MessageBuffer* const rspOut;
+    MessageBuffer* const datOut;
+    MessageBuffer* const reqIn;
+    MessageBuffer* const snpIn;
+    MessageBuffer* const rspIn;
+    MessageBuffer* const datIn;
+
+    std::vector<RubyPort*> sequencers;
+
+  public:
+    const int cacheLineSize;
+    const int cacheLineBits;
+    const int dataChannelSize;
+    const int dataMsgsPerLine;
+
+    // interface to generic requesters and responders
+
+    enum CHIChannel
+    {
+        CHI_REQ = 0,
+        CHI_SNP = 1,
+        CHI_RSP = 2,
+        CHI_DAT = 3
+    };
+
+    typedef std::shared_ptr<CHIRequestMsg> CHIRequestMsgPtr;
+    typedef std::shared_ptr<CHIResponseMsg> CHIResponseMsgPtr;
+    typedef std::shared_ptr<CHIDataMsg> CHIDataMsgPtr;
+
+    bool
+    sendRequestMsg(CHIRequestMsgPtr msg)
+    {
+        return sendMessage(msg, reqOut);
+    }
+
+    bool
+    sendSnoopMsg(CHIRequestMsgPtr msg)
+    {
+        return sendMessage(msg, snpOut);
+    }
+
+    bool
+    sendResponseMsg(CHIResponseMsgPtr msg)
+    {
+        return sendMessage(msg, rspOut);
+    }
+
+    bool
+    sendDataMsg(CHIDataMsgPtr msg)
+    {
+        return sendMessage(msg, datOut);
+    }
+
+  protected:
+    virtual bool recvRequestMsg(const CHIRequestMsg *msg) = 0;
+    virtual bool recvSnoopMsg(const CHIRequestMsg *msg) = 0;
+    virtual bool recvResponseMsg(const CHIResponseMsg *msg) = 0;
+    virtual bool recvDataMsg(const CHIDataMsg *msg) = 0;
+
+  private:
+    template<typename MsgType>
+    bool receiveAllRdyMessages(MessageBuffer *buffer,
+                        const std::function<bool(const MsgType*)> &callback)
+    {
+        bool pending = false;
+        Tick cur_tick = curTick();
+        while (buffer->isReady(cur_tick)) {
+            const MsgType *msg =
+                dynamic_cast<const MsgType*>(buffer->peek());
+            assert(msg);
+            if (callback(msg))
+                buffer->dequeue(cur_tick);
+            else {
+                pending = true;
+                break;
+            }
+        }
+        return pending;
+    }
+
+    template<typename MessageType>
+    bool sendMessage(MessageType &msg, MessageBuffer *buffer)
+    {
+        Tick cur_tick = curTick();
+        if (buffer->areNSlotsAvailable(1, cur_tick)) {
+            buffer->enqueue(msg, curTick(), cyclesToTicks(Cycles(1)),
+                m_ruby_system->getRandomization(),
+                m_ruby_system->getWarmupEnabled());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+};
+
+} // namespace ruby
+} // namespace gem5
+
+#endif // __CHIGenericController_H__

--- a/src/mem/ruby/protocol/chi/generic/SConscript
+++ b/src/mem/ruby/protocol/chi/generic/SConscript
@@ -1,0 +1,49 @@
+# -*- mode:python -*-
+
+# Copyright (c) 2023 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Import('*')
+
+if env['CONF']['PROTOCOL'] != 'CHI':
+    Return()
+
+SimObject('CHIGeneric.py',
+    sim_objects=['CHIGenericController'])
+
+DebugFlag('RubyCHIGeneric')
+DebugFlag('RubyCHIGenericVerbose')
+
+Source('CHIGenericController.cc')

--- a/src/mem/ruby/protocol/chi/tlm/SConscript
+++ b/src/mem/ruby/protocol/chi/tlm/SConscript
@@ -1,0 +1,75 @@
+# -*- mode:python -*-
+# Copyright (c) 2024 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Import("*")
+
+
+def get_tlm_paths():
+    tlm_dir = Dir(env["CONF"]["TLM_PATH"])
+    assert tlm_dir is not None and tlm_dir != "."
+
+    include_dir = tlm_dir.Dir("include")
+    lib_dir = tlm_dir.Dir("lib")
+
+    model_lib = "libarmtlmchi.so"
+    if not lib_dir.File(model_lib).exists():
+        print(f"Error: Can't find {model_lib} in AMBA TLM directory.")
+        print(f"TLM path: {tlm_dir}")
+        Exit(1)
+
+    return include_dir, lib_dir, "armtlmchi"
+
+
+if env["CONF"]["BUILD_TLM"]:
+    include_path, lib_path, tlm_lib = get_tlm_paths()
+
+    env.Append(CPPPATH=include_path)
+    env.Append(LIBPATH=lib_path)
+    env.Append(LIBS=[tlm_lib])
+
+    SimObject(
+        "TlmController.py", sim_objects=["TlmController"], tags="arm isa"
+    )
+    Source("utils.cc", tags="arm isa")
+    Source("controller.cc", tags="arm isa")
+    DebugFlag("TLM", tags="arm isa")
+
+    print(
+        "BUILD_TLM set: "
+        f"Building TLM integration with libarmtlmchi.so from '{lib_path}'\n"
+    )
+elif not GetOption("silent"):
+    print("BUILD_TLM not set, not building CHI-TLM integration\n")

--- a/src/mem/ruby/protocol/chi/tlm/SConsopts
+++ b/src/mem/ruby/protocol/chi/tlm/SConsopts
@@ -1,0 +1,58 @@
+# -*- mode:python -*-
+# Copyright (c) 2023 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Import('*')
+
+import os
+
+tlm_vars = Variables()
+tlm_vars.AddVariables(
+    PathVariable('TLM_PATH', "CHI TLM library path", '.', PathVariable.PathIsDir),
+    )
+tlm_vars.Update(main)
+
+main["CONF"]["BUILD_TLM"] = False
+
+tlm_path_ev = os.environ.get("TLM_PATH", None)
+if tlm_path_ev is not None and tlm_path_ev != ".":
+    print(f"Setting TLM_PATH from os.environ: {tlm_path_ev}")
+    main["CONF"]["TLM_PATH"] = tlm_path_ev
+    main["CONF"]["BUILD_TLM"] = True
+
+if "TLM_PATH" in main and main["TLM_PATH"] != ".":
+    print(f"Setting TLM_PATH to SCons command line: {main['TLM_PATH']}")
+    main["CONF"]["TLM_PATH"] = str(main["TLM_PATH"])
+    main["CONF"]["BUILD_TLM"] = True

--- a/src/mem/ruby/protocol/chi/tlm/TlmController.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmController.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects.CHIGeneric import CHIGenericController
+from m5.params import *
+
+
+class TlmController(CHIGenericController):
+    type = "TlmController"
+    cxx_header = "mem/ruby/protocol/chi/tlm/controller.hh"
+    cxx_class = "gem5::tlm::chi::CacheController"

--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -34,46 +34,36 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import("*")
 
-def get_tlm_paths():
-    tlm_dir = Dir(env["CONF"]["TLM_PATH"])
-    assert tlm_dir is not None and tlm_dir != "."
-
-    include_dir = tlm_dir.Dir("include")
-    lib_dir = tlm_dir.Dir("lib")
-
-    model_lib = "libarmtlmchi.so"
-    if not lib_dir.File(model_lib).exists():
-        print(f"Error: Can't find {model_lib} in AMBA TLM directory.")
-        print(f"TLM path: {tlm_dir}")
-        Exit(1)
-
-    return include_dir, lib_dir, "armtlmchi"
+from m5.objects.TlmController import TlmController
+from m5.params import *
+from m5.SimObject import (
+    PyBindMethod,
+    SimObject,
+)
 
 
-if env["CONF"]["BUILD_TLM"]:
-    include_path, lib_path, tlm_lib = get_tlm_paths()
+class TlmGenerator(SimObject):
+    type = "TlmGenerator"
+    cxx_header = "mem/ruby/protocol/chi/tlm/generator.hh"
+    cxx_class = "gem5::tlm::chi::TlmGenerator"
 
-    env.Append(CPPPATH=include_path)
-    env.Append(LIBPATH=lib_path)
-    env.Append(LIBS=[tlm_lib])
+    cxx_exports = [
+        PyBindMethod("scheduleTransaction"),
+    ]
 
-    SimObject(
-        "TlmController.py", sim_objects=["TlmController"], tags="arm isa"
-    )
-    SimObject('TlmGenerator.py', sim_objects=['TlmGenerator'], tags='arm isa')
-    Source("utils.cc", tags="arm isa")
-    Source("controller.cc", tags="arm isa")
-    Source('tlm_chi.cc', tags='arm isa')
-    Source('tlm_chi_gen.cc', tags='arm isa')
-    Source('generator.cc', tags='arm isa')
-    PySource('m5', 'tlm_chi.py')
-    DebugFlag("TLM", tags="arm isa")
+    _transactions = []
 
-    print(
-        "BUILD_TLM set: "
-        f"Building TLM integration with libarmtlmchi.so from '{lib_path}'\n"
-    )
-elif not GetOption("silent"):
-    print("BUILD_TLM not set, not building CHI-TLM integration\n")
+    def injectAt(self, when, payload, phase):
+        from m5.tlm_chi import Transaction
+
+        transaction = Transaction(payload, phase)
+        self._transactions.append((when, transaction))
+        return transaction
+
+    def init(self):
+        for when, tr in self._transactions:
+            self.getCCObject().scheduleTransaction(when, tr)
+
+    cpu_id = Param.Int("TlmGenerator CPU identifier")
+    chi_controller = Param.TlmController("TLM-to-Ruby CacheController")

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2023 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/tlm/controller.hh"
+
+#include "debug/TLM.hh"
+#include "mem/ruby/protocol/CHIDataMsg.hh"
+#include "mem/ruby/protocol/CHIRequestMsg.hh"
+#include "mem/ruby/protocol/CHIResponseMsg.hh"
+#include "mem/ruby/protocol/chi/tlm/utils.hh"
+
+namespace gem5 {
+
+namespace tlm::chi {
+
+using namespace ruby;
+
+CacheController::CacheController(const Params &p)
+  : CHIGenericController(p)
+{
+}
+
+bool
+CacheController::recvRequestMsg(const CHIRequestMsg *msg)
+{
+    panic("recvRequestMsg");
+    return true;
+}
+
+bool
+CacheController::recvSnoopMsg(const CHIRequestMsg *msg)
+{
+    ARM::CHI::Phase phase;
+    ARM::CHI::Payload *payload = ARM::CHI::Payload::new_payload();
+
+    payload->address = msg->m_addr;
+    payload->ns = msg->m_ns;
+    phase.channel = ARM::CHI::CHANNEL_SNP;
+    phase.snp_opcode = ruby_to_tlm::snpOpcode(msg->m_type);
+    phase.txn_id = msg->m_txnId % 1024;
+
+    bw(payload, &phase);
+
+    // payload->unref(); ??
+    return true;
+}
+
+void
+CacheController::pCreditGrant(const CHIResponseMsg *msg)
+{
+    ARM::CHI::Phase phase;
+    ARM::CHI::Payload *payload = ARM::CHI::Payload::new_payload();
+    phase.channel = ARM::CHI::CHANNEL_RSP;
+    phase.rsp_opcode = ARM::CHI::RSP_OPCODE_PCRD_GRANT;
+    phase.pcrd_type = 0; // TODO: set this one depending on allow retry
+
+    bw(payload, &phase);
+
+    payload->unref(); // TODO: check this
+}
+
+bool
+CacheController::recvResponseMsg(const CHIResponseMsg *msg)
+{
+
+    if (msg->m_type == ruby::CHIResponseType_PCrdGrant) {
+        // P-credit grant does not refer to a specific transaction id
+        pCreditGrant(msg);
+        return true;
+    }
+
+    auto txn_id = msg->m_txnId;
+    if (auto it = pendingTransactions.find(txn_id);
+        it != pendingTransactions.end()) {
+
+        auto& transaction = it->second;
+        if (transaction->handle(msg))
+            pendingTransactions.erase(it);
+    } else {
+        panic("recvResponseMsg");
+    }
+    return true;
+}
+
+bool
+CacheController::recvDataMsg(const CHIDataMsg *msg)
+{
+    auto txn_id = msg->m_txnId;
+    if (auto it = pendingTransactions.find(txn_id);
+        it != pendingTransactions.end()) {
+        auto& transaction = it->second;
+        if (transaction->handle(msg))
+            pendingTransactions.erase(it);
+    } else {
+        panic("Not able to find transaction");
+    }
+    return true;
+}
+
+bool
+CacheController::Transaction::handle(const CHIResponseMsg *msg)
+{
+    const auto opcode = ruby_to_tlm::rspOpcode(msg->m_type);
+    phase.channel = ARM::CHI::CHANNEL_RSP;
+    phase.rsp_opcode = opcode;
+    phase.resp = ruby_to_tlm::rspResp(msg->m_type);
+    phase.txn_id = msg->m_txnId % 1024;
+
+    controller->bw(payload, &phase);
+    return opcode != ARM::CHI::RSP_OPCODE_RETRY_ACK;
+}
+
+bool
+CacheController::ReadTransaction::handle(const CHIDataMsg *msg)
+{
+    dataMsgCnt++;
+
+    for (auto byte = 0; byte < controller->cacheLineSize; byte++) {
+        if (msg->m_bitMask.test(byte))
+            payload->data[byte] = msg->m_dataBlk.getByte(byte);
+    }
+
+    // ARM::CHI::Phase phase;
+    phase.channel = ARM::CHI::CHANNEL_DAT;
+    phase.dat_opcode = ruby_to_tlm::datOpcode(msg->m_type);
+    phase.resp = ruby_to_tlm::datResp(msg->m_type);
+    phase.txn_id = msg->m_txnId % 1024;
+    phase.data_id = dataId(msg->m_addr + msg->m_bitMask.firstBitSet(true));
+
+    // This is a hack, we should fix it on the ruby side
+    if (forward(msg)) {
+        controller->bw(payload, &phase);
+    }
+
+    if (dataMsgCnt == controller->dataMsgsPerLine) {
+        if (phase.exp_comp_ack == false) {
+            // The client is not sending a CompAck but ruby is
+            // expecting it so we send it anyway
+            controller->sendCompAck(*payload, phase);
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool
+CacheController::ReadTransaction::handle(const CHIResponseMsg *msg)
+{
+    /// TODO: remove this, DBID is not sent
+    phase.dbid = msg->m_dbid % 1024;
+    return Transaction::handle(msg);
+}
+
+bool
+CacheController::ReadTransaction::forward(const CHIDataMsg *msg)
+{
+    if (payload->size == 6) {
+        return true;
+    } else {
+        if (msg->m_bitMask.test(payload->address - msg->m_addr)) {
+            return true;
+        } else {
+            // This is not the packet holding the original address
+            // Do not forward it back (just drop it)
+            return false;
+        }
+    }
+}
+
+bool
+CacheController::DatalessTransaction::handle(const CHIResponseMsg *msg)
+{
+    const auto opcode = ruby_to_tlm::rspOpcode(msg->m_type);
+    assert(opcode == ARM::CHI::RSP_OPCODE_COMP ||
+           opcode == ARM::CHI::RSP_OPCODE_RETRY_ACK);
+
+    return Transaction::handle(msg);
+}
+
+bool
+CacheController::WriteTransaction::handle(const CHIResponseMsg *msg)
+{
+    const auto opcode = ruby_to_tlm::rspOpcode(msg->m_type);
+    if (opcode == ARM::CHI::RSP_OPCODE_COMP_DBID_RESP) {
+        recvComp = true;
+        recvDBID = true;
+    }
+    if (opcode == ARM::CHI::RSP_OPCODE_COMP) {
+        recvComp = true;
+    }
+    if (opcode == ARM::CHI::RSP_OPCODE_DBID_RESP) {
+        recvDBID = true;
+    }
+
+    phase.dbid = msg->m_dbid % 1024;
+    Transaction::handle(msg);
+
+    return recvComp && recvDBID;
+}
+
+void
+CacheController::sendCompAck(ARM::CHI::Payload &payload,
+                             ARM::CHI::Phase &phase)
+{
+    auto res_msg = std::make_shared<CHIResponseMsg>(
+        curTick(), cacheLineSize, m_ruby_system);
+
+    res_msg->m_addr = ruby::makeLineAddress(payload.address, cacheLineBits);
+    res_msg->m_type = CHIResponseType_CompAck;
+    res_msg->m_Destination.add(mapAddressToDownstreamMachine(payload.address));
+    res_msg->m_responder = getMachineID();
+
+    res_msg->m_txnId = phase.txn_id;
+
+    sendResponseMsg(res_msg);
+}
+
+void
+CacheController::sendMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase)
+{
+    switch (phase.channel) {
+      case ARM::CHI::CHANNEL_REQ:
+        sendRequestMsg(payload, phase);
+        break;
+      case ARM::CHI::CHANNEL_DAT:
+        sendDataMsg(payload, phase);
+        break;
+      case ARM::CHI::CHANNEL_RSP:
+        sendResponseMsg(payload, phase);
+        break;
+      default:
+        panic("Unimplemented channel: %d", phase.channel);
+    }
+}
+
+Addr
+CacheController::reqAddr(ARM::CHI::Payload &payload,
+                         ARM::CHI::Phase &phase) const
+{
+    switch (phase.req_opcode) {
+      case ARM::CHI::REQ_OPCODE_WRITE_NO_SNP_PTL:
+        return ruby::makeLineAddress(payload.address, cacheLineBits) +
+            ctz64(payload.byte_enable);
+      default:
+        return payload.address;
+    }
+}
+
+Addr
+CacheController::reqSize(ARM::CHI::Payload &payload,
+                         ARM::CHI::Phase &phase) const
+{
+    switch (phase.req_opcode) {
+      case ARM::CHI::REQ_OPCODE_WRITE_NO_SNP_PTL:
+        assert(transactionSize(payload.size) >= popCount(payload.byte_enable));
+        return popCount(payload.byte_enable);
+      default:
+        return transactionSize(payload.size);
+    }
+}
+
+void
+CacheController::sendRequestMsg(ARM::CHI::Payload &payload,
+                                ARM::CHI::Phase &phase)
+{
+    auto req_msg = std::make_shared<CHIRequestMsg>(
+        curTick(), cacheLineSize, m_ruby_system);
+
+    req_msg->m_addr = ruby::makeLineAddress(payload.address, cacheLineBits);
+    req_msg->m_accAddr = reqAddr(payload, phase);
+    req_msg->m_accSize = reqSize(payload, phase);
+    req_msg->m_requestor = getMachineID();
+    req_msg->m_fwdRequestor = getMachineID();
+    req_msg->m_dataToFwdRequestor = false;
+    req_msg->m_type = tlm_to_ruby::reqOpcode(phase.req_opcode);
+    req_msg->m_isSeqReqValid = false;
+    req_msg->m_is_local_pf = false;
+    req_msg->m_is_remote_pf = false;
+    req_msg->m_allowRetry = phase.allow_retry;
+    req_msg->m_Destination.add(mapAddressToDownstreamMachine(payload.address));
+
+    req_msg->m_txnId = phase.txn_id + (payload.lpid * 1024);
+    req_msg->m_ns = payload.ns;
+
+    sendRequestMsg(req_msg);
+
+    pendingTransactions[req_msg->m_txnId] = Transaction::gen(
+        this, payload, phase);
+}
+
+void
+CacheController::sendDataMsg(ARM::CHI::Payload &payload,
+                             ARM::CHI::Phase &phase)
+{
+    auto data_msg = std::make_shared<CHIDataMsg>(
+        curTick(), cacheLineSize, m_ruby_system);
+
+    data_msg->m_addr = ruby::makeLineAddress(payload.address, cacheLineBits);
+    data_msg->m_responder = getMachineID();
+    data_msg->m_type = tlm_to_ruby::datOpcode(phase.dat_opcode, phase.resp);
+    data_msg->m_Destination.add(
+        mapAddressToDownstreamMachine(payload.address));
+    data_msg->m_txnId = phase.txn_id + (payload.lpid * 1024);
+    data_msg->m_dataBlk.setData(payload.data, 0, cacheLineSize);
+
+    std::vector<bool> byte_enabled(cacheLineSize, false);
+
+    const Addr data_id_offset = phase.data_id * 16;
+    for (int bit = data_id_offset; bit < data_id_offset + 32; bit++) {
+        if (bits(payload.byte_enable, bit)) {
+            byte_enabled[bit] = true;
+        }
+    }
+
+    data_msg->m_bitMask = WriteMask(byte_enabled.size(), byte_enabled);
+
+    sendDataMsg(data_msg);
+}
+
+void
+CacheController::sendResponseMsg(ARM::CHI::Payload &payload,
+                                 ARM::CHI::Phase &phase)
+{
+    auto res_msg = std::make_shared<CHIResponseMsg>(
+        curTick(), cacheLineSize, m_ruby_system);
+
+    res_msg->m_addr = ruby::makeLineAddress(payload.address, cacheLineBits);
+    res_msg->m_responder = getMachineID();
+    res_msg->m_type = tlm_to_ruby::rspOpcode(phase.rsp_opcode, phase.resp);
+    res_msg->m_Destination.add(mapAddressToDownstreamMachine(payload.address));
+    res_msg->m_txnId = phase.txn_id + (payload.lpid * 1024);
+
+    sendResponseMsg(res_msg);
+}
+
+CacheController::Transaction::Transaction(CacheController *_controller,
+    ARM::CHI::Payload &_payload,
+    ARM::CHI::Phase &_phase)
+  : controller(_controller), payload(&_payload), phase(_phase)
+{
+    payload->ref();
+}
+
+CacheController::Transaction::~Transaction()
+{
+    payload->unref();
+}
+
+std::unique_ptr<CacheController::Transaction>
+CacheController::Transaction::gen(CacheController *controller,
+    ARM::CHI::Payload &payload,
+    ARM::CHI::Phase &phase)
+{
+    switch (phase.req_opcode) {
+      case ARM::CHI::REQ_OPCODE_READ_SHARED:
+      case ARM::CHI::REQ_OPCODE_READ_CLEAN:
+      case ARM::CHI::REQ_OPCODE_READ_ONCE:
+      case ARM::CHI::REQ_OPCODE_READ_NO_SNP:
+      case ARM::CHI::REQ_OPCODE_READ_UNIQUE:
+      case ARM::CHI::REQ_OPCODE_READ_NOT_SHARED_DIRTY:
+      case ARM::CHI::REQ_OPCODE_READ_PREFER_UNIQUE:
+      case ARM::CHI::REQ_OPCODE_MAKE_READ_UNIQUE:
+        return std::make_unique<ReadTransaction>(controller, payload, phase);
+      case ARM::CHI::REQ_OPCODE_WRITE_NO_SNP_PTL:
+      case ARM::CHI::REQ_OPCODE_WRITE_NO_SNP_FULL:
+      case ARM::CHI::REQ_OPCODE_WRITE_UNIQUE_ZERO:
+      case ARM::CHI::REQ_OPCODE_WRITE_UNIQUE_FULL:
+      case ARM::CHI::REQ_OPCODE_WRITE_BACK_FULL:
+      // This is a write transaction for now. Will
+      // this still be the case once WriteEvictOrEvict will also be supported
+      // in ruby
+      case ARM::CHI::REQ_OPCODE_WRITE_EVICT_OR_EVICT:
+        return std::make_unique<WriteTransaction>(
+            controller, payload, phase);
+      case ARM::CHI::REQ_OPCODE_CLEAN_UNIQUE:
+      case ARM::CHI::REQ_OPCODE_MAKE_UNIQUE:
+      case ARM::CHI::REQ_OPCODE_EVICT:
+      case ARM::CHI::REQ_OPCODE_STASH_ONCE_SEP_SHARED:
+      case ARM::CHI::REQ_OPCODE_STASH_ONCE_SEP_UNIQUE:
+        return std::make_unique<DatalessTransaction>(
+            controller, payload, phase);
+      default:
+        panic("Impossible to generate transaction object");
+    }
+}
+
+} // namespace tlm::chi
+
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_TLM_CONTROLLER_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_TLM_CONTROLLER_HH__
+
+#include <ARM/TLM/arm_chi.h>
+
+#include "mem/ruby/protocol/chi/generic/CHIGenericController.hh"
+#include "mem/ruby/protocol/CHIDataType.hh"
+#include "mem/ruby/protocol/CHIRequestType.hh"
+#include "mem/ruby/protocol/CHIResponseType.hh"
+#include "mem/ruby/protocol/RequestStatus.hh"
+#include "mem/ruby/protocol/WriteMask.hh"
+#include "params/TlmController.hh"
+
+namespace gem5 {
+
+namespace ruby {
+class CHIRequestMsg;
+class CHIResponseMsg;
+class CHIDataMsg;
+}
+
+namespace tlm::chi {
+
+/**
+ * The tlm::chi::CacheController is a ruby CacheController which acts as
+ * a bridge between the AMBA TLM 2.0 implementation of CHI [1][2] with
+ * the gem5 (ruby) one.
+ *
+ * In other words it translates AMBA CHI transactions into ruby
+ * messages (which are then forwarded to the MessageQueues)
+ * and viceversa.
+ *
+ * ARM::CHI::Payload,        CHIRequestMsg
+ *                     <-->  CHIDataMsg
+ * ARM::CHI::Phase           CHIResponseMsg
+ *                           CHIDataMsg
+ *
+ * To connect the tlm::chi::CacheController in python is relatively
+ * straightforward. The upstream initiator/RNF needs to have a pointer
+ * to the controller, and this can be done for example with
+ * SimObject params.
+ * Example:
+ *
+ * class MyRNF():
+ *     chi_controller = Param.TlmController("TLM-to-Ruby CacheController")
+ *
+ * The RNF C++ code would then have to set the
+ * tlm::chi::CacheController::bw callback to implement the backward path
+ * to send data from downstream to upstream.
+ *
+ * [1]: https://developer.arm.com/documentation/101459/latest
+ * [2]: https://developer.arm.com/Architectures/AMBA#Downloads
+ */
+class CacheController : public ruby::CHIGenericController
+{
+  public:
+    PARAMS(TlmController);
+    CacheController(const Params &p);
+
+    /** Set this to send data upstream */
+    std::function<void(ARM::CHI::Payload* payload, ARM::CHI::Phase* phase)> bw;
+
+    bool recvRequestMsg(const ruby::CHIRequestMsg *msg) override;
+    bool recvSnoopMsg(const ruby::CHIRequestMsg *msg) override;
+    bool recvResponseMsg(const ruby::CHIResponseMsg *msg) override;
+    bool recvDataMsg(const ruby::CHIDataMsg *msg) override;
+
+    void sendMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
+    using CHIGenericController::sendRequestMsg;
+    void sendRequestMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
+    using CHIGenericController::sendResponseMsg;
+    void sendResponseMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
+    void sendCompAck(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
+    using CHIGenericController::sendDataMsg;
+    void sendDataMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
+
+    Addr reqAddr(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase) const;
+    Addr reqSize(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase) const;
+
+    void pCreditGrant(const ruby::CHIResponseMsg *msg);
+
+    struct Transaction
+    {
+        enum class Type
+        {
+            READ,
+            WRITE,
+            DATALESS
+        };
+
+        Transaction(CacheController *parent,
+            ARM::CHI::Payload &_payload,
+            ARM::CHI::Phase &_phase);
+        ~Transaction();
+
+        static std::unique_ptr<Transaction> gen(CacheController *parent,
+            ARM::CHI::Payload &_payload,
+            ARM::CHI::Phase &_phase);
+
+        virtual bool
+        handle(const ruby::CHIDataMsg *msg)
+        {
+            panic("Unimplemented");
+        }
+
+        virtual bool handle(const ruby::CHIResponseMsg *msg);
+
+        CacheController *controller;
+        ARM::CHI::Payload *payload;
+        ARM::CHI::Phase phase;
+    };
+    struct ReadTransaction : public Transaction
+    {
+        using Transaction::Transaction;
+        bool handle(const ruby::CHIDataMsg *msg) override;
+        bool handle(const ruby::CHIResponseMsg *msg) override;
+        bool forward(const ruby::CHIDataMsg *msg);
+
+        uint8_t dataMsgCnt = 0;
+    };
+    struct DatalessTransaction : public Transaction
+    {
+        using Transaction::Transaction;
+        bool handle(const ruby::CHIResponseMsg *msg) override;
+    };
+    struct WriteTransaction : public Transaction
+    {
+        using Transaction::Transaction;
+        bool handle(const ruby::CHIResponseMsg *msg) override;
+        bool recvComp = false;
+        bool recvDBID = false;
+    };
+    std::unordered_map<uint16_t, std::unique_ptr<Transaction>> pendingTransactions;
+};
+
+} // namespace tlm::chi
+
+} // namespace gem5
+
+#endif // __MEM_RUBY_PROTOCOL_CHI_TLM_CONTROLLER_HH__

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/tlm/generator.hh"
+
+#include "mem/ruby/protocol/chi/tlm/controller.hh"
+#include "debug/TLM.hh"
+
+namespace gem5 {
+
+namespace tlm::chi {
+
+bool
+TlmGenerator::Transaction::Expectation::run(Transaction *tran)
+{
+    auto res_print = csprintf("Checking %s...", name());
+    if (cb(tran)) {
+        inform("%s\n", res_print + " Success ");
+        return true;
+    } else {
+        inform("%s\n", res_print + " Fail ");
+        return false;
+    }
+}
+
+bool
+TlmGenerator::Transaction::Assertion::run(Transaction *tran)
+{
+    if (Expectation::run(tran)) {
+        return true;
+    } else {
+        panic("Failing assertion\n");
+    }
+}
+
+TlmGenerator::Transaction::Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph)
+  : passed(true), parent(nullptr), _payload(pa), _phase(ph)
+{
+    _payload->ref();
+}
+
+TlmGenerator::Transaction::~Transaction()
+{
+    _payload->unref();
+}
+
+void
+TlmGenerator::Transaction::setGenerator(TlmGenerator *gen)
+{
+    parent = gen;
+}
+
+std::string
+TlmGenerator::Transaction::str() const
+{
+    return transactionToString(*_payload, _phase);
+}
+
+void
+TlmGenerator::Transaction::inject()
+{
+    parent->inject(this);
+}
+
+bool
+TlmGenerator::Transaction::hasCallbacks() const
+{
+    return !actions.empty();
+}
+
+bool
+TlmGenerator::Transaction::failed() const
+{
+    return !passed;
+}
+
+void
+TlmGenerator::Transaction::addCallback(ActionPtr &&action)
+{
+    actions.push_back(std::move(action));
+}
+
+void
+TlmGenerator::Transaction::runCallbacks()
+{
+    // print transaction
+    auto it = actions.begin();
+    while (it != actions.end()) {
+        const bool is_passing = (*it)->run(this);
+        if (!is_passing) {
+            passed = false;
+        }
+        bool wait = (*it)->wait();
+
+        it = actions.erase(it);
+
+        if (wait) {
+            break;
+        }
+    }
+}
+
+void
+TlmGenerator::TransactionEvent::process()
+{
+    transaction->inject();
+}
+
+TlmGenerator::TlmGenerator(const Params &p)
+  : SimObject(p), cpuId(p.cpu_id), controller(p.chi_controller)
+{
+    controller->bw = [this] (ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
+    {
+        this->recv(payload, phase);
+    };
+
+    registerExitCallback([this](){ passFailCheck(); });
+}
+
+void
+TlmGenerator::scheduleTransaction(Tick when, Transaction *transaction)
+{
+    transaction->setGenerator(this);
+
+    auto event = new TransactionEvent(transaction, when);
+
+    scheduledTransactions.push(event);
+
+    schedule(event, when);
+}
+
+void
+TlmGenerator::inject(Transaction *transaction)
+{
+    auto payload = transaction->payload();
+    ARM::CHI::Phase &phase = transaction->phase();
+
+    if (transaction->hasCallbacks())
+        pendingTransactions.insert({phase.txn_id, transaction});
+
+    DPRINTF(TLM, "[c%d] send %s\n", cpuId, transactionToString(*payload, phase));
+
+    controller->sendMsg(*payload, phase);
+}
+
+void
+TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
+{
+    DPRINTF(TLM, "[c%d] rcvd %s\n", cpuId, transactionToString(*payload, *phase));
+
+    auto txn_id = phase->txn_id;
+    if (auto it = pendingTransactions.find(txn_id);
+        it != pendingTransactions.end()) {
+        // Copy the new phase
+        it->second->phase() = *phase;
+
+        // Check existing expectations
+        it->second->runCallbacks();
+    } else {
+        warn("Transaction untested\n");
+    }
+}
+
+void
+TlmGenerator::passFailCheck()
+{
+    for (auto [txn_id, transaction] : pendingTransactions) {
+        // We are failing either if a condition hasn't been met,
+        // or if there are pending actions when simulation exits
+        if (transaction->failed()) {
+            inform(" Suite Fail: failed transaction ");
+            return;
+        }
+        if (transaction->hasCallbacks()) {
+            inform(" Suite Fail: non-empty action queue ");
+            return;
+        }
+    }
+    inform(" Suite Success ");
+}
+
+} // namespace tlm::chi
+
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2024 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_TLM_GENERATOR_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_TLM_GENERATOR_HH__
+
+#include <queue>
+#include <unordered_map>
+
+#include <ARM/TLM/arm_chi.h>
+
+#include "mem/ruby/protocol/chi/tlm/utils.hh"
+#include "params/TlmGenerator.hh"
+#include "sim/eventq.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5 {
+
+namespace tlm::chi {
+
+class CacheController;
+
+/**
+ * TlmGenerator: this class is basically a CHI-tlm traffic generator.
+ * Its interface is mainly allowing to inject transactions at a specific
+ * point in simulated time and to set expectations on what has
+ * to be returned to the generator.
+ * The intended use is as a testbench for the CHI implementation
+ * in ruby. As such it requires to be hooked with a TlmController
+ * as a bridge for converting the CHI-tlm transactions into ruby messages.
+ *
+ *                                         +---------------+
+ * +--------------+   +---------------+    |               |
+ * |              |   |               |    |               |
+ * | TlmGenerator |-->| TlmController |--->|     Ruby      |
+ * |              |<--|               |<---|               |
+ * +--------------+   +---------------+    |               |
+ *                                         +---------------+
+ *
+ * The APIs are entirely exposed to the python world for flexible
+ * definition of the unit tests.
+ *
+ * To inject a CHI-tlm transaction at a specific tick in the
+ * simulation, the following TlmGenerator method should be
+ * used:
+ *
+ * def injectAt(self, when, payload, phase):
+ *
+ * This will return a Transaction object and from that point that will be the
+ * handle for managing the transaction: either adding transaction expectations
+ * upon response (e.g, what will be the cacheline state), or by adding action
+ * callbacks (execute some logic)
+ */
+class TlmGenerator : public SimObject
+{
+  public:
+    PARAMS(TlmGenerator);
+    TlmGenerator(const Params &p);
+
+    /**
+     * Transaction object
+     * It stores ARM::CHI::Payload and ARM::CHI::Phase objects,
+     * and a list of action callables which will be executed
+     * in the order they have been registered once a transaction
+     * response arrives. These could be:
+     *  1) Expectation callbacks (Transaction::Expectation)
+     *     which will check a specific condition and will warn if
+     *     the condition is not met
+     *  2) Assertion callbacks (Transaction::Assertion)
+     *     Identical to expectations, they will fail simulation instead
+     *     of warning, which means later conditions won't be checked.
+     *  3) Action callbacks (Transaction::Action)
+     *     Does something without condition checking
+     *
+     * Once the response arrives, the Transaction::runCallbacks will
+     * enter the dispatching loop. Actions/callbacks will be dispatched
+     * until the list is empty or until a waiting action is encountered.
+     * This will break the dispatching loop.
+     */
+    class Transaction
+    {
+      public:
+        /**
+         * Action:
+         * Does something without condition checking. It is
+         * possible to program from python whether the callback
+         * is a waiting action
+         */
+        class Action
+        {
+          public:
+            using Callback = std::function<
+                bool(Transaction *tran)
+            >;
+
+            Action(Callback _cb, bool waiting)
+              : cb(_cb), _wait(waiting)
+            {}
+            virtual ~Action() {};
+
+            /* A basic action always returns true */
+            virtual bool
+            run(Transaction *tran)
+            {
+                cb(tran);
+                return true;
+            }
+
+            /**
+             * Returns true if the action dispatcher should break
+             * the dispatching loop once the action has been executed
+             */
+            bool wait() const { return _wait; }
+
+          protected:
+            Callback cb;
+            bool _wait;
+        };
+
+        /**
+         * Expectation:
+         * Will check for a specific condition and will warn if
+         * the condition is not met.
+         * The expectation is never a waiting action
+         */
+        class Expectation : public Action
+        {
+          public:
+            Expectation(std::string exp_name, Callback _cb)
+              : Action(_cb, false), _name(exp_name)
+            {}
+
+            bool run(Transaction *tran) override;
+
+            std::string name() const { return _name; }
+
+          private:
+            std::string _name;
+        };
+
+        /**
+         * Assertion:
+         * Will check for a specific condition and will fail if
+         * the condition is not met.
+         * The assertion is never a waiting action
+         */
+        class Assertion : public Expectation
+        {
+          public:
+            Assertion(std::string exp_name, Callback _cb)
+              : Expectation(exp_name, _cb)
+            {}
+
+            bool run(Transaction *tran) override;
+        };
+
+        using ActionPtr = std::unique_ptr<Action>;
+        using Actions = std::list<ActionPtr>;
+
+        Transaction(const Transaction &rhs) = delete;
+        Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph);
+        ~Transaction();
+
+        /**
+         * Registers the TlmGenerator in the transaction. This is
+         * used as a reference to the generator is required when
+         * injection the transaction
+         */
+        void setGenerator(TlmGenerator *gen);
+
+        std::string str() const;
+
+        void inject();
+
+        /**
+         * Returns true if the transaction has failed, false
+         * otherwise
+         */
+        bool failed() const;
+
+        /**
+         * Returns true if the transaction has some
+         * registered callbacks, false otherwise
+         */
+        bool hasCallbacks() const;
+
+        /**
+         * Appends a callback to the list of actions
+         */
+        void addCallback(ActionPtr &&action);
+
+        /**
+         * Enters the dispatching loop and runs the callbacks
+         * in insertion order until a waiting callback is
+         * encountered (or if there is a failing assertion)
+         */
+        void runCallbacks();
+
+        ARM::CHI::Payload* payload() const { return _payload; }
+        ARM::CHI::Phase& phase() { return _phase; }
+
+      private:
+        Actions actions;
+        bool passed;
+
+        TlmGenerator *parent;
+        ARM::CHI::Payload *_payload;
+        ARM::CHI::Phase _phase;
+    };
+
+    void scheduleTransaction(Tick when, Transaction *tr);
+
+  protected:
+    struct TransactionEvent : public Event
+    {
+      public:
+        struct Compare
+        {
+            bool
+            operator()(const TransactionEvent *lhs,
+                       const TransactionEvent *rhs)
+            {
+                return lhs->when < rhs->when;
+            }
+        };
+
+        TransactionEvent(Transaction *_transaction,
+                         Tick _when)
+          : Event(), transaction(_transaction), when(_when)
+        {}
+
+        void process() override;
+
+        const char*
+        description() const override
+        {
+            return "CHI Transaction event";
+        }
+
+        Transaction *transaction;
+        Tick when;
+    };
+
+    void inject(Transaction *transaction);
+    void recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
+    void passFailCheck();
+
+  protected:
+    /** cpuId to mimic the behaviour of a CPU */
+    uint8_t cpuId;
+
+    using SchedulingQueue = std::priority_queue<TransactionEvent*,
+        std::vector<TransactionEvent*>,
+        TransactionEvent::Compare>;
+
+    /** PQ of transactions whose injection needs to be scheduled */
+    SchedulingQueue scheduledTransactions;
+
+    /** Map of pending (injected) transactions indexed by the txn_id */
+    std::unordered_map<uint16_t, Transaction*> pendingTransactions;
+
+    /** Pointer to the CHI-tlm controller */
+    CacheController *controller;
+};
+
+} // namespace tlm::chi
+
+} // namespace gem5
+
+#endif // __MEM_RUBY_PROTOCOL_CHI_TLM_GENERATOR_HH__

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2024 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ARM/TLM/arm_chi.h>
+
+#include "python/pybind11/pybind.hh"
+#include "sim/init.hh"
+
+namespace py = pybind11;
+
+using namespace ARM::CHI;
+
+namespace gem5 {
+
+namespace {
+
+/** We are forced to define a custom deleter as the Payload
+ * destructor is deleted and pybind11 will complain */
+template <typename T>
+struct PayloadDeleter
+{
+    void
+    operator()(T * p) const
+    {
+        p->unref();
+    }
+};
+
+void
+tlm_chi_pybind(pybind11::module_ &m_internal)
+{
+    auto tlm_chi = m_internal.def_submodule("tlm_chi");
+    py::class_<Payload, std::unique_ptr<Payload, PayloadDeleter<Payload>>>(
+        tlm_chi, "TlmPayload")
+        .def(py::init(&Payload::new_payload))
+        .def_readwrite("address", &Payload::address)
+        .def_property("size",
+            [] (const Payload &p) { return p.size; },
+            [] (Payload &p, SizeEnum val) { p.size = val; })
+        .def_readwrite("lpid", &Payload::lpid)
+        .def_property("ns",
+            [] (const Payload &p) { return p.ns; },
+            [] (Payload &p, bool val) { p.ns = val; })
+        ;
+
+    py::class_<Phase>(tlm_chi, "TlmPhase")
+        .def(py::init<>())
+        .def_readwrite("txn_id", &Phase::txn_id)
+        .def_readwrite("src_id", &Phase::src_id)
+        .def_readwrite("tgt_id", &Phase::tgt_id)
+        .def_readwrite("opcode", &Phase::raw_opcode)
+        .def_property("channel",
+            [] (const Phase &p) { return p.channel; },
+            [] (Phase &p, Channel val) { p.channel = val; })
+        .def_property("sub_channel",
+            [] (const Phase &p) { return p.sub_channel; },
+            [] (Phase &p, uint8_t val) { p.sub_channel = val; })
+        .def_property("lcrd",
+            [] (const Phase &p) { return p.lcrd; },
+            [] (Phase &p, bool val) { p.lcrd = val; })
+        .def_property("exp_comp_ack",
+            [] (const Phase &p) { return p.exp_comp_ack; },
+            [] (Phase &p, bool val) { p.exp_comp_ack = val; })
+        .def_property("snp_attr",
+            [] (const Phase &p) { return p.snp_attr; },
+            [] (Phase &p, bool val) { p.snp_attr = val; })
+        .def_property("allow_retry",
+            [] (const Phase &p) { return p.allow_retry; },
+            [] (Phase &p, bool val) { p.allow_retry = val; })
+        .def_property("do_dwt",
+            [] (const Phase &p) { return p.do_dwt; },
+            [] (Phase &p, bool val) { p.do_dwt = val; })
+        .def_property("data_id",
+            [] (const Phase &p) { return p.data_id; },
+            [] (Phase &p, uint8_t val) { p.data_id = val; })
+        .def_property("c_busy",
+            [] (const Phase &p) { return p.c_busy; },
+            [] (Phase &p, uint8_t val) { p.c_busy = val; })
+        .def_property("pcrd_type",
+            [] (const Phase &p) { return p.pcrd_type; },
+            [] (Phase &p, uint8_t val) { p.pcrd_type = val; })
+        .def_property("qos",
+            [] (const Phase &p) { return p.qos; },
+            [] (Phase &p, uint8_t val) { p.qos = val; })
+        .def_property("resp",
+            [] (const Phase &p) { return p.resp; },
+            [] (Phase &p, Resp val) { p.resp = val; })
+        .def_property("fwd_state",
+            [] (const Phase &p) { return p.fwd_state; },
+            [] (Phase &p, Resp val) { p.fwd_state = val; })
+        .def_property("order",
+            [] (const Phase &p) { return p.order; },
+            [] (Phase &p, Order val) { p.order = val; })
+        .def_property("resp_err",
+            [] (const Phase &p) { return p.resp_err; },
+            [] (Phase &p, RespErr val) { p.resp_err = val; })
+        .def_property("tag_op",
+            [] (const Phase &p) { return p.tag_op; },
+            [] (Phase &p, TagOp val) { p.tag_op = val; })
+        ;
+
+    py::enum_<Resp>(tlm_chi, "Resp")
+        .value("RESP_I", RESP_I)
+        .value("RESP_SC", RESP_SC)
+        .value("RESP_UC", RESP_UC)
+        .value("RESP_UD", RESP_UD)
+        .value("RESP_SD", RESP_SD)
+        .value("RESP_I_PD", RESP_I_PD)
+        .value("RESP_SC_PD", RESP_SC_PD)
+        .value("RESP_UC_PD", RESP_UC_PD)
+        .value("RESP_UD_PD", RESP_UD_PD)
+        .value("RESP_SD_PD", RESP_SD_PD)
+        ;
+
+    py::enum_<RespErr>(tlm_chi, "RespErr")
+        .value("RESP_ERR_OK", RESP_ERR_OK)
+        .value("RESP_ERR_EXOK", RESP_ERR_EXOK)
+        .value("RESP_ERR_DERR", RESP_ERR_DERR)
+        .value("RESP_ERR_NDERR", RESP_ERR_NDERR)
+        ;
+
+    py::enum_<Order>(tlm_chi, "Order")
+        .value("ORDER_NO_ORDER", ORDER_NO_ORDER)
+        .value("ORDER_REQUEST_ACCEPTED", ORDER_REQUEST_ACCEPTED)
+        .value("ORDER_REQUEST_ORDER", ORDER_REQUEST_ORDER)
+        .value("ORDER_ENDPOINT_ORDER", ORDER_ENDPOINT_ORDER)
+        ;
+
+    py::enum_<TagOp>(tlm_chi, "TagOp")
+        .value("TAG_OP_INVALID", TAG_OP_INVALID)
+        .value("TAG_OP_TRANSFER", TAG_OP_TRANSFER)
+        .value("TAG_OP_UPDATE", TAG_OP_UPDATE)
+        .value("TAG_OP_MATCH", TAG_OP_MATCH)
+        .value("TAG_OP_FETCH", TAG_OP_FETCH)
+        ;
+
+    py::enum_<SizeEnum>(tlm_chi, "Size")
+        .value("SIZE_1", SIZE_1)
+        .value("SIZE_2", SIZE_2)
+        .value("SIZE_4", SIZE_4)
+        .value("SIZE_8", SIZE_8)
+        .value("SIZE_16", SIZE_16)
+        .value("SIZE_32", SIZE_32)
+        .value("SIZE_64", SIZE_64)
+        ;
+
+    py::enum_<Channel>(tlm_chi, "Channel")
+        .value("REQ", CHANNEL_REQ)
+        .value("DAT", CHANNEL_DAT)
+        .value("RSP", CHANNEL_RSP)
+        .value("SNP", CHANNEL_SNP)
+        ;
+
+    py::enum_<ReqOpcodeEnum>(tlm_chi, "ReqOpcode")
+        .value("READ_SHARED", REQ_OPCODE_READ_SHARED)
+        .value("READ_CLEAN", REQ_OPCODE_READ_CLEAN)
+        .value("READ_ONCE", REQ_OPCODE_READ_ONCE)
+        .value("READ_NO_SNP", REQ_OPCODE_READ_NO_SNP)
+        .value("PCRD_RETURN", REQ_OPCODE_PCRD_RETURN)
+        .value("READ_UNIQUE", REQ_OPCODE_READ_UNIQUE)
+        .value("CLEAN_SHARED", REQ_OPCODE_CLEAN_SHARED)
+        .value("CLEAN_INVALID", REQ_OPCODE_CLEAN_INVALID)
+        .value("MAKE_INVALID", REQ_OPCODE_MAKE_INVALID)
+        .value("CLEAN_UNIQUE", REQ_OPCODE_CLEAN_UNIQUE)
+        .value("MAKE_UNIQUE", REQ_OPCODE_MAKE_UNIQUE)
+        .value("EVICT", REQ_OPCODE_EVICT)
+        .value("EO_BARRIER", REQ_OPCODE_EO_BARRIER)
+        .value("EC_BARRIER", REQ_OPCODE_EC_BARRIER)
+        .value("READ_NO_SNP_SEP", REQ_OPCODE_READ_NO_SNP_SEP)
+        .value("CLEAN_SHARED_PERSIST_SEP", REQ_OPCODE_CLEAN_SHARED_PERSIST_SEP)
+        .value("DVM_OP", REQ_OPCODE_DVM_OP)
+        .value("WRITE_EVICT_FULL", REQ_OPCODE_WRITE_EVICT_FULL)
+        .value("WRITE_CLEAN_PTL", REQ_OPCODE_WRITE_CLEAN_PTL)
+        .value("WRITE_CLEAN_FULL", REQ_OPCODE_WRITE_CLEAN_FULL)
+        .value("WRITE_UNIQUE_PTL", REQ_OPCODE_WRITE_UNIQUE_PTL)
+        .value("WRITE_UNIQUE_FULL", REQ_OPCODE_WRITE_UNIQUE_FULL)
+        .value("WRITE_BACK_PTL", REQ_OPCODE_WRITE_BACK_PTL)
+        .value("WRITE_BACK_FULL", REQ_OPCODE_WRITE_BACK_FULL)
+        .value("WRITE_NO_SNP_PTL", REQ_OPCODE_WRITE_NO_SNP_PTL)
+        .value("WRITE_NO_SNP_FULL", REQ_OPCODE_WRITE_NO_SNP_FULL)
+        .value("WRITE_UNIQUE_FULL_STASH", REQ_OPCODE_WRITE_UNIQUE_FULL_STASH)
+        .value("WRITE_UNIQUE_PTL_STASH", REQ_OPCODE_WRITE_UNIQUE_PTL_STASH)
+        .value("STASH_ONCE_SHARED", REQ_OPCODE_STASH_ONCE_SHARED)
+        .value("STASH_ONCE_UNIQUE", REQ_OPCODE_STASH_ONCE_UNIQUE)
+        ;
+
+    py::enum_<RspOpcodeEnum>(tlm_chi, "RspOpcode")
+        .value("RSP_LCRD_RETURN", RSP_OPCODE_RSP_LCRD_RETURN)
+        .value("SNP_RESP", RSP_OPCODE_SNP_RESP)
+        .value("COMP_ACK", RSP_OPCODE_COMP_ACK)
+        .value("RETRY_ACK", RSP_OPCODE_RETRY_ACK)
+        .value("COMP", RSP_OPCODE_COMP)
+        .value("COMP_DBID_RESP", RSP_OPCODE_COMP_DBID_RESP)
+        .value("DBID_RESP", RSP_OPCODE_DBID_RESP)
+        .value("PCRD_GRANT", RSP_OPCODE_PCRD_GRANT)
+        .value("READ_RECEIPT", RSP_OPCODE_READ_RECEIPT)
+        .value("SNP_RESP_FWDED", RSP_OPCODE_SNP_RESP_FWDED)
+        .value("TAG_MATCH", RSP_OPCODE_TAG_MATCH)
+        .value("RESP_SEP_DATA", RSP_OPCODE_RESP_SEP_DATA)
+        .value("PERSIST", RSP_OPCODE_PERSIST)
+        .value("COMP_PERSIST", RSP_OPCODE_COMP_PERSIST)
+        .value("DBID_RESP_ORD", RSP_OPCODE_DBID_RESP_ORD)
+        .value("STASH_DONE", RSP_OPCODE_STASH_DONE)
+        .value("COMP_STASH_DONE", RSP_OPCODE_COMP_STASH_DONE)
+        .value("COMP_CMO", RSP_OPCODE_COMP_CMO)
+        ;
+
+    py::enum_<DatOpcodeEnum>(tlm_chi, "DatOpcode")
+        .value("DAT_LCRD_RETURN", DAT_OPCODE_DAT_LCRD_RETURN)
+        .value("SNP_RESP_DATA", DAT_OPCODE_SNP_RESP_DATA)
+        .value("COPY_BACK_WR_DATA", DAT_OPCODE_COPY_BACK_WR_DATA)
+        .value("NON_COPY_BACK_WR_DATA", DAT_OPCODE_NON_COPY_BACK_WR_DATA)
+        .value("COMP_DATA", DAT_OPCODE_COMP_DATA)
+        .value("SNP_RESP_DATA_PTL", DAT_OPCODE_SNP_RESP_DATA_PTL)
+        .value("SNP_RESP_DATA_FWDED", DAT_OPCODE_SNP_RESP_DATA_FWDED)
+        .value("WRITE_DATA_CANCEL", DAT_OPCODE_WRITE_DATA_CANCEL)
+        .value("DATA_SEP_RESP", DAT_OPCODE_DATA_SEP_RESP)
+        .value("NCB_WR_DATA_COMP_ACK", DAT_OPCODE_NCB_WR_DATA_COMP_ACK)
+        ;
+
+    py::enum_<SnpOpcodeEnum>(tlm_chi, "SnpOpcode")
+        .value("SNP_LCRD_RETURN", SNP_OPCODE_SNP_LCRD_RETURN)
+        .value("SNP_SHARED", SNP_OPCODE_SNP_SHARED)
+        .value("SNP_CLEAN", SNP_OPCODE_SNP_CLEAN)
+        .value("SNP_ONCE", SNP_OPCODE_SNP_ONCE)
+        .value("SNP_NOT_SHARED_DIRTY", SNP_OPCODE_SNP_NOT_SHARED_DIRTY)
+        .value("SNP_UNIQUE_STASH", SNP_OPCODE_SNP_UNIQUE_STASH)
+        .value("SNP_MAKE_INVALID_STASH", SNP_OPCODE_SNP_MAKE_INVALID_STASH)
+        .value("SNP_UNIQUE", SNP_OPCODE_SNP_UNIQUE)
+        .value("SNP_CLEAN_SHARED", SNP_OPCODE_SNP_CLEAN_SHARED)
+        .value("SNP_CLEAN_INVALID", SNP_OPCODE_SNP_CLEAN_INVALID)
+        .value("SNP_MAKE_INVALID", SNP_OPCODE_SNP_MAKE_INVALID)
+        .value("SNP_STASH_UNIQUE", SNP_OPCODE_SNP_STASH_UNIQUE)
+        .value("SNP_STASH_SHARED", SNP_OPCODE_SNP_STASH_SHARED)
+        .value("SNP_DVM_OP", SNP_OPCODE_SNP_DVM_OP)
+        .value("SNP_QUERY", SNP_OPCODE_SNP_QUERY)
+        .value("SNP_SHARED_FWD", SNP_OPCODE_SNP_SHARED_FWD)
+        .value("SNP_CLEAN_FWD", SNP_OPCODE_SNP_CLEAN_FWD)
+        .value("SNP_ONCE_FWD", SNP_OPCODE_SNP_ONCE_FWD)
+        .value("SNP_NOT_SHARED_DIRTY_FWD", SNP_OPCODE_SNP_NOT_SHARED_DIRTY_FWD)
+        .value("SNP_PREFER_UNIQUE", SNP_OPCODE_SNP_PREFER_UNIQUE)
+        .value("SNP_PREFER_UNIQUE_FWD", SNP_OPCODE_SNP_PREFER_UNIQUE_FWD)
+        .value("SNP_UNIQUE_FWD", SNP_OPCODE_SNP_UNIQUE_FWD)
+        ;
+}
+
+EmbeddedPyBind embed_("tlm_chi", &tlm_chi_pybind);
+
+} // namespace
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi.py
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi.py
@@ -1,4 +1,3 @@
-# -*- mode:python -*-
 # Copyright (c) 2024 Arm Limited
 # All rights reserved.
 #
@@ -34,43 +33,5 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import("*")
-
-def get_tlm_paths():
-    tlm_dir = Dir(env["CONF"]["TLM_PATH"])
-    assert tlm_dir is not None and tlm_dir != "."
-
-    include_dir = tlm_dir.Dir("include")
-    lib_dir = tlm_dir.Dir("lib")
-
-    model_lib = "libarmtlmchi.so"
-    if not lib_dir.File(model_lib).exists():
-        print(f"Error: Can't find {model_lib} in AMBA TLM directory.")
-        print(f"TLM path: {tlm_dir}")
-        Exit(1)
-
-    return include_dir, lib_dir, "armtlmchi"
-
-
-if env["CONF"]["BUILD_TLM"]:
-    include_path, lib_path, tlm_lib = get_tlm_paths()
-
-    env.Append(CPPPATH=include_path)
-    env.Append(LIBPATH=lib_path)
-    env.Append(LIBS=[tlm_lib])
-
-    SimObject(
-        "TlmController.py", sim_objects=["TlmController"], tags="arm isa"
-    )
-    Source("utils.cc", tags="arm isa")
-    Source("controller.cc", tags="arm isa")
-    Source('tlm_chi.cc', tags='arm isa')
-    PySource('m5', 'tlm_chi.py')
-    DebugFlag("TLM", tags="arm isa")
-
-    print(
-        "BUILD_TLM set: "
-        f"Building TLM integration with libarmtlmchi.so from '{lib_path}'\n"
-    )
-elif not GetOption("silent"):
-    print("BUILD_TLM not set, not building CHI-TLM integration\n")
+import _m5.tlm_chi
+from _m5.tlm_chi import *

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi.py
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi.py
@@ -34,4 +34,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import _m5.tlm_chi
+import _m5.tlm_chi_gen
 from _m5.tlm_chi import *
+from _m5.tlm_chi_gen import *
+
+
+def expect_equal(received, expected):
+    if received != expected:
+        print(f"Comparison mismatch. Received:{received}, Expected:{expected}")
+        return False
+    else:
+        return True

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ARM/TLM/arm_chi.h>
+
+#include "mem/ruby/protocol/chi/tlm/generator.hh"
+// This is required by Transaction::expect
+#include "pybind11/functional.h"
+#include "python/pybind11/pybind.hh"
+#include "sim/init.hh"
+
+namespace py = pybind11;
+
+using namespace ARM::CHI;
+
+namespace gem5 {
+
+namespace {
+
+void
+tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
+{
+    auto tlm_chi_gen = m_tlm_chi.def_submodule("tlm_chi_gen");
+
+    using Action = tlm::chi::TlmGenerator::Transaction::Action;
+    using Expectation = tlm::chi::TlmGenerator::Transaction::Expectation;
+    using Assertion = tlm::chi::TlmGenerator::Transaction::Assertion;
+    using Callback = Action::Callback;
+    py::class_<tlm::chi::TlmGenerator::Transaction>(tlm_chi_gen, "Transaction")
+        .def(py::init<Payload*, Phase&>())
+        .def("EXPECT_STR",
+            [] (tlm::chi::TlmGenerator::Transaction &self,
+                std::string name,
+                Callback cb)
+            {
+                self.addCallback(std::make_unique<Expectation>(name, cb));
+            })
+        .def("EXPECT",
+            [] (tlm::chi::TlmGenerator::Transaction &self,
+                py::function cb)
+            {
+                self.addCallback(std::make_unique<Expectation>(
+                    cb.attr("__name__").cast<std::string>(),
+                    cb.cast<Callback>()));
+            })
+        .def("ASSERT",
+            [] (tlm::chi::TlmGenerator::Transaction &self,
+                std::string name,
+                Callback cb)
+            {
+                self.addCallback(std::make_unique<Assertion>(name, cb));
+            })
+        .def("DO",
+            [] (tlm::chi::TlmGenerator::Transaction &self,
+                Callback cb)
+            {
+                self.addCallback(std::make_unique<Action>(cb, false));
+            })
+        .def("DO_WAIT",
+            [] (tlm::chi::TlmGenerator::Transaction &self,
+                Callback cb)
+            {
+                self.addCallback(std::make_unique<Action>(cb, true));
+            })
+        .def("inject", &tlm::chi::TlmGenerator::Transaction::inject)
+        .def_property("phase",
+            &tlm::chi::TlmGenerator::Transaction::phase,
+            &tlm::chi::TlmGenerator::Transaction::phase)
+        ;
+}
+
+EmbeddedPyBind embed_("tlm_chi_gen", &tlm_chi_generator_pybind, "tlm_chi");
+
+} // namespace
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -1,0 +1,498 @@
+/*
+ * Copyright (c) 2023 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/tlm/utils.hh"
+
+#include "base/bitfield.hh"
+#include "base/logging.hh"
+
+namespace gem5 {
+
+namespace tlm::chi {
+
+namespace {
+
+using namespace ARM::CHI;
+
+std::string
+reqOpcodeToName(ReqOpcode req_opcode)
+{
+    switch (req_opcode) {
+      case REQ_OPCODE_REQ_LCRD_RETURN: return "ReqLCrdReturn";
+      case REQ_OPCODE_READ_SHARED: return "ReadShared";
+      case REQ_OPCODE_READ_CLEAN: return "ReadClean";
+      case REQ_OPCODE_READ_ONCE: return "ReadOnce";
+      case REQ_OPCODE_READ_NO_SNP: return "ReadNoSnp";
+      case REQ_OPCODE_PCRD_RETURN: return "PCrdReturn";
+      case REQ_OPCODE_READ_UNIQUE: return "ReadUnique";
+      case REQ_OPCODE_CLEAN_SHARED: return "CleanShared";
+      case REQ_OPCODE_CLEAN_INVALID: return "CleanInvalid";
+      case REQ_OPCODE_MAKE_INVALID: return "MakeInvalid";
+      case REQ_OPCODE_CLEAN_UNIQUE: return "CleanUnique";
+      case REQ_OPCODE_MAKE_UNIQUE: return "MakeUnique";
+      case REQ_OPCODE_EVICT: return "Evict";
+      case REQ_OPCODE_EO_BARRIER: return "EoBarrier";
+      case REQ_OPCODE_EC_BARRIER: return "EcBarrier";
+      case REQ_OPCODE_READ_NO_SNP_SEP: return "ReadNoSnpSep";
+      case REQ_OPCODE_CLEAN_SHARED_PERSIST_SEP: return "CleanSharedPersistSep";
+      case REQ_OPCODE_DVM_OP: return "DvmOp";
+      case REQ_OPCODE_WRITE_EVICT_FULL: return "WriteEvictFull";
+      case REQ_OPCODE_WRITE_CLEAN_PTL: return "WriteCleanPtl";
+      case REQ_OPCODE_WRITE_CLEAN_FULL: return "WriteCleanFull";
+      case REQ_OPCODE_WRITE_UNIQUE_PTL: return "WriteUniquePtl";
+      case REQ_OPCODE_WRITE_UNIQUE_FULL: return "WriteUniqueFull";
+      case REQ_OPCODE_WRITE_BACK_PTL: return "WriteBackPtl";
+      case REQ_OPCODE_WRITE_BACK_FULL: return "WriteBackFull";
+      case REQ_OPCODE_WRITE_NO_SNP_PTL: return "WriteNoSnpPtl";
+      case REQ_OPCODE_WRITE_NO_SNP_FULL: return "WriteNoSnpFull";
+      case REQ_OPCODE_WRITE_UNIQUE_FULL_STASH: return "WriteUniqueFullStash";
+      case REQ_OPCODE_WRITE_UNIQUE_PTL_STASH: return "WriteUniquePtlStash";
+      case REQ_OPCODE_STASH_ONCE_SHARED: return "StashOnceShared";
+      case REQ_OPCODE_STASH_ONCE_UNIQUE: return "StashOnceUnique";
+      case REQ_OPCODE_READ_ONCE_CLEAN_INVALID: return "ReadOnceCleanInvalid";
+      case REQ_OPCODE_READ_ONCE_MAKE_INVALID: return "ReadOnceMakeInvalid";
+      case REQ_OPCODE_READ_NOT_SHARED_DIRTY: return "ReadNotSharedDirty";
+      case REQ_OPCODE_CLEAN_SHARED_PERSIST: return "CleanSharedPersist";
+      case REQ_OPCODE_ATOMIC_STORE_ADD: return "AtomicStoreAdd";
+      case REQ_OPCODE_ATOMIC_STORE_CLR: return "AtomicStoreClr";
+      case REQ_OPCODE_ATOMIC_STORE_EOR: return "AtomicStoreEor";
+      case REQ_OPCODE_ATOMIC_STORE_SET: return "AtomicStoreSet";
+      case REQ_OPCODE_ATOMIC_STORE_SMAX: return "AtomicStoreSmax";
+      case REQ_OPCODE_ATOMIC_STORE_SMIN: return "AtomicStoreSmin";
+      case REQ_OPCODE_ATOMIC_STORE_UMAX: return "AtomicStoreUmax";
+      case REQ_OPCODE_ATOMIC_STORE_UMIN: return "AtomicStoreUmin";
+      case REQ_OPCODE_ATOMIC_LOAD_ADD: return "AtomicLoadAdd";
+      case REQ_OPCODE_ATOMIC_LOAD_CLR: return "AtomicLoadClr";
+      case REQ_OPCODE_ATOMIC_LOAD_EOR: return "AtomicLoadEor";
+      case REQ_OPCODE_ATOMIC_LOAD_SET: return "AtomicLoadSet";
+      case REQ_OPCODE_ATOMIC_LOAD_SMAX: return "AtomicLoadSmax";
+      case REQ_OPCODE_ATOMIC_LOAD_SMIN: return "AtomicLoadSmin";
+      case REQ_OPCODE_ATOMIC_LOAD_UMAX: return "AtomicLoadUmax";
+      case REQ_OPCODE_ATOMIC_LOAD_UMIN: return "AtomicLoadUmin";
+      case REQ_OPCODE_ATOMIC_SWAP: return "AtomicSwap";
+      case REQ_OPCODE_ATOMIC_COMPARE: return "AtomicCompare";
+      case REQ_OPCODE_PREFETCH_TGT: return "PrefetchTgt";
+      case REQ_OPCODE_MAKE_READ_UNIQUE: return "MakeReadUnique";
+      case REQ_OPCODE_WRITE_EVICT_OR_EVICT: return "WriteEvictOrEvict";
+      case REQ_OPCODE_WRITE_UNIQUE_ZERO: return "WriteUniqueZero";
+      case REQ_OPCODE_WRITE_NO_SNP_ZERO: return "WriteNoSnpZero";
+      case REQ_OPCODE_STASH_ONCE_SEP_SHARED: return "StashOnceSepShared";
+      case REQ_OPCODE_STASH_ONCE_SEP_UNIQUE: return "StashOnceSepUnique";
+      case REQ_OPCODE_READ_PREFER_UNIQUE: return "ReadPreferUnique";
+      case REQ_OPCODE_WRITE_NO_SNP_FULL_CLEAN_SH: return "WriteNoSnpFullCleanSh";
+      default: return std::string{};
+    }
+}
+
+std::string
+snpOpcodeToName(SnpOpcode snp_opcode)
+{
+    switch (snp_opcode) {
+      case SNP_OPCODE_SNP_LCRD_RETURN: return "SnpLcrdReturn";
+      case SNP_OPCODE_SNP_SHARED: return "SnpShared";
+      case SNP_OPCODE_SNP_CLEAN: return "SnpClean";
+      case SNP_OPCODE_SNP_ONCE: return "SnpOnce";
+      case SNP_OPCODE_SNP_NOT_SHARED_DIRTY: return "SnpNotSharedDirty";
+      case SNP_OPCODE_SNP_UNIQUE_STASH: return "SnpUniqueStash";
+      case SNP_OPCODE_SNP_MAKE_INVALID_STASH: return "SnpMakeInvalidStash";
+      case SNP_OPCODE_SNP_UNIQUE: return "SnpUnique";
+      case SNP_OPCODE_SNP_CLEAN_SHARED: return "SnpCleanShared";
+      case SNP_OPCODE_SNP_CLEAN_INVALID: return "SnpCleanInvalid";
+      case SNP_OPCODE_SNP_MAKE_INVALID: return "SnpMakeInvalid";
+      case SNP_OPCODE_SNP_STASH_UNIQUE: return "SnpStashUnique";
+      case SNP_OPCODE_SNP_STASH_SHARED: return "SnpStashShared";
+      case SNP_OPCODE_SNP_DVM_OP: return "SnpDvmOp";
+      case SNP_OPCODE_SNP_QUERY: return "SnpQuery";
+      case SNP_OPCODE_SNP_SHARED_FWD: return "SnpSharedFwd";
+      case SNP_OPCODE_SNP_CLEAN_FWD: return "SnpCleanFwd";
+      case SNP_OPCODE_SNP_ONCE_FWD: return "SnpOnceFwd";
+      case SNP_OPCODE_SNP_NOT_SHARED_DIRTY_FWD: return "SnpNotSharedDirtyFwd";
+      case SNP_OPCODE_SNP_PREFER_UNIQUE: return "SnpPreferUnique";
+      case SNP_OPCODE_SNP_PREFER_UNIQUE_FWD: return "SnpPreferUniqueFwd";
+      case SNP_OPCODE_SNP_UNIQUE_FWD: return "SnpUniqueFwd";
+      default: return std::string{};
+    }
+}
+
+std::string
+datOpcodeToName(DatOpcode dat_opcode)
+{
+    switch (dat_opcode) {
+      case DAT_OPCODE_DAT_LCRD_RETURN: return "DatLcrdReturn";
+      case DAT_OPCODE_SNP_RESP_DATA: return "SnpRespData";
+      case DAT_OPCODE_COPY_BACK_WR_DATA: return "CopyBackWrData";
+      case DAT_OPCODE_NON_COPY_BACK_WR_DATA: return "NonCopyBackWrData";
+      case DAT_OPCODE_COMP_DATA: return "CompData";
+      case DAT_OPCODE_SNP_RESP_DATA_PTL: return "SnpRespDataPtl";
+      case DAT_OPCODE_SNP_RESP_DATA_FWDED: return "SnpRespDataFwded";
+      case DAT_OPCODE_WRITE_DATA_CANCEL: return "WriteDataCancel";
+      case DAT_OPCODE_DATA_SEP_RESP: return "DataSepResp";
+      case DAT_OPCODE_NCB_WR_DATA_COMP_ACK: return "NcbWrDataCompAck";
+      default: return std::string{};
+    }
+}
+
+std::string
+rspOpcodeToName(RspOpcode rsp_opcode)
+{
+    switch (rsp_opcode) {
+      case RSP_OPCODE_RSP_LCRD_RETURN: return "RspLcrdReturn";
+      case RSP_OPCODE_SNP_RESP: return "SnpResp";
+      case RSP_OPCODE_COMP_ACK: return "CompAck";
+      case RSP_OPCODE_RETRY_ACK: return "RetryAck";
+      case RSP_OPCODE_COMP: return "OpcodeComp";
+      case RSP_OPCODE_COMP_DBID_RESP: return "CompDbidResp";
+      case RSP_OPCODE_DBID_RESP: return "DbidResp";
+      case RSP_OPCODE_PCRD_GRANT: return "PcrdGrant";
+      case RSP_OPCODE_READ_RECEIPT: return "ReadReceipt";
+      case RSP_OPCODE_SNP_RESP_FWDED: return "SnpRespFwded";
+      case RSP_OPCODE_TAG_MATCH: return "TagMatch";
+      case RSP_OPCODE_RESP_SEP_DATA: return "RespSepData";
+      case RSP_OPCODE_PERSIST: return "Persist";
+      case RSP_OPCODE_COMP_PERSIST: return "CompPersist";
+      case RSP_OPCODE_DBID_RESP_ORD: return "DbidRespOrd";
+      case RSP_OPCODE_STASH_DONE: return "StashDone";
+      case RSP_OPCODE_COMP_STASH_DONE: return "CompStashDone";
+      case RSP_OPCODE_COMP_CMO: return "CompCMO";
+      default: return std::string{};
+    }
+}
+
+std::string
+phaseToOpcodeName(const Phase &phase)
+{
+    switch (phase.channel) {
+      case CHANNEL_REQ:
+        return reqOpcodeToName(phase.req_opcode);
+      case CHANNEL_SNP:
+        return snpOpcodeToName(phase.snp_opcode);
+      case CHANNEL_DAT:
+        return datOpcodeToName(phase.dat_opcode);
+      case CHANNEL_RSP:
+        return rspOpcodeToName(phase.rsp_opcode);
+      default:
+        break;
+      }
+      return std::string{};
+}
+
+std::string
+phaseToChannelName(const Phase &phase)
+{
+    switch (phase.channel) {
+      case CHANNEL_REQ:
+        return "REQ";
+      case CHANNEL_SNP:
+        return "SNP";
+      case CHANNEL_DAT:
+        return "DAT";
+      case CHANNEL_RSP:
+        return "RSP";
+      default:
+        return std::string{};
+    }
+}
+
+} // namespace
+
+std::string
+transactionToString(const Payload &payload,
+                    const Phase &phase)
+{
+    return csprintf("%s %s addr=0x%08lx ns=%d size=%d attrs=0x%x",
+        phaseToChannelName(phase),
+        phaseToOpcodeName(phase).c_str(),
+        payload.address, payload.ns,
+        (int)payload.size, (int)payload.mem_attr);
+}
+
+namespace tlm_to_ruby {
+
+ruby::CHIRequestType
+reqOpcode(ReqOpcode req)
+{
+    static std::unordered_map<uint8_t, ruby::CHIRequestType> translation_map = {
+        { REQ_OPCODE_READ_SHARED, ruby::CHIRequestType_ReadShared },
+        { REQ_OPCODE_READ_CLEAN, ruby::CHIRequestType_ReadOnce }, // TODO
+        { REQ_OPCODE_READ_ONCE, ruby::CHIRequestType_ReadOnce },
+        { REQ_OPCODE_READ_NO_SNP, ruby::CHIRequestType_ReadNoSnp }, // TODO
+        { REQ_OPCODE_READ_UNIQUE, ruby::CHIRequestType_ReadUnique },
+        { REQ_OPCODE_READ_NOT_SHARED_DIRTY, ruby::CHIRequestType_ReadNotSharedDirty },
+        { REQ_OPCODE_READ_PREFER_UNIQUE, ruby::CHIRequestType_ReadUnique }, // TODO
+        { REQ_OPCODE_MAKE_READ_UNIQUE, ruby::CHIRequestType_MakeReadUnique }, // TODO
+
+        { REQ_OPCODE_CLEAN_UNIQUE, ruby::CHIRequestType_CleanUnique },
+        { REQ_OPCODE_MAKE_UNIQUE, ruby::CHIRequestType_CleanUnique }, // TODO
+        { REQ_OPCODE_EVICT, ruby::CHIRequestType_Evict },
+        { REQ_OPCODE_STASH_ONCE_SEP_SHARED, ruby::CHIRequestType_StashOnceShared }, // TODO
+        { REQ_OPCODE_STASH_ONCE_SEP_UNIQUE, ruby::CHIRequestType_StashOnceUnique },
+        { REQ_OPCODE_WRITE_NO_SNP_PTL, ruby::CHIRequestType_WriteUniquePtl },
+        { REQ_OPCODE_WRITE_NO_SNP_FULL, ruby::CHIRequestType_WriteUniqueFull },
+        { REQ_OPCODE_WRITE_UNIQUE_FULL, ruby::CHIRequestType_WriteUniqueFull },
+        { REQ_OPCODE_WRITE_UNIQUE_ZERO, ruby::CHIRequestType_WriteUniqueZero },
+        { REQ_OPCODE_WRITE_BACK_FULL, ruby::CHIRequestType_WriteBackFull },
+        { REQ_OPCODE_WRITE_EVICT_OR_EVICT, ruby::CHIRequestType_WriteEvictFull }, // TODO
+    };
+
+    auto it = translation_map.find(req);
+    if (it != translation_map.end()) {
+        return it->second;
+    } else {
+        panic("Unsupported Translation: %s\n", reqOpcodeToName(req));
+    }
+}
+
+#define RESP_CASE(opc) \
+  switch (resp) { \
+    case RESP_I: return opc ## _ ## I; \
+    case RESP_SC: return opc ## _ ## SC; \
+    case RESP_UC: return opc ## _ ## UC; \
+    case RESP_SD: return opc ## _ ## SD; \
+    case RESP_I_PD: return opc ## _ ## I_PD; \
+    case RESP_SC_PD: return opc ## _ ## SC_PD; \
+    case RESP_UC_PD: return opc ## _ ## UC; \
+    case RESP_SD_PD: return opc ## _ ## SD; \
+    default: panic(""); \
+    }
+
+ruby::CHIDataType
+datOpcode(DatOpcode dat, Resp resp)
+{
+    switch (dat) {
+      case DAT_OPCODE_NON_COPY_BACK_WR_DATA:
+        return ruby::CHIDataType_NCBWrData;
+      case DAT_OPCODE_COPY_BACK_WR_DATA:
+        switch (resp) {
+          case RESP_I: return ruby::CHIDataType_CBWrData_I;
+          case RESP_UC: return ruby::CHIDataType_CBWrData_UC;
+          case RESP_SC: return ruby::CHIDataType_CBWrData_SC;
+          case RESP_UD_PD: return ruby::CHIDataType_CBWrData_UD_PD;
+          default: panic("");
+        }
+      case DAT_OPCODE_SNP_RESP_DATA:
+        RESP_CASE(ruby::CHIDataType_SnpRespData)
+      default:
+        panic("Unsupported Translation: %s\n", datOpcodeToName(dat));
+    }
+}
+
+ruby::CHIResponseType
+rspOpcode(RspOpcode opc, Resp resp)
+{
+    switch(opc) {
+      case RSP_OPCODE_COMP_ACK: return ruby::CHIResponseType_CompAck;
+      case RSP_OPCODE_SNP_RESP:
+        switch (resp) {
+          case RESP_I: return ruby::CHIResponseType_SnpResp_I;
+          default: panic("Invalid resp %d for %d\n", resp, opc);
+        }
+      default:
+        panic("Unsupported Translation: %s\n", rspOpcodeToName(opc));
+    };
+}
+
+}
+
+namespace ruby_to_tlm {
+
+uint8_t
+datOpcode(ruby::CHIDataType dat)
+{
+    switch (dat) {
+      case ruby::CHIDataType_CompData_I:
+      case ruby::CHIDataType_CompData_UC:
+      case ruby::CHIDataType_CompData_SC:
+      case ruby::CHIDataType_CompData_UD_PD:
+      case ruby::CHIDataType_CompData_SD_PD:
+        return 0x4;
+      case ruby::CHIDataType_DataSepResp_UC:
+        return 0xb;
+      case ruby::CHIDataType_CBWrData_UC:
+      case ruby::CHIDataType_CBWrData_SC:
+      case ruby::CHIDataType_CBWrData_UD_PD:
+      case ruby::CHIDataType_CBWrData_SD_PD:
+      case ruby::CHIDataType_CBWrData_I:
+        return 0x2;
+      case ruby::CHIDataType_NCBWrData:
+        return 0x3;
+      case ruby::CHIDataType_SnpRespData_I:
+      case ruby::CHIDataType_SnpRespData_I_PD:
+      case ruby::CHIDataType_SnpRespData_SC:
+      case ruby::CHIDataType_SnpRespData_SC_PD:
+      case ruby::CHIDataType_SnpRespData_SD:
+      case ruby::CHIDataType_SnpRespData_UC:
+      case ruby::CHIDataType_SnpRespData_UD:
+        return 0x1;
+      case ruby::CHIDataType_SnpRespData_SC_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_SC_Fwded_SD_PD:
+      case ruby::CHIDataType_SnpRespData_SC_PD_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_SD_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_I_Fwded_SD_PD:
+      case ruby::CHIDataType_SnpRespData_I_PD_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_I_Fwded_SC:
+        return 0x6;
+      default:
+        panic("Unrecognised data opcode: %d\n", dat);
+    }
+}
+
+uint8_t
+rspOpcode(ruby::CHIResponseType rsp)
+{
+    switch (rsp) {
+      case ruby::CHIResponseType_Comp_UD_PD:
+      case ruby::CHIResponseType_Comp_UC:
+      case ruby::CHIResponseType_Comp_I:
+        return RSP_OPCODE_COMP;
+      case ruby::CHIResponseType_CompDBIDResp:
+        return RSP_OPCODE_COMP_DBID_RESP;
+      case ruby::CHIResponseType_RetryAck:
+        return RSP_OPCODE_RETRY_ACK;
+      default:
+        panic("Unrecognised rsp opcode: %d\n", rsp);
+    }
+}
+
+uint8_t
+snpOpcode(ruby::CHIRequestType snp)
+{
+    switch (snp) {
+      case ruby::CHIRequestType_SnpOnceFwd:
+        return SNP_OPCODE_SNP_ONCE_FWD;
+      case ruby::CHIRequestType_SnpOnce:
+        return SNP_OPCODE_SNP_ONCE;
+      case ruby::CHIRequestType_SnpShared:
+        return SNP_OPCODE_SNP_SHARED;
+      case ruby::CHIRequestType_SnpCleanInvalid:
+        return SNP_OPCODE_SNP_CLEAN_INVALID;
+      case ruby::CHIRequestType_SnpUnique:
+        return SNP_OPCODE_SNP_UNIQUE;
+      default:
+        panic("Unrecognised snp opcode: %d\n", snp);
+    }
+}
+
+Resp
+datResp(ruby::CHIDataType dat)
+{
+    switch (dat) {
+      case ruby::CHIDataType_SnpRespData_I:
+      case ruby::CHIDataType_CompData_I:
+      case ruby::CHIDataType_CBWrData_I:
+        return RESP_I;
+      case ruby::CHIDataType_SnpRespData_SC:
+      case ruby::CHIDataType_CompData_SC:
+      case ruby::CHIDataType_CBWrData_SC:
+        return RESP_SC;
+      case ruby::CHIDataType_SnpRespData_UC:
+      case ruby::CHIDataType_CompData_UC:
+      case ruby::CHIDataType_CBWrData_UC:
+      case ruby::CHIDataType_DataSepResp_UC:
+        return RESP_UC;
+      case ruby::CHIDataType_SnpRespData_UD:
+        return RESP_UD;
+      case ruby::CHIDataType_SnpRespData_SD:
+        return RESP_SD;
+      case ruby::CHIDataType_SnpRespData_I_PD:
+        return RESP_I_PD;
+      case ruby::CHIDataType_SnpRespData_SC_PD:
+        return RESP_SC_PD;
+      case ruby::CHIDataType_CompData_UD_PD:
+      case ruby::CHIDataType_CBWrData_UD_PD:
+        return RESP_UD_PD;
+      case ruby::CHIDataType_CompData_SD_PD:
+      case ruby::CHIDataType_CBWrData_SD_PD:
+        return RESP_SD_PD;
+      // TODO
+      case ruby::CHIDataType_SnpRespData_SC_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_SC_Fwded_SD_PD:
+      case ruby::CHIDataType_SnpRespData_SC_PD_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_SD_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_I_Fwded_SD_PD:
+      case ruby::CHIDataType_SnpRespData_I_PD_Fwded_SC:
+      case ruby::CHIDataType_SnpRespData_I_Fwded_SC:
+      default:
+        panic("Unrecognised data opcode: %d\n", dat);
+    }
+}
+
+Resp
+rspResp(ruby::CHIResponseType rsp)
+{
+    switch (rsp) {
+      case ruby::CHIResponseType_Comp_I:
+        return RESP_I;
+      case ruby::CHIResponseType_Comp_UC:
+        return RESP_UC;
+      case ruby::CHIResponseType_Comp_UD_PD:
+        return RESP_UD_PD;
+      case ruby::CHIResponseType_CompDBIDResp:
+        return RESP_I;
+      case ruby::CHIResponseType_RetryAck:
+        // Just setup to zero
+        return RESP_I;
+      default:
+        panic("Unrecognised rsp opcode: %d\n", rsp);
+    }
+}
+
+}
+
+Addr
+transactionSize(Size sz)
+{
+    return 1 << sz;
+}
+
+uint8_t
+dataId(Addr address)
+{
+    uint64_t bus_width = 256;
+    switch (bus_width) {
+      case 128:
+       return bits(address, 5, 4);
+      case 256:
+        return bits(address, 5, 4) & 0b10;
+      case 512:
+      default:
+        return 0b00;
+    }
+}
+
+} // namespace tlm::chi
+
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/utils.hh
+++ b/src/mem/ruby/protocol/chi/tlm/utils.hh
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_TLM_UTILS_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_TLM_UTILS_HH__
+
+#include <ARM/TLM/arm_chi.h>
+
+#include "base/types.hh"
+#include "mem/ruby/protocol/CHIDataType.hh"
+#include "mem/ruby/protocol/CHIRequestType.hh"
+#include "mem/ruby/protocol/CHIResponseType.hh"
+
+namespace gem5 {
+
+namespace tlm::chi {
+
+std::string transactionToString(const ARM::CHI::Payload &payload,
+                                const ARM::CHI::Phase &phase);
+
+namespace tlm_to_ruby {
+
+ruby::CHIRequestType reqOpcode(ARM::CHI::ReqOpcode req);
+ruby::CHIDataType datOpcode(ARM::CHI::DatOpcode dat, ARM::CHI::Resp resp);
+ruby::CHIResponseType rspOpcode(ARM::CHI::RspOpcode res, ARM::CHI::Resp resp);
+
+}
+
+namespace ruby_to_tlm {
+
+uint8_t datOpcode(ruby::CHIDataType dat);
+uint8_t rspOpcode(ruby::CHIResponseType res);
+uint8_t snpOpcode(ruby::CHIRequestType snp);
+
+ARM::CHI::Resp datResp(ruby::CHIDataType dat);
+ARM::CHI::Resp rspResp(ruby::CHIResponseType rsp);
+
+}
+
+Addr transactionSize(ARM::CHI::Size sz);
+
+uint8_t dataId(Addr address);
+
+} // namespace tlm::chi
+
+} // namespace gem5
+
+#endif // __MEM_RUBY_PROTOCOL_CHI_TLM_UTILS_HH__

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 ARM Limited
+ * Copyright (c) 2019-2021,2023 ARM Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -1045,7 +1045,8 @@ Sequencer::makeRequest(PacketPtr pkt)
             m_cache_inv_pkt = pkt;
             invL1();
         } else {
-            panic("Unsupported ruby packet type\n");
+            panic("Cannot convert packet [%s] to ruby request\n",
+                  pkt->print());
         }
     }
 

--- a/tests/gem5/chi_tlm_tests/configs/ruby_mem_test.py
+++ b/tests/gem5/chi_tlm_tests/configs/ruby_mem_test.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2024 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2006-2007 The Regents of The University of Michigan
+# Copyright (c) 2009 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import importlib
+import os
+import sys
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.tlm_chi import *
+from m5.util import addToPath
+
+m5.util.addToPath(os.path.join(m5.util.repoPath(), "configs"))
+from common import Options
+from ruby import (
+    CHI,
+    Ruby,
+)
+from ruby.CHI_config import (
+    CHI_MN,
+    CHI_Node,
+    Versions,
+)
+
+
+class TLM_RNF(CHI_Node):
+    # The CHI controller can be a child of this object or another if
+    # 'parent' is specified
+    def __init__(self, ruby_system, parent):
+        super().__init__(ruby_system)
+
+        self._cntrl = TlmController(
+            version=Versions.getVersion(Cache_Controller),
+            ruby_system=ruby_system,
+        )
+
+        parent.chi_controller = self._cntrl
+        self.connectController(self._cntrl)
+
+    def getSequencers(self):
+        return []
+
+    def getAllControllers(self):
+        return [self._cntrl]
+
+    def getNetworkSideControllers(self):
+        return [self._cntrl]
+
+
+def rnf_gen(options, ruby_system, cpus):
+    return [TLM_RNF(ruby_system, cpu) for cpu in system.cpu]
+
+
+def mn_gen(options, ruby_system, cpus):
+    all_rnf_cntrls = []
+    for rnf in ruby_system.rnf:
+        all_rnf_cntrls.extend(rnf.getAllControllers())
+    return [CHI_MN(ruby_system, all_rnf_cntrls)]
+
+
+def suite_importer(file_path):
+    """
+    Used to import the suite file.
+    :param file_path: Path of the file to import
+    """
+    module_name = os.path.basename(file_path)
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_system(options, system):
+    system.ruby = RubySystem()
+
+    # Instantiate the network object
+    # so that the controllers can connect to it.
+    system.ruby.network = SimpleNetwork(
+        ruby_system=system.ruby,
+        topology=options.topology,
+        routers=[],
+        ext_links=[],
+        int_links=[],
+        netifs=[],
+    )
+
+    bootmem = None
+    dma_ports = []
+    (cpu_sequencers, dir_cntrls, topology) = CHI.create_system(
+        options, False, system, dma_ports, bootmem, system.ruby, system.cpu
+    )
+
+    # Create the network topology
+    topology.makeTopology(
+        options, system.ruby.network, SimpleIntLink, SimpleExtLink, Switch
+    )
+
+    system.ruby.network.setup_buffers()
+
+    # Create a port proxy for connecting the system port. This is
+    # independent of the protocol and kept in the protocol-agnostic
+    # part (i.e. here).
+    # Give the system port proxy a SimObject parent without creating a
+    # full-fledged controller
+    system.sys_port_proxy = RubyPortProxy(ruby_system=system.ruby)
+
+    # Connect the system port for loading of binaries etc
+    system.system_port = system.sys_port_proxy.in_ports
+
+    Ruby.setup_memory_controllers(system, system.ruby, dir_cntrls, options)
+
+    system.ruby.number_of_virtual_networks = (
+        system.ruby.network.number_of_virtual_networks
+    )
+    system.ruby._cpu_ports = cpu_sequencers
+    system.ruby.num_of_sequencers = len(cpu_sequencers)
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+parser.add_argument(
+    "suite",
+    type=str,
+    help="Path to the suite file",
+)
+Options.addNoISAOptions(parser)
+
+#
+# Add the ruby specific and protocol specific options
+#
+Ruby.define_options(parser)
+
+args = parser.parse_args()
+
+#
+# Configuring 4GiBs of SimpleMemory
+#
+args.mem_type = "SimpleMemory"
+args.mem_size = "4GiB"
+
+#
+# Currently ruby does not support atomic or uncacheable accesses
+#
+cpus = [TlmGenerator(cpu_id=i) for i in range(args.num_cpus)]
+
+for cpu in cpus:
+    suite = suite_importer(args.suite)
+    suite.test_all(cpu)
+
+system = System(
+    cpu=cpus,
+    clk_domain=SrcClockDomain(clock=args.sys_clock),
+    mem_ranges=[AddrRange(args.mem_size)],
+)
+m5.util.addToPath("../common")
+
+# Hooking up the RN-F generation callback
+system._rnf_gen = rnf_gen
+system._mn_gen = mn_gen
+
+create_system(args, system)
+
+# Create a top-level voltage domain and clock domain
+system.voltage_domain = VoltageDomain(voltage=args.sys_voltage)
+system.clk_domain = SrcClockDomain(
+    clock=args.sys_clock, voltage_domain=system.voltage_domain
+)
+# Create a seperate clock domain for Ruby
+system.ruby.clk_domain = SrcClockDomain(
+    clock=args.ruby_clock, voltage_domain=system.voltage_domain
+)
+
+# To make unit-tests reproducible, we disable randomization
+system.ruby.randomization = False
+
+# -----------------------
+# run simulation
+# -----------------------
+
+root = Root(full_system=False, system=system)
+root.system.mem_mode = "timing"
+
+# Not much point in this being higher than the L1 latency
+m5.ticks.setGlobalFrequency("1ns")
+
+# instantiate configuration
+m5.instantiate()
+
+# simulate until program terminates
+exit_event = m5.simulate(args.abs_max_tick)
+
+print("Exiting @ tick", m5.curTick(), "because", exit_event.getCause())

--- a/tests/gem5/chi_tlm_tests/configs/suites/read_shared_unit.py
+++ b/tests/gem5/chi_tlm_tests/configs/suites/read_shared_unit.py
@@ -1,0 +1,103 @@
+# -*- mode:python -*-
+# Copyright (c) 2024 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.tlm_chi import *
+
+
+def payload_gen():
+    # Populating payload
+    payload = TlmPayload()
+    payload.address = 0x80000000
+    payload.ns = True
+    payload.size = Size.SIZE_64
+    return payload
+
+
+def phase_gen():
+    # Populating phase
+    phase = TlmPhase()
+    phase.opcode = ReqOpcode.READ_SHARED
+    phase.src_id = 0
+    phase.tgt_id = 0
+    phase.exp_comp_ack = True
+    return phase
+
+
+def channel_check(transaction):
+    return expect_equal(transaction.phase.channel, Channel.DAT)
+
+
+def opcode_check(transaction):
+    return expect_equal(transaction.phase.opcode, DatOpcode.COMP_DATA)
+
+
+def cacheline_check(transaction):
+    return expect_equal(transaction.phase.resp, Resp.RESP_UC)
+
+
+def data_id_check_gen(exp):
+    def data_id_check(transaction):
+        return expect_equal(transaction.phase.data_id, exp)
+
+    return data_id_check
+
+
+def wait_data(transaction):
+    return True
+
+
+def do_comp_ack(transaction):
+    transaction.phase.channel = Channel.RSP
+    transaction.phase.opcode = RspOpcode.COMP_ACK
+    transaction.inject()
+    return False
+
+
+def test_all(generator):
+    payload = payload_gen()
+    phase = phase_gen()
+
+    tran = generator.injectAt(10, payload, phase)
+    tran.EXPECT(channel_check)
+    tran.EXPECT(opcode_check)
+    tran.EXPECT(cacheline_check)
+    tran.EXPECT(data_id_check_gen(0))
+    tran.DO_WAIT(wait_data)
+    tran.EXPECT(channel_check)
+    tran.EXPECT(opcode_check)
+    tran.EXPECT(cacheline_check)
+    tran.EXPECT(data_id_check_gen(2))
+    tran.DO(do_comp_ack)


### PR DESCRIPTION
This PR is implement a CacheController which acts as a bridge between the
AMBA TLM 2.0 implementation of CHI [[1]](https://developer.arm.com/documentation/101459/latest) [[2](https://developer.arm.com/Architectures/AMBA#Downloads)] with the gem5 (ruby) one.

In other words it translates AMBA CHI transactions into ruby
messages (which are then forwarded to the MessageQueues)
and viceversa.

```
ARM::CHI::Payload,         CHIRequestMsg
                     <-->  CHIDataMsg
ARM::CHI::Phase            CHIResponseMsg
                           CHIDataMsg
```

To be able to do so, it first adds a CHIGenericController class to model a coherence controller entirely
in C++ to work with ruby. Adding a CHIGenericController removes the limitation of using the gem5 Sequencer
and associated data structures, therefore allowing the aforementioned CHI to CHI bridge/controller
and potentially a hybrid setup with classic caches + ruby.

The PR also adds a CHI tester, which is a transaction generator directly connected to the CHI-TLM controller. It will
be possible to write small unit tests in python (the library has been wrapped with pybind) for CHI transactions and unlock unit-testing for ruby