### PR TITLE
arch-x86: set AF=0 when logical instructions execute

### DIFF
--- a/src/arch/x86/isa/insts/general_purpose/compare_and_test/test.py
+++ b/src/arch/x86/isa/insts/general_purpose/compare_and_test/test.py
@@ -37,26 +37,26 @@ microcode = """
 def macroop TEST_M_R
 {
     ld t1, seg, sib, disp
-    and t0, t1, reg, flags=(OF, SF, ZF, PF, CF)
+    and t0, t1, reg, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_P_R
 {
     rdip t7
     ld t1, seg, riprel, disp
-    and t0, t1, reg, flags=(OF, SF, ZF, PF, CF)
+    and t0, t1, reg, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_R_R
 {
-    and t0, reg, regm, flags=(OF, SF, ZF, PF, CF)
+    and t0, reg, regm, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_M_I
 {
     ld t1, seg, sib, disp
     limm t2, imm
-    and t0, t1, t2, flags=(OF, SF, ZF, PF, CF)
+    and t0, t1, t2, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_P_I
@@ -64,12 +64,12 @@ def macroop TEST_P_I
     rdip t7
     ld t1, seg, riprel, disp
     limm t2, imm
-    and t0, t1, t2, flags=(OF, SF, ZF, PF, CF)
+    and t0, t1, t2, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_R_I
 {
     limm t1, imm
-    and t0, reg, t1, flags=(OF, SF, ZF, PF, CF)
+    and t0, reg, t1, flags=(OF, SF, ZF, PF, CF, AF)
 };
 """

