### PR TITLE
mem: Fix "Need is_secure arg" prefetcher crash

### DIFF
--- a/src/mem/cache/prefetch/associative_set.hh
+++ b/src/mem/cache/prefetch/associative_set.hh
@@ -90,7 +90,7 @@ class AssociativeSet : public AssociativeCache<Entry>
     using AssociativeCache<Entry>::accessEntryByAddr;
     using AssociativeCache<Entry>::findEntry;
     using AssociativeCache<Entry>::insertEntry;
-    using AssociativeCache<Entry>::getPossibleEntries;
+    // using AssociativeCache<Entry>::getPossibleEntries;
 
     using AssociativeCache<Entry>::replPolicy;
     using AssociativeCache<Entry>::indexingPolicy;

--- a/src/mem/cache/prefetch/associative_set.hh
+++ b/src/mem/cache/prefetch/associative_set.hh
@@ -90,8 +90,6 @@ class AssociativeSet : public AssociativeCache<Entry>
     using AssociativeCache<Entry>::accessEntryByAddr;
     using AssociativeCache<Entry>::findEntry;
     using AssociativeCache<Entry>::insertEntry;
-    // using AssociativeCache<Entry>::getPossibleEntries;
-
     using AssociativeCache<Entry>::replPolicy;
     using AssociativeCache<Entry>::indexingPolicy;
 };

--- a/src/mem/cache/prefetch/indirect_memory.cc
+++ b/src/mem/cache/prefetch/indirect_memory.cc
@@ -85,7 +85,7 @@ IndirectMemory::calculatePrefetch(const PrefetchInfo &pfi,
         }
     } else {
         // if misses are not being tracked, attempt to detect stream accesses
-        PrefetchTableEntry *pt_entry = prefetchTable.findEntry(pc);
+        PrefetchTableEntry *pt_entry = prefetchTable.findEntry(pc, is_secure);
         if (pt_entry != nullptr) {
             prefetchTable.accessEntry(pt_entry);
 
@@ -159,7 +159,7 @@ IndirectMemory::calculatePrefetch(const PrefetchInfo &pfi,
         } else {
             pt_entry = prefetchTable.findVictim(pc);
             assert(pt_entry != nullptr);
-            prefetchTable.insertEntry(pc, pt_entry);
+            prefetchTable.insertEntry(pc, pt_entry-> secure, pt_entry);
             pt_entry->address = addr;
             pt_entry->secure = is_secure;
         }

--- a/src/mem/cache/prefetch/indirect_memory.hh
+++ b/src/mem/cache/prefetch/indirect_memory.hh
@@ -121,7 +121,7 @@ class IndirectMemory : public Queued
         }
     };
     /** Prefetch table */
-    AssociativeCache<PrefetchTableEntry> prefetchTable;
+    AssociativeSet<PrefetchTableEntry> prefetchTable;
 
     /** Indirect Pattern Detector entrt */
     struct IndirectPatternDetectorEntry : public TaggedEntry

--- a/src/mem/cache/prefetch/pif.cc
+++ b/src/mem/cache/prefetch/pif.cc
@@ -176,15 +176,15 @@ PIF::notifyRetiredInst(const Addr pc)
                 // Insert the spatial entry into the history buffer and update
                 // the 'iterator' table to point to the new entry
                 historyBuffer.push_back(spatialCompactor);
