### PR TITLE
arch-riscv: add VLEN/ELEN as class attributes for all vec insts

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -412,10 +412,10 @@ VMvWholeMicroInst::generateDisassembly(Addr pc,
 }
 
 VMaskMergeMicroInst::VMaskMergeMicroInst(ExtMachInst extMachInst,
-    uint8_t _dstReg, uint8_t _numSrcs, uint32_t _vlen, size_t _elemSize)
+    uint8_t _dstReg, uint8_t _numSrcs, uint32_t _elen, uint32_t _vlen,
+    size_t _elemSize)
     : VectorArithMicroInst("vmask_mv_micro", extMachInst,
-                            SimdAddOp, 0, 0),
-      vlen(_vlen),
+                            SimdAddOp, 0, 0, _elen, _vlen),
       elemSize(_elemSize)
 {
     setRegIdxArrays(
@@ -439,9 +439,8 @@ VMaskMergeMicroInst::execute(ExecContext* xc,
     trace::InstRecord* traceData) const
 {
     vreg_t& tmp_d0 = *(vreg_t *)xc->getWritableRegOperand(this, 0);
-    PCStateBase *pc_ptr = xc->tcBase()->pcState().clone();
     auto Vd = tmp_d0.as<uint8_t>();
-    uint32_t vlenb = pc_ptr->as<PCState>().vlenb();
+    uint32_t vlenb = vlen >> 3;
     const uint32_t elems_per_vreg = vlenb / elemSize;
     size_t bit_cnt = elems_per_vreg;
 
@@ -503,9 +502,10 @@ VxsatMicroInst::generateDisassembly(Addr pc,
 }
 
 VlFFTrimVlMicroOp::VlFFTrimVlMicroOp(ExtMachInst _machInst, uint32_t _microVl,
-    uint32_t _microIdx, uint32_t _vlen, std::vector<StaticInstPtr>& _microops)
+    uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+    std::vector<StaticInstPtr>& _microops)
     : VectorMicroInst("vlff_trimvl_v_micro", _machInst, SimdConfigOp,
-                      _microVl, _microIdx, _vlen),
+                      _microVl, _microIdx, _elen, _vlen),
       microops(_microops)
 {
     setRegIdxArrays(
@@ -614,13 +614,13 @@ std::string VlSegMicroInst::generateDisassembly(Addr pc,
     return ss.str();
 }
 
-VlSegDeIntrlvMicroInst::VlSegDeIntrlvMicroInst(ExtMachInst extMachInst, uint32_t _micro_vl,
-                        uint32_t _dstReg, uint32_t _numSrcs,
-                        uint32_t _microIdx, uint32_t _numMicroops,
-                        uint32_t _field, uint32_t _vlen, uint32_t _sizeOfElement)
+VlSegDeIntrlvMicroInst::VlSegDeIntrlvMicroInst(ExtMachInst extMachInst,
+                        uint32_t _micro_vl, uint32_t _dstReg,
+                        uint32_t _numSrcs, uint32_t _microIdx,
+                        uint32_t _numMicroops, uint32_t _field, uint32_t _elen,
+                        uint32_t _vlen, uint32_t _sizeOfElement)
     : VectorArithMicroInst("vlseg_deintrlv_micro", extMachInst,
-                            SimdAddOp, 0, 0),
-        vlen(_vlen)
+                            SimdAddOp, 0, 0, _elen, _vlen)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -716,13 +716,13 @@ std::string VsSegMicroInst::generateDisassembly(Addr pc,
     return ss.str();
 }
 
-VsSegIntrlvMicroInst::VsSegIntrlvMicroInst(ExtMachInst extMachInst, uint32_t _micro_vl,
-                        uint32_t _dstReg, uint32_t _numSrcs,
-                        uint32_t _microIdx, uint32_t _numMicroops,
-                        uint32_t _field, uint32_t _vlen, uint32_t _sizeOfElement)
+VsSegIntrlvMicroInst::VsSegIntrlvMicroInst(ExtMachInst extMachInst,
+                        uint32_t _micro_vl, uint32_t _dstReg,
+                        uint32_t _numSrcs, uint32_t _microIdx,
+                        uint32_t _numMicroops, uint32_t _field, uint32_t _elen,
+                        uint32_t _vlen, uint32_t _sizeOfElement)
     : VectorArithMicroInst("vsseg_reintrlv_micro", extMachInst,
-                            SimdAddOp, 0, 0),
-        vlen(_vlen)
+                            SimdAddOp, 0, 0, _elen, _vlen)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -802,9 +802,10 @@ VsSegIntrlvMicroInst::generateDisassembly(Addr pc,
 }
 
 VCpyVsMicroInst::VCpyVsMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
-                                 uint8_t _vsRegIdx)
+                                 uint8_t _vsRegIdx, uint32_t _elen,
+                                 uint32_t _vlen)
     : VectorArithMicroInst("vcpyvs_v_micro", _machInst, SimdMiscOp, 0,
-                           _microIdx)
+                           _microIdx, _elen, _vlen)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -857,9 +858,10 @@ VCpyVsMicroInst::generateDisassembly(Addr pc,
 }
 
 VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
-                                 uint32_t _numVdPins, bool _hasVdOffset)
+                                 uint32_t _numVdPins, uint32_t _elen,
+                                 uint32_t _vlen, bool _hasVdOffset)
     : VectorArithMicroInst("vpinvd_v_micro", _machInst, SimdMiscOp, 0,
-                           _microIdx)
+                           _microIdx, _elen, _vlen)
     , hasVdOffset(_hasVdOffset)
 {
     setRegIdxArrays(

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -70,14 +70,16 @@ class VConfOp : public RiscvStaticInst
     uint64_t zimm11;
     uint64_t uimm;
     uint32_t elen;
+    uint32_t vlen;
     VConfOp(const char *mnem, ExtMachInst _extMachInst,
-            uint32_t _elen, OpClass __opClass)
+            uint32_t _elen, uint32_t _vlen, OpClass __opClass)
         : RiscvStaticInst(mnem, _extMachInst, __opClass),
           bit30(_extMachInst.bit30), bit31(_extMachInst.bit31),
           zimm10(_extMachInst.zimm_vsetivli),
           zimm11(_extMachInst.zimm_vsetvli),
           uimm(_extMachInst.uimm_vsetivli),
-          elen(_elen)
+          elen(_elen),
+          vlen(_vlen)
     {
         this->flags[IsVector] = true;
     }
@@ -102,11 +104,15 @@ class VectorNonSplitInst : public RiscvStaticInst
   protected:
     uint32_t vl;
     uint8_t vtype;
+    uint32_t elen;
+    uint32_t vlen;
     VectorNonSplitInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
         : RiscvStaticInst(mnem, _machInst, __opClass),
         vl(_machInst.vl),
-        vtype(_machInst.vtype8)
+        vtype(_machInst.vtype8),
+        elen(_elen),
+        vlen(_vlen)
     {
         this->flags[IsVector] = true;
     }
@@ -120,13 +126,15 @@ class VectorMacroInst : public RiscvMacroInst
   protected:
     uint32_t vl;
     uint8_t vtype;
+    uint32_t elen;
     uint32_t vlen;
 
     VectorMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen = 256)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
         : RiscvMacroInst(mnem, _machInst, __opClass),
         vl(_machInst.vl),
         vtype(_machInst.vtype8),
+        elen(_elen),
         vlen(_vlen)
     {
         this->flags[IsVector] = true;
@@ -136,17 +144,20 @@ class VectorMacroInst : public RiscvMacroInst
 class VectorMicroInst : public RiscvMicroInst
 {
 protected:
-    uint32_t vlen;
     uint32_t microVl;
     uint32_t microIdx;
     uint8_t vtype;
+    uint32_t elen;
+    uint32_t vlen;
+
     VectorMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
-      uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen = 256)
+      uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
         : RiscvMicroInst(mnem, _machInst, __opClass),
-        vlen(_vlen),
         microVl(_microVl),
         microIdx(_microIdx),
-        vtype(_machInst.vtype8)
+        vtype(_machInst.vtype8),
+        elen(_elen),
+        vlen(_vlen)
     {
         this->flags[IsVector] = true;
     }
@@ -179,8 +190,9 @@ class VectorArithMicroInst : public VectorMicroInst
 protected:
     VectorArithMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint32_t _microIdx)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
+                         uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -191,8 +203,8 @@ class VectorArithMacroInst : public VectorMacroInst
 {
   protected:
     VectorArithMacroInst(const char* mnem, ExtMachInst _machInst,
-                         OpClass __opClass, uint32_t _vlen = 256)
-        : VectorMacroInst(mnem, _machInst, __opClass, _vlen)
+                         OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {
         this->flags[IsVector] = true;
     }
@@ -205,8 +217,9 @@ class VectorVMUNARY0MicroInst : public VectorMicroInst
 protected:
     VectorVMUNARY0MicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint32_t _microIdx)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
