### PR TITLE
arch: Mark FailUnimplemented instructions as Invalid instructions

### DIFF
--- a/src/arch/arm/insts/pseudo.cc
+++ b/src/arch/arm/insts/pseudo.cc
@@ -116,6 +116,7 @@ FailUnimplemented::FailUnimplemented(const char *_mnemonic,
     // don't call execute() (which panics) if we're on a
     // speculative path
     flags[IsNonSpeculative] = true;
+    flags[IsInvalid] = true;
 }
 
 FailUnimplemented::FailUnimplemented(const char *_mnemonic,
@@ -127,6 +128,7 @@ FailUnimplemented::FailUnimplemented(const char *_mnemonic,
     // don't call execute() (which panics) if we're on a
     // speculative path
     flags[IsNonSpeculative] = true;
+    flags[IsInvalid] = true;
 }
 
 Fault

--- a/src/arch/mips/isa/formats/unimp.isa
+++ b/src/arch/mips/isa/formats/unimp.isa
@@ -49,6 +49,7 @@ output header {{
             // don't call execute() (which panics) if we're on a
             // speculative path
             flags[IsNonSpeculative] = true;
+            flags[IsInvalid] = true;
         }
 
         Fault execute(ExecContext *, trace::InstRecord *) const override;

--- a/src/arch/power/isa/formats/unimp.isa
+++ b/src/arch/power/isa/formats/unimp.isa
@@ -51,6 +51,7 @@ output header {{
             // don't call execute() (which panics) if we're on a
             // speculative path
             flags[IsNonSpeculative] = true;
+            flags[IsInvalid] = true;
         }
 
         Fault execute(ExecContext *, trace::InstRecord *) const override;

--- a/src/arch/sparc/insts/unimp.hh
+++ b/src/arch/sparc/insts/unimp.hh
@@ -59,7 +59,9 @@ class FailUnimplemented : public SparcStaticInst
     /// Constructor
     FailUnimplemented(const char *_mnemonic, ExtMachInst _machInst) :
             SparcStaticInst(_mnemonic, _machInst, No_OpClass)
-    {}
+    {
+        flags[IsInvalid] = true;
+    }
 
     Fault
     execute(ExecContext *xc, trace::InstRecord *traceData) const override

--- a/src/arch/x86/isa/formats/unimp.isa
+++ b/src/arch/x86/isa/formats/unimp.isa
@@ -58,6 +58,7 @@ output header {{
             // don't call execute() (which panics) if we're on a
             // speculative path
             flags[IsNonSpeculative] = true;
+            flags[IsInvalid] = true;
         }
 
         Fault execute(ExecContext *, trace::InstRecord *) const override;


### PR DESCRIPTION
This is a follow-up on the discussion here [1].

The IsInvalid flag was previously defined as an instruction that does not appear in the ISA. However, a micro-architecture can choose to not recognize an instruction in and raise illegal instruction fault even if the instruction is in the ISA.

This change modifies the definition of a Invalid instruction such that, if a StaticInst instruction is marked as IsInvalid, it means the instruction is not recognized by the decoder. This means that any instruction recognized by the decoder are not invalid, even if the instruction is not in the official ISA spec; e.g., m5 pseudo-instructions.

Note that instructions that are recognized by the decoder but are chosen to act as a nop are not invalid. This applies to WarnUnimplemented instructions, e.g. hint instructions.

[1] https://github.com/gem5/gem5/pull/1071

Change-Id: I1371b222d8b06793d47f434d0f148c5571672068