### PR TITLE
arch-riscv: Sign-extend the address in newPCState

### DIFF
--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -117,6 +117,9 @@ class ISA : public BaseISA
     newPCState(Addr new_inst_addr=0) const override
     {
         unsigned vlenb = vlen >> 3;
+        if (_rvType == RV32) {
+            new_inst_addr = sext<32>(new_inst_addr);
+        }
         return new PCState(new_inst_addr, _rvType, vlenb);
     }
 


### PR DESCRIPTION
From #1316, creating the new PCState should sign-extend the address to avoid wrong address issue.

Change-Id: I884b4e3708f5f1cc49cfd44d51bec5a2b63cc47a