### PR TITLE
gpu-compute: Reuse RP list in GPU_VIPER

### DIFF
--- a/configs/example/apu_se.py
+++ b/configs/example/apu_se.py
@@ -50,6 +50,7 @@ from common import (
     FileSystemConfig,
     GPUTLBConfig,
     GPUTLBOptions,
+    ObjectList,
     Options,
     Simulation,
 )
@@ -393,6 +394,7 @@ parser.add_argument(
     "--tcp-rp",
     type=str,
     default="TreePLRURP",
+    choices=ObjectList.rp_list.get_names(),
     help="cache replacement policy" "policy for tcp",
 )
 
@@ -400,6 +402,7 @@ parser.add_argument(
     "--tcc-rp",
     type=str,
     default="TreePLRURP",
+    choices=ObjectList.rp_list.get_names(),
     help="cache replacement policy" "policy for tcc",
 )
 
@@ -408,6 +411,7 @@ parser.add_argument(
     "--sqc-rp",
     type=str,
     default="TreePLRURP",
+    choices=ObjectList.rp_list.get_names(),
     help="cache replacement policy" "policy for sqc",
 )
 

--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -199,6 +199,7 @@ def addRunFSOptions(parser):
         "--tcp-rp",
         type=str,
         default="TreePLRURP",
+        choices=ObjectList.rp_list.get_names(),
         help="cache replacement policy" "policy for tcp",
     )
 
@@ -206,6 +207,7 @@ def addRunFSOptions(parser):
         "--tcc-rp",
         type=str,
         default="TreePLRURP",
+        choices=ObjectList.rp_list.get_names(),
         help="cache replacement policy" "policy for tcc",
     )
 
@@ -214,6 +216,7 @@ def addRunFSOptions(parser):
         "--sqc-rp",
         type=str,
         default="TreePLRURP",
+        choices=ObjectList.rp_list.get_names(),
         help="cache replacement policy" "policy for sqc",
     )
 

--- a/configs/ruby/GPU_VIPER.py
+++ b/configs/ruby/GPU_VIPER.py
@@ -150,7 +150,7 @@ class TCPCache(RubyCache):
         self.assoc = options.tcp_assoc
         self.resourceStalls = options.no_tcc_resource_stalls
         if hasattr(options, "tcp_rp"):
-            self.replacement_policy = RP_choose(options.tcp_rp)
+            self.replacement_policy = ObjectList.rp_list.get(options.tcp_rp)()
 
 
 class TCPCntrl(TCP_Controller, CntrlBase):
@@ -243,7 +243,7 @@ class SQCCache(RubyCache):
         self.size = MemorySize(options.sqc_size)
         self.assoc = options.sqc_assoc
         if hasattr(options, "sqc_rp"):
-            self.replacement_policy = RP_choose(options.sqc_rp)
+            self.replacement_policy = ObjectList.rp_list.get(options.sqc_rp)()
 
 
 class SQCCntrl(SQC_Controller, CntrlBase):
@@ -306,7 +306,7 @@ class TCC(RubyCache):
             options.num_tccs, 2
         )
         if hasattr(options, "tcc_rp"):
-            self.replacement_policy = RP_choose(options.tcc_rp)
+            self.replacement_policy = ObjectList.rp_list.get(options.tcc_rp)()
 
 
 class TCCCntrl(TCC_Controller, CntrlBase):
@@ -1127,28 +1127,3 @@ def create_system(
     ruby_system.network.number_of_virtual_networks = 11
 
     return (cpu_sequencers, dir_cntrl_nodes, mainCluster)
-
-
-def RP_choose(test_name):
-    if test_name == "TreePLRURP":
-        replacement_policy = TreePLRURP()
-    elif test_name == "LRURP":
-        replacement_policy = LRURP()
-    elif test_name == "FIFORP":
-        replacement_policy = FIFORP()
-    elif test_name == "LFURP":
-        replacement_policy = LFURP()
-    elif test_name == "LIPRP":
-        replacement_policy = LIPRP()
-    elif test_name == "MRURP":
-        replacement_policy = MRURP()
-    elif test_name == "NRURP":
-        replacement_policy = NRURP()
-    elif test_name == "RRIPRP":
-        replacement_policy = RRIPRP()
-    elif test_name == "SecondChanceRP":
-        replacement_policy = SecondChanceRP()
-    elif test_name == "SHiPMemRP":
-        replacement_policy = SHiPMemRP()
-
-    return replacement_policy


### PR DESCRIPTION
It is safer to reuse the dynamic list than manually listing all possible replacement policies.