### PR TITLE
arch-arm: Fix incorrect behaviour of VFNMS and VFNMA

### DIFF
--- a/src/arch/arm/isa/formats/fp.isa
+++ b/src/arch/arm/isa/formats/fp.isa
@@ -2725,7 +2725,7 @@ let {{
             }
             break;
           case 0x9:
-            if ((opc3 & 0x1) == 0) {
+            if (bits(machInst, 6) == 1) {
                 if (single) {
                     return decodeVfpRegRegRegOp<VfnmaS>(
                             machInst, vd, vn, vm, false);


### PR DESCRIPTION
This was found while comparing a diverging execution against QEMU traces
and checking for the first mismatched program counter. Fortunately this was
caused by a branch shortly after this incorrect computation but still took
a long time to track down.

There are two issues here: the decoder had inverted the cases for *S and *A,
and the sign bit was wrong for VFN*.