### PR TITLE
configs: Check before use replacement policy options

### DIFF
--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -149,7 +149,8 @@ class TCPCache(RubyCache):
         self.size = MemorySize(options.tcp_size)
         self.assoc = options.tcp_assoc
         self.resourceStalls = options.no_tcc_resource_stalls
-        self.replacement_policy = RP_choose(options.tcp_rp)
+        if hasattr(options, "tcp_rp"):
+            self.replacement_policy = RP_choose(options.tcp_rp)
 
 
 class TCPCntrl(TCP_Controller, CntrlBase):
@@ -241,7 +242,8 @@ class SQCCache(RubyCache):
     def create(self, options):
         self.size = MemorySize(options.sqc_size)
         self.assoc = options.sqc_assoc
-        self.replacement_policy = RP_choose(options.tcp_rp)
+        if hasattr(options, "sqc_rp"):
+            self.replacement_policy = RP_choose(options.sqc_rp)
 
 
 class SQCCntrl(SQC_Controller, CntrlBase):
@@ -303,7 +305,8 @@ class TCC(RubyCache):
         self.start_index_bit = math.log(options.cacheline_size, 2) + math.log(
             options.num_tccs, 2
         )
-        self.replacement_policy = RP_choose(options.tcp_rp)
+        if hasattr(options, "tcc_rp"):
+            self.replacement_policy = RP_choose(options.tcc_rp)
 
 
 class TCCCntrl(TCC_Controller, CntrlBase):


### PR DESCRIPTION
Rather than adding the options to *every* config that might be using GPU_VIPER.py, just change the Ruby config to check if the option is available before trying to use it. Otherwise, reverts to what was the default on stable.

Change-Id: Ia6f1d0827d489ee2a35c598b644461cbff59e247