### PR TITLE
mem-ruby, sim-se: Add support for Maybe_Stale blocks in functional reads

### DIFF
--- a/src/mem/ruby/protocol/MESI_Three_Level-L1cache.sm
+++ b/src/mem/ruby/protocol/MESI_Three_Level-L1cache.sm
@@ -90,9 +90,9 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
     // For all of the following states, invalidate
     // message has been sent to L0 cache. The response
     // from the L0 cache has not been seen yet.
-    S_IL0, AccessPermission:Busy, desc="Shared in L1, invalidation sent to L0, have not seen response yet";
-    E_IL0, AccessPermission:Busy, desc="Exclusive in L1, invalidation sent to L0, have not seen response yet";
-    M_IL0, AccessPermission:Busy, desc="Modified in L1, invalidation sent to L0, have not seen response yet";
+    S_IL0, AccessPermission:Read_Only, desc="Shared in L1, invalidation sent to L0, have not seen response yet";
+    E_IL0, AccessPermission:Maybe_Stale, desc="Exclusive in L1, invalidation sent to L0, have not seen response yet";
+    M_IL0, AccessPermission:Maybe_Stale, desc="Modified in L1, invalidation sent to L0, have not seen response yet";
     MM_IL0, AccessPermission:Read_Write, desc="Invalidation sent to L0, have not seen response yet";
     SM_IL0, AccessPermission:Busy, desc="Invalidation sent to L0, have not seen response yet";
   }
@@ -229,6 +229,10 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
     } else {
       testAndRead(addr, getCacheEntry(addr).DataBlk, pkt);
     }
+  }
+
+  int functionalReadPriority() {
+    return 10;
   }
 
   int functionalWrite(Addr addr, Packet *pkt) {

--- a/src/mem/ruby/protocol/MESI_Three_Level-msg.sm
+++ b/src/mem/ruby/protocol/MESI_Three_Level-msg.sm
@@ -83,6 +83,8 @@ structure(CoherenceMsg, desc="...", interface="Message") {
   bool functionalRead(Packet *pkt) {
     // Valid data block is only present in message with following types
     if (Class == CoherenceClass:PUTX ||
+        Class == CoherenceClass:INV_DATA ||
+        Class == CoherenceClass:DATA ||
         Class == CoherenceClass:DATA_EXCLUSIVE) {
         return testAndRead(addr, DataBlk, pkt);
     }

--- a/src/mem/ruby/protocol/MESI_Two_Level-L2cache.sm
+++ b/src/mem/ruby/protocol/MESI_Two_Level-L2cache.sm
@@ -238,6 +238,10 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     }
   }
 
+  int functionalReadPriority() {
+    return 20;
+  }
+
   int functionalWrite(Addr addr, Packet *pkt) {
     int num_functional_writes := 0;
 

--- a/src/mem/ruby/protocol/MESI_Two_Level-dir.sm
+++ b/src/mem/ruby/protocol/MESI_Two_Level-dir.sm
@@ -163,6 +163,10 @@ machine(MachineType:Directory, "MESI Two Level directory protocol")
     }
   }
 
+  int functionalReadPriority() {
+    return 30;
+  }
+
   int functionalWrite(Addr addr, Packet *pkt) {
     int num_functional_writes := 0;
 

--- a/src/mem/ruby/slicc_interface/AbstractController.hh
+++ b/src/mem/ruby/slicc_interface/AbstractController.hh
@@ -134,6 +134,14 @@ class AbstractController : public ClockedObject, public Consumer
     virtual bool functionalReadBuffers(PacketPtr&) = 0;
     virtual void functionalRead(const Addr &addr, PacketPtr)
     { panic("functionalRead(Addr,PacketPtr) not implemented"); }
+    /**
+     * Returns the priority used by functional reads when deciding from which
+     * controller to read a Maybe_Stale data block.
+     * Lower positive values have higher priority, negative values are ignored.
+     *
+     * @return the controller's priority
+     */
+    virtual int functionalReadPriority() { return -1; }
 
     //! Functional read that reads only blocks not present in the mask.
     //! Return number of bytes read.

--- a/src/mem/ruby/system/RubySystem.cc
+++ b/src/mem/ruby/system/RubySystem.cc
@@ -518,6 +518,7 @@ RubySystem::functionalRead(PacketPtr pkt)
 
     AbstractController *ctrl_ro = nullptr;
     AbstractController *ctrl_rw = nullptr;
+    AbstractController *ctrl_ms = nullptr;
     AbstractController *ctrl_backing_store = nullptr;
 
     // In this loop we count the number of controllers that have the given
@@ -534,9 +535,25 @@ RubySystem::functionalRead(PacketPtr pkt)
         }
         else if (access_perm == AccessPermission_Busy)
             num_busy++;
