### PR TITLE
gpu-compute: Added functions to choose replacement policies for GPU

### DIFF
--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -380,6 +380,16 @@ parser.add_argument(
     help="Gfx version for gpuNote: gfx902 is not fully supported by ROCm",
 )
 
+parser.add_argument("--tcp-rp", type=str, default="TreePLRURP", help="cache replacement policy"
+                    "policy for tcp")
+
+parser.add_argument("--tcc-rp", type=str, default="TreePLRURP", help="cache replacement policy"
+                    "policy for tcc")
+
+# sqc rp both changes sqc rp and scalar cache rp
+parser.add_argument("--sqc-rp", type=str, default="TreePLRURP", help="cache replacement policy"
+                    "policy for sqc")
+
 Ruby.define_options(parser)
 
 # add TLB options to the parser

--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -892,9 +892,9 @@ gpu_port_idx = gpu_port_idx - args.num_cp * 2
 token_port_idx = 0
 for i in range(len(system.ruby._cpu_ports)):
     if isinstance(system.ruby._cpu_ports[i], VIPERCoalescer):
-        system.cpu[shader_idx].CUs[token_port_idx].gmTokenPort = (
-            system.ruby._cpu_ports[i].gmTokenPort
-        )
+        system.cpu[shader_idx].CUs[
+            token_port_idx
+        ].gmTokenPort = system.ruby._cpu_ports[i].gmTokenPort
         token_port_idx += 1
 
 wavefront_size = args.wf_size

--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -1132,8 +1132,6 @@ def RP_choose(test_name):
         replacement_policy = LRURP()
     elif test_name == 'FIFORP':
         replacement_policy = FIFORP()
-    elif test_name == 'LRURP':
-        replacement_policy = LRURP()
     elif test_name == 'LFURP':
         replacement_policy = LFURP()
     elif test_name == 'LIPRP':

--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -149,7 +149,7 @@ class TCPCache(RubyCache):
         self.size = MemorySize(options.tcp_size)
         self.assoc = options.tcp_assoc
         self.resourceStalls = options.no_tcc_resource_stalls
-        self.replacement_policy = TreePLRURP()
+        self.replacement_policy = RP_choose(options.tcp_rp)
 
 
 class TCPCntrl(TCP_Controller, CntrlBase):
@@ -241,7 +241,7 @@ class SQCCache(RubyCache):
     def create(self, options):
         self.size = MemorySize(options.sqc_size)
         self.assoc = options.sqc_assoc
-        self.replacement_policy = TreePLRURP()
+        self.replacement_policy = RP_choose(options.tcp_rp)
 
 
 class SQCCntrl(SQC_Controller, CntrlBase):
@@ -303,7 +303,7 @@ class TCC(RubyCache):
         self.start_index_bit = math.log(options.cacheline_size, 2) + math.log(
             options.num_tccs, 2
         )
-        self.replacement_policy = TreePLRURP()
+        self.replacement_policy = RP_choose(options.tcp_rp)
 
 
 class TCCCntrl(TCC_Controller, CntrlBase):
@@ -1124,3 +1124,29 @@ def create_system(
     ruby_system.network.number_of_virtual_networks = 11
 
     return (cpu_sequencers, dir_cntrl_nodes, mainCluster)
+
+def RP_choose(test_name):
+    if test_name == 'TreePLRURP':
+        replacement_policy = TreePLRURP()
+    elif test_name == 'LRURP':
+        replacement_policy = LRURP()
+    elif test_name == 'FIFORP':
+        replacement_policy = FIFORP()
+    elif test_name == 'LRURP':
+        replacement_policy = LRURP()
+    elif test_name == 'LFURP':
+        replacement_policy = LFURP()
+    elif test_name == 'LIPRP':
+        replacement_policy = LIPRP()
+    elif test_name == 'MRURP':
+        replacement_policy = MRURP()
+    elif test_name == 'NRURP':
+        replacement_policy = NRURP()
+    elif test_name == 'RRIPRP':
+        replacement_policy = RRIPRP()
+    elif test_name == 'SecondChanceRP':
+        replacement_policy = SecondChanceRP()
+    elif test_name == 'SHiPMemRP':
+        replacement_policy = SHiPMemRP()
+
+    return replacement_policy


### PR DESCRIPTION
Adding RP_choose functions to change replacement policies among
TreePLRU, LRU, FIFO, LFU, LIP, MRU, NRU, RRIP, SecondChance AND ShiPMem replacement 
policies  for TCC, TCP and SQC caches for GPU