### PR TITLE
arch-riscv: Change wfi behaviour

### DIFF
--- a/src/arch/riscv/interrupts.hh
+++ b/src/arch/riscv/interrupts.hh
@@ -82,6 +82,11 @@ class Interrupts : public BaseInterrupts
         return checkNonMaskableInterrupt() || (ip & ie & globalMask()).any();
     }
 
+    bool checkInterruptsWfi() const
+    {
+        return checkNonMaskableInterrupt() || (ip & ie).any();
+    }
+
     Fault getInterrupt() override;
 
     void updateIntrInfo() override {}

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4880,8 +4880,7 @@ decode QUADRANT default Unknown::unknown() {
                             auto ic = dynamic_cast<RiscvISA::Interrupts*>(
                                 cpu->getInterruptController(tc->threadId()));
                             panic_if(!ic, "Invalid Interrupt Controller.");
-                            if (ic->readIP() == 0
-                                && xc->readMiscReg(MISCREG_NMIP) == 0) {
+                            if (!ic->checkInterruptsWfi()) {
                                 tc->quiesce();
                             }
                         }}, IsNonSpeculative, IsQuiesce,


### PR DESCRIPTION
Previously we were only checking if there are any pending interrupts regardless of whether its enabled or not.This resulted in the simulator spending lots of cpu cycles simulating the wfi loop which results in poor performance of the simulator

Related to issue #1355 
Change-Id: Ifb6214509e65de7f6bb7db91af30c43bd582c873