### PR TITLE
misc: Remove gcc 8 support, gem5 support GCC >= v10

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -16,8 +16,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                image: [gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, gcc-version-8, clang-version-16, clang-version-15, clang-version-14,
-                    clang-version-13, clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
+                image: [gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-16, clang-version-15, clang-version-14, clang-version-13,
+                    clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
                     ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
                 opts: [.opt, .fast]
         runs-on: [self-hosted, linux, x64]

--- a/SConstruct
+++ b/SConstruct
@@ -631,8 +631,8 @@ for variant_path in variant_paths:
               "src/SConscript to support that compiler.")))
 
     if env['GCC']:
-        if compareVersions(env['CXXVERSION'], "7") < 0:
-            error('gcc version 7 or newer required.\n'
+        if compareVersions(env['CXXVERSION'], "10") < 0:
+            error('gcc version 10 or newer required.\n'
                   'Installed version:', env['CXXVERSION'])
 
         # Add the appropriate Link-Time Optimization (LTO) flags if
@@ -655,17 +655,6 @@ for variant_path in variant_paths:
         env.Append(TCMALLOC_CCFLAGS=[
             '-fno-builtin-malloc', '-fno-builtin-calloc',
             '-fno-builtin-realloc', '-fno-builtin-free'])
-
-        if compareVersions(env['CXXVERSION'], "9") < 0:
-            # `libstdc++fs`` must be explicitly linked for `std::filesystem``
-            # in GCC version 8. As of GCC version 9, this is not required.
-            #
-            # In GCC 7 the `libstdc++fs`` library explicit linkage is also
-            # required but the `std::filesystem` is under the `experimental`
-            # namespace(`std::experimental::filesystem`).
-            #
-            # Note: gem5 does not support GCC versions < 7.
-            env.Append(LIBS=['stdc++fs'])
 
     elif env['CLANG']:
         if compareVersions(env['CXXVERSION'], "6") < 0:

--- a/util/dockerfiles/docker-compose.yaml
+++ b/util/dockerfiles/docker-compose.yaml
@@ -42,13 +42,6 @@ services:
             context: ubuntu-24.04_min-dependencies
             dockerfile: Dockerfile
         image: ghcr.io/gem5/ubuntu-24.04_min-dependencies:latest
-    gcc-8:
-        build:
-            context: ubuntu-20.04_gcc-version
-            dockerfile: Dockerfile
-            args:
-                - version=8
-        image: ghcr.io/gem5/gcc-version-8:latest
     gcc-10:
         build:
             context: ubuntu-20.04_gcc-version

--- a/util/dockerfiles/sst/Dockerfile
+++ b/util/dockerfiles/sst/Dockerfile
@@ -36,6 +36,17 @@ RUN apt -y update && apt -y upgrade && \
 
 ENV SST_CORE_HOME="/sst/"
 
+# Use GCC 10
+RUN apt update && apt -y install gcc-10 g++-10
+RUN update-alternatives --install \
+    /usr/bin/g++ g++ /usr/bin/g++-10 100
+RUN update-alternatives --install \
+    /usr/bin/gcc gcc /usr/bin/gcc-10 100
+RUN update-alternatives --install \
+    /usr/bin/c++ c++ /usr/bin/g++-10 100
+RUN update-alternatives --install \
+    /usr/bin/cc cc /usr/bin/gcc-10 100
+
 # SST Stuff
 RUN mkdir /sst
 


### PR DESCRIPTION
note: Due to #556 / #555, we don't support GCC 9. This PR removes gcc-8 which means gem5 would support GCC >= version 10.

The reason for removing gcc-8:

1. We already dropped support for gcc-9. I don't see any good reason to support anything <9 as a result.
2. GCC is relatively old, and we're probably supporting a bit too many compiler versions anyway. In Ubuntu 22.04, gcc-11 is downloaded by default with `apt`. It doesn't seem many system are still using gcc.
3. There is a weird compiler bug in gcc-8 which is causes failure when compiling gem5 since the inclusion of #1123. The error received is as follows:

```sh
In file included from src/arch/riscv/tlb.hh:42,
                 from src/arch/riscv/mmu.hh:45,
                 from build/ALL/arch/riscv/generated/exec-g.cc.inc:14,
                 from build/ALL/arch/riscv/generated/generic_cpu_exec.cc:5:
src/arch/riscv/utility.hh: In instantiation of ‘FloatType gem5::RiscvISA::ftype(IntType) [with FloatType = float8_t; IntType = unsigned char]’:
build/ALL/arch/riscv/generated/exec-ns.cc.inc:38839:42:   required from ‘gem5::Fault gem5::RiscvISAInst::Vfwcvt_xu_f_vMicro<ElemType>::execute(gem5::ExecContext*, gem5::trace::InstRecord*) const [with ElemType = float8_t; gem5::Fault = std::shared_ptr<gem5::FaultBase>]’
build/ALL/arch/riscv/generated/exec-ns.cc.inc:38856:16:   required from here
src/arch/riscv/utility.hh:327:15: error: parameter ‘a’ set but not used [-Werror=unused-but-set-parameter]
 ftype(IntType a) -> FloatType
       ~~~~~~~~^
src/arch/riscv/utility.hh: In instantiation of ‘IntType gem5::RiscvISA::f_to_wui(FloatType, uint_fast8_t) [with FloatType = float8_t; IntType = short unsigned int; uint_fast8_t = unsigned char]’:
build/ALL/arch/riscv/generated/exec-ns.cc.inc:38838:49:   required from ‘gem5::Fault gem5::RiscvISAInst::Vfwcvt_xu_f_vMicro<ElemType>::execute(gem5::ExecContext*, gem5::trace::InstRecord*) const [with ElemType = float8_t; gem5::Fault = std::shared_ptr<gem5::FaultBase>]’
build/ALL/arch/riscv/generated/exec-ns.cc.inc:38856:16:   required from here
src/arch/riscv/utility.hh:570:20: error: parameter ‘a’ set but not used [-Werror=unused-but-set-parameter]
 f_to_wui(FloatType a, uint_fast8_t mode)
```

Note: This is currently causing our SST Daily tests to fail, and our compiler tests to fail.