### PR TITLE
cpu-minor: Integrate executeStats with int/fp/vec ALU Accesses

### DIFF
--- a/src/cpu/minor/execute.cc
+++ b/src/cpu/minor/execute.cc
@@ -876,6 +876,15 @@ Execute::doInstCommitAccounting(MinorDynInstPtr inst)
     cpu.commitStats[inst->id.threadId]->numOps++;
     cpu.commitStats[inst->id.threadId]
         ->committedInstType[inst->staticInst->opClass()]++;
+    if (inst->isInst()) {
+        if (inst->staticInst->isVector()) {
+            cpu.executeStats[inst->id.threadId]->numVecAluAccesses++;
+        } else if (inst->staticInst->isFloating()) {
+            cpu.executeStats[inst->id.threadId]->numFpAluAccesses++;
+        } else if (inst->staticInst->isInteger()) {
+            cpu.executeStats[inst->id.threadId]->numIntAluAccesses++;
+        }
+    }
 
     /* Set the CP SeqNum to the numOps commit number */
     if (inst->traceData)


### PR DESCRIPTION
Although stats for int instructions are already tracked in Minor, might be better to be more consistent and include `executeStats` in tracking statistics, so whenever users are searching for # of int ALU ops, they would find it under execute rather than under the commit stats for Minor. Moreover, this gives a bit more granularity to the stats, as users can see per thread ALU accesses alongside the total.

Perhaps others have some differing opinions about tracking such stats, and prefer leaving `intInstructions` as is?