### PR TITLE
cpu-o3: Do not set Executed on load instruction to be replayed

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -611,6 +611,12 @@ LSQUnit::executeLoad(const DynInstPtr &inst)
     if (inst->isTranslationDelayed() && load_fault == NoFault)
         return load_fault;
 
+    // Partial Store-to-Load Forwarding condition marks the load to be
+    // reissued during LSQUnit::read(). In this case we shouldn't notify
+    // iewStage that the instruction is ready for commit.
+    if (!inst->isIssued() && !inst->effAddrValid())
+        return load_fault;
+
     if (load_fault != NoFault && inst->translationCompleted() &&
             inst->savedRequest->isPartialFault()
             && !inst->savedRequest->isComplete()) {


### PR DESCRIPTION
A load instruction can be replayed when
1) it's strictly ordered or
2) it falls into load-store forwarding mismatch.

Case 1 was considered in executeLoad function but the case 2 wasn't. It causes the case-2 replayed load instruction to violate the assertion condition "assert(!load_inst->isExecuted())" in LSQUnit::read. This commit fixes the problem by adding consideration of the case 2 in LSQUnit::executeLoad.