### PR TITLE
sim,mem,cpu,arch-arm: Add support for cache PMU events

### DIFF
--- a/src/arch/arm/ArmPMU.py
+++ b/src/arch/arm/ArmPMU.py
@@ -135,10 +135,13 @@ class ArmPMU(SimObject):
         # 0x00: SW_INCR
         self.addEvent(SoftwareIncrement(self, 0x00))
         # 0x01: L1I_CACHE_REFILL
+        self.addEvent(ProbeEvent(self, 0x01, icache, "Fill"))
         # 0x02: L1I_TLB_REFILL,
         self.addEvent(ProbeEvent(self, 0x02, itb, "Refills"))
         # 0x03: L1D_CACHE_REFILL
+        self.addEvent(ProbeEvent(self, 0x03, dcache, "Fill"))
         # 0x04: L1D_CACHE
+        self.addEvent(ProbeEvent(self, 0x04, dcache, "Hit", "Miss"))
         # 0x05: L1D_TLB_REFILL
         self.addEvent(ProbeEvent(self, 0x05, dtb, "Refills"))
         # 0x06: LD_RETIRED
@@ -167,9 +170,12 @@ class ArmPMU(SimObject):
             ProbeEvent(self, 0x13, cpu, "RetiredLoads", "RetiredStores")
         )
         # 0x14: L1I_CACHE
+        self.addEvent(ProbeEvent(self, 0x14, icache, "Hit", "Miss"))
         # 0x15: L1D_CACHE_WB
         # 0x16: L2D_CACHE
+        self.addEvent(ProbeEvent(self, 0x16, l2cache, "Hit", "Miss"))
         # 0x17: L2D_CACHE_REFILL
+        self.addEvent(ProbeEvent(self, 0x17, l2cache, "Fill"))
         # 0x18: L2D_CACHE_WB
         # 0x19: BUS_ACCESS
         # 0x1A: MEMORY_ERROR

--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -498,8 +498,9 @@ void
 PMU::RegularEvent::enable()
 {
     for (auto& subEvents: microArchitectureEventSet) {
-        attachedProbePointList.emplace_back(
-            new RegularProbe(this, subEvents.first, subEvents.second));
+        attachedProbePointList.push_back(
+            subEvents.first->getProbeManager()->connect<RegularProbe>(
+                this, subEvents.second));
     }
 }
 

--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -498,9 +498,20 @@ void
 PMU::RegularEvent::enable()
 {
     for (auto& subEvents: microArchitectureEventSet) {
-        attachedProbePointList.push_back(
-            subEvents.first->getProbeManager()->connect<RegularProbe>(
-                this, subEvents.second));
+        ProbeManager *pm = subEvents.first->getProbeManager();
+        ProbePoint *probe = pm->getFirstProbePoint(subEvents.second);
+        // The PMU currently handles explicit PMU probes as well as
+        // cache events. For any further types of events we will need
+        // to handle them in this function.
+        if (dynamic_cast<probing::PMU *>(probe)) {
+            attachedProbePointList.push_back(
+                pm->connect<RegularProbe>(this, subEvents.second));
+        } else if (dynamic_cast<ProbePointArg<CacheAccessProbeArg> *>(probe)) {
+            attachedProbePointList.push_back(
+                pm->connect<CacheProbe>(this, subEvents.second));
+        } else {
+            panic("Unsupported probe kind for event %s", probe->getName());
+        }
     }
 }
 

--- a/src/arch/arm/pmu.hh
+++ b/src/arch/arm/pmu.hh
@@ -358,12 +358,11 @@ class PMU : public SimObject, public ArmISA::BaseISADevice
         }
 
       protected:
