### PR TITLE
cpu: LoopPoint analysis object

### DIFF
--- a/src/cpu/probes/pc_count_pair.hh
+++ b/src/cpu/probes/pc_count_pair.hh
@@ -42,12 +42,12 @@ class PcCountPair
     /** The Program Counter address */
     Addr pc;
     /** The count of the Program Counter address */
-    int count;
+    uint64_t count;
 
   public:
 
     /** Explicit constructor assigning the pc and count values */
-    explicit constexpr PcCountPair(Addr _pc, int _count) :
+    explicit constexpr PcCountPair(Addr _pc, uint64_t _count) :
         pc(_pc), count(_count) {}
 
     /** Default constructor for parameter classes */
@@ -56,7 +56,7 @@ class PcCountPair
     /** Returns the Program Counter address */
     constexpr Addr getPC() const { return pc; }
     /** Returns the count of the Program */
-    constexpr int getCount() const { return count; }
+    constexpr uint64_t getCount() const { return count; }
 
     /** Greater than comparison */
     constexpr bool
@@ -86,8 +86,8 @@ class PcCountPair
     {
         size_t operator()(const PcCountPair& item) const
         {
-            size_t xHash = std::hash<int>()(item.pc);
-            size_t yHash = std::hash<int>()(item.count);
+            size_t xHash = std::hash<uint64_t>()(item.pc);
+            size_t yHash = std::hash<uint64_t>()(item.count);
             return xHash * 2 + yHash;
         }
     };