+                         uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -217,8 +230,8 @@ class VectorVMUNARY0MacroInst : public VectorMacroInst
 {
   protected:
     VectorVMUNARY0MacroInst(const char* mnem, ExtMachInst _machInst,
-                         OpClass __opClass, uint32_t _vlen)
-        : VectorMacroInst(mnem, _machInst, __opClass, _vlen)
+                         OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {
         this->flags[IsVector] = true;
     }
@@ -231,8 +244,8 @@ class VectorSlideMacroInst : public VectorMacroInst
 {
   protected:
     VectorSlideMacroInst(const char* mnem, ExtMachInst _machInst,
-                         OpClass __opClass, uint32_t _vlen = 256)
-        : VectorMacroInst(mnem, _machInst, __opClass, _vlen)
+                         OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {
         this->flags[IsVector] = true;
     }
@@ -248,8 +261,10 @@ class VectorSlideMicroInst : public VectorMicroInst
     uint32_t vs2Idx;
     VectorSlideMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
-                         uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
+                         uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx,
+                         uint32_t _elen, uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
         , vdIdx(_vdIdx), vs2Idx(_vs2Idx)
     {}
 
@@ -265,8 +280,10 @@ class VectorMemMicroInst : public VectorMicroInst
 
     VectorMemMicroInst(const char* mnem, ExtMachInst _machInst,
                        OpClass __opClass, uint32_t _microVl,
-                       uint32_t _microIdx, uint32_t _offset)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
+                       uint32_t _microIdx, uint32_t _offset, uint32_t _elen,
+                       uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
         , offset(_offset)
         , memAccessFlags(0)
     {}
@@ -276,8 +293,8 @@ class VectorMemMacroInst : public VectorMacroInst
 {
   protected:
     VectorMemMacroInst(const char* mnem, ExtMachInst _machInst,
-                        OpClass __opClass, uint32_t _vlen = 256)
-        : VectorMacroInst(mnem, _machInst, __opClass, _vlen)
+                        OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 };
 
@@ -285,8 +302,8 @@ class VleMacroInst : public VectorMemMacroInst
 {
   protected:
     VleMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -297,8 +314,8 @@ class VseMacroInst : public VectorMemMacroInst
 {
   protected:
     VseMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -315,9 +332,10 @@ class VleMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VleMicroInst(const char *mnem, ExtMachInst _machInst,OpClass __opClass,
-                  uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
-                            _microIdx, _vlen)
+                 uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
+                 uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
         , trimVl(false), faultIdx(_microVl)
     {
         this->flags[IsLoad] = true;
@@ -333,9 +351,10 @@ class VseMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VseMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
-                  uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
-                            _microIdx, _vlen)
+                 uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
+                 uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
     {
         this->flags[IsStore] = true;
     }
@@ -348,8 +367,8 @@ class VlWholeMacroInst : public VectorMemMacroInst
 {
   protected:
     VlWholeMacroInst(const char *mnem, ExtMachInst _machInst,
-                     OpClass __opClass, uint32_t _vlen)
-      : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                     OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+      : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -363,9 +382,9 @@ class VlWholeMicroInst : public VectorMicroInst
 
     VlWholeMicroInst(const char *mnem, ExtMachInst _machInst,
           OpClass __opClass, uint32_t _microVl, uint32_t _microIdx,
-          uint32_t _vlen)
-        : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
-                            _microIdx, _vlen)
+          uint32_t _elen, uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -376,8 +395,8 @@ class VsWholeMacroInst : public VectorMemMacroInst
 {
   protected:
     VsWholeMacroInst(const char *mnem, ExtMachInst _machInst,
-                     OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                     OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -390,10 +409,10 @@ class VsWholeMicroInst : public VectorMicroInst
     Request::Flags memAccessFlags;
 
     VsWholeMicroInst(const char *mnem, ExtMachInst _machInst,
-                      OpClass __opClass, uint32_t _microVl,
-                      uint32_t _microIdx, uint32_t _vlen)
+                     OpClass __opClass, uint32_t _microVl,
+                     uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass , _microVl,
-                          _microIdx, _vlen)
+                          _microIdx, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -404,8 +423,8 @@ class VlStrideMacroInst : public VectorMemMacroInst
 {
   protected:
     VlStrideMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -418,9 +437,10 @@ class VlStrideMicroInst : public VectorMemMicroInst
   uint32_t regIdx;
     VlStrideMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint32_t _regIdx,
-                      uint32_t _microIdx, uint32_t _microVl)
+                      uint32_t _microIdx, uint32_t _microVl, uint32_t _elen,
+                      uint32_t _vlen)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
-                             _microIdx, 0)
+                             _microIdx, 0, _elen, _vlen)
         , regIdx(_regIdx)
     {}
 
@@ -432,8 +452,8 @@ class VsStrideMacroInst : public VectorMemMacroInst
 {
   protected:
     VsStrideMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -446,9 +466,10 @@ class VsStrideMicroInst : public VectorMemMicroInst
     uint32_t regIdx;
     VsStrideMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint32_t _regIdx,
-                      uint32_t _microIdx, uint32_t _microVl)
+                      uint32_t _microIdx, uint32_t _microVl, uint32_t _elen,
+                      uint32_t _vlen)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
-                             _microIdx, 0)
+                             _microIdx, 0, _elen, _vlen)
         , regIdx(_regIdx)
     {}
 
@@ -460,8 +481,8 @@ class VlIndexMacroInst : public VectorMemMacroInst
 {
   protected:
     VlIndexMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -477,9 +498,10 @@ class VlIndexMicroInst : public VectorMemMicroInst
     uint32_t vs2ElemIdx;
     VlIndexMicroInst(const char *mnem, ExtMachInst _machInst,
                     OpClass __opClass, uint32_t _vdRegIdx, uint32_t _vdElemIdx,
-                    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
+                    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx, uint32_t _elen,
+                    uint32_t _vlen)
         : VectorMemMicroInst(mnem, _machInst, __opClass, 1,
-                             0, 0)
+                             0, 0, _elen, _vlen)
         , vdRegIdx(_vdRegIdx), vdElemIdx(_vdElemIdx)
         , vs2RegIdx(_vs2RegIdx), vs2ElemIdx(_vs2ElemIdx)
     {}
@@ -492,8 +514,8 @@ class VsIndexMacroInst : public VectorMemMacroInst
 {
   protected:
     VsIndexMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -508,10 +530,11 @@ class VsIndexMicroInst : public VectorMemMicroInst
     uint32_t vs2RegIdx;
     uint32_t vs2ElemIdx;
     VsIndexMicroInst(const char *mnem, ExtMachInst _machInst,
-                    OpClass __opClass, uint32_t _vs3RegIdx,
-                    uint32_t _vs3ElemIdx, uint32_t _vs2RegIdx,
-                    uint32_t _vs2ElemIdx)
-        : VectorMemMicroInst(mnem, _machInst, __opClass, 1, 0, 0),
+                     OpClass __opClass, uint32_t _vs3RegIdx,
+                     uint32_t _vs3ElemIdx, uint32_t _vs2RegIdx,
+                     uint32_t _vs2ElemIdx, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMicroInst(mnem, _machInst, __opClass, 1, 0, 0, _elen,
+                             _vlen),
           vs3RegIdx(_vs3RegIdx), vs3ElemIdx(_vs3ElemIdx),
           vs2RegIdx(_vs2RegIdx), vs2ElemIdx(_vs2ElemIdx)
     {}
@@ -524,8 +547,8 @@ class VMvWholeMacroInst : public VectorArithMacroInst
 {
   protected:
     VMvWholeMacroInst(const char* mnem, ExtMachInst _machInst,
-                         OpClass __opClass)
-        : VectorArithMacroInst(mnem, _machInst, __opClass)
+                      OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorArithMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -536,9 +559,10 @@ class VMvWholeMicroInst : public VectorArithMicroInst
 {
   protected:
     VMvWholeMicroInst(const char *mnem, ExtMachInst _machInst,
-                         OpClass __opClass, uint32_t _microVl,
-                         uint32_t _microIdx)
-        : VectorArithMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx)
+                      OpClass __opClass, uint32_t _microVl,
+                      uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
+        : VectorArithMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                               _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -553,10 +577,10 @@ class VMaskMergeMicroInst : public VectorArithMicroInst
     RegId destRegIdxArr[1];
 
   public:
-    uint32_t vlen;
     size_t elemSize;
-    VMaskMergeMicroInst(ExtMachInst extMachInst,
-        uint8_t _dstReg, uint8_t _numSrcs, uint32_t _vlen, size_t _elemSize);
+    VMaskMergeMicroInst(ExtMachInst extMachInst, uint8_t _dstReg,
+                        uint8_t _numSrcs, uint32_t _elen, uint32_t _vlen,
+                        size_t _elemSize);
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     std::string generateDisassembly(Addr,
         const loader::SymbolTable *) const override;
@@ -567,9 +591,10 @@ class VxsatMicroInst : public VectorArithMicroInst
   private:
     bool* vxsat;
   public:
-    VxsatMicroInst(bool* Vxsat, ExtMachInst extMachInst)
-        : VectorArithMicroInst("vxsat_micro", extMachInst,
-          SimdMiscOp, 0, 0)
+    VxsatMicroInst(bool* Vxsat, ExtMachInst extMachInst, uint32_t _elen,
+                   uint32_t _vlen)
+        : VectorArithMicroInst("vxsat_micro", extMachInst, SimdMiscOp, 0, 0,
+                               _elen, _vlen)
     {
         vxsat = Vxsat;
     }
@@ -587,8 +612,8 @@ class VlFFTrimVlMicroOp : public VectorMicroInst
 
   public:
     VlFFTrimVlMicroOp(ExtMachInst _machInst, uint32_t _microVl,
-        uint32_t _microIdx, uint32_t _vlen,
-        std::vector<StaticInstPtr>& _microops);
+                      uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+                      std::vector<StaticInstPtr>& _microops);
     uint32_t calcVl() const;
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     std::unique_ptr<PCStateBase> branchTarget(ThreadContext *) const override;
@@ -600,8 +625,8 @@ class VlSegMacroInst : public VectorMemMacroInst
 {
   protected:
     VlSegMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -618,9 +643,9 @@ class VlSegMicroInst : public VectorMicroInst
                    OpClass __opClass, uint32_t _microVl,
                    uint32_t _microIdx, uint32_t _numMicroops,
                    uint32_t _field, uint32_t _numFields,
-                   uint32_t _vlen)
+                   uint32_t _elen, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
-                          _microIdx, _vlen)
+                          _microIdx, _elen, _vlen)
     {
       this->flags[IsLoad] = true;
     }
@@ -641,12 +666,10 @@ class VlSegDeIntrlvMicroInst : public VectorArithMicroInst
     uint32_t micro_vl;
 
   public:
-    uint32_t vlen;
-
     VlSegDeIntrlvMicroInst(ExtMachInst extMachInst, uint32_t _micro_vl,
                             uint32_t _dstReg, uint32_t _numSrcs,
                             uint32_t _microIdx, uint32_t _numMicroops,
-                            uint32_t _field, uint32_t _vlen,
+                            uint32_t _field, uint32_t _elen, uint32_t _vlen,
                             uint32_t _sizeOfElement);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
