### PR TITLE
util-docker,tests: Up clang support: >=v10

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -14,8 +14,8 @@ jobs:
             fail-fast: false
             matrix:
                 image: [gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-16, clang-version-15, clang-version-14, clang-version-13,
-                    clang-version-12, clang-version-11, clang-version-10, clang-version-9, clang-version-8, clang-version-7, ubuntu-20.04_all-dependencies,
-                    ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
+                    clang-version-12, clang-version-11, clang-version-10 ubuntu-20.04_all-dependencies, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies,
+                    ubuntu-24.04_min-dependencies]
                 opts: [.opt, .fast]
         runs-on: [self-hosted, linux, x64]
         timeout-minutes: 2880 # 48 hours

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -160,7 +160,7 @@ target "clang-compilers-base-20-04" {
   context = "ubuntu-20.04_clang-version"
   dockerfile = "Dockerfile"
   matrix = {
-    ver = ["7", "8", "9", "10", "11", "12"]
+    ver = ["10", "11", "12"]
   }
   args = {
     version = ver


### PR DESCRIPTION
The compiler tests are failing to to a compile bug in Clang 7: https://github.com/gem5/gem5/actions/runs/10170081794

Given Ubuntu 20.04 APT installs v10 by default (i.e., with `apt install clang`). This is the oldest LTS Ubuntu version. It therefore seems sensible to drop support for older (<v10) versions of clang.