### PR TITLE
arch,cpu: Implement generic reset method for MMU

### DIFF
--- a/src/arch/generic/mmu.cc
+++ b/src/arch/generic/mmu.cc
@@ -94,6 +94,13 @@ BaseMMU::flushAll()
 }
 
 void
+BaseMMU::reset()
+{
+    // flush the TLBs by defaults
+    flushAll();
+}
+
+void
 BaseMMU::demapPage(Addr vaddr, uint64_t asn)
 {
     itb->demapPage(vaddr, asn);

--- a/src/arch/generic/mmu.hh
+++ b/src/arch/generic/mmu.hh
@@ -109,6 +109,8 @@ class BaseMMU : public SimObject
 
     virtual void flushAll();
 
+    virtual void reset();
+
     void demapPage(Addr vaddr, uint64_t asn);
 
     virtual Fault

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -694,8 +694,8 @@ BaseCPU::setReset(bool state)
             tc->getIsaPtr()->resetThread();
             // reset the decoder in case it had partially decoded something,
             tc->getDecoderPtr()->reset();
-            // flush the TLBs,
-            tc->getMMUPtr()->flushAll();
+            // reset MMU,
+            tc->getMMUPtr()->reset();
             // Clear any interrupts,
             interrupts[tc->threadId()]->clearAll();
             // and finally reenable execution.


### PR DESCRIPTION
Implementing generic reset method for MMU allows each ISA implementing their own reset methods. The default reset MMU method is flush all TLB entries. For example, The RISC-V needs to do PMP reset when received the reset signal, but the TLBs don't require to be flushed.

Change-Id: I158261570fb6e5216ec105fbdc53460f83f88d15