@@ -659,8 +682,8 @@ class VsSegMacroInst : public VectorMemMacroInst
 {
   protected:
     VsSegMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _vlen)
+                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
     {}
 
     std::string generateDisassembly(
@@ -677,9 +700,9 @@ class VsSegMicroInst : public VectorMicroInst
                    OpClass __opClass, uint32_t _microVl,
                    uint32_t _microIdx, uint32_t _numMicroops,
                    uint32_t _field, uint32_t _numFields,
-                   uint32_t _vlen)
+                   uint32_t _elen, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
-                          _microIdx, _vlen)
+                          _microIdx, _elen, _vlen)
     {
       this->flags[IsStore] = true;
     }
@@ -700,12 +723,10 @@ class VsSegIntrlvMicroInst : public VectorArithMicroInst
     uint32_t micro_vl;
 
   public:
-    uint32_t vlen;
-
     VsSegIntrlvMicroInst(ExtMachInst extMachInst, uint32_t _micro_vl,
                             uint32_t _dstReg, uint32_t _numSrcs,
                             uint32_t _microIdx, uint32_t _numMicroops,
-                            uint32_t _field, uint32_t _vlen,
+                            uint32_t _field, uint32_t _elen, uint32_t _vlen,
                             uint32_t _sizeOfElement);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
@@ -722,7 +743,7 @@ class VCpyVsMicroInst : public VectorArithMicroInst
 
     public:
         VCpyVsMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
-                        uint8_t _vsRegIdx);
+                        uint8_t _vsRegIdx, uint32_t _elen, uint32_t _vlen);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;
@@ -737,7 +758,8 @@ class VPinVdMicroInst : public VectorArithMicroInst
 
     public:
         VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
