### PR TITLE
arch-arm: Rewrite performTlbi to use map instead of switch

### DIFF
--- a/src/arch/arm/insts/misc64.hh
+++ b/src/arch/arm/insts/misc64.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013,2017-2019, 2021-2022 Arm Limited
+ * Copyright (c) 2011-2013,2017-2019, 2021-2022, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -39,6 +39,7 @@
 #define __ARCH_ARM_INSTS_MISC64_HH__
 
 #include "arch/arm/insts/static_inst.hh"
+#include "arch/arm/types.hh"
 
 namespace gem5
 {
@@ -283,6 +284,45 @@ class RegNone : public ArmISA::ArmStaticInst
 
 class TlbiOp64 : public MiscRegRegImmOp64
 {
+  protected:
+    using TlbiFunc = std::function<void(ThreadContext*,RegVal)>;
+
+    static std::unordered_map<ArmISA::MiscRegIndex, TlbiFunc> tlbiOps;
+
+    static void tlbiAll(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable);
+
+    static void tlbiVmall(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool stage2=false);
+
+    static void tlbiVa(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool last_level);
+
+    static void tlbiVaa(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool last_level);
+
+    static void tlbiAsid(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable);
+
+    static void tlbiIpaS2(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool last_level);
+
+    static void tlbiRvaa(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool last_level);
+
+    static void tlbiRva(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool last_level);
+
+    static void tlbiRipaS2(ThreadContext *tc, RegVal value,
+        bool secure, ArmISA::TranslationRegime regime, bool shareable,
+        bool last_level);
+
   protected:
     TlbiOp64(const char *mnem, ArmISA::ExtMachInst _machInst,
              OpClass __opClass, ArmISA::MiscRegIndex _dest,

--- a/src/arch/arm/utility.cc
+++ b/src/arch/arm/utility.cc
@@ -89,6 +89,15 @@ isSecureBelowEL3(ThreadContext *tc)
         static_cast<SCR>(tc->readMiscRegNoEffect(MISCREG_SCR_EL3)).ns == 0;
 }
 
+bool
+isSecureAtEL(ThreadContext *tc, ExceptionLevel el)
+{
+    if (ArmSystem::haveEL(tc, EL3) && el == EL3)
+        return true;
+    else
+        return isSecureBelowEL3(tc);
+}
+
 ExceptionLevel
 debugTargetFrom(ThreadContext *tc, bool secure)
 {

--- a/src/arch/arm/utility.hh
+++ b/src/arch/arm/utility.hh
@@ -217,6 +217,8 @@ int computeAddrTop(ThreadContext *tc, bool selbit, bool isInstr,
 
 bool isSecureBelowEL3(ThreadContext *tc);
 
+bool isSecureAtEL(ThreadContext *tc, ExceptionLevel el);
+
 bool longDescFormatInUse(ThreadContext *tc);
 
 /** This helper function is either returing the value of


### PR DESCRIPTION
This is making it easier for TLBI instructions to share code. Common code (under the form of tlbi* functions) are closely matching the instruction description in the Arm pseudocode

Change-Id: If10c22fb4a7df2bcd0335e9761286ad3c458722b