### PR TITLE
misc: Do not share the random number generator across components

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -632,7 +632,7 @@ ISA::readMiscReg(RegIndex idx)
         tc->setReg(cc_reg::Nz, (RegVal)0);
         tc->setReg(cc_reg::C, (RegVal)0);
         tc->setReg(cc_reg::V, (RegVal)0);
-        return random_mt.random<RegVal>();
+        return rng->random<RegVal>();
       case MISCREG_RNDRRS:
         tc->setReg(cc_reg::Nz, (RegVal)0);
         tc->setReg(cc_reg::C, (RegVal)0);
@@ -641,7 +641,7 @@ ISA::readMiscReg(RegIndex idx)
         // The random number generator already has an hardcoded
         // seed for the sake of determinism. There is no point
         // in simulating non-determinism here
-        return random_mt.random<RegVal>();
+        return rng->random<RegVal>();
 
       // Generic Timer registers
       case MISCREG_CNTFRQ ... MISCREG_CNTVOFF:

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -53,6 +53,7 @@
 #include "arch/arm/types.hh"
 #include "arch/arm/utility.hh"
 #include "arch/generic/isa.hh"
+#include "base/random.hh"
 #include "debug/Checkpoint.hh"
 #include "enums/DecoderFlavor.hh"
 #include "sim/sim_object.hh"
@@ -110,6 +111,8 @@ namespace ArmISA
         bool impdefAsNop;
 
         SelfDebug * selfDebug;
+
+        Random::RandomPtr rng = Random::genRandom();
 
         const MiscRegLUTEntryInitializer
         InitReg(uint32_t reg)

--- a/src/arch/riscv/process.cc
+++ b/src/arch/riscv/process.cc
@@ -44,7 +44,6 @@
 #include "base/loader/elf_object.hh"
 #include "base/loader/object_file.hh"
 #include "base/logging.hh"
-#include "base/random.hh"
 #include "cpu/thread_context.hh"
 #include "debug/Stack.hh"
 #include "mem/page_table.hh"
@@ -172,7 +171,7 @@ RiscvProcess::argsInit(int pageSize)
     memState->setStackMin(memState->getStackMin() - RandomBytes);
     uint8_t at_random[RandomBytes];
     std::generate(std::begin(at_random), std::end(at_random),
-                  [&]{ return random_mt.random(0, 0xFF); });
+                  [&]{ return rng->random(0, 0xFF); });
     initVirtMem->writeBlob(memState->getStackMin(), at_random, RandomBytes);
 
     // Copy argv to stack

--- a/src/arch/riscv/process.hh
+++ b/src/arch/riscv/process.hh
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 
+#include "base/random.hh"
 #include "mem/page_table.hh"
 #include "sim/process.hh"
 #include "sim/syscall_abi.hh"
@@ -56,6 +57,9 @@ class RiscvProcess : public Process
 
   public:
     virtual bool mmapGrowsDown() const override { return false; }
+
+  protected:
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 class RiscvProcess64 : public RiscvProcess

--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -45,12 +45,6 @@
 namespace gem5
 {
 
-Random::Random()
-{
-    // default random seed
-    init(5489);
-}
-
 Random::Random(uint32_t s)
 {
     init(s);
@@ -58,6 +52,26 @@ Random::Random(uint32_t s)
 
 Random::~Random()
 {
+    assert(instances);
+
+    int removed = 0;
+
+    instances->erase(std::remove_if(instances->begin(), instances->end(),
+    [&](const auto& s_ptr)
+    {
+        removed += s_ptr.expired();
+        return s_ptr.expired();
+    }));
+
+    // Can only remove one pointer
+    // since we are destroying one
+    // object
+    assert(removed == 1);
+
+    if (instances->empty()) {
+        delete instances;
+        instances = nullptr;
+    }
 }
 
 void
@@ -66,6 +80,7 @@ Random::init(uint32_t s)
     gen.seed(s);
 }
 
-Random random_mt;
+uint64_t Random::globalSeed = 5489;
+Random::Instances* Random::instances = nullptr;
 
 } // namespace gem5

--- a/src/cpu/minor/cpu.hh
+++ b/src/cpu/minor/cpu.hh
@@ -88,6 +88,8 @@ class MinorCPU : public BaseCPU
      *  Elements of pipeline call TheISA to implement the model. */
     minor::Pipeline *pipeline;
 
+    Random::RandomPtr rng = Random::genRandom();
+
   public:
     /** Activity recording for pipeline.  This belongs to Pipeline but
      *  stages will access it through the CPU as the MinorCPU object
@@ -186,7 +188,7 @@ class MinorCPU : public BaseCPU
         }
 
         std::shuffle(prio_list.begin(), prio_list.end(),
-                     random_mt.gen);
+                     rng->gen);
 
         return prio_list;
     }

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -48,7 +48,6 @@
 #include <queue>
 
 #include "arch/generic/tlb.hh"
-#include "base/random.hh"
 #include "base/types.hh"
 #include "cpu/base.hh"
 #include "cpu/exetrace.hh"
@@ -881,7 +880,7 @@ Fetch::tick()
     // Pick a random thread to start trying to grab instructions from
     auto tid_itr = activeThreads->begin();
     std::advance(tid_itr,
-            random_mt.random<uint8_t>(0, activeThreads->size() - 1));
+            rng->random<uint8_t>(0, activeThreads->size() - 1));
 
     while (available_insts != 0 && insts_to_decode < decodeWidth) {
         ThreadID tid = *tid_itr;

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -43,6 +43,7 @@
 
 #include "arch/generic/decoder.hh"
 #include "arch/generic/mmu.hh"
+#include "base/random.hh"
 #include "base/statistics.hh"
 #include "cpu/o3/comm.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
@@ -199,6 +200,8 @@ class Fetch
     ProbePointArg<DynInstPtr> *ppFetch;
     /** To probe when a fetch request is successfully sent. */
     ProbePointArg<RequestPtr> *ppFetchRequestSent;
+
+    Random::RandomPtr rng = Random::genRandom();
 
   public:
     /** Fetch constructor. */

--- a/src/cpu/pred/loop_predictor.cc
+++ b/src/cpu/pred/loop_predictor.cc
@@ -45,7 +45,6 @@
 
 #include "cpu/pred/loop_predictor.hh"
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/LTage.hh"
 #include "params/LoopPredictor.hh"
