### PR TITLE
mem: Change long in src/mem/physical.cc to int64_t

### DIFF
--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -367,7 +367,7 @@ PhysicalMemory::serializeStore(CheckpointOut &cp, unsigned int store_id,
     // memories that are not part of the address map can overlap
     std::string filename =
         name() + ".store" + std::to_string(store_id) + ".pmem";
-    int64_t range_size = range.size();
+    Addr range_size = range.size();
 
     DPRINTF(Checkpoint, "Serializing physical memory %s with size %d\n",
             filename, range_size);
@@ -452,7 +452,7 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
     uint8_t* pmem = backingStore[store_id].pmem;
     AddrRange range = backingStore[store_id].range;
 
-    int64_t range_size;
+    Addr range_size;
     UNSERIALIZE_SCALAR(range_size);
 
     DPRINTF(Checkpoint, "Unserializing physical memory %s with size %d\n",
@@ -463,8 +463,8 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
               range_size, range.size());
 
     uint64_t curr_size = 0;
-    int64_t* temp_page = new int64_t[chunk_size];
-    int64_t* pmem_current;
+    uint8_t* temp_page = new uint8_t[chunk_size];
+    uint8_t* pmem_current;
     uint32_t bytes_read;
     while (curr_size < range.size()) {
         bytes_read = gzread(compressed_mem, temp_page, chunk_size);
@@ -473,11 +473,12 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
 
         assert(bytes_read % sizeof(int64_t) == 0);
 
-        for (uint32_t x = 0; x < bytes_read / sizeof(int64_t); x++) {
+        for (uint32_t x = 0; x < bytes_read / sizeof(uint8_t); x++) {
             // Only copy bytes that are non-zero, so we don't give
             // the VM system hell
             if (*(temp_page + x) != 0) {
-                pmem_current = (int64_t*)(pmem + curr_size + x * sizeof(int64_t));
+                pmem_current = (uint8_t*)(pmem + curr_size + x *
+                sizeof(uint8_t));
                 *pmem_current = *(temp_page + x);
             }
         }

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -367,7 +367,7 @@ PhysicalMemory::serializeStore(CheckpointOut &cp, unsigned int store_id,
     // memories that are not part of the address map can overlap
     std::string filename =
         name() + ".store" + std::to_string(store_id) + ".pmem";
-    long range_size = range.size();
+    int64_t range_size = range.size();
 
     DPRINTF(Checkpoint, "Serializing physical memory %s with size %d\n",
             filename, range_size);
@@ -452,7 +452,7 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
     uint8_t* pmem = backingStore[store_id].pmem;
     AddrRange range = backingStore[store_id].range;
 
-    long range_size;
+    int64_t range_size;
     UNSERIALIZE_SCALAR(range_size);
 
     DPRINTF(Checkpoint, "Unserializing physical memory %s with size %d\n",
@@ -463,21 +463,21 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
               range_size, range.size());
 
     uint64_t curr_size = 0;
-    long* temp_page = new long[chunk_size];
-    long* pmem_current;
+    int64_t* temp_page = new int64_t[chunk_size];
+    int64_t* pmem_current;
     uint32_t bytes_read;
     while (curr_size < range.size()) {
         bytes_read = gzread(compressed_mem, temp_page, chunk_size);
         if (bytes_read == 0)
             break;
 
-        assert(bytes_read % sizeof(long) == 0);
+        assert(bytes_read % sizeof(int64_t) == 0);
 
-        for (uint32_t x = 0; x < bytes_read / sizeof(long); x++) {
+        for (uint32_t x = 0; x < bytes_read / sizeof(int64_t); x++) {
             // Only copy bytes that are non-zero, so we don't give
             // the VM system hell
             if (*(temp_page + x) != 0) {
-                pmem_current = (long*)(pmem + curr_size + x * sizeof(long));
+                pmem_current = (int64_t*)(pmem + curr_size + x * sizeof(int64_t));
                 *pmem_current = *(temp_page + x);
             }
         }

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -468,8 +468,6 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
         bytes_read = gzread(compressed_mem, pmem, chunk_size);
         if (bytes_read == 0)
             break;
-
-        assert(bytes_read % sizeof(int64_t) == 0);
         curr_size += bytes_read;
         pmem += bytes_read;
     }

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -463,8 +463,8 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
               range_size, range.size());
 
     uint64_t curr_size = 0;
-    uint8_t* temp_page = new uint8_t[chunk_size];
-    uint8_t* pmem_current;
+    long* temp_page = new long[chunk_size];
+    long* pmem_current;
     uint32_t bytes_read;
     while (curr_size < range.size()) {
         bytes_read = gzread(compressed_mem, temp_page, chunk_size);
@@ -473,12 +473,11 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
 
         assert(bytes_read % sizeof(int64_t) == 0);
 
-        for (uint32_t x = 0; x < bytes_read / sizeof(uint8_t); x++) {
-            // Only copy bytes that are non-zero, so we don't give
-            // the VM system hell
+        for (uint32_t x = 0; x < bytes_read / sizeof(long); x++) {
+        // Only copy bytes that are non-zero, so we don't give
+        // the VM system hell
             if (*(temp_page + x) != 0) {
-                pmem_current = (uint8_t*)(pmem + curr_size + x *
-                sizeof(uint8_t));
+                pmem_current = (long*)(pmem + curr_size + x * sizeof(long));
                 *pmem_current = *(temp_page + x);
             }
         }

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -463,28 +463,16 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
               range_size, range.size());
 
     uint64_t curr_size = 0;
-    long* temp_page = new long[chunk_size];
-    long* pmem_current;
     uint32_t bytes_read;
     while (curr_size < range.size()) {
-        bytes_read = gzread(compressed_mem, temp_page, chunk_size);
+        bytes_read = gzread(compressed_mem, pmem, chunk_size);
         if (bytes_read == 0)
             break;
 
         assert(bytes_read % sizeof(int64_t) == 0);
-
-        for (uint32_t x = 0; x < bytes_read / sizeof(long); x++) {
-        // Only copy bytes that are non-zero, so we don't give
-        // the VM system hell
-            if (*(temp_page + x) != 0) {
-                pmem_current = (long*)(pmem + curr_size + x * sizeof(long));
-                *pmem_current = *(temp_page + x);
-            }
-        }
         curr_size += bytes_read;
+        pmem += bytes_read;
     }
-
-    delete[] temp_page;
 
     if (gzclose(compressed_mem))
         fatal("Close failed on physical memory checkpoint file '%s'\n",


### PR DESCRIPTION
This changes `long`s in src/mem/physical.cc, which are 32 bits or more, to `uint64_t`s, which are exactly 64 bits.

Change-Id: I64e089a2ac087bcf58b9c3c918c59dc5ff75d010