### PR TITLE
configs: GPUFS: Disable KVM perf counters by default

### DIFF
--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -189,10 +189,10 @@ def addRunFSOptions(parser):
     )
 
     parser.add_argument(
-        "--no-kvm-perf",
+        "--kvm-perf",
         default=False,
         action="store_true",
-        help="Disable KVM perf counters (use this with LSF / ETX)",
+        help="Enable KVM perf counters",
     )
 
     parser.add_argument(

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -312,11 +312,15 @@ def makeGpuFSSystem(args):
                 obj.eventq_index = 0
             cpu.eventq_index = i + 1
 
-    # Disable KVM Perf counters if specified. This is useful for machines
-    # with more restrictive KVM paranoid levels.
-    if args.no_kvm_perf and ObjectList.is_kvm_cpu(TestCPUClass):
-        for i, cpu in enumerate(system.cpu[:-1]):
-            cpu.usePerf = False
+    # Only enable KVM perf counters if explicitly set, as this is more
+    # restrictive.
+    if ObjectList.is_kvm_cpu(TestCPUClass):
+        if args.kvm_perf:
+            for i, cpu in enumerate(system.cpu[:-1]):
+                cpu.usePerf = True
+        else:
+            for i, cpu in enumerate(system.cpu[:-1]):
+                cpu.usePerf = False
 
     gpu_port_idx = (
         len(system.ruby._cpu_ports)


### PR DESCRIPTION
This is on by default in gem5 (see src/cpu/kvm/BaseKvmCPU.py), however the perf counters only measure host instruction counters and GPUFS is not concerned about accuracy of KVM CPU stats. There are also a larger set of users who have access to KVM, but do not have the paranoid level low enough to attach performance counters.

Therefore, make the performance counters OFF by default. They can still be enabled, but this will allow for a larger set of users to follow the upcoming GPUFS documentation without needing to read through a troubleshooting section after seeing a gem5 error about the KVM paranoid level.

Change-Id: I6b465559edf3ce17e7117ada049c60bd39aecd83