### PR TITLE
arch-arm: Do not issue memory requests for uncacheable prefetches

### DIFF
--- a/src/arch/arm/isa/templates/mem.isa
+++ b/src/arch/arm/isa/templates/mem.isa
@@ -490,6 +490,14 @@ def template LoadCompleteAcc {{
                                 trace::InstRecord *traceData) const
     {
         Fault fault = NoFault;
+        if (isPrefetch()) {
+            // We shouldn't actually need a response for prefetches and instead
+            // retire the instruction immediately, but changing that behaviour
+            // is an invasive change, so return early instead and ignore the
+            // reponse we got from the cache/memory.
+            // TODO: this should probably be a panic_if(isPrefetch(), ...)
+            return fault;
+        }
 
         %(op_decl)s;
         %(op_rd)s;

--- a/src/mem/abstract_mem.cc
+++ b/src/mem/abstract_mem.cc
@@ -384,6 +384,9 @@ AbstractMemory::access(PacketPtr pkt)
                 pkt->getAddr());
         return;
     }
+    panic_if(pkt->req->isUncacheable() && pkt->req->isPrefetch(),
+             "Uncacheable prefetches should be discarded by CPU: %s",
+             pkt->print());
 
     if (pkt->cmd == MemCmd::CleanEvict || pkt->cmd == MemCmd::WritebackClean) {
         DPRINTF(MemoryAccess, "CleanEvict  on 0x%x: not responding\n",

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -406,6 +406,9 @@ BaseCache::handleTimingReqMiss(PacketPtr pkt, MSHR *mshr, CacheBlk *blk,
 void
 BaseCache::recvTimingReq(PacketPtr pkt)
 {
+    panic_if(pkt->req->isUncacheable() && pkt->req->isPrefetch(),
+             "Uncacheable prefetches should be discarded by CPU: %s",
+             pkt->print());
     // anything that is merely forwarded pays for the forward latency and
     // the delay provided by the crossbar
     Tick forward_time = clockEdge(forwardLatency) + pkt->headerDelay;
@@ -637,6 +640,9 @@ BaseCache::recvTimingResp(PacketPtr pkt)
 Tick
 BaseCache::recvAtomic(PacketPtr pkt)
 {
+    panic_if(pkt->req->isUncacheable() && pkt->req->isPrefetch(),
+         "Uncacheable prefetches should be discarded by CPU: %s",
+         pkt->print());
     // should assert here that there are no outstanding MSHRs or
     // writebacks... that would mean that someone used an atomic
     // access in timing mode

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -418,6 +418,9 @@ void
 Cache::recvTimingReq(PacketPtr pkt)
 {
     DPRINTF(CacheTags, "%s tags:\n%s\n", __func__, tags->print());
+    panic_if(pkt->req->isUncacheable() && pkt->req->isPrefetch(),
+             "Uncacheable prefetches should be discarded by CPU: %s",
+             pkt->print());
 
     promoteWholeLineWrites(pkt);
 
@@ -683,6 +686,10 @@ Cache::recvAtomic(PacketPtr pkt)
 
         return memSidePort.sendAtomic(pkt);
     }
+
+    panic_if(pkt->req->isUncacheable() && pkt->req->isPrefetch(),
+             "Uncacheable prefetches should be discarded by CPU: %s",
+             pkt->print());
 
     return BaseCache::recvAtomic(pkt);
 }


### PR DESCRIPTION
Currently, a prefetch instruction will result in an infinite sleep where
the CPU never wakes back up as it is expecting a dcache response even
though this will not be delivered for prefetches. Avoid this problem by
rejecting uncacheable prefetches in the MMU translation logic.

This allows my test workload from https://github.com/gem5/gem5/issues/1139
to continue running beyond strlen(). Tested using Atomic,Timing,Minor
and O3 CPU. See https://github.com/gem5/gem5/issues/1139 for the test
case that was used.

Fixes: https://github.com/gem5/gem5/issues/1139

Change-Id: Ic44bdb87f4099b11a7f9c6c99768a12fbef5842e