### PR TITLE
arch-arm: avoid using an uninitialized variable use in MMU walks

### DIFF
--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -890,17 +890,24 @@ class TableWalker : public ClockedObject
 
         /** If the access comes from the secure state. */
         bool isSecure;
+        /** Whether lookups should be treated as using the secure state.
+         * This is usually the same as isSecure, but can be set to false by the
+         * long descriptor table attributes. */
+        bool secureLookup = false;
 
         /** True if table walks are uncacheable (for table descriptors) */
         bool isUncacheable;
 
         /** Helper variables used to implement hierarchical access permissions
-         * when the long-desc. format is used (LPAE only) */
-        bool secureLookup;
-        bool rwTable;
-        bool userTable;
-        bool xnTable;
-        bool pxnTable;
+         * when the long-desc. format is used. */
+        struct LongDescData
+        {
+            bool rwTable = false;
+            bool userTable = false;
+            bool xnTable = false;
+            bool pxnTable = false;
+        };
+        std::optional<LongDescData> longDescData;
 
         /** Hierarchical access permission disable */
         bool hpd;


### PR DESCRIPTION
While running a simple Arm32 binary, I noticed that all memory transactions were being marked as NS instead of S once I turn on the MMU (even though the page tables have the NS bit set to zero). The result of this was that semihosting calls were failing since they were using functional accesses with the SECURE flag set, but the caches only contained NS tagged entries so these accesses always read stale values from DRAM.

Digging through the Arm MMU code it appears that the NS bit lookup was being keyed of the `secureLookup` flag which is only used for long descriptors. I believe 0c28712f51f5b0748c3afd5b287969ceb615ea8d should have used isSecure instead of secureLookup. To avoid using these uninitialized values in the future I wrapped the LPAE state in a std::optional to ensure that it is only accessed once initialized.

Change-Id: Ibc406ed3f4cfa768f470e34a5eca3c1a2bf45cd8