-        struct RegularProbe: public  ProbeListenerArgBase<uint64_t>
+        struct RegularProbe : public ProbeListenerArgBase<uint64_t>
         {
-            RegularProbe(RegularEvent *parent, SimObject* obj,
-                std::string name)
-                : ProbeListenerArgBase(obj->getProbeManager(), name),
-                  parentEvent(parent) {}
+            RegularProbe(RegularEvent *parent, std::string name)
+                : ProbeListenerArgBase(std::move(name)), parentEvent(parent)
+            {}
 
             RegularProbe() = delete;
 
@@ -379,7 +378,7 @@ class PMU : public SimObject, public ArmISA::BaseISADevice
         /** Set of probe listeners tapping onto each of the input micro-arch
          *  events which compose this pmu event
          */
-        std::vector<std::unique_ptr<RegularProbe>> attachedProbePointList;
+        std::vector<ProbeListenerPtr<>> attachedProbePointList;
 
         void enable() override;
 

--- a/src/arch/arm/pmu.hh
+++ b/src/arch/arm/pmu.hh
@@ -47,6 +47,7 @@
 #include "base/cprintf.hh"
 #include "cpu/base.hh"
 #include "debug/PMUVerbose.hh"
+#include "mem/cache/cache_probe_arg.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_object.hh"
 #include "sim/system.hh"
@@ -366,7 +367,24 @@ class PMU : public SimObject, public ArmISA::BaseISADevice
 
             RegularProbe() = delete;
 
-            void notify(const uint64_t &val);
+            void notify(const uint64_t &val) override;
+
+          protected:
+            RegularEvent *parentEvent;
+        };
+
+        struct CacheProbe : public ProbeListenerArgBase<CacheAccessProbeArg>
+        {
+            CacheProbe(RegularEvent *parent, std::string name)
+                : ProbeListenerArgBase(std::move(name)), parentEvent(parent)
+            {}
+
+            CacheProbe() = delete;
+
+            void notify(const CacheAccessProbeArg &val) override
+            {
+                parentEvent->increment(1);
+            };
 
           protected:
             RegularEvent *parentEvent;

--- a/src/cpu/o3/probe/elastic_trace.cc
+++ b/src/cpu/o3/probe/elastic_trace.cc
@@ -125,25 +125,20 @@ ElasticTrace::regEtraceListeners()
         " probe listeners", curTick(), cpu->totalNumSimulatedInsts());
     // Create new listeners: provide method to be called upon a notify() for
     // each probe point.
-    listeners.push_back(new ProbeListenerArg<ElasticTrace, RequestPtr>(this,
-                        "FetchRequest", &ElasticTrace::fetchReqTrace));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Execute",
-                &ElasticTrace::recordExecTick));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "ToCommit",
-                &ElasticTrace::recordToCommTick));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Rename",
-                &ElasticTrace::updateRegDep));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace, SeqNumRegPair>(this,
-                        "SquashInRename", &ElasticTrace::removeRegDepMapEntry));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Squash",
-                &ElasticTrace::addSquashedInst));
-    listeners.push_back(new ProbeListenerArg<ElasticTrace,
-            DynInstConstPtr>(this, "Commit",
-                &ElasticTrace::addCommittedInst));
+    connectListener<ProbeListenerArg<ElasticTrace, RequestPtr>>(
+        this, "FetchRequest", &ElasticTrace::fetchReqTrace);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Execute", &ElasticTrace::recordExecTick);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "ToCommit", &ElasticTrace::recordToCommTick);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Rename", &ElasticTrace::updateRegDep);
+    connectListener<ProbeListenerArg<ElasticTrace, SeqNumRegPair>>(
+        this, "SquashInRename", &ElasticTrace::removeRegDepMapEntry);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Squash", &ElasticTrace::addSquashedInst);
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+        this, "Commit", &ElasticTrace::addCommittedInst);
     allProbesReg = true;
 }
 

