### PR TITLE
arch-arm: Implement FEAT_TTST

### DIFF
--- a/src/arch/arm/ArmSystem.py
+++ b/src/arch/arm/ArmSystem.py
@@ -96,6 +96,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_TLBIRANGE",
         "FEAT_FLAGM",
         "FEAT_IDST",
+        "FEAT_TTST",
         # Armv8.5
         "FEAT_FLAGM2",
         "FEAT_RNG",
@@ -204,6 +205,7 @@ class ArmDefaultRelease(Armv8):
         "FEAT_TLBIRANGE",
         "FEAT_FLAGM",
         "FEAT_IDST",
+        "FEAT_TTST",
         # Armv8.5
         "FEAT_FLAGM2",
         "FEAT_EVT",
@@ -252,6 +254,7 @@ class Armv84(Armv83):
         "FEAT_TLBIRANGE",
         "FEAT_FLAGM",
         "FEAT_IDST",
+        "FEAT_TTST",
     ]
 
 

--- a/src/arch/arm/pagetable.cc
+++ b/src/arch/arm/pagetable.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018-2019, 2021 Arm Limited
+ * Copyright (c) 2013, 2018-2019, 2021, 2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -247,6 +247,7 @@ V8PageTableOps4k::firstS2Level(uint8_t sl0) const
       case 0: return LookupLevel::L2;
       case 1: return LookupLevel::L1;
       case 2: return LookupLevel::L0;
+      case 3: return LookupLevel::L3; // Only when FEAT_TTST is implemented
       default: panic("Unsupported VTCR_EL2.SL0: %d", sl0);
     }
 }

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -4976,6 +4976,7 @@ ISA::initializeMiscRegMetadata()
           AA64MMFR2 mmfr2_el1 = p.id_aa64mmfr2_el1;
           mmfr2_el1.uao = release->has(ArmExtension::FEAT_UAO) ? 0x1 : 0x0;
           mmfr2_el1.varange = release->has(ArmExtension::FEAT_LVA) ? 0x1 : 0x0;
+          mmfr2_el1.st = release->has(ArmExtension::FEAT_TTST) ? 0x1 : 0x0;
           mmfr2_el1.ids = release->has(ArmExtension::FEAT_IDST) ? 0x1 : 0x0;
           mmfr2_el1.evt = release->has(ArmExtension::FEAT_EVT) ? 0x2 : 0x0;
           return mmfr2_el1;

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1216,8 +1216,11 @@ class TableWalker : public ClockedObject
     Fault processWalk();
     Fault processWalkLPAE();
 
-    bool checkVAddrSizeFaultAArch64(Addr addr, int top_bit,
-        GrainSize granule, int tsz, bool low_range);
+    Addr maxTxSz(GrainSize tg) const;
+    Addr s1MinTxSz(GrainSize tg) const;
+    bool s1TxSzFault(GrainSize tg, int tsz) const;
+    bool checkVAOutOfRange(Addr addr, int top_bit,
+        int tsz, bool low_range);
 
     /// Returns true if the address exceeds the range permitted by the
     /// system-wide setting or by the TCR_ELx IPS/PS setting


### PR DESCRIPTION
Implement small translation table extension.
This feature relaxes the lower limit on the size of the translation tables, by increasing the maximum permitted values of the T1SZ and T0SZ field in: TCR_EL1, TCR_EL2, TCR_EL3,VTCR_EL2 and VSTCR_EL2

Change-Id: I4c2187815b2d7f14407edb38095c6bcc2004b62a