### PR TITLE
python: Ignore *args and **kwargs when generating cxxMethod pybinding script

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -489,6 +489,12 @@ def cxxMethod(*args, **kwargs):
                 # We don't cound 'self' as an argument in this case.
                 continue
             param = sig.parameters[param_name]
+            if param.kind in [
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ]:
+                # *args and **kwargs shouldn't be in generated parameters
+                continue
             if param.default is param.empty:
                 args.append(param_name)
             else:


### PR DESCRIPTION
When generating a `@cxxMethod` decorated Python method, a method

```python
  @cxxMethod 
  def f(arg1, arg2):
    pass
```
will be generated into

```cpp
  ...
  .def("f", &f, py::arg("arg1"), py::arg("arg2"))
  ...
```

This align with the general pybind usage.

However, for function signatures including `*args` and `**kwargs`, these shouldn't be in the pybinding `def` arguments. ([reference](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#accepting-args-and-kwargs))

This commit attempts to fix this and thus to support *args and **kwargs.