--- a/src/cpu/o3/probe/simple_trace.cc
+++ b/src/cpu/o3/probe/simple_trace.cc
@@ -68,10 +68,9 @@ SimpleTrace::regProbeListeners()
 {
     typedef ProbeListenerArg<SimpleTrace,
             DynInstConstPtr> DynInstListener;
-    listeners.push_back(new DynInstListener(this, "Commit",
-                &SimpleTrace::traceCommit));
-    listeners.push_back(new DynInstListener(this, "Fetch",
-                &SimpleTrace::traceFetch));
+    connectListener<DynInstListener>(this, "Commit",
+                                     &SimpleTrace::traceCommit);
+    connectListener<DynInstListener>(this, "Fetch", &SimpleTrace::traceFetch);
 }
 
 } // namespace o3

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -44,9 +44,8 @@ LocalInstTracker::regProbeListeners()
 {
     if (ifListening) {
         if (listeners.empty()) {
-            listeners.push_back(new LocalInstTrackerListener(this,
-                                    "RetiredInsts",
-                                    &LocalInstTracker::retiredInstsHandler));
+            connectListener<LocalInstTrackerListener>(
+                this, "RetiredInsts", &LocalInstTracker::retiredInstsHandler);
             DPRINTF(InstTracker, "Start listening to RetiredInsts\n");
         }
     }
@@ -62,18 +61,6 @@ void
 LocalInstTracker::stopListening()
 {
     ifListening = false;
-    bool _ifRemoved;
-    for (auto &_listener : listeners) {
-        _ifRemoved = getProbeManager()->removeListener(
-            "RetiredInsts",
-            *_listener
-        );
-        panic_if(!_ifRemoved, "Failed to remove listener");
-        if (_listener != nullptr) {
-            delete(_listener);
-            DPRINTF(InstTracker, "Deleted Listener pointer\n");
-        }
-    }
     listeners.clear();
     DPRINTF(InstTracker, "Stop listening to RetiredInsts\n");
 }

--- a/src/cpu/probes/pc_count_tracker.cc
+++ b/src/cpu/probes/pc_count_tracker.cc
@@ -54,8 +54,8 @@ PcCountTracker::regProbeListeners()
     // when "RetiredInstsPC" notifies the probe listener, then the function
     // 'check_pc' is automatically called
     typedef ProbeListenerArg<PcCountTracker, Addr> PcCountTrackerListener;
-    listeners.push_back(new PcCountTrackerListener(this, "RetiredInstsPC",
-                                            &PcCountTracker::checkPc));
+    connectListener<PcCountTrackerListener>(this, "RetiredInstsPC",
+                                            &PcCountTracker::checkPc);
 }
 
 void

