### PR TITLE
arch-riscv: Fix implicit int-to-float conversion in .isa files

### DIFF
--- a/src/arch/riscv/isa/formats/vector_conf.isa
+++ b/src/arch/riscv/isa/formats/vector_conf.isa
@@ -125,7 +125,7 @@ def template VConfExecute {{
 
             uint32_t newVill =
                 !(vflmul >= 0.125 && vflmul <= 8) ||
-                    sew > std::min(vflmul, 1.0f) * elen ||
+                    (float)sew > std::min(vflmul, 1.0f) * (float)elen ||
                     bits(reqVtype, 62, 8) != 0;
             if (newVill) {
                 newVtype = 0;

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1761,7 +1761,8 @@ Fault
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
 
-    panic_if((pow(2, vlmul) * this->numFields) > 8, "LMUL value is illegal for vlseg inst");
+    panic_if(((1 << vlmul) * this->numFields) > 8,
+        "LMUL value is illegal for vlseg inst");
 
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);
@@ -1819,7 +1820,8 @@ Fault
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
 
-    panic_if((pow(2, vlmul) * this->numFields) > 8, "LMUL value is illegal for vlseg inst");
+    panic_if(((1 << vlmul) * this->numFields) > 8,
+        "LMUL value is illegal for vlseg inst");
 
     const std::vector<bool> byte_enable(mem_size, true);
     Fault fault = initiateMemRead(xc, EA, mem_size, memAccessFlags,
@@ -2003,7 +2005,7 @@ Fault
     %(ea_code)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-    panic_if((pow(2, vlmul) * this->numFields) > 8,
+    panic_if(((1 << vlmul) * this->numFields) > 8,
         "LMUL value is illegal for vsseg inst");
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
@@ -2060,7 +2062,7 @@ Fault
     %(ea_code)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-        panic_if((pow(2, vlmul) * this->numFields) > 8,
+        panic_if(((1 << vlmul) * this->numFields) > 8,
             "LMUL value is illegal for vsseg inst");
 
 


### PR DESCRIPTION
Explicitly convert to float/double to fix compiler warnings that I have turned on locally.

Change-Id: I09e1aca0048bc990c49906778e81276c0c4ebb80