### PR TITLE
Indirect memory fix

### DIFF
--- a/src/mem/cache/prefetch/indirect_memory.cc
+++ b/src/mem/cache/prefetch/indirect_memory.cc
@@ -148,6 +148,8 @@ IndirectMemory::calculatePrefetch(const PrefetchInfo &pfi,
                                 Addr pf_addr = pt_entry->baseAddr +
                                     (pt_entry->index << pt_entry->shift);
                                 addresses.push_back(AddrPriority(pf_addr, 0));
+                                pf_addr = pt_entry->baseAddr + ((index + distance) << pt_entry->shift);
+                                addresses.push_back(AddrPriority(pf_addr, 0));
                             }
                         }
                     }

--- a/src/mem/cache/prefetch/indirect_memory.cc
+++ b/src/mem/cache/prefetch/indirect_memory.cc
@@ -144,13 +144,11 @@ IndirectMemory::calculatePrefetch(const PrefetchInfo &pfi,
                         if (pt_entry->indirectCounter > prefetchThreshold) {
                             unsigned distance = maxPrefetchDistance *
                                 pt_entry->indirectCounter.calcSaturation();
-                            for (int delta = 1; delta < distance; delta += 1) {
-                                Addr pf_addr = pt_entry->baseAddr +
-                                    (pt_entry->index << pt_entry->shift);
-                                addresses.push_back(AddrPriority(pf_addr, 0));
-                                pf_addr = pt_entry->baseAddr + ((index + distance) << pt_entry->shift);
-                                addresses.push_back(AddrPriority(pf_addr, 0));
-                            }
+                            Addr pf_addr = pt_entry->baseAddr +
+                                (pt_entry->index << pt_entry->shift);
+                            addresses.push_back(AddrPriority(pf_addr, 0));
+                            pf_addr = pt_entry->baseAddr + ((index + distance) << pt_entry->shift);
+                            addresses.push_back(AddrPriority(pf_addr, 0));
                         }
                     }
                 }


### PR DESCRIPTION
I re-read the IMP paper and saw in 3.2.3 Indirect Prefetching, that along with prefetching B[i], B[i + delta] should also be prefetched. Because of this, I removed the for loop that causes repetitive additions of addresses that are the same. Instead, I only add (base address + (index << shift)) and (base address + ((index + distance) << shift), which the paper states are the only two prefetches that should be done in both the intro and in 3.2.3.

fix #1050 