### PR TITLE
mem-ruby: Implement NS bit for CHI transactions

### DIFF
--- a/src/mem/ruby/protocol/RubySlicc_Types.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Types.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021,2023 ARM Limited
+ * Copyright (c) 2020-2021,2023-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -189,6 +189,7 @@ structure(RubyRequest, desc="...", interface="Message", external="yes") {
   Addr tlbiTransactionUid,   desc="Unique identifier of the TLB shootdown operation that produced this request";
   bool isGLCSet,             default="false",desc="If flag is set, bypass GPU L1 cache";
   bool isSLCSet,             default="false",desc="If flag is set, bypass GPU L1 and L2 caches";
+  bool isSecure,             default="false",desc="If flag is set, request is in secure PA space";
 
   RequestPtr getRequestPtr();
 }

--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 ARM Limited
+ * Copyright (c) 2021-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -147,6 +147,7 @@ action(AllocateTBE_SeqRequest, desc="") {
       out_msg.is_local_pf := false;
       out_msg.is_remote_pf := false;
       out_msg.txnId := max_outstanding_transactions;
+      out_msg.ns := !in_msg.isSecure;
 
       out_msg.atomic_op.clear();
       out_msg.atomic_op.orMask(in_msg.writeMask);
@@ -1762,6 +1763,7 @@ action(Send_SnpCleanInvalid, desc="") {
     prepareRequest(tbe, CHIRequestType:SnpCleanInvalid, out_msg);
     out_msg.Destination.addNetDest(tbe.dir_sharers);
     out_msg.retToSrc := false;
+    out_msg.ns := tbe.ns;
   }
   setExpectedForInvSnoop(tbe, false);
 }
@@ -1776,6 +1778,7 @@ action(Send_SnpCleanInvalid_NoReq, desc="") {
     // at least one sharer other than requestor
     assert(out_msg.Destination.count() > 0);
     out_msg.retToSrc := false;
+    out_msg.ns := tbe.ns;
     setExpectedForInvSnoop(tbe, false);
     tbe.expected_snp_resp.setExpectedCount(out_msg.Destination.count());
   }
@@ -1792,6 +1795,7 @@ action(Send_SnpUnique, desc="") {
     prepareRequest(tbe, CHIRequestType:SnpUnique, out_msg);
     out_msg.Destination.addNetDest(tbe.dir_sharers);
     out_msg.retToSrc := false;
+    out_msg.ns := tbe.ns;
   }
 }
 
@@ -1813,6 +1817,7 @@ action(Send_SnpUnique_RetToSrc, desc="") {
     prepareRequest(tbe, CHIRequestType:SnpUnique, out_msg);
     out_msg.Destination.add(dest);
     out_msg.retToSrc := true;
+    out_msg.ns := tbe.ns;
   }
   // if other sharers send with retToSrc=false to others
   if (tbe.dir_sharers.count() > 1) {
@@ -1821,6 +1826,7 @@ action(Send_SnpUnique_RetToSrc, desc="") {
       out_msg.Destination.addNetDest(tbe.dir_sharers);
       out_msg.Destination.remove(dest);
       out_msg.retToSrc := false;
+      out_msg.ns := tbe.ns;
     }
   }
 }
@@ -1840,6 +1846,7 @@ action(Send_SnpUniqueFwd, desc="") {
     prepareRequest(tbe, CHIRequestType:SnpUniqueFwd, out_msg);
     out_msg.Destination.addNetDest(tbe.dir_sharers);
     out_msg.retToSrc := false;
+    out_msg.ns := tbe.ns;
   }
 }
 
@@ -1861,6 +1868,7 @@ action(Send_SnpShared, desc="") {
     prepareRequest(tbe, CHIRequestType:SnpShared, out_msg);
     out_msg.Destination.add(tbe.dir_owner);
     out_msg.retToSrc := false;
+    out_msg.ns := tbe.ns;
   }
 }
 
@@ -1910,6 +1918,7 @@ action(Send_SnpSharedFwd_ToOwner, desc="") {
     }
     out_msg.Destination.add(tbe.dir_owner);
     out_msg.retToSrc := retToSrc;
+    out_msg.ns := tbe.ns;
   }
 }
 
@@ -1937,6 +1946,7 @@ action(Send_SnpSharedFwd_ToSharer, desc="") {
     // TODO should be random or the closest one to the fwd dest
     out_msg.Destination.add(tbe.dir_sharers.smallestElement());
     out_msg.retToSrc := retToSrc;
+    out_msg.ns := tbe.ns;
   }
 }
 
@@ -1970,6 +1980,7 @@ action(Send_SnpOnce, desc="") {
       out_msg.Destination.add(tbe.dir_sharers.smallestElement());
     }
     out_msg.retToSrc := true;
