### PR TITLE
stdlib,tests: Update resources to v24.0 in Pyunit test

### DIFF
--- a/tests/pyunit/stdlib/resources/refs/mongo-mock.json
+++ b/tests/pyunit/stdlib/resources/refs/mongo-mock.json
@@ -22,7 +22,8 @@
         "source_url": "https://github.com/gem5/gem5-resources/tree/develop/src/x86-ubuntu",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "example_usage": "get_resource(resource_name=\"x86-ubuntu-18.04-img\")"
     },
@@ -49,7 +50,8 @@
         "source_url": "https://github.com/gem5/gem5-resources/tree/develop/src/x86-ubuntu",
         "resource_version": "1.1.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "example_usage": "get_resource(resource_name=\"x86-ubuntu-18.04-img\")"
     }

--- a/tests/pyunit/stdlib/resources/refs/obtain-resource.json
+++ b/tests/pyunit/stdlib/resources/refs/obtain-resource.json
@@ -10,7 +10,8 @@
         "source": "src/test-source",
         "resource_version": "2.5.0",
         "gem5_versions": [
-            "25.0"
+            "25.0",
+            "24.0"
         ]
     },
     {
@@ -24,7 +25,8 @@
         "source": "src/test-source",
         "resource_version": "2.0.0",
         "gem5_versions": [
-            "23.0"
+            "23.0",
+            "24.0"
         ]
     },
     {
@@ -39,7 +41,8 @@
         "resource_version": "1.7.0",
         "gem5_versions": [
             "develop",
-            "develop-2"
+            "develop-2",
+            "24.0"
         ]
     },
     {
@@ -53,7 +56,8 @@
         "source": "src/test-source",
         "resource_version": "1.5.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     }
 ]

--- a/tests/pyunit/stdlib/resources/refs/resource-specialization.json
+++ b/tests/pyunit/stdlib/resources/refs/resource-specialization.json
@@ -114,7 +114,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "24.0"
         ]
     },
     {

--- a/tests/pyunit/stdlib/resources/refs/resources.json
+++ b/tests/pyunit/stdlib/resources/refs/resources.json
@@ -21,7 +21,8 @@
         "source_url": "https://github.com/gem5/gem5-resources/tree/develop/src/asmtest",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "example_usage": "get_resource(resource_name=\"rv64mi-p-sbreak\")"
     },
@@ -48,7 +49,8 @@
         "source_url": "https://github.com/gem5/gem5-resources/tree/develop/src/asmtest",
         "resource_version": "1.1.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "example_usage": "get_resource(resource_name=\"rv64mi-p-sbreak\")"
     },
@@ -94,7 +96,8 @@
         "source_url": "",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -122,7 +125,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -150,7 +154,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -178,7 +183,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -206,7 +212,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -234,7 +241,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -262,7 +270,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -290,7 +299,8 @@
         "source_url": "",
         "resource_version": "0.2.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "workload_name": "x86-print-this-15000-with-simpoints",
         "example_usage": "get_resource(resource_name=\"x86-print-this-1500-simpoints\")",
@@ -322,7 +332,8 @@
         "source_url": "https://github.com/gem5/gem5-resources/tree/develop/src/x86-ubuntu",
         "resource_version": "2.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ],
         "example_usage": "get_resource(resource_name=\"x86-ubuntu-18.04-img\")"
     }

--- a/tests/pyunit/stdlib/resources/refs/suite-checks.json
+++ b/tests/pyunit/stdlib/resources/refs/suite-checks.json
@@ -3,7 +3,7 @@
         "id": "suite-example",
         "category": "suite",
         "resource_version": "1.0.0",
-        "gem5_versions": ["develop","23.1"],
+        "gem5_versions": ["develop","23.1", "24.0"],
         "workloads": [
             {
                 "id": "simple-workload-1",
@@ -37,7 +37,8 @@
         },
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -60,7 +61,8 @@
         },
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -74,7 +76,8 @@
         "source": "src/linux-kernel",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -89,7 +92,8 @@
         "root_partition": "1",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -103,7 +107,8 @@
         "source": "src/simple",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     }
 ]

--- a/tests/pyunit/stdlib/resources/refs/workload-checks.json
+++ b/tests/pyunit/stdlib/resources/refs/workload-checks.json
@@ -10,7 +10,8 @@
         "source": "src/linux-kernel",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -25,7 +26,8 @@
         "root_partition": "1",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -48,7 +50,8 @@
         },
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     },
     {
@@ -62,7 +65,8 @@
         "source": "src/simple",
         "resource_version": "1.0.0",
         "gem5_versions": [
-            "develop"
+            "develop",
+            "24.0"
         ]
     }
 ]


### PR DESCRIPTION
This needs a better fix. I don't like having to update these files for every release. Though for now, this will mean the tests passing in v24.0