### PR TITLE
arch-arm: Properly implement IPASpace in the MMU

### DIFF
--- a/src/arch/arm/insts/misc.cc
+++ b/src/arch/arm/insts/misc.cc
@@ -411,12 +411,13 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
-            TLBIALL tlbiOp(TranslationRegime::EL10, secure);
+            TLBIALL tlbiOp(TranslationRegime::EL10, ss);
             if (shareable) {
                 tlbiOp.broadcast(tc);
             } else {
@@ -429,8 +430,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIALL tlbiOp(TranslationRegime::EL10, secure);
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIALL tlbiOp(TranslationRegime::EL10, ss);
             tlbiOp.broadcast(tc);
             return;
         }
@@ -440,12 +442,13 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
-            ITLBIALL tlbiOp(TranslationRegime::EL10, secure);
+            ITLBIALL tlbiOp(TranslationRegime::EL10, ss);
             if (shareable) {
                 tlbiOp.broadcast(tc);
             } else {
@@ -459,12 +462,13 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
-            DTLBIALL tlbiOp(TranslationRegime::EL10, secure);
+            DTLBIALL tlbiOp(TranslationRegime::EL10, ss);
             if (shareable) {
                 tlbiOp.broadcast(tc);
             } else {
@@ -478,13 +482,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
             TLBIMVA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            mbits(value, 31, 12),
                            bits(value, 7, 0),
                            false);
@@ -502,13 +507,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
             TLBIMVA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            mbits(value, 31, 12),
                            bits(value, 7, 0),
                            true);
@@ -525,9 +531,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIMVA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            mbits(value, 31, 12),
                            bits(value, 7, 0),
                            false);
@@ -540,9 +547,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIMVA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            mbits(value, 31, 12),
                            bits(value, 7, 0),
                            true);
