### PR TITLE
configs: Add replacement policy options for GPUFS

### DIFF
--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -195,6 +195,28 @@ def addRunFSOptions(parser):
         help="Disable KVM perf counters (use this with LSF / ETX)",
     )
 
+    parser.add_argument(
+        "--tcp-rp",
+        type=str,
+        default="TreePLRURP",
+        help="cache replacement policy" "policy for tcp",
+    )
+
+    parser.add_argument(
+        "--tcc-rp",
+        type=str,
+        default="TreePLRURP",
+        help="cache replacement policy" "policy for tcc",
+    )
+
+    # sqc rp both changes sqc rp and scalar cache rp
+    parser.add_argument(
+        "--sqc-rp",
+        type=str,
+        default="TreePLRURP",
+        help="cache replacement policy" "policy for sqc",
+    )
+
 
 def runGpuFSSystem(args):
     """


### PR DESCRIPTION
GPU_VIPER.py was modified to use these options but they did not exist, breaking GPUFS.  This commit adds them to fix the issue.

Change-Id: I0095f400ea606c4e8d91a41870ef208465cef803