### PR TITLE
arch-arm: Fix 32-bit semihosting ABI

### DIFF
--- a/src/arch/arm/semihosting.hh
+++ b/src/arch/arm/semihosting.hh
@@ -91,13 +91,13 @@ class ArmSemihosting : public BaseSemihosting
     {
         using UintPtr = uint64_t;
 
-        class State : public StateBase<uint64_t, ArmSemihosting>
+        class State : public StateBase<Abi64::UintPtr, ArmSemihosting>
         {
           public:
             // For 64 bit semihosting, the params are pointer to by X1.
             explicit
             State(const ThreadContext *tc) :
-                StateBase<uint64_t, ArmSemihosting>(tc,
+                StateBase<Abi64::UintPtr, ArmSemihosting>(tc,
                         tc->getReg(ArmISA::int_reg::X1), &ArmISA::byteOrder)
             {}
         };
@@ -107,13 +107,13 @@ class ArmSemihosting : public BaseSemihosting
     {
         using UintPtr = uint32_t;
 
-        class State : public StateBase<uint64_t, ArmSemihosting>
+        class State : public StateBase<Abi32::UintPtr, ArmSemihosting>
         {
           public:
             // For 32 bit semihosting, the params are pointer to by R1.
             explicit
             State(const ThreadContext *tc) :
-                StateBase<uint64_t, ArmSemihosting>(tc,
+                StateBase<Abi32::UintPtr, ArmSemihosting>(tc,
                         tc->getReg(ArmISA::int_reg::R1), &ArmISA::byteOrder)
             {}
         };


### PR DESCRIPTION
It appears we have been trying to read 64-bit arguments for ARM32 since 695583709b8c09d32f86057e63868bc125f1a86b. I noticed that SYS_OPEN was trying to read a really long string as the pathname argument and it turned out it was reading from the wrong stack offset. With this change I can successfully run some of the semihosting tests for ARM32.

Change-Id: Ie154052dac4211993fb6c4c99d93990123c2eacf