### PR TITLE
mem-cache: Fix maybe-uninitialized warning

### DIFF
--- a/src/mem/cache/replacement_policies/replaceable_entry.hh
+++ b/src/mem/cache/replacement_policies/replaceable_entry.hh
@@ -73,7 +73,7 @@ class ReplaceableEntry
     uint32_t _way;
 
   public:
-    ReplaceableEntry() = default;
+    ReplaceableEntry() : _set(0), _way(0) {}
     virtual ~ReplaceableEntry() = default;
 
     /**


### PR DESCRIPTION
When compiler tries to inline a vector construction with a default value as default constructed ReplaceableEntry. It can complain about the uninitialized member.

Let's provide basic initialization to the members.

Example codepath:
 SignaturePathV2 constructor
 -> GlobalHistoryEntry() as init_value to AssociativeSet
 -> AssociativeSet initialize vector<Entry> with init_value