### PR TITLE
Revert "cpu-o3: Do not set Executed on load instruction to be replayed"

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -611,12 +611,6 @@ LSQUnit::executeLoad(const DynInstPtr &inst)
     if (inst->isTranslationDelayed() && load_fault == NoFault)
         return load_fault;
 
-    // Partial Store-to-Load Forwarding condition marks the load to be
-    // reissued during LSQUnit::read(). In this case we shouldn't notify
-    // iewStage that the instruction is ready for commit.
-    if (!inst->isIssued() && !inst->effAddrValid())
-        return load_fault;
-
     if (load_fault != NoFault && inst->translationCompleted() &&
             inst->savedRequest->isPartialFault()
             && !inst->savedRequest->isComplete()) {


### PR DESCRIPTION
Reverts gem5/gem5#1182

This is breaking O3 execution. Investigating the matter