--- a/src/cpu/probes/pc_count_tracker_manager.cc
+++ b/src/cpu/probes/pc_count_tracker_manager.cc
@@ -57,7 +57,7 @@ PcCountTrackerManager::checkCount(Addr pc)
 {
 
     if(ifListNotEmpty) {
-        int count = ++counter.find(pc)->second;
+        uint64_t count = ++counter.find(pc)->second;
         // increment the counter of the encountered PC address by 1
 
         currentPair = PcCountPair(pc,count);

--- a/src/cpu/probes/pc_count_tracker_manager.hh
+++ b/src/cpu/probes/pc_count_tracker_manager.hh
@@ -54,7 +54,7 @@ class PcCountTrackerManager : public SimObject {
     /** a counter that stores all the target PC addresses and the number
      * of times the target PC has been executed
      */
-    std::unordered_map<Addr, int> counter;
+    std::unordered_map<Addr, uint64_t> counter;
 
     /** a set that stores all the PC Count pairs that should raise an
      * exit event at

--- a/src/cpu/probes/pc_count_tracker_manager.hh
+++ b/src/cpu/probes/pc_count_tracker_manager.hh
@@ -82,7 +82,7 @@ class PcCountTrackerManager : public SimObject {
      * @return the corresponding value of count for the inputted Program
      * Counter address
      */
-    int
+    uint64_t
     getPcCount(Addr pc) const
     {
         if (counter.find(pc) != counter.end()) {

--- a/src/cpu/simple/probes/LooppointAnalysis.py
+++ b/src/cpu/simple/probes/LooppointAnalysis.py
@@ -84,6 +84,7 @@ class LooppointAnalysisManager(SimObject):
     cxx_exports = [
         PyBindMethod("getGlobalBBV"),
         PyBindMethod("clearGlobalBBV"),
+        PyBindMethod("getBBInstMap"),
         PyBindMethod("getGlobalInstCounter"),
         PyBindMethod("clearGlobalInstCounter"),
         PyBindMethod("getBackwardBranchCounter"),

--- a/src/cpu/simple/probes/LooppointAnalysis.py
+++ b/src/cpu/simple/probes/LooppointAnalysis.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/cpu/simple/probes/LooppointAnalysis.py
+++ b/src/cpu/simple/probes/LooppointAnalysis.py
@@ -24,6 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from m5.citations import add_citation
 from m5.objects import SimObject
 from m5.objects.Probe import ProbeListenerObject
 from m5.params import *
@@ -54,16 +55,19 @@ class LooppointAnalysis(ProbeListenerObject):
         "the LooppointAnalysis manager"
     )
     bb_valid_addr_range = Param.AddrRange(
-        AddrRange(start=0, end=0), "the valid address range for basic blocks"
+        "the valid address range for basic blocks. If the address start and"
+        "end are both 0 (AddrRange(start=0, end=0)), it means every address is"
+        "valid."
     )
     marker_valid_addr_range = Param.AddrRange(
-        AddrRange(start=0, end=0), "the valid address range for markers"
+        "the valid address range for markers. If the address start and end are"
+        "both 0 (AddrRange(start=0, end=0)), it means every address is valid."
     )
     bb_excluded_addr_ranges = VectorParam.AddrRange(
         [], "the excluded address ranges for basic blocks"
     )
     if_listening = Param.Bool(
-        True, "if the LooppointAnalysis is listening to " "the probe point"
+        True, "if the LooppointAnalysis is listening to the probe point"
     )
 
 
@@ -87,4 +91,43 @@ class LooppointAnalysisManager(SimObject):
         PyBindMethod("getMostRecentBackwardBranchCount"),
     ]
 
-    region_length = Param.Int(100000000, "the length of the region")
+    region_length = Param.Int(100_000_000, "the length of the region")
+
+
+add_citation(
+    LooppointAnalysis,
+    """
+    @INPROCEEDINGS{9773236,
+        author={Sabu, Alen and Patil, Harish and Heirman, Wim and Carlson, Trevor E.},
+        booktitle={2022 IEEE International Symposium on High-Performance Computer Architecture (HPCA)},
+        title={LoopPoint: Checkpoint-driven Sampled Simulation for Multi-threaded Applications},
+        year={2022},
+        volume={},
+        number={},
+        pages={604-618},
+        keywords={Data centers;Codes;Multicore processing;Computational modeling;
+            Computer architecture;Parallel processing;
+            Benchmark testing;checkpointing;multi-threaded;
+            record-and-replay;sampling;simulation},
+        doi={10.1109/HPCA53966.2022.00051}}
+    """,
+)
+
+add_citation(
+    LooppointAnalysisManager,
+    """
+    @INPROCEEDINGS{9773236,
+        author={Sabu, Alen and Patil, Harish and Heirman, Wim and Carlson, Trevor E.},
+        booktitle={2022 IEEE International Symposium on High-Performance Computer Architecture (HPCA)},
+        title={LoopPoint: Checkpoint-driven Sampled Simulation for Multi-threaded Applications},
+        year={2022},
+        volume={},
+        number={},
+        pages={604-618},
+        keywords={Data centers;Codes;Multicore processing;Computational modeling;
+            Computer architecture;Parallel processing;
+            Benchmark testing;checkpointing;multi-threaded;
+            record-and-replay;sampling;simulation},
+        doi={10.1109/HPCA53966.2022.00051}}
+    """,
+)

--- a/src/cpu/simple/probes/LooppointAnalysis.py
+++ b/src/cpu/simple/probes/LooppointAnalysis.py
@@ -40,7 +40,7 @@ class LooppointAnalysis(ProbeListenerObject):
     """
 
     type = "LooppointAnalysis"
-    cxx_header = "cpu/simple/probes/LooppointAnalysis.hh"
+    cxx_header = "cpu/simple/probes/looppoint_analysis.hh"
     cxx_class = "gem5::LooppointAnalysis"
 
     cxx_exports = [
@@ -74,7 +74,7 @@ class LooppointAnalysisManager(SimObject):
     """
 
     type = "LooppointAnalysisManager"
-    cxx_header = "cpu/simple/probes/LooppointAnalysis.hh"
+    cxx_header = "cpu/simple/probes/looppoint_analysis.hh"
     cxx_class = "gem5::LooppointAnalysisManager"
 
     cxx_exports = [

--- a/src/cpu/simple/probes/LooppointAnalysis.py
+++ b/src/cpu/simple/probes/LooppointAnalysis.py
@@ -23,3 +23,68 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects import SimObject
+from m5.objects.Probe import ProbeListenerObject
+from m5.params import *
+from m5.util.pybind import *
+
+
+class LooppointAnalysis(ProbeListenerObject):
+    """This ProbeListenerObject is meant to attach to the ATOMIC CPU and use
+    the ATOMIC CPU's ppCommit probe point to collect information needed to
+    perform the LoopPoint analysis.
+    It is notified when the ATOMIC CPU commits an instruction.
+    Each LooppointAnalysis object only attaches to one core and listen to one
+    probe point.
+    """
+
+    type = "LooppointAnalysis"
+    cxx_header = "cpu/simple/probes/LooppointAnalysis.hh"
+    cxx_class = "gem5::LooppointAnalysis"
+
+    cxx_exports = [
+        PyBindMethod("startListening"),
+        PyBindMethod("stopListening"),
+        PyBindMethod("getLocalBBV"),
+        PyBindMethod("clearLocalBBV"),
+    ]
+
+    looppoint_analysis_manager = Param.LooppointAnalysisManager(
+        "the LooppointAnalysis manager"
+    )
+    bb_valid_addr_range = Param.AddrRange(
+        AddrRange(start=0, end=0), "the valid address range for basic blocks"
+    )
+    marker_valid_addr_range = Param.AddrRange(
+        AddrRange(start=0, end=0), "the valid address range for markers"
+    )
+    bb_excluded_addr_ranges = VectorParam.AddrRange(
+        [], "the excluded address ranges for basic blocks"
+    )
+    if_listening = Param.Bool(
+        True, "if the LooppointAnalysis is listening to " "the probe point"
+    )
+
+
+class LooppointAnalysisManager(SimObject):
+    """This SimObject is meant to manage the LooppointAnalysis objects and
+    collect the global information needed to perform the LoopPoint analysis
+    across all cores.
+    """
+
+    type = "LooppointAnalysisManager"
+    cxx_header = "cpu/simple/probes/LooppointAnalysis.hh"
+    cxx_class = "gem5::LooppointAnalysisManager"
+
+    cxx_exports = [
+        PyBindMethod("getGlobalBBV"),
+        PyBindMethod("clearGlobalBBV"),
+        PyBindMethod("getGlobalInstCounter"),
+        PyBindMethod("clearGlobalInstCounter"),
+        PyBindMethod("getBackwardBranchCounter"),
+        PyBindMethod("getMostRecentBackwardBranchPC"),
+        PyBindMethod("getMostRecentBackwardBranchCount"),
+    ]
+
+    region_length = Param.Int(100000000, "the length of the region")

--- a/src/cpu/simple/probes/LooppointAnalysis.py
+++ b/src/cpu/simple/probes/LooppointAnalysis.py
@@ -55,13 +55,13 @@ class LooppointAnalysis(ProbeListenerObject):
         "the LooppointAnalysis manager"
     )
     bb_valid_addr_range = Param.AddrRange(
-        "the valid address range for basic blocks. If the address start and"
+        "the valid address range for basic blocks. If the address start and "
         "end are both 0 (AddrRange(start=0, end=0)), it means every address is"
-        "valid."
+        " valid."
     )
     marker_valid_addr_range = Param.AddrRange(
         "the valid address range for markers. If the address start and end are"
-        "both 0 (AddrRange(start=0, end=0)), it means every address is valid."
+        " both 0 (AddrRange(start=0, end=0)), it means every address is valid."
     )
     bb_excluded_addr_ranges = VectorParam.AddrRange(
         [], "the excluded address ranges for basic blocks"

--- a/src/cpu/simple/probes/SConscript
+++ b/src/cpu/simple/probes/SConscript
@@ -3,6 +3,9 @@
 # Copyright (c) 2014 ARM Limited
 # All rights reserved.
 #
+# Copyright (c) 2024 The Regents of the University of California
+# All rights reserved.
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met: redistributions of source code must retain the above copyright

--- a/src/cpu/simple/probes/SConscript
+++ b/src/cpu/simple/probes/SConscript
@@ -31,3 +31,10 @@ Import('*')
 if env['CONF']['BUILD_ISA']:
     SimObject('SimPoint.py', sim_objects=['SimPoint'])
     Source('simpoint.cc')
+
+    SimObject(
+        'LooppointAnalysis.py',
+        sim_objects=['LooppointAnalysis','LooppointAnalysisManager']
+    )
+    Source('looppoint_analysis.cc')
+    DebugFlag("LooppointAnalysis")

--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -200,7 +200,7 @@ LooppointAnalysis::stopListening()
         if (_listener != nullptr) {
             delete(_listener);
             DPRINTF(LooppointAnalysis,
-                "Stop listening to the RetiredInstsPC\n");
+                "Deleted Listener pointer\n");
         }
     }
     listeners.clear();

--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -49,7 +49,7 @@ LooppointAnalysis::LooppointAnalysis(const LooppointAnalysisParams &params)
                 params.bb_excluded_addr_ranges[i].start(),
                 params.bb_excluded_addr_ranges[i].end()
             )
-        )
+        );
         DPRINTF(LooppointAnalysis, "Excluding address range: (%li, %li)\n",
                 params.bb_excluded_addr_ranges[i].start(),
                 params.bb_excluded_addr_ranges[i].end()
@@ -180,7 +180,7 @@ LooppointAnalysis::regProbeListeners()
 {
     if (ifListening)
     {
-        listeners.push_back(new LooppointAnalysisListener(this,
+        listeners.push_back(new looppointAnalysisListener(this,
                             "Commit", &LooppointAnalysis::checkPc));
         DPRINTF(LooppointAnalysis, "Start listening to the RetiredInstsPC\n");
     }

--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -25,3 +25,227 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "cpu/simple/probes/looppoint_analysis.hh"
+
+namespace gem5
+{
+
+LooppointAnalysis::LooppointAnalysis(const LooppointAnalysisParams &params)
+    : ProbeListenerObject(params),
+      lpaManager(params.looppoint_analysis_manager),
+      bbValidAddrRange(params.bb_valid_addr_range),
+      markerValidAddrRange(params.marker_valid_addr_range),
+      ifListening(params.if_listening),
+      bbInstCounter(0)
+{
+    DPRINTF(LooppointAnalysis, "Start listening from the beginning of the "
+                            "simulation? %s\n", ifListening ? "Yes" : "No");
+
+    for (int i = 0; i < params.bb_excluded_addr_ranges.size(); i++)
+    {
+        bbExcludedAddrRanges.push_back(
+            AddrRange(
+                params.bb_excluded_addr_ranges[i].start(),
+                params.bb_excluded_addr_ranges[i].end()
+            )
+        )
+        DPRINTF(LooppointAnalysis, "Excluding address range: (%li, %li)\n",
+                params.bb_excluded_addr_ranges[i].start(),
+                params.bb_excluded_addr_ranges[i].end()
+        );
+    }
+
+    DPRINTF(LooppointAnalysis, "Valid address range: (%li, %li)\n",
+            bbValidAddrRange.start(), bbValidAddrRange.end());
+    DPRINTF(LooppointAnalysis, "Valid marker address range: (%li, %li)\n",
+            markerValidAddrRange.start(), markerValidAddrRange.end());
+}
+
+void
+LooppointAnalysis::updateLocalBBV(const Addr pc)
+{
+    if (localBBV.find(pc) == localBBV.end())
+    {
+        localBBV.insert(std::make_pair(pc, 1));
+    }
+    else
+    {
+        localBBV.find(pc)->second++;
+    }
+}
+
+void
+LooppointAnalysis::checkPc(const std::pair<SimpleThread*,
+                                                     StaticInstPtr>& inst_pair)
+{
+    SimpleThread* thread = inst_pair.first;
+    const StaticInstPtr &inst = inst_pair.second;
+    auto &pcstate =
+                thread->getTC()->pcState().as<GenericISA::PCStateWithNext>();
+    Addr pc = pcstate.pc();
+
+    if (lpaManager->ifEncountered(pc))
+    {
+        if (lpaManager->ifValidNotControl(pc))
+        {
+            lpaManager->incrementGlobalInstCounter();
+            bbInstCounter++;
+        }
+        else if (lpaManager->ifValidControl(pc))
+        {
+            bbInstCounter ++;
+            lpaManager->incrementGlobalInstCounter();
+            lpaManager->updateBBInstMap(pc, bbInstCounter);
+            updateLocalBBV(pc);
+            lpaManager->updateGlobalBBV(pc);
+            bbInstCounter = 0;
+            if (lpaManager->ifBackwardBranch(pc))
+            {
+                lpaManager->countBackwardBranch(pc);
+            }
+        }
+        return;
+    }
+
+    lpaManager->updateEncountered(pc);
+
+        if (inst->isMicroop() && !inst->isLastMicroop())
+    {
+        return;
+    }
+
+    if (!thread->getIsaPtr()->inUserMode())
+    {
+        return;
+    }
+
+    if (bbValidAddrRange.end() > 0 &&
+        (pc < bbValidAddrRange.start() || pc > bbValidAddrRange.end()))
+    {
+        return;
+    }
+
+    if (bbExcludedAddrRanges.size() > 0)
+    {
+        for (int i = 0; i < bbExcludedAddrRanges.size(); i++)
+        {
+            if (pc >= bbExcludedAddrRanges[i].start() &&
+                pc <= bbExcludedAddrRanges[i].end())
+            {
+                return;
+            }
+        }
+    }
+
+    bbInstCounter++;
+    lpaManager->incrementGlobalInstCounter();
+
+    if (inst->isControl())
+    {
+        lpaManager->updateValidControl(pc);
+        lpaManager->updateBBInstMap(pc, bbInstCounter);
+        updateLocalBBV(pc);
+        lpaManager->updateGlobalBBV(pc);
+        bbInstCounter = 0;
+
+        if (markerValidAddrRange.end() > 0 &&
+         (pc < markerValidAddrRange.start() || pc > markerValidAddrRange.end())
+        )
+        {
+            return;
+        }
+
+        if (inst->isDirectCtrl())
+        {
+            // We only consider direct control instructions as possible
+            // loop branch instructions because it is PC-relative and it
+            // excludes return instructions.
+            if (pcstate.npc() < pc)
+            {
+                lpaManager->updateBackwardBranch(pc);
+                lpaManager->countBackwardBranch(pc);
+            }
+
+        }
+    }
+    else
+    {
+        lpaManager->updateValidNotControl(pc);
+    }
+}
+
+void
+LooppointAnalysis::regProbeListeners()
+{
+    if (ifListening)
+    {
+        listeners.push_back(new LooppointAnalysisListener(this,
+                            "Commit", &LooppointAnalysis::checkPc));
+        DPRINTF(LooppointAnalysis, "Start listening to the RetiredInstsPC\n");
+    }
+
+}
+
+void
+LooppointAnalysis::startListening()
+{
+    ifListening = true;
+    regProbeListeners();
+}
+
+void
+LooppointAnalysis::stopListening()
+{
+    ifListening = false;
+
+    for (auto l = listeners.begin(); l != listeners.end(); ++l) {
+        delete (*l);
+    }
+    listeners.clear();
+}
+
+LooppointAnalysisManager::LooppointAnalysisManager(const
+                                    LooppointAnalysisManagerParams &params)
+    : SimObject(params),
+    regionLength(params.region_length),
+    globalInstCounter(0),
+    mostRecentBackwardBranchPC(0)
+{
+    DPRINTF(LooppointAnalysis, "regionLength = %i\n", regionLength);
+}
+
+void
+LooppointAnalysisManager::countBackwardBranch(const Addr pc)
+{
+    if (backwardBranchCounter.find(pc) == backwardBranchCounter.end())
+    {
+        backwardBranchCounter.insert(std::make_pair(pc, 1));
+    }
+    else
+    {
+        backwardBranchCounter.find(pc)->second++;
+    }
+
+    mostRecentBackwardBranchPC = pc;
+
+    if (globalInstCounter >= regionLength)
+    {
+        exitSimLoopNow("simpoint starting point found");
+    }
+}
+
+void
+LooppointAnalysisManager::updateGlobalBBV(const Addr pc)
+{
+    if (globalBBV.find(pc) == globalBBV.end())
+    {
+        globalBBV.insert(std::make_pair(pc, 1));
+    }
+    else
+    {
+        globalBBV.find(pc)->second++;
+    }
+}
+
+}// namespace gem5

--- a/src/cpu/simple/probes/looppoint_analysis.hh
+++ b/src/cpu/simple/probes/looppoint_analysis.hh
@@ -279,6 +279,11 @@ class LooppointAnalysisManager: public SimObject
         }
     };
 
+    std::unordered_map<Addr, uint64_t> getBBInstMap() const
+    {
+        return bbInstMap;
+    };
+
     std::unordered_map<Addr, uint64_t>
     getGlobalBBV() const
     {

--- a/src/cpu/simple/probes/looppoint_analysis.hh
+++ b/src/cpu/simple/probes/looppoint_analysis.hh
@@ -132,12 +132,14 @@ class LooppointAnalysis : public ProbeListenerObject
     void updateLocalBBV(const Addr pc);
 
   public:
-    std::unordered_map<Addr, uint64_t> getLocalBBV() const
+    std::unordered_map<Addr, uint64_t>
+    getLocalBBV() const
     {
         return localBBV;
     };
 
-    void clearLocalBBV()
+    void
+    clearLocalBBV()
     {
         localBBV.clear();
     };
@@ -210,11 +212,6 @@ class LooppointAnalysisManager: public SimObject
     Addr mostRecentBackwardBranchPC;
 
     /**
-     * This set stores the Program Counter addresses of the valid backward
-     * branches.
-     */
-    std::unordered_set<Addr> backwardBranchPC;
-    /**
      * This set stores the Program Counter addresses of the valid not control
      * instructions.
      */
@@ -231,47 +228,50 @@ class LooppointAnalysisManager: public SimObject
     std::unordered_set<Addr> encounteredPC;
 
   public:
-    bool ifBackwardBranch(const Addr pc) const
+    bool
+    ifBackwardBranch(const Addr pc) const
     {
-        return backwardBranchPC.find(pc) != backwardBranchPC.end();
+        return backwardBranchCounter.find(pc) != backwardBranchCounter.end();
     };
 
-    bool ifValidNotControl(const Addr pc) const
+    bool
+    ifValidNotControl(const Addr pc) const
     {
         return validNotControlPC.find(pc) != validNotControlPC.end();
     };
 
-    bool ifValidControl(const Addr pc) const
+    bool
+    ifValidControl(const Addr pc) const
     {
         return validControlPC.find(pc) != validControlPC.end();
     };
 
-    bool ifEncountered(const Addr pc) const
+    bool
+    ifEncountered(const Addr pc) const
     {
         return encounteredPC.find(pc) != encounteredPC.end();
     };
 
-    void updateBackwardBranch(const Addr pc)
-    {
-        backwardBranchPC.insert(pc);
-    };
-
-    void updateValidNotControl(const Addr pc)
+    void
+    updateValidNotControl(const Addr pc)
     {
         validNotControlPC.insert(pc);
     };
 
-    void updateValidControl(const Addr pc)
+    void
+    updateValidControl(const Addr pc)
     {
         validControlPC.insert(pc);
     };
 
-    void updateEncountered(const Addr pc)
+    void
+    updateEncountered(const Addr pc)
     {
         encounteredPC.insert(pc);
     };
 
-    void updateBBInstMap(Addr pc, uint64_t inst_ount)
+    void
+    updateBBInstMap(Addr pc, uint64_t inst_ount)
     {
         if (bbInstMap.find(pc) == bbInstMap.end())
         {
@@ -279,45 +279,53 @@ class LooppointAnalysisManager: public SimObject
         }
     };
 
-    std::unordered_map<Addr, uint64_t> getGlobalBBV() const
+    std::unordered_map<Addr, uint64_t>
+    getGlobalBBV() const
     {
         return globalBBV;
     };
 
-    void clearGlobalBBV()
+    void
+    clearGlobalBBV()
     {
         globalBBV.clear();
         DPRINTF(LooppointAnalysis,"globalBBV is cleared\n");
     };
 
-    uint64_t getGlobalInstCounter() const
+    uint64_t
+    getGlobalInstCounter() const
     {
         return globalInstCounter;
     };
 
-    void clearGlobalInstCounter()
+    void
+    clearGlobalInstCounter()
     {
         globalInstCounter = 0;
         DPRINTF(LooppointAnalysis,"globalInstCounter is cleared\n current "
             "globalInstCounter = %lu\n", globalInstCounter);
     };
 
-    void incrementGlobalInstCounter()
+    void
+    incrementGlobalInstCounter()
     {
         globalInstCounter++;
     };
 
-    Addr getMostRecentBackwardBranchPC() const
+    Addr
+    getMostRecentBackwardBranchPC() const
     {
         return mostRecentBackwardBranchPC;
     };
 
-    std::unordered_map<Addr, uint64_t> getBackwardBranchCounter() const
+    std::unordered_map<Addr, uint64_t>
+    getBackwardBranchCounter() const
     {
         return backwardBranchCounter;
     };
 
-    uint64_t getMostRecentBackwardBranchCount() const
+    uint64_t
+    getMostRecentBackwardBranchCount() const
     {
         return backwardBranchCounter.find(mostRecentBackwardBranchPC)->second;
     };

--- a/src/cpu/simple/probes/looppoint_analysis.hh
+++ b/src/cpu/simple/probes/looppoint_analysis.hh
@@ -287,6 +287,7 @@ class LooppointAnalysisManager: public SimObject
     void clearGlobalBBV()
     {
         globalBBV.clear();
+        DPRINTF(LooppointAnalysis,"globalBBV is cleared\n");
     };
 
     uint64_t getGlobalInstCounter() const
@@ -297,6 +298,8 @@ class LooppointAnalysisManager: public SimObject
     void clearGlobalInstCounter()
     {
         globalInstCounter = 0;
+        DPRINTF(LooppointAnalysis,"globalInstCounter is cleared\n current "
+            "globalInstCounter = %lu\n", globalInstCounter);
     };
 
     void incrementGlobalInstCounter()

--- a/src/cpu/simple/probes/looppoint_analysis.hh
+++ b/src/cpu/simple/probes/looppoint_analysis.hh
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_SIMPLE_PROBES_LOOPPOINT_ANALYSIS_HH__
+#define __CPU_SIMPLE_PROBES_LOOPPOINT_ANALYSIS_HH__
+
+// C++ includes
+#include <list>
+#include <unordered_map>
+#include <unordered_set>
+
+// m5 includes
+#include "arch/generic/pcstate.hh"
+#include "cpu/probes/pc_count_pair.hh"
+#include "cpu/simple_thread.hh"
+#include "sim/sim_exit.hh"
+
+// class includes
+#include "debug/LooppointAnalysis.hh"
+#include "params/LooppointAnalysis.hh"
+#include "params/LooppointAnalysisManager.hh"
+
+namespace gem5
+{
+
+class LooppointAnalysis : public ProbeListenerObject
+{
+  public:
+    LooppointAnalysis(const LooppointAnalysisParams &params);
+
+    virtual void regProbeListeners();
+
+    void checkPc(const std::pair<SimpleThread*, StaticInstPtr>& inst_pair);
+
+    void startListening();
+    void stopListening();
+
+    typedef ProbeListenerArg<LooppointAnalysis,
+        std::pair<SimpleThread*, StaticInstPtr>> looppointAnalysisListener;
+
+  private:
+
+    LooppointAnalysisManager *lpaManager;
+    AddrRange bbValidAddrRange;
+    AddrRange markerValidAddrRange;
+    std::vector<AddrRange> bbExcludedAddrRanges;
+    bool ifListening;
+
+    uint64_t bbInstCounter;
+
+    std::unordered_map<Addr, uint64_t> localBBV;
+
+    void updateLocalBBV(const Addr pc);
+
+  public:
+    std::unordered_map<Addr, uint64_t> getLocalBBV() const
+    {
+        return localBBV;
+    };
+
+    void clearLocalBBV()
+    {
+        localBBV.clear();
+    };
+};
+
+class LooppointAnalysisManager: public SimObject
+{
+  public:
+    LooppointAnalysisManager(const LooppointAnalysisManagerParams &params);
+
+    void countPc(const Addr pc);
+    void updateBBV(const Addr pc);
+
+  private:
+    std::unordered_map<Addr, uint64_t> loopCounter;
+    std::unordered_map<Addr, uint64_t> globalBBV;
+    std::unordered_map<Addr, uint64_t> bbInstMap;
+
+    uint64_t regionLength;
+    uint64_t globalInstCounter;
+
+    Addr mostRecentLoopPC;
+
+    std::unordered_set<Addr> backwardBranchPC;
+    std::unordered_set<Addr> validNotControlPC;
+    std::unordered_set<Addr> validControlPC;
+    std::unordered_set<Addr> encounteredPC;
+
+  public:
+    bool ifBackwardBranch(const Addr pc) const
+    {
+        return backwardBranchPC.find(pc) != backwardBranchPC.end();
+    };
+
+    bool ifValidNotControl(const Addr pc) const
+    {
+        return validNotControlPC.find(pc) != validNotControlPC.end();
+    };
+
+    bool ifValidControl(const Addr pc) const
+    {
+        return validControlPC.find(pc) != validControlPC.end();
+    };
+
+    bool ifEncountered(const Addr pc) const
+    {
+        return encounteredPC.find(pc) != encounteredPC.end();
+    };
+
+    void updateBackwardBranch(const Addr pc)
+    {
+        backwardBranchPC.insert(pc);
+    };
+
+    void updateValidNotControl(const Addr pc)
+    {
+        validNotControlPC.insert(pc);
+    };
+
+    void updateValidControl(const Addr pc)
+    {
+        validControlPC.insert(pc);
+    };
+
+    void updateEncountered(const Addr pc)
+    {
+        encounteredPC.insert(pc);
+    };
+
+    void updateBBInstMap(Addr pc, uint64_t inst_ount)
+    {
+        if (bbInstMap.find(pc) == bbInstMap.end())
+        {
+            bbInstMap.insert(std::make_pair(pc, inst_ount));
+        }
+    };
+
+    std::unordered_map<Addr, uint64_t> getGlobalBBV() const
+    {
+        return globalBBV;
+    };
+
+    void clearGlobalBBV()
+    {
+        globalBBV.clear();
+    };
+
+    uint64_t getGlobalInstCounter() const
+    {
+        return globalInstCounter;
+    };
+
+    void clearGlobalInstCounter()
+    {
+        globalInstCounter = 0;
+    };
+
+    void incrementGlobalInstCounter()
+    {
+        globalInstCounter++;
+    };
+
+    Addr getMostRecentLoopPC() const
+    {
+        return mostRecentLoopPC;
+    };
+
+    std::unordered_map<Addr, uint64_t> getLoopCounter() const
+    {
+        return loopCounter;
+    };
+
+    uint64_t getMostRecentLoopCount() const
+    {
+        return loopCounter.find(mostRecentLoopPC)->second;
+    };
+};
+
+} // namespace gem5
+
+
+
+
+#endif // __CPU_SIMPLE_PROBES_LOOPPOINT_ANALYSIS_HH__

--- a/src/python/pybind11/core.cc
+++ b/src/python/pybind11/core.cc
@@ -170,12 +170,12 @@ init_pc(py::module_ &m_native)
     py::module_ m = m_native.def_submodule("pc");
     py::class_<PcCountPair>(m, "PcCountPair")
         .def(py::init<>())
-        .def(py::init<Addr, int>())
+        .def(py::init<Addr, uint64_t>())
         .def("__eq__", [](const PcCountPair& self, py::object other) {
             py::int_ pyPC = other.attr("get_pc")();
             py::int_ pyCount = other.attr("get_count")();
             uint64_t cPC = pyPC.cast<uint64_t>();
-            int cCount = pyCount.cast<int>();
+            uint64_t cCount = pyCount.cast<uint64_t>();
             return (self.getPC() == cPC && self.getCount() == cCount);
         })
         .def("__hash__", [](const PcCountPair& self){


### PR DESCRIPTION
Adding SimObject and ProbeListener objects for gem5 to perform LoopPoint analysis.
The original paper for the LoopPoint paper: https://ieeexplore.ieee.org/document/9773236
LoopPoint is a sampling methodology that uses the program counter of a set of selected loops and their number of iteration to mark the execution points in a macro-benchmark for the defined regions.

Therefore, the LoopPont analysis object in gem5 will 
1. Define regions with the number of user-level instruction executed
2. Collect loop iterations for every region
3. Collect user-level basic block vector for every region
4. Exclude specific memory ranges to avoid analyzing multi-threaded libraries
5. Raise an exit event at the end of every region

The LoopPoint analysis object in gem5 is only tested with full-system simulation.