@@ -256,9 +255,9 @@ LoopPredictor::loopUpdate(Addr pc, bool taken, BranchInfo* bi, bool tage_pred)
         }
 
     } else if (useDirectionBit ? (bi->predTaken != taken) : taken) {
-        if ((random_mt.random<int>() & 3) == 0 || !restrictAllocation) {
+        if ((rng->random<int>() & 3) == 0 || !restrictAllocation) {
             //try to allocate an entry on taken branch
-            int nrand = random_mt.random<int>();
+            int nrand = rng->random<int>();
             for (int i = 0; i < (1 << logLoopTableAssoc); i++) {
                 int loop_hit = (nrand + i) & ((1 << logLoopTableAssoc) - 1);
                 idx = finallindex(bi->loopIndex, bi->loopIndexB, loop_hit);

--- a/src/cpu/pred/loop_predictor.hh
+++ b/src/cpu/pred/loop_predictor.hh
@@ -44,6 +44,7 @@
 #ifndef __CPU_PRED_LOOP_PREDICTOR_HH__
 #define __CPU_PRED_LOOP_PREDICTOR_HH__
 
+#include "base/random.hh"
 #include "base/statistics.hh"
 #include "base/types.hh"
 #include "sim/sim_object.hh"
@@ -69,6 +70,8 @@ class LoopPredictor : public SimObject
     const uint16_t loopTagMask;
     const uint16_t loopNumIterMask;
     const int loopSetMask;
+
+    mutable Random::RandomPtr rng = Random::genRandom();
 
     // Prediction Structures
     // Loop Predictor Entry

--- a/src/cpu/pred/ltage.cc
+++ b/src/cpu/pred/ltage.cc
@@ -51,7 +51,6 @@
 
 #include "base/intmath.hh"
 #include "base/logging.hh"
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/Fetch.hh"
 #include "debug/LTage.hh"
@@ -126,7 +125,7 @@ LTAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
         return;
     }
 
-    int nrand = random_mt.random<int>() & 3;
+    int nrand = rng->random<int>() & 3;
     if (bi->tageBranchInfo->condBranch) {
         DPRINTF(LTage, "Updating tables for branch:%lx; taken?:%d\n",
                 pc, taken);

--- a/src/cpu/pred/multiperspective_perceptron.cc
+++ b/src/cpu/pred/multiperspective_perceptron.cc
@@ -50,7 +50,6 @@
 
 #include "cpu/pred/multiperspective_perceptron.hh"
 
-#include "base/random.hh"
 #include "debug/Branch.hh"
 
 namespace gem5
@@ -513,7 +512,7 @@ MultiperspectivePerceptron::train(ThreadID tid, MPPBranchInfo &bi, bool taken)
             do {
                 // udpate a random weight
                 int besti = -1;
-                int nrand = random_mt.random<int>() % specs.size();
+                int nrand = rng->random<int>() % specs.size();
                 int pout;
                 found = false;
                 for (int j = 0; j < specs.size(); j += 1) {
@@ -685,7 +684,7 @@ MultiperspectivePerceptron::update(ThreadID tid, Addr pc,  bool taken,
         // filter, blow a random filter entry away
         if (decay && transition &&
             ((threadData[tid]->occupancy > decay) || (decay == 1))) {
-            int rnd = random_mt.random<int>() %
+            int rnd = rng->random<int>() %
                       threadData[tid]->filterTable.size();
             FilterEntry &frand = threadData[tid]->filterTable[rnd];
             if (frand.seenTaken && frand.seenUntaken) {

--- a/src/cpu/pred/multiperspective_perceptron.hh
+++ b/src/cpu/pred/multiperspective_perceptron.hh
@@ -54,6 +54,7 @@
 #include <array>
 #include <vector>
 
+#include "base/random.hh"
 #include "cpu/pred/bpred_unit.hh"
 #include "params/MultiperspectivePerceptron.hh"
 
@@ -305,6 +306,8 @@ class MultiperspectivePerceptron : public BPredUnit
     static int xlat[];
     /** Transfer function for 5-width tables */
     static int xlat4[];
+
+    Random::RandomPtr rng = Random::genRandom();
 
     /** History data is kept for each thread */
     struct ThreadData

--- a/src/cpu/pred/multiperspective_perceptron_tage.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage.cc
@@ -113,7 +113,7 @@ MPP_TAGE::handleAllocAndUReset(bool alloc, bool taken,
 
     int a = 1;
 
-    if ((random_mt.random<int>() & 127) < 32) {
+    if ((rng->random<int>() & 127) < 32) {
         a = 2;
     }
     int dep = bi->hitBank + a;
@@ -195,7 +195,7 @@ void
 MPP_TAGE::adjustAlloc(bool & alloc, bool taken, bool pred_taken)
 {
     // Do not allocate too often if the prediction is ok
-    if ((taken == pred_taken) && ((random_mt.random<int>() & 31) != 0)) {
+    if ((taken == pred_taken) && ((rng->random<int>() & 31) != 0)) {
         alloc = false;
     }
 }
@@ -269,7 +269,7 @@ MPP_LoopPredictor::calcConf(int index) const
 bool
 MPP_LoopPredictor::optionalAgeInc() const
 {
-    return ((random_mt.random<int>() & 7) == 0);
+    return ((rng->random<int>() & 7) == 0);
 }
 
 MPP_StatisticalCorrector::MPP_StatisticalCorrector(
@@ -644,7 +644,7 @@ MultiperspectivePerceptronTAGE::update(ThreadID tid, Addr pc, bool taken,
                 tage->getPathHist(tid));
 
         tage->condBranchUpdate(tid, pc, taken, bi->tageBranchInfo,
-                               random_mt.random<int>(), target,
+                               rng->random<int>(), target,
                                bi->predictedTaken, true);
 
         updateHistories(tid, *bi, taken);

--- a/src/cpu/pred/multiperspective_perceptron_tage.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage.hh
@@ -51,6 +51,7 @@
 #ifndef __CPU_PRED_MULTIPERSPECTIVE_PERCEPTRON_TAGE_HH__
 #define __CPU_PRED_MULTIPERSPECTIVE_PERCEPTRON_TAGE_HH__
 
+#include "base/random.hh"
 #include "cpu/pred/loop_predictor.hh"
 #include "cpu/pred/multiperspective_perceptron.hh"
 #include "cpu/pred/statistical_corrector.hh"
@@ -69,6 +70,9 @@ namespace branch_prediction
 class MPP_TAGE : public TAGEBase
 {
     std::vector<unsigned int> tunedHistoryLengths;
+
+    Random::RandomPtr rng = Random::genRandom();
+
   public:
     struct BranchInfo : public TAGEBase::BranchInfo
     {

--- a/src/cpu/pred/tage.cc
+++ b/src/cpu/pred/tage.cc
@@ -83,7 +83,7 @@ TAGE::update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
         return;
     }
 
-    int nrand = random_mt.random<int>() & 3;
+    int nrand = rng->random<int>() & 3;
     if (bi->tageBranchInfo->condBranch) {
         DPRINTF(Tage, "Updating tables for branch:%lx; taken?:%d\n",
                 pc, taken);

--- a/src/cpu/pred/tage.hh
+++ b/src/cpu/pred/tage.hh
@@ -62,6 +62,7 @@
 
 #include <vector>
 
+#include "base/random.hh"
 #include "base/types.hh"
 #include "cpu/pred/bpred_unit.hh"
 #include "cpu/pred/tage_base.hh"
@@ -77,6 +78,8 @@ class TAGE: public BPredUnit
 {
   protected:
     TAGEBase *tage;
+
+    Random::RandomPtr rng = Random::genRandom();
 
     struct TageBranchInfo
     {

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -54,7 +54,6 @@
 
 #include "cpu/pred/tage_sc_l.hh"
 
-#include "base/random.hh"
 #include "debug/TageSCL.hh"
 
 namespace gem5
@@ -73,7 +72,7 @@ TAGE_SC_L_LoopPredictor::calcConf(int index) const
 bool
 TAGE_SC_L_LoopPredictor::optionalAgeInc() const
 {
-    return (random_mt.random<int>() & 7) == 0;
+    return (rng->random<int>() & 7) == 0;
 }
 
 TAGE_SC_L::TAGE_SC_L(const TAGE_SC_LParams &p)
@@ -308,7 +307,7 @@ void
 TAGE_SC_L_TAGE::adjustAlloc(bool & alloc, bool taken, bool pred_taken)
 {
     // Do not allocate too often if the prediction is ok
-    if ((taken == pred_taken) && ((random_mt.random<int>() & 31) != 0)) {
+    if ((taken == pred_taken) && ((rng->random<int>() & 31) != 0)) {
         alloc = false;
     }
 }
@@ -317,11 +316,11 @@ int
 TAGE_SC_L_TAGE::calcDep(TAGEBase::BranchInfo* bi)
 {
     int a = 1;
-    if ((random_mt.random<int>() & 127) < 32) {
+    if ((rng->random<int>() & 127) < 32) {
         a = 2;
     }
     return ((((bi->hitBank - 1 + 2 * a) & 0xffe)) ^
-            (random_mt.random<int>() & 1));
+            (rng->random<int>() & 1));
 }
 
 void
@@ -443,7 +442,7 @@ TAGE_SC_L::update(ThreadID tid, Addr pc, bool taken, void *&bp_history,
         return;
     }
 
-    int nrand = random_mt.random<int>() & 3;
+    int nrand = rng->random<int>() & 3;
     if (tage_bi->condBranch) {
         DPRINTF(TageSCL, "Updating tables for branch:%lx; taken?:%d\n",
                 pc, taken);

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -55,6 +55,7 @@
 #ifndef __CPU_PRED_TAGE_SC_L_HH__
 #define __CPU_PRED_TAGE_SC_L_HH__
 
+#include "base/random.hh"
 #include "cpu/pred/ltage.hh"
 #include "cpu/pred/statistical_corrector.hh"
 #include "params/TAGE_SC_L.hh"
@@ -79,6 +80,9 @@ class TAGE_SC_L_TAGE : public TAGEBase
     const unsigned longTagsTageFactor;
 
     const bool truncatePathHist;
+
+  protected:
+    Random::RandomPtr rng = Random::genRandom();
 
   public:
     struct BranchInfo : public TAGEBase::BranchInfo

--- a/src/cpu/pred/tage_sc_l_8KB.cc
+++ b/src/cpu/pred/tage_sc_l_8KB.cc
@@ -208,7 +208,7 @@ TAGE_SC_L_TAGE_8KB::handleAllocAndUReset(
             if (noSkip[i]) {
                 if (gtable[i][bi->tableIndices[i]].u == 0) {
                     gtable[i][bi->tableIndices[i]].u =
-                        ((random_mt.random<int>() & 31) == 0);
+                        ((rng->random<int>() & 31) == 0);
                     // protect randomly from fast replacement
                     gtable[i][bi->tableIndices[i]].tag = bi->tableTags[i];
                     gtable[i][bi->tableIndices[i]].ctr = taken ? 0 : -1;
@@ -223,7 +223,7 @@ TAGE_SC_L_TAGE_8KB::handleAllocAndUReset(
                     int8_t ctr = gtable[i][bi->tableIndices[i]].ctr;
                     if ((gtable[i][bi->tableIndices[i]].u == 1) &
                         (abs (2 * ctr + 1) == 1)) {
-                        if ((random_mt.random<int>() & 7) == 0) {
+                        if ((rng->random<int>() & 7) == 0) {
                             gtable[i][bi->tableIndices[i]].u = 0;
                         }
                     } else {

--- a/src/cpu/testers/directedtest/SeriesRequestGenerator.cc
+++ b/src/cpu/testers/directedtest/SeriesRequestGenerator.cc
@@ -29,7 +29,6 @@
 
 #include "cpu/testers/directedtest/SeriesRequestGenerator.hh"
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "cpu/testers/directedtest/DirectedGenerator.hh"
 #include "cpu/testers/directedtest/RubyDirectedTester.hh"
@@ -67,7 +66,7 @@ SeriesRequestGenerator::initiate()
                                                requestorId);
 
     Packet::Command cmd;
-    bool do_write = (random_mt.random(0, 100) < m_percent_writes);
+    bool do_write = (rng->random(0, 100) < m_percent_writes);
     if (do_write) {
         cmd = MemCmd::WriteReq;
     } else {

--- a/src/cpu/testers/directedtest/SeriesRequestGenerator.hh
+++ b/src/cpu/testers/directedtest/SeriesRequestGenerator.hh
@@ -35,6 +35,7 @@
 #ifndef __CPU_DIRECTEDTEST_SERIESREQUESTGENERATOR_HH__
 #define __CPU_DIRECTEDTEST_SERIESREQUESTGENERATOR_HH__
 
+#include "base/random.hh"
 #include "cpu/testers/directedtest/DirectedGenerator.hh"
 #include "cpu/testers/directedtest/RubyDirectedTester.hh"
 #include "mem/ruby/protocol/SeriesRequestGeneratorStatus.hh"
@@ -60,6 +61,7 @@ class SeriesRequestGenerator : public DirectedGenerator
     uint32_t m_active_node;
     uint32_t m_addr_increment_size;
     uint32_t m_percent_writes;
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 } // namespace gem5

--- a/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.cc
+++ b/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.cc
@@ -35,7 +35,6 @@
 #include <vector>
 
 #include "base/logging.hh"
-#include "base/random.hh"
 #include "base/statistics.hh"
 #include "debug/GarnetSyntheticTraffic.hh"
 #include "mem/packet.hh"
@@ -151,7 +150,7 @@ GarnetSyntheticTraffic::tick()
     // - send pkt if this number is < injRate*(10^precision)
     bool sendAllowedThisCycle;
     double injRange = pow((double) 10, (double) precision);
-    unsigned trySending = random_mt.random<unsigned>(0, (int) injRange);
+    unsigned trySending = rng->random<unsigned>(0, (int) injRange);
     if (trySending < injRate*injRange)
         sendAllowedThisCycle = true;
     else
@@ -196,7 +195,7 @@ GarnetSyntheticTraffic::generatePkt()
     {
         destination = singleDest;
     } else if (traffic == UNIFORM_RANDOM_) {
-        destination = random_mt.random<unsigned>(0, num_destinations - 1);
+        destination = rng->random<unsigned>(0, num_destinations - 1);
     } else if (traffic == BIT_COMPLEMENT_) {
         dest_x = radix - src_x - 1;
         dest_y = radix - src_y - 1;
@@ -285,7 +284,7 @@ GarnetSyntheticTraffic::generatePkt()
     if (injReqType < 0 || injReqType > 2)
     {
         // randomly inject in any vnet
-        injReqType = random_mt.random(0, 2);
+        injReqType = rng->random(0, 2);
     }
 
     if (injReqType == 0) {

--- a/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.hh
+++ b/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.hh
@@ -31,6 +31,7 @@
 
 #include <set>
 
+#include "base/random.hh"
 #include "base/statistics.hh"
 #include "mem/port.hh"
 #include "params/GarnetSyntheticTraffic.hh"
@@ -134,6 +135,8 @@ class GarnetSyntheticTraffic : public ClockedObject
     const Cycles responseLimit;
 
     RequestorID requestorId;
+
+    Random::RandomPtr rng = Random::genRandom();
 
     void completeRequest(PacketPtr pkt);
 

--- a/src/cpu/testers/gpu_ruby_test/address_manager.hh
+++ b/src/cpu/testers/gpu_ruby_test/address_manager.hh
@@ -37,6 +37,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/random.hh"
 #include "base/types.hh"
 #include "sim/eventq.hh"
 
@@ -235,6 +236,8 @@ class AddressManager
         typedef std::unordered_set<Value> ExpectedValueSet;
         ExpectedValueSet expectedValues;
 
+        Random::RandomPtr rng = Random::genRandom();
+
         // swap two locations in locArray
         void swap(LocProperty& prop_1, LocProperty& prop_2);
 
@@ -270,6 +273,8 @@ class AddressManager
     // internal log table
     typedef std::vector<LastWriter*> LogTable;
     LogTable logTable;
+
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 } // namespace gem5

--- a/src/cpu/testers/gpu_ruby_test/episode.cc
+++ b/src/cpu/testers/gpu_ruby_test/episode.cc
@@ -34,7 +34,6 @@
 #include <fstream>
 #include <unordered_set>
 
-#include "base/random.hh"
 #include "cpu/testers/gpu_ruby_test/protocol_tester.hh"
 #include "cpu/testers/gpu_ruby_test/tester_thread.hh"
 
@@ -101,7 +100,7 @@ Episode::initActions()
     int num_loads = numLoads;
     int num_stores = numStores;
     while ((num_loads + num_stores) > 0) {
-        switch (random_mt.random<unsigned int>() % 2) {
+        switch (rng->random<unsigned int>() % 2) {
             case 0: // Load
                 if (num_loads > 0) {
                     actions.push_back(new Action(Action::Type::LOAD,

--- a/src/cpu/testers/gpu_ruby_test/episode.hh
+++ b/src/cpu/testers/gpu_ruby_test/episode.hh
@@ -34,6 +34,7 @@
 
 #include <vector>
 
+#include "base/random.hh"
 #include "cpu/testers/gpu_ruby_test/address_manager.hh"
 
 namespace gem5
@@ -111,6 +112,8 @@ class Episode
     // list of atomic locations picked for this episode
     typedef std::vector<Location> AtomicLocationList;
     AtomicLocationList atomicLocs;
+
+    Random::RandomPtr rng = Random::genRandom();
 
     // is a thread running this episode?
     bool isActive;

--- a/src/cpu/testers/gpu_ruby_test/protocol_tester.cc
+++ b/src/cpu/testers/gpu_ruby_test/protocol_tester.cc
@@ -35,7 +35,6 @@
 #include <ctime>
 #include <fstream>
 
-#include "base/random.hh"
 #include "cpu/testers/gpu_ruby_test/cpu_thread.hh"
 #include "cpu/testers/gpu_ruby_test/dma_thread.hh"
 #include "cpu/testers/gpu_ruby_test/gpu_wavefront.hh"
@@ -145,7 +144,7 @@ ProtocolTester::ProtocolTester(const Params &p)
     // Note: random_m5 will use a fixed key if random_seed is not set.
     // This ensures a reproducable.
     if (p.random_seed != 0) {
-        random_mt.init(p.random_seed);
+        rng->init(p.random_seed);
     } else {
         warn(
             "If `random_seed == 0` (or `random_seed` is unset) "

--- a/src/cpu/testers/gpu_ruby_test/protocol_tester.hh
+++ b/src/cpu/testers/gpu_ruby_test/protocol_tester.hh
@@ -52,6 +52,7 @@
 #include <string>
 #include <vector>
 
+#include "base/random.hh"
 #include "base/types.hh"
 #include "cpu/testers/gpu_ruby_test/address_manager.hh"
 #include "mem/packet.hh"
@@ -197,6 +198,8 @@ class ProtocolTester : public ClockedObject
     bool sentExitSignal;
 
     OutputStream* logFile;
+
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 } // namespace gem5

--- a/src/cpu/testers/gpu_ruby_test/tester_thread.cc
+++ b/src/cpu/testers/gpu_ruby_test/tester_thread.cc
@@ -33,7 +33,6 @@
 
 #include <fstream>
 
-#include "base/random.hh"
 #include "debug/ProtocolTest.hh"
 
 namespace gem5
@@ -147,7 +146,7 @@ void
 TesterThread::issueNewEpisode()
 {
     int num_reg_loads = \
-        random_mt.random<unsigned int>() % tester->getEpisodeLength();
+        rng->random<unsigned int>() % tester->getEpisodeLength();
     int num_reg_stores = tester->getEpisodeLength() - num_reg_loads;
 
     // create a new episode

--- a/src/cpu/testers/gpu_ruby_test/tester_thread.hh
+++ b/src/cpu/testers/gpu_ruby_test/tester_thread.hh
@@ -36,6 +36,7 @@
 #ifndef CPU_TESTERS_PROTOCOL_TESTER_TESTER_THREAD_HH_
 #define CPU_TESTERS_PROTOCOL_TESTER_TESTER_THREAD_HH_
 
+#include "base/random.hh"
 #include "cpu/testers/gpu_ruby_test/address_manager.hh"
 #include "cpu/testers/gpu_ruby_test/episode.hh"
 #include "cpu/testers/gpu_ruby_test/protocol_tester.hh"
@@ -205,7 +206,11 @@ class TesterThread : public ClockedObject
 
     void printOutstandingReqs(const OutstandingReqTable& table,
                               std::stringstream& ss) const;
+
     std::string printAddress(Addr addr) const;
+
+  private:
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 } // namespace gem5

--- a/src/cpu/testers/memtest/memtest.cc
+++ b/src/cpu/testers/memtest/memtest.cc
@@ -41,7 +41,6 @@
 #include "cpu/testers/memtest/memtest.hh"
 
 #include "base/compiler.hh"
-#include "base/random.hh"
 #include "base/statistics.hh"
 #include "base/trace.hh"
 #include "debug/MemTest.hh"
@@ -241,12 +240,12 @@ MemTest::tick()
     assert(!waitResponse);
 
     // create a new request
-    unsigned cmd = random_mt.random(0, 100);
-    uint8_t data = random_mt.random<uint8_t>();
-    bool uncacheable = random_mt.random(0, 100) < percentUncacheable;
-    bool do_atomic = (random_mt.random(0, 100) < percentAtomic) &&
+    unsigned cmd = rng->random(0, 100);
+    uint8_t data = rng->random<uint8_t>();
+    bool uncacheable = rng->random(0, 100) < percentUncacheable;
+    bool do_atomic = (rng->random(0, 100) < percentAtomic) &&
                      !uncacheable;
-    unsigned base = random_mt.random(0, 1);
+    unsigned base = rng->random(0, 1);
     Request::Flags flags;
     Addr paddr;
 
@@ -259,7 +258,7 @@ MemTest::tick()
 
     // generate a unique address
     do {
-        unsigned offset = random_mt.random<unsigned>(0, size - 1);
+        unsigned offset = rng->random<unsigned>(0, size - 1);
 
         // use the tester id as offset within the block for false sharing
         offset = blockAlign(offset);
@@ -273,7 +272,7 @@ MemTest::tick()
         }
     } while (outstandingAddrs.find(paddr) != outstandingAddrs.end());
 
-    bool do_functional = (random_mt.random(0, 100) < percentFunctional) &&
+    bool do_functional = (rng->random(0, 100) < percentFunctional) &&
         !uncacheable;
     RequestPtr req = std::make_shared<Request>(paddr, 1, flags, requestorId);
     req->setContext(id);

--- a/src/cpu/testers/memtest/memtest.hh
+++ b/src/cpu/testers/memtest/memtest.hh
@@ -44,6 +44,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "base/random.hh"
 #include "base/statistics.hh"
 #include "mem/port.hh"
 #include "params/MemTest.hh"
@@ -198,6 +199,8 @@ class MemTest : public ClockedObject
 
     void recvRetry();
 
+  private:
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 } // namespace gem5

--- a/src/cpu/testers/rubytest/Check.hh
+++ b/src/cpu/testers/rubytest/Check.hh
@@ -32,6 +32,7 @@
 
 #include <iostream>
 
+#include "base/random.hh"
 #include "cpu/testers/rubytest/RubyTester.hh"
 #include "mem/ruby/common/Address.hh"
 #include "mem/ruby/protocol/RubyAccessMode.hh"
@@ -84,6 +85,7 @@ class Check
     int m_num_writers;
     int m_num_readers;
     RubyTester* m_tester_ptr;
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 inline std::ostream&

--- a/src/cpu/testers/rubytest/CheckTable.cc
+++ b/src/cpu/testers/rubytest/CheckTable.cc
@@ -30,7 +30,6 @@
 #include "cpu/testers/rubytest/CheckTable.hh"
 
 #include "base/intmath.hh"
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "cpu/testers/rubytest/Check.hh"
 #include "debug/RubyTest.hh"
@@ -114,7 +113,7 @@ Check*
 CheckTable::getRandomCheck()
 {
     assert(m_check_vector.size() > 0);
-    return m_check_vector[random_mt.random<unsigned>(0, m_check_vector.size() - 1)];
+    return m_check_vector[rng->random<unsigned>(0, m_check_vector.size() - 1)];
 }
 
 Check*

--- a/src/cpu/testers/rubytest/CheckTable.hh
+++ b/src/cpu/testers/rubytest/CheckTable.hh
@@ -34,6 +34,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "base/random.hh"
 #include "mem/ruby/common/Address.hh"
 
 namespace gem5
@@ -71,6 +72,7 @@ class CheckTable
     int m_num_writers;
     int m_num_readers;
     RubyTester* m_tester_ptr;
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 inline std::ostream&

--- a/src/cpu/testers/spatter_gen/utility_structs.hh
+++ b/src/cpu/testers/spatter_gen/utility_structs.hh
@@ -148,11 +148,14 @@ struct SpatterAccess : public Packet::SenderState
         uint8_t* pkt_data = new uint8_t[req->getSize()];
         // Randomly intialize pkt_data, for testing cache coherence.
         for (int i = 0; i < req->getSize(); i++) {
-            pkt_data[i] = random_mt.random<uint8_t>();
+            pkt_data[i] = rng->random<uint8_t>();
         }
         pkt->dataDynamic(pkt_data);
         return pkt;
     }
+
+  private:
+    mutable Random::RandomPtr rng = Random::genRandom();
 };
 
 class SpatterKernel

--- a/src/cpu/testers/traffic_gen/base_gen.hh
+++ b/src/cpu/testers/traffic_gen/base_gen.hh
@@ -46,6 +46,7 @@
 #include <cstdint>
 #include <string>
 
+#include "base/random.hh"
 #include "base/types.hh"
 #include "mem/packet.hh"
 #include "mem/request.hh"
@@ -71,6 +72,8 @@ class BaseGen
 
     /** The RequestorID used for generating requests */
     const RequestorID requestorId;
+
+    mutable Random::RandomPtr rng = Random::genRandom();
 
     /**
      * Generate a new request and associated packet

--- a/src/cpu/testers/traffic_gen/dram_gen.cc
+++ b/src/cpu/testers/traffic_gen/dram_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 #include "enums/AddrMap.hh"
@@ -87,7 +86,7 @@ DramGen::getNextPacket()
 
         // choose if we generate a read or a write here
         isRead = readPercent != 0 &&
-            (readPercent == 100 || random_mt.random(0, 100) < readPercent);
+            (readPercent == 100 || rng->random(0, 100) < readPercent);
 
         assert((readPercent == 0 && !isRead) ||
                (readPercent == 100 && isRead) ||
@@ -95,11 +94,11 @@ DramGen::getNextPacket()
 
         // pick a random bank
         unsigned int new_bank =
-            random_mt.random<unsigned int>(0, nbrOfBanksUtil - 1);
+            rng->random<unsigned int>(0, nbrOfBanksUtil - 1);
 
         // pick a random rank
         unsigned int new_rank =
-            random_mt.random<unsigned int>(0, nbrOfRanks - 1);
+            rng->random<unsigned int>(0, nbrOfRanks - 1);
 
         // Generate the start address of the command series
         // routine will update addr variable with bank, rank, and col
@@ -146,7 +145,7 @@ void
 DramGen::genStartAddr(unsigned int new_bank, unsigned int new_rank)
 {
     // start by picking a random address in the range
-    addr = random_mt.random<Addr>(startAddr, endAddr - 1);
+    addr = rng->random<Addr>(startAddr, endAddr - 1);
 
     // round down to start address of a block, i.e. a DRAM burst
     addr -= addr % blocksize;
@@ -167,7 +166,7 @@ DramGen::genStartAddr(unsigned int new_bank, unsigned int new_rank)
     // pick a random column, but ensure that there is room for
     // numSeqPkts sequential columns in the same page
     unsigned int new_col =
-        random_mt.random<unsigned int>(0, columns_per_page - numSeqPkts);
+        rng->random<unsigned int>(0, columns_per_page - numSeqPkts);
 
     if (addrMapping == enums::RoRaBaCoCh ||
         addrMapping == enums::RoRaBaChCo) {

--- a/src/cpu/testers/traffic_gen/dram_rot_gen.cc
+++ b/src/cpu/testers/traffic_gen/dram_rot_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 #include "enums/AddrMap.hh"

--- a/src/cpu/testers/traffic_gen/gups_gen.cc
+++ b/src/cpu/testers/traffic_gen/gups_gen.cc
@@ -31,7 +31,6 @@
 #include <cstring>
 #include <string>
 
-#include "base/random.hh"
 #include "debug/GUPSGen.hh"
 #include "sim/sim_exit.hh"
 
@@ -212,7 +211,7 @@ GUPSGen::createNextReq()
         assert (readRequests < numUpdates);
 
         uint64_t value = readRequests;
-        uint64_t index = random_mt.random((int64_t) 0, tableSize);
+        uint64_t index = rng->random<int64_t>((int64_t) 0, tableSize);
         Addr addr = indexToAddr(index);
         PacketPtr pkt = getReadPacket(addr, elementSize);
         updateTable[pkt->req] = value;

--- a/src/cpu/testers/traffic_gen/gups_gen.hh
+++ b/src/cpu/testers/traffic_gen/gups_gen.hh
@@ -41,6 +41,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "base/random.hh"
 #include "base/statistics.hh"
 #include "mem/port.hh"
 #include "params/GUPSGen.hh"
@@ -300,6 +301,8 @@ class GUPSGen : public ClockedObject
      * @brief The number of read requests currently created.
      */
     int readRequests;
+
+    Random::RandomPtr rng = Random::genRandom();
 
     struct GUPSGenStat : public statistics::Group
     {

--- a/src/cpu/testers/traffic_gen/hybrid_gen.cc
+++ b/src/cpu/testers/traffic_gen/hybrid_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 #include "enums/AddrMap.hh"
@@ -142,11 +141,11 @@ HybridGen::getNextPacket()
     // start counting again
     if (countNumSeqPkts == 0) {
         isNvm = nvmPercent != 0 &&
-            (nvmPercent == 100 || random_mt.random(0, 100) < nvmPercent);
+            (nvmPercent == 100 || rng->random(0, 100) < nvmPercent);
 
         // choose if we generate a read or a write here
         isRead = readPercent != 0 &&
-            (readPercent == 100 || random_mt.random(0, 100) < readPercent);
+            (readPercent == 100 || rng->random(0, 100) < readPercent);
 
         assert((readPercent == 0 && !isRead) ||
                (readPercent == 100 && isRead) ||
@@ -186,11 +185,11 @@ HybridGen::getNextPacket()
 
         // pick a random bank
         unsigned int new_bank =
-            random_mt.random<unsigned int>(0, nbrOfBanksUtil - 1);
+            rng->random<unsigned int>(0, nbrOfBanksUtil - 1);
 
         // pick a random rank
         unsigned int new_rank =
-            random_mt.random<unsigned int>(0, nbrOfRanks - 1);
+            rng->random<unsigned int>(0, nbrOfRanks - 1);
 
         // Generate the start address of the command series
         // routine will update addr variable with bank, rank, and col
@@ -238,7 +237,7 @@ void
 HybridGen::genStartAddr(unsigned int new_bank, unsigned int new_rank)
 {
     // start by picking a random address in the range
-    addr = random_mt.random<Addr>(startAddr, endAddr - 1);
+    addr = rng->random<Addr>(startAddr, endAddr - 1);
 
     // round down to start address of a block, i.e. a DRAM burst
     addr -= addr % blocksize;
@@ -259,7 +258,7 @@ HybridGen::genStartAddr(unsigned int new_bank, unsigned int new_rank)
     // pick a random column, but ensure that there is room for
     // numSeqPkts sequential columns in the same page
     unsigned int new_col =
-        random_mt.random<unsigned int>(0, burst_per_page - numSeqPkts);
+        rng->random<unsigned int>(0, burst_per_page - numSeqPkts);
 
     if (addrMapping == enums::RoRaBaCoCh ||
         addrMapping == enums::RoRaBaChCo) {
@@ -296,7 +295,7 @@ HybridGen::nextPacketTick(bool elastic, Tick delay) const
         return MaxTick;
     } else {
         // return the time when the next request should take place
-        Tick wait = random_mt.random(minPeriod, maxPeriod);
+        Tick wait = rng->random(minPeriod, maxPeriod);
 
         // compensate for the delay experienced to not be elastic, by
         // default the value we generate is from the time we are

--- a/src/cpu/testers/traffic_gen/idle_gen.cc
+++ b/src/cpu/testers/traffic_gen/idle_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 

--- a/src/cpu/testers/traffic_gen/linear_gen.cc
+++ b/src/cpu/testers/traffic_gen/linear_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 
@@ -59,7 +58,7 @@ LinearGen::getNextPacket()
 {
     // choose if we generate a read or a write here
     bool isRead = readPercent != 0 &&
-        (readPercent == 100 || random_mt.random(0, 100) < readPercent);
+        (readPercent == 100 || rng->random(0, 100) < readPercent);
 
     assert((readPercent == 0 && !isRead) || (readPercent == 100 && isRead) ||
            readPercent != 100);
@@ -99,7 +98,7 @@ LinearGen::nextPacketTick(bool elastic, Tick delay) const
         return MaxTick;
     } else {
         // return the time when the next request should take place
-        Tick wait = random_mt.random(minPeriod, maxPeriod);
+        Tick wait = rng->random(minPeriod, maxPeriod);
 
         // compensate for the delay experienced to not be elastic, by
         // default the value we generate is from the time we are

--- a/src/cpu/testers/traffic_gen/nvm_gen.cc
+++ b/src/cpu/testers/traffic_gen/nvm_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 #include "enums/AddrMap.hh"
@@ -87,7 +86,7 @@ NvmGen::getNextPacket()
 
         // choose if we generate a read or a write here
         isRead = readPercent != 0 &&
-            (readPercent == 100 || random_mt.random(0, 100) < readPercent);
+            (readPercent == 100 || rng->random(0, 100) < readPercent);
 
         assert((readPercent == 0 && !isRead) ||
                (readPercent == 100 && isRead) ||
@@ -95,11 +94,11 @@ NvmGen::getNextPacket()
 
         // pick a random bank
         unsigned int new_bank =
-            random_mt.random<unsigned int>(0, nbrOfBanksUtil - 1);
+            rng->random<unsigned int>(0, nbrOfBanksUtil - 1);
 
         // pick a random rank
         unsigned int new_rank =
-            random_mt.random<unsigned int>(0, nbrOfRanks - 1);
+            rng->random<unsigned int>(0, nbrOfRanks - 1);
 
         // Generate the start address of the command series
         // routine will update addr variable with bank, rank, and col
@@ -147,7 +146,7 @@ void
 NvmGen::genStartAddr(unsigned int new_bank, unsigned int new_rank)
 {
     // start by picking a random address in the range
-    addr = random_mt.random<Addr>(startAddr, endAddr - 1);
+    addr = rng->random<Addr>(startAddr, endAddr - 1);
 
     // round down to start address of a block, i.e. a NVM burst
     addr -= addr % blocksize;
@@ -162,7 +161,7 @@ NvmGen::genStartAddr(unsigned int new_bank, unsigned int new_rank)
     // pick a random burst address, but ensure that there is room for
     // numSeqPkts sequential bursts in the same buffer
     unsigned int new_col =
-        random_mt.random<unsigned int>(0, burst_per_buffer - numSeqPkts);
+        rng->random<unsigned int>(0, burst_per_buffer - numSeqPkts);
 
     if (addrMapping == enums::RoRaBaCoCh ||
         addrMapping == enums::RoRaBaChCo) {

--- a/src/cpu/testers/traffic_gen/random_gen.cc
+++ b/src/cpu/testers/traffic_gen/random_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 
@@ -58,13 +57,13 @@ RandomGen::getNextPacket()
 {
     // choose if we generate a read or a write here
     bool isRead = readPercent != 0 &&
-        (readPercent == 100 || random_mt.random(0, 100) < readPercent);
+        (readPercent == 100 || rng->random(0, 100) < readPercent);
 
     assert((readPercent == 0 && !isRead) || (readPercent == 100 && isRead) ||
            readPercent != 100);
 
     // address of the request
-    Addr addr = random_mt.random(startAddr, endAddr - 1);
+    Addr addr = rng->random(startAddr, endAddr - 1);
 
     // round down to start address of block
     addr -= addr % blocksize;
@@ -93,7 +92,7 @@ RandomGen::nextPacketTick(bool elastic, Tick delay) const
         return MaxTick;
     } else {
         // return the time when the next request should take place
-        Tick wait = random_mt.random(minPeriod, maxPeriod);
+        Tick wait = rng->random(minPeriod, maxPeriod);
 
         // compensate for the delay experienced to not be elastic, by
         // default the value we generate is from the time we are

--- a/src/cpu/testers/traffic_gen/stream_gen.cc
+++ b/src/cpu/testers/traffic_gen/stream_gen.cc
@@ -37,8 +37,6 @@
 
 #include "stream_gen.hh"
 
-#include "base/random.hh"
-
 namespace gem5
 {
 
@@ -60,7 +58,7 @@ uint32_t
 RandomStreamGen::randomPick(const std::vector<uint32_t> &svec)
 {
     // Pick a random entry in the vector of IDs
-    return svec[random_mt.random<size_t>(0, svec.size()-1)];
+    return svec[rng->random<size_t>(0, svec.size()-1)];
 }
 
 } // namespace gem5

--- a/src/cpu/testers/traffic_gen/stream_gen.hh
+++ b/src/cpu/testers/traffic_gen/stream_gen.hh
@@ -44,6 +44,7 @@
 #ifndef __CPU_TRAFFIC_GEN_STREAM_GEN_HH__
 #define __CPU_TRAFFIC_GEN_STREAM_GEN_HH__
 
+#include "base/random.hh"
 #include "params/BaseTrafficGen.hh"
 
 namespace gem5
@@ -137,6 +138,8 @@ class RandomStreamGen : public StreamGen
   protected:
     /** Function to pick one of the preset Stream or Substream ID */
     uint32_t randomPick(const std::vector<uint32_t> &svec);
+
+    Random::RandomPtr rng = Random::genRandom();
 };
 
 } // namespace gem5

--- a/src/cpu/testers/traffic_gen/strided_gen.cc
+++ b/src/cpu/testers/traffic_gen/strided_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 
@@ -76,7 +75,7 @@ StridedGen::getNextPacket()
 {
     // choose if we generate a read or a write here
     bool isRead = readPercent != 0 &&
-        (readPercent == 100 || random_mt.random(0, 100) < readPercent);
+        (readPercent == 100 || rng->random(0, 100) < readPercent);
 
     assert((readPercent == 0 && !isRead) || (readPercent == 100 && isRead) ||
            readPercent != 100);
@@ -122,7 +121,7 @@ StridedGen::nextPacketTick(bool elastic, Tick delay) const
         return MaxTick;
     } else {
         // return the time when the next request should take place
-        Tick wait = random_mt.random(minPeriod, maxPeriod);
+        Tick wait = rng->random(minPeriod, maxPeriod);
 
         // compensate for the delay experienced to not be elastic, by
         // default the value we generate is from the time we are

--- a/src/cpu/testers/traffic_gen/trace_gen.cc
+++ b/src/cpu/testers/traffic_gen/trace_gen.cc
@@ -39,7 +39,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/TrafficGen.hh"
 #include "proto/packet.pb.h"

--- a/src/cpu/testers/traffic_gen/traffic_gen.cc
+++ b/src/cpu/testers/traffic_gen/traffic_gen.cc
@@ -377,7 +377,7 @@ TrafficGen::parseConfig()
 size_t
 TrafficGen::nextState()
 {
-    double p = random_mt.random<double>();
+    double p = rng->random<double>();
     assert(currState < transitionMatrix.size());
     double cumulative = 0.0;
     size_t i = 0;

--- a/src/cpu/testers/traffic_gen/traffic_gen.hh
+++ b/src/cpu/testers/traffic_gen/traffic_gen.hh
@@ -40,6 +40,7 @@
 
 #include <unordered_map>
 
+#include "base/random.hh"
 #include "cpu/testers/traffic_gen/base.hh"
 
 namespace gem5
@@ -118,6 +119,8 @@ class TrafficGen : public BaseTrafficGen
 
     /** Map of generator states */
     std::unordered_map<uint32_t, std::shared_ptr<BaseGen>> states;
+
+    Random::RandomPtr rng = Random::genRandom();
 
   protected: // BaseTrafficGen
     std::shared_ptr<BaseGen> nextGenerator() override;

--- a/src/dev/arm/smmu_v3_caches.cc
+++ b/src/dev/arm/smmu_v3_caches.cc
@@ -65,7 +65,7 @@ SMMUv3BaseCache::SMMUv3BaseCache(const std::string &policy_name, uint32_t seed,
     statistics::Group *parent, const std::string &name)
   : replacementPolicy(decodePolicyName(policy_name)),
     nextToReplace(0),
-    random(seed),
+    random(Random::genRandom(seed)),
     useStamp(0),
     baseCacheStats(parent, name)
 {}
@@ -410,9 +410,9 @@ SMMUTLB::pickEntryIdxToReplace(const Set &set, AllocPolicy alloc)
     case SMMU_CACHE_REPL_RANDOM:
         switch (alloc) {
         case ALLOC_ANY_WAY:
-            return random.random<size_t>(0, associativity-1);
+            return random->random<size_t>(0, associativity-1);
         case ALLOC_ANY_BUT_LAST_WAY:
-            return random.random<size_t>(0, associativity-2);
+            return random->random<size_t>(0, associativity-2);
         default:
             panic("Unknown allocation mode %d\n", alloc);
         }
@@ -615,7 +615,7 @@ ARMArchTLB::pickEntryIdxToReplace(const Set &set)
         return nextToReplace = ((nextToReplace+1) % associativity);
 
     case SMMU_CACHE_REPL_RANDOM:
-        return random.random<size_t>(0, associativity-1);
+        return random->random<size_t>(0, associativity-1);
 
     case SMMU_CACHE_REPL_LRU:
         return lru_idx;
@@ -795,7 +795,7 @@ IPACache::pickEntryIdxToReplace(const Set &set)
         return nextToReplace = ((nextToReplace+1) % associativity);
 
     case SMMU_CACHE_REPL_RANDOM:
-        return random.random<size_t>(0, associativity-1);
+        return random->random<size_t>(0, associativity-1);
 
     case SMMU_CACHE_REPL_LRU:
         return lru_idx;
@@ -959,7 +959,7 @@ ConfigCache::pickEntryIdxToReplace(const Set &set)
         return nextToReplace = ((nextToReplace+1) % associativity);
 
     case SMMU_CACHE_REPL_RANDOM:
-        return random.random<size_t>(0, associativity-1);
+        return random->random<size_t>(0, associativity-1);
 
     case SMMU_CACHE_REPL_LRU:
         return lru_idx;
@@ -1218,7 +1218,7 @@ WalkCache::pickEntryIdxToReplace(const Set &set,
         return nextToReplace = ((nextToReplace+1) % associativity);
 
     case SMMU_CACHE_REPL_RANDOM:
-        return random.random<size_t>(0, associativity-1);
+        return random->random<size_t>(0, associativity-1);
 
     case SMMU_CACHE_REPL_LRU:
         return lru_idx;

--- a/src/dev/arm/smmu_v3_caches.hh
+++ b/src/dev/arm/smmu_v3_caches.hh
@@ -66,7 +66,7 @@ class SMMUv3BaseCache
   protected:
     int replacementPolicy;
     size_t nextToReplace;
-    Random random;
+    Random::RandomPtr random;
     uint32_t useStamp;
 
     struct SMMUv3BaseCacheStats : public statistics::Group

--- a/src/dev/net/dist_etherlink.cc
+++ b/src/dev/net/dist_etherlink.cc
@@ -50,7 +50,6 @@
 #include <string>
 #include <vector>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/DistEthernet.hh"
 #include "debug/DistEthernetPkt.hh"
@@ -195,7 +194,7 @@ DistEtherLink::TxLink::transmit(EthPacketPtr pkt)
     packet = pkt;
     Tick delay = (Tick)ceil(((double)pkt->simLength * ticksPerByte) + 1.0);
     if (delayVar != 0)
-        delay += random_mt.random<Tick>(0, delayVar);
+        delay += rng->random<Tick>(0, delayVar);
 
     // send the packet to the peers
     assert(distIface);

--- a/src/dev/net/dist_etherlink.hh
+++ b/src/dev/net/dist_etherlink.hh
@@ -51,6 +51,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "base/random.hh"
 #include "base/types.hh"
 #include "dev/net/etherlink.hh"
 #include "params/DistEtherLink.hh"
@@ -124,6 +125,8 @@ class DistEtherLink : public SimObject
          */
         void txDone();
         EventFunctionWrapper doneEvent;
+
+        Random::RandomPtr rng = Random::genRandom();
 
       public:
         TxLink(const std::string &name, DistEtherLink *p,

--- a/src/dev/net/dist_iface.cc
+++ b/src/dev/net/dist_iface.cc
@@ -44,7 +44,6 @@
 #include <queue>
 #include <thread>
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "cpu/thread_context.hh"
 #include "debug/DistEthernet.hh"
@@ -806,7 +805,7 @@ DistIface::init(const Event *done_event, Tick link_delay)
     // in all gem5 peer processes
     assert(primary != nullptr);
     if (this == primary)
-        random_mt.init(5489 * (rank+1) + 257);
+        rng->init(5489 * (rank+1) + 257);
 }
 
 void

--- a/src/dev/net/dist_iface.hh
+++ b/src/dev/net/dist_iface.hh
@@ -82,6 +82,7 @@
 #include <utility>
 
 #include "base/logging.hh"
+#include "base/random.hh"
 #include "dev/net/dist_packet.hh"
 #include "dev/net/etherpkt.hh"
 #include "sim/drain.hh"
@@ -474,6 +475,8 @@ class DistIface : public Drainable, public Serializable
      * Use pseudoOp to start synchronization.
      */
     bool syncStartOnPseudoOp;
+
+    Random::RandomPtr rng = Random::genRandom();
 
   protected:
     /**

--- a/src/dev/net/etherlink.cc
+++ b/src/dev/net/etherlink.cc
@@ -51,7 +51,6 @@
 #include <vector>
 
 #include "base/logging.hh"
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/Ethernet.hh"
 #include "debug/EthernetData.hh"
@@ -189,7 +188,7 @@ EtherLink::Link::transmit(EthPacketPtr pkt)
     packet = pkt;
     Tick delay = (Tick)ceil(((double)pkt->simLength * ticksPerByte) + 1.0);
     if (delayVar != 0)
-        delay += random_mt.random<Tick>(0, delayVar);
+        delay += rng->random<Tick>(0, delayVar);
 
     DPRINTF(Ethernet, "scheduling packet: delay=%d, (rate=%f)\n",
             delay, ticksPerByte);

--- a/src/dev/net/etherlink.hh
+++ b/src/dev/net/etherlink.hh
@@ -48,6 +48,7 @@
 #include <queue>
 #include <utility>
 
+#include "base/random.hh"
 #include "base/types.hh"
 #include "dev/net/etherint.hh"
 #include "dev/net/etherpkt.hh"
@@ -86,6 +87,8 @@ class EtherLink : public SimObject
         const Tick linkDelay;
         const Tick delayVar;
         EtherDump *const dump;
+
+        Random::RandomPtr rng = Random::genRandom();
 
       protected:
         /*

--- a/src/dev/net/etherswitch.cc
+++ b/src/dev/net/etherswitch.cc
@@ -32,7 +32,6 @@
 
 #include "dev/net/etherswitch.hh"
 
-#include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/EthernetAll.hh"
 #include "sim/core.hh"
@@ -204,7 +203,7 @@ EtherSwitch::Interface::switchingDelay()
     Tick delay = (Tick)ceil(((double)outputFifo.front()->simLength
                                      * ticksPerByte) + 1.0);
     if (delayVar != 0)
-                delay += random_mt.random<Tick>(0, delayVar);
+                delay += rng->random<Tick>(0, delayVar);
     delay += switchDelay;
     return delay;
 }

--- a/src/dev/net/etherswitch.hh
+++ b/src/dev/net/etherswitch.hh
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "base/inet.hh"
+#include "base/random.hh"
 #include "dev/net/etherint.hh"
 #include "dev/net/etherlink.hh"
 #include "dev/net/etherpkt.hh"
@@ -95,6 +96,7 @@ class EtherSwitch : public SimObject
         const Tick switchDelay;
         const Tick delayVar;
         const unsigned interfaceId;
+        Random::RandomPtr rng = Random::genRandom();
 
         EtherSwitch *parent;
       protected:

--- a/src/dev/virtio/rng.cc
+++ b/src/dev/virtio/rng.cc
@@ -38,7 +38,6 @@
 
 #include "dev/virtio/rng.hh"
 
-#include "base/random.hh"
 #include "debug/VIORng.hh"
 #include "params/VirtIORng.hh"
 #include "sim/system.hh"
@@ -80,7 +79,7 @@ VirtIORng::RngQueue::trySend()
         DPRINTF(VIORng, "Got descriptor (len: %i)\n", d->size());
         size_t len = 0;
         while (len < d->size()) {
-            uint8_t byte = gem5::random_mt.random<uint8_t>();
+            uint8_t byte = rng->random<uint8_t>();
             d->chainWrite(len, &byte, sizeof(uint8_t));
             ++len;
         }

--- a/src/dev/virtio/rng.hh
+++ b/src/dev/virtio/rng.hh
@@ -40,6 +40,7 @@
 #define __DEV_VIRTIO_RNG_HH__
 
 #include "base/compiler.hh"
+#include "base/random.hh"
 #include "dev/virtio/base.hh"
 
 namespace gem5
@@ -70,8 +71,7 @@ class VirtIORng : public VirtIODeviceBase
     /**
      * Virtqueue for data going from the host to the guest.
      */
-    class RngQueue
-        : public VirtQueue
+    class RngQueue : public VirtQueue
     {
       public:
         RngQueue(PortProxy &proxy, ByteOrder bo, uint16_t size,
@@ -87,6 +87,8 @@ class VirtIORng : public VirtIODeviceBase
 
       protected:
         VirtIORng &parent;
+
+        Random::RandomPtr rng = Random::genRandom();
     };
     /** Receive queue for port 0 */
     RngQueue qReq;

--- a/src/kern/linux/linux.cc
+++ b/src/kern/linux/linux.cc
@@ -45,7 +45,7 @@ namespace gem5
 
 // The OS methods are called statically. Instantiate the random number
 // generator for access to /dev/urandom here.
-Random Linux::random;
+Random::RandomPtr Linux::random = Random::genRandom();
 
 int
 Linux::openSpecialFile(std::string path, Process *process,
@@ -128,7 +128,7 @@ Linux::devRandom(Process *process, ThreadContext *tc)
     std::stringstream line;
     int max = 1E5;
     for (int i = 0; i < max; i++) {
-        uint8_t rand_uint = random.random<uint8_t>(0, 255);
+        uint8_t rand_uint = random->random<uint8_t>(0, 255);
 
         line << rand_uint;
     }

--- a/src/kern/linux/linux.hh
+++ b/src/kern/linux/linux.hh
@@ -256,7 +256,7 @@ class Linux : public OperatingSystem
     };
 
     // For /dev/urandom accesses
-    static Random random;
+    static Random::RandomPtr random;
 
     static int openSpecialFile(std::string path, Process *process,
                                ThreadContext *tc);

--- a/src/learning_gem5/part2/simple_cache.cc
+++ b/src/learning_gem5/part2/simple_cache.cc
@@ -29,7 +29,6 @@
 #include "learning_gem5/part2/simple_cache.hh"
 
 #include "base/compiler.hh"
-#include "base/random.hh"
 #include "debug/SimpleCache.hh"
 #include "sim/system.hh"
 
@@ -373,10 +372,10 @@ SimpleCache::insert(PacketPtr pkt)
         // are using a std::unordered_map. See http://bit.ly/2hrnLP2
         int bucket, bucket_size;
         do {
-            bucket = random_mt.random(0, (int)cacheStore.bucket_count() - 1);
+            bucket = rng->random(0, (int)cacheStore.bucket_count() - 1);
         } while ( (bucket_size = cacheStore.bucket_size(bucket)) == 0 );
         auto block = std::next(cacheStore.begin(bucket),
-                               random_mt.random(0, bucket_size - 1));
+                               rng->random(0, bucket_size - 1));
 
         DPRINTF(SimpleCache, "Removing addr %#x\n", block->first);
 

--- a/src/learning_gem5/part2/simple_cache.hh
+++ b/src/learning_gem5/part2/simple_cache.hh
@@ -31,6 +31,7 @@
 
 #include <unordered_map>
 
+#include "base/random.hh"
 #include "base/statistics.hh"
 #include "mem/port.hh"
 #include "params/SimpleCache.hh"
@@ -49,7 +50,6 @@ namespace gem5
 class SimpleCache : public ClockedObject
 {
   private:
-
     /**
      * Port on the CPU-side that receives requests.
      * Mostly just forwards requests to the cache (owner)
@@ -293,6 +293,8 @@ class SimpleCache : public ClockedObject
 
     /// An incredibly simple cache storage. Maps block addresses to data
     std::unordered_map<Addr, uint8_t*> cacheStore;
+
+    Random::RandomPtr rng = Random::genRandom();
 
     /// Cache statistics
   protected:

--- a/src/mem/cache/replacement_policies/bip_rp.cc
+++ b/src/mem/cache/replacement_policies/bip_rp.cc
@@ -30,7 +30,6 @@
 
 #include <memory>
 
-#include "base/random.hh"
 #include "params/BIPRP.hh"
 #include "sim/cur_tick.hh"
 
@@ -52,7 +51,7 @@ BIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
         std::static_pointer_cast<LRUReplData>(replacement_data);
 
     // Entries are inserted as MRU if lower than btp, LRU otherwise
-    if (random_mt.random<unsigned>(1, 100) <= btp) {
+    if (rng->random<unsigned>(1, 100) <= btp) {
         casted_replacement_data->lastTouchTick = curTick();
     } else {
         // Make their timestamps as old as possible, so that they become LRU

--- a/src/mem/cache/replacement_policies/bip_rp.hh
+++ b/src/mem/cache/replacement_policies/bip_rp.hh
@@ -42,6 +42,7 @@
 #ifndef __MEM_CACHE_REPLACEMENT_POLICIES_BIP_RP_HH__
 #define __MEM_CACHE_REPLACEMENT_POLICIES_BIP_RP_HH__
 
+#include "base/random.hh"
 #include "mem/cache/replacement_policies/lru_rp.hh"
 
 namespace gem5
@@ -60,6 +61,8 @@ class BIP : public LRU
      * if a new entry is inserted at the MRU or LRU position.
      */
     const unsigned btp;
+
+    mutable Random::RandomPtr rng = Random::genRandom();
 
   public:
     typedef BIPRPParams Params;

--- a/src/mem/cache/replacement_policies/brrip_rp.cc
+++ b/src/mem/cache/replacement_policies/brrip_rp.cc
@@ -32,7 +32,6 @@
 #include <memory>
 
 #include "base/logging.hh" // For fatal_if
-#include "base/random.hh"
 #include "params/BRRIPRP.hh"
 
 namespace gem5
@@ -84,7 +83,7 @@ BRRIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
     // Replacement data is inserted as "long re-reference" if lower than btp,
     // "distant re-reference" otherwise
     casted_replacement_data->rrpv.saturate();
-    if (random_mt.random<unsigned>(1, 100) <= btp) {
+    if (rng->random<unsigned>(1, 100) <= btp) {
         casted_replacement_data->rrpv--;
     }
 

--- a/src/mem/cache/replacement_policies/brrip_rp.hh
+++ b/src/mem/cache/replacement_policies/brrip_rp.hh
@@ -52,6 +52,7 @@
 #ifndef __MEM_CACHE_REPLACEMENT_POLICIES_BRRIP_RP_HH__
 #define __MEM_CACHE_REPLACEMENT_POLICIES_BRRIP_RP_HH__
 
+#include "base/random.hh"
 #include "base/sat_counter.hh"
 #include "mem/cache/replacement_policies/base.hh"
 
@@ -110,6 +111,8 @@ class BRRIP : public Base
      * if a new entry is inserted with long or distant re-reference.
      */
     const unsigned btp;
+
+    mutable Random::RandomPtr rng = Random::genRandom();
 
   public:
     typedef BRRIPRPParams Params;

--- a/src/mem/cache/replacement_policies/random_rp.cc
+++ b/src/mem/cache/replacement_policies/random_rp.cc
@@ -31,7 +31,6 @@
 #include <cassert>
 #include <memory>
 
-#include "base/random.hh"
 #include "params/RandomRP.hh"
 
 namespace gem5
@@ -73,7 +72,7 @@ Random::getVictim(const ReplacementCandidates& candidates) const
     assert(candidates.size() > 0);
 
     // Choose one candidate at random
-    ReplaceableEntry* victim = candidates[random_mt.random<unsigned>(0,
+    ReplaceableEntry* victim = candidates[rng->random<unsigned>(0,
                                     candidates.size() - 1)];
 
     // Visit all candidates to search for an invalid entry. If one is found,

--- a/src/mem/cache/replacement_policies/random_rp.hh
+++ b/src/mem/cache/replacement_policies/random_rp.hh
@@ -35,6 +35,7 @@
 #ifndef __MEM_CACHE_REPLACEMENT_POLICIES_RANDOM_RP_HH__
 #define __MEM_CACHE_REPLACEMENT_POLICIES_RANDOM_RP_HH__
 
+#include "base/random.hh"
 #include "mem/cache/replacement_policies/base.hh"
 
 namespace gem5
@@ -48,6 +49,8 @@ namespace replacement_policy
 class Random : public Base
 {
   protected:
+    mutable gem5::Random::RandomPtr rng = gem5::Random::genRandom();
+
     /** Random-specific implementation of replacement data. */
     struct RandomReplData : ReplacementData
     {

--- a/src/mem/cfi_mem.cc
+++ b/src/mem/cfi_mem.cc
@@ -406,7 +406,7 @@ Tick
 CfiMemory::getLatency() const
 {
     return latency +
-        (latency_var ? random_mt.random<Tick>(0, latency_var) : 0);
+        (latency_var ? rng->random<Tick>(0, latency_var) : 0);
 }
 
 void

--- a/src/mem/cfi_mem.hh
+++ b/src/mem/cfi_mem.hh
@@ -41,6 +41,7 @@
 #ifndef __MEM_FLASH_MEM_HH__
 #define __MEM_FLASH_MEM_HH__
 
+#include "base/random.hh"
 #include "mem/abstract_mem.hh"
 #include "params/CfiMemory.hh"
 
@@ -346,6 +347,8 @@ class CfiMemory : public AbstractMemory
     ProgramBuffer programBuffer;
 
     uint8_t cfiQueryTable[61];
+
+    mutable Random::RandomPtr rng = Random::genRandom();
 
   public:
     CfiMemory(const CfiMemoryParams &p);

--- a/src/mem/ruby/network/MessageBuffer.cc
+++ b/src/mem/ruby/network/MessageBuffer.cc
@@ -205,10 +205,11 @@ MessageBuffer::peek() const
 Tick
 random_time()
 {
+    static Random::RandomPtr rng = Random::genRandom();
     Tick time = 1;
-    time += random_mt.random(0, 3);  // [0...3]
-    if (random_mt.random(0, 7) == 0) {  // 1 in 8 chance
-        time += 100 + random_mt.random(1, 15); // 100 + [1...15]
+    time += rng->random(0, 3);  // [0...3]
+    if (rng->random(0, 7) == 0) {  // 1 in 8 chance
+        time += 100 + rng->random(1, 15); // 100 + [1...15]
     }
     return time;
 }

--- a/src/mem/ruby/network/simple/routing/WeightBased.cc
+++ b/src/mem/ruby/network/simple/routing/WeightBased.cc
@@ -42,7 +42,6 @@
 
 #include <algorithm>
 
-#include "base/random.hh"
 #include "mem/ruby/network/simple/Switch.hh"
 
 namespace gem5
@@ -95,7 +94,7 @@ WeightBased::route(const Message &msg,
                 // improve load distribution by randomizing order of links
                 // with the same queue length
                 link->m_order =
-                    (out_queue_length << 8) | random_mt.random(0, 0xff);
+                    (out_queue_length << 8) | rng->random(0, 0xff);
             }
         }
         sortLinks();

--- a/src/mem/ruby/network/simple/routing/WeightBased.hh
+++ b/src/mem/ruby/network/simple/routing/WeightBased.hh
@@ -41,6 +41,7 @@
 #ifndef __MEM_RUBY_NETWORK_SIMPLE_WEIGHTBASEDROUTINGUNIT_HH__
 #define __MEM_RUBY_NETWORK_SIMPLE_WEIGHTBASEDROUTINGUNIT_HH__
 
+#include "base/random.hh"
 #include "mem/ruby/network/simple/routing/BaseRoutingUnit.hh"
 #include "params/WeightBased.hh"
 
@@ -79,6 +80,8 @@ class WeightBased : public BaseRoutingUnit
     };
 
     std::vector<std::unique_ptr<LinkInfo>> m_links;
+
+    Random::RandomPtr rng = Random::genRandom();
 
     void findRoute(const Message &msg,
                    std::vector<RouteInfo> &out_links) const;

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -237,7 +237,7 @@ Tick
 SimpleMemory::getLatency() const
 {
     return latency +
-        (latency_var ? random_mt.random<Tick>(0, latency_var) : 0);
+        (latency_var ? rng->random<Tick>(0, latency_var) : 0);
 }
 
 void

--- a/src/mem/simple_mem.hh
+++ b/src/mem/simple_mem.hh
@@ -48,6 +48,7 @@
 
 #include <list>
 
+#include "base/random.hh"
 #include "mem/abstract_mem.hh"
 #include "mem/port.hh"
 #include "params/SimpleMemory.hh"
@@ -149,6 +150,8 @@ class SimpleMemory : public AbstractMemory
      * retry. This is only used as a check.
      */
     bool retryResp;
+
+    mutable Random::RandomPtr rng = Random::genRandom();
 
     /**
      * Release the memory after being busy and send a retry if a

--- a/src/python/pybind11/core.cc
+++ b/src/python/pybind11/core.cc
@@ -310,7 +310,9 @@ pybind_init_core(py::module_ &m_native)
         .def("disableAllListeners", &ListenSocket::disableAll)
         .def("listenersDisabled", &ListenSocket::allDisabled)
         .def("listenersLoopbackOnly", &ListenSocket::loopbackOnly)
-        .def("seedRandom", [](uint64_t seed) { random_mt.init(seed); })
+        .def("seedRandom", [](uint64_t seed) {
+            Random::reseedAll(seed);
+        })
 
 
         .def("fixClockFrequency", &fixClockFrequency)

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -3218,11 +3218,12 @@ getrandomFunc(SyscallDesc *desc, ThreadContext *tc,
               VPtr<> buf_ptr, typename OS::size_t count,
               unsigned int flags)
 {
+    static Random::RandomPtr se_prng = Random::genRandom();
     SETranslatingPortProxy proxy(tc);
 
     TypedBufferArg<uint8_t> buf(buf_ptr, count);
     for (int i = 0; i < count; ++i) {
-        buf[i] = gem5::random_mt.random<uint8_t>();
+        buf[i] = se_prng->random<uint8_t>();
     }
     buf.copyOut(proxy);
 


### PR DESCRIPTION
Component that require randomness should not share their randomness
source with other components to avoid simulation noise. For instance,
the branch predictor of one core should not impact the random
cache replacement policy of the cache of another core. This currently
happens as all components share a single random number generator.
    
This PR provides their own generators to relevant components, although
a couple components still use rand().
    
Change-Id: I3fb7226111c9194ee457af0f0f2b83f8c7b69d1e



