### PR TITLE
arch-arm: Add arm demo board

### DIFF
--- a/configs/example/gem5_library/arm-demo-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-demo-ubuntu-run.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This script further shows an example of booting an ARM based full system Ubuntu
+disk image. This simulation boots the disk image using the ArmDemoBoard.
+
+Usage
+-----
+
+```
+scons build/ARM/gem5.opt -j<NUM_CPUS>
+./build/ARM/gem5.opt configs/example/gem5_library/arm-demo-ubuntu-run.py
+
+"""
+import argparse
+
+from gem5.isas import ISA
+from gem5.prebuilt.demo.arm_demo_board import ArmDemoBoard
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
+
+# This runs a check to ensure the gem5 binary is compiled for ARM.
+requires(isa_required=ISA.ARM)
+
+parser = argparse.ArgumentParser(
+    description="An example configuration script to run the arm demo mode."
+)
+
+parser.add_argument(
+    "--use-kvm",
+    action="store_true",
+    help="Use KVM for full system simulation.",
+)
+args = parser.parse_args()
+
+board = ArmDemoBoard(use_kvm=args.use_kvm)
+
+
+board.set_workload(
+    obtain_resource("arm64-ubuntu-20.04-boot", resource_version="2.0.0")
+)
+# We define the system with the aforementioned system defined.
+simulator = Simulator(
+    board=board,
+)
+
+simulator.run()

--- a/configs/example/gem5_library/arm-demo-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-demo-ubuntu-run.py
@@ -55,7 +55,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     "--use-kvm",
     action="store_true",
-    help="Use KVM for full system simulation.",
+    help="Use KVM cores instead of Timing.",
 )
 args = parser.parse_args()
 

--- a/configs/example/gem5_library/arm-demo-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-demo-ubuntu-run.py
@@ -31,10 +31,10 @@ disk image. This simulation boots the disk image using the ArmDemoBoard.
 Usage
 -----
 
-```
-scons build/ARM/gem5.opt -j<NUM_CPUS>
+```bash
+scons build/ARM/gem5.opt -j $(nproc)
 ./build/ARM/gem5.opt configs/example/gem5_library/arm-demo-ubuntu-run.py
-
+```
 """
 import argparse
 
@@ -49,7 +49,7 @@ from gem5.utils.requires import requires
 requires(isa_required=ISA.ARM)
 
 parser = argparse.ArgumentParser(
-    description="An example configuration script to run the arm demo mode."
+    description="An example configuration script to run the ArmDemoBoard."
 )
 
 parser.add_argument(

--- a/configs/example/gem5_library/arm-demo-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-demo-ubuntu-run.py
@@ -45,7 +45,7 @@ from gem5.simulate.exit_event import ExitEvent
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires
 
-# This runs a check to ensure the gem5 binary is compiled for ARM.
+# This runs a check to ensure the gem5 binary interpreting this file is compiled to include the ARM ISA.
 requires(isa_required=ISA.ARM)
 
 parser = argparse.ArgumentParser(

--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -280,6 +280,7 @@ PySource('gem5.components.processors',
 PySource('gem5.prebuilt', 'gem5/prebuilt/__init__.py')
 PySource('gem5.prebuilt.demo', 'gem5/prebuilt/demo/__init__.py')
 PySource('gem5.prebuilt.demo', 'gem5/prebuilt/demo/x86_demo_board.py')
+PySource('gem5.prebuilt.demo', 'gem5/prebuilt/demo/arm_demo_board.py')
 PySource('gem5.prebuilt.riscvmatched',
     'gem5/prebuilt/riscvmatched/__init__.py')
 PySource('gem5.prebuilt.riscvmatched',

--- a/src/python/gem5/prebuilt/demo/arm_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/arm_demo_board.py
@@ -94,7 +94,7 @@ class ArmDemoBoard(ArmBoard):
 
         else:
             processor = SimpleProcessor(
-                cpu_type=CPUTypes.TIMING, num_cores=4, isa=ISA.ARM
+                cpu_type=CPUTypes.TIMING, num_cores=2, isa=ISA.ARM
             )
             release = ArmDefaultRelease()
 

--- a/src/python/gem5/prebuilt/demo/arm_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/arm_demo_board.py
@@ -45,19 +45,19 @@ from gem5.utils.requires import requires
 class ArmDemoBoard(ArmBoard):
     """
     This prebuilt ARM board is used for demonstration purposes. It simulates an
