### PR TITLE
arch-generic: Avoid out-of-memory errors for bad semihosting calls

### DIFF
--- a/src/arch/generic/semihosting.hh
+++ b/src/arch/generic/semihosting.hh
@@ -42,6 +42,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -381,7 +382,9 @@ class BaseSemihosting : public SimObject
         return tick >> tickShift;
     }
     void semiExit(uint64_t code, uint64_t subcode);
-    std::string readString(ThreadContext *tc, Addr ptr, size_t len);
+
+    std::optional<std::string> readString(ThreadContext *tc,
+                                          Addr ptr, size_t len);
 
   public:
     typedef std::pair<uint64_t, SemiErrno> RetErrno;


### PR DESCRIPTION
In BaseSemihosting::readString() we were using the len argument to allocate a std::vector without checking whether the value makes any sense. This resulted in a std::bad_alloc exception being raised prior to https://github.com/gem5/gem5/pull/1142 for my semihosting tests. This commit prevents semihosting from reading more than 64K for string arguments which should be more than sufficient for any valid code.

Change-Id: I059669016ee2c5721fedb914595d0494f6cfd4cd