### PR TITLE
arch-vega: Revert incorrect SOPC compare

### DIFF
--- a/src/arch/amdgpu/vega/insts/sopc.cc
+++ b/src/arch/amdgpu/vega/insts/sopc.cc
@@ -368,7 +368,7 @@ namespace VegaISA
         src0.read();
         src1.read();
 
-        scc = (src0.rawData() < src1.rawData()) ? 1 : 0;
+        scc = (src0.rawData() <= src1.rawData()) ? 1 : 0;
 
         scc.write();
     } // execute


### PR DESCRIPTION
LT <= was previously correct while < is not. Can lead to incorrect program execution. Related to #1366 related to #1520 

Change-Id: I00b7838e920eee7c8adb508e869fdf53a9373e1f