@@ -556,13 +564,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
             TLBIASID tlbiOp(TranslationRegime::EL10,
-                            secure,
+                            ss,
                             bits(value, 7, 0));
 
             if (shareable) {
@@ -577,9 +586,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIASID tlbiOp(TranslationRegime::EL10,
-                            secure,
+                            ss,
                             bits(value, 7, 0));
 
             tlbiOp.broadcast(tc);
@@ -591,11 +601,12 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
-            TLBIMVAA tlbiOp(TranslationRegime::EL10, secure,
+            TLBIMVAA tlbiOp(TranslationRegime::EL10, ss,
                             mbits(value, 31, 12), false);
 
             if (shareable) {
@@ -611,12 +622,13 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
-            TLBIMVAA tlbiOp(TranslationRegime::EL10, secure,
+            TLBIMVAA tlbiOp(TranslationRegime::EL10, ss,
                             mbits(value, 31, 12), true);
 
             if (shareable) {
@@ -631,8 +643,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIMVAA tlbiOp(TranslationRegime::EL10, secure,
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIMVAA tlbiOp(TranslationRegime::EL10, ss,
                             mbits(value, 31, 12), false);
 
             tlbiOp.broadcast(tc);
@@ -643,8 +656,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIMVAA tlbiOp(TranslationRegime::EL10, secure,
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIMVAA tlbiOp(TranslationRegime::EL10, ss,
                             mbits(value, 31, 12), true);
 
             tlbiOp.broadcast(tc);
@@ -655,8 +669,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIMVAA tlbiOp(TranslationRegime::EL2, secure,
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIMVAA tlbiOp(TranslationRegime::EL2, ss,
                             mbits(value, 31, 12), false);
 
             tlbiOp(tc);
@@ -667,8 +682,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIMVAA tlbiOp(TranslationRegime::EL2, secure,
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIMVAA tlbiOp(TranslationRegime::EL2, ss,
                             mbits(value, 31, 12), true);
 
             tlbiOp(tc);
@@ -679,8 +695,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIMVAA tlbiOp(TranslationRegime::EL2, secure,
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIMVAA tlbiOp(TranslationRegime::EL2, ss,
                             mbits(value, 31, 12), false);
 
             tlbiOp.broadcast(tc);
@@ -691,8 +708,9 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
-            TLBIMVAA tlbiOp(TranslationRegime::EL2, secure,
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
+            TLBIMVAA tlbiOp(TranslationRegime::EL2, ss,
                             mbits(value, 31, 12), true);
 
             tlbiOp.broadcast(tc);
@@ -703,9 +721,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIIPA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            static_cast<Addr>(bits(value, 35, 0)) << 12,
                            false);
 
@@ -718,9 +737,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIIPA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            static_cast<Addr>(bits(value, 35, 0)) << 12,
                            true);
 
@@ -733,9 +753,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIIPA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            static_cast<Addr>(bits(value, 35, 0)) << 12,
                            false);
 
@@ -748,9 +769,10 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
         {
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             TLBIIPA tlbiOp(TranslationRegime::EL10,
-                           secure,
+                           ss,
                            static_cast<Addr>(bits(value, 35, 0)) << 12,
                            true);
 
@@ -763,12 +785,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
+
             ITLBIMVA tlbiOp(TranslationRegime::EL10,
-                            secure,
+                            ss,
                             mbits(value, 31, 12),
                             bits(value, 7, 0));
 
@@ -785,13 +809,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
             DTLBIMVA tlbiOp(TranslationRegime::EL10,
-                            secure,
+                            ss,
                             mbits(value, 31, 12),
                             bits(value, 7, 0));
 
@@ -808,13 +833,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
             ITLBIASID tlbiOp(TranslationRegime::EL10,
-                             secure,
+                             ss,
                              bits(value, 7, 0));
 
             if (shareable) {
@@ -830,13 +856,14 @@ TlbiOp::performTlbi(ExecContext *xc, MiscRegIndex dest_idx, RegVal value) const
             HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
             SCR scr = tc->readMiscReg(MISCREG_SCR_EL3);
 
-            bool secure = release->has(ArmExtension::SECURITY) && !scr.ns;
+            auto ss = release->has(ArmExtension::SECURITY) && !scr.ns ?
+                SecurityState::Secure : SecurityState::NonSecure;
             // Check for Force Broadcast. Ignored if HCR_EL2.TGE == 1
             bool shareable = currEL(tc) == EL1 && EL2Enabled(tc) &&
                 hcr.fb && !hcr.tge;
 
             DTLBIASID tlbiOp(TranslationRegime::EL10,
-                             secure,
+                             ss,
                              bits(value, 7, 0));
 
             if (shareable) {

--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -339,14 +339,7 @@ TlbiOp64::tlbiIpaS2(ThreadContext *tc, RegVal value,
     bool last_level, TlbiAttr attrs)
 {
     if (EL2Enabled(tc)) {
-        if (ss == SecurityState::Secure && bits(value, 63)) {
-            ss = SecurityState::NonSecure;
-        }
-
-        const int top_bit = ArmSystem::physAddrRange(tc) == 52 ?
-            39 : 35;
-        TLBIIPA tlbi_op(TranslationRegime::EL10, ss,
-            static_cast<Addr>(bits(value, top_bit, 0)) << 12,
+        TLBIIPA tlbi_op(tc, TranslationRegime::EL10, ss, value,
             last_level, attrs);
 
         if (shareable) {
@@ -398,11 +391,7 @@ TlbiOp64::tlbiRipaS2(ThreadContext *tc, RegVal value,
     bool last_level, TlbiAttr attrs)
 {
     if (EL2Enabled(tc)) {
-        if (ss == SecurityState::Secure && bits(value, 63)) {
-            ss = SecurityState::NonSecure;
-        }
-
-        TLBIRIPA tlbi_op(TranslationRegime::EL10, ss, value,
+        TLBIRIPA tlbi_op(tc, TranslationRegime::EL10, ss, value,
             last_level, attrs);
 
         if (shareable) {

--- a/src/arch/arm/insts/misc64.hh
+++ b/src/arch/arm/insts/misc64.hh
@@ -292,40 +292,40 @@ class TlbiOp64 : public MiscRegRegImmOp64
     static std::unordered_map<ArmISA::MiscRegIndex, TlbiFunc> tlbiOps;
 
     static void tlbiAll(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiVmall(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool stage2=false, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, bool stage2=false, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiVa(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool last_level, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, bool last_level, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiVaa(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool last_level, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, bool last_level, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiAsid(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiIpaS2(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool last_level, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, bool last_level, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiRvaa(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool last_level, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, bool last_level, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiRva(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool last_level, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable,  bool last_level, TlbiAttr attrs=TlbiAttr::None);
 
     static void tlbiRipaS2(ThreadContext *tc, RegVal value,
-        bool secure, ArmISA::TranslationRegime regime, bool shareable,
-        bool last_level, TlbiAttr attrs=TlbiAttr::None);
+        ArmISA::SecurityState ss, ArmISA::TranslationRegime regime,
+        bool shareable, bool last_level, TlbiAttr attrs=TlbiAttr::None);
 
     static bool fnxsAttrs(ThreadContext *tc);
 

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -412,12 +412,14 @@ class MMU : public BaseMMU
     Fault getTE(TlbEntry **te, const RequestPtr &req,
                 ThreadContext *tc, Mode mode,
                 Translation *translation, bool timing, bool functional,
-                SecurityState ss, ArmTranslationType tran_type,
+                SecurityState ss, PASpace ipaspace,
+                ArmTranslationType tran_type,
                 bool stage2);
     Fault getTE(TlbEntry **te, const RequestPtr &req,
                 ThreadContext *tc, Mode mode,
                 Translation *translation, bool timing, bool functional,
-                SecurityState ss, ArmTranslationType tran_type,
+                SecurityState ss, PASpace ipaspace,
+                ArmTranslationType tran_type,
                 CachedState &state);
 
     Fault getResultTe(TlbEntry **te, const RequestPtr &req,

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -306,7 +306,7 @@ class MMU : public BaseMMU
         }
 
         if (tlbi_op.stage2Flush()) {
-            flushStage2(tlbi_op.makeStage2());
+            flushStage2(tlbi_op);
         }
     }
 

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -149,7 +149,7 @@ class MMU : public BaseMMU
             sctlr = rhs.sctlr;
             scr = rhs.scr;
             isPriv = rhs.isPriv;
-            isSecure = rhs.isSecure;
+            securityState = rhs.securityState;
             ttbcr = rhs.ttbcr;
             asid = rhs.asid;
             vmid = rhs.vmid;
@@ -184,7 +184,7 @@ class MMU : public BaseMMU
         SCTLR sctlr = 0;
         SCR scr = 0;
         bool isPriv = false;
-        bool isSecure = false;
+        SecurityState securityState = SecurityState::NonSecure;
         TTBCR ttbcr = 0;
         uint16_t asid = 0;
         vmid_t vmid = 0;
@@ -397,7 +397,7 @@ class MMU : public BaseMMU
      * @param vpn virtual address
      * @param asn context id/address space id to use
      * @param vmid The virtual machine ID used for stage 2 translation
-     * @param secure if the lookup is secure
+     * @param ss security state of the PE
      * @param functional if the lookup should modify state
      * @param ignore_asn if on lookup asn should be ignored
      * @param target_regime selecting the translation regime
@@ -405,19 +405,19 @@ class MMU : public BaseMMU
      * @return pointer to TLB entry if it exists
      */
     TlbEntry *lookup(Addr vpn, uint16_t asn, vmid_t vmid,
-                     bool secure, bool functional,
+                     SecurityState ss, bool functional,
                      bool ignore_asn, TranslationRegime target_regime,
                      bool stage2, BaseMMU::Mode mode);
 
     Fault getTE(TlbEntry **te, const RequestPtr &req,
                 ThreadContext *tc, Mode mode,
                 Translation *translation, bool timing, bool functional,
-                bool is_secure, ArmTranslationType tran_type,
+                SecurityState ss, ArmTranslationType tran_type,
                 bool stage2);
     Fault getTE(TlbEntry **te, const RequestPtr &req,
                 ThreadContext *tc, Mode mode,
                 Translation *translation, bool timing, bool functional,
-                bool is_secure, ArmTranslationType tran_type,
+                SecurityState ss, ArmTranslationType tran_type,
                 CachedState &state);
 
     Fault getResultTe(TlbEntry **te, const RequestPtr &req,

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -241,6 +241,8 @@ struct TlbEntry : public Serializable
     bool ns;
     // Security state of the translation regime
     SecurityState ss;
+    // IPA Space (stage2 entries only)
+    PASpace ipaSpace;
     // Translation regime on insert, AARCH64 EL0&1, AARCH32 -> el=1
     TranslationRegime regime;
     // This is used to distinguish between instruction and data entries
@@ -272,6 +274,7 @@ struct TlbEntry : public Serializable
          domain(DomainType::Client),  mtype(MemoryType::StronglyOrdered),
          longDescFormat(false), global(false), valid(true),
          ns(true), ss(SecurityState::NonSecure),
+         ipaSpace(PASpace::NonSecure),
          regime(TranslationRegime::EL10),
          type(TypeTLB::unified), partial(false),
          nonCacheable(uncacheable),
@@ -292,6 +295,7 @@ struct TlbEntry : public Serializable
          domain(DomainType::Client), mtype(MemoryType::StronglyOrdered),
          longDescFormat(false), global(false), valid(false),
          ns(true), ss(SecurityState::NonSecure),
+         ipaSpace(PASpace::NonSecure),
          regime(TranslationRegime::EL10),
          type(TypeTLB::unified), partial(false), nonCacheable(false),
          shareable(false), outerShareable(false), xn(0), pxn(0),

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -199,7 +199,7 @@ struct TlbEntry : public Serializable
         // The virtual machine ID used for stage 2 translation
         vmid_t vmid = 0;
         // if the lookup is secure
-        bool secure = false;
+        SecurityState ss = SecurityState::NonSecure;
         // if the lookup should modify state
         bool functional = false;
         // selecting the translation regime
@@ -239,8 +239,8 @@ struct TlbEntry : public Serializable
 
     // True if the entry targets the non-secure physical address space
     bool ns;
-    // True if the entry was brought in from a non-secure page table
-    bool nstid;
+    // Security state of the translation regime
+    SecurityState ss;
     // Translation regime on insert, AARCH64 EL0&1, AARCH32 -> el=1
     TranslationRegime regime;
     // This is used to distinguish between instruction and data entries
@@ -271,7 +271,8 @@ struct TlbEntry : public Serializable
          innerAttrs(0), outerAttrs(0), ap(read_only ? 0x3 : 0), hap(0x3),
          domain(DomainType::Client),  mtype(MemoryType::StronglyOrdered),
          longDescFormat(false), global(false), valid(true),
-         ns(true), nstid(true), regime(TranslationRegime::EL10),
+         ns(true), ss(SecurityState::NonSecure),
+         regime(TranslationRegime::EL10),
          type(TypeTLB::unified), partial(false),
          nonCacheable(uncacheable),
          shareable(false), outerShareable(false), xn(0), pxn(0),
@@ -290,7 +291,8 @@ struct TlbEntry : public Serializable
          innerAttrs(0), outerAttrs(0), ap(0), hap(0x3),
          domain(DomainType::Client), mtype(MemoryType::StronglyOrdered),
          longDescFormat(false), global(false), valid(false),
-         ns(true), nstid(true), regime(TranslationRegime::EL10),
+         ns(true), ss(SecurityState::NonSecure),
+         regime(TranslationRegime::EL10),
          type(TypeTLB::unified), partial(false), nonCacheable(false),
          shareable(false), outerShareable(false), xn(0), pxn(0),
          xs(true)
@@ -330,8 +332,7 @@ struct TlbEntry : public Serializable
     match(const Lookup &lookup) const
     {
         bool match = false;
-        if (valid && matchAddress(lookup) &&
-            (lookup.secure == !nstid))
+        if (valid && matchAddress(lookup) && lookup.ss == ss)
         {
             match = checkRegime(lookup.targetRegime);
 
@@ -410,8 +411,8 @@ struct TlbEntry : public Serializable
     print() const
     {
         return csprintf("%#x, asn %d vmn %d ppn %#x size: %#x ap:%d "
-                        "ns:%d nstid:%d g:%d xs: %d regime:%s", vpn << N, asid, vmid,
-                        pfn << N, size, ap, ns, nstid, global,
+                        "ns:%d ss:%s g:%d xs: %d regime:%s", vpn << N, asid, vmid,
+                        pfn << N, size, ap, ns, ss, global,
                         xs, regimeToStr(regime));
     }
 
@@ -428,7 +429,7 @@ struct TlbEntry : public Serializable
         SERIALIZE_SCALAR(global);
         SERIALIZE_SCALAR(valid);
         SERIALIZE_SCALAR(ns);
-        SERIALIZE_SCALAR(nstid);
+        SERIALIZE_ENUM(ss);
         SERIALIZE_ENUM(type);
         SERIALIZE_SCALAR(nonCacheable);
         SERIALIZE_ENUM(lookupLevel);
@@ -458,7 +459,7 @@ struct TlbEntry : public Serializable
         UNSERIALIZE_SCALAR(global);
         UNSERIALIZE_SCALAR(valid);
         UNSERIALIZE_SCALAR(ns);
-        UNSERIALIZE_SCALAR(nstid);
+        UNSERIALIZE_ENUM(ss);
         UNSERIALIZE_ENUM(type);
         UNSERIALIZE_SCALAR(nonCacheable);
         UNSERIALIZE_ENUM(lookupLevel);

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -655,6 +655,10 @@ namespace ArmISA
         Bitfield<19> vs;     // Only defined for VTCR_EL2
         Bitfield<21> ha;     // Only defined for VTCR_EL2
         Bitfield<22> hd;     // Only defined for VTCR_EL2
+        Bitfield<29> nsw;    // Only defined for VTCR_EL2
+        Bitfield<29> sw;     // Only defined for VSTCR_EL2
+        Bitfield<30> nsa;    // Only defined for VTCR_EL2
+        Bitfield<30> sa;     // Only defined for VSTCR_EL2
     EndBitUnion(VTCR_t)
 
     BitUnion32(PRRR)

--- a/src/arch/arm/stage2_lookup.cc
+++ b/src/arch/arm/stage2_lookup.cc
@@ -57,7 +57,7 @@ Fault
 Stage2LookUp::getTe(ThreadContext *tc, TlbEntry *destTe)
 {
     fault = mmu->getTE(&stage2Te, req, tc, mode, this, timing,
-        functional, secure, tranType, true);
+        functional, ss, tranType, true);
 
     // Call finish if we're done already
     if ((fault != NoFault) || (stage2Te != NULL)) {
@@ -193,7 +193,7 @@ Stage2LookUp::finish(const Fault &_fault, const RequestPtr &req,
     if ((fault == NoFault) && (stage2Te == NULL)) {
         // OLD_LOOK: stage2Tlb
         fault = mmu->getTE(&stage2Te, req, tc, mode, this,
-            timing, functional, secure, tranType, true);
+            timing, functional, ss, tranType, true);
     }
 
     // Now we have the stage 2 table entry we need to merge it with the stage

--- a/src/arch/arm/stage2_lookup.cc
+++ b/src/arch/arm/stage2_lookup.cc
@@ -57,7 +57,7 @@ Fault
 Stage2LookUp::getTe(ThreadContext *tc, TlbEntry *destTe)
 {
     fault = mmu->getTE(&stage2Te, req, tc, mode, this, timing,
-        functional, ss, tranType, true);
+        functional, ss, ipaSpace, tranType, true);
 
     // Call finish if we're done already
     if ((fault != NoFault) || (stage2Te != NULL)) {
@@ -193,7 +193,7 @@ Stage2LookUp::finish(const Fault &_fault, const RequestPtr &req,
     if ((fault == NoFault) && (stage2Te == NULL)) {
         // OLD_LOOK: stage2Tlb
         fault = mmu->getTE(&stage2Te, req, tc, mode, this,
-            timing, functional, ss, tranType, true);
+            timing, functional, ss, ipaSpace, tranType, true);
     }
 
     // Now we have the stage 2 table entry we need to merge it with the stage

--- a/src/arch/arm/stage2_lookup.hh
+++ b/src/arch/arm/stage2_lookup.hh
@@ -73,6 +73,7 @@ class Stage2LookUp : public BaseMMU::Translation
     bool                    complete;
     bool                    selfDelete;
     SecurityState           ss;
+    PASpace                 ipaSpace;
 
   public:
     Stage2LookUp(MMU *_mmu, TlbEntry s1_te, const RequestPtr &_req,
@@ -82,7 +83,8 @@ class Stage2LookUp : public BaseMMU::Translation
       : mmu(_mmu), stage1Te(s1_te), s1Req(_req),
         transState(_transState), mode(_mode), timing(_timing),
         functional(_functional), tranType(_tranType), stage2Te(nullptr),
-        fault(NoFault), complete(false), selfDelete(false), ss(_ss)
+        fault(NoFault), complete(false), selfDelete(false), ss(_ss),
+        ipaSpace(s1_te.ns ? PASpace::NonSecure : PASpace::Secure)
     {
         req = std::make_shared<Request>();
         req->setVirt(s1_te.pAddr(s1Req->getVaddr()), s1Req->getSize(),

--- a/src/arch/arm/stage2_lookup.hh
+++ b/src/arch/arm/stage2_lookup.hh
@@ -72,16 +72,17 @@ class Stage2LookUp : public BaseMMU::Translation
     Fault                   fault;
     bool                    complete;
     bool                    selfDelete;
-    bool                    secure;
+    SecurityState           ss;
 
   public:
     Stage2LookUp(MMU *_mmu, TlbEntry s1_te, const RequestPtr &_req,
         MMU::Translation *_transState, BaseMMU::Mode _mode, bool _timing,
-        bool _functional, bool _secure, MMU::ArmTranslationType _tranType) :
-        mmu(_mmu), stage1Te(s1_te), s1Req(_req),
+        bool _functional, SecurityState _ss,
+        MMU::ArmTranslationType _tranType)
+      : mmu(_mmu), stage1Te(s1_te), s1Req(_req),
         transState(_transState), mode(_mode), timing(_timing),
         functional(_functional), tranType(_tranType), stage2Te(nullptr),
-        fault(NoFault), complete(false), selfDelete(false), secure(_secure)
+        fault(NoFault), complete(false), selfDelete(false), ss(_ss)
     {
         req = std::make_shared<Request>();
         req->setVirt(s1_te.pAddr(s1Req->getVaddr()), s1Req->getSize(),

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -843,6 +843,7 @@ TableWalker::processWalkLPAE()
     currState->longDesc.lookupLevel = start_lookup_level;
     currState->longDesc.aarch64 = false;
     currState->longDesc.grainSize = Grain4KB;
+    currState->longDesc.isStage2 = isStage2;
 
     fetchDescriptor(
         desc_addr, currState->longDesc,
@@ -1095,6 +1096,7 @@ TableWalker::processWalkAArch64()
     currState->longDesc.aarch64 = true;
     currState->longDesc.grainSize = tg;
     currState->longDesc.physAddrRange = _physAddrRange;
+    currState->longDesc.isStage2 = isStage2;
 
     fetchDescriptor(desc_addr, currState->longDesc,
                     sizeof(uint64_t), flag, start_lookup_level,

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -436,7 +436,7 @@ class TableWalker : public ClockedObject
 
         LongDescriptor()
           : data(0), _dirty(false), aarch64(false), grainSize(Grain4KB),
-            physAddrRange(0)
+            physAddrRange(0), isStage2(false)
         {}
 
         /** The raw bits of the entry */
@@ -453,6 +453,8 @@ class TableWalker : public ClockedObject
         GrainSize grainSize;
 
         uint8_t physAddrRange;
+
+        bool isStage2;
 
         uint8_t*
         getRawPtr() override

--- a/src/arch/arm/tlb.cc
+++ b/src/arch/arm/tlb.cc
@@ -160,15 +160,16 @@ TLB::lookup(const Lookup &lookup_data)
 
     TlbEntry *retval = match(lookup_data);
 
-    DPRINTF(TLBVerbose, "Lookup %#x, asn %#x -> %s vmn 0x%x secure %d "
-            "ppn %#x size: %#x pa: %#x ap:%d ns:%d nstid:%d g:%d asid: %d "
+    DPRINTF(TLBVerbose, "Lookup %#x, asn %#x -> %s vmn 0x%x ss %s "
+            "ppn %#x size: %#x pa: %#x ap:%d ns:%d ss:%s g:%d asid: %d "
             "xs: %d regime: %s\n",
             lookup_data.va, lookup_data.asn, retval ? "hit" : "miss",
-            lookup_data.vmid, lookup_data.secure,
+            lookup_data.vmid, lookup_data.ss,
             retval ? retval->pfn       : 0, retval ? retval->size  : 0,
             retval ? retval->pAddr(lookup_data.va) : 0,
             retval ? retval->ap        : 0,
-            retval ? retval->ns        : 0, retval ? retval->nstid : 0,
+            retval ? retval->ns        : 0,
+            retval ? retval->ss : SecurityState::NonSecure,
             retval ? retval->global    : 0, retval ? retval->asid  : 0,
             retval ? retval->xs : 0,
             retval ? regimeToStr(retval->regime) : "None");
@@ -243,19 +244,19 @@ TLB::insert(TlbEntry &entry)
 {
     DPRINTF(TLB, "Inserting entry into TLB with pfn:%#x size:%#x vpn: %#x"
             " asid:%d vmid:%d N:%d global:%d valid:%d nc:%d xn:%d"
-            " ap:%#x domain:%#x ns:%d nstid:%d, xs:%d regime: %s\n", entry.pfn,
+            " ap:%#x domain:%#x ns:%d ss:%s xs:%d regime: %s\n", entry.pfn,
             entry.size, entry.vpn, entry.asid, entry.vmid, entry.N,
             entry.global, entry.valid, entry.nonCacheable, entry.xn,
             entry.ap, static_cast<uint8_t>(entry.domain), entry.ns,
-            entry.nstid, entry.xs, regimeToStr(entry.regime));
+            entry.ss, entry.xs, regimeToStr(entry.regime));
 
     if (table[size - 1].valid)
         DPRINTF(TLB, " - Replacing Valid entry %#x, asn %d vmn %d ppn %#x "
-                "size: %#x ap:%d ns:%d nstid:%d g:%d xs:%d regime: %s\n",
+                "size: %#x ap:%d ns:%d ss:%s g:%d xs:%d regime: %s\n",
                 table[size-1].vpn << table[size-1].N, table[size-1].asid,
                 table[size-1].vmid, table[size-1].pfn << table[size-1].N,
                 table[size-1].size, table[size-1].ap, table[size-1].ns,
-                table[size-1].nstid, table[size-1].global,
+                table[size-1].ss, table[size-1].global,
                 table[size-1].xs, regimeToStr(table[size-1].regime));
 
     // inserting to MRU position and evicting the LRU one

--- a/src/arch/arm/tlbi_op.cc
+++ b/src/arch/arm/tlbi_op.cc
@@ -69,7 +69,7 @@ TLBIALL::operator()(ThreadContext* tc)
 bool
 TLBIALL::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    return te->valid && secureLookup == !te->nstid &&
+    return te->valid && ss == te->ss &&
         (te->vmid == vmid || el2Enabled) &&
         te->checkRegime(targetRegime);
 }
@@ -115,7 +115,7 @@ TLBIALLEL::operator()(ThreadContext* tc)
 bool
 TLBIALLEL::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    return te->valid && secureLookup == !te->nstid &&
+    return te->valid && ss == te->ss &&
         te->checkRegime(targetRegime);
 }
 
@@ -136,7 +136,7 @@ TLBIVMALL::operator()(ThreadContext* tc)
 bool
 TLBIVMALL::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    return te->valid && secureLookup == !te->nstid &&
+    return te->valid && ss == te->ss &&
         te->checkRegime(targetRegime) &&
         (te->vmid == vmid || !el2Enabled || !useVMID(targetRegime));
 }
@@ -157,7 +157,7 @@ bool
 TLBIASID::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
     return te->valid && te->asid == asid &&
-        secureLookup == !te->nstid &&
+        ss == te->ss &&
         te->checkRegime(targetRegime) &&
         (te->vmid == vmid || !el2Enabled || !useVMID(targetRegime));
 }
@@ -202,7 +202,7 @@ TLBIALLN::operator()(ThreadContext* tc)
 bool
 TLBIALLN::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    return te->valid && te->nstid &&
+    return te->valid && te->ss == SecurityState::NonSecure &&
         te->checkRegime(targetRegime);
 }
 
@@ -213,7 +213,7 @@ TLBIMVAA::lookupGen(vmid_t vmid) const
     lookup_data.va = sext<56>(addr);
     lookup_data.ignoreAsn = true;
     lookup_data.vmid = vmid;
-    lookup_data.secure = secureLookup;
+    lookup_data.ss = ss;
     lookup_data.functional = true;
     lookup_data.targetRegime = targetRegime;
     lookup_data.mode = BaseMMU::Read;
@@ -247,7 +247,7 @@ TLBIMVA::lookupGen(vmid_t vmid) const
     lookup_data.asn = asid;
     lookup_data.ignoreAsn = false;
     lookup_data.vmid = vmid;
-    lookup_data.secure = secureLookup;
+    lookup_data.ss = ss;
     lookup_data.functional = true;
     lookup_data.targetRegime = targetRegime;
     lookup_data.mode = BaseMMU::Read;

--- a/src/arch/arm/tlbi_op.cc
+++ b/src/arch/arm/tlbi_op.cc
@@ -301,12 +301,34 @@ DTLBIMVA::matchEntry(TlbEntry* te, vmid_t vmid) const
 void
 TLBIIPA::operator()(ThreadContext* tc)
 {
-    getMMUPtr(tc)->flushStage2(makeStage2());
+    getMMUPtr(tc)->flushStage2(*this);
 
     CheckerCPU *checker = tc->getCheckerCpuPtr();
     if (checker) {
-        getMMUPtr(checker)->flushStage2(makeStage2());
+        getMMUPtr(checker)->flushStage2(*this);
     }
+}
+
+TlbEntry::Lookup
+TLBIIPA::lookupGen(vmid_t vmid) const
+{
+    TlbEntry::Lookup lookup_data;
+    lookup_data.va = szext<56>(addr);
+    lookup_data.ignoreAsn = true;
+    lookup_data.vmid = vmid;
+    lookup_data.ss = ss;
+    lookup_data.functional = true;
+    lookup_data.targetRegime = targetRegime;
+    lookup_data.mode = BaseMMU::Read;
+    return lookup_data;
+}
+
+bool
+TLBIIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
+{
+    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+
+    return te->match(lookup_data) && (!lastLevel || !te->partial);
 }
 
 bool
@@ -327,6 +349,22 @@ TLBIRMVA::matchEntry(TlbEntry* te, vmid_t vmid) const
 
 bool
 TLBIRMVAA::matchEntry(TlbEntry* te, vmid_t vmid) const
+{
+    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    lookup_data.size = rangeSize();
+
+    auto addr_match = te->match(lookup_data) && (!lastLevel || !te->partial);
+    if (addr_match) {
+        return tgMap[rangeData.tg] == te->tg &&
+        (resTLBIttl(rangeData.tg, rangeData.ttl) ||
+            rangeData.ttl == te->lookupLevel);
+    } else {
+        return false;
+    }
+}
+
+bool
+TLBIRIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
     TlbEntry::Lookup lookup_data = lookupGen(vmid);
     lookup_data.size = rangeSize();

--- a/src/arch/arm/tlbi_op.cc
+++ b/src/arch/arm/tlbi_op.cc
@@ -328,7 +328,8 @@ TLBIIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
     TlbEntry::Lookup lookup_data = lookupGen(vmid);
 
-    return te->match(lookup_data) && (!lastLevel || !te->partial);
+    return te->match(lookup_data) && (!lastLevel || !te->partial) &&
+        ipaSpace == te->ipaSpace;
 }
 
 bool
@@ -371,9 +372,10 @@ TLBIRIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
 
     auto addr_match = te->match(lookup_data) && (!lastLevel || !te->partial);
     if (addr_match) {
-        return tgMap[rangeData.tg] == te->tg &&
-        (resTLBIttl(rangeData.tg, rangeData.ttl) ||
-            rangeData.ttl == te->lookupLevel);
+        return ipaSpace == te->ipaSpace &&
+            tgMap[rangeData.tg] == te->tg &&
+            (resTLBIttl(rangeData.tg, rangeData.ttl) ||
+                rangeData.ttl == te->lookupLevel);
     } else {
         return false;
     }

--- a/src/arch/arm/types.hh
+++ b/src/arch/arm/types.hh
@@ -275,6 +275,13 @@ namespace ArmISA
         Secure
     };
 
+    /** Physical Address Space */
+    enum class PASpace
+    {
+        NonSecure,
+        Secure
+    };
+
     enum ExceptionLevel
     {
         EL0 = 0,

--- a/src/arch/arm/types.hh
+++ b/src/arch/arm/types.hh
@@ -268,6 +268,13 @@ namespace ArmISA
         RND_NEAREST
     };
 
+    /** Security State */
+    enum class SecurityState
+    {
+        NonSecure,
+        Secure
+    };
+
     enum ExceptionLevel
     {
         EL0 = 0,
@@ -485,6 +492,22 @@ namespace ArmISA
           default:
             GEM5_UNREACHABLE;
         }
+    }
+
+    static inline std::ostream&
+    operator<<(std::ostream& os, SecurityState ss)
+    {
+        switch (ss) {
+          case SecurityState::NonSecure:
+            os << "NonSecure";
+            break;
+          case SecurityState::Secure:
+            os << "Secure";
+            break;
+          default:
+            panic("Invalid SecurityState\n");
+        }
+        return os;
     }
 
     constexpr unsigned MaxSveVecLenInBits = 2048;

--- a/src/arch/arm/utility.cc
+++ b/src/arch/arm/utility.cc
@@ -89,13 +89,14 @@ isSecureBelowEL3(ThreadContext *tc)
         static_cast<SCR>(tc->readMiscRegNoEffect(MISCREG_SCR_EL3)).ns == 0;
 }
 
-bool
-isSecureAtEL(ThreadContext *tc, ExceptionLevel el)
+SecurityState
+securityStateAtEL(ThreadContext *tc, ExceptionLevel el)
 {
     if (ArmSystem::haveEL(tc, EL3) && el == EL3)
-        return true;
+        return SecurityState::Secure;
     else
-        return isSecureBelowEL3(tc);
+        return isSecureBelowEL3(tc) ? SecurityState::Secure :
+                                      SecurityState::NonSecure;
 }
 
 ExceptionLevel

--- a/src/arch/arm/utility.hh
+++ b/src/arch/arm/utility.hh
@@ -217,7 +217,7 @@ int computeAddrTop(ThreadContext *tc, bool selbit, bool isInstr,
 
 bool isSecureBelowEL3(ThreadContext *tc);
 
-bool isSecureAtEL(ThreadContext *tc, ExceptionLevel el);
+SecurityState securityStateAtEL(ThreadContext *tc, ExceptionLevel el);
 
 bool longDescFormatInUse(ThreadContext *tc);
 


### PR DESCRIPTION
This PR is introducing the concept of IPA space in gem5, which is necessary after the implementation
of FEAT_SEL2. In fact we can now have Secure and Non-Secure intermediate physical address spaces when the PE is
executing in Secure state.