+    out_msg.ns := tbe.ns;
   }
 }
 
@@ -2003,6 +2014,7 @@ action(Send_SnpOnceFwd, desc="") {
       out_msg.Destination.add(tbe.dir_sharers.smallestElement());
     }
     out_msg.retToSrc := false;
+    out_msg.ns := tbe.ns;
   }
 }
 

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Arm Limited
+ * Copyright (c) 2021-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -430,6 +430,7 @@ TBE allocateRequestTBE(Addr addr, CHIRequestMsg in_msg), return_by_pointer="yes"
   } else {
     tbe.txnId := in_msg.txnId;
   }
+  tbe.ns := in_msg.ns;
 
   assert(tbe.is_snp_tbe == false);
   assert(tbe.is_repl_tbe == false);

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 ARM Limited
+ * Copyright (c) 2021-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -650,6 +650,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     int accSize,            desc="Access size for Load/Store/WriteUniquePtl; otherwisse == blockSize";
     CHIRequestType reqType, desc="Request type that initiated this transaction";
     Addr txnId,             desc="Transaction ID. We default to -1 for debug purposes", default="-1";
+    bool ns,                desc="Secure State of the transaction. NS=NonSecure", default="true";
     MachineID requestor,    desc="Requestor ID";
     MachineID fwdRequestor, desc="Requestor to receive data on fwding snoops";
     bool use_DMT,           desc="Use DMT for this transaction";

--- a/src/mem/ruby/protocol/chi/CHI-msg.sm
+++ b/src/mem/ruby/protocol/chi/CHI-msg.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Arm Limited
+ * Copyright (c) 2021, 2023-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -121,6 +121,7 @@ structure(CHIRequestMsg, desc="", interface="Message") {
 
   bool usesTxnId,       desc="True if using a Transaction ID", default="false";
   Addr txnId,           desc="Transaction ID", default="0";
+  bool ns,              desc="Secure State of the transaction. NS=NonSecure", default="true";
 
   MessageSizeType MessageSize, default="MessageSizeType_Control";
 

--- a/src/mem/ruby/slicc_interface/RubyRequest.hh
+++ b/src/mem/ruby/slicc_interface/RubyRequest.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 ARM Limited
+ * Copyright (c) 2020-2021, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -84,6 +84,7 @@ class RubyRequest : public Message
     // explicitly set to true in the program in order to bypass caches
     bool m_isGLCSet;
     bool m_isSLCSet;
+    bool m_isSecure;
 
     RubyRequest(Tick curTime, uint64_t _paddr, int _len,
         uint64_t _pc, RubyRequestType _type, RubyAccessMode _access_mode,
@@ -101,7 +102,8 @@ class RubyRequest : public Message
           m_htmFromTransaction(false),
           m_htmTransactionUid(0),
           m_isTlbi(false),
-          m_tlbiTransactionUid(0)
+          m_tlbiTransactionUid(0),
+          m_isSecure(m_pkt->req->isSecure())
     {
         m_LineAddress = makeLineAddress(m_PhysicalAddress);
         if (_pkt) {
@@ -129,7 +131,8 @@ class RubyRequest : public Message
           m_htmFromTransaction(false),
           m_htmTransactionUid(0),
           m_isTlbi(false),
-          m_tlbiTransactionUid(0)
+          m_tlbiTransactionUid(0),
+          m_isSecure(m_pkt->req->isSecure())
     {
         assert(m_pkt->req->isMemMgmt());
         if (_pkt) {
@@ -164,7 +167,8 @@ class RubyRequest : public Message
           m_htmFromTransaction(false),
           m_htmTransactionUid(0),
           m_isTlbi(false),
-          m_tlbiTransactionUid(0)
+          m_tlbiTransactionUid(0),
+          m_isSecure(m_pkt->req->isSecure())
     {
         m_LineAddress = makeLineAddress(m_PhysicalAddress);
         if (_pkt) {
@@ -200,7 +204,8 @@ class RubyRequest : public Message
           m_htmFromTransaction(false),
           m_htmTransactionUid(0),
           m_isTlbi(false),
-          m_tlbiTransactionUid(0)
+          m_tlbiTransactionUid(0),
+          m_isSecure(m_pkt->req->isSecure())
     {
         m_LineAddress = makeLineAddress(m_PhysicalAddress);
         if (_pkt) {


### PR DESCRIPTION
This patch is adding the NS bit to CHI requests to make sure they are properly tagged according to their security


Change-Id: I33d3610edefbb5a05a6090e9125c35d4fb8bca58
Reviewed-by: Tiago Muck <tiago.muck@arm.com>