### PR TITLE
arch-riscv: Add rvZext to BranchTarget

### DIFF
--- a/src/arch/riscv/isa/formats/compressed.isa
+++ b/src/arch/riscv/isa/formats/compressed.isa
@@ -173,7 +173,7 @@ def template CJumpExecute {{
     %(class_name)s::branchTarget(ThreadContext *tc) const
     {
         PCStateBase *pc_ptr = tc->pcState().clone();
-        pc_ptr->as<PCState>().set(tc->getReg(srcRegIdx(0)) & ~0x1);
+        pc_ptr->as<PCState>().set(rvZext(tc->getReg(srcRegIdx(0)) & ~0x1));
         return std::unique_ptr<PCStateBase>{pc_ptr};
     }
 

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -199,7 +199,7 @@ def template BranchExecute {{
     {
         auto &rpc = branch_pc.as<RiscvISA::PCState>();
         std::unique_ptr<PCState> npc(dynamic_cast<PCState*>(rpc.clone()));
-        npc->set(rpc.pc() + imm);
+        npc->set(rvZext(rpc.pc() + imm));
         return npc;
     }
 
@@ -306,7 +306,8 @@ def template JumpExecute {{
     %(class_name)s::branchTarget(ThreadContext *tc) const
     {
         PCStateBase *pc_ptr = tc->pcState().clone();
-        pc_ptr->as<PCState>().set((tc->getReg(srcRegIdx(0)) + imm) & ~0x1);
+        pc_ptr->as<PCState>().set(
+            rvZext((tc->getReg(srcRegIdx(0)) + imm) & ~0x1));
         return std::unique_ptr<PCStateBase>{pc_ptr};
     }
 


### PR DESCRIPTION
Ensure the upper xlen bits are all zeros

Change-Id: Id81330eced907d21320bc1af85ad38fb6e95f6b1