### PR TITLE
configs: GPUFS: Fix HSA packet processor address

### DIFF
--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -108,7 +108,7 @@ def makeGpuFSSystem(args):
     system.cpu.append(shader)
 
     # This arbitrary address is something in the X86 I/O hole
-    hsapp_gpu_map_paddr = 0xE00000000
+    hsapp_gpu_map_paddr = 0xE0000000
     hsapp_pt_walker = VegaPagetableWalker()
     gpu_hsapp = HSAPacketProcessor(
         pioAddr=hsapp_gpu_map_paddr,


### PR DESCRIPTION
The address has one too many zeros and is therefore placed in a memory region usually used for system memory. As a result this causes failure when trying to run a simulation with a large amount of memory (e.g. 32GB+).

Change the address to be within the C000'0000h - FFFF'FFFFh X86 I/O hole as was intended.

Change-Id: I5d03ac19ea3b2c01a8c431073c12fa1868b3df24