### PR TITLE
stdlib: change default exit event for SIMPOINT_BEGIN

### DIFF
--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -52,6 +52,7 @@ from .exit_event_generators import (
     exit_generator,
     reset_stats_generator,
     save_checkpoint_generator,
+    skip_generator,
     switch_generator,
     warn_default_decorator,
 )
@@ -299,7 +300,7 @@ class Simulator:
             ExitEvent.MAX_TICK: exit_generator(),
             ExitEvent.SCHEDULED_TICK: exit_generator(),
             ExitEvent.SIMPOINT_BEGIN: warn_default_decorator(
-                reset_stats_generator,
+                skip_generator,
                 "simpoint begin",
                 "resetting the stats and continuing",
             )(),


### PR DESCRIPTION
The SIMPOINT_BEGIN should do nothing by default since it might be used in various cases.

In [https://www.mail-archive.com/gem5-users@gem5.org/msg22383.html](mailing list), a user discovered a bug with the current `simpoints-se-restore.py` example. 
The bug is caused by the default behavior of the SIMPOINT_BEGIN exit event.
When taking a checkpoint with `simpoints-se-checkpoint.py`, it stores the future exit event scheduled at the beginning of the simulation. I did not notice this when I wrote and tested the example script due to the long print out log and my custom handler of the SIMPOINT_BEGIN exit event.
In the restoring, the SIMPOINT_BEGIN exit event was triggered right before the region end, so it resets the stats before the final stats dump. Therefore, the simulation time is 0 as the user discovered.
This patch should fix this bug.

Change-Id: I800dfbd28d7b2c842864a1ab7d84b8f8e17b9b3c
