### PR TITLE
dev-amdgpu: Implement UNMAP_QUEUES queue_sel==2

### DIFF
--- a/src/dev/amdgpu/amdgpu_device.cc
+++ b/src/dev/amdgpu/amdgpu_device.cc
@@ -943,13 +943,13 @@ AMDGPUDevice::deallocatePasid(uint16_t pasid)
 }
 
 void
-AMDGPUDevice::deallocateAllQueues()
+AMDGPUDevice::deallocateAllQueues(bool unmap_static)
 {
     idMap.erase(idMap.begin(), idMap.end());
     usedVMIDs.erase(usedVMIDs.begin(), usedVMIDs.end());
 
     for (auto& it : sdmaEngs) {
-        it.second->deallocateRLCQueues();
+        it.second->deallocateRLCQueues(unmap_static);
     }
 
     // "All" queues implicitly refers to all user queues. User queues begin at

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -217,7 +217,7 @@ class AMDGPUDevice : public PciDevice
     uint16_t allocateVMID(uint16_t pasid);
     void deallocateVmid(uint16_t vmid);
     void deallocatePasid(uint16_t pasid);
-    void deallocateAllQueues();
+    void deallocateAllQueues(bool unmap_static);
     void mapDoorbellToVMID(Addr doorbell, uint16_t vmid);
     uint16_t getVMID(Addr doorbell) { return doorbellVMIDMap[doorbell]; }
     std::unordered_map<uint16_t, std::set<int>>& getUsedVMIDs();

--- a/src/dev/amdgpu/pm4_packet_processor.hh
+++ b/src/dev/amdgpu/pm4_packet_processor.hh
@@ -67,6 +67,8 @@ class PM4PacketProcessor : public DmaVirtDevice
     int _ipId;
     AddrRange _mmioRange;
 
+    void unmapAllQueues(bool unmap_static);
+
   public:
     PM4PacketProcessor(const PM4PacketProcessorParams &p);
 

--- a/src/dev/amdgpu/pm4_queues.hh
+++ b/src/dev/amdgpu/pm4_queues.hh
@@ -486,12 +486,16 @@ class PM4Queue
     uint32_t pipe() { return _pkt.pipe; }
     uint32_t queue() { return _pkt.queueSlot; }
     bool privileged() { return _pkt.queueSel == 0 ? 1 : 0; }
+    uint32_t queueType() { return _pkt.queueType; }
+    bool isStatic() { return (_pkt.queueType != 0); }
     PM4MapQueues* getPkt() { return &_pkt; }
-    void setPkt(uint32_t me, uint32_t pipe, uint32_t queue, bool privileged) {
+    void setPkt(uint32_t me, uint32_t pipe, uint32_t queue, bool privileged,
+                uint32_t queueType) {
         _pkt.me = me - 1;
         _pkt.pipe = pipe;
         _pkt.queueSlot = queue;
         _pkt.queueSel = (privileged == 0) ? 1 : 0;
+        _pkt.queueType = queueType;
     }
 
     // Same computation as processMQD. See comment there for details.

--- a/src/dev/amdgpu/sdma_engine.hh
+++ b/src/dev/amdgpu/sdma_engine.hh
@@ -69,6 +69,7 @@ class SDMAEngine : public DmaVirtDevice
         SDMAQueueDesc *_mqd;
         Addr _mqd_addr = 0;
         bool _priv = true; // Only used for RLC queues. True otherwise.
+        bool _static = false;
       public:
         SDMAQueue() : _rptr(0), _wptr(0), _valid(false), _processing(false),
             _parent(nullptr), _ib(nullptr), _type(SDMAGfx), _mqd(nullptr) {}
@@ -89,6 +90,7 @@ class SDMAEngine : public DmaVirtDevice
         SDMAQueueDesc* getMQD() { return _mqd; }
         Addr getMQDAddr() { return _mqd_addr; }
         bool priv() { return _priv; }
+        bool isStatic() { return _static; }
 
         void base(Addr value) { _base = value; }
 
@@ -124,6 +126,7 @@ class SDMAEngine : public DmaVirtDevice
         void setMQD(SDMAQueueDesc *mqd) { _mqd = mqd; }
         void setMQDAddr(Addr mqdAddr) { _mqd_addr = mqdAddr; }
         void setPriv(bool priv) { _priv = priv; }
+        void setStatic(bool isStatic) { _static = isStatic; }
     };
 
     /* SDMA Engine ID */
@@ -307,9 +310,10 @@ class SDMAEngine : public DmaVirtDevice
     /**
      * Methods for RLC queues
      */
-    void registerRLCQueue(Addr doorbell, Addr mqdAddr, SDMAQueueDesc *mqd);
-    void unregisterRLCQueue(Addr doorbell);
-    void deallocateRLCQueues();
+    void registerRLCQueue(Addr doorbell, Addr mqdAddr, SDMAQueueDesc *mqd,
+                          bool isStatic);
+    void unregisterRLCQueue(Addr doorbell, bool unmap_static);
+    void deallocateRLCQueues(bool unmap_static);
 
     int cur_vmid = 0;
 };


### PR DESCRIPTION
Unmap queues with queue_sel of 2 unmaps all queues while queue_sel of 3 unmaps all non-static queues. The implementation of 3 was actually correct for 2. Static queues are queues which were mapped using a map queues packet with a queue_type of 1 or 2.

This commit adds ability to mark a queue as static. When unmap queues with queue_sel of 2 is sent, the existing code is now executed. With a value of 3, we now check if the queue was marked static and do not unmap it if marked.

Change-Id: I87d7cf78a0600c7baa516c01f42c294d3c4e90c5