### PR TITLE
arch-arm: when programming an invalid PMU ID detach the counter

### DIFF
--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -601,6 +601,7 @@ PMU::updateCounter(CounterState &ctr)
         if (sourceEvent == eventMap.end()) {
             warn("Can't enable PMU counter of type '0x%x': "
                  "No such event type.\n", ctr.eventId);
+            ctr.detach();
         } else {
             ctr.attach(sourceEvent->second);
         }


### PR DESCRIPTION
I'm not entirely sure what the mandated behaviour is according the the ARM ARM, but I was very confused by the counters continuing to increment with the old event even when programmed to an event ID that is not currently supported by GEM5. Disconnecting the counter if the event is not supported is less surprising behaviour IMO.

Change-Id: I927d9339c138dafa1484db1515c2aa09b0a9a0a9