### PR TITLE
util: Add GNU non executable line to x86 m5

### DIFF
--- a/util/m5/src/abi/x86/m5op.S
+++ b/util/m5/src/abi/x86/m5op.S
@@ -44,4 +44,8 @@
         M5OP_FOREACH
 #undef M5OP
 
+/* The line below is added to remove the warning
+* saying that the file is not specifiying GNU non
+* executable stack in ubuntu 24.04
+*/
 .section .note.GNU-stack

--- a/util/m5/src/abi/x86/m5op.S
+++ b/util/m5/src/abi/x86/m5op.S
@@ -43,3 +43,5 @@
 #define M5OP(name, func) m5op_func name, func;
         M5OP_FOREACH
 #undef M5OP
+
+.section .note.GNU-stack

--- a/util/m5/src/abi/x86/m5op_addr.S
+++ b/util/m5/src/abi/x86/m5op_addr.S
@@ -55,3 +55,5 @@
 #define M5OP(name, func) m5op_func M5OP_MERGE_TOKENS(name, _addr), func;
         M5OP_FOREACH
 #undef M5OP
+
+.section .note.GNU-stack

--- a/util/m5/src/abi/x86/m5op_addr.S
+++ b/util/m5/src/abi/x86/m5op_addr.S
@@ -56,4 +56,8 @@
         M5OP_FOREACH
 #undef M5OP
 
+/* The line below is added to remove the warning
+* saying that the file is not specifiying GNU non
+* executable stack in ubuntu 24.04
+*/
 .section .note.GNU-stack


### PR DESCRIPTION
- Adding this line as not specifiying GNU non executable stack was throwing warnings when building m5
for ubuntu 24.04

Change-Id: I620c508be4090804698391cff671ba5091b053d7