### PR TITLE
gpu-compute,mem-ruby: Add RubyHitMiss flag for TCP and TCC cache

### DIFF
--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -493,7 +493,7 @@ void
 GPUCoalescer::readCallback(Addr address,
                         MachineType mach,
                         DataBlock& data,
-                        bool externalHit)
+                        bool externalHit = false)
 {
     readCallback(address, mach, data, Cycles(0), Cycles(0), Cycles(0), externalHit);
 }
@@ -505,7 +505,7 @@ GPUCoalescer::readCallback(Addr address,
                         Cycles initialRequestTime,
                         Cycles forwardRequestTime,
                         Cycles firstResponseTime,
-                        bool externalHit)
+                        bool externalHit = false)
 {
 
     readCallback(address, mach, data,
@@ -521,7 +521,7 @@ GPUCoalescer::readCallback(Addr address,
                         Cycles forwardRequestTime,
                         Cycles firstResponseTime,
                         bool isRegion,
-                        bool externalHit)
+                        bool externalHit = false)
 {
     assert(address == makeLineAddress(address));
     assert(coalescedTable.count(address));
@@ -552,7 +552,7 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                        Cycles forwardRequestTime,
                        Cycles firstResponseTime,
                        bool isRegion,
-                       bool externalHit)
+                       bool externalHit = false)
 {
     PacketPtr pkt = crequest->getFirstPkt();
     Addr request_address = pkt->getAddr();

--- a/src/mem/ruby/system/GPUCoalescer.hh
+++ b/src/mem/ruby/system/GPUCoalescer.hh
@@ -292,7 +292,7 @@ class GPUCoalescer : public RubyPort
     void readCallback(Addr address,
                       MachineType mach,
                       DataBlock& data,
-                      bool externalHit = false);
+                      bool externalHit);
 
     void readCallback(Addr address,
                       MachineType mach,
@@ -300,7 +300,7 @@ class GPUCoalescer : public RubyPort
                       Cycles initialRequestTime,
                       Cycles forwardRequestTime,
                       Cycles firstResponseTime,
-                      bool externalHit = false);
+                      bool externalHit);
 
     void readCallback(Addr address,
                       MachineType mach,
@@ -309,7 +309,7 @@ class GPUCoalescer : public RubyPort
                       Cycles forwardRequestTime,
                       Cycles firstResponseTime,
                       bool isRegion,
-                      bool externalHit = false);
+                      bool externalHit);
 
     /* atomics need their own callback because the data
        might be const coming from SLICC */
@@ -396,7 +396,7 @@ class GPUCoalescer : public RubyPort
                      Cycles forwardRequestTime,
                      Cycles firstResponseTime,
                      bool isRegion,
-                     bool externalHit = false);
+                     bool externalHit);
 
     void recordMissLatency(CoalescedRequest* crequest,
                            MachineType mach,


### PR DESCRIPTION
Fix the compilation problem.
Add hit and miss print for TCP and TCC cache with RubyHitMiss debug flag.
