### PR TITLE
systemc: Use headerDelay in timing annotation

### DIFF
--- a/src/systemc/tlm_bridge/gem5_to_tlm.cc
+++ b/src/systemc/tlm_bridge/gem5_to_tlm.cc
@@ -418,7 +418,7 @@ Gem5ToTlmBridge<BITWIDTH>::recvTimingReq(PacketPtr packet)
      *       payload delay and comparing it to the time between BEGIN_REQ and
      *       END_REQ. Then, a warning should be printed.
      */
-    auto delay = sc_core::sc_time::from_value(packet->payloadDelay);
+    auto delay = sc_core::sc_time::from_value(packet->headerDelay);
     // Reset the delays
     packet->payloadDelay = 0;
     packet->headerDelay = 0;

--- a/src/systemc/tlm_bridge/tlm_to_gem5.cc
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.cc
@@ -515,7 +515,7 @@ TlmToGem5Bridge<BITWIDTH>::recvTimingResp(PacketPtr pkt)
      *
      * See recvTimingReq in sc_slave_port.cc for a detailed description.
      */
-    auto delay = sc_core::sc_time::from_value(pkt->payloadDelay);
+    auto delay = sc_core::sc_time::from_value(pkt->headerDelay);
     // reset the delays
     pkt->payloadDelay = 0;
     pkt->headerDelay = 0;

--- a/util/tlm/src/sc_master_port.cc
+++ b/util/tlm/src/sc_master_port.cc
@@ -331,7 +331,7 @@ SCMasterPort::recvTimingResp(gem5::PacketPtr pkt)
      *
      * See recvTimingReq in sc_slave_port.cc for a detailed description.
      */
-    auto delay = sc_core::sc_time::from_value(pkt->payloadDelay);
+    auto delay = sc_core::sc_time::from_value(pkt->headerDelay);
     // reset the delays
     pkt->payloadDelay = 0;
     pkt->headerDelay = 0;

--- a/util/tlm/src/sc_slave_port.cc
+++ b/util/tlm/src/sc_slave_port.cc
@@ -231,7 +231,7 @@ SCSlavePort::recvTimingReq(gem5::PacketPtr packet)
      *       payload delay and comparing it to the time between BEGIN_REQ and
      *       END_REQ. Then, a warning should be printed.
      */
-    auto delay = sc_core::sc_time::from_value(packet->payloadDelay);
+    auto delay = sc_core::sc_time::from_value(packet->headerDelay);
     // reset the delays
     packet->payloadDelay = 0;
     packet->headerDelay = 0;


### PR DESCRIPTION
1. Responder (downstream components):

    When sending a BEGIN_REQ, the timing annotation marks the time when
    a transaction is visible to the target (see [1] on page 465).

    When writing the data, the downstream component calculates the
    transfer time and would send END_REQ after this time (see [1] on
    page 540). Therefore, not the payloadDelay, but the headerDelay
    should be used, as already written as a comment in the source files.
    When reading data, payloadDelay will be 0 anyway.

2. Requester (upstream component):

    For data read, the begin of the transfer is marked by BEGIN_RESP
    and the upstream component would delay END_RESP to model the
    data transfer (see [1] on page 540). Therefore, BEGIN_RESP should be
    delayed by the headerDelay, not the payloadDelay.

[1] "IEEE Standard for Standard SystemC® Language Reference Manual," in IEEE Std 1666-2023 (Revision of IEEE Std 1666-2011), vol., no., pp.1-618, 8 Sept. 2023, doi: 10.1109/IEEESTD.2023.10246125.

Change-Id: I3b5e8ad6bc37cbb309b124efdc8764fca3728b7a