### PR TITLE
python: move cache coherence protocol check above imports

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
@@ -36,6 +36,10 @@ from m5.objects import (
 from m5.objects.SubSystem import SubSystem
 
 from gem5.coherence_protocol import CoherenceProtocol
+from gem5.utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.CHI)
+
 from gem5.components.boards.abstract_board import AbstractBoard
 from gem5.components.cachehierarchies.abstract_cache_hierarchy import (
     AbstractCacheHierarchy,
@@ -49,7 +53,6 @@ from gem5.components.cachehierarchies.ruby.topologies.simple_pt2pt import (
 from gem5.components.processors.abstract_core import AbstractCore
 from gem5.isas import ISA
 from gem5.utils.override import overrides
-from gem5.utils.requires import requires
 
 from .nodes.directory import SimpleDirectory
 from .nodes.dma_requestor import DMARequestor
@@ -79,8 +82,6 @@ class PrivateL1CacheHierarchy(AbstractRubyCacheHierarchy):
 
     @overrides(AbstractCacheHierarchy)
     def incorporate_cache(self, board: AbstractBoard) -> None:
-        requires(coherence_protocol_required=CoherenceProtocol.CHI)
-
         self.ruby_system = RubySystem()
 
         # Ruby's global network.

--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
@@ -33,8 +33,11 @@ from m5.objects import (
 )
 
 from ....coherence_protocol import CoherenceProtocol
-from ....isas import ISA
 from ....utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.MESI_THREE_LEVEL)
+
+from ....isas import ISA
 from ...boards.abstract_board import AbstractBoard
 from ..abstract_three_level_cache_hierarchy import (
     AbstractThreeLevelCacheHierarchy,
@@ -84,10 +87,6 @@ class MESIThreeLevelCacheHierarchy(
         self._num_l3_banks = num_l3_banks
 
     def incorporate_cache(self, board: AbstractBoard) -> None:
-        requires(
-            coherence_protocol_required=CoherenceProtocol.MESI_THREE_LEVEL
-        )
-
         cache_line_size = board.get_cache_line_size()
 
         self.ruby_system = RubySystem()

--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_two_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_two_level_cache_hierarchy.py
@@ -33,8 +33,11 @@ from m5.objects import (
 )
 
 from ....coherence_protocol import CoherenceProtocol
-from ....isas import ISA
 from ....utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.MESI_TWO_LEVEL)
+
+from ....isas import ISA
 from ...boards.abstract_board import AbstractBoard
 from ..abstract_two_level_cache_hierarchy import AbstractTwoLevelCacheHierarchy
 from .abstract_ruby_cache_hierarchy import AbstractRubyCacheHierarchy
@@ -80,8 +83,6 @@ class MESITwoLevelCacheHierarchy(
         self._num_l2_banks = num_l2_banks
 
     def incorporate_cache(self, board: AbstractBoard) -> None:
-        requires(coherence_protocol_required=CoherenceProtocol.MESI_TWO_LEVEL)
-
         cache_line_size = board.get_cache_line_size()
 
         self.ruby_system = RubySystem()

--- a/src/python/gem5/components/cachehierarchies/ruby/mi_example_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mi_example_cache_hierarchy.py
@@ -32,9 +32,12 @@ from m5.objects import (
 )
 
 from ....coherence_protocol import CoherenceProtocol
+from ....utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.MI_EXAMPLE)
+
 from ....isas import ISA
 from ....utils.override import overrides
-from ....utils.requires import requires
 from ...boards.abstract_board import AbstractBoard
 from ..abstract_cache_hierarchy import AbstractCacheHierarchy
 from .abstract_ruby_cache_hierarchy import AbstractRubyCacheHierarchy
@@ -62,8 +65,6 @@ class MIExampleCacheHierarchy(AbstractRubyCacheHierarchy):
 
     @overrides(AbstractCacheHierarchy)
     def incorporate_cache(self, board: AbstractBoard) -> None:
-        requires(coherence_protocol_required=CoherenceProtocol.MI_EXAMPLE)
-
         self.ruby_system = RubySystem()
 
         # Ruby's global network.


### PR DESCRIPTION
This commit moves the requires() call that checks the cache coherence protocol above the imports. This change was made for the chi private l1, ruby mesi three level, mesi two level, and mi example cache hierarchies. This ensures that a clear error message about having the wrong coherence protocol is printed, rather than a less useful message.

Change-Id: I3bac1ffcb1f8a9d94e486237f880cf248e442ba8