### PR TITLE
util-docker: Move `LABEL` to after image import

### DIFF
--- a/util/dockerfiles/clang-compiler/Dockerfile
+++ b/util/dockerfiles/clang-compiler/Dockerfile
@@ -1,8 +1,8 @@
+FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies for gem5, with Clang 16."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 ARG version=16 # Version of Clang to install in this image. Default is 16.
 

--- a/util/dockerfiles/devcontainer/Dockerfile
+++ b/util/dockerfiles/devcontainer/Dockerfile
@@ -29,10 +29,6 @@
 # container that can be built for x86, arm, and riscv and includes all
 # dependencies required for gem5 development.
 
-LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="This Dockerfile creates a devcontainer for gem5 development referenced in ./devcontainer/devcontainer.json. The devcontainer is a multi-platform container that can be built for x86, arm, and riscv and includes all dependencies required for gem5 development."
-LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
 # As this is a multi-platform image, we must build it using the
 # "docker-bake.hcl" specification via `docker buildx`. To do so, execute the
 # following:
@@ -44,6 +40,11 @@ LABEL org.opencontainers.image.licenses=BSD-3-Clause
 # there is a pre-built gem5 binary in each devcontainer. This can save time
 # if the container is used for education or demonstration purposes.
 FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest as builder
+
+LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
+LABEL org.opencontainers.image.description="This Dockerfile creates a devcontainer for gem5 development referenced in ./devcontainer/devcontainer.json. The devcontainer is a multi-platform container that can be built for x86, arm, and riscv and includes all dependencies required for gem5 development."
+LABEL org.opencontainers.image.licenses=BSD-3-Clause
+
 RUN wget https://github.com/gem5/gem5/archive/refs/tags/v24.0.tar.gz && \
     tar xzf v24.0.tar.gz && mv gem5-24.0 gem5 && rm v24.0.tar.gz
 WORKDIR /gem5

--- a/util/dockerfiles/gcc-compiler/Dockerfile
+++ b/util/dockerfiles/gcc-compiler/Dockerfile
@@ -1,8 +1,8 @@
+FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies for gem5, with GCC 13."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 ARG version=13 # Version of GCC to install in this image. Default is 13.
 

--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -24,11 +24,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+FROM --platform=${BUILDPLATFORM} ubuntu:20.04
+
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="This dockerfile contains all the dependences necessary to run GPU applications in gem5 using the gcn5 (Vega) APU model."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
-FROM --platform=${BUILDPLATFORM} ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt -y update && \

--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -27,11 +27,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04
+
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="The Dockerfile in this directory is used to build applications to be run with GPU full system. Applications targeting AMD's ROCm GPU framework can be built using this docker (e.g., HIP, HSA, OpenCL, etc.)."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
-FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \
     apt -y install build-essential git m4 scons zlib1g zlib1g-dev \

--- a/util/dockerfiles/sst/Dockerfile
+++ b/util/dockerfiles/sst/Dockerfile
@@ -23,13 +23,11 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile for using SST with gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 # Setting the environmental variables
 ENV PATH=$PATH:$SST_CORE_HOME/bin

--- a/util/dockerfiles/systemc/Dockerfile
+++ b/util/dockerfiles/systemc/Dockerfile
@@ -23,13 +23,10 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
+FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile for using SystemC with gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 ENV CXX="g++"
 ENV CXXFLAGS="-std=c++17"

--- a/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
@@ -23,13 +23,11 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 22.04 docker image with all dependencies required for building and using gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \

--- a/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
@@ -23,13 +23,11 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+FROM --platform=${BUILDPLATFORM} ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies required for building and using gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && apt -y install \

--- a/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile
@@ -23,13 +23,11 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+FROM --platform=${BUILDPLATFORM} ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with minimal dependencies required for building and using gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
-
-FROM --platform=${BUILDPLATFORM} ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \


### PR DESCRIPTION
A Dockerfile must start with the importation of a docker base image. It is only after this point that `LABEL` be provided. Having `LABEL` at the top of the Dockerfiles resulted in the Docker images failing to build.

Change-Id: I7213fb1cf01dc004ec91e58c21e4fc17f0b68aa8