-    ARM 3GHz dual-core system with a 2GB DDR4_2400 memory system. A
-    PrivateL1PrivateL2 cache hierarchy is set with an l1 data and instruction
-    cache, each 16kB, and a single bank l2 cache of 256kB.
+    ARM 1.4GHz dual-core system with a 4GiB DDR4_2400 memory system. It uses
+    a PrivateL1SharedL2CacheHierarchy with l1d and l1i caches set to 64KiB and
+    l2 shared cache set to 1MiB
 
     **DISCLAIMER**: This board is solely for demonstration purposes. This board
     is not known to be representative of any real-world system or produce
     reliable statistical results.
     """
 
-    def __init__(self, use_kvm=False):
+    def __init__(self, use_kvm: bool = False) -> None:
         """
         :param use_kvm: If True, the board will use a SimpleProcessor
-            with cpy type of CPUTypes.KVM. If False, the board will use a SimpleProcessor with
+            with cpu type of CPUTypes.KVM. If False, the board will use a SimpleProcessor with
             a cpu type of CPUTypes.TIMING.
         """
         requires(
@@ -70,14 +70,17 @@ class ArmDemoBoard(ArmBoard):
             "real-world system. Use with caution."
         )
         cache_hierarchy = PrivateL1SharedL2CacheHierarchy(
-            l1d_size="16KiB", l1i_size="16KiB", l2_size="8MiB"
+            l1d_size="64KiB", l1i_size="64KiB", l2_size="1MiB"
         )
 
-        memory = DualChannelDDR4_2400(size="8GB")
+        # Note: Normally a system with these specification would have 1
+        # GiB for memory but because some benchmarks would not run with
+        # 1 GiB of memory so we have set it to 4 GiB.
+        memory = DualChannelDDR4_2400(size="4GiB")
 
         if use_kvm:
             processor = SimpleProcessor(
-                cpu_type=CPUTypes.KVM, num_cores=4, isa=ISA.ARM
+                cpu_type=CPUTypes.KVM, num_cores=2, isa=ISA.ARM
             )
             # The ArmBoard requires a `release` to be specified. This adds all the
             # extensions or features to the system. We are setting this to for_kvm()
@@ -100,7 +103,7 @@ class ArmDemoBoard(ArmBoard):
             platform = VExpress_GEM5_Foundation()
 
         super().__init__(
-            clk_freq="3GHz",
+            clk_freq="1.4GHz",
             processor=processor,
             memory=memory,
             cache_hierarchy=cache_hierarchy,

--- a/src/python/gem5/prebuilt/demo/arm_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/arm_demo_board.py
@@ -45,9 +45,9 @@ from ...utils.requires import requires
 class ArmDemoBoard(ArmBoard):
     """
     This prebuilt ARM board is used for demonstration purposes. It simulates an
-    ARM 1.4GHz dual-core system with a 4GiB DDR4_2400 memory system. It uses
+    ARM 3GHz dual-core system with a 4GiB DDR4_2400 memory system. It uses
     a PrivateL1SharedL2CacheHierarchy with l1d and l1i caches set to 64KiB and
-    l2 shared cache set to 1MiB
+    l2 shared cache set to 8MiB
 
     **DISCLAIMER**: This board is solely for demonstration purposes. This board
     is not known to be representative of any real-world system or produce
