### PR TITLE
mem-cache: Implementation of HPCA variant of Best Offset prefetcher

### DIFF
--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -552,6 +552,24 @@ class SlimAMPMPrefetcher(QueuedPrefetcher):
     )
 
 
+class BoPrefetcher(QueuedPrefetcher):
+    # Paper: https://doi.org/10.1109/HPCA.2016.7446087
+    type = "BoPrefetcher"
+    cxx_class = "gem5::prefetch::Bo"
+    cxx_header = "mem/cache/prefetch/bo.hh"
+    round_max = Param.Int(100, "Number of rounds for training")
+    max_score = Param.Int(31, "Maximum score to finish training")
+    bad_score = Param.Int(1, "Below this score switch off prefetcher")
+    rr_size = Param.Int(256, "Size of recent request table")
+
+    queue_squash = True
+    queue_filter = True
+    cache_snoop = True
+    prefetch_on_pf_hit = True
+    on_miss = True
+    on_inst = False
+
+
 class BOPPrefetcher(QueuedPrefetcher):
     type = "BOPPrefetcher"
     cxx_class = "gem5::prefetch::BOP"

--- a/src/mem/cache/prefetch/SConscript
+++ b/src/mem/cache/prefetch/SConscript
@@ -29,7 +29,8 @@
 Import('*')
 
 SimObject('Prefetcher.py', sim_objects=[
-    'BasePrefetcher', 'MultiPrefetcher', 'QueuedPrefetcher',
+    'BasePrefetcher', 'BoPrefetcher',
+    'MultiPrefetcher', 'QueuedPrefetcher',
     'StridePrefetcherHashedSetAssociative', 'StridePrefetcher',
     'TaggedPrefetcher', 'IndirectMemoryPrefetcher', 'SignaturePathPrefetcher',
     'SignaturePathPrefetcherV2', 'AccessMapPatternMatching', 'AMPMPrefetcher',
@@ -39,6 +40,7 @@ SimObject('Prefetcher.py', sim_objects=[
 
 Source('access_map_pattern_matching.cc')
 Source('base.cc')
+Source('bo.cc')
 Source('multi.cc')
 Source('bop.cc')
 Source('delta_correlating_prediction_tables.cc')

--- a/src/mem/cache/prefetch/bo.cc
+++ b/src/mem/cache/prefetch/bo.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Describes a HPCA variant Best-Offset prefetcher based on template policies.
+ */
+
+#include "mem/cache/prefetch/bo.hh"
+
+#include "params/BoPrefetcher.hh"
+
+namespace gem5
+{
+
+namespace prefetch
+{
+
+Bo::Bo(const BoPrefetcherParams &p)
+    : Queued(p), roundMax(p.round_max), maxScore(p.max_score),
+    badScore(p.bad_score), rrSize(p.rr_size)
+{
+    bestOffset = 0;
+    for (auto offsets : offsetList) {
+        scoreTable[offsets] = 0;
+    }
+    rrTable.clear();
+    offsetIndex = 0;
+    round = 0;
+    maxScoreAttained = false;
+}
+
+void
+Bo::calculatePrefetch(const PrefetchInfo &pfi,
+    std::vector<AddrPriority> &addresses,
+    const CacheAccessor &cache)
+{
+    Addr blkAddr = blockAddress(pfi.getAddr());
+
+    assert (scoreTable.size() == offsetList.size());
+
+    //lookup into RR
+    Addr lookupAddr = blkAddr - (blkSize * offsetList.at(offsetIndex));
+    for (auto rrEntry: rrTable) {
+        if (rrEntry == lookupAddr) {
+            scoreTable[offsetList.at(offsetIndex)] += 1;
+            if (scoreTable[offsetList.at(offsetIndex)] >= maxScore) {
+                maxScoreAttained = true;
+                break;
+            }
+        }
+    }
+
+    //prepare for next learning phase
+    if (offsetIndex >= (offsetList.size() - 1)) {
+        //Next round
+        round += 1;
+        offsetIndex = 0;
+    }
+    else
+        offsetIndex += 1;
+
+   //Update BestOffset based on learning phase
+    if ((round > roundMax) || maxScoreAttained) {
+        //get max score
+        int max = 0;
+        bestOffset = 0;
+        for (auto score: scoreTable) {
+            if (max < score.second) {
+                max = score.second;
+                bestOffset = score.first;
+            }
+        }
+
+        if (max <= badScore) bestOffset = 0;
+
+        //Reset
+        for (auto &score : scoreTable) {
+             score.second = 0;
+        }
+        round = 0;
+        offsetIndex = 0;
+        maxScoreAttained = false;
+    }
+
+    //Degree 1 prefetching if bestOffset
+    if (bestOffset != 0) {
+        Addr newAddr = blkAddr + (bestOffset * blkSize);
+        if (samePage(blkAddr, newAddr)) {
+            addresses.push_back(AddrPriority(newAddr,0));
+        }
+    }
+}
+
+void
+Bo::notifyFill(const CacheAccessProbeArg &arg)
+{
+    const PacketPtr& pkt = arg.pkt;
+    Addr blkAddr = blockAddress(pkt->getAddr());
+    //Insert in RR
+    if (pkt->cmd.isHWPrefetch() || (bestOffset == 0)) {
+        Addr insertAddr = blkAddr - (blkSize * bestOffset);
+        if (samePage(blkAddr, insertAddr)) rrTable.push_back(insertAddr);
+        //Maintain the RR size
+        while (rrTable.size() > rrSize) {
+                rrTable.erase(rrTable.begin());
+        }
+    }
+
+}
+
+} // namespace prefetch
+} // namespace gem5

--- a/src/mem/cache/prefetch/bo.hh
+++ b/src/mem/cache/prefetch/bo.hh
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Describes a HPCA variant of Best-Offset prefetcher.
+ */
+
+#ifndef __MEM_CACHE_PREFETCH_BO_HH__
+#define __MEM_CACHE_PREFETCH_BO_HH__
+
+#include "mem/cache/prefetch/queued.hh"
+#include "mem/packet.hh"
+
+namespace gem5
+{
+
+struct BoPrefetcherParams;
+
+namespace prefetch
+{
+
+class Bo : public Queued
+{
+
+  protected:
+      int roundMax, bestOffset, maxScore, badScore, rrSize, offsetIndex, round;
+      const std::vector<int> offsetList {1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 15,
+       16, 18, 20, 24, 25, 27, 30, 32, 36, 40, 45, 48, 50, 54, 60, 64, 72,
+       75, 80, 81, 90, 96, 100, 108, 120, 125, 128, 135, 144, 150, 160,
+       162, 180, 192, 200, 216, 225, 240, 243, 250, 256};
+      std::map<Addr, Addr> scoreTable;
+      std::vector<Addr> rrTable;
+      bool maxScoreAttained;
+
+      void notifyFill(const CacheAccessProbeArg &arg) override;
+
+  public:
+    Bo(const BoPrefetcherParams &p);
+    ~Bo() = default;
+
+    void calculatePrefetch(const PrefetchInfo &pfi,
+                           std::vector<AddrPriority> &addresses,
+                           const CacheAccessor &cache) override;
+};
+
+} // namespace prefetch
+} // namespace gem5
+
+#endif // __MEM_CACHE_PREFETCH_BO_HH__


### PR DESCRIPTION
This PR adds the BO prefetcher described in [this](https://doi.org/10.1109/HPCA.2016.7446087) paper.

On branch bo
Changes to be committed:
modified: src/mem/cache/prefetch/Prefetcher.py
modified: src/mem/cache/prefetch/SConscript
new file: src/mem/cache/prefetch/bo.cc
new file: src/mem/cache/prefetch/bo.hh

Change-Id: I930ec4858a442b6bb337c59c51848bc285324329