### PR TITLE
tests,gpu-compute: Fix Daily/Weekly GPU tests failures

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -94,7 +94,7 @@ jobs:
 
             - name: Run Testlib GPU Tests
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --length=long --skip-build -vvv -t $(nproc) --host gcn_gpu
+              run: ./main.py run --length=long --skip-build -vvv -t $(nproc) --host gcn_gpu  gem5/gpu
 
             - name: Upload results
               if: success() || failure()

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -74,7 +74,7 @@ jobs:
 
             - name: Run Testlib GPU Tests
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --length=very-long --skip-build -vvv -t $(nproc) --host gcn_gpu
+              run: ./main.py run --length=very-long --skip-build -vvv -t $(nproc) --host gcn_gpu  gem5/gpu
 
             - name: Upload results
               if: success() || failure()


### PR DESCRIPTION
Without specifying the "gem5/gpu" directory, this test attempted to run the entire test suite. This caused the daily and weekly tests to fail. This change fixes this.