### PR TITLE
util, ext: Fix building TLM

### DIFF
--- a/ext/systemc/SConscript
+++ b/ext/systemc/SConscript
@@ -25,13 +25,16 @@
 
 import os
 from m5.util.terminal import get_termcap
-import gem5_scons
+import sys
 
 Import('env')
 systemc = env.Clone()
 
 build_root = Dir('.').abspath
 src_root = Dir('.').srcdir.abspath
+gem5_root = Dir('#../..').srcnode().abspath
+sys.path.append(os.path.join(gem5_root, 'site_scons'))
+import gem5_scons
 
 systemc.Prepend(CPPPATH=Dir('./src').srcnode())
 systemc.Prepend(CPATH=Dir('./src'))

--- a/util/tlm/SConstruct
+++ b/util/tlm/SConstruct
@@ -44,6 +44,7 @@ env = Environment()
 
 #Make the gem5 root available in SConscripts
 env['GEM5_ROOT'] = gem5_root
+env['GEM5BUILD'] = os.path.join(gem5_root, 'build')
 
 shlibsuffix = env['SHLIBSUFFIX']
 
@@ -52,6 +53,7 @@ env.Append(CPPPATH=[gem5_root + '/build/' + gem5_arch,
                     gem5_root + '/util/systemc/gem5_within_systemc',
                     gem5_root + '/ext/systemc/src',
                     gem5_root + '/ext',
+                    gem5_root + '/src',
                     '#src',
                     '#examples/common',
                     ])
@@ -63,6 +65,12 @@ env.Append(CXXFLAGS=['-std=c++17',
 
 if gem5_variant == 'debug':
     env.Append(CXXFLAGS=['-g', '-DGEM5_DEBUG'])
+
+AddOption('--duplicate-sources', action='store_true', default=False,
+          dest='duplicate_sources',
+          help='Create symlinks to sources in the build directory')
+AddOption('--verbose', action='store_true',
+          help='Print full tool command lines')
 
 deps = [] # keep track of all dependencies required for building the binaries
 

--- a/util/tlm/SConstruct
+++ b/util/tlm/SConstruct
@@ -44,6 +44,8 @@ env = Environment()
 
 #Make the gem5 root available in SConscripts
 env['GEM5_ROOT'] = gem5_root
+#This won't work with kconfig-based builds, where the build directory is
+# not necessarily named "build".
 env['GEM5BUILD'] = os.path.join(gem5_root, 'build')
 
 shlibsuffix = env['SHLIBSUFFIX']
@@ -66,9 +68,12 @@ env.Append(CXXFLAGS=['-std=c++17',
 if gem5_variant == 'debug':
     env.Append(CXXFLAGS=['-g', '-DGEM5_DEBUG'])
 
-AddOption('--duplicate-sources', action='store_true', default=False,
+# An option not to link source files in the build directory.
+# Not enabled by default.
+AddOption('--no-duplicate-sources', action='store_false', default=True,
           dest='duplicate_sources',
-          help='Create symlinks to sources in the build directory')
+          help='Do not create symlinks to sources in the build directory')
+
 AddOption('--verbose', action='store_true',
           help='Print full tool command lines')
 
@@ -87,12 +92,6 @@ deps += SConscript('examples/common/SConscript',
 sys.path.append(gem5_root + '/src/python')
 AddOption('--no-colors', dest='use_colors', action='store_false',
           help="Don't add color to abbreviated scons output")
-
-# An option not to link source files in the build directory.
-# Not enabled by default.
-AddOption('--no-duplicate-sources', action='store_false', default=True,
-          dest='duplicate_sources',
-          help='Do not create symlinks to sources in the build directory')
 
 env.SConsignFile('build/systemc/sconsign')
 SConscript(gem5_root + '/ext/systemc/SConscript',


### PR DESCRIPTION
Fixed the issue that did not allow building TLM.

Build commands:
```bash
scons build/ARM/gem5.opt
scons setconfig build/ARM USE_SYSTEMC=n
scons --with-cxx-config --without-python --without-tcmalloc build/ARM/libgem5_opt.so
cd util/tlm
scons
```
Following this README, I tested it succeeds with the simple examples:
https://gem5.googlesource.com/public/gem5/+/master/util/tlm/README

GitHub Issue: #591 
Change-Id: If07fae2eb20ad62627e733573f61bc42d594f970