### PR TITLE
arch-vega: Fix unconditional clamps in VOP3

### DIFF
--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -2464,7 +2464,9 @@ namespace VegaISA
             if (wf->execMask(lane)) {
                 float out = std::fma(src0[lane], src1[lane], vdst[lane]);
                 out = omodModifier(out, extData.OMOD);
-                out = std::clamp(vdst[lane], 0.0f, 1.0f);
+                if (instData.CLAMP) {
+                    out = std::clamp(vdst[lane], 0.0f, 1.0f);
+                }
                 vdst[lane] = out;
             }
         }
@@ -2879,7 +2881,9 @@ namespace VegaISA
                 if (neg & 1) tmp = -tmp;
 
                 tmp = omodModifier(tmp, extData.OMOD);
-                tmp = std::clamp(tmp, 0.0f, 1.0f);
+                if (instData.CLAMP) {
+                    tmp = std::clamp(tmp, 0.0f, 1.0f);
+                }
 
                 AMDGPU::mxfloat16 out(tmp);
 
@@ -2934,7 +2938,9 @@ namespace VegaISA
                 if (neg & 1) tmp = -tmp;
 
                 float out = omodModifier(float(tmp), extData.OMOD);
-                out = std::clamp(out, 0.0f, 1.0f);
+                if (instData.CLAMP) {
+                    out = std::clamp(out, 0.0f, 1.0f);
+                }
 
                 vdst[lane] = out;
             }


### PR DESCRIPTION
Some instructions are clamping floating point outputs unconditionally, leading to incorrect results. This commit finds instructions with this issue and checks the clamp bit before applying clamp.

Change-Id: Ibc6de3813d81fd4f9d2c98dd497d19dd34cf6bde