### PR TITLE
dev: add reset wrap mode to mouse.cc

### DIFF
--- a/src/dev/ps2/mouse.cc
+++ b/src/dev/ps2/mouse.cc
@@ -122,7 +122,9 @@ PS2Mouse::recv(const std::vector<uint8_t> &data)
       case mouse::ReadData:
         panic("Reading mouse data unimplemented.\n");
       case mouse::ResetWrapMode:
-        panic("Resetting mouse wrap mode unimplemented.\n");
+        DPRINTF(PS2, "Resetting Wrap Mode\n");
+        sendAck();
+        return true;
       case mouse::WrapMode:
         panic("Setting mouse wrap mode unimplemented.\n");
       case mouse::RemoteMode:


### PR DESCRIPTION
This change fixes #1148 

I have only added an acknowledged return, as we dont ahve remote and wrap mode so it can only be in  stream mode.

Change-Id: I1882042d873ff0e9465c9491238554c8fbb9aa76