### PR TITLE
misc: Remove GCN3 from maintainers

### DIFF
--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -51,12 +51,6 @@ arch-arm:
         - Giacomo Travaglini <giacomo.travaglini@arm.com>
         - Andreas Sandberg <andreas.sandberg@arm.com>
 
-arch-gcn3:
-    status: maintained
-    maintainers:
-        - Matt Sinclair <sinclair@cs.wisc.edu>
-        - Matt Poremba <matthew.poremba@amd.com>
-
 arch-vega:
     status: maintained
     maintainers:


### PR DESCRIPTION
These files no longer exist. This was missed when GCN3 support was removed in the last release.

Change-Id: I5d2aab1952c37e64da5c362a6201aa6750531c1b