### PR TITLE
Updating hex addr printing

### DIFF
--- a/src/cpu/testers/traffic_gen/dram_gen.cc
+++ b/src/cpu/testers/traffic_gen/dram_gen.cc
@@ -124,7 +124,7 @@ DramGen::getNextPacket()
         }
     }
 
-    DPRINTF(TrafficGen, "DramGen::getNextPacket: %c to addr %x, "
+    DPRINTF(TrafficGen, "DramGen::getNextPacket: %c to addr %#x, "
             "size %d, countNumSeqPkts: %d, numSeqPkts: %d\n",
             isRead ? 'r' : 'w', addr, blocksize, countNumSeqPkts, numSeqPkts);
 

--- a/src/cpu/testers/traffic_gen/dram_rot_gen.cc
+++ b/src/cpu/testers/traffic_gen/dram_rot_gen.cc
@@ -118,7 +118,7 @@ DramRotGen::getNextPacket()
         }
     }
 
-    DPRINTF(TrafficGen, "DramRotGen::getNextPacket: %c to addr %x, "
+    DPRINTF(TrafficGen, "DramRotGen::getNextPacket: %c to addr %#x, "
             "size %d, countNumSeqPkts: %d, numSeqPkts: %d\n",
             isRead ? 'r' : 'w', addr, blocksize, countNumSeqPkts, numSeqPkts);
 

--- a/src/cpu/testers/traffic_gen/hybrid_gen.cc
+++ b/src/cpu/testers/traffic_gen/hybrid_gen.cc
@@ -216,7 +216,7 @@ HybridGen::getNextPacket()
         }
     }
 
-    DPRINTF(TrafficGen, "HybridGen::getNextPacket: %c to addr %x, "
+    DPRINTF(TrafficGen, "HybridGen::getNextPacket: %c to addr %#x, "
             "size %d, countNumSeqPkts: %d, numSeqPkts: %d\n",
             isRead ? 'r' : 'w', addr, blocksize, countNumSeqPkts, numSeqPkts);
 

--- a/src/cpu/testers/traffic_gen/linear_gen.cc
+++ b/src/cpu/testers/traffic_gen/linear_gen.cc
@@ -64,7 +64,7 @@ LinearGen::getNextPacket()
     assert((readPercent == 0 && !isRead) || (readPercent == 100 && isRead) ||
            readPercent != 100);
 
-    DPRINTF(TrafficGen, "LinearGen::getNextPacket: %c to addr %x, size %d\n",
+    DPRINTF(TrafficGen, "LinearGen::getNextPacket: %c to addr %#x, size %d\n",
             isRead ? 'r' : 'w', nextAddr, blocksize);
 
     // Add the amount of data manipulated to the total

--- a/src/cpu/testers/traffic_gen/nvm_gen.cc
+++ b/src/cpu/testers/traffic_gen/nvm_gen.cc
@@ -125,7 +125,7 @@ NvmGen::getNextPacket()
         }
     }
 
-    DPRINTF(TrafficGen, "NvmGen::getNextPacket: %c to addr %x, "
+    DPRINTF(TrafficGen, "NvmGen::getNextPacket: %c to addr %#x, "
             "size %d, countNumSeqPkts: %d, numSeqPkts: %d\n",
             isRead ? 'r' : 'w', addr, blocksize, countNumSeqPkts, numSeqPkts);
 

--- a/src/cpu/testers/traffic_gen/random_gen.cc
+++ b/src/cpu/testers/traffic_gen/random_gen.cc
@@ -69,7 +69,7 @@ RandomGen::getNextPacket()
     // round down to start address of block
     addr -= addr % blocksize;
 
-    DPRINTF(TrafficGen, "RandomGen::getNextPacket: %c to addr %x, size %d\n",
+    DPRINTF(TrafficGen, "RandomGen::getNextPacket: %c to addr %#x, size %d\n",
             isRead ? 'r' : 'w', addr, blocksize);
 
     // add the amount of data manipulated to the total

--- a/src/cpu/testers/traffic_gen/strided_gen.cc
+++ b/src/cpu/testers/traffic_gen/strided_gen.cc
@@ -81,7 +81,7 @@ StridedGen::getNextPacket()
     assert((readPercent == 0 && !isRead) || (readPercent == 100 && isRead) ||
            readPercent != 100);
 
-    DPRINTF(TrafficGen, "StridedGen::getNextPacket: %c to addr %x, size %d\n",
+    DPRINTF(TrafficGen, "StridedGen::getNextPacket: %c to addr %#x, size %d\n",
             isRead ? 'r' : 'w', nextAddr, blocksize);
 
     // Add the amount of data manipulated to the total


### PR DESCRIPTION
This change changes the addresses that are printed when TrafficGen DebugFlag is enabled. Previously, hex strings were printed without a preceding 0x. This change fixes that to distinguish between decimal and hex.