--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -173,8 +173,8 @@ LooppointAnalysis::regProbeListeners()
 {
     if (ifListening) {
         if (listeners.empty()) {
-            listeners.push_back(new looppointAnalysisListener(this,
-                                "Commit", &LooppointAnalysis::checkPc));
+            connectListener<looppointAnalysisListener>(
+                this, "Commit", &LooppointAnalysis::checkPc);
             DPRINTF(LooppointAnalysis,
                                     "Start listening to the RetiredInstsPC\n");
         }
@@ -193,16 +193,6 @@ void
 LooppointAnalysis::stopListening()
 {
     ifListening = false;
-    bool _ifRemoved;
-    for (auto &_listener : listeners) {
-        _ifRemoved = getProbeManager()->removeListener("Commit", *_listener);
-        panic_if(!_ifRemoved, "Failed to remove listener");
-        if (_listener != nullptr) {
-            delete(_listener);
-            DPRINTF(LooppointAnalysis,
-                "Deleted Listener pointer\n");
-        }
-    }
     listeners.clear();
     DPRINTF(LooppointAnalysis, "Stop listening to Commit\n");
 }

--- a/src/cpu/simple/probes/simpoint.cc
+++ b/src/cpu/simple/probes/simpoint.cc
@@ -70,8 +70,7 @@ SimPoint::regProbeListeners()
 {
     typedef ProbeListenerArg<SimPoint, std::pair<SimpleThread*,StaticInstPtr>>
         SimPointListener;
-    listeners.push_back(new SimPointListener(this, "Commit",
-                                             &SimPoint::profile));
+    connectListener<SimPointListener>(this, "Commit", &SimPoint::profile);
 }
 
 void

--- a/src/mem/cache/compressors/frequent_values.cc
+++ b/src/mem/cache/compressors/frequent_values.cc
@@ -290,8 +290,9 @@ FrequentValues::regProbeListeners()
 {
     assert(listeners.empty());
     assert(cache != nullptr);
-    listeners.push_back(new FrequentValuesListener(
-        *this, cache->getProbeManager(), "Data Update"));
+    listeners.push_back(
+        cache->getProbeManager()->connect<FrequentValuesListener>(
+            *this, "Data Update"));
 }
 
 void

--- a/src/mem/cache/compressors/frequent_values.hh
+++ b/src/mem/cache/compressors/frequent_values.hh
@@ -72,14 +72,14 @@ class FrequentValues : public Base
         FrequentValues &parent;
 
       public:
-        FrequentValuesListener(FrequentValues &_parent, ProbeManager *pm,
-            const std::string &name)
-          : ProbeListenerArgBase(pm, name), parent(_parent)
+        FrequentValuesListener(FrequentValues &_parent, std::string name)
+            : ProbeListenerArgBase(std::move(name)), parent(_parent)
         {
         }
         void notify(const DataUpdate &data_update) override;
     };
-    std::vector<FrequentValuesListener*> listeners;
+
+    std::vector<ProbeListenerPtr<FrequentValuesListener>> listeners;
 
     /** Whether Huffman encoding is applied to the VFT indices. */
     const bool useHuffmanEncoding;

--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -277,22 +277,22 @@ Base::regProbeListeners()
      * cache is configured to prefetch on accesses.
      */
     if (listeners.empty() && probeManager != nullptr) {
-        listeners.push_back(new PrefetchListener(*this, probeManager,
-                                                "Miss", false, true));
-        listeners.push_back(new PrefetchListener(*this, probeManager,
-                                                 "Fill", true, false));
-        listeners.push_back(new PrefetchListener(*this, probeManager,
-                                                 "Hit", false, false));
-        listeners.push_back(new PrefetchEvictListener(*this, probeManager,
-                                                 "Data Update"));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "Miss", false, true));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "Fill", false, true));
+        listeners.push_back(probeManager->connect<PrefetchListener>(
+            *this, "Hit", false, true));
+        listeners.push_back(probeManager->connect<PrefetchEvictListener>(
+            *this, "Data Update"));
     }
 }
 
 void
 Base::addEventProbe(SimObject *obj, const char *name)
 {
-    ProbeManager *pm(obj->getProbeManager());
-    listeners.push_back(new PrefetchListener(*this, pm, name));
+    ProbeManager *pm = obj->getProbeManager();
+    listeners.push_back(pm->connect<PrefetchListener>(*this, name));
 }
 
 void

