### PR TITLE
Updating Traffic Generators

### DIFF
--- a/src/cpu/testers/traffic_gen/linear_gen.cc
+++ b/src/cpu/testers/traffic_gen/linear_gen.cc
@@ -78,7 +78,7 @@ LinearGen::getNextPacket()
 
     // If we have reached the end of the address space, reset the
     // address to the start of the range
-    if (nextAddr > endAddr) {
+    if (nextAddr >= endAddr) {
         DPRINTF(TrafficGen, "Wrapping address to the start of "
                 "the range\n");
         nextAddr = startAddr;

--- a/src/cpu/testers/traffic_gen/strided_gen.cc
+++ b/src/cpu/testers/traffic_gen/strided_gen.cc
@@ -101,7 +101,7 @@ StridedGen::getNextPacket()
 
     // If we have reached the end of the address space, reset the
     // address to the start of the range
-    if (nextAddr > endAddr) {
+    if (nextAddr >= endAddr) {
         DPRINTF(TrafficGen, "Wrapping address to the start of "
                 "the range\n");
         nextAddr = startAddr + offset;

--- a/src/python/gem5/components/processors/linear_generator.py
+++ b/src/python/gem5/components/processors/linear_generator.py
@@ -65,7 +65,8 @@ class LinearGenerator(AbstractGenerator):
 
         :param num_cores: The number of linear generator cores to create.
         :param duration: The duration of time for which the generator generates
-                         traffic.
+                         traffic. Must be a string containing a positive number
+                         and some unit. For example, "1ms".
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each
                            request.
@@ -77,7 +78,8 @@ class LinearGenerator(AbstractGenerator):
                         requests. The write percentage would be equal to
                         ``100 - rd_perc``.
         :param data_limit: The amount of data in bytes to read/write by the
-                           generator before stopping generation.
+                           generator before stopping generation. If set to 0,
+                           there will be no data limit.
         """
 
     def _create_cores(

--- a/src/python/gem5/components/processors/linear_generator.py
+++ b/src/python/gem5/components/processors/linear_generator.py
@@ -64,7 +64,7 @@ class LinearGenerator(AbstractGenerator):
         generator cores that could replace the processing cores in a board.
 
         :param num_cores: The number of linear generator cores to create.
-        :param duration: The number of ticks for the generator to generate
+        :param duration: The duration of time for which the generator generates
                          traffic.
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each

--- a/src/python/gem5/components/processors/linear_generator_core.py
+++ b/src/python/gem5/components/processors/linear_generator_core.py
@@ -61,7 +61,8 @@ class LinearGeneratorCore(AbstractGeneratorCore):
         uses PyTrafficGen to create and inject the synthetic traffic.
 
         :param duration: The duration of time for which the generator core generates
-                         traffic.
+                         traffic. Must be a string containing a positive number
+                         and some unit. For example, "1ms".
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each
                            request.
@@ -73,7 +74,8 @@ class LinearGeneratorCore(AbstractGeneratorCore):
                         requests. The write percentage would be equal to
                         ``100 - rd_perc``.
         :param data_limit: The amount of data in bytes to read/write by the
-                           generator before stopping generation.
+                           generator before stopping generation. If set to 0,
+                           there will be no data limit.
         """
         self.generator = PyTrafficGen()
         self._duration = duration

--- a/src/python/gem5/components/processors/linear_generator_core.py
+++ b/src/python/gem5/components/processors/linear_generator_core.py
@@ -60,7 +60,7 @@ class LinearGeneratorCore(AbstractGeneratorCore):
         a linear (stream) traffic specific to the parameters below. This core
         uses PyTrafficGen to create and inject the synthetic traffic.
 
-        :param duration: The number of ticks for the generator core to generate
+        :param duration: The duration of time for which the generator core generates
                          traffic.
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each

--- a/src/python/gem5/components/processors/random_generator.py
+++ b/src/python/gem5/components/processors/random_generator.py
@@ -63,7 +63,7 @@ class RandomGenerator(AbstractGenerator):
         generator cores that could replace the processing cores in a board.
 
         :param num_cores: The number of linear generator cores to create.
-        :param duration: The number of ticks for the generator to generate
+        :param duration: The duration of time for which the generator generates
                          traffic.
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each

--- a/src/python/gem5/components/processors/random_generator.py
+++ b/src/python/gem5/components/processors/random_generator.py
@@ -64,7 +64,8 @@ class RandomGenerator(AbstractGenerator):
 
         :param num_cores: The number of linear generator cores to create.
         :param duration: The duration of time for which the generator generates
-                         traffic.
+                         traffic. Must be a string containing a positive number
+                         and some unit. For example, "1ms".
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each
                            request.
@@ -76,7 +77,8 @@ class RandomGenerator(AbstractGenerator):
                         requests. The write percentage would be equal to
                         ``100 - rd_perc``.
         :param data_limit: The amount of data in bytes to read/write by the
-                           generator before stopping generation.
+                           generator before stopping generation. If set to 0,
+                           there will be no data limit.
         """
 
     def _create_cores(

--- a/src/python/gem5/components/processors/random_generator_core.py
+++ b/src/python/gem5/components/processors/random_generator_core.py
@@ -61,7 +61,8 @@ class RandomGeneratorCore(AbstractGeneratorCore):
         PyTrafficGen to create and inject the synthetic traffic.
 
         :param duration: The duration of time for which the generator core generates
-                         traffic.
+                         traffic. Must be a string containing a positive number
+                         and some unit. For example, "1ms".
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each
                            request.
@@ -73,7 +74,8 @@ class RandomGeneratorCore(AbstractGeneratorCore):
                         requests. The write percentage would be equal to
                         ``100 - rd_perc``.
         :param data_limit: The amount of data in bytes to read/write by the
-        		   generator before stopping generation.
+        		   generator before stopping generation. If set to 0,
+                           there will be no data limit.
         """
         self.generator = PyTrafficGen()
         self._duration = duration

--- a/src/python/gem5/components/processors/random_generator_core.py
+++ b/src/python/gem5/components/processors/random_generator_core.py
@@ -60,7 +60,7 @@ class RandomGeneratorCore(AbstractGeneratorCore):
         a random traffic specific to the parameters below. This core uses
         PyTrafficGen to create and inject the synthetic traffic.
 
-        :param duration: The number of ticks for the generator core to generate
+        :param duration: The duration of time for which the generator core generates
                          traffic.
         :param rate: The rate at which the synthetic data is read/written.
         :param block_size: The number of bytes to be read/written with each

--- a/src/python/gem5/components/processors/strided_generator.py
+++ b/src/python/gem5/components/processors/strided_generator.py
@@ -65,6 +65,33 @@ class StridedGenerator(AbstractGenerator):
                 data_limit=data_limit,
             )
         )
+        """The strided generator
+
+        This class defines an external interface to create a list of strided
+        generator cores that could replace the processing cores in a board.
+
+        :param duration: The duration of time for which the generator generates
+                         traffic.
+        :param rate: The rate at which the data accesses are demanded.
+        :param block_size: The number of bytes to be read/written with each
+                           request.
+        :param superblock_size: The number of bytes to read/write contiguously
+                                per stride. Must be a multiple of block_size.
+        :param stride_size: The number of bytes from the beginning of one superblock
+                            to the beginning of the next superblock.
+                            Must be a multiple of superblock_size.
+        :param min_addr: The lower bound of the address range the generator
+                         will read/write from/to.
+        :param max_addr: The upper bound of the address range the generator
+                         will read/write from/to.
+        :param offset: The starting offset in bytes from min_addr at which
+                       the generator reads/writes. Must be a multiple of superblock_size.
+        :param rd_perc: The percentage of read requests among all the generated
+                        requests. The write percentage would be equal to
+                        ``100 - rd_perc``.
+        :param data_limit: The amount of data in bytes to read/write by the
+                           generator before stopping generation.
+        """
 
     def _create_cores(
         self,

--- a/src/python/gem5/components/processors/strided_generator.py
+++ b/src/python/gem5/components/processors/strided_generator.py
@@ -71,7 +71,8 @@ class StridedGenerator(AbstractGenerator):
         generator cores that could replace the processing cores in a board.
 
         :param duration: The duration of time for which the generator generates
-                         traffic.
+                         traffic. Must be a string containing a positive number
+                         and some unit. For example, "1ms".
         :param rate: The rate at which the data accesses are demanded.
         :param block_size: The number of bytes to be read/written with each
                            request.
@@ -90,7 +91,8 @@ class StridedGenerator(AbstractGenerator):
                         requests. The write percentage would be equal to
                         ``100 - rd_perc``.
         :param data_limit: The amount of data in bytes to read/write by the
-                           generator before stopping generation.
+                           generator before stopping generation. If set to 0,
+                           there will be no data limit.
         """
 
     def _create_cores(

--- a/src/python/gem5/components/processors/strided_generator_core.py
+++ b/src/python/gem5/components/processors/strided_generator_core.py
@@ -59,6 +59,34 @@ class StridedGeneratorCore(AbstractGeneratorCore):
         data_limit: int,
     ) -> None:
         super().__init__()
+        """ The strided generator core interface.
+
+        This class defines the interface for a generator core that will create
+        a strided traffic specific to the parameters below. This core
+        uses PyTrafficGen to create and inject the synthetic traffic.
+
+        :param duration: The duration of time for which the generator core generates
+                         traffic.
+        :param rate: The rate at which the data accesses are demanded.
+        :param block_size: The number of bytes to be read/written with each
+                           request.
+        :param superblock_size: The number of bytes to read/write contiguously
+                                per stride. Must be a multiple of block_size.
+        :param stride_size: The number of bytes from the beginning of one superblock
+                            to the beginning of the next superblock.
+                            Must be a multiple of superblock_size.
+        :param min_addr: The lower bound of the address range the generator
+                         will read/write from/to.
+        :param max_addr: The upper bound of the address range the generator
+                         will read/write from/to.
+        :param offset: The starting offset in bytes from min_addr at which
+                       the generator reads/writes. Must be a multiple of superblock_size.
+        :param rd_perc: The percentage of read requests among all the generated
+                        requests. The write percentage would be equal to
+                        ``100 - rd_perc``.
+        :param data_limit: The amount of data in bytes to read/write by the
+                           generator before stopping generation.
+        """
 
         self.generator = PyTrafficGen()
         self._duration = duration

--- a/src/python/gem5/components/processors/strided_generator_core.py
+++ b/src/python/gem5/components/processors/strided_generator_core.py
@@ -66,7 +66,8 @@ class StridedGeneratorCore(AbstractGeneratorCore):
         uses PyTrafficGen to create and inject the synthetic traffic.
 
         :param duration: The duration of time for which the generator core generates
-                         traffic.
+                         traffic. Must be a string containing a positive number
+                         and some unit. For example, "1ms".
         :param rate: The rate at which the data accesses are demanded.
         :param block_size: The number of bytes to be read/written with each
                            request.
@@ -85,7 +86,8 @@ class StridedGeneratorCore(AbstractGeneratorCore):
                         requests. The write percentage would be equal to
                         ``100 - rd_perc``.
         :param data_limit: The amount of data in bytes to read/write by the
-                           generator before stopping generation.
+                           generator before stopping generation. If set to 0,
+                           there will be no data limit.
         """
 
         self.generator = PyTrafficGen()


### PR DESCRIPTION
Added documentation for `strided_generator.py` and `strided_generator_core.py.`

Updated clarity of documentation for `linear_generator.py`, `linear_generator_core.py`, `random_generator.py`, and `random_generator_core.py`.

Made `max_addr` exclusive instead of inclusive for strided and linear traffic generation in `strided_gen.cc` and `linear_gen.cc`.