### PR TITLE
arch-riscv: Update local interrupts citation

### DIFF
--- a/src/arch/riscv/RiscvInterrupts.py
+++ b/src/arch/riscv/RiscvInterrupts.py
@@ -47,16 +47,17 @@ class RiscvInterrupts(BaseInterrupts):
 
 add_citation(
     RiscvInterrupts,
-    r"""@inproceedings{Hauser:2024:LocalRiscvInterrupts,
-    author = {Robert Hauser  and
-              Lukas Steffen and
-              Florian Gr{\"u}tzmacher and
-              Christian Haubelt},
-    title = {Analyzing Local RISC-V Interrupt Latencies with Virtual Prototyping},
-    booktitle = {Workshop Methoden und Beschreibungssprachen zur Modellierung und Verifikation von Schaltungen und Systemen (MBMV24)},
-    pages = {1-7},
-    year = {2024},
-    month = {2}
-    }
+    r"""@INPROCEEDINGS{Hauser:2024:LocalRiscvInterrupts,
+  author    = {Hauser, Robert and
+               Steffen, Lukas and
+               Gr{\"u}tzmacher, Florian and
+               Haubelt, Christian},
+  booktitle = {MBMV 2024; 27. Workshop},
+  title     = {Analyzing Local RISC-V Interrupt Latencies
+               with Virtual Prototyping},
+  year      = {2024},
+  pages     = {7-14},
+  address   = {Kaiserslautern, Germany},
+  }
     """,
 )


### PR DESCRIPTION
Updated the bib information of the local RISC-V interrupts.

Change-Id: I666c3df4529e159bd1946ca1a9623e47f84d5d9e