### PR TITLE
util: Bump GPUSE docker to GCC 10

### DIFF
--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -31,6 +31,10 @@ RUN apt -y update && apt -y upgrade && \
     python3-dev python-is-python3 doxygen libboost-all-dev \
     libhdf5-serial-dev python3-pydot libpng-dev libelf-dev pkg-config gdb
 
+# gem5 requires gcc 10+
+RUN apt -y install gcc-10 g++-10 cpp-10
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+
 # Requirements for ROCm
 RUN apt -y install cmake mesa-common-dev libgflags-dev libgoogle-glog-dev
 

--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -81,7 +81,12 @@ RUN cmake -DOPENCL_DIR="/ROCm-OpenCL-Runtime" \
     make -j$(nproc) && make install
 WORKDIR /
 
-WORKDIR ROCm-OpenCL-Runtime/build
+# We apply a patch to avoid a linking error -- "multiple definition of 'ret_val'"
+# Issue here: https://github.com/ROCm/ROCm-OpenCL-Runtime/issues/113
+WORKDIR /ROCm-OpenCL-Runtime/khronos/icd
+RUN wget -q -O - https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/101/commits/319ba95eb08aa7c622efae50cb62c7cd7de14c1b.patch | patch -p1
+
+WORKDIR /ROCm-OpenCL-Runtime/build
 RUN cmake -DUSE_COMGR_LIBRARY=ON -DCMAKE_PREFIX_PATH="/opt/rocm" \
     -DCMAKE_BUILD_TYPE=Release .. && \
     make -j$(nproc) && make package


### PR DESCRIPTION
The docker image uses GCC 8 by default which is no longer supported in gem5. Bump the version to GCC 10.

Change-Id: I0e46e0f82d881fe73eccef75e2f343b41073f6fe