### PR TITLE
cpu: Fix `std::min` type mismatch in reg_class.hh

### DIFF
--- a/src/cpu/reg_class.hh
+++ b/src/cpu/reg_class.hh
@@ -248,7 +248,7 @@ class RegClass
         return _ops->valString(val, regBytes());
     }
     std::string
-    valString(const void *val, const uint64_t& num_bytes) const
+    valString(const void *val, const size_t& num_bytes) const
     {
         return _ops->valString(val, std::min(regBytes(), num_bytes));
     }


### PR DESCRIPTION
Introduced in #1234, this caused compilation to faill in Apple Silicon systems. This bug is the same as #582 where a more detailed explanation is provided