### PR TITLE
arch-arm: TLBIs targeting EL2 regime are executable from S state

### DIFF
--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -5348,47 +5348,47 @@ ISA::initializeMiscRegMetadata()
       .faultWrite(EL1, faultHcrFgtInstEL1<&HCR::ttlb, &HFGITR::tlbivaale1>)
       .writes(1).exceptUserMode();
     InitReg(MISCREG_TLBI_IPAS2E1OS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_IPAS2LE1OS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE2OS)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VAE2OS)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE1OS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VALE2OS)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VMALLS12E1OS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_IPAS2E1IS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_IPAS2LE1IS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE2IS)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VAE2IS)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE1IS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VALE2IS)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VMALLS12E1IS)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_IPAS2E1)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_IPAS2LE1)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE2)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VAE2)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE1)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VALE2)
       .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VMALLS12E1)
-      .hypWrite().monSecureWrite().monNonSecureWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE3OS)
       .monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_VAE3OS)

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -5352,13 +5352,13 @@ ISA::initializeMiscRegMetadata()
     InitReg(MISCREG_TLBI_IPAS2LE1OS)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_ALLE2OS)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VAE2OS)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE1OS)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_VALE2OS)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VMALLS12E1OS)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_IPAS2E1IS)
@@ -5366,13 +5366,13 @@ ISA::initializeMiscRegMetadata()
     InitReg(MISCREG_TLBI_IPAS2LE1IS)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_ALLE2IS)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VAE2IS)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE1IS)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_VALE2IS)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VMALLS12E1IS)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_IPAS2E1)
@@ -5380,13 +5380,13 @@ ISA::initializeMiscRegMetadata()
     InitReg(MISCREG_TLBI_IPAS2LE1)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_ALLE2)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VAE2)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_ALLE1)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_VALE2)
-      .monNonSecureWrite().hypWrite();
+      .monWrite().hypWrite();
     InitReg(MISCREG_TLBI_VMALLS12E1)
       .hypWrite().monSecureWrite().monNonSecureWrite();
     InitReg(MISCREG_TLBI_ALLE3OS)


### PR DESCRIPTION
Those AArch64 instructions/registers were labelled as executable
from EL3 only if SCR_EL3.NS == 1. This is not valid anymore
after the introduction of FEAT_SEL2