### PR TITLE
arch-arm: Use .f32/.f64 suffixes for vfp mnemonics

### DIFF
--- a/src/arch/arm/insts/vfp.cc
+++ b/src/arch/arm/insts/vfp.cc
@@ -135,8 +135,7 @@ FpRegRegRegCondOp::generateDisassembly(
     const
 {
     std::stringstream ss;
-    printMnemonic(ss);
-    printCondition(ss, cond);
+    printMnemonic(ss, "", /*withPred=*/false, /*withCond64=*/true, cond);
     printFloatReg(ss, dest);
     ss << ", ";
     printFloatReg(ss, op1);

--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -528,12 +528,12 @@ let {{
         global header_output, decoder_output, exec_output
 
         code = singleTernOp % { "op": singleOp, "palam": paramStr }
-        sIop = ArmInstObjParams(Name.lower() + "s", Name + "S", base,
+        sIop = ArmInstObjParams(Name.lower() + ".f32", Name + "S", base,
                 { "code": code,
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
         code = doubleTernOp % { "op": doubleOp, "palam": paramStr }
-        dIop = ArmInstObjParams(Name.lower() + "d", Name + "D", base,
+        dIop = ArmInstObjParams(Name.lower() + ".f64", Name + "D", base,
                 { "code": code,
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
@@ -560,13 +560,13 @@ let {{
 
         code = singleCode % { "op": singleBinOp }
         code = code % { "func": singleOp }
-        sIop = ArmInstObjParams(name + "s", Name + "S", base,
+        sIop = ArmInstObjParams(name + ".f32", Name + "S", base,
                 { "code": code,
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
         code = doubleCode % { "op": doubleBinOp }
         code = code % { "func": doubleOp }
-        dIop = ArmInstObjParams(name + "d", Name + "D", base,
+        dIop = ArmInstObjParams(name + ".f64", Name + "D", base,
                 { "code": code,
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
@@ -655,13 +655,13 @@ let {{
 
         code = singleCode % { "op": singleUnaryOp }
         code = code % { "func": singleOp }
-        sIop = ArmInstObjParams(name + "s", Name + "S", base,
+        sIop = ArmInstObjParams(name + ".f32", Name + "S", base,
                 { "code": code,
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
         code = doubleCode % { "op": doubleUnaryOp }
         code = code % { "func": doubleOp }
-        dIop = ArmInstObjParams(name + "d", Name + "D", base,
+        dIop = ArmInstObjParams(name + ".f64", Name + "D", base,
                 { "code": code,
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
@@ -682,11 +682,11 @@ let {{
             doubleOp = singleOp
         global header_output, decoder_output, exec_output
 
-        sIop = ArmInstObjParams(name + "s", Name + "S", base,
+        sIop = ArmInstObjParams(name + ".f32", Name + "S", base,
                 { "code": singleSimpleCode % { "op": singleOp },
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
-        dIop = ArmInstObjParams(name + "d", Name + "D", base,
+        dIop = ArmInstObjParams(name + ".f64", Name + "D", base,
                 { "code": doubleCode % { "op": doubleOp },
                   "predicate_test": predicateTest,
                   "op_class": opClass }, [])
@@ -1531,7 +1531,7 @@ let {{
             FpDest = FpOp2;
         } '''
 
-    vselSIop = ArmInstObjParams("vsels", "VselS", "FpRegRegRegCondOp",
+    vselSIop = ArmInstObjParams("vsel.f32", "VselS", "FpRegRegRegCondOp",
                                 { "code" : vselSCode,
                                   "predicate_test" : predicateTest,
                                   "op_class" : "SimdFloatCmpOp" }, [] )
@@ -1548,7 +1548,7 @@ let {{
             FpDestP1_uw = FpOp2P1_uw;
         } '''
 
-    vselDIop = ArmInstObjParams("vseld", "VselD", "FpRegRegRegCondOp",
+    vselDIop = ArmInstObjParams("vsel.f64", "VselD", "FpRegRegRegCondOp",
                                 { "code" : vselDCode,
                                   "predicate_test" : predicateTest,
                                   "op_class" : "SimdFloatCmpOp" }, [] )


### PR DESCRIPTION
This matches the Arm manual and the output produced by capstone. Also avoid unnecessary spaces in vsel* instruction printing.

Change-Id: I071dd834b7104f10f6358a6b2e2895bdab64df82