### PR TITLE
base: Allow DPRINTF debugging of AssociativeCache

### DIFF
--- a/src/base/cache/associative_cache.hh
+++ b/src/base/cache/associative_cache.hh
@@ -232,6 +232,12 @@ class AssociativeCache : public Named
 
         auto victim = static_cast<Entry*>(replPolicy->getVictim(candidates));
 
+        if (debugFlag && debugFlag->tracing() && victim->isValid()) {
+            ::gem5::trace::getDebugLogger()->dprintf_flag(
+                curTick(), name(), debugFlag->name(),
+                "Replacing entry: %s\n", victim->print());
+        }
+
         invalidate(victim);
 
         return victim;
@@ -257,6 +263,12 @@ class AssociativeCache : public Named
     virtual void
     insertEntry(const KeyType &key, Entry *entry)
     {
+        if (debugFlag && debugFlag->tracing()) {
+            ::gem5::trace::getDebugLogger()->dprintf_flag(
+                curTick(), name(), debugFlag->name(),
+                "Inserting entry: %s\n", entry->print());
+        }
+
         entry->insert(key);
         replPolicy->reset(entry->replacementData);
     }

--- a/src/base/cache/associative_cache.hh
+++ b/src/base/cache/associative_cache.hh
@@ -81,6 +81,8 @@ class AssociativeCache : public Named
     /** The entries */
     std::vector<Entry> entries;
 
+    const ::gem5::debug::SimpleFlag* debugFlag = nullptr;
+
   private:
 
     void
@@ -120,7 +122,8 @@ class AssociativeCache : public Named
           associativity(associativity_),
           replPolicy(repl_policy),
           indexingPolicy(indexing_policy),
-          entries(num_entries, init_val)
+          entries(num_entries, init_val),
+          debugFlag(nullptr)
     {
         initParams(num_entries, associativity);
     }
@@ -160,6 +163,12 @@ class AssociativeCache : public Named
         entries.resize(num_entries, init_val);
 
         initParams(num_entries, associativity);
+    }
+
+    void
+    setDebugFlag(const ::gem5::debug::SimpleFlag& flag)
+    {
+        debugFlag = &flag;
     }
 
     /**


### PR DESCRIPTION
The AssociativeCache is used by different caching agents.
This PR will allow to pass the appropriate flag to the cache so that we can meaningfully debug
its internals. For instance, when used to model a prefetcher table, will will pass the
HWPrefetch flag; when used to model a TLB, we will pass the TLB flag.
