### PR TITLE
mem-ruby,sim-se: Clear LL/SC locks after functional writes

### DIFF
--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -269,6 +269,9 @@ Sequencer::functionalWrite(Packet *func_pkt)
                 ++num_written;
         }
     }
+    // Functional writes to addresses being monitored
+    // will fail (remove) the monitor entry.
+    llscClearMonitor(makeLineAddress(func_pkt->getAddr()));
 
     return num_written;
 }


### PR DESCRIPTION
Functional writes atomically update all copies of a data block, so they should invalidate any pending LL/SC locks, just like a conventional write would.

Change-Id: Ic79d2d8d24901f1b6a2ce81dc0e2decc84c0ebbc