### PR TITLE
dev-amdgpu: Fix pending PCI RLC doorbell

### DIFF
--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -196,6 +196,7 @@ class AMDGPUDevice : public PciDevice
      * Set handles to GPU blocks.
      */
     void setDoorbellType(uint32_t offset, QueueType qt, int ip_id = 0);
+    void unsetDoorbell(uint32_t offset);
     void processPendingDoorbells(uint32_t offset);
     void setSDMAEngine(Addr offset, SDMAEngine *eng);
 

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -269,6 +269,7 @@ SDMAEngine::deallocateRLCQueues()
     for (auto doorbell: rlcInfo) {
         if (doorbell) {
             unregisterRLCQueue(doorbell);
+            gpuDevice->unsetDoorbell(doorbell);
         }
     }
 }


### PR DESCRIPTION
SDMA RLC queues do not currently remove their doorbell mapping. This can cause issues re-registering the queue and prevents the pending doorbells feature from working. In addition the data value of the doorbell (the ring buffer rptr) is not saved, leading to UB when this workaround is used.

This commit removes the doorbell mapping from the gpu device when the SDMA engine unmaps an RLC queue and copies the next doorbell value to the pending packet as was originally intended.

Change-Id: Ifd551450f439c065579afcf916f8ff192e7598ab