--- a/src/arch/x86/isa/insts/general_purpose/logical.py
+++ b/src/arch/x86/isa/insts/general_purpose/logical.py
@@ -36,14 +36,14 @@
 microcode = """
 def macroop OR_R_R
 {
-    or reg, reg, regm, flags=(OF,SF,ZF,PF,CF)
+    or reg, reg, regm, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop OR_M_I
 {
     limm t2, imm
     ldst t1, seg, sib, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
@@ -52,7 +52,7 @@ def macroop OR_P_I
     limm t2, imm
     rdip t7
     ldst t1, seg, riprel, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
@@ -61,7 +61,7 @@ def macroop OR_LOCKED_M_I
     limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -72,7 +72,7 @@ def macroop OR_LOCKED_P_I
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -80,7 +80,7 @@ def macroop OR_LOCKED_P_I
 def macroop OR_M_R
 {
     ldst t1, seg, sib, disp
-    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
@@ -88,7 +88,7 @@ def macroop OR_P_R
 {
     rdip t7
     ldst t1, seg, riprel, disp
-    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
@@ -96,7 +96,7 @@ def macroop OR_LOCKED_M_R
 {
     mfence
     ldstl t1, seg, sib, disp
-    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -106,7 +106,7 @@ def macroop OR_LOCKED_P_R
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    or t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -114,38 +114,38 @@ def macroop OR_LOCKED_P_R
 def macroop OR_R_M
 {
     ld t1, seg, sib, disp
-    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop OR_R_P
 {
     rdip t7
     ld t1, seg, riprel, disp
-    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop OR_R_I
 {
     limm t1, imm
-    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop XOR_R_R
 {
-    xor reg, reg, regm, flags=(OF,SF,ZF,PF,CF)
+    xor reg, reg, regm, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop XOR_R_I
 {
     limm t1, imm
-    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop XOR_M_I
 {
     limm t2, imm
     ldst t1, seg, sib, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
@@ -154,7 +154,7 @@ def macroop XOR_P_I
     limm t2, imm
     rdip t7
     ldst t1, seg, riprel, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
@@ -163,7 +163,7 @@ def macroop XOR_LOCKED_M_I
     limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -174,7 +174,7 @@ def macroop XOR_LOCKED_P_I
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -182,7 +182,7 @@ def macroop XOR_LOCKED_P_I
 def macroop XOR_M_R
 {
     ldst t1, seg, sib, disp
-    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
@@ -190,7 +190,7 @@ def macroop XOR_P_R
 {
     rdip t7
     ldst t1, seg, riprel, disp
-    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
@@ -198,7 +198,7 @@ def macroop XOR_LOCKED_M_R
 {
     mfence
     ldstl t1, seg, sib, disp
-    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -208,7 +208,7 @@ def macroop XOR_LOCKED_P_R
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    xor t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -216,45 +216,45 @@ def macroop XOR_LOCKED_P_R
 def macroop XOR_R_M
 {
     ld t1, seg, sib, disp
-    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop XOR_R_P
 {
     rdip t7
     ld t1, seg, riprel, disp
-    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop AND_R_R
 {
-    and reg, reg, regm, flags=(OF,SF,ZF,PF,CF)
+    and reg, reg, regm, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop AND_R_M
 {
     ld t1, seg, sib, disp
-    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop AND_R_P
 {
     rdip t7
     ld t1, seg, riprel, disp
-    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop AND_R_I
 {
     limm t1, imm
-    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF)
+    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop AND_M_I
 {
     ldst t2, seg, sib, disp
     limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF)
+    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
     st t2, seg, sib, disp
 };
 
@@ -263,7 +263,7 @@ def macroop AND_P_I
     rdip t7
     ldst t2, seg, riprel, disp
     limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF)
+    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
     st t2, seg, riprel, disp
 };
 
@@ -272,7 +272,7 @@ def macroop AND_LOCKED_M_I
     mfence
     ldstl t2, seg, sib, disp
     limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF)
+    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
     stul t2, seg, sib, disp
     mfence
 };
@@ -283,7 +283,7 @@ def macroop AND_LOCKED_P_I
     mfence
     ldstl t2, seg, riprel, disp
     limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF)
+    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
     stul t2, seg, riprel, disp
     mfence
 };
@@ -291,7 +291,7 @@ def macroop AND_LOCKED_P_I
 def macroop AND_M_R
 {
     ldst t1, seg, sib, disp
-    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
@@ -299,7 +299,7 @@ def macroop AND_P_R
 {
     rdip t7
     ldst t1, seg, riprel, disp
-    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
@@ -307,7 +307,7 @@ def macroop AND_LOCKED_M_R
 {
     mfence
     ldstl t1, seg, sib, disp
-    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -317,7 +317,7 @@ def macroop AND_LOCKED_P_R
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF)
+    and t1, t1, reg, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };

--- a/src/arch/x86/isa/microops/regop.isa
+++ b/src/arch/x86/isa/microops/regop.isa
@@ -398,8 +398,8 @@ let {{
     class LogicRegOp(BasicRegOp):
         abstract = True
         flag_code = '''
-            //Don't have genFlags handle the OF or CF bits
-            uint64_t mask = CFBit | ECFBit | OFBit;
+            //Don't have genFlags handle the OF, CF, or AF bits
+            uint64_t mask = CFBit | ECFBit | OFBit | AFBit;
             uint64_t newFlags = genFlags(PredccFlagBits | PreddfBit |
                     PredezfBit, ext & ~mask, result, PSrcReg1, op2);
             PredezfBit = newFlags & EZFBit;
@@ -407,7 +407,7 @@ let {{
             PredccFlagBits = newFlags & CcFlagMask;
 
             //If a logic microop wants to set these, it wants to set them to 0.
-            PredcfofBits = PredcfofBits & ~((CFBit | OFBit) & ext);
+            PredcfofBits = PredcfofBits & ~((CFBit | OFBit | AFBit) & ext);
             PredecfBit = PredecfBit & ~(ECFBit & ext);
         '''
 


### PR DESCRIPTION
Fix #1168. Prevent logical instructions like AND, OR, and TEST from having input dependencies on the previous value of the Zaps register (ZF+AF+PF+SF) by having them set AF=0, rather than not modifying AF.