### PR TITLE
arch-generic: More reliable special file name handling in semihosting

### DIFF
--- a/src/arch/generic/semihosting.cc
+++ b/src/arch/generic/semihosting.cc
@@ -180,7 +180,8 @@ BaseSemihosting::callOpen(
         return retError(EINVAL);
 
     std::string fname = readString(tc, name_base, name_size);
-    if (!fname.empty() && fname.front() != '/')
+    if (!fname.empty() && fname.front() != '/' && fname != ":tt" &&
+            fname != ":semihosting-features")
         fname = filesRootDir + fname;
 
     std::unique_ptr<BaseSemihosting::FileBase> file =


### PR DESCRIPTION
Currently, the filesRootDir is prepended for all paths that do not start with '/'. However, we should not be doing this for the special files :tt and :semihosting-features. Noticed this while testing semihosting with a non-empty filesRootDir.

Change-Id: I156c8b680cb71cdc88788be3b0e93fc1d52e11e5