-
+                bool is_secure = false;
                 auto idx_entry = index.findEntry(spatialCompactor.trigger,
-                false);
+                is_secure);
                 if (idx_entry != nullptr) {
                     index.accessEntry(idx_entry);
                 } else {
                     idx_entry = index.findVictim(spatialCompactor.trigger);
                     assert(idx_entry != nullptr);
-                    index.insertEntry(spatialCompactor.trigger, false,
+                    index.insertEntry(spatialCompactor.trigger, is_secure,
                     idx_entry);
                 }
                 idx_entry->historyIt =
@@ -207,6 +207,7 @@ PIF::calculatePrefetch(const PrefetchInfo &pfi,
     }
 
     const Addr pc = pfi.getPC();
+    bool is_secure = pfi.isSecure();
 
     // First check if the access has been prefetched, this is done by
     // comparing the access against the active Stream Address Buffers
@@ -221,7 +222,7 @@ PIF::calculatePrefetch(const PrefetchInfo &pfi,
 
     // Check if a valid entry in the 'index' table is found and allocate a new
     // active prediction stream
-    IndexEntry *idx_entry = index.findEntry(pc, false);
+    IndexEntry *idx_entry = index.findEntry(pc, is_secure);
 
     if (idx_entry != nullptr) {
         index.accessEntry(idx_entry);

--- a/src/mem/cache/prefetch/pif.cc
+++ b/src/mem/cache/prefetch/pif.cc
@@ -177,13 +177,15 @@ PIF::notifyRetiredInst(const Addr pc)
                 // the 'iterator' table to point to the new entry
                 historyBuffer.push_back(spatialCompactor);
 
-                auto idx_entry = index.findEntry(spatialCompactor.trigger);
+                auto idx_entry = index.findEntry(spatialCompactor.trigger,
+                false);
                 if (idx_entry != nullptr) {
                     index.accessEntry(idx_entry);
                 } else {
                     idx_entry = index.findVictim(spatialCompactor.trigger);
                     assert(idx_entry != nullptr);
-                    index.insertEntry(spatialCompactor.trigger, idx_entry);
+                    index.insertEntry(spatialCompactor.trigger, false,
+                    idx_entry);
                 }
                 idx_entry->historyIt =
                     historyBuffer.getIterator(historyBuffer.tail());
@@ -219,7 +221,7 @@ PIF::calculatePrefetch(const PrefetchInfo &pfi,
 
     // Check if a valid entry in the 'index' table is found and allocate a new
     // active prediction stream
-    IndexEntry *idx_entry = index.findEntry(pc);
+    IndexEntry *idx_entry = index.findEntry(pc, false);
 
     if (idx_entry != nullptr) {
         index.accessEntry(idx_entry);

--- a/src/mem/cache/prefetch/pif.cc
+++ b/src/mem/cache/prefetch/pif.cc
@@ -176,7 +176,7 @@ PIF::notifyRetiredInst(const Addr pc)
                 // Insert the spatial entry into the history buffer and update
                 // the 'iterator' table to point to the new entry
                 historyBuffer.push_back(spatialCompactor);
-                bool is_secure = false;
+                constexpr bool is_secure = false;
                 auto idx_entry = index.findEntry(spatialCompactor.trigger,
                 is_secure);
                 if (idx_entry != nullptr) {

--- a/src/mem/cache/prefetch/pif.hh
+++ b/src/mem/cache/prefetch/pif.hh
@@ -143,7 +143,7 @@ class PIF : public Queued
          * The index table is a small cache-like structure that facilitates
          * fast search of the history buffer.
          */
-        AssociativeCache<IndexEntry> index;
+        AssociativeSet<IndexEntry> index;
 
         /**
          * A Stream Address Buffer (SAB) tracks a window of consecutive

--- a/src/mem/cache/prefetch/signature_path.cc
+++ b/src/mem/cache/prefetch/signature_path.cc
@@ -192,7 +192,8 @@ SignaturePath::getSignatureEntry(Addr ppn, bool is_secure,
 SignaturePath::PatternEntry &
 SignaturePath::getPatternEntry(Addr signature)
 {
-    PatternEntry* pattern_entry = patternTable.findEntry(signature);
+    bool is_secure = false;
+    PatternEntry* pattern_entry = patternTable.findEntry(signature, is_secure);
     if (pattern_entry != nullptr) {
         // Signature found
         patternTable.accessEntry(pattern_entry);
@@ -201,7 +202,7 @@ SignaturePath::getPatternEntry(Addr signature)
         pattern_entry = patternTable.findVictim(signature);
         assert(pattern_entry != nullptr);
 
-        patternTable.insertEntry(signature, pattern_entry);
+        patternTable.insertEntry(signature, is_secure, pattern_entry);
     }
     return *pattern_entry;
 }
@@ -277,7 +278,7 @@ SignaturePath::calculatePrefetch(const PrefetchInfo &pfi,
         //   confidence, these are prefetch candidates
         // - select the entry with the highest counter as the "lookahead"
         PatternEntry *current_pattern_entry =
-            patternTable.findEntry(current_signature);
+            patternTable.findEntry(current_signature, false); //,
         PatternStrideEntry const *lookahead = nullptr;
         if (current_pattern_entry != nullptr) {
             unsigned long max_counter = 0;

--- a/src/mem/cache/prefetch/signature_path.cc
+++ b/src/mem/cache/prefetch/signature_path.cc
@@ -192,7 +192,7 @@ SignaturePath::getSignatureEntry(Addr ppn, bool is_secure,
 SignaturePath::PatternEntry &
 SignaturePath::getPatternEntry(Addr signature)
 {
-    bool is_secure = false;
+    constexpr bool is_secure = false;
     PatternEntry* pattern_entry = patternTable.findEntry(signature, is_secure);
     if (pattern_entry != nullptr) {
         // Signature found

--- a/src/mem/cache/prefetch/signature_path.cc
+++ b/src/mem/cache/prefetch/signature_path.cc
@@ -278,7 +278,7 @@ SignaturePath::calculatePrefetch(const PrefetchInfo &pfi,
         //   confidence, these are prefetch candidates
         // - select the entry with the highest counter as the "lookahead"
         PatternEntry *current_pattern_entry =
-            patternTable.findEntry(current_signature, false); //,
+            patternTable.findEntry(current_signature, is_secure);
         PatternStrideEntry const *lookahead = nullptr;
         if (current_pattern_entry != nullptr) {
             unsigned long max_counter = 0;

--- a/src/mem/cache/prefetch/signature_path.hh
+++ b/src/mem/cache/prefetch/signature_path.hh
@@ -148,7 +148,7 @@ class SignaturePath : public Queued
     };
 
     /** Pattern table */
-    AssociativeCache<PatternEntry> patternTable;
+    AssociativeSet<PatternEntry> patternTable;
 
     /**
      * Generates a new signature from an existing one and a new stride

--- a/src/mem/cache/prefetch/signature_path_v2.cc
+++ b/src/mem/cache/prefetch/signature_path_v2.cc
@@ -125,7 +125,8 @@ SignaturePathV2::handlePageCrossingLookahead(signature_t signature,
     GlobalHistoryEntry *gh_entry = globalHistoryRegister.findVictim(0);
     assert(gh_entry != nullptr);
     // Any address value works, as it is never used
-    globalHistoryRegister.insertEntry(0, false, gh_entry); // false,
+    bool is_secure = false;
+    globalHistoryRegister.insertEntry(0, is_secure, gh_entry); // false,
 
     gh_entry->signature = signature;
     gh_entry->lastBlock = last_offset;

--- a/src/mem/cache/prefetch/signature_path_v2.cc
+++ b/src/mem/cache/prefetch/signature_path_v2.cc
@@ -125,7 +125,7 @@ SignaturePathV2::handlePageCrossingLookahead(signature_t signature,
     GlobalHistoryEntry *gh_entry = globalHistoryRegister.findVictim(0);
     assert(gh_entry != nullptr);
     // Any address value works, as it is never used
-    globalHistoryRegister.insertEntry(0, gh_entry);
+    globalHistoryRegister.insertEntry(0, false, gh_entry); // false,
 
     gh_entry->signature = signature;
     gh_entry->lastBlock = last_offset;

--- a/src/mem/cache/prefetch/signature_path_v2.cc
+++ b/src/mem/cache/prefetch/signature_path_v2.cc
@@ -124,8 +124,9 @@ SignaturePathV2::handlePageCrossingLookahead(signature_t signature,
     // of them are unique, there are never "hits" in the GHR
     GlobalHistoryEntry *gh_entry = globalHistoryRegister.findVictim(0);
     assert(gh_entry != nullptr);
+    // Any address value works, as it is never used
     constexpr bool is_secure = false;
-    globalHistoryRegister.insertEntry(0, is_secure, gh_entry); // false,
+    globalHistoryRegister.insertEntry(0, is_secure, gh_entry);
 
     gh_entry->signature = signature;
     gh_entry->lastBlock = last_offset;

--- a/src/mem/cache/prefetch/signature_path_v2.cc
+++ b/src/mem/cache/prefetch/signature_path_v2.cc
@@ -124,8 +124,7 @@ SignaturePathV2::handlePageCrossingLookahead(signature_t signature,
     // of them are unique, there are never "hits" in the GHR
     GlobalHistoryEntry *gh_entry = globalHistoryRegister.findVictim(0);
     assert(gh_entry != nullptr);
-    // Any address value works, as it is never used
-    bool is_secure = false;
+    constexpr bool is_secure = false;
     globalHistoryRegister.insertEntry(0, is_secure, gh_entry); // false,
 
     gh_entry->signature = signature;

--- a/src/mem/cache/prefetch/signature_path_v2.hh
+++ b/src/mem/cache/prefetch/signature_path_v2.hh
@@ -66,7 +66,7 @@ class SignaturePathV2 : public SignaturePath
                                delta(0) {}
     };
     /** Global History Register */
-    AssociativeCache<GlobalHistoryEntry> globalHistoryRegister;
+    AssociativeSet<GlobalHistoryEntry> globalHistoryRegister;
 
     double calculateLookaheadConfidence(PatternEntry const &sig,
             PatternStrideEntry const &lookahead) const override;

--- a/src/mem/cache/prefetch/spatio_temporal_memory_streaming.cc
+++ b/src/mem/cache/prefetch/spatio_temporal_memory_streaming.cc
@@ -92,12 +92,14 @@ STeMS::checkForActiveGenerationsEnd(const CacheAccessor &cache)
             }
             if (generation_ended) {
                 // PST is indexed using the PC (secure bit is unused)
-                auto pst_entry = patternSequenceTable.findEntry(pst_addr);
+                auto pst_entry = patternSequenceTable.findEntry(pst_addr,
+                false);
                 if (pst_entry == nullptr) {
                     // Tipically an entry will not exist
                     pst_entry = patternSequenceTable.findVictim(pst_addr);
                     assert(pst_entry != nullptr);
-                    patternSequenceTable.insertEntry(pst_addr, pst_entry);
+                    patternSequenceTable.insertEntry(pst_addr, false,
+                    pst_entry);
                 } else {
                     patternSequenceTable.accessEntry(pst_entry);
                 }
@@ -221,7 +223,7 @@ STeMS::reconstructSequence(
     idx = 0;
     for (auto it = rmob_it; it != rmob.end() && (idx < reconstructionEntries);
         it++) {
-        auto pst_entry = patternSequenceTable.findEntry(it->pstAddress);
+        auto pst_entry = patternSequenceTable.findEntry(it->pstAddress, false);
         if (pst_entry != nullptr) {
             patternSequenceTable.accessEntry(pst_entry);
             for (auto &seq_entry : pst_entry->sequence) {

--- a/src/mem/cache/prefetch/spatio_temporal_memory_streaming.cc
+++ b/src/mem/cache/prefetch/spatio_temporal_memory_streaming.cc
@@ -92,13 +92,14 @@ STeMS::checkForActiveGenerationsEnd(const CacheAccessor &cache)
             }
             if (generation_ended) {
                 // PST is indexed using the PC (secure bit is unused)
+                bool is_secure = false;
                 auto pst_entry = patternSequenceTable.findEntry(pst_addr,
-                false);
+                is_secure);
                 if (pst_entry == nullptr) {
                     // Tipically an entry will not exist
                     pst_entry = patternSequenceTable.findVictim(pst_addr);
                     assert(pst_entry != nullptr);
-                    patternSequenceTable.insertEntry(pst_addr, false,
+                    patternSequenceTable.insertEntry(pst_addr, is_secure,
                     pst_entry);
                 } else {
                     patternSequenceTable.accessEntry(pst_entry);
@@ -221,9 +222,11 @@ STeMS::reconstructSequence(
 
     // Now query the PST with the PC of each RMOB entry
     idx = 0;
+    bool is_secure = false;
     for (auto it = rmob_it; it != rmob.end() && (idx < reconstructionEntries);
         it++) {
-        auto pst_entry = patternSequenceTable.findEntry(it->pstAddress, false);
+        auto pst_entry = patternSequenceTable.findEntry(it->pstAddress,
+        is_secure);
         if (pst_entry != nullptr) {
             patternSequenceTable.accessEntry(pst_entry);
             for (auto &seq_entry : pst_entry->sequence) {

--- a/src/mem/cache/prefetch/spatio_temporal_memory_streaming.cc
+++ b/src/mem/cache/prefetch/spatio_temporal_memory_streaming.cc
@@ -92,7 +92,7 @@ STeMS::checkForActiveGenerationsEnd(const CacheAccessor &cache)
             }
             if (generation_ended) {
                 // PST is indexed using the PC (secure bit is unused)
-                bool is_secure = false;
+                constexpr bool is_secure = false;
                 auto pst_entry = patternSequenceTable.findEntry(pst_addr,
                 is_secure);
                 if (pst_entry == nullptr) {
@@ -222,7 +222,7 @@ STeMS::reconstructSequence(
 
     // Now query the PST with the PC of each RMOB entry
     idx = 0;
-    bool is_secure = false;
+    constexpr bool is_secure = false;
     for (auto it = rmob_it; it != rmob.end() && (idx < reconstructionEntries);
         it++) {
         auto pst_entry = patternSequenceTable.findEntry(it->pstAddress,

--- a/src/mem/cache/prefetch/spatio_temporal_memory_streaming.hh
+++ b/src/mem/cache/prefetch/spatio_temporal_memory_streaming.hh
@@ -155,7 +155,7 @@ class STeMS : public Queued
     /** Active Generation Table (AGT) */
     AssociativeSet<ActiveGenerationTableEntry> activeGenerationTable;
     /** Pattern Sequence Table (PST) */
-    AssociativeCache<ActiveGenerationTableEntry> patternSequenceTable;
+    AssociativeSet<ActiveGenerationTableEntry> patternSequenceTable;
 
     /** Data type of the Region Miss Order Buffer entry */
     struct RegionMissOrderBufferEntry


### PR DESCRIPTION
This PR fixes the "Need is_secure arg" crash that occurs when using IndirectMemoryPrefetcher, SignaturePathPrefetcher, SignaturePathPrefetcherV2, STeMSPrefetcher, and PIFPrefetcher. This was done by changing some variables to have the type AssociativeSet<...> instead of AssociativeCache<...> and adding in "false" or an existing value for the value of the secure bit in some function calls. Further changes may be needed to move away from hard-coding values.