-        else if (access_perm == AccessPermission_Maybe_Stale)
+        else if (access_perm == AccessPermission_Maybe_Stale) {
+            int priority = cntrl->functionalReadPriority();
+            if (priority >= 0) {
+                if (ctrl_ms == nullptr) {
+                    ctrl_ms = cntrl;
+                } else {
+                    int current_priority = ctrl_ms->functionalReadPriority();
+                    if (ctrl_ms == nullptr || priority < current_priority) {
+                        ctrl_ms = cntrl;
+                    } else if (priority == current_priority) {
+                        warn("More than one Abstract Controller with "
+                             "Maybe_Stale permission and same priority (%d) "
+                             "for addr: %#x on cacheline: %#x.", priority,
+                             address, line_address);
+                    }
+                }
+            }
             num_maybe_stale++;
-        else if (access_perm == AccessPermission_Backing_Store) {
+        } else if (access_perm == AccessPermission_Backing_Store) {
             // See RubySlicc_Exports.sm for details, but Backing_Store is meant
             // to represent blocks in memory *for Broadcast/Snooping protocols*,
             // where memory has no idea whether it has an exclusive copy of data
@@ -604,6 +621,13 @@ RubySystem::functionalRead(PacketPtr pkt)
         for (auto& network : m_networks) {
             if (network->functionalRead(pkt))
                 return true;
+        }
+        if (ctrl_ms != nullptr) {
+            // No copy in transit or buffered indicates that a block marked
+            // as Maybe_Stale is actually up-to-date, just waiting an Ack or
+            // similar type of message which carries no data.
+            ctrl_ms->functionalRead(line_address, pkt);
+            return true;
         }
     }
 


### PR DESCRIPTION
Functional reads can be satisfied by one of the following, in order:
1. Main memory (when the data is not present in the cache hierarchy);
2. Valid data block in cache;
3. Valid data block in coherence message;
4. Valid data block marked as `Maybe_Stale`;

Number 4 is not handled by the current implementation. A `Maybe_Stale` block can be either truly stale or actually valid. When it is stale, the memory read will be satisfied by either number 2 or number 3. When it is valid, there will be no coherence message with valid data inside, and the `Maybe_Stale` block will transition to a valid state after receiving some kind of acknowledgement.

The main challenge to handle number 4 is how to know from which `Maybe_Stale` block the data should be read from. For instance, in a two level cache hierarchy, we might have a block marked as `Maybe_Stale` in both L1 and L2. In this case, we should prioritize the cache controller that is closest to the CPU. To define this priority, a new virtual function `functionalReadPriority` was added to the `AbstractController` class.

This PR also fixes `MESI_Three_Level` and `MESI_Two_Level` protocols so that they make use of the new support for `Maybe_Stale` blocks, and additionally fixes two more issues related to functional reads:

1) Fix incorrect access permissions in `MESI_Three_Level-L1cache`:
* `S_IL0` is `Read_Only`, it is waiting for L0 to acknowledge the invalidation request before moving to `SS`, also a `Read_Only` state.
* `E_IL0` is `Maybe_Stale`, its contents might be valid, since there is a transition `(E_IL0, L0_Ack, EE)` with no writeback data.
* `M_IL0` is `Maybe_Stale`, its contents might be valid, since there is a transition `(M_IL0, L0_Ack, MM)` with no writeback data.

2) Add missing message types carrying valid data in functional reads:
* `INV_DATA` is a writeback from L0 to L1.
* `DATA` is a response to `GET_S`, but there are scenarios where it might be the only place with valid data (e.g. during L2 replacement).