--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -74,11 +74,13 @@ class Base : public ClockedObject
     class PrefetchListener : public ProbeListenerArgBase<CacheAccessProbeArg>
     {
       public:
-        PrefetchListener(Base &_parent, ProbeManager *pm,
-                         const std::string &name, bool _isFill = false,
+        PrefetchListener(Base &_parent, std::string name, bool _isFill = false,
                          bool _miss = false)
-            : ProbeListenerArgBase(pm, name),
-              parent(_parent), isFill(_isFill), miss(_miss) {}
+            : ProbeListenerArgBase(std::move(name)),
+              parent(_parent),
+              isFill(_isFill),
+              miss(_miss)
+        {}
         void notify(const CacheAccessProbeArg &arg) override;
       protected:
         Base &parent;
@@ -91,15 +93,15 @@ class Base : public ClockedObject
     class PrefetchEvictListener : public ProbeListenerArgBase<EvictionInfo>
     {
       public:
-        PrefetchEvictListener(Base &_parent, ProbeManager *pm,
-                              const std::string &name)
-            : ProbeListenerArgBase(pm, name), parent(_parent) {}
+        PrefetchEvictListener(Base &_parent, std::string name)
+            : ProbeListenerArgBase(std::move(name)), parent(_parent)
+        {}
         void notify(const EvictionInfo &info) override;
       protected:
         Base &parent;
     };
 
-    std::vector<ProbeListener *> listeners;
+    std::vector<ProbeListenerPtr<>> listeners;
 
   public:
 

--- a/src/mem/cache/prefetch/pif.cc
+++ b/src/mem/cache/prefetch/pif.cc
@@ -245,8 +245,8 @@ PIF::PrefetchListenerPC::notify(const Addr& pc)
 void
 PIF::addEventProbeRetiredInsts(SimObject *obj, const char *name)
 {
-    ProbeManager *pm(obj->getProbeManager());
-    listenersPC.push_back(new PrefetchListenerPC(*this, pm, name));
+    ProbeManager *pm = obj->getProbeManager();
+    listenersPC.push_back(pm->connect<PrefetchListenerPC>(*this, name));
 }
 
 } // namespace prefetch

--- a/src/mem/cache/prefetch/pif.hh
+++ b/src/mem/cache/prefetch/pif.hh
@@ -172,17 +172,16 @@ class PIF : public Queued
         class PrefetchListenerPC : public ProbeListenerArgBase<Addr>
         {
           public:
-            PrefetchListenerPC(PIF &_parent, ProbeManager *pm,
-                             const std::string &name)
-                : ProbeListenerArgBase(pm, name),
-                  parent(_parent) {}
+            PrefetchListenerPC(PIF &_parent, std::string name)
+                : ProbeListenerArgBase(std::move(name)), parent(_parent)
+            {}
             void notify(const Addr& pc) override;
           protected:
             PIF &parent;
         };
 
         /** Array of probe listeners */
-        std::vector<PrefetchListenerPC *> listenersPC;
+        std::vector<ProbeListenerPtr<PrefetchListenerPC>> listenersPC;
 
 
     public:

--- a/src/mem/probes/base.cc
+++ b/src/mem/probes/base.cc
@@ -53,10 +53,10 @@ BaseMemProbe::regProbeListeners()
     const BaseMemProbeParams &p =
         dynamic_cast<const BaseMemProbeParams &>(params());
 
-    listeners.resize(p.manager.size());
+    listeners.reserve(p.manager.size());
     for (int i = 0; i < p.manager.size(); i++) {
         ProbeManager *const mgr(p.manager[i]->getProbeManager());
-        listeners[i].reset(new PacketListener(*this, mgr, p.probe_name));
+        listeners.push_back(mgr->connect<PacketListener>(*this, p.probe_name));
     }
 }
 

--- a/src/mem/probes/base.hh
+++ b/src/mem/probes/base.hh
@@ -78,10 +78,9 @@ class BaseMemProbe : public SimObject
     class PacketListener : public ProbeListenerArgBase<probing::PacketInfo>
     {
       public:
-        PacketListener(BaseMemProbe &_parent,
-                       ProbeManager *pm, const std::string &name)
-            : ProbeListenerArgBase(pm, name),
-              parent(_parent) {}
+        PacketListener(BaseMemProbe &_parent, std::string name)
+            : ProbeListenerArgBase(std::move(name)), parent(_parent)
+        {}
 
         void notify(const probing::PacketInfo &pkt_info) override {
             parent.handleRequest(pkt_info);
@@ -91,7 +90,7 @@ class BaseMemProbe : public SimObject
         BaseMemProbe &parent;
     };
 
-    std::vector<std::unique_ptr<PacketListener>> listeners;
+    std::vector<ProbeListenerPtr<>> listeners;
 };
 
 } // namespace gem5

--- a/src/sim/power/power_model.cc
+++ b/src/sim/power/power_model.cc
@@ -102,9 +102,9 @@ PowerModel::thermalUpdateCallback(const Temperature &temp)
 void
 PowerModel::regProbePoints()
 {
-    thermalListener.reset(new ThermalProbeListener (
-        *this, this->subsystem->getProbeManager(), "thermalUpdate"
-    ));
+    thermalListener =
+        subsystem->getProbeManager()->connect<ThermalProbeListener>(
+            *this, "thermalUpdate");
 }
 
 double

