### PR TITLE
arch-riscv: Fix TLB lookup with vaddrs

### DIFF
--- a/src/arch/riscv/pagetable.cc
+++ b/src/arch/riscv/pagetable.cc
@@ -60,5 +60,20 @@ TlbEntry::unserialize(CheckpointIn &cp)
     UNSERIALIZE_SCALAR(lruSeq);
 }
 
+Addr
+getVPNFromVAddr(Addr vaddr, Addr mode)
+{
+    switch (mode) {
+    case SV39:
+        return bits(vaddr, 38, 12);
+    case SV48:
+        return bits(vaddr, 47, 12);
+    case SV57:
+        return bits(vaddr, 56, 12);
+    default:
+        panic("Unknown address translation mode %d\n", mode);
+    }
+}
+
 } // namespace RiscvISA
 } // namespace gem5

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -53,6 +53,7 @@ enum AddrXlateMode
     BARE = 0,
     SV39 = 8,
     SV48 = 9,
+    SV57 = 10,
 };
 
 // Sv39 paging
@@ -75,6 +76,13 @@ BitUnion64(PTESv39)
     Bitfield<1> r;
     Bitfield<0> v;
 EndBitUnion(PTESv39)
+
+/**
+ * Remove the page offset and the upper bits that are
+ * not part of the VPN from the address.
+ * Note that this must assume the smallest page size
+ */
+Addr getVPNFromVAddr(Addr vaddr, Addr mode);
 
 struct TlbEntry;
 typedef Trie<Addr, TlbEntry> TlbEntryTrie;

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -97,6 +97,14 @@ class TLB : public BaseTLB
 
     void takeOverFrom(BaseTLB *old) override {}
 
+    /**
+     * Insert an entry into the TLB.
+     * @param vpn The virtual page number extracted from the address.
+     *            It is shifted based on the page size. We assume the
+     *            smallest defined page size and remove the upper bits of the
+     *            virtual address that are not part of the page number.
+     * @param entry The entry to insert.
+     */
     TlbEntry *insert(Addr vpn, const TlbEntry &entry);
     void flushAll() override;
     void demapPage(Addr vaddr, uint64_t asn) override;
@@ -123,7 +131,8 @@ class TLB : public BaseTLB
      */
     Port *getTableWalkerPort() override;
 
-    Addr translateWithTLB(Addr vaddr, uint16_t asid, BaseMMU::Mode mode);
+    Addr translateWithTLB(Addr vaddr, uint16_t asid, Addr xmode,
+                          BaseMMU::Mode mode);
 
     Fault translateAtomic(const RequestPtr &req,
                           ThreadContext *tc, BaseMMU::Mode mode) override;
@@ -134,6 +143,17 @@ class TLB : public BaseTLB
                               BaseMMU::Mode mode) override;
     Fault finalizePhysical(const RequestPtr &req, ThreadContext *tc,
                            BaseMMU::Mode mode) const override;
+
+    /**
+     * Perform the tlb lookup
+     * @param vpn The virtual page number extracted from the address.
+     *            It is shifted based on the page size. We assume the
+     *            smallest defined page size and remove the upper bits of the
+     *            virtual address that are not part of the page number.
+     * @param asid The address space identifier as specified by satp.
+     * @param mode The mode of the memory operation.
+     * @param hidden If the lookup should be hidden from the statistics.
+     */
     TlbEntry *lookup(Addr vpn, uint16_t asid, BaseMMU::Mode mode, bool hidden);
 
   private:


### PR DESCRIPTION
Previously, all of the TLB lookup/insert functions were using the full virtual addresses even though the variables in the functions said "vpn." This change explicitly converts the virtual address to the VPN without any least significant zeros for the offset. I.e., vpn >> page_size.

The main bug solved in this changeset is the asid was |'d with the upper bits of the virtual address, but sometimes there were all 1's. Therefore, you could get a TLB hit even if the ASID was different. Interestingly, the page that seemed to cause these issues was a 1 GiB page.

This change also starts refactoring some of the page table details to support sv46 and sv57 page table formats.

In my testing, the Linux kernel boot uses large pages (even OpenSBI uses large pages), so it seems that large pages also work. However, this seems like magic to me, so I'm not sure if it's correct.

This change also updates some asserts, and debug statements with more useful debugging information.

Partially fixes #1235. More testing needs to be done to be confident.

Change-Id: If832fe8ae89874cf48d7367f5694c5adba2bd6d7