### PR TITLE
arch-vega: Swizzle multi-dword scratch requests

### DIFF
--- a/src/gpu-compute/gpu_dyn_inst.hh
+++ b/src/gpu-compute/gpu_dyn_inst.hh
@@ -384,9 +384,10 @@ class GPUDynInst : public GPUExecContext
     void
     setStatusVector(int lane, int newVal)
     {
-        // currently we can have up to 2 memory requests per lane (if the
-        // lane's request goes across multiple cache lines)
-        assert((newVal >= 0) && (newVal <= 2));
+        // Currently we can have up to 4 memory requests per lane. This can
+        // occur on a memory request loading 4x dwords where the memory is
+        // swizzled.
+        assert((newVal >= 0) && (newVal <= 4));
         statusVector[lane] = newVal;
     }
 


### PR DESCRIPTION
Scratch memory requests that are larger than one dword are using a different memory layout than global instructions. Rather than being placed contiguously, each dword is interleaved 64 lanes * 4 bytes away as described in Section 9.1.5.2. "Swizzled Buffer Addressing" in the MI300 specification. This was verified by comparing MI300 output (which uses scratch_ instructions) with MI200 (which uses buffer instructions). MI300 FashionMNIST bs=1 now matches CPU reference.

This requires several changes to the instruction implementations:
 - For stores, data in the GPUDynInst can be swizzled before the data is written to memory. This is easy to do using a helper method. This is done in the template<int N> variant of initMemWrite. To use this x2 stores are changed to use template<int N> rather than loading a U64. The swizzle function is renamed to swizzleAddr to avoid confusion with swizzleData.
 - For loads, data is unswizzled in completeAcc when writing register values. This is not as easy to implement as a helper and is thus implemented for the three load instructions that load more than one dword.
 - Accessing swizzled data requires at least one packet per dword. A new GPU memory helper is added to create these packets for scratch requests specifically. This is called in the template<int N> variant of initMemRead / initMemWrite. Loads and stores of x2 are changed to use this variant instead of accessing a U64.

The GPUDynInst status vector restrictions are increased to allow for swizzled x4 accesses. For simplicity this does not currently support misaligned swizzled accesses and will panic upon seeing such a case.

Change-Id: Ic686c51e28e0af029a043d5a5b3d4069f2cb94f9