### PR TITLE
arch-arm: downgrade a warning to a DPRINTF

### DIFF
--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -543,8 +543,9 @@ PMU::CounterState::detach()
         sourceEvent->detachEvent(this);
         sourceEvent = nullptr;
     } else {
-        debugCounter("detaching event not currently attached"
-            " to any event\n");
+        DPRINTFS(PMUVerbose, &pmu,
+                 "detaching event %d not currently attached to any event"
+                 " [counterId = %d]\n", eventId, counterId);
     }
 }
 


### PR DESCRIPTION
Programming an event ID while counters are disabled is perfectly fine, so we should just log this using DPRINTF instead of printing a warn() every time it happens.

Change-Id: Ib9499857271033ef941f74a7f012d8694328eaf3