### PR TITLE
arch-riscv: Fix setRegs from GDB failed after #1099

### DIFF
--- a/src/arch/riscv/remote_gdb.cc
+++ b/src/arch/riscv/remote_gdb.cc
@@ -368,7 +368,7 @@ RemoteGDB::Riscv32GdbRegCache::setRegs(ThreadContext *context) const
     // TODO: implement CSR counter registers for mcycle(h), minstret(h)
 
     // U mode CSR
-    setRegNoEffectWithMask(context, RV32, pms, CSR_USTATUS, r.ustatus);
+    setRegWithMask(context, RV32, pms, CSR_USTATUS, r.ustatus);
     setRegWithMask(context, RV32, pms, CSR_UIE, r.uie);
     setRegWithMask(context, RV32, pms, CSR_UIP, r.uip);
     context->setMiscRegNoEffect(
@@ -383,7 +383,7 @@ RemoteGDB::Riscv32GdbRegCache::setRegs(ThreadContext *context) const
         CSRData.at(CSR_UTVAL).physIndex, r.utval);
 
     // S mode CSR
-    setRegNoEffectWithMask(context, RV32, pms, CSR_SSTATUS, r.sstatus);
+    setRegWithMask(context, RV32, pms, CSR_SSTATUS, r.sstatus);
     setRegWithMask(context, RV32, pms, CSR_SIE, r.sie);
     setRegWithMask(context, RV32, pms, CSR_SIP, r.sip);
     context->setMiscRegNoEffect(
@@ -406,7 +406,7 @@ RemoteGDB::Riscv32GdbRegCache::setRegs(ThreadContext *context) const
         CSRData.at(CSR_SATP).physIndex, r.satp);
 
     // M mode CSR
-    setRegNoEffectWithMask(context, RV32, pms, CSR_MSTATUS, r.mstatus);
+    setRegWithMask(context, RV32, pms, CSR_MSTATUS, r.mstatus);
     setRegNoEffectWithMask(context, RV32, pms, CSR_MISA, r.misa);
     setRegWithMask(context, RV32, pms, CSR_MIE, r.mie);
     setRegWithMask(context, RV32, pms, CSR_MIP, r.mip);
@@ -559,7 +559,7 @@ RemoteGDB::Riscv64GdbRegCache::setRegs(ThreadContext *context) const
     // TODO: implement CSR counter registers for mcycle, minstret
 
     // U mode CSR
-    setRegNoEffectWithMask(context, RV64, pms, CSR_USTATUS, r.ustatus);
+    setRegWithMask(context, RV64, pms, CSR_USTATUS, r.ustatus);
     setRegWithMask(context, RV64, pms, CSR_UIE, r.uie);
     setRegWithMask(context, RV64, pms, CSR_UIP, r.uip);
     context->setMiscRegNoEffect(
@@ -574,8 +574,7 @@ RemoteGDB::Riscv64GdbRegCache::setRegs(ThreadContext *context) const
         CSRData.at(CSR_UTVAL).physIndex, r.utval);
 
     // S mode CSR
-    setRegNoEffectWithMask(
-        context, RV64, pms, CSR_SSTATUS, r.sstatus);
+    setRegWithMask(context, RV64, pms, CSR_SSTATUS, r.sstatus);
     setRegWithMask(context, RV64, pms, CSR_SIE, r.sie);
     setRegWithMask(context, RV64, pms, CSR_SIP, r.sip);
     context->setMiscRegNoEffect(
@@ -598,8 +597,7 @@ RemoteGDB::Riscv64GdbRegCache::setRegs(ThreadContext *context) const
         CSRData.at(CSR_SATP).physIndex, r.satp);
 
     // M mode CSR
-    setRegNoEffectWithMask(
-        context, RV64, pms, CSR_MSTATUS, r.mstatus);
+    setRegWithMask(context, RV64, pms, CSR_MSTATUS, r.mstatus);
     setRegNoEffectWithMask(context, RV64, pms, CSR_MISA, r.misa);
     setRegWithMask(context, RV64, pms, CSR_MIE, r.mie);
     setRegWithMask(context, RV64, pms, CSR_MIP, r.mip);


### PR DESCRIPTION
The gem5 crashed when user try to update register value from GDB because PR[1] changes the index of CSR_XSTATUS to MISCREG_XSTATUS, which is out of NUM_PHYS_MISCREGS.

The CSR_XSTATUS should use setRegWithMask to update it.

[1] : https://github.com/gem5/gem5/pull/1099

gem5 issue: https://github.com/gem5/gem5/issues/1299

Change-Id: Iefc0d1f5adfb98ecfda0e74907964b47d1864b6d