### PR TITLE
mem-ruby: This commit fixes MI_example protocol

### DIFF
--- a/src/mem/ruby/protocol/MI_example-dir.sm
+++ b/src/mem/ruby/protocol/MI_example-dir.sm
@@ -535,7 +535,7 @@ machine(MachineType:Directory, "Directory protocol")
     z_recycleRequestQueue;
   }
 
-  transition({IM, MI, ID, ID_W}, {DMA_READ, DMA_WRITE} ) {
+  transition({IM, MI, ID, ID_W, M_DRDI}, {DMA_READ, DMA_WRITE} ) {
     y_recycleDMARequestQueue;
   }
 
@@ -648,6 +648,11 @@ machine(MachineType:Directory, "Directory protocol")
   }
 
   transition(I, PUTX_NotOwner, I) {
+    b_sendWriteBackNack;
+    i_popIncomingRequestQueue;
+  }
+
+  transition({M_DWR, M_DRD, M_DRDI, M_DWRI}, PUTX_NotOwner) {
     b_sendWriteBackNack;
     i_popIncomingRequestQueue;
   }


### PR DESCRIPTION
mem-ruby: Fix bugs in MI_example protocol

fix two bugs in MI_example-dir.sm:
1. Directory cannot handle DMA_READ & DMA_WRITE events in M_DRDI state.
2. Directory cannot handle PUTX_NotOwner events in {M_DWR, M_DRD, M_DRDI, M_DWRI} state.

Github Issue: https://github.com/gem5/gem5/issues/1210

Change-Id: I52a9d674ce0688dcfbbcc2b583f17de95afdeb87