### PR TITLE
stdlib: Add function to append kernel args

### DIFF
--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -249,3 +249,11 @@ class KernelDiskWorkload:
                     "Checkpoints must be passed as a Path or an "
                     "CheckpointResource."
                 )
+
+    def append_kernel_arg(self, arg: str) -> None:
+        """
+        Append a kernel argument to the list of kernel arguments.
+
+        :param arg: The kernel argument to append.
+        """
+        self.workload.command_line += f" {arg}"


### PR DESCRIPTION
Often, you want to add another argument to the default kernel arguments. This function allows you to do that on the `kernel_disk_workload` board mixin.

Change-Id: I45c83bf3b330a8848293c171703cbdc4f0d90e98