### PR TITLE
mem-ruby: Fix NullPointerException in RubyRequest

### DIFF
--- a/src/mem/ruby/slicc_interface/RubyRequest.hh
+++ b/src/mem/ruby/slicc_interface/RubyRequest.hh
@@ -103,7 +103,7 @@ class RubyRequest : public Message
           m_htmTransactionUid(0),
           m_isTlbi(false),
           m_tlbiTransactionUid(0),
-          m_isSecure(m_pkt->req->isSecure())
+          m_isSecure(m_pkt ? m_pkt->req->isSecure() : false)
     {
         m_LineAddress = makeLineAddress(m_PhysicalAddress);
         if (_pkt) {


### PR DESCRIPTION
This PR includes a check for `m_pkt` being null and appropriately handles that case. This issue was causing the Daily tests to fail.

Change-Id: I87142ca14ca4ab3d8306153a1cf34c2629a119ba