### PR TITLE
sim: Add error message for kernel exceeding memory size

### DIFF
--- a/src/sim/kernel_workload.cc
+++ b/src/sim/kernel_workload.cc
@@ -104,12 +104,22 @@ KernelWorkload::initState()
     };
     if (params().object_file != "")  {
         if (params().addr_check) {
+            auto memory_size = system->memSize();
+            auto kernel_size = _end - _start;
             // Validate kernel mapping before loading binary
+            fatal_if((kernel_size > memory_size),
+                "Kernel is mapped to invalid location (not memory). start"
+                " (%#lx) - end (%#lx) %#lx:%#lx\n"
+                "The kernel size (%ld bytes, %ld MB) appears to be larger "
+                "than total system memory (%ld bytes, %ld MB). Try increasing"
+                " system memory.", _start, _end, mapper(_start), mapper(_end),
+                kernel_size, kernel_size>>20, memory_size, memory_size>>20);
             fatal_if(!system->isMemAddr(mapper(_start)) ||
-                    !system->isMemAddr(mapper(_end)),
-                    "Kernel is mapped to invalid location (not memory). "
-                    "start (%#x) - end (%#x) %#x:%#x\n",
-                    _start, _end, mapper(_start), mapper(_end));
+                !system->isMemAddr(mapper(_end)),
+                "Kernel is mapped to invalid location (not memory). start"
+                " (%#lx) - end (%#lx) %#lx:%#lx\n", _start, _end,
+                mapper(_start), mapper(_end));
+
         }
         // Load program sections into memory
         image.write(phys_mem);


### PR DESCRIPTION
This commit adds an error message to src/sim/kernel_workload.cc to tell the user when the end address of the kernel is greater than the size of memory. The error message also specifies the minimum memory size needed to fit the kernel.                                                            

Change-Id: I7d8f50889ed8172f64b84f98301a35e5f2f352d3  