--- a/src/sim/power/power_model.hh
+++ b/src/sim/power/power_model.hh
@@ -137,9 +137,9 @@ class PowerModel : public SimObject
     class ThermalProbeListener : public ProbeListenerArgBase<Temperature>
     {
       public:
-        ThermalProbeListener(PowerModel &_pm, ProbeManager *pm,
-                      const std::string &name)
-            : ProbeListenerArgBase(pm, name), pm(_pm) {}
+        ThermalProbeListener(PowerModel &_pm, std::string name)
+            : ProbeListenerArgBase(std::move(name)), pm(_pm)
+        {}
 
         void notify(const Temperature &temp)
         {
@@ -154,7 +154,7 @@ class PowerModel : public SimObject
     std::vector<PowerModelState*> states_pm;
 
     /** Listener to catch temperature changes in the SubSystem */
-    std::unique_ptr<ThermalProbeListener> thermalListener;
+    ProbeListenerPtr<ThermalProbeListener> thermalListener;
 
     /** The subsystem this power model belongs to */
     SubSystem * subsystem;

--- a/src/sim/probe/probe.cc
+++ b/src/sim/probe/probe.cc
@@ -98,14 +98,23 @@ ProbeManager::addPoint(ProbePoint &point)
     DPRINTFR(ProbeVerbose, "Probes: Call to addPoint \"%s\" to %s.\n",
         point.getName(), name());
 
-    for (auto p = points.begin(); p != points.end(); ++p) {
-        if ((*p)->getName() == point.getName()) {
-            DPRINTFR(ProbeVerbose, "Probes: Call to addPoint \"%s\" to %s "
-                "failed, already added.\n", point.getName(), name());
-            return;
-        }
+    if (getFirstProbePoint(point.getName())) {
+        DPRINTFR(ProbeVerbose, "Probes: Call to addPoint \"%s\" to %s "
+                 "failed, already added.\n", point.getName(), name());
+        return;
     }
     points.push_back(&point);
+}
+
+ProbePoint *
+ProbeManager::getFirstProbePoint(std::string_view point_name) const
+{
+    for (auto p : points) {
+        if (p->getName() == point_name) {
+            return p;
+        }
+    }
+    return nullptr;
 }
 
 } // namespace gem5

--- a/src/sim/probe/probe.cc
+++ b/src/sim/probe/probe.cc
@@ -54,7 +54,7 @@ ProbePoint::ProbePoint(ProbeManager *manager, const std::string& _name)
 }
 
 bool
-ProbeManager::addListener(std::string point_name, ProbeListener &listener)
+ProbeManager::addListener(std::string_view point_name, ProbeListener &listener)
 {
     DPRINTFR(ProbeVerbose, "Probes: Call to addListener to \"%s\" on %s.\n",
         point_name, name());
@@ -73,7 +73,8 @@ ProbeManager::addListener(std::string point_name, ProbeListener &listener)
 }
 
 bool
-ProbeManager::removeListener(std::string point_name, ProbeListener &listener)
+ProbeManager::removeListener(std::string_view point_name,
+                             ProbeListener &listener)
 {
     DPRINTFR(ProbeVerbose, "Probes: Call to removeListener from \"%s\" on "
         "%s.\n", point_name, name());

--- a/src/sim/probe/probe.cc
+++ b/src/sim/probe/probe.cc
@@ -53,17 +53,6 @@ ProbePoint::ProbePoint(ProbeManager *manager, const std::string& _name)
     }
 }
 
