### PR TITLE
gpu-compute: update GPUKernelInfo print to print WG number

### DIFF
--- a/src/gpu-compute/dispatcher.cc
+++ b/src/gpu-compute/dispatcher.cc
@@ -206,7 +206,8 @@ GPUDispatcher::exec()
             } else if (!launched) {
                 launched = true;
                 disp_count++;
-                DPRINTF(GPUKernelInfo, "Launched kernel %d\n", exec_id);
+                DPRINTF(GPUKernelInfo, "Launched kernel %d for WG %d\n",
+                            exec_id, disp_count);
             }
         }
 


### PR DESCRIPTION
Whenever a GPU kernel is launching a new WG, the GPUKernelInfo debug flag will print that the kernel is being launched, without the context of which WG from that kernel is being launched.  This has caused some confusion to users, who think the entire kernel is being launched repeatedly.  To resolve this confusion, update this print to make it clear which WG is being launched when this print is enabled.

Change-Id: I9017c500a7f09ef3b58984419643c39113d1da26