### PR TITLE
arch-riscv: Fix the bug of vsetivli frequently flushing the pipeline

### DIFF
--- a/src/arch/riscv/isa/formats/vector_conf.isa
+++ b/src/arch/riscv/isa/formats/vector_conf.isa
@@ -202,6 +202,7 @@ def template VSetiVliBranchTarget {{
             rpc.vl(), requested_vl, vlmax, rd_bits, rs1_bits);
 
         std::unique_ptr<PCState> npc(dynamic_cast<PCState*>(rpc.clone()));
+        npc->set(rvSext(npc->pc() + 4));
         npc->vtype(new_vtype);
         npc->vl(new_vl);
         return npc;


### PR DESCRIPTION
This PR fix the bug of vsetivli frequently flushing the pipeline.

Here are two pictures of the pipeline illustrate this phenomenon.

![20240830-200208](https://github.com/user-attachments/assets/532a1a8e-8acd-483f-b9a0-c25dadbe76b4)
![20240830-200213](https://github.com/user-attachments/assets/9354a6ad-4024-4afb-be6f-01f08dc9610c)

The vsetivli(0x00013334.0) instruction in the first picture flushes the pipeline every time it is executed. This is due to vsetivli being incorrectly flagged as a 'DirectControl' instruction. The branch predictor cannot predict it correctly.

The second picture is the pipeline after fixing the bug.

Change-Id: I5bede47919c06cea86fa23a81624b502fbdc1159