### PR TITLE
Update on-create.sh

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -31,6 +31,9 @@
 
 set -e
 
+# Making the downloaded repository safe as the owner might differ for .devcontainer env.
+git config --global --add safe.directory /workspaces/gem5
+
 # Refresh the git index.
 git update-index
 


### PR DESCRIPTION
After merging the old personal gem5 repository with the stable version v24, I tried to run the project inside the `.devcontainer` environment. During the image build process, I encountered the following error:

```sh
[7683 ms] Start: Run in container: /bin/sh -c ./.devcontainer/on-create.sh
fatal: detected dubious ownership in repository at '/workspaces/gem5'
To add an exception for this directory, call:

        git config --global --add safe.directory /workspaces/gem5
[7724 ms] onCreateCommand failed with exit code 128. Skipping any further user-provided commands.
```
This error occurred due to an ownership permission problem, which I resolved by adding the following line.