### PR TITLE
gpu-compute: fix typo in GPUMem debug print

### DIFF
--- a/src/gpu-compute/gpu_dyn_inst.cc
+++ b/src/gpu-compute/gpu_dyn_inst.cc
@@ -314,7 +314,7 @@ void
 GPUDynInst::completeAcc(GPUDynInstPtr gpuDynInst)
 {
     DPRINTF(GPUMem, "CU%d: WF[%d][%d]: mempacket status bitvector="
-            "%#x\n complete",
+            "%#x complete\n",
             cu->cu_id, simdId, wfSlotId, exec_mask);
 
     _staticInst->completeAcc(gpuDynInst);


### PR DESCRIPTION
The GPUMem print for when a memstatus request completes accidentally put a newline before the word "complete", causing complete to print on a newline and cause confusion.  This commit resolves that.

Change-Id: I1a406d5148306932cac9580daf30240bbcac4420