### PR TITLE
misc: Add 'scheduler.yaml' workflow

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -4,10 +4,7 @@
 name: Compiler Tests
 
 on:
-  # Runs every Friday from 7AM UTC
-    schedule:
-        - cron: 00 7 * * 5
-  # Allows us to manually start workflow for testing
+    # This is triggered weekly via the 'scheduler.yaml' workflow.
     workflow_dispatch:
 
 jobs:
@@ -25,10 +22,6 @@ jobs:
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.image }}
               run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j$(nproc)
               timeout-minutes: 600 # 10 hours
@@ -47,10 +40,6 @@ jobs:
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: Compile build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} with ${{ matrix.image }}
               run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} -j$(nproc)
               timeout-minutes: 600 # 10 hours

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -4,10 +4,7 @@
 name: Daily Tests
 
 on:
-  # Runs every day from 7AM UTC
-    schedule:
-        - cron: 0 7 * * *
-  # Allows us to manually start workflow for testing
+    # This is triggered weekly via the 'scheduler.yaml' workflow.
     workflow_dispatch:
 
 jobs:
@@ -49,10 +46,6 @@ jobs:
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         steps:
             - uses: actions/checkout@v4
-              with:
-          # Scheduled workflows run on the default branch by default. We
-          # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: defconfig gem5
               if: ${{ matrix.setconfig-option  != '' }}
               run: scons defconfig build/${{ matrix.image }} build_opts/${{ matrix.isa-option }}
@@ -96,10 +89,6 @@ jobs:
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v4
-              with:
-          # Scheduled workflows run on the default branch by default. We
-          # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: ALL/unittests.${{ matrix.type }} UnitTests
               run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
 
@@ -118,10 +107,6 @@ jobs:
             - name: Clean runner
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             # download all artifacts for each test. Thoguh this is inelegant,
             # it's simpler than figuring otu which long tests requires which
             # binary.
@@ -163,10 +148,6 @@ jobs:
             - name: Clean runner
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - uses: actions/download-artifact@v4.0.0
               with:
                   name: ${{needs.name-artifacts.outputs.build-name}}ALL
@@ -195,10 +176,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: Build RISCV/libgem5_opt.so with SST
               run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style -j $(nproc)
             - name: Makefile ext/sst
@@ -220,10 +197,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: Build ARM/gem5.opt
               run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources -j$(nproc)
             - name: disable systemc
@@ -246,10 +219,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              with:
-        # Scheduled workflows run on the default branch by default. We
-        # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: Compile build/VEGA_X86/gem5.opt
               run: scons build/VEGA_X86/gem5.opt -j $(nproc)
             - name: Get Square test-prog from gem5-resources

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -1,0 +1,91 @@
+---
+name: Workflow Scheduler
+
+# GitHub scheduled workflows run on the default branch ('stable' in the case of
+# gem5). this means for changes in a workflow to take effect, the default
+# branch must be updated. This is not ideal as it requires regular commits into
+# the stable branch. Ideally we just want to update the workflow on develop and
+# have it run on the develop branch.
+#
+# This workflow is designed to run on the stable branch and will trigger other
+# workflows on the develop branch.
+#
+# To do so we simply schedule this workflow to run every hour and use some
+# simple bash logic to determine if the current time is when we want to run the
+# other workflows.
+
+on:
+    schedule:
+    # Runs every hour, 30 minutes past the hour.
+        - cron: 30 * * * *
+
+env:
+  # This is the token used to authenticate with GitHub.
+  # It is required to run the `gh` CLI.
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+    schedule-workflows:
+        runs-on: ubuntu-latest
+        steps:
+            # This step is necessary to allow the `gh` CLI to be used in the
+            # following steps. The `gh` CLI is used to trigger the workflows.
+            # and needs to be used inside a the same repository where the
+            # workflows are defined.
+            - name: Checkout Repository
+              uses: actions/checkout@v4
+
+            - name: Record day and time
+              id: timedate-recorder
+              run: |
+                  # `date +H` returns the current hour as a number from
+                  # `00` to `23`.
+                  echo "HOUR=$(date +%H)" >> $GITHUB_OUTPUT
+
+                  # `date +%u` returns the day of the week as a number from
+                  # `1` to `7`.
+                  # `1` is Monday and `7` is Sunday.
+                  echo "DAY=$(date +%u)" >> $GITHUB_OUTPUT
+
+            - name: Daily Tests
+              env:
+                  HOUR: ${{ steps.timedate-recorder.outputs.HOUR }}
+              run: |
+                  # If current time is 7pm then run the workflow.
+                  if [[ $HOUR  == '19' ]]
+                  then
+                    gh workflow run daily-tests.yaml --ref develop >/dev/null
+                    echo "Daily test scheduled to run on develop branch."
+                  else
+                    echo "Daily tests not scheduled."
+                  fi
+
+            - name: Weekly Tests
+              env:
+                  DAY: ${{ steps.timedate-recorder.outputs.DAY }}
+                  HOUR: ${{ steps.timedate-recorder.outputs.HOUR }}
+              run: |
+                  # If the current day is Friday and the time is 7pm then run
+                  # the workflow.
+                  if [[ $DAY == '5' ]] && [[ $HOUR  == '19' ]]
+                  then
+                    gh workflow run weekly-tests.yaml --ref develop >/dev/null
+                    echo "Weekly test scheduled to run on develop branch."
+                  else
+                    echo "Weekly tests not scheduled."
+                  fi
+
+            - name: Compiler Tests
+              env:
+                  DAY: ${{ steps.timedate-recorder.outputs.DAY }}
+                  HOUR: ${{ steps.timedate-recorder.outputs.HOUR }}
+              run: |
+                  # If the current day is Tuesday and the time is 9pm then run
+                  # the workflow.
+                  if [[ $DAY == '2' ]] && [[ $HOUR  == '21' ]]
+                  then
+                    gh workflow run compiler-tests.yaml --ref develop >/dev/null
+                    echo "Compiler tests scheduled to run on the develop branch."
+                  else
+                    echo "Compiler tests not scheduled."
+                  fi

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -4,10 +4,7 @@
 name: Weekly Tests
 
 on:
-    # Runs every Sunday from 7AM UTC
-    schedule:
-        - cron: 00 7 * * 6
-    # Allows us to manually start workflow for testing
+    # This is triggered weekly via the 'scheduler.yaml' workflow.
     workflow_dispatch:
 
 jobs:
@@ -16,10 +13,6 @@ jobs:
         container: ghcr.io/gem5/gcn-gpu:latest
         steps:
             - uses: actions/checkout@v4
-              with:
-                  # Scheduled workflows run on the default branch by default. We
-                  # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - name: Build gem5
               run: scons build/VEGA_X86/gem5.opt -j $(nproc) --ignore-style
             - uses: actions/upload-artifact@v4
@@ -36,10 +29,6 @@ jobs:
         timeout-minutes: 480 # 8 hours
         steps:
             - uses: actions/checkout@v4
-              with:
-                  # Scheduled workflows run on the default branch by default. We
-                  # therefore need to explicitly checkout the develop branch.
-                  ref: develop
 
             - name: Download build/VEGA_X86/gem5.opt
               uses: actions/download-artifact@v4
@@ -68,10 +57,6 @@ jobs:
         timeout-minutes: 120 # 2 hours
         steps:
             - uses: actions/checkout@v4
-              with:
-                  # Scheduled workflows run on the default branch by default. We
-                  # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - uses: actions/download-artifact@v4
               with:
                   name: weekly-test-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gem5-build-vega
@@ -97,10 +82,6 @@ jobs:
             build-name: ${{ steps.artifact-name.outputs.name }}
         steps:
             - uses: actions/checkout@v4
-              with:
-                  # Scheduled workflows run on the default branch by default. We
-                  # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - id: artifact-name
               run: echo "name=$(date +"%Y-%m-%d_%H.%M.%S")-ALL" >> $GITHUB_OUTPUT
             - name: Build gem5
@@ -127,10 +108,6 @@ jobs:
             - name: Clean runner
               run: rm -rf ./* || true rm -rf ./.??* || true rm -rf ~/.cache || true
             - uses: actions/checkout@v4
-              with:
-                  # Scheduled workflows run on the default branch by default. We
-                  # therefore need to explicitly checkout the develop branch.
-                  ref: develop
             - uses: actions/download-artifact@v4
               with:
                   name: ${{needs.build-gem5.outputs.build-name}}
@@ -156,11 +133,6 @@ jobs:
         timeout-minutes: 4320 # 3 days
         steps:
             - uses: actions/checkout@v4
-              with:
-                  # Scheduled workflows run on the default branch by default. We
-                  # therefore need to explicitly checkout the develop branch.
-                  ref: develop
-
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
               run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.0 --depth 1 DRAMSys


### PR DESCRIPTION
This is made to run on the 'stable' branch to schedule workflow runs on the `develop` branch. This solves the problem of GitHub Workflows being scheduled to only run on 'stable' branch' thus ignoring changes made to them on 'develop'
