### PR TITLE
ext,tests,misc: Suppress incorrect GCC 12 error in Pybind

### DIFF
--- a/ext/pybind11/include/pybind11/pybind11.h
+++ b/ext/pybind11/include/pybind11/pybind11.h
@@ -1333,7 +1333,22 @@ protected:
         } else {
             internals.registered_types_cpp[tindex] = tinfo;
         }
-        internals.registered_types_py[(PyTypeObject *) m_ptr] = {tinfo};
+
+       
+            PYBIND11_WARNING_PUSH
+#if defined(__GNUC__) && __GNUC__ == 12
+            // When using GCC 12 the `array-bounds` and `stringop-overread`
+            // warnings are disabled as they trigger false positive warnings.
+            //
+            // This is a known GCC 12 issue and is discussed here:
+            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824. This
+            // solution is based on advice given in this discussion but
+            // refactored with `PYBIND11_WARNING_DISABLE_GCC` MACRO.
+            PYBIND11_WARNING_DISABLE_GCC("-Warray-bounds")
+            PYBIND11_WARNING_DISABLE_GCC("-Wstringop-overread")
+#endif
+            internals.registered_types_py[(PyTypeObject *) m_ptr] = {tinfo};
+            PYBIND11_WARNING_POP
 
         if (rec.bases.size() > 1 || rec.multiple_inheritance) {
             mark_parents_nonsimple(tinfo->type);


### PR DESCRIPTION
There is a compiler error with GCC 12 discussed here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824

This Pybind code triggers the bug and was causing our compiler tests to fail.

To fix gem5 compilation for gcc 12 these warnings/errors have been suppressed for this code.
