### PR TITLE
gpu-compute,mem,systemc: This commit corrects typos of 'cache'

### DIFF
--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -1019,7 +1019,7 @@ class ComputeUnit : public ClockedObject
 
     // hold the time of the arrival of the first cache block related to
     // a particular GPUDynInst. This is used to calculate the difference
-    // between the first and last chace block arrival times.
+    // between the first and last cache block arrival times.
     std::unordered_map<GPUDynInstPtr, Tick> headTailMap;
 
   public:

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -861,7 +861,7 @@ Cache::serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt, CacheBlk *blk)
                 }
                 // not a cache fill, just forwarding response
                 // responseLatency is the latency of the return path
-                // from lower level cahces/memory to the core.
+                // from lower level caches/memory to the core.
                 completion_time += clockEdge(responseLatency) +
                     pkt->payloadDelay;
                 if (!is_error) {

--- a/src/mem/probes/stack_dist.cc
+++ b/src/mem/probes/stack_dist.cc
@@ -53,7 +53,7 @@ StackDistProbe::StackDistProbe(const StackDistProbeParams &p)
 {
     fatal_if(p.system->cacheLineSize() > p.line_size,
              "The stack distance probe must use a cache line size that is "
-             "larger or equal to the system's cahce line size.");
+             "larger or equal to the system's cache line size.");
 }
 
 StackDistProbe::StackDistProbeStats::StackDistProbeStats(

--- a/src/systemc/tests/systemc/utils/sc_report/cached/cached.cpp
+++ b/src/systemc/tests/systemc/utils/sc_report/cached/cached.cpp
@@ -95,7 +95,7 @@ void dump_cached_report(const char* ctx)
 
 SC_MODULE( M )
 {
-    sc_in<bool> emit;  // 1: emit, 0: dump cahced report
+    sc_in<bool> emit;  // 1: emit, 0: dump cached report
     sc_in<const char*> id;
     sc_in<bool> ofs; 
     sc_event t1, t2, m1, m2;


### PR DESCRIPTION
I noticed while using the stable branch that there were a few typos of the word 'cache' and so I've corrected a few files where I found such typos.

Change-Id: I7c7f64812039f34fe39d0c45c4f5ce921cba06d0