### PR TITLE
sim: Enable debug tracing configuration with M5Op

### DIFF
--- a/include/gem5/asm/generic/m5ops.h
+++ b/include/gem5/asm/generic/m5ops.h
@@ -12,6 +12,7 @@
  * modified or unmodified, in source code or in binary form.
  *
  * Copyright (c) 2003-2006 The Regents of The University of Michigan
+ * Copyright (c) 2024 University of Rostock
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,6 +61,7 @@
 #define M5OP_DUMP_STATS         0x41
 #define M5OP_DUMP_RESET_STATS   0x42
 #define M5OP_CHECKPOINT         0x43
+#define M5OP_CONFIGURE_TRACING  0x4E
 #define M5OP_WRITE_FILE         0x4F
 #define M5OP_READ_FILE          0x50
 #define M5OP_DEBUG_BREAK        0x51
@@ -98,6 +100,7 @@
     M5OP(m5_dump_stats, M5OP_DUMP_STATS)                        \
     M5OP(m5_dump_reset_stats, M5OP_DUMP_RESET_STATS)            \
     M5OP(m5_checkpoint, M5OP_CHECKPOINT)                        \
+    M5OP(m5_configure_tracing, M5OP_CONFIGURE_TRACING)          \
     M5OP(m5_write_file, M5OP_WRITE_FILE)                        \
     M5OP(m5_read_file, M5OP_READ_FILE)                          \
     M5OP(m5_debug_break, M5OP_DEBUG_BREAK)                      \

--- a/include/gem5/m5ops.h
+++ b/include/gem5/m5ops.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2003-2006 The Regents of The University of Michigan
+ * Copyright (c) 2024 University of Rostock
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,6 +56,15 @@ void m5_checkpoint(uint64_t ns_delay, uint64_t ns_period);
 void m5_reset_stats(uint64_t ns_delay, uint64_t ns_period);
 void m5_dump_stats(uint64_t ns_delay, uint64_t ns_period);
 void m5_dump_reset_stats(uint64_t ns_delay, uint64_t ns_period);
+/**
+ * @brief Can be used to turn on / off debug tracing from workload.
+ * To turn off debug tracing at the beginning, use `--debug-start=-1` as
+ * CLI option.
+ *
+ * @param enable 0 for disabling debug tracing, otherwise it is enabled
+ * @return Nothing
+ */
+void m5_configure_tracing(uint64_t enable);
 uint64_t m5_read_file(void *buffer, uint64_t len, uint64_t offset);
 uint64_t m5_write_file(void *buffer, uint64_t len, uint64_t offset,
                        const char *filename);

--- a/src/python/m5/main.py
+++ b/src/python/m5/main.py
@@ -11,6 +11,7 @@
 # modified or unmodified, in source code or in binary form.
 #
 # Copyright (c) 2005 The Regents of The University of Michigan
+# Copyright (c) 2024 University of Rostock
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -286,7 +287,8 @@ def parse_options():
         "--debug-start",
         metavar="TICK",
         type="int",
-        help="Start debug output at TICK",
+        help="If >= 0, start debug output at TICK. If -1, debug tracing is "
+        "disabled at the beginning",
     )
     option(
         "--debug-end",
@@ -600,8 +602,11 @@ def main():
 
     if options.debug_start:
         _check_tracing()
-        e = event.create(trace.enable, event.Event.Debug_Enable_Pri)
-        event.mainq.schedule(e, options.debug_start)
+        if options.debug_start == -1:
+            trace.disable()
+        else:
+            e = event.create(trace.enable, event.Event.Debug_Enable_Pri)
+            event.mainq.schedule(e, options.debug_start)
     else:
         trace.enable()
 

--- a/src/sim/pseudo_inst.cc
+++ b/src/sim/pseudo_inst.cc
@@ -14,6 +14,7 @@
  *
  * Copyright (c) 2011 Advanced Micro Devices, Inc.
  * Copyright (c) 2003-2006 The Regents of The University of Michigan
+ * Copyright (c) 2024 University of Rostock
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -364,6 +365,17 @@ m5checkpoint(ThreadContext *tc, Tick delay, Tick period)
         Tick when = curTick() + delay * sim_clock::as_int::ns;
         Tick repeat = period * sim_clock::as_int::ns;
         exitSimLoop("checkpoint", 0, when, repeat);
+    }
+}
+
+void
+configureTracing(ThreadContext *tc, uint64_t enable)
+{
+    DPRINTF(PseudoInst, "pseudo_inst::configureTracing(%#x)\n", enable);
+    if (enable) {
+        gem5::trace::enable();
+    } else {
+        gem5::trace::disable();
     }
 }
 

--- a/src/sim/pseudo_inst.hh
+++ b/src/sim/pseudo_inst.hh
@@ -12,6 +12,7 @@
  * modified or unmodified, in source code or in binary form.
  *
  * Copyright (c) 2003-2006 The Regents of The University of Michigan
+ * Copyright (c) 2024 University of Rostock
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -89,6 +90,7 @@ void quiesceSkip(ThreadContext *tc);
 void quiesceNs(ThreadContext *tc, uint64_t ns);
 void quiesceCycles(ThreadContext *tc, uint64_t cycles);
 uint64_t quiesceTime(ThreadContext *tc);
+void configureTracing(ThreadContext *tc, uint64_t enable);
 uint64_t readfile(ThreadContext *tc, GuestAddr vaddr, uint64_t len,
     uint64_t offset);
 uint64_t writefile(ThreadContext *tc, GuestAddr vaddr, uint64_t len,
@@ -200,6 +202,10 @@ pseudoInstWork(ThreadContext *tc, uint8_t func, uint64_t &result)
 
       case M5OP_CHECKPOINT:
         invokeSimcall<ABI>(tc, m5checkpoint);
+        return true;
+
+      case M5OP_CONFIGURE_TRACING:
+        invokeSimcall<ABI>(tc, configureTracing);
         return true;
 
       case M5OP_WRITE_FILE:


### PR DESCRIPTION
Adds a new pseudo instruction m5_configure_tracing. It can be used to turn on or turn off the debug tracing from the workload, e.g., to skip the booting.

Change-Id: I7b86762b8e4fa918df6cf697fa7abe9e359a88b1