### PR TITLE
arch-generic: flush streams after semihosting write calls

### DIFF
--- a/src/arch/generic/semihosting.cc
+++ b/src/arch/generic/semihosting.cc
@@ -238,6 +238,7 @@ BaseSemihosting::callWriteC(ThreadContext *tc, InPlaceArg arg)
 
     DPRINTF(Semihosting, "Semihosting SYS_WRITEC('%c')\n", c);
     std::cout.put(c);
+    std::cout.flush();
 
     return retOK(0);
 }
@@ -250,6 +251,7 @@ BaseSemihosting::callWrite0(ThreadContext *tc, InPlaceArg arg)
     std::string str;
     proxy.readString(str, arg.addr);
     std::cout.write(str.c_str(), str.size());
+    std::cout.flush();
 
     return retOK(0);
 }


### PR DESCRIPTION
The SYS_WRITEC and SYS_WRITE0 calls are specified as writing to the debug channel, so it is a reasonable expectation for these messages to be visibile immediately after the semihosting call.

Change-Id: I8e6e9a7aab593a59e82ecb9cf4603c18c7a8acbe