### PR TITLE
mem: Stride Prefetcher Fix (#1448)

### DIFF
--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -190,6 +190,13 @@ class StridePrefetcher(QueuedPrefetcher):
 
     use_requestor_id = Param.Bool(True, "Use requestor id based history")
 
+    use_cache_line_address = Param.Bool(
+        True,
+        "If this parameter is set to True, then the prefetcher will "
+        "operate on cache line addresses, else it would operate on word "
+        "addresses",
+    )
+
     degree = Param.Int(4, "Number of prefetches to generate")
     distance = Param.Unsigned(
         0,

--- a/src/mem/cache/prefetch/stride.cc
+++ b/src/mem/cache/prefetch/stride.cc
@@ -184,7 +184,7 @@ Stride::calculatePrefetch(const PrefetchInfo &pfi,
         // Round strides up to at least 1 cacheline
         int prefetch_stride = entry->stride;
         if (abs(prefetch_stride) < blkSize) {
-            prefetch_stride = (new_stride < 0) ? -blkSize : blkSize;
+            prefetch_stride = (prefetch_stride < 0) ? -blkSize : blkSize;
         }
 
         Addr new_addr = pf_addr + distance * prefetch_stride;

--- a/src/mem/cache/prefetch/stride.cc
+++ b/src/mem/cache/prefetch/stride.cc
@@ -149,6 +149,11 @@ Stride::calculatePrefetch(const PrefetchInfo &pfi,
 
         // Hit in table
         int new_stride = pf_addr - entry->lastAddr;
+
+        // Do nothing on repeated memory access
+        if (new_stride == 0)
+            return;
+
         bool stride_match = (new_stride == entry->stride);
 
         // Adjust confidence for stride entry
@@ -176,12 +181,6 @@ Stride::calculatePrefetch(const PrefetchInfo &pfi,
         // Abort prefetch generation if below confidence threshold
         if (entry->confidence.calcSaturation() < threshConf) {
             return;
-        }
-
-        // Round strides up to atleast 1 cacheline
-        int prefetch_stride = new_stride;
-        if (abs(new_stride) < blkSize) {
-            prefetch_stride = (new_stride < 0) ? -blkSize : blkSize;
         }
 
         Addr new_addr = pf_addr + distance * prefetch_stride;

--- a/src/mem/cache/prefetch/stride.cc
+++ b/src/mem/cache/prefetch/stride.cc
@@ -133,7 +133,7 @@ Stride::calculatePrefetch(const PrefetchInfo &pfi,
     }
 
     // Get required packet info
-    Addr pf_addr = pfi.getAddr();
+    Addr pf_addr = blockAddress(pfi.getAddr());
     Addr pc = pfi.getPC();
     bool is_secure = pfi.isSecure();
     RequestorID requestor_id = useRequestorId ? pfi.getRequestorId() : 0;
@@ -168,6 +168,10 @@ Stride::calculatePrefetch(const PrefetchInfo &pfi,
                 (int)entry->confidence);
 
         entry->lastAddr = pf_addr;
+
+        // Return if we don't see a stride match
+        if (!stride_match)
+            return;
 
         // Abort prefetch generation if below confidence threshold
         if (entry->confidence.calcSaturation() < threshConf) {

--- a/src/mem/cache/prefetch/stride.hh
+++ b/src/mem/cache/prefetch/stride.hh
@@ -148,6 +148,13 @@ class Stride : public Queued
     std::unordered_map<int, PCTable> pcTables;
 
     /**
+     * If this parameter is set to true, then the prefetcher will operate at
+     * the granularity of cache line. Otherwise it would operate on the
+     * granularity of word addresses
+     */
+    const bool useCachelineAddr;
+
+    /**
      * Try to find a table of entries for the given context. If none is
      * found, a new table is created.
      *


### PR DESCRIPTION
This PR fixes the issues mentioned in #1448.

**Note that this contribution is the result of a joint collaboration with @AbhishekUoR**

This PR introduces the following 4 changes:
1. It changes the addresses which are used to compute the stride to cache line aligned addresses (the current version uses word aligned addresses)
2. It correctly returns if the stride does not match (as opposed to issuing prefetches using the new stride incorrectly)
3. It returns if the new stride is 0, indicating multiple reads from the same cache line.
4. It removes code which is no longer necessary after the addition of changes number 1 and 3.

Change-Id: Ic346d0e15df6d07e2b93289c8d6b89b4c2f45a34