### PR TITLE
arch-arm: return 64-bit cycle counter for MISCREG_PMCCNTR

### DIFF
--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -349,10 +349,8 @@ PMU::readMiscRegInt(int misc_reg)
         return reg_pmceid1 & 0xFFFFFFFF;
 
       case MISCREG_PMCCNTR_EL0:
-        return cycleCounter.getValue();
-
       case MISCREG_PMCCNTR:
-        return cycleCounter.getValue() & 0xFFFFFFFF;
+        return cycleCounter.getValue();
 
       case MISCREG_PMEVTYPER0_EL0...MISCREG_PMEVTYPER5_EL0:
         return getCounterTypeRegister(misc_reg - MISCREG_PMEVTYPER0_EL0);


### PR DESCRIPTION
In AArch32 mode it is possible to read a 64-bit counter using mrrc. Instead of truncating in the PMU code, just allow the instruction implementation to truncate to 32 bits if accessed using mrc.

Change-Id: I77620f6d1852a7d9e79c1ecee50f4297b4103b1c