### PR TITLE
dev-arm: This commit fixes a typo in the ARM ldaddalx instruction

### DIFF
--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -741,7 +741,7 @@ namespace Aarch64
                         if (o3 == 1)
                             return new SWPLAB(machInst, rt, rnsp, rs);
                         else
-                            return new LDADDLAB(machInst, rt, rnsp, rs);
+                            return new LDADDALB(machInst, rt, rnsp, rs);
                     case 0x4:
                         if (o3 == 1)
                             return new SWPH(machInst, rt, rnsp, rs);
@@ -765,7 +765,7 @@ namespace Aarch64
                         if (o3 == 1)
                             return new SWPLAH(machInst, rt, rnsp, rs);
                         else
-                            return new LDADDLAH(machInst, rt, rnsp, rs);
+                            return new LDADDALH(machInst, rt, rnsp, rs);
                     case 0x8:
                         if (o3 == 1)
                             return new SWP(machInst, rt, rnsp, rs);
@@ -789,7 +789,7 @@ namespace Aarch64
                         if (o3 == 1)
                             return new SWPLA(machInst, rt, rnsp, rs);
                         else
-                            return new LDADDLA(machInst, rt, rnsp, rs);
+                            return new LDADDAL(machInst, rt, rnsp, rs);
                     case 0xc:
                         if (o3 == 1)
                             return new SWP64(machInst, rt, rnsp, rs);
@@ -814,7 +814,7 @@ namespace Aarch64
                         if (o3 == 1)
                             return new SWPLA64(machInst, rt, rnsp, rs);
                         else
-                            return new LDADDLA64(machInst, rt, rnsp, rs);
+                            return new LDADDAL64(machInst, rt, rnsp, rs);
                     default:
                         GEM5_UNREACHABLE;
                 }

--- a/src/arch/arm/isa/insts/amo64.isa
+++ b/src/arch/arm/isa/insts/amo64.isa
@@ -427,7 +427,7 @@ let {{
                    flavor="release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldaddab",   "LDADDAB",   1, unsign=True,
                    flavor="acquire").emit(OP_DICT['ADD'])
-    AtomicArithmeticSingleOp("ldaddlab",  "LDADDLAB",  1, unsign=True,
+    AtomicArithmeticSingleOp("ldaddalb",  "LDADDALB",  1, unsign=True,
                    flavor="acquire_release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldaddh",    "LDADDH",    2, unsign=True,
                    flavor="normal").emit(OP_DICT['ADD'])
@@ -435,7 +435,7 @@ let {{
                    flavor="release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldaddah",   "LDADDAH",   2, unsign=True,
                    flavor="acquire").emit(OP_DICT['ADD'])
-    AtomicArithmeticSingleOp("ldaddlah",  "LDADDLAH",  2, unsign=True,
+    AtomicArithmeticSingleOp("ldaddalh",  "LDADDALH",  2, unsign=True,
                    flavor="acquire_release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldadd",     "LDADD",     4, unsign=True,
                    flavor="normal").emit(OP_DICT['ADD'])
@@ -443,7 +443,7 @@ let {{
                    flavor="release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldadda",    "LDADDA",    4, unsign=True,
                    flavor="acquire").emit(OP_DICT['ADD'])
-    AtomicArithmeticSingleOp("ldaddla",   "LDADDLA",   4, unsign=True,
+    AtomicArithmeticSingleOp("ldaddal",   "LDADDAL",   4, unsign=True,
                    flavor="acquire_release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldadd64",   "LDADD64",   8, unsign=True,
                    flavor="normal").emit(OP_DICT['ADD'])
@@ -451,7 +451,7 @@ let {{
                    flavor="release").emit(OP_DICT['ADD'])
     AtomicArithmeticSingleOp("ldadda64",  "LDADDA64",  8, unsign=True,
                    flavor="acquire").emit(OP_DICT['ADD'])
-    AtomicArithmeticSingleOp("ldaddla64", "LDADDLA64", 8, unsign=True,
+    AtomicArithmeticSingleOp("ldaddal64", "LDADDAL64", 8, unsign=True,
                    flavor="acquire_release").emit(OP_DICT['ADD'])
 
     AtomicArithmeticSingleOp("ldclrb",    "LDCLRB",    1, unsign=True,


### PR DESCRIPTION
The acquire-release flavor of the ldadd instruction should read ldaddalx (eg. ldaddalb/ldaddalh) according to specification. However, this is currently noted as ldadd"la"x (eg. ldaddlab/ldaddlah).

Issue: https://github.com/gem5/gem5/issues/1224
Change-Id: Ib932fa0e572207729c923c27f24c34cc21dff0e5