-ProbeListener::ProbeListener(ProbeManager *_manager, const std::string &_name)
-    : manager(_manager), name(_name)
-{
-    manager->addListener(name, *this);
-}
-
-ProbeListener::~ProbeListener()
-{
-    manager->removeListener(name, *this);
-}
-
 bool
 ProbeManager::addListener(std::string point_name, ProbeListener &listener)
 {

--- a/src/sim/probe/probe.hh
+++ b/src/sim/probe/probe.hh
@@ -293,12 +293,16 @@ class ProbePointArg : public ProbePoint
      * @param l the ProbeListener to add to the notify list.
      */
     void
-    addListener(ProbeListener *l) override
+    addListener(ProbeListener *l_base) override
     {
+        auto *l = dynamic_cast<ProbeListenerArgBase<Arg> *>(l_base);
+        panic_if(!l, "Wrong type of listener: expected %s got %s",
+                 typeid(ProbeListenerArgBase<Arg>).name(),
+                 typeid(*l_base).name());
         // check listener not already added
         if (std::find(listeners.begin(), listeners.end(), l) ==
             listeners.end()) {
-            listeners.push_back(static_cast<ProbeListenerArgBase<Arg> *>(l));
+            listeners.push_back(l);
         }
     }
 
@@ -307,8 +311,12 @@ class ProbePointArg : public ProbePoint
      * @param l the ProbeListener to remove from the notify list.
      */
     void
-    removeListener(ProbeListener *l) override
+    removeListener(ProbeListener *l_base) override
     {
+        auto *l = dynamic_cast<ProbeListenerArgBase<Arg> *>(l_base);
+        panic_if(!l, "Wrong type of listener expected %s got %s",
+                 typeid(ProbeListenerArgBase<Arg>).name(),
+                 typeid(*l_base).name());
         listeners.erase(std::remove(listeners.begin(), listeners.end(), l),
                         listeners.end());
     }
@@ -320,8 +328,8 @@ class ProbePointArg : public ProbePoint
     void
     notify(const Arg &arg)
     {
-        for (auto l = listeners.begin(); l != listeners.end(); ++l) {
-            (*l)->notify(arg);
+        for (auto *l : listeners) {
+            l->notify(arg);
         }
     }
 };

--- a/src/sim/probe/probe.hh
+++ b/src/sim/probe/probe.hh
@@ -192,6 +192,7 @@ class ProbeManager : public Named
      * @param point the ProbePoint to add.
      */
     void addPoint(ProbePoint &point);
+    ProbePoint *getFirstProbePoint(std::string_view point_name) const;
 
     template <typename Listener, typename... Args>
     ProbeListenerPtr<Listener> connect(Args &&...args)

--- a/src/sim/probe/probe.hh
+++ b/src/sim/probe/probe.hh
@@ -175,7 +175,7 @@ class ProbeManager : public Named
      * @param listener the ProbeListener to add.
      * @return true if added, false otherwise.
      */
-    bool addListener(std::string point_name, ProbeListener &listener);
+    bool addListener(std::string_view point_name, ProbeListener &listener);
 
     /**
      * @brief Remove a ProbeListener from the ProbePoint named by pointName.
@@ -185,7 +185,7 @@ class ProbeManager : public Named
      * @param listener the ProbeListener to remove.
      * @return true if removed, false otherwise.
      */
-    bool removeListener(std::string point_name, ProbeListener &listener);
+    bool removeListener(std::string_view point_name, ProbeListener &listener);
 
     /**
      * @brief Add a ProbePoint to this SimObject ProbeManager.

--- a/src/sim/probe/probe_listener_object.cc
+++ b/src/sim/probe/probe_listener_object.cc
@@ -54,9 +54,6 @@ ProbeListenerObject::ProbeListenerObject(
 
 ProbeListenerObject::~ProbeListenerObject()
 {
-    for (auto l = listeners.begin(); l != listeners.end(); ++l) {
-        delete (*l);
-    }
     listeners.clear();
 }
 

--- a/src/sim/probe/probe_listener_object.hh
+++ b/src/sim/probe/probe_listener_object.hh
@@ -65,12 +65,19 @@ class ProbeListenerObject : public SimObject
 {
   protected:
     ProbeManager *manager;
-    std::vector<ProbeListener *> listeners;
+    std::vector<ProbeListenerPtr<>> listeners;
 
   public:
     ProbeListenerObject(const ProbeListenerObjectParams &params);
     virtual ~ProbeListenerObject();
-    ProbeManager* getProbeManager() { return manager; }
+    ProbeManager *getProbeManager() { return manager; }
+
+    template <typename T, typename... Args>
+    void connectListener(Args &&...args)
+    {
+        listeners.push_back(
+            getProbeManager()->connect<T>(std::forward<Args>(args)...));
+    }
 };
 
 } // namespace gem5


### PR DESCRIPTION
See individual commits for details.

This was rather tricky to figure out - I noticed I could not check the dynamic type of the connected probes since we were calling virtual functions on partially constructed objects.