### PR TITLE
gpu-compute, util-m5: add GPU kernel exit events

### DIFF
--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -894,9 +894,9 @@ gpu_port_idx = gpu_port_idx - args.num_cp * 2
 token_port_idx = 0
 for i in range(len(system.ruby._cpu_ports)):
     if isinstance(system.ruby._cpu_ports[i], VIPERCoalescer):
-        system.cpu[shader_idx].CUs[token_port_idx].gmTokenPort = (
-            system.ruby._cpu_ports[i].gmTokenPort
-        )
+        system.cpu[shader_idx].CUs[
+            token_port_idx
+        ].gmTokenPort = system.ruby._cpu_ports[i].gmTokenPort
         token_port_idx += 1
 
 wavefront_size = args.wf_size

--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -894,9 +894,9 @@ gpu_port_idx = gpu_port_idx - args.num_cp * 2
 token_port_idx = 0
 for i in range(len(system.ruby._cpu_ports)):
     if isinstance(system.ruby._cpu_ports[i], VIPERCoalescer):
-        system.cpu[shader_idx].CUs[
-            token_port_idx
-        ].gmTokenPort = system.ruby._cpu_ports[i].gmTokenPort
+        system.cpu[shader_idx].CUs[token_port_idx].gmTokenPort = (
+            system.ruby._cpu_ports[i].gmTokenPort
+        )
         token_port_idx += 1
 
 wavefront_size = args.wf_size
@@ -1015,7 +1015,7 @@ while True:
         exit_event.getCause() == "m5_exit instruction encountered"
         or exit_event.getCause() == "user interrupt received"
         or exit_event.getCause() == "simulate() limit reached"
-        or  "exiting with last active thread context" in exit_event.getCause()
+        or "exiting with last active thread context" in exit_event.getCause()
     ):
         print(f"breaking loop due to: {exit_event.getCause()}.")
         break
@@ -1045,9 +1045,7 @@ while True:
         m5.stats.dump()
         m5.stats.reset()
     else:
-        print(
-            f"Unknown exit event: {exit_event.getCause()}. Continuing..."
-        )
+        print(f"Unknown exit event: {exit_event.getCause()}. Continuing...")
 
     exit_event = m5.simulate(maxtick - m5.curTick())
 

--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -1032,10 +1032,6 @@ while True:
         print("GPU Blit Kernel Completed dump and reset")
         m5.stats.dump()
         m5.stats.reset()
-    elif "Skipping GPU Kernel" in exit_event.getCause():
-        print("Skipping GPU Kernel dump and reset")
-        m5.stats.dump()
-        m5.stats.reset()
     elif "workbegin" in exit_event.getCause():
         print("m5 work begin dump and reset")
         m5.stats.dump()

--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -707,7 +707,7 @@ render_driver = GPURenderDriver(filename=f"dri/renderD{renderDriNum}")
 gpu_hsapp = HSAPacketProcessor(
     pioAddr=hsapp_gpu_map_paddr, numHWQueues=args.num_hw_queues
 )
-dispatcher = GPUDispatcher()
+dispatcher = GPUDispatcher(kernel_exit_events=True)
 gpu_cmd_proc = GPUCommandProcessor(hsapp=gpu_hsapp, dispatcher=dispatcher)
 gpu_driver.device = gpu_cmd_proc
 shader.dispatcher = dispatcher
@@ -833,6 +833,8 @@ if fast_forward:
 
 # configure the TLB hierarchy
 GPUTLBConfig.config_tlb_hierarchy(args, system, shader_idx)
+
+system.exit_on_work_items = True
 
 # create Ruby system
 system.piobus = IOXBar(
@@ -1007,6 +1009,47 @@ if args.fast_forward:
     print("Switch at instruction count: %d" % cpu_list[0].max_insts_any_thread)
 
 exit_event = m5.simulate(maxtick)
+
+while True:
+    if (
+        exit_event.getCause() == "m5_exit instruction encountered"
+        or exit_event.getCause() == "user interrupt received"
+        or exit_event.getCause() == "simulate() limit reached"
+        or  "exiting with last active thread context" in exit_event.getCause()
+    ):
+        print(f"breaking loop due to: {exit_event.getCause()}.")
+        break
+    elif "checkpoint" in exit_event.getCause():
+        assert args.checkpoint_dir is not None
+        m5.checkpoint(args.checkpoint_dir)
+        print("breaking loop with checkpoint")
+        break
+    elif "GPU Kernel Completed" in exit_event.getCause():
+        print("GPU Kernel Completed dump and reset")
+        m5.stats.dump()
+        m5.stats.reset()
+    elif "GPU Blit Kernel Completed" in exit_event.getCause():
+        print("GPU Blit Kernel Completed dump and reset")
+        m5.stats.dump()
+        m5.stats.reset()
+    elif "Skipping GPU Kernel" in exit_event.getCause():
+        print("Skipping GPU Kernel dump and reset")
+        m5.stats.dump()
+        m5.stats.reset()
+    elif "workbegin" in exit_event.getCause():
+        print("m5 work begin dump and reset")
+        m5.stats.dump()
+        m5.stats.reset()
+    elif "workend" in exit_event.getCause():
+        print("m5 work end dump and reset")
+        m5.stats.dump()
+        m5.stats.reset()
+    else:
+        print(
+            f"Unknown exit event: {exit_event.getCause()}. Continuing..."
+        )
+
+    exit_event = m5.simulate(maxtick - m5.curTick())
 
 if args.fast_forward:
     if exit_event.getCause() == "a thread reached the max instruction count":


### PR DESCRIPTION
The GPUFS scripts include support for dumping and resetting
stats at kernel boundaries by identifying specific GPU kernel 
exit events. This commit extends that support to work with 
GPU SE-mode support.

Change-Id: I662233ae71e2987d90af1fd0100e29036b2ef1c6