### PR TITLE
configs: nvm sweep fix

### DIFF
--- a/configs/nvm/sweep.py
+++ b/configs/nvm/sweep.py
@@ -59,7 +59,7 @@ nvm_generators = {"NVM": lambda x: x.createNvm}
 
 # Use a single-channel DDR3-1600 x64 (8x8 topology) by default
 parser.add_argument(
-    "--nvm-type",
+    "--mem-type",
     default="NVM_2400_1x64",
     choices=ObjectList.mem_list.get_names(),
     help="type of memory to use",
@@ -212,7 +212,7 @@ def trace():
                 nbr_banks,
                 bank,
                 addr_map,
-                args.dram_ranks,
+                args.nvm_ranks,
             )
     yield system.tgen.createExit(0)
 

--- a/configs/nvm/sweep_hybrid.py
+++ b/configs/nvm/sweep_hybrid.py
@@ -143,7 +143,7 @@ MemConfig.config_mem(args, system)
 
 # the following assumes that we are using the native controller
 # with NVM and DRAM interfaces, check to be sure
-if not isinstance(system.mem_ctrls[0], m5.objects.HeteroMemCtrl):
+if not isinstance(system.mem_ctrls[0], m5.objects.MemCtrl):
     fatal("This script assumes the controller is a HeteroMemCtrl subclass")
 if not isinstance(system.mem_ctrls[0].dram, m5.objects.DRAMInterface):
     fatal("This script assumes the first memory is a DRAMInterface subclass")


### PR DESCRIPTION
These changes to sweep and sweep_hybrid for NVM allow them to run. I'm not an expert on this, so I'm not sure if these are technically correct, but they no longer fail when running
`build/X86/gem5.opt configs/nvm/sweep.py` and `build/X86/gem5.opt configs/nvm/sweep_hybrid.py`

GitHub Issue: #669 
Change-Id: If5412bd3a53804ba48f7c1eac09829e5900f85de