### PR TITLE
misc, tests: Fix missing 's' in GPU tests

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -186,7 +186,7 @@ jobs:
         needs:
             - testlib-very-long-tests
             - dramsys-tests
-            - LULESH-test
-            - HACC-test
+            - LULESH-tests
+            - HACC-tests
         steps:
             - run: echo "This weekly tests have passed."


### PR DESCRIPTION
This caused the weekly tests to fail. It's 'tests' not 'test'.

Change-Id: Ib01d2c4cc3aa51c137d13453ef8c8628f57c9adf