### PR TITLE
resources: Update client_query to trim gem5 version

### DIFF
--- a/src/python/gem5/resources/client_api/client_query.py
+++ b/src/python/gem5/resources/client_api/client_query.py
@@ -45,7 +45,10 @@ class ClientQuery:
     ):
         self.resource_id = resource_id
         self.resource_version = resource_version
-        self.gem5_version = gem5_version
+        # We only need the major and minor version numbers.
+        # As on database side, we only store the major and minor
+        # version numbers.
+        self.gem5_version = ".".join(gem5_version.split(".")[:2])
 
     def get_resource_id(self) -> str:
         return self.resource_id


### PR DESCRIPTION
- gem5 was querying the full version of gem5 that is `24.0.0.0` while searching for resources.
This was causing an error to find resources on staging branch. 
This change trims the gem5 version to be just the major.minor version.

Change-Id: I30c3a1b38c631981f797ef0fd2b616e6a66ca18e