-                        uint32_t _numVdPins, bool _hasVdOffset=false);
+                        uint32_t _numVdPins, uint32_t _elen, uint32_t _vlen,
+                        bool _hasVdOffset=false);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -581,8 +581,7 @@ ISA::readMiscReg(RegIndex idx)
         }
       case MISCREG_VLENB:
         {
-            auto rpc = tc->pcState().as<PCState>();
-            return rpc.vlenb();
+            return getVecLenInBytes();
         }
       case MISCREG_VTYPE:
         {

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -116,11 +116,10 @@ class ISA : public BaseISA
     PCStateBase*
     newPCState(Addr new_inst_addr=0) const override
     {
-        unsigned vlenb = vlen >> 3;
         if (_rvType == RV32) {
             new_inst_addr = sext<32>(new_inst_addr);
         }
-        return new PCState(new_inst_addr, _rvType, vlenb);
+        return new PCState(new_inst_addr, _rvType);
     }
 
   public:

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4705,7 +4705,6 @@ decode QUADRANT default Unknown::unknown() {
                         uint64_t rs1_bits = RS1;
                         uint64_t requested_vl = Rs1_ud;
                         uint64_t requested_vtype = zimm11;
-                        uint32_t vlen = VlenbBits * 8;
                         uint32_t vlmax = getVlmax(Vtype, vlen);
                         uint32_t current_vl = VL;
                     }}, {{
@@ -4721,7 +4720,6 @@ decode QUADRANT default Unknown::unknown() {
                             uint64_t rs1_bits = RS1;
                             uint64_t requested_vl = Rs1_ud;
                             uint64_t requested_vtype = Rs2_ud;
-                            uint32_t vlen = VlenbBits * 8;
                             uint32_t vlmax = getVlmax(Vtype, vlen);
                             uint32_t current_vl = VL;
                         }}, {{
@@ -4736,7 +4734,6 @@ decode QUADRANT default Unknown::unknown() {
                             uint64_t rs1_bits = -1;
                             uint64_t requested_vl = uimm;
                             uint64_t requested_vtype = zimm10;
-                            uint32_t vlen = VlenbBits * 8;
                             uint32_t vlmax = getVlmax(Vtype, vlen);
                             uint32_t current_vl = VL;
                         }}, {{

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -28,10 +28,8 @@
 
 
 let {{
-    def setVlen():
-        return "uint32_t vlen = VlenbBits * 8;\n"
     def setVlenb():
-        return "[[maybe_unused]] uint32_t vlenb = VlenbBits;\n"
+        return "[[maybe_unused]] uint32_t vlenb = vlen >> 3;\n"
     def setDestWrapper(destRegId):
         return "setDestRegIdx(_numDestRegs++, " + destRegId + ");\n" + \
                "_numTypedDestRegs[VecRegClass]++;\n"
@@ -255,7 +253,6 @@ def format VectorIntFormat(code, category, *flags) {{
         vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb()
-    set_vlen = setVlen() if need_elem_idx else ""
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
@@ -264,7 +261,6 @@ def format VectorIntFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb' : set_vlenb,
-         'set_vlen' : set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': declareVArithTemplate(Name + "Micro")},
@@ -312,7 +308,6 @@ def format VectorIntExtFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
@@ -321,7 +316,6 @@ def format VectorIntExtFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'ext_div': ext_div,
@@ -404,7 +398,6 @@ def format VectorIntWideningFormat(code, category, *flags) {{
         vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     varith_micro_declare = declareVArithTemplate(Name + "Micro", max_size=32)
     microiop = InstObjParams(name + "_micro",
@@ -414,7 +407,6 @@ def format VectorIntWideningFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare},
@@ -472,7 +464,6 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     varith_micro_declare = declareVArithTemplate(Name + "Micro", max_size=32)
     microiop = InstObjParams(name + "_micro",
@@ -482,7 +473,6 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare
@@ -543,7 +533,6 @@ def format VectorIntMaskFormat(code, category, *flags) {{
         vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb()
-    set_vlen = setVlen() if need_elem_idx else ""
 
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
@@ -552,7 +541,6 @@ def format VectorIntMaskFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'declare_varith_template': declareVArithTemplate(Name + "Micro")},
         flags)
@@ -607,7 +595,6 @@ def format VectorGatherFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     varith_micro_declare = declareGatherTemplate(Name + "Micro", idx_type)
     microiop = InstObjParams(name + "_micro",
@@ -617,7 +604,6 @@ def format VectorGatherFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'idx_type': idx_type,
          'declare_varith_template': varith_micro_declare},
@@ -685,7 +671,6 @@ def format VectorFloatFormat(code, category, *flags) {{
         vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen() if need_elem_idx else ""
 
     varith_micro_declare = declareVArithTemplate(Name + "Micro", 'float', 16)
     microiop = InstObjParams(name + "_micro",
@@ -695,7 +680,6 @@ def format VectorFloatFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(2),
          'declare_varith_template': varith_micro_declare},
@@ -739,7 +723,6 @@ def format VectorFloatCvtFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen()
 
     varith_micro_declare = declareVArithTemplate(Name + "Micro", 'float', 16)
     microiop = InstObjParams(name + "_micro",
@@ -749,7 +732,6 @@ def format VectorFloatCvtFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare},
@@ -830,7 +812,6 @@ def format VectorFloatWideningFormat(code, category, *flags) {{
         vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     varith_micro_declare = declareVArithTemplate(
         Name + "Micro", 'float', 16, 32)
@@ -841,7 +822,6 @@ def format VectorFloatWideningFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(2),
          'declare_varith_template': varith_micro_declare},
@@ -886,7 +866,6 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     varith_micro_declare = declareVArithTemplate(
         Name + "Micro", 'float', 8, 32)
@@ -897,7 +876,6 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare},
@@ -944,7 +922,6 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb();
-    set_vlen = setVlen();
 
     varith_micro_declare = declareVArithTemplate(
         Name + "Micro", 'float', 8, 32)
@@ -955,7 +932,6 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare},
@@ -996,7 +972,6 @@ def format VectorFloatMaskFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
 
     code = maskCondWrapper(code)
     code = eiDeclarePrefix(code)
@@ -1011,7 +986,6 @@ def format VectorFloatMaskFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'declare_varith_template': varith_micro_declare},
         flags)
@@ -1032,8 +1006,7 @@ def format VMvWholeFormat(code, category, *flags) {{
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
         'VMvWholeMicroInst',
-        {'code': code,
-         'set_vlen': setVlen()},
+        {'code': code},
         flags)
 
     header_output = \
@@ -1043,7 +1016,7 @@ def format VMvWholeFormat(code, category, *flags) {{
         VMvWholeMacroConstructor.subst(iop) + \
         VMvWholeMicroConstructor.subst(microiop)
     exec_output = VMvWholeMicroExecute.subst(microiop)
-    decode_block = BasicDecode.subst(iop)
+    decode_block = VMvWholeDecodeBlock.subst(iop)
 }};
 
 def format ViotaFormat(code, category, *flags){{
@@ -1241,7 +1214,6 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
 
     type_def = '''
         using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
@@ -1254,7 +1226,6 @@ def format VectorReduceIntFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb' : set_vlenb,
-         'set_vlen' : set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
          'copy_old_vd': copyOldVd(2),
@@ -1291,7 +1262,6 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
 
     type_def = '''
         using et = ElemType;
@@ -1308,7 +1278,6 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
          'copy_old_vd': copyOldVd(2),
@@ -1346,7 +1315,6 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
     type_def = '''
         using et = ElemType;
         using vu [[maybe_unused]] = decltype(et::v);
@@ -1363,7 +1331,6 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
          'copy_old_vd': copyOldVd(2),
@@ -1413,7 +1380,6 @@ def format VectorIntVxsatFormat(code, category, *flags) {{
     vm_decl_rd = vmDeclAndReadData()
 
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
 
     code = maskCondWrapper(code)
     code = eiDeclarePrefix(code)
@@ -1426,7 +1392,6 @@ def format VectorIntVxsatFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': declareVArithTemplate(Name + "Micro")},
@@ -1462,7 +1427,6 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
 
     varith_micro_declare = declareVArithTemplate(Name + "Micro", max_size=32)
     microiop = InstObjParams(name + "_micro",
@@ -1472,7 +1436,6 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'copy_old_vd': copyOldVd(2),
          'declare_varith_template': varith_micro_declare},
@@ -1531,7 +1494,6 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
     vm_decl_rd = vmDeclAndReadData()
     set_src_reg_idx += setSrcVm()
     set_vlenb = setVlenb()
-    set_vlen = setVlen()
 
     if decode_template is VectorIntDecodeBlock:
         varith_micro_declare = declareVArithTemplate(Name + "Micro")
@@ -1546,7 +1508,6 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'set_vlen': set_vlen,
          'vm_decl_rd': vm_decl_rd,
          'declare_varith_template': varith_micro_declare},
         flags)

--- a/src/arch/riscv/isa/formats/vector_conf.isa
+++ b/src/arch/riscv/isa/formats/vector_conf.isa
@@ -55,13 +55,13 @@ def template VSetVlDeclare {{
     {
       private:
         %(reg_idx_arr_decl)s;
-        VTYPE getNewVtype(VTYPE, VTYPE, uint32_t) const;
+        VTYPE getNewVtype(VTYPE, VTYPE) const;
         uint32_t getNewVL(
             uint32_t, uint32_t, uint32_t, uint64_t, uint64_t) const;
 
       public:
         /// Constructor.
-        %(class_name)s(ExtMachInst machInst, uint32_t elen);
+        %(class_name)s(ExtMachInst machInst, uint32_t elen, uint32_t vlen);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::unique_ptr<PCStateBase> branchTarget(
                 ThreadContext *tc) const override;
@@ -80,13 +80,13 @@ def template VSetiVliDeclare {{
     {
       private:
         %(reg_idx_arr_decl)s;
-        VTYPE getNewVtype(VTYPE, VTYPE, uint32_t) const;
+        VTYPE getNewVtype(VTYPE, VTYPE) const;
         uint32_t getNewVL(
             uint32_t, uint32_t, uint32_t, uint64_t, uint64_t) const;
 
       public:
         /// Constructor.
-        %(class_name)s(ExtMachInst machInst, uint32_t elen);
+        %(class_name)s(ExtMachInst machInst, uint32_t elen, uint32_t vlen);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::unique_ptr<PCStateBase> branchTarget(
                 const PCStateBase &branch_pc) const override;
@@ -98,8 +98,9 @@ def template VSetiVliDeclare {{
 }};
 
 def template VConfConstructor {{
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen)
-    : %(base_class)s("%(mnemonic)s", _machInst, _elen, %(op_class)s)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, _elen, _vlen, %(op_class)s)
     {
         %(set_reg_idx_arr)s;
         %(constructor)s;
@@ -107,13 +108,13 @@ def template VConfConstructor {{
 }};
 
 def template VConfDecodeBlock {{
-    return new %(class_name)s(machInst,elen);
+    return new %(class_name)s(machInst, elen, vlen);
 }};
 
 def template VConfExecute {{
     VTYPE
     %(class_name)s::getNewVtype(
-        VTYPE oldVtype, VTYPE reqVtype, uint32_t vlen) const
+        VTYPE oldVtype, VTYPE reqVtype)  const
     {
         VTYPE newVtype = oldVtype;
         if (oldVtype != reqVtype) {
@@ -170,8 +171,7 @@ def template VConfExecute {{
 
         tc->setMiscReg(MISCREG_VSTART, 0);
 
-        VTYPE new_vtype = getNewVtype(Vtype, requested_vtype,
-            vlen);
+        VTYPE new_vtype = getNewVtype(Vtype, requested_vtype);
         vlmax = new_vtype.vill ? 0 : getVlmax(new_vtype, vlen);
         uint32_t new_vl = getNewVL(
             current_vl, requested_vl, vlmax, rd_bits, rs1_bits);
@@ -196,9 +196,7 @@ def template VSetiVliBranchTarget {{
         uint64_t requested_vl = uimm;
         uint64_t requested_vtype = zimm10;
 
-        uint32_t vlen = rpc.vlenb() * 8;
-
-        VTYPE new_vtype = getNewVtype(rpc.vtype(), requested_vtype, vlen);
+        VTYPE new_vtype = getNewVtype(rpc.vtype(), requested_vtype);
         uint32_t vlmax = new_vtype.vill ? 0 : getVlmax(new_vtype, vlen);
         uint32_t new_vl = getNewVL(
             rpc.vl(), requested_vl, vlmax, rd_bits, rs1_bits);
@@ -221,10 +219,8 @@ def template VSetVliBranchTarget {{
         uint64_t requested_vl = tc->getReg(srcRegIdx(0));
         uint64_t requested_vtype = zimm11;
 
-        uint32_t vlen = pc_ptr->as<PCState>().vlenb() * 8;
-
         VTYPE new_vtype = getNewVtype(
-            pc_ptr->as<PCState>().vtype(), requested_vtype, vlen);
+            pc_ptr->as<PCState>().vtype(), requested_vtype);
         uint32_t vlmax = new_vtype.vill ? 0 : getVlmax(new_vtype, vlen);
         uint32_t new_vl = getNewVL(
             pc_ptr->as<PCState>().vl(), requested_vl, vlmax, rd_bits, rs1_bits);
@@ -246,10 +242,8 @@ def template VSetVlBranchTarget {{
         uint64_t requested_vl = tc->getReg(srcRegIdx(0));
         uint64_t requested_vtype = tc->getReg(srcRegIdx(1));
 
-        uint32_t vlen = pc_ptr->as<PCState>().vlenb() * 8;
-
         VTYPE new_vtype = getNewVtype(
-            pc_ptr->as<PCState>().vtype(), requested_vtype, vlen);
+            pc_ptr->as<PCState>().vtype(), requested_vtype);
         uint32_t vlmax = new_vtype.vill ? 0 : getVlmax(new_vtype, vlen);
         uint32_t new_vl = getNewVL(
             pc_ptr->as<PCState>().vl(), requested_vl, vlmax, rd_bits, rs1_bits);

--- a/src/arch/riscv/isa/formats/vector_mem.isa
+++ b/src/arch/riscv/isa/formats/vector_mem.isa
@@ -28,11 +28,8 @@
 
 
 let {{
-
-def setVlen():
-        return "uint32_t vlen = VlenbBits * 8;\n"
 def setVlenb():
-        return "[[maybe_unused]] uint32_t vlenb = VlenbBits;\n"
+        return "[[maybe_unused]] uint32_t vlenb = vlen >> 3;\n"
 
 def declareVMemTemplate(class_name):
     return f'''
@@ -103,7 +100,6 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags,
          'memacc_code': memacc_code,
          'postacc_code': postacc_code,
          'set_vlenb': setVlenb(),
-         'set_vlen': setVlen(),
          'declare_vmem_template': declareVMemTemplate(Name + 'Micro'),
          'fault_code': getFaultCode() if fault_only_first else '',
          'tail_mask_policy_code': getTailMaskPolicyCode()},

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -75,7 +75,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen, uint32_t _elen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -84,8 +84,9 @@ public:
 def template VectorIntMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -100,7 +101,8 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
@@ -127,7 +129,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx);
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -138,9 +140,10 @@ def template VectorIntMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint32_t _microIdx)
-    : %(base_class)s("%(mnemonic)s", _machInst,
-                     %(op_class)s, _microVl, _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx,
+                                         uint32_t _elen, uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
+                     _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -181,7 +184,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
     %(code)s;
@@ -201,7 +203,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override;
 };
@@ -219,7 +221,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx);
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override;
@@ -260,7 +262,6 @@ Fault
         %(op_decl)s;
         %(op_rd)s;
         %(set_vlenb)s;
-        %(set_vlen)s;
         %(vm_decl_rd)s;
         %(copy_old_vd)s;
         %(code)s;
@@ -273,7 +274,6 @@ Fault
         %(op_decl)s;
         %(op_rd)s;
         %(set_vlenb)s;
-        %(set_vlen)s;
         %(vm_decl_rd)s;
         %(copy_old_vd)s;
         %(code)s;
@@ -286,7 +286,6 @@ Fault
         %(op_decl)s;
         %(op_rd)s;
         %(set_vlenb)s;
-        %(set_vlen)s;
         %(vm_decl_rd)s;
         %(copy_old_vd)s;
         %(code)s;
@@ -336,10 +335,10 @@ std::string
 def template VectorIntDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b000: return new %(class_name)s<uint8_t>(machInst, vlen);
-case 0b001: return new %(class_name)s<uint16_t>(machInst, vlen);
-case 0b010: return new %(class_name)s<uint32_t>(machInst, vlen);
-case 0b011: return new %(class_name)s<uint64_t>(machInst, vlen);
+case 0b000: return new %(class_name)s<uint8_t>(machInst, elen, vlen);
+case 0b001: return new %(class_name)s<uint16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<uint32_t>(machInst, elen, vlen);
+case 0b011: return new %(class_name)s<uint64_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -352,7 +351,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -361,8 +360,9 @@ public:
 def template VectorIntWideningMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -383,7 +383,8 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
@@ -409,7 +410,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx);
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -420,9 +421,9 @@ def template VectorIntWideningMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx)
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst,
-                     %(op_class)s, _microVl, _microIdx)
+                     %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -458,7 +459,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
 
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
@@ -506,7 +506,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
 
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
@@ -534,9 +533,9 @@ Fault
 def template VectorIntWideningDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b000: return new %(class_name)s<uint8_t>(machInst, vlen);
-case 0b001: return new %(class_name)s<uint16_t>(machInst, vlen);
-case 0b010: return new %(class_name)s<uint32_t>(machInst, vlen);
+case 0b000: return new %(class_name)s<uint8_t>(machInst, elen, vlen);
+case 0b001: return new %(class_name)s<uint16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<uint32_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -549,7 +548,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -557,8 +556,9 @@ public:
 
 def template VectorFloatMacroConstructor {{
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -573,7 +573,8 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
@@ -599,7 +600,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -609,9 +610,10 @@ public:
 def template VectorFloatMicroConstructor {{
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint32_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx,
+                                         uint32_t _elen, uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst,
-                     %(op_class)s, _microVl, _microIdx)
+                     %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -653,7 +655,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
     %(code)s;
@@ -669,9 +670,9 @@ Fault
 def template VectorFloatDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b001: return new %(class_name)s<float16_t>(machInst, vlen);
-case 0b010: return new %(class_name)s<float32_t>(machInst, vlen);
-case 0b011: return new %(class_name)s<float64_t>(machInst, vlen);
+case 0b001: return new %(class_name)s<float16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<float32_t>(machInst, elen, vlen);
+case 0b011: return new %(class_name)s<float64_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -684,7 +685,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
     {
@@ -709,7 +710,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
@@ -755,7 +756,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
     const int32_t t_micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
@@ -804,7 +804,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
     const int32_t t_micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
@@ -826,8 +825,8 @@ Fault
 def template VectorFloatWideningDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b001: return new %(class_name)s<float16_t>(machInst, vlen);
-case 0b010: return new %(class_name)s<float32_t>(machInst, vlen);
+case 0b001: return new %(class_name)s<float16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<float32_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -837,9 +836,9 @@ default: GEM5_UNREACHABLE;
 def template VectorFloatWideningAndNarrowingCvtDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b000: return new %(class_name)s<float8_t>(machInst, vlen);
-case 0b001: return new %(class_name)s<float16_t>(machInst, vlen);
-case 0b010: return new %(class_name)s<float32_t>(machInst, vlen);
+case 0b000: return new %(class_name)s<float8_t>(machInst, elen, vlen);
+case 0b001: return new %(class_name)s<float16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<float32_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -853,7 +852,7 @@ private:
     int cnt = 0;
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
     {
@@ -871,8 +870,9 @@ public:
 def template ViotaMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -886,7 +886,7 @@ template<typename ElemType>
     // Allow one empty micro op to hold IsLastMicroop flag
     for (int i = 0; i < num_microops && micro_vl >= 0; ++i) {
         microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
-            &cnt);
+                                                    &cnt, _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
@@ -912,7 +912,8 @@ private:
     int* cnt;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx, int* cnt);
+                   uint32_t _microIdx, int* cnt, uint32_t _elen,
+                   uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
@@ -931,9 +932,10 @@ def template ViotaMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint32_t _microIdx, int* cnt)
+    uint32_t _microVl, uint32_t _microIdx, int* cnt, uint32_t _elen,
+    uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst,
-                     %(op_class)s, _microVl, _microIdx)
+                     %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     this->cnt = cnt;
@@ -993,7 +995,7 @@ private:
     RegId destRegIdxArr[1];
     bool vm;
 public:
-    %(class_name)s(ExtMachInst _machInst);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1003,8 +1005,9 @@ public:
 def template Vector1Vs1VdMaskConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -1060,7 +1063,7 @@ private:
     RegId destRegIdxArr[1];
     bool vm;
 public:
-    %(class_name)s(ExtMachInst _machInst);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1070,8 +1073,9 @@ public:
 def template Vector1Vs1RdMaskConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -1124,7 +1128,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -1133,8 +1137,9 @@ public:
 def template VectorIntMaskMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1145,13 +1150,14 @@ template<typename ElemType>
     StaticInstPtr microop;
 
     for (int i = 0; i < num_microops && micro_vl >= 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
     microop = new VMaskMergeMicroInst(_machInst, _machInst.vd,
-        this->microops.size(), _vlen, sizeof(ElemType));
+        this->microops.size(), _elen, _vlen, sizeof(ElemType));
     this->microops.push_back(microop);
 
     this->microops.front()->setFirstMicroop();
@@ -1175,7 +1181,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint32_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
+                   uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1186,9 +1193,10 @@ def template VectorIntMaskMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint32_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx,
+                                         uint32_t _elen, uint32_t _vlen)
 : %(base_class)s("%(mnemonic)s", _machInst,
-                 %(op_class)s, _microVl, _microIdx)
+                 %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -1227,7 +1235,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
 
     const uint32_t bit_offset = vlenb / sizeof(ElemType);
@@ -1249,7 +1256,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -1258,8 +1265,9 @@ public:
 def template VectorFloatMaskMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1270,13 +1278,14 @@ template<typename ElemType>
     StaticInstPtr microop;
 
     for (int i = 0; i < num_microops && micro_vl >= 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
     microop = new VMaskMergeMicroInst(_machInst, _machInst.vd,
-        this->microops.size(), _vlen, sizeof(ElemType));
+        this->microops.size(), _elen, _vlen, sizeof(ElemType));
     this->microops.push_back(microop);
 
     this->microops.front()->setFirstMicroop();
@@ -1299,7 +1308,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint32_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
+                   uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1310,9 +1320,10 @@ def template VectorFloatMaskMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint32_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx,
+                                         uint32_t _elen, uint32_t _vlen)
 : %(base_class)s("%(mnemonic)s", _machInst,
-                 %(op_class)s, _microVl, _microIdx)
+                 %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -1351,7 +1362,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
 
     const uint32_t bit_offset = vlenb / sizeof(ElemType);
@@ -1372,7 +1382,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -1380,8 +1390,9 @@ public:
 
 def template VMvWholeMacroConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1389,7 +1400,7 @@ def template VMvWholeMacroConstructor {{
     StaticInstPtr microop;
 
     for (int i = 0; i < num_microops; ++i) {
-        microop = new %(class_name)sMicro(_machInst, 0, i);
+        microop = new %(class_name)sMicro(_machInst, 0, i, _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
     }
@@ -1410,7 +1421,7 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx);
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1420,9 +1431,10 @@ public:
 def template VMvWholeMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst,
-                               uint32_t _microVl, uint32_t _microIdx)
+                               uint32_t _microVl, uint32_t _microIdx,
+                               uint32_t _elen, uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst,
-                     %(op_class)s, _microVl, _microIdx)
+                     %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -1454,7 +1466,6 @@ Fault
 
     %(op_decl)s;
     %(op_rd)s;
-    %(set_vlen)s;
     for (size_t i = 0; i < (vlen / 64); i++) {
         %(code)s;
     }
@@ -1462,6 +1473,10 @@ Fault
     return NoFault;
 }
 
+}};
+
+def template VMvWholeDecodeBlock {{
+    return new %(class_name)s(machInst, elen, vlen);
 }};
 
 def template VectorMaskDeclare {{
@@ -1472,7 +1487,7 @@ private:
     RegId srcRegIdxArr[2];
     RegId destRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1482,8 +1497,9 @@ public:
 def template VectorMaskConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(set_dest_reg_idx)s;
@@ -1535,7 +1551,7 @@ Fault
 
 def template VectorMaskDecodeBlock {{
 
-return new %(class_name)s<uint8_t>(machInst);
+return new %(class_name)s<uint8_t>(machInst, elen, vlen);
 
 }};
 
@@ -1547,7 +1563,7 @@ private:
     RegId srcRegIdxArr[2];
     RegId destRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1557,8 +1573,9 @@ public:
 def template VectorNonSplitConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1640,9 +1657,9 @@ Fault
 def template VectorFloatNonSplitDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b001: return new %(class_name)s<float16_t>(machInst);
-case 0b010: return new %(class_name)s<float32_t>(machInst);
-case 0b011: return new %(class_name)s<float64_t>(machInst);
+case 0b001: return new %(class_name)s<float16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<float32_t>(machInst, elen, vlen);
+case 0b011: return new %(class_name)s<float64_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -1651,10 +1668,10 @@ default: GEM5_UNREACHABLE;
 def template VectorIntNonSplitDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
-case 0b000: return new %(class_name)s<uint8_t>(machInst);
-case 0b001: return new %(class_name)s<uint16_t>(machInst);
-case 0b010: return new %(class_name)s<uint32_t>(machInst);
-case 0b011: return new %(class_name)s<uint64_t>(machInst);
+case 0b000: return new %(class_name)s<uint8_t>(machInst, elen, vlen);
+case 0b001: return new %(class_name)s<uint16_t>(machInst, elen, vlen);
+case 0b010: return new %(class_name)s<uint32_t>(machInst, elen, vlen);
+case 0b011: return new %(class_name)s<uint64_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 
@@ -1667,7 +1684,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -1676,8 +1693,9 @@ public:
 def template VectorReduceMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1692,7 +1710,8 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i);
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
@@ -1717,7 +1736,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint32_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
+                   uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1728,9 +1748,10 @@ def template VectorReduceMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-                                         uint32_t _microVl, uint32_t _microIdx)
+                                         uint32_t _microVl, uint32_t _microIdx,
+                                         uint32_t _elen, uint32_t _vlen)
 : %(base_class)s("%(mnemonic)s", _machInst,
-                 %(op_class)s, _microVl, _microIdx)
+                 %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -1769,7 +1790,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
@@ -1820,7 +1840,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
@@ -1870,7 +1889,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
@@ -1903,7 +1921,7 @@ class %(class_name)s : public %(base_class)s{
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -1913,8 +1931,8 @@ def template VectorGatherMacroConstructor {{
 
 template<typename ElemType, typename IndexType>
 %(class_name)s<ElemType, IndexType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+    uint32_t _elen, uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1944,7 +1962,7 @@ template<typename ElemType, typename IndexType>
         uint32_t pinvd_micro_vl = (vd_vlmax*(i+1) <= remaining_vl)
                                   ? vd_vlmax : remaining_vl;
         uint8_t num_vd_pins = ceil((float) pinvd_micro_vl/vs1_vlmax)*vs2_vregs;
-        microop = new VPinVdMicroInst(machInst, i, num_vd_pins);
+        microop = new VPinVdMicroInst(machInst, i, num_vd_pins, elen, vlen);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
 
@@ -1956,7 +1974,7 @@ template<typename ElemType, typename IndexType>
             i++) {
         for (uint8_t j = 0; j < vs2_vregs; j++) {
             microop = new %(class_name)sMicro<ElemType, IndexType>(
-                _machInst, micro_vl, i * vs2_vregs + j);
+                _machInst, micro_vl, i * vs2_vregs + j, _elen, _vlen);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
         }
@@ -1983,7 +2001,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint32_t _microIdx);
+                   uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
+                   uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1994,9 +2013,9 @@ def template VectorGatherMicroConstructor {{
 
 template<typename ElemType, typename IndexType>
 %(class_name)s<ElemType, IndexType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint32_t _microIdx)
+    uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
 : %(base_class)s("%(mnemonic)s", _machInst,
-                 %(op_class)s, _microVl, _microIdx)
+                 %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -2047,7 +2066,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     const uint32_t vlmax = vtype_VLMAX(vtype,vlen);
     constexpr uint32_t vd_eewb = sizeof(ElemType);
@@ -2086,19 +2104,22 @@ def template VectorGatherDecodeBlock {{
 switch(machInst.vtype8.vsew) {
     case 0b000: {
         using elem_type [[maybe_unused]] = uint8_t;
-        return new %(class_name)s<uint8_t, %(idx_type)s>(machInst, vlen);
+        return new %(class_name)s<uint8_t, %(idx_type)s>(machInst, elen, vlen);
     }
     case 0b001: {
         using elem_type [[maybe_unused]] = uint16_t;
-        return new %(class_name)s<uint16_t, %(idx_type)s>(machInst, vlen);
+        return new %(class_name)s<uint16_t, %(idx_type)s>(machInst, elen,
+                                                          vlen);
     }
     case 0b010: {
         using elem_type [[maybe_unused]] = uint32_t;
-        return new %(class_name)s<uint32_t, %(idx_type)s>(machInst, vlen);
+        return new %(class_name)s<uint32_t, %(idx_type)s>(machInst, elen,
+                                                          vlen);
     }
     case 0b011: {
         using elem_type [[maybe_unused]] = uint64_t;
-        return new %(class_name)s<uint64_t, %(idx_type)s>(machInst, vlen);
+        return new %(class_name)s<uint64_t, %(idx_type)s>(machInst, elen,
+                                                          vlen);
     }
     default: GEM5_UNREACHABLE;
 }
@@ -2113,7 +2134,7 @@ private:
     %(reg_idx_arr_decl)s;
     bool vxsat = false;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -2122,8 +2143,9 @@ public:
 def template VectorIntVxsatMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -2139,13 +2161,13 @@ template<typename ElemType>
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
         microop = new %(class_name)sMicro<ElemType>(_machInst,
-            micro_vl, i, &vxsat);
+            micro_vl, i, &vxsat, _elen, _vlen);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
 
-    microop = new VxsatMicroInst(&vxsat, _machInst);
+    microop = new VxsatMicroInst(&vxsat, _machInst, _elen, _vlen);
     microop->setFlag(StaticInst::IsSerializeAfter);
     microop->setFlag(StaticInst::IsNonSpeculative);
     this->microops.push_back(microop);
@@ -2169,7 +2191,8 @@ private:
     bool* vxsatptr;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx, bool* vxsatptr);
+                   uint32_t _microIdx, bool* vxsatptr, uint32_t _elen,
+                   uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2180,9 +2203,10 @@ def template VectorIntVxsatMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint32_t _microIdx, bool* vxsatptr)
+    uint32_t _microVl, uint32_t _microIdx, bool* vxsatptr, uint32_t _elen,
+    uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst,
-                     %(op_class)s, _microVl, _microIdx)
+                     %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     this->vxsatptr = vxsatptr;
@@ -2224,7 +2248,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(vm_decl_rd)s;
     %(copy_old_vd)s;
 
@@ -2257,7 +2280,7 @@ class %(class_name)s : public %(base_class)s {
 private:
     %(reg_idx_arr_decl)s;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -2266,8 +2289,9 @@ public:
 def template VectorSlideUpMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -2283,7 +2307,7 @@ template<typename ElemType>
     }
 
     for (uint32_t i = 0; i < ceil((float) this->vl/micro_vlmax); i++) {
-        microop = new VPinVdMicroInst(machInst, i, i+1, true);
+        microop = new VPinVdMicroInst(machInst, i, i+1, elen, vlen, true);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
@@ -2293,7 +2317,7 @@ template<typename ElemType>
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
         for (int j = 0; j <= i; ++j) {
             microop = new %(class_name)sMicro<ElemType>(
-                _machInst, micro_vl, micro_idx++, i, j);
+                _machInst, micro_vl, micro_idx++, i, j, _elen, _vlen);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
         }
@@ -2310,8 +2334,9 @@ template<typename ElemType>
 def template VectorSlideDownMacroConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -2327,7 +2352,8 @@ template<typename ElemType>
     }
 
     for (uint32_t i = 0; i < ceil((float) this->vl / micro_vlmax); i++) {
-        microop = new VPinVdMicroInst(machInst, i, num_microops-i, false);
+        microop = new VPinVdMicroInst(machInst, i, num_microops-i, elen, vlen,
+                                      false);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
@@ -2337,7 +2363,7 @@ template<typename ElemType>
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
         for (int j = i; j < num_microops; ++j) {
             microop = new %(class_name)sMicro<ElemType>(
-                _machInst, micro_vl, micro_idx++, i, j);
+                _machInst, micro_vl, micro_idx++, i, j, _elen, _vlen);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
         }
@@ -2364,7 +2390,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-        uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx);
+        uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx, uint32_t _elen,
+        uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2376,9 +2403,9 @@ def template VectorSlideMicroConstructor {{
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
         uint32_t _microVl, uint32_t _microIdx, uint32_t _vdIdx,
-        uint32_t _vs2Idx)
+        uint32_t _vs2Idx, uint32_t _elen, uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
-        _microIdx, _vdIdx, _vs2Idx)
+        _microIdx, _vdIdx, _vs2Idx, _elen, _vlen)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -2417,7 +2444,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
 
     [[maybe_unused]]const uint32_t vlmax = vtype_VLMAX(vtype, vlen);
 
