### PR TITLE
dev-arm: Fix -Wdeprecated-copy warning

### DIFF
--- a/src/dev/arm/smmu_v3_transl.hh
+++ b/src/dev/arm/smmu_v3_transl.hh
@@ -142,6 +142,7 @@ class SMMUTranslationProcess : public SMMUProcess
             addr(0), addrMask(0), writable(false)
         {}
 
+        TranslResult(const TranslResult&) = default;
         TranslResult& operator=(const TranslResult &rhs) = default;
 
         bool isFaulting() const { return fault.isFaulting(); }


### PR DESCRIPTION
Clang warns as follows: `warning: definition of implicit copy constructor for 'TranslResult' is deprecated because it has a user-declared copy assignment operator`

Change-Id: Ic701d8522aac75d569f4f513f54de91f76a17e48