### PR TITLE
arch-riscv: Fix viota instruction

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3570,27 +3570,9 @@ decode QUADRANT default Unknown::unknown() {
                         }
                     }}, OPMVV, SimdAluOp);
                     0x10: ViotaFormat::viota_m({{
-                        RiscvISAInst::VecRegContainer tmp_s2;
-                        xc->getRegOperand(this, 2,
-                            &tmp_s2);
-                        auto Vs2bit = tmp_s2.as<vu>();
-                        for (uint32_t i = 0; i < this->microVl; i++) {
-                            uint32_t ei = i +
-                                vtype_VLMAX(vtype, vlen, true) *
-                                this->microIdx;
-                            bool vs2_lsb = elem_mask(Vs2bit, ei);
-                            bool do_mask = elem_mask(v0, ei);
-                            bool has_one = false;
-                            if (this->vm || (do_mask && !this->vm)) {
-                                if (vs2_lsb) {
-                                    has_one = true;
-                                }
-                            }
-                            bool use_ori = (!this->vm) && !do_mask;
-                            if(use_ori == false){
-                                Vd_vu[i] = *cnt;
-                            }
-                            if (has_one) {
+                        if (this->vm || elem_mask(v0, ei)) {
+                            Vd_vu[i] = *cnt;
+                            if (elem_mask(Vs2_vu, ei)) {
                                 *cnt = *cnt+1;
                             }
                         }

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -980,7 +980,7 @@ def format ViotaFormat(code, category, *flags){{
 
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd + _microIdx]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    src2_reg_id = "vecRegClass[_machInst.vs2]"
     # The tail of vector mask inst should be treated as tail-agnostic.
     # We treat it with tail-undisturbed policy, since
     # the test suits only support undisturbed policy.
@@ -989,10 +989,14 @@ def format ViotaFormat(code, category, *flags){{
     set_src_reg_idx = ""
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
     set_src_reg_idx += setSrcWrapper(old_dest_reg_id)
+    set_src_reg_idx += setSrcVm()
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     vm_decl_rd = vmDeclAndReadData()
     set_vm_idx = setSrcVm()
     set_vlenb = setVlenb()
+
+    code = eiDeclarePrefix(code)
+    code = loopWrapper(code)
 
     microiop = InstObjParams(name+"_micro",
         Name+"Micro",

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -836,7 +836,15 @@ private:
     %(reg_idx_arr_decl)s;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
-    using %(base_class)s::generateDisassembly;
+    std::string generateDisassembly(Addr pc,
+        const loader::SymbolTable *symtab) const override
+    {
+        std::stringstream ss;
+        ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", "
+            << registerName(srcRegIdx(0));
+        if (machInst.vm == 0) ss << ", v0.t";
+        return ss.str();
+    }
 };
 
 }};
@@ -880,7 +888,7 @@ template<typename ElemType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    RegId srcRegIdxArr[4];
+    RegId srcRegIdxArr[3];
     RegId destRegIdxArr[1];
     bool vm;
     int* cnt;
@@ -888,7 +896,15 @@ public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
                    uint32_t _microIdx, int* cnt);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
-    using %(base_class)s::generateDisassembly;
+    std::string generateDisassembly(Addr pc,
+        const loader::SymbolTable *symtab) const override
+    {
+        std::stringstream ss;
+        ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", "
+            << registerName(srcRegIdx(0));
+        if (machInst.vm == 0) ss << ", v0.t";
+        return ss.str();
+    }
 };
 
 }};
@@ -908,7 +924,6 @@ template<typename ElemType>
     _numDestRegs = 0;
     %(set_dest_reg_idx)s;
     %(set_src_reg_idx)s;
-    setSrcRegIdx(_numSrcRegs++, vecRegClass[_machInst.vs2]);
 }
 
 %(declare_varith_template)s;


### PR DESCRIPTION
This commit fixes and refactors the implementation of viota. It also overrides the generateDisassembly function in viota's macro/micro to correctly print out the instruction when tacing/debugging. 

For example, it changes from:
viota_m vd, vd, vs2, v0.t
to:
viota_m vd, vs2, v0.t

Change-Id: I6339a806db7c638f418533db57e44f4a76d609f9