@@ -103,7 +103,7 @@ class ArmDemoBoard(ArmBoard):
             platform = VExpress_GEM5_Foundation()
 
         super().__init__(
-            clk_freq="1.4GHz",
+            clk_freq="3GHz",
             processor=processor,
             memory=memory,
             cache_hierarchy=cache_hierarchy,

--- a/src/python/gem5/prebuilt/demo/arm_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/arm_demo_board.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects import (
+    ArmDefaultRelease,
+    VExpress_GEM5_Foundation,
+    VExpress_GEM5_V1,
+)
+from m5.util import warn
+
+from gem5.components.boards.arm_board import ArmBoard
+from gem5.components.cachehierarchies.classic.private_l1_private_l2_cache_hierarchy import (
+    PrivateL1PrivateL2CacheHierarchy,
+)
+from gem5.components.memory import DualChannelDDR4_2400
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.utils.requires import requires
+
+
+class ArmDemoBoard(ArmBoard):
+    """
+    This prebuilt ARM board is used for demonstration purposes. It simulates an
+    ARM 3GHz dual-core system with a 2GB DDR4_2400 memory system. A
+    PrivateL1PrivateL2 cache hierarchy is set with an l1 data and instruction
+    cache, each 16kB, and a single bank l2 cache of 256kB.
+
+    **DISCLAIMER**: This board is solely for demonstration purposes. This board
+    is not known to be representative of any real-world system or produce
+    reliable statistical results.
+    """
+
+    def __init__(self, use_kvm=False):
+        """
+        :param use_kvm: If True, the board will use a SimpleProcessor
+            with cpy type of CPUTypes.KVM. If False, the board will use a SimpleProcessor with
+            a cpu type of CPUTypes.TIMING.
+        """
+        requires(
+            isa_required=ISA.ARM,
+        )
+
+        warn(
+            "The ARMDemoBoard is solely for demonstration purposes. "
+            "This board is not known to be be representative of any "
+            "real-world system. Use with caution."
+        )
+        cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
+            l1d_size="16kB", l1i_size="16kB", l2_size="256kB"
+        )
+
+        memory = DualChannelDDR4_2400(size="2GB")
+
+        if use_kvm:
+            processor = SimpleProcessor(
+                cpu_type=CPUTypes.TIMING, num_cores=2, isa=ISA.ARM
+            )
+            release = ArmDefaultRelease.for_kvm()
+            platform = VExpress_GEM5_V1()
+
+        else:
+            processor = SimpleProcessor(
+                cpu_type=CPUTypes.TIMING, num_cores=2, isa=ISA.ARM
+            )
+            release = ArmDefaultRelease()
+            platform = VExpress_GEM5_Foundation()
+
+        super().__init__(
+            clk_freq="3GHz",
+            processor=processor,
+            memory=memory,
+            cache_hierarchy=cache_hierarchy,
+            release=release,
+            platform=platform,
+        )

--- a/src/python/gem5/prebuilt/demo/arm_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/arm_demo_board.py
@@ -31,15 +31,15 @@ from m5.objects import (
 )
 from m5.util import warn
 
-from gem5.components.boards.arm_board import ArmBoard
-from gem5.components.cachehierarchies.classic.private_l1_shared_l2_cache_hierarchy import (
+from ...components.boards.arm_board import ArmBoard
+from ...components.cachehierarchies.classic.private_l1_shared_l2_cache_hierarchy import (
     PrivateL1SharedL2CacheHierarchy,
 )
-from gem5.components.memory import DualChannelDDR4_2400
-from gem5.components.processors.cpu_types import CPUTypes
-from gem5.components.processors.simple_processor import SimpleProcessor
-from gem5.isas import ISA
-from gem5.utils.requires import requires
+from ...components.memory import DualChannelDDR4_2400
+from ...components.processors.cpu_types import CPUTypes
+from ...components.processors.simple_processor import SimpleProcessor
+from ...isas import ISA
+from ...utils.requires import requires
 
 
 class ArmDemoBoard(ArmBoard):
@@ -70,7 +70,7 @@ class ArmDemoBoard(ArmBoard):
             "real-world system. Use with caution."
         )
         cache_hierarchy = PrivateL1SharedL2CacheHierarchy(
-            l1d_size="64KiB", l1i_size="64KiB", l2_size="1MiB"
+            l1d_size="64KiB", l1i_size="64KiB", l2_size="8MiB"
         )
 
         # Note: Normally a system with these specification would have 1


### PR DESCRIPTION
This demo board is a preset arm board, that can be used to run example gem5 simulations. This board doesnt simulate any known hardware.

The board will be used to run benchmarks such as gapbs and npb to collect stats. The plan is to show these stats on the gem5 resources website to provide more details about the resources. 