### PR TITLE
arch-riscv: Move pmpReset implementation to MMU::reset()

### DIFF
--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -188,13 +188,10 @@ Reset::invoke(ThreadContext *tc, const StaticInstPtr &inst)
     new_pc->vl(0);
     tc->pcState(*new_pc);
 
-    // Reset PMP Cfg
-    auto* mmu = dynamic_cast<RiscvISA::MMU*>(tc->getMMUPtr());
-    if (mmu == nullptr) {
-        warn("MMU is not Riscv MMU instance, we can't reset PMP");
-        return;
+    auto* mmu = tc->getMMUPtr();
+    if (mmu != nullptr) {
+        mmu->reset();
     }
-    mmu->getPMP()->pmpReset();
 }
 
 void

--- a/src/arch/riscv/mmu.hh
+++ b/src/arch/riscv/mmu.hh
@@ -42,6 +42,7 @@
 #include "arch/riscv/isa.hh"
 #include "arch/riscv/page_size.hh"
 #include "arch/riscv/pma_checker.hh"
+#include "arch/riscv/pmp.hh"
 #include "arch/riscv/tlb.hh"
 
 #include "params/RiscvMMU.hh"
@@ -59,6 +60,13 @@ class MMU : public BaseMMU
     MMU(const RiscvMMUParams &p)
       : BaseMMU(p), pma(p.pma_checker)
     {}
+
+    void
+    reset() override
+    {
+        // Reset PMP Cfg
+        getPMP()->pmpReset();
+    }
 
     TranslationGenPtr
     translateFunctional(Addr start, Addr size, ThreadContext *tc,


### PR DESCRIPTION
The PMP is part of RISC-V MMU subssystem, it should be put in RiscvISA::MMU::reset()

Change-Id: I1e47fa0e73f1685893e0ae53571886a164b315b6