### PR TITLE
arch-arm: Fix implicit int-to-float conversion in VCMP

### DIFF
--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -1360,13 +1360,12 @@ let {{
     vcmpZeroSCode = vfpEnabledCheckCode + '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         vfpFlushToZero(fpscr, FpDest);
-        // This only handles imm == 0 for now.
-        assert(imm == 0);
-        if (FpDest == imm) {
+        assert(imm == 0); // immediate must be zero.
+        if (FpDest == 0.0f) {
             fpscr.n = 0; fpscr.z = 1; fpscr.c = 1; fpscr.v = 0;
-        } else if (FpDest < imm) {
+        } else if (FpDest < 0.0f) {
             fpscr.n = 1; fpscr.z = 0; fpscr.c = 0; fpscr.v = 0;
-        } else if (FpDest > imm) {
+        } else if (FpDest > 0.0f) {
             fpscr.n = 0; fpscr.z = 0; fpscr.c = 1; fpscr.v = 0;
         } else {
             const uint32_t qnan = 0x7fc00000;
@@ -1388,16 +1387,15 @@ let {{
     exec_output += PredOpExecute.subst(vcmpZeroSIop);
 
     vcmpZeroDCode = vfpEnabledCheckCode + '''
-        // This only handles imm == 0 for now.
-        assert(imm == 0);
         double cDest = dbl(FpDestP0_uw, FpDestP1_uw);
         FPSCR fpscr = (FPSCR) FpscrExc;
         vfpFlushToZero(fpscr, cDest);
-        if (cDest == imm) {
+        assert(imm == 0); // immediate must be zero.
+        if (cDest == 0.0) {
             fpscr.n = 0; fpscr.z = 1; fpscr.c = 1; fpscr.v = 0;
-        } else if (cDest < imm) {
+        } else if (cDest < 0.0) {
             fpscr.n = 1; fpscr.z = 0; fpscr.c = 0; fpscr.v = 0;
-        } else if (cDest > imm) {
+        } else if (cDest > 0.0) {
             fpscr.n = 0; fpscr.z = 0; fpscr.c = 1; fpscr.v = 0;
         } else {
             const uint64_t qnan = 0x7ff8000000000000ULL;
@@ -1471,11 +1469,12 @@ let {{
     vcmpeZeroSCode = vfpEnabledCheckCode + '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         vfpFlushToZero(fpscr, FpDest);
-        if (FpDest == imm) {
+        assert(imm == 0); // immediate must be zero.
+        if (FpDest == 0.0f) {
             fpscr.n = 0; fpscr.z = 1; fpscr.c = 1; fpscr.v = 0;
-        } else if (FpDest < imm) {
+        } else if (FpDest < 0.0f) {
             fpscr.n = 1; fpscr.z = 0; fpscr.c = 0; fpscr.v = 0;
-        } else if (FpDest > imm) {
+        } else if (FpDest > 0.0f) {
             fpscr.n = 0; fpscr.z = 0; fpscr.c = 1; fpscr.v = 0;
         } else {
             fpscr.ioc = 1;
@@ -1496,11 +1495,12 @@ let {{
         double cDest = dbl(FpDestP0_uw, FpDestP1_uw);
         FPSCR fpscr = (FPSCR) FpscrExc;
         vfpFlushToZero(fpscr, cDest);
-        if (cDest == imm) {
+        assert(imm == 0); // immediate must be zero.
+        if (cDest == 0.0) {
             fpscr.n = 0; fpscr.z = 1; fpscr.c = 1; fpscr.v = 0;
-        } else if (cDest < imm) {
+        } else if (cDest < 0.0) {
             fpscr.n = 1; fpscr.z = 0; fpscr.c = 0; fpscr.v = 0;
-        } else if (cDest > imm) {
+        } else if (cDest > 0.0) {
             fpscr.n = 0; fpscr.z = 0; fpscr.c = 1; fpscr.v = 0;
         } else {
             fpscr.ioc = 1;


### PR DESCRIPTION
Explicitly convert to float/double to fix compiler warnings that I have turned on locally. It might make sense to make use of fplib functions to be portable across different host float formats but something as simple as comparison against zero should be safe.

Change-Id: I96c6ee7c5497fece11be07234ff80ff86e7555e2