### PR TITLE
misc: Revert Dramsys Ubuntu to 22.04 to compile in gcc <13

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -152,7 +152,7 @@ jobs:
 
     dramsys-tests:
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
         timeout-minutes: 4320 # 3 days
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Until https://github.com/gem5/gem5/issues/1121 is fixed, this change will ensure our Weekly tests pass.