### PR TITLE
arch-riscv: Overwrite getEMI() for timing expr

### DIFF
--- a/src/arch/riscv/insts/static_inst.hh
+++ b/src/arch/riscv/insts/static_inst.hh
@@ -86,6 +86,8 @@ class RiscvStaticInst : public StaticInst
         tc->pcState(pc);
     }
 
+    uint64_t getEMI() const override { return machInst; }
+
     std::unique_ptr<PCStateBase>
     buildRetPC(const PCStateBase &cur_pc,
             const PCStateBase &call_pc) const override


### PR DESCRIPTION
TimingExpression enables runtime calculation of the commit latency in MinorCPU. For this, machInst is obtained by getEMI() to match it with a given instruction. At default, getEMI() always returns 0 and is therefore overwritten to enable timing expressions for RISC-V. This was already done for ARM (see src/arch/arm/insts/static_inst.hh).

Change-Id: I03d669b3439fd24e00cbf893f5db9951dfe56b1f