### PR TITLE
arch-arm: Fix remaining implicit float conversion warnings in .isa

### DIFF
--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -913,7 +913,7 @@ let {{
         FPSCR fpscr = (FPSCR) FpscrExc;
         VfpSavedState state = prepFpState(fpscr.rMode);
         __asm__ __volatile__("" : "=m" (FpOp1_uw) : "m" (FpOp1_uw));
-        FpDest = FpOp1_uw;
+        FpDest = (float)FpOp1_uw;  // Should use fplib here instead.
         __asm__ __volatile__("" :: "m" (FpDest));
         finishVfp(fpscr, state, fpscr.fz);
         FpscrExc = fpscr;
@@ -930,7 +930,8 @@ let {{
         FPSCR fpscr = (FPSCR) FpscrExc;
         VfpSavedState state = prepFpState(fpscr.rMode);
         __asm__ __volatile__("" : "=m" (FpOp1P0_uw) : "m" (FpOp1P0_uw));
-        double cDest = (uint64_t)FpOp1P0_uw;
+        // Should use fplib here instead.
+        double cDest = (double)(uint64_t)FpOp1P0_uw;
         __asm__ __volatile__("" :: "m" (cDest));
         finishVfp(fpscr, state, fpscr.fz);
         FpDestP0_uw = dblLow(cDest);
@@ -949,7 +950,7 @@ let {{
         FPSCR fpscr = (FPSCR) FpscrExc;
         VfpSavedState state = prepFpState(fpscr.rMode);
         __asm__ __volatile__("" : "=m" (FpOp1_sw) : "m" (FpOp1_sw));
-        FpDest = FpOp1_sw;
+        FpDest = (float)FpOp1_sw;  // Should use fplib here instead.
         __asm__ __volatile__("" :: "m" (FpDest));
         finishVfp(fpscr, state, fpscr.fz);
         FpscrExc = fpscr;
@@ -966,7 +967,7 @@ let {{
         FPSCR fpscr = (FPSCR) FpscrExc;
         VfpSavedState state = prepFpState(fpscr.rMode);
         __asm__ __volatile__("" : "=m" (FpOp1P0_sw) : "m" (FpOp1P0_sw));
-        double cDest = FpOp1P0_sw;
+        double cDest = (double)FpOp1P0_sw;  // Should use fplib here instead.
         __asm__ __volatile__("" :: "m" (cDest));
         finishVfp(fpscr, state, fpscr.fz);
         FpDestP0_uw = dblLow(cDest);

--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -3052,7 +3052,7 @@ let {{
         FPSCR fpscr = (FPSCR) FpscrExc;
         float mid = binaryOp(fpscr, srcReg1, srcReg2, fpSubS,
                              true, true, VfpRoundNearest);
-        destReg = fabs(mid);
+        destReg = fabsf(mid);
         FpscrExc = fpscr;
     '''
     threeEqualRegInstFp("vabd", "VabdDFp", "SimdFloatAddOp", ("float",), 2, vabdfpCode)

--- a/src/arch/isa_parser/isa_parser.py
+++ b/src/arch/isa_parser/isa_parser.py
@@ -732,6 +732,21 @@ class ISAParser(Grammar):
                 print("namespace %s {" % self.namespace, file=f)
                 if splits > 1:
                     print("#define __SPLIT %u" % i, file=f)
+                # TODO: enable warning for all ISAs
+                if self.namespace == "ArmISAInst":
+                    print(f"#ifdef __clang__", file=f)
+                    print(
+                        f"#pragma clang diagnostic warning "
+                        f'"-Wfloat-conversion"',
+                        file=f,
+                    )
+                    print(
+                        f"#pragma clang diagnostic warning "
+                        f'"-Wimplicit-float-conversion"',
+                        file=f,
+                    )
+                    print(f"#endif", file=f)
+
                 print(f'#include "{fn}"', file=f)
                 print("} // namespace %s" % self.namespace, file=f)
                 print("} // namespace gem5", file=f)


### PR DESCRIPTION
This fixes the remaining implicit int/float conversions and enables the float conversion warnings for clang when building the Arm instruction execution logic. This depends on the previous fixes.

Change-Id: I51aac94644a483175842c36da2d49d308aaceb49