### PR TITLE
stdlib: Getter method to get monolith range.

### DIFF
--- a/src/python/gem5/components/memory/abstract_memory_system.py
+++ b/src/python/gem5/components/memory/abstract_memory_system.py
@@ -83,6 +83,14 @@ class AbstractMemorySystem(SubSystem):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def get_uninterleaved_range(self) -> List[AddrRange]:
+        """Returns the range of the memory system without interleaving.
+        This is useful when other components in the system want to interleave
+        the memory range different to how the memory has interleaved them.
+        """
+        raise NotImplementedError
+
     def _post_instantiate(self) -> None:
         """Called to set up anything needed after ``m5.instantiate``."""
         pass

--- a/src/python/gem5/components/memory/memory.py
+++ b/src/python/gem5/components/memory/memory.py
@@ -203,3 +203,7 @@ class ChanneledMemory(AbstractMemorySystem):
             )
         self._mem_range = ranges[0]
         self._interleave_addresses()
+
+    @overrides(AbstractMemorySystem)
+    def get_uninterleaved_range(self) -> List[AddrRange]:
+        return [self._mem_range]


### PR DESCRIPTION
This change extend the AbstractMemory class to add a getter method that allows other components to get the memory's range without interleaving. 
This method will be useful if other components in the system need to interleave the memory range different to the way the memory has interleaved them.