### PR TITLE
arch-x86: Fix Intel MCG_CAP MSR update on switch

### DIFF
--- a/src/arch/x86/isa.cc
+++ b/src/arch/x86/isa.cc
@@ -201,7 +201,7 @@ copyMiscRegs(ThreadContext *src, ThreadContext *dest)
 	mcgCap.count = 8;
 	dest->setMiscReg(misc_reg::McgCap, mcgCap);
 
-	
+
     dest->getMMUPtr()->flushAll();
 }
 

--- a/src/arch/x86/isa.cc
+++ b/src/arch/x86/isa.cc
@@ -195,6 +195,13 @@ copyMiscRegs(ThreadContext *src, ThreadContext *dest)
     // CPU switch have different frequencies.
     dest->setMiscReg(misc_reg::Tsc, src->readMiscReg(misc_reg::Tsc));
 
+	// MCG_CAP register count field holds how many MC MSRs are defined,
+	// to function correctly it must be updated with the number of simulated MC MSRs.
+	X86ISA::McgCap mcgCap = src->readMiscReg(misc_reg::McgCap);
+	mcgCap.count = 8;
+	dest->setMiscReg(misc_reg::McgCap, mcgCap);
+
+	
     dest->getMMUPtr()->flushAll();
 }
 


### PR DESCRIPTION
reason: https://www.intel.com/content/dam/develop/external/us/en/documents/335592-sdm-vol-4.pdf (2-30)


**Note**: This a direct copy of PR #957. For reasons I do not understand the CI tests refuse to run on that PR. The entire purpose this PR is to get around this. Otherwise the change is the same