### PR TITLE
mem: Fix name() helper for DRAM rank

### DIFF
--- a/src/mem/dram_interface.hh
+++ b/src/mem/dram_interface.hh
@@ -350,7 +350,11 @@ class DRAMInterface : public MemInterface
         Rank(const DRAMInterfaceParams &_p, int _rank,
              DRAMInterface& _dram);
 
-        const std::string name() const { return csprintf("%d", rank); }
+        const std::string
+        name() const
+        {
+            return csprintf("%s.rank%d", dram.name(), rank);
+        }
 
         /**
          * Kick off accounting for power and refresh states and


### PR DESCRIPTION
At the moment the method simply returns the rank number. This is not particularly useful when enabling debug flags as the beginning of the line prints something like:

1: <debug_message>

whereas it should really be:

system.dram.rank1: <debug_message>

Change-Id: I0136dc3d182afa4ae2e5a719cb366d8d0f444667