### PR TITLE
cpu: add GlobalInstTracker and LocalInstTracker

### DIFF
--- a/configs/example/gem5_library/x86-global-inst-tracker.py
+++ b/configs/example/gem5_library/x86-global-inst-tracker.py
@@ -24,6 +24,33 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+"""
+
+This script demonstrates how to use global and local instruction trackers to
+monitor and control the simulation based on the number of instructions
+committed.
+
+This script will create a global instruction tracker to manage each local
+instruction tracker and connects each local instruction tracker to a core.
+The global instruction tracker will raise an event when the number of
+instructions committed across all cores reaches a certain threshold.
+
+In this script, we expect to start monitorning the instruction committed from
+the start of the simulation and raise a SIMPOINT_BEGIN exit event when all
+cores in combination have committed 100,000,000 instructions. Then, we will
+change the threshold to 20,000 instructions and raise another SIMPOINT_BEGIN
+event when the new threshold is reached. Finally, we will stop listening to
+instructions.
+
+Usage:
+------
+
+scons build/X86/gem5.opt
+./build/X86/gem5.opt [--debug-flags=InstTracker] \
+    configs/example/gem5_library/x86-global-inst-tracker.py
+
+"""
+
 import m5
 from m5.objects import (
     GlobalInstTracker,
@@ -41,14 +68,6 @@ from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_event import ExitEvent
 from gem5.simulate.simulator import Simulator
-
-"""
-
-Usage:
-
-gem5.opt configs/example/gem5_library/x86-global-inst-tracker.py
-
-"""
 
 cache_hierarchy = PrivateL1CacheHierarchy(
     l1d_size="64kB",
@@ -118,13 +137,10 @@ def max_inst_handler():
     # we can stop listening to instructions
     for tracker in all_trackers:
         tracker.stopListening()
-    """
-    similarly, we can start listening to instructions again by calling:
-
-    for tracker in all_trackers:
-        tracker.startListening()
-
-    """
+    # similarly, we can start listening to instructions again by calling:
+    #
+    # for tracker in all_trackers:
+    #     tracker.startListening()
     m5.stats.dump()
     m5.stats.reset()
     yield False

--- a/configs/example/gem5_library/x86-global-inst-tracker.py
+++ b/configs/example/gem5_library/x86-global-inst-tracker.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import m5
+from m5.objects import (
+    GlobalInstTracker,
+    LocalInstTracker,
+)
+
+from gem5.components.boards.simple_board import SimpleBoard
+from gem5.components.cachehierarchies.classic.private_l1_cache_hierarchy import (
+    PrivateL1CacheHierarchy,
+)
+from gem5.components.memory.single_channel import SingleChannelDDR4_2400
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.exit_event import ExitEvent
+from gem5.simulate.simulator import Simulator
+
+"""
+
+Usage:
+
+gem5.opt configs/example/gem5_library/x86-global-inst-tracker.py
+
+"""
+
+cache_hierarchy = PrivateL1CacheHierarchy(
+    l1d_size="64kB",
+    l1i_size="64kB",
+)
+
+memory = SingleChannelDDR4_2400("1GB")
+
+processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, num_cores=9, isa=ISA.X86)
+
+# setup instruction tracker
+
+# first, we need to create a global instruction tracker
+global_inst_tracker = GlobalInstTracker(
+    # threshold to trigger the event
+    inst_threshold=100_000_000
+)
+
+# then, we create a local instruction tracker for each core
+# and store them in a list
+all_trackers = []
+
+for core in processor.get_cores():
+    tracker = LocalInstTracker(
+        # we pass in the glboal instruction tracker to the local one
+        global_inst_tracker=global_inst_tracker,
+        # this parameter tells the tracker to start listening to instructions
+        # from the beginning of the simulation. If set to False, the tracker
+        # will
+        start_listening=True,
+    )
+    # we attach the tracker to the core
+    core.core.probeListener = tracker
+    # then store the tracker in the list
+    all_trackers.append(tracker)
+
+
+board = SimpleBoard(
+    clk_freq="1GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+)
+
+board.set_se_binary_workload(
+    binary=obtain_resource(resource_id="x86-matrix-multiply-omp"),
+    arguments=[100, 8],
+)
+
+
+def max_inst_handler():
+    # this handler tests the instruction tracker
+    # when it reached this function, it means that it successfully raised
+    # the ExitEvent.MAX_INSTS event
+    print("Reached MAX_INSTS with 100000000 instructions")
+    print("Changing threshold to 20000")
+    # we can change the threshold of the global instruction tracker
+    global_inst_tracker.changeThreshold(20000)
+    # we need to reset the counter of the global instruction tracker
+    # the counter does not reset automatically
+    global_inst_tracker.resetCounter()
+    m5.stats.dump()
+    m5.stats.reset()
+    yield False
+    print("Reached MAX_INSTS with 20000 instructions")
+    print("Stop listening to instructions")
+    # we can stop listening to instructions
+    for tracker in all_trackers:
+        tracker.stopListening()
+    """
+    similarly, we can start listening to instructions again by calling:
+
+    for tracker in all_trackers:
+        tracker.startListening()
+
+    """
+    m5.stats.dump()
+    m5.stats.reset()
+    yield False
+
+
+simulator = Simulator(
+    board=board,
+    on_exit_event={
+        # the global instruction tracker will raise the MAX_INSTS event
+        ExitEvent.MAX_INSTS: max_inst_handler()
+    },
+)
+
+simulator.run()
+
+print("Simulation Done")

--- a/src/cpu/probes/InstTracker.py
+++ b/src/cpu/probes/InstTracker.py
@@ -41,13 +41,15 @@ class GlobalInstTracker(SimObject):
     cxx_class = "gem5::GlobalInstTracker"
 
     cxx_exports = [
-        PyBindMethod("changeThreshold"),
+        PyBindMethod("addThreshold"),
+        PyBindMethod("getCounter"),
         PyBindMethod("resetCounter"),
-        PyBindMethod("getThreshold"),
+        PyBindMethod("getThresholds"),
+        PyBindMethod("resetThresholds"),
     ]
 
-    inst_threshold = Param.Counter(
-        "The instruction threshold to trigger an" " exit event"
+    inst_thresholds = VectorParam.Counter(
+        "A list of instruction thresholds to trigger an exit event"
     )
 
 

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -43,8 +43,7 @@ void
 LocalInstTracker::regProbeListeners()
 {
     if (ifListening) {
-        if (listeners.empty())
-        {
+        if (listeners.empty()) {
             listeners.push_back(new LocalInstTrackerListener(this,
                                     "RetiredInsts",
                                     &LocalInstTracker::retiredInstsHandler));
@@ -63,11 +62,14 @@ void
 LocalInstTracker::stopListening()
 {
     ifListening = false;
-    for (auto l = listeners.begin(); l != listeners.end(); ++l) {
-        delete (*l);
+    bool _ifRemoved;
+    for (auto &listener : listeners) {
+        _ifRemoved = getProbeManager()->removeListener(
+            "RetiredInsts",
+            *listener
+        );
+        DPRINTF(InstTracker, "If removed: %s\n", _ifRemoved ? "Yes" : "No");
     }
-    listeners.clear();
-    DPRINTF(InstTracker, "Stopped listening\n");
 }
 
 

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -63,13 +63,18 @@ LocalInstTracker::stopListening()
 {
     ifListening = false;
     bool _ifRemoved;
-    for (auto &listener : listeners) {
+    for (auto &_listener : listeners) {
         _ifRemoved = getProbeManager()->removeListener(
             "RetiredInsts",
-            *listener
+            *_listener
         );
-        DPRINTF(InstTracker, "If removed: %s\n", _ifRemoved ? "Yes" : "No");
+        panic_if(!_ifRemoved, "Failed to remove listener");
+        if (_listener != nullptr) {
+            delete(_listener);
+            DPRINTF(InstTracker, "Deleted Listener pointer\n");
+        }
     }
+    DPRINTF(InstTracker, "Stop listening to RetiredInsts\n");
 }
 
 

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -74,6 +74,7 @@ LocalInstTracker::stopListening()
             DPRINTF(InstTracker, "Deleted Listener pointer\n");
         }
     }
+    listeners.clear();
     DPRINTF(InstTracker, "Stop listening to RetiredInsts\n");
 }
 

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/probes/inst_tracker.hh"
+
+namespace gem5
+{
+
+LocalInstTracker::LocalInstTracker(const LocalInstTrackerParams &p)
+    : ProbeListenerObject(p),
+      globalInstTracker(p.global_inst_tracker),
+      ifListening(p.start_listening)
+{
+    DPRINTF(InstTracker, "ifListening = %s\n", ifListening ? "true" : "false");
+}
+
+void
+LocalInstTracker::regProbeListeners()
+{
+    if (ifListening) {
+        if (listeners.empty())
+        {
+            listeners.push_back(new LocalInstTrackerListener(this,
+                                    "RetiredInsts",
+                                    &LocalInstTracker::retiredInstsHandler));
+            DPRINTF(InstTracker, "Listening to RetiredInsts\n");
+        }
+    }
+}
+
+void
+LocalInstTracker::stopListening()
+{
+    ifListening = false;
+    for (auto l = listeners.begin(); l != listeners.end(); ++l) {
+        delete (*l);
+    }
+    listeners.clear();
+    DPRINTF(InstTracker, "Stopped listening\n");
+}
+
+void
+LocalInstTracker::retiredInstsHandler(const uint64_t& inst)
+{
+    globalInstTracker->updateAndCheckInstCount(inst);
+}
+
+GlobalInstTracker::GlobalInstTracker(const GlobalInstTrackerParams &p)
+    : SimObject(p),
+      instCount(0),
+      instThreshold(p.inst_threshold)
+{}
+
+void
+GlobalInstTracker::updateAndCheckInstCount(const uint64_t& inst)
+{
+    instCount ++;
+    if (instCount >= instThreshold) {
+        DPRINTF(InstTracker, "Instruction count reached the threshold\n"
+                                "instCount = %lu\n"
+                                "instThreshold = %lu\n",
+                                instCount, instThreshold);
+
+        exitSimLoopNow("a thread reached the max instruction count");
+    }
+}
+
+} // namespace gem5

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -81,22 +81,26 @@ LocalInstTracker::stopListening()
 
 GlobalInstTracker::GlobalInstTracker(const GlobalInstTrackerParams &params)
     : SimObject(params),
-      instCount(0),
-      instThreshold(params.inst_threshold)
+      instCount(0)
 {
-    DPRINTF(InstTracker, "instThreshold = %lu\n", instThreshold);
+    for (const auto &threshold : params.inst_thresholds) {
+        instThresholdSet.insert(threshold);
+        DPRINTF(InstTracker, "adding the instruction threshold\n"
+                              "instThreshold = %lu\n", threshold);
+    }
+    DPRINTF(InstTracker, "instThresholdSet size = %lu\n",
+            instThresholdSet.size());
 }
 
 void
 GlobalInstTracker::updateAndCheckInstCount(const uint64_t& inst)
 {
     instCount ++;
-    if (instCount >= instThreshold) {
+    if (instThresholdSet.find(instCount) != instThresholdSet.end()) {
         DPRINTF(InstTracker, "Instruction count reached the threshold\n"
-                                "instCount = %lu\n"
-                                "instThreshold = %lu\n",
-                                instCount, instThreshold);
-
+                                "instCount = %lu\n",
+                                instCount);
+        instThresholdSet.erase(instCount);
         // note that when the threshold is reached, the simulation will raise
         // and exit event but it will not reset the instruction counter.
         // user can reset the counter by calling the resetCounter() function

--- a/src/cpu/probes/inst_tracker.hh
+++ b/src/cpu/probes/inst_tracker.hh
@@ -55,7 +55,7 @@ class LocalInstTracker : public ProbeListenerObject
 
   private:
     typedef ProbeListenerArg<LocalInstTracker, uint64_t>
-                                                    LocalInstTrackerListener;
+        LocalInstTrackerListener;
 
     /** a boolean variable that determines if the LocalInstTracker is
      * listening to the ProbePoints or not
@@ -74,10 +74,11 @@ class LocalInstTracker : public ProbeListenerObject
     void stopListening();
 
     /** start listening to the ProbePoints */
-    void startListening()
+    void
+    startListening()
     {
-      ifListening = true;
-      regProbeListeners();
+        ifListening = true;
+        regProbeListeners();
     }
 
 };
@@ -99,7 +100,6 @@ class GlobalInstTracker : public SimObject
     */
     uint64_t instCount;
 
-
     /**
       * the threshold for the number of instructions that should be executed
       * before the simulation exits
@@ -107,23 +107,26 @@ class GlobalInstTracker : public SimObject
     uint64_t instThreshold;
 
   public:
-    void changeThreshold(uint64_t new_threshold)
+    void
+    changeThreshold(uint64_t new_threshold)
     {
-      instThreshold = new_threshold;
-      DPRINTF(InstTracker, "Changing the instruction threshold\n"
-                          "instThreshold = %lu\n", instThreshold);
+        instThreshold = new_threshold;
+        DPRINTF(InstTracker, "Changing the instruction threshold\n"
+                                  "instThreshold = %lu\n", instThreshold);
     };
 
-    void resetCounter()
+    void
+    resetCounter()
     {
-      instCount = 0;
-      DPRINTF(InstTracker, "Resetting the instruction counter\n"
+        instCount = 0;
+        DPRINTF(InstTracker, "Resetting the instruction counter\n"
                                               "instCount = %lu\n", instCount);
     };
 
-    uint64_t getThreshold() const
+    uint64_t
+    getThreshold() const
     {
-      return instThreshold;
+        return instThreshold;
     };
 };
 

--- a/src/cpu/probes/inst_tracker.hh
+++ b/src/cpu/probes/inst_tracker.hh
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_PROBES_INST_TRACKER_HH__
+#define __CPU_PROBES_INST_TRACKER_HH__
+
+#include "debug/InstTracker.hh"
+#include "params/GlobalInstTracker.hh"
+#include "params/LocalInstTracker.hh"
+#include "sim/probe/probe.hh"
+#include "sim/sim_exit.hh"
+
+namespace gem5
+{
+
+class GlobalInstTracker : public SimObject
+{
+  public:
+    GlobalInstTracker(const GlobalInstTrackerParams &params);
+
+    /**
+     * this function is called by the LocalInstTracker object to update the
+      * instruction count and check if the instruction count has reached the
+      * threshold across all the cores.
+     */
+    void updateAndCheckInstCount(const uint64_t& inst);
+
+  private:
+    /** the number of instructions that have been executed across all the cores
+    */
+    uint64_t instCount;
+
+
+    /**
+      * the threshold for the number of instructions that should be executed
+      * before the simulation exits
+     */
+    uint64_t instThreshold;
+
+  public:
+    void changeThreshold(uint64_t new_threshold)
+    {
+      instThreshold = new_threshold;
+      DPRINTF(InstTracker, "Changing the instruction threshold\n"
+                          "instThreshold = %lu\n", instThreshold);
+    };
+
+    void resetCounter()
+    {
+      instCount = 0;
+      DPRINTF(InstTracker, "Resetting the instruction counter\n"
+                                              "instCount = %lu\n", instCount);
+    };
+
+    uint64_t getThreshold() const
+    {
+      return instThreshold;
+    };
+};
+
+class LocalInstTracker : public ProbeListenerObject
+{
+  public:
+    LocalInstTracker(const LocalInstTrackerParams &params);
+
+    /** setup the probelistener */
+    virtual void regProbeListeners();
+
+    /**
+     * this function is called when the ProbePoint "RetiredInsts" is notified
+     *
+     * @param inst the number of retired instructions. It is usually 1.
+     */
+    void retiredInstsHandler(const uint64_t& inst);
+
+  private:
+    typedef ProbeListenerArg<LocalInstTracker, uint64_t>
+                                                    LocalInstTrackerListener;
+
+    /** a boolean variable that determines if the LocalInstTracker is
+     * listening to the ProbePoints or not
+     */
+    bool ifListening;
+
+    /**
+     * the pointer to the GlobalInstTracker object. It is used to update the
+      * instruction count and check if the instruction count has reached the
+      * threshold across all the cores.
+     */
+    GlobalInstTracker *globalInstTracker;
+
+  public:
+    /** stop listening to the ProbePoints */
+    void stopListening();
+
+    /** start listening to the ProbePoints */
+    void startListening()
+    {
+      ifListening = true;
+      regProbeListeners();
+    }
+
+};
+
+}
+
+#endif // __CPU_PROBES_INST_TRACKER_HH__

--- a/src/cpu/probes/inst_tracker.hh
+++ b/src/cpu/probes/inst_tracker.hh
@@ -38,6 +38,50 @@
 namespace gem5
 {
 
+class LocalInstTracker : public ProbeListenerObject
+{
+  public:
+    LocalInstTracker(const LocalInstTrackerParams &params);
+
+    /** setup the probelistener */
+    virtual void regProbeListeners();
+
+    /**
+     * this function is called when the ProbePoint "RetiredInsts" is notified
+     *
+     * @param inst the number of retired instructions. It is usually 1.
+     */
+    void retiredInstsHandler(const uint64_t& inst);
+
+  private:
+    typedef ProbeListenerArg<LocalInstTracker, uint64_t>
+                                                    LocalInstTrackerListener;
+
+    /** a boolean variable that determines if the LocalInstTracker is
+     * listening to the ProbePoints or not
+     */
+    bool ifListening;
+
+    /**
+     * the pointer to the GlobalInstTracker object. It is used to update the
+      * instruction count and check if the instruction count has reached the
+      * threshold across all the cores.
+     */
+    GlobalInstTracker *globalInstTracker;
+
+  public:
+    /** stop listening to the ProbePoints */
+    void stopListening();
+
+    /** start listening to the ProbePoints */
+    void startListening()
+    {
+      ifListening = true;
+      regProbeListeners();
+    }
+
+};
+
 class GlobalInstTracker : public SimObject
 {
   public:
@@ -81,50 +125,6 @@ class GlobalInstTracker : public SimObject
     {
       return instThreshold;
     };
-};
-
-class LocalInstTracker : public ProbeListenerObject
-{
-  public:
-    LocalInstTracker(const LocalInstTrackerParams &params);
-
-    /** setup the probelistener */
-    virtual void regProbeListeners();
-
-    /**
-     * this function is called when the ProbePoint "RetiredInsts" is notified
-     *
-     * @param inst the number of retired instructions. It is usually 1.
-     */
-    void retiredInstsHandler(const uint64_t& inst);
-
-  private:
-    typedef ProbeListenerArg<LocalInstTracker, uint64_t>
-                                                    LocalInstTrackerListener;
-
-    /** a boolean variable that determines if the LocalInstTracker is
-     * listening to the ProbePoints or not
-     */
-    bool ifListening;
-
-    /**
-     * the pointer to the GlobalInstTracker object. It is used to update the
-      * instruction count and check if the instruction count has reached the
-      * threshold across all the cores.
-     */
-    GlobalInstTracker *globalInstTracker;
-
-  public:
-    /** stop listening to the ProbePoints */
-    void stopListening();
-
-    /** start listening to the ProbePoints */
-    void startListening()
-    {
-      ifListening = true;
-      regProbeListeners();
-    }
-
 };
 
 }

--- a/src/cpu/probes/inst_tracker.hh
+++ b/src/cpu/probes/inst_tracker.hh
@@ -29,6 +29,8 @@
 #ifndef __CPU_PROBES_INST_TRACKER_HH__
 #define __CPU_PROBES_INST_TRACKER_HH__
 
+#include <unordered_set>
+
 #include "debug/InstTracker.hh"
 #include "params/GlobalInstTracker.hh"
 #include "params/LocalInstTracker.hh"
@@ -101,18 +103,24 @@ class GlobalInstTracker : public SimObject
     uint64_t instCount;
 
     /**
-      * the threshold for the number of instructions that should be executed
-      * before the simulation exits
+      * a set of thresholds for the number of instructions that should be
+      * executed before the simulation exits
      */
-    uint64_t instThreshold;
+    std::unordered_set<uint64_t> instThresholdSet;
 
   public:
     void
-    changeThreshold(uint64_t new_threshold)
+    addThreshold(uint64_t new_threshold)
     {
-        instThreshold = new_threshold;
-        DPRINTF(InstTracker, "Changing the instruction threshold\n"
-                                  "instThreshold = %lu\n", instThreshold);
+        instThresholdSet.insert(new_threshold);
+        DPRINTF(InstTracker, "adding the instruction threshold %lu\n",
+                                                              new_threshold);
+    };
+
+    uint64_t
+    getCounter() const
+    {
+        return instCount;
     };
 
     void
@@ -123,10 +131,17 @@ class GlobalInstTracker : public SimObject
                                               "instCount = %lu\n", instCount);
     };
 
-    uint64_t
-    getThreshold() const
+    std::unordered_set<uint64_t>
+    getThresholds() const
     {
-        return instThreshold;
+        return instThresholdSet;
+    };
+
+    void
+    resetThresholds()
+    {
+        instThresholdSet.clear();
+        DPRINTF(InstTracker, "Resetting the instruction thresholds\n");
     };
 };
 


### PR DESCRIPTION
The GlobalInstTracker manages the global instruction counter and responsible for triggering an exit event when the global instruction counter reaches the defined threshold.

The LocalInstTracker listens to one core's retiredInsts probe point and updates the GlobalInstTracker every time there is an instruction committed.

The purpose of this instruction tracker is to raise an instruction executed exit event with multi-core simulation.

Related discussion can be found:
https://github.com/gem5/gem5/issues/1087

Change-Id: Iab6fec57f14f28e590b035506282130ba8662706