### PR TITLE
arch-arm: Fix Execution Permission in Stage2 Direct Permission.

### DIFF
--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -627,7 +627,7 @@ MMU::s2PermBits64(TlbEntry *te, const RequestPtr &req, Mode mode,
             "w:%d, x:%d\n", te->hap, xn, pxn, r, w, x);
 
     if (x) {
-        grant = grant_read && !xn;
+        grant = !xn;
     } else if (req->isAtomic()) {
         grant = grant_read || grant_write;
     } else if (w) {


### PR DESCRIPTION
In Stage 2 under AArch64, execution permission does not need read permission.

Change-Id: I45887e8f4d50ed5edc4afaed9a2dd8a74db9d0d4