@@ -2457,7 +2483,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
 
     [[maybe_unused]]const uint32_t vlmax = vtype_VLMAX(vtype, vlen);
 

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -34,7 +34,7 @@ private:
     %(reg_idx_arr_decl)s;
 public:
     %(class_name)s(ExtMachInst _machInst);
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -49,7 +49,7 @@ private:
     %(reg_idx_arr_decl)s;
 public:
     %(class_name)s(ExtMachInst _machInst);
-    %(class_name)s(ExtMachInst _machInst, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
     using %(base_class)s::generateDisassembly;
 };
 
@@ -57,8 +57,9 @@ public:
 
 def template VleConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -75,7 +76,7 @@ def template VleConstructor {{
         this->microops.push_back(microop);
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro(_machInst, micro_vl, i, vlen);
+        microop = new %(class_name)sMicro(_machInst, micro_vl, i, elen, vlen);
         microop->setDelayedCommit();
         microop->setFlag(IsLoad);
         this->microops.push_back(microop);
@@ -84,7 +85,7 @@ def template VleConstructor {{
 
     if (_opClass == SimdUnitStrideFaultOnlyFirstLoadOp) {
         microop = new VlFFTrimVlMicroOp(_machInst, this->vl, num_microops,
-                                        vlen, microops);
+                                        elen, vlen, microops);
         this->microops.push_back(microop);
     }
 
@@ -103,7 +104,7 @@ private:
     RegId destRegIdxArr[1];
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-        uint32_t _microIdx, uint32_t _vlen);
+        uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -118,9 +119,10 @@ public:
 def template VleMicroConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-    uint32_t _microIdx, uint32_t _vlen)
-  : %(base_class)s(
-        "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
+                               uint32_t _microIdx, uint32_t _elen,
+                               uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
+                   _microIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -147,7 +149,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(ea_code)s;
 
     RiscvISA::vreg_t tmp_v0;
@@ -241,7 +242,6 @@ Fault
 {
     %(op_decl)s;
     %(op_rd)s;
-    %(set_vlen)s;
 
     STATUS status = xc->readMiscReg(MISCREG_STATUS);
     status.vs = VPUStatus::DIRTY;
@@ -277,8 +277,9 @@ Fault
 
 def template VseConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -295,7 +296,7 @@ def template VseConstructor {{
         this->microops.push_back(microop);
     }
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro(_machInst, micro_vl, i, vlen);
+        microop = new %(class_name)sMicro(_machInst, micro_vl, i, elen, vlen);
         microop->setDelayedCommit();
         microop->setFlag(IsStore);
         this->microops.push_back(microop);
@@ -317,7 +318,7 @@ private:
     RegId destRegIdxArr[0];
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -330,10 +331,11 @@ public:
 
 def template VseMicroConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
-  : %(base_class)s(
-        "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                               uint32_t _microIdx, uint32_t _elen,
+                               uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
+                    _microIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -374,7 +376,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(ea_code)s;
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
@@ -425,7 +426,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(ea_code)s;
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
@@ -463,8 +463,9 @@ Fault
 
 def template VlmConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -475,7 +476,7 @@ def template VlmConstructor {{
     if (micro_vl == 0) {
         microop = new VectorNopMicroInst(_machInst);
     } else {
-        microop = new Vle8_vMicro(_machInst, micro_vl, 0, vlen);
+        microop = new Vle8_vMicro(_machInst, micro_vl, 0, elen, vlen);
         microop->setDelayedCommit();
         microop->setFlag(IsLoad);
     }
@@ -489,8 +490,9 @@ def template VlmConstructor {{
 
 def template VsmConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -501,7 +503,7 @@ def template VsmConstructor {{
     if (micro_vl == 0) {
         microop = new VectorNopMicroInst(_machInst);
     } else {
-        microop = new Vse8_vMicro(_machInst, micro_vl, 0, vlen);
+        microop = new Vse8_vMicro(_machInst, micro_vl, 0, elen, vlen);
         microop->setDelayedCommit();
         microop->setFlag(IsStore);
     }
@@ -515,8 +517,9 @@ def template VsmConstructor {{
 
 def template VsWholeConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -526,7 +529,8 @@ def template VsWholeConstructor {{
 
     StaticInstPtr microop;
     for (int i = 0; i < NFIELDS; ++i) {
-        microop = new %(class_name)sMicro(_machInst, micro_vlmax, i, vlen);
+        microop = new %(class_name)sMicro(_machInst, micro_vlmax, i, elen,
+                                          vlen);
         microop->setDelayedCommit();
         microop->setFlag(IsStore);
         this->microops.push_back(microop);
@@ -546,8 +550,8 @@ private:
     RegId destRegIdxArr[0];
     RegId srcRegIdxArr[2];
 public:
-    %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -560,10 +564,11 @@ public:
 
 def template VsWholeMicroConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
-  : %(base_class)s(
-        "%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                               uint32_t _microIdx, uint32_t _elen,
+                               uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
+                   _microIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -648,8 +653,9 @@ Fault
 
 def template VlWholeConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -660,7 +666,8 @@ def template VlWholeConstructor {{
 
     StaticInstPtr microop;
     for (int i = 0; i < NFIELDS; ++i) {
-        microop = new %(class_name)sMicro(_machInst, micro_vlmax, i, vlen);
+        microop = new %(class_name)sMicro(_machInst, micro_vlmax, i, elen,
+                                          vlen);
         microop->setDelayedCommit();
         microop->setFlag(IsLoad);
         this->microops.push_back(microop);
@@ -680,8 +687,8 @@ private:
     RegId destRegIdxArr[1];
     RegId srcRegIdxArr[1];
 public:
-    %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -694,10 +701,11 @@ public:
 
 def template VlWholeMicroConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _microVl, uint32_t _microIdx, uint32_t _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                               uint32_t _microIdx, uint32_t _elen,
+                               uint32_t _vlen)
   : %(base_class)s("%(mnemonic)s_micro", _machInst, %(op_class)s, _microVl,
-      _microIdx, _vlen)
+                   _microIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -730,7 +738,6 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(set_vlenb)s;
-    %(set_vlen)s;
     %(ea_code)s;
 
     Fault fault = readMemAtomicLE(xc, traceData, EA,
@@ -783,7 +790,6 @@ Fault
 {
     %(op_decl)s;
     %(op_rd)s;
-    %(set_vlen)s;
 
     STATUS status = xc->readMiscReg(MISCREG_STATUS);
     status.vs = VPUStatus::DIRTY;
@@ -804,8 +810,9 @@ Fault
 
 def template VlStrideConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -826,14 +833,15 @@ def template VlStrideConstructor {{
     for (uint32_t i = 0; i < num_pinvd_microops; i++) {
         uint32_t vdNumElems = (vl >= num_elems_per_vreg*(i+1))
                               ? num_elems_per_vreg : vl-num_elems_per_vreg*i;
-        microop = new VPinVdMicroInst(machInst, i, vdNumElems);
+        microop = new VPinVdMicroInst(machInst, i, vdNumElems, elen, vlen);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
 
     for (int i = 0; micro_vl > 0; ++i) {
         for (int j = 0; j < micro_vl; ++j) {
-            microop = new %(class_name)sMicro(machInst, i, j, micro_vl);
+            microop = new %(class_name)sMicro(machInst, i, j, micro_vl, elen,
+                                              vlen);
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsLoad);
             this->microops.push_back(microop);
@@ -859,7 +867,7 @@ private:
     RegId destRegIdxArr[1];
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
-        uint32_t _microVl);
+                   uint32_t _microVl, uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -872,11 +880,11 @@ public:
 
 def template VlStrideMicroConstructor {{
 
-%(class_name)s::%(class_name)s(
-    ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
-    uint32_t _microVl)
-  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
-        _regIdx, _microIdx, _microVl)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _regIdx,
+                               uint32_t _microIdx, uint32_t _microVl,
+                               uint32_t _elen, uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _regIdx, _microIdx,
+                   _microVl, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -1020,8 +1028,9 @@ Fault
 
 def template VsStrideConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1038,7 +1047,8 @@ def template VsStrideConstructor {{
     }
     for (int i = 0; micro_vl > 0; ++i) {
         for (int j = 0; j < micro_vl; ++j) {
-            microop = new %(class_name)sMicro(machInst, i, j, micro_vl);
+            microop = new %(class_name)sMicro(machInst, i, j, micro_vl, elen,
+                                              vlen);
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsStore);
             this->microops.push_back(microop);
@@ -1064,8 +1074,7 @@ private:
     RegId destRegIdxArr[0];
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
-            uint32_t _microVl);
-
+                   uint32_t _microVl, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
     Fault completeAcc(PacketPtr, ExecContext *,
@@ -1077,11 +1086,11 @@ public:
 
 def template VsStrideMicroConstructor {{
 
-%(class_name)s::%(class_name)s(
-    ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
-    uint32_t _microVl)
-  : %(base_class)s("%(mnemonic)s""_micro", _machInst, %(op_class)s,
-      _regIdx, _microIdx, _microVl)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _regIdx,
+                               uint32_t _microIdx, uint32_t _microVl,
+                               uint32_t _elen, uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s""_micro", _machInst, %(op_class)s, _regIdx,
+                   _microIdx, _microVl, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -1197,8 +1206,9 @@ Fault
 def template VlIndexConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1223,11 +1233,11 @@ template<typename ElemType>
     for (uint32_t i = 0; i < num_pinvdcpyvs_microops; i++) {
         uint32_t vdNumElems = (vl >= vd_vlmax*(i+1)) ? vd_vlmax:vl-vd_vlmax*i;
 
-        microop = new VCpyVsMicroInst(machInst, i, machInst.vs2);
+        microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen, vlen);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
 
-        microop = new VPinVdMicroInst(machInst, i, vdNumElems);
+        microop = new VPinVdMicroInst(machInst, i, vdNumElems, elen, vlen);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
@@ -1238,8 +1248,10 @@ template<typename ElemType>
             uint32_t vs2RegIdx = i / vs2_split_num;
             uint32_t vdElemIdx = j + micro_vlmax * (i % vd_split_num);
             uint32_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
-            microop = new %(class_name)sMicro<ElemType>(machInst,
-                vdRegIdx, vdElemIdx, vs2RegIdx, vs2ElemIdx);
+            microop = new %(class_name)sMicro<ElemType>(machInst, vdRegIdx,
+                                                        vdElemIdx, vs2RegIdx,
+                                                        vs2ElemIdx, elen,
+                                                        vlen);
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsLoad);
             this->microops.push_back(microop);
@@ -1269,7 +1281,8 @@ private:
 public:
     %(class_name)s(ExtMachInst _machInst,
         uint32_t _vdRegIdx, uint32_t _vdElemIdx,
-        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx);
+        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx,
+        uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -1285,9 +1298,9 @@ def template VlIndexMicroConstructor {{
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(
     ExtMachInst _machInst,uint32_t _vdRegIdx, uint32_t _vdElemIdx,
-    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
-  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
-      _vdRegIdx, _vdElemIdx, _vs2RegIdx, _vs2ElemIdx)
+    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx, uint32_t _elen, uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vdRegIdx,
+                   _vdElemIdx, _vs2RegIdx, _vs2ElemIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -1442,8 +1455,9 @@ Fault
 def template VsIndexConstructor {{
 
 template<typename ElemType>
-%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1468,8 +1482,10 @@ template<typename ElemType>
             uint32_t vs2RegIdx = i / vs2_split_num;
             uint32_t vs3ElemIdx = j + micro_vlmax * (i % vs3_split_num);
             uint32_t vs2ElemIdx = j + micro_vlmax * (i % vs2_split_num);
-            microop = new %(class_name)sMicro<ElemType>(machInst,
-                vs3RegIdx, vs3ElemIdx, vs2RegIdx, vs2ElemIdx);
+            microop = new %(class_name)sMicro<ElemType>(machInst, vs3RegIdx,
+                                                        vs3ElemIdx, vs2RegIdx,
+                                                        vs2ElemIdx, elen,
+                                                        vlen);
             microop->setFlag(IsDelayedCommit);
             microop->setFlag(IsStore);
             this->microops.push_back(microop);
@@ -1497,9 +1513,9 @@ private:
     RegId srcRegIdxArr[4];
     RegId destRegIdxArr[0];
 public:
-    %(class_name)s(ExtMachInst _machInst,
-        uint32_t _vs3RegIdx, uint32_t _vs3ElemIdx,
-        uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _vs3RegIdx,
+                   uint32_t _vs3ElemIdx, uint32_t _vs2RegIdx,
+                   uint32_t _vs2ElemIdx, uint32_t _elen, uint32_t _vlen);
 
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
@@ -1514,10 +1530,13 @@ def template VsIndexMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-    uint32_t _vs3RegIdx, uint32_t _vs3ElemIdx,
-    uint32_t _vs2RegIdx, uint32_t _vs2ElemIdx)
-  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s,
-      _vs3RegIdx, _vs3ElemIdx, _vs2RegIdx, _vs2ElemIdx)
+                                         uint32_t _vs3RegIdx,
+                                         uint32_t _vs3ElemIdx,
+                                         uint32_t _vs2RegIdx,
+                                         uint32_t _vs2ElemIdx,
+                                         uint32_t _elen, uint32_t _vlen)
+  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vs3RegIdx,
+                   _vs3ElemIdx, _vs2RegIdx, _vs2ElemIdx, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
@@ -1640,8 +1659,9 @@ Fault
 
 def template VlSegConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1662,7 +1682,9 @@ def template VlSegConstructor {{
             remaining_vl = this->vl;
             micro_vl = std::min(remaining_vl, micro_vlmax);
             for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-                microop = new %(class_name)sMicro(_machInst, micro_vl, i, num_microops, f, NFIELDS, vlen);
+                microop = new %(class_name)sMicro(_machInst, micro_vl, i,
+                                                  num_microops, f, NFIELDS,
+                                                  elen, vlen);
                 microop->setDelayedCommit();
                 microop->setFlag(IsLoad);
                 this->microops.push_back(microop);
@@ -1673,8 +1695,9 @@ def template VlSegConstructor {{
             remaining_vl = this->vl;
             micro_vl = std::min(remaining_vl, micro_vlmax);
             for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-                microop = new VlSegDeIntrlvMicroInst(_machInst, micro_vl, _machInst.vd + i + (f * num_microops),
-                    NFIELDS, i, num_microops, f, vlen, size_per_elem);
+                microop = new VlSegDeIntrlvMicroInst(_machInst, micro_vl,
+                    _machInst.vd + i + (f * num_microops), NFIELDS, i,
+                    num_microops, f, elen, vlen, size_per_elem);
                 this->microops.push_back(microop);
                 micro_vl = std::min(remaining_vl -= micro_vlmax, micro_vlmax);
             }
@@ -1699,8 +1722,9 @@ private:
     uint32_t numFields;
     uint32_t numMicroops;
 public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl, uint32_t _microIdx, uint32_t _numMicroops, uint32_t _field, uint32_t _numFields, uint32_t _vlen);
-
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                   uint32_t _microIdx, uint32_t _numMicroops, uint32_t _field,
+                   uint32_t _numFields, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
     Fault completeAcc(PacketPtr, ExecContext *,
@@ -1712,8 +1736,13 @@ public:
 
 def template VlSegMicroConstructor {{
 
-    %(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl, uint32_t _microIdx, uint32_t _numMicroops, uint32_t _field, uint32_t _numFields, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl, _microIdx , _numMicroops, _field, _numFields, _vlen)
+    %(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                                   uint32_t _microIdx, uint32_t _numMicroops,
+                                   uint32_t _field, uint32_t _numFields,
+                                   uint32_t _elen, uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
+                     _microIdx , _numMicroops, _field, _numFields, _elen,
+                     _vlen)
 {
     %(set_reg_idx_arr)s;
 
@@ -1747,7 +1776,6 @@ Fault
 
     %(op_decl)s;
     %(op_rd)s;
-    %(set_vlen)s;
     %(ea_code)s;
 
     RiscvISA::vreg_t tmp_v0;
@@ -1843,7 +1871,6 @@ Fault
 {
     %(op_decl)s;
     %(op_rd)s;
-    %(set_vlen)s;
 
     STATUS status = xc->readMiscReg(MISCREG_STATUS);
     status.vs = VPUStatus::DIRTY;
@@ -1878,8 +1905,9 @@ Fault
 
 def template VsSegConstructor {{
 
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _vlen)
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                               uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
@@ -1901,7 +1929,7 @@ def template VsSegConstructor {{
             micro_vl = std::min(remaining_vl, micro_vlmax);
             for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
                 microop = new VsSegIntrlvMicroInst(_machInst, micro_vl,
-                    _machInst.vs3, NFIELDS, i, num_microops, f, vlen,
+                    _machInst.vs3, NFIELDS, i, num_microops, f, elen, vlen,
                     size_per_elem);
                 this->microops.push_back(microop);
                 micro_vl = std::min(remaining_vl -= micro_vlmax, micro_vlmax);
@@ -1912,7 +1940,8 @@ def template VsSegConstructor {{
             micro_vl = std::min(remaining_vl, micro_vlmax);
             for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
                 microop = new %(class_name)sMicro(_machInst, micro_vl, i,
-                    num_microops, f, NFIELDS, vlen);
+                                                  num_microops, f, NFIELDS,
+                                                  elen, vlen);
                 microop->setDelayedCommit();
                 microop->setFlag(IsStore);
                 this->microops.push_back(microop);
@@ -1940,9 +1969,8 @@ private:
     uint32_t numMicroops;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-    uint32_t _microIdx, uint32_t _numMicroops, uint32_t _field,
-    uint32_t _numFields, uint32_t _vlen);
-
+                   uint32_t _microIdx, uint32_t _numMicroops, uint32_t _field,
+                   uint32_t _numFields, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
     Fault completeAcc(PacketPtr, ExecContext *,
@@ -1955,10 +1983,11 @@ public:
 def template VsSegMicroConstructor {{
 
     %(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-    uint32_t _microIdx, uint32_t _numMicroops, uint32_t _field,
-    uint32_t _numFields, uint32_t _vlen)
+                                   uint32_t _microIdx, uint32_t _numMicroops,
+                                   uint32_t _field, uint32_t _numFields,
+                                   uint32_t _elen, uint32_t _vlen)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
-    _microIdx, _numMicroops, _field, _numFields, _vlen)
+                     _microIdx, _numMicroops, _field, _numFields, _elen, _vlen)
 {
     %(set_reg_idx_arr)s;
 
@@ -2008,7 +2037,6 @@ Fault
 
     %(op_decl)s;
     %(op_rd)s;
-    %(set_vlen)s;
     %(ea_code)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
@@ -2107,23 +2135,23 @@ Fault
 }};
 
 def template VMemBaseDecodeBlock {{
-    return new %(class_name)s(machInst, vlen);
+    return new %(class_name)s(machInst, elen, vlen);
 }};
 
 def template VMemTemplateDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
     case 0b000: {
-        return new %(class_name)s<uint8_t>(machInst);
+        return new %(class_name)s<uint8_t>(machInst, elen, vlen);
     }
     case 0b001: {
-        return new %(class_name)s<uint16_t>(machInst);
+        return new %(class_name)s<uint16_t>(machInst, elen, vlen);
     }
     case 0b010: {
-        return new %(class_name)s<uint32_t>(machInst);
+        return new %(class_name)s<uint32_t>(machInst, elen, vlen);
     }
     case 0b011: {
-        return new %(class_name)s<uint64_t>(machInst);
+        return new %(class_name)s<uint64_t>(machInst, elen, vlen);
     }
     default: GEM5_UNREACHABLE;
 }
@@ -2134,16 +2162,16 @@ def template VMemSplitTemplateDecodeBlock {{
 
 switch(machInst.vtype8.vsew) {
     case 0b000: {
-        return new %(class_name)s<uint8_t>(machInst, vlen);
+        return new %(class_name)s<uint8_t>(machInst, elen, vlen);
     }
     case 0b001: {
-        return new %(class_name)s<uint16_t>(machInst, vlen);
+        return new %(class_name)s<uint16_t>(machInst, elen, vlen);
     }
     case 0b010: {
-        return new %(class_name)s<uint32_t>(machInst, vlen);
+        return new %(class_name)s<uint32_t>(machInst, elen, vlen);
     }
     case 0b011: {
-        return new %(class_name)s<uint64_t>(machInst, vlen);
+        return new %(class_name)s<uint64_t>(machInst, elen, vlen);
     }
     default: GEM5_UNREACHABLE;
 }

--- a/src/arch/riscv/pcstate.hh
+++ b/src/arch/riscv/pcstate.hh
@@ -65,23 +65,20 @@ class PCState : public GenericISA::UPCState<4>
 
     bool _compressed = false;
     RiscvType _rvType = RV64;
-    uint64_t _vlenb = 32;
     VTYPE _vtype = (1ULL << 63); // vtype.vill = 1 at initial;
     uint32_t _vl = 0;
 
   public:
     PCState(const PCState &other) : Base(other),
-        _rvType(other._rvType), _vlenb(other._vlenb),
-        _vtype(other._vtype), _vl(other._vl)
+        _rvType(other._rvType), _vtype(other._vtype), _vl(other._vl)
     {}
     PCState &operator=(const PCState &other) = default;
     PCState() = default;
     explicit PCState(Addr addr) { set(addr); }
-    explicit PCState(Addr addr, RiscvType rvType, uint64_t vlenb)
+    explicit PCState(Addr addr, RiscvType rvType)
     {
         set(addr);
         _rvType = rvType;
-        _vlenb = vlenb;
     }
 
     PCStateBase *clone() const override { return new PCState(*this); }
@@ -93,7 +90,6 @@ class PCState : public GenericISA::UPCState<4>
         auto &pcstate = other.as<PCState>();
         _compressed = pcstate._compressed;
         _rvType = pcstate._rvType;
-        _vlenb = pcstate._vlenb;
         _vtype = pcstate._vtype;
         _vl = pcstate._vl;
     }
@@ -103,9 +99,6 @@ class PCState : public GenericISA::UPCState<4>
 
     void rvType(RiscvType rvType) { _rvType = rvType; }
     RiscvType rvType() const { return _rvType; }
-
-    void vlenb(uint64_t v) { _vlenb = v; }
-    uint64_t vlenb() const { return _vlenb; }
 
     void vtype(VTYPE v) { _vtype = v; }
     VTYPE vtype() const { return _vtype; }
@@ -126,7 +119,6 @@ class PCState : public GenericISA::UPCState<4>
     {
         auto &opc = other.as<PCState>();
         return Base::equals(other) &&
-            _vlenb == opc._vlenb &&
             _vtype == opc._vtype &&
             _vl == opc._vl;
     }
@@ -136,7 +128,6 @@ class PCState : public GenericISA::UPCState<4>
     {
         Base::serialize(cp);
         SERIALIZE_SCALAR(_rvType);
-        SERIALIZE_SCALAR(_vlenb);
         SERIALIZE_SCALAR(_vtype);
         SERIALIZE_SCALAR(_vl);
         SERIALIZE_SCALAR(_compressed);
@@ -147,7 +138,6 @@ class PCState : public GenericISA::UPCState<4>
     {
         Base::unserialize(cp);
         UNSERIALIZE_SCALAR(_rvType);
-        UNSERIALIZE_SCALAR(_vlenb);
         UNSERIALIZE_SCALAR(_vtype);
         UNSERIALIZE_SCALAR(_vl);
         UNSERIALIZE_SCALAR(_compressed);


### PR DESCRIPTION
This refactor attempts to homogenize all riscv's vector (macro/micro) instruction classes so that ELEN and VLEN are guaranteed to be a class attribute. Since both are constant, all instructions will get it on the decoding process passed through to their vector base class.

This allows the removal of VLEN in the PC state and also in some constructor default parameters (solves issue #1207).

Change-Id: I6f0471004335f49b00b015c37e95dc7f9569e303