### PR TITLE
python: Redirect into correct subdirectory when using -re with multisim

### DIFF
--- a/src/python/gem5/utils/multiprocessing/_command_line.py
+++ b/src/python/gem5/utils/multiprocessing/_command_line.py
@@ -70,7 +70,8 @@ def _gem5_args_for_multiprocessing(name):
     arguments = [
         # Keep the original outdir. This will be overridden by multisim
         f"--outdir={options.outdir}",
-        # Update the stdout and stderr names so we can see them.
+        # Update the stdout and stderr names so we can see them. These will be
+        # overridden by multisim
         f"--stdout-file={name}_{options.stdout_file}",
         f"--stderr-file={name}_{options.stderr_file}",
         # Keep the stats file name. It will be in the new outdir

--- a/src/python/gem5/utils/multisim/multisim.py
+++ b/src/python/gem5/utils/multisim/multisim.py
@@ -57,6 +57,8 @@ from typing import (
     Set,
 )
 
+from m5.core import override_re_outdir
+
 # A global variable which __main__.py flips to `True` when multisim is run as
 # an executable module.
 module_run = False
@@ -168,6 +170,8 @@ def _run(module_path: Path, id: str) -> None:
 
     subdir = Path(Path(m5.options.outdir) / Path(sim_list[0].get_id()))
     sim_list[0].override_outdir(subdir)
+    # This doesn't do anything if none of the redirect options are passed
+    override_re_outdir(subdir)
 
     sim_list[0].run()
 

--- a/src/python/m5/core.py
+++ b/src/python/m5/core.py
@@ -36,5 +36,35 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+import sys
+from pathlib import Path
+
+import m5
+
 from _m5.core import setOutputDir
 from _m5.loader import setInterpDir
+
+"""
+This function is meant to have a similar functionality to override_outdir in
+src/python/gem5/simulate/simulator.py. It changes the output directory for
+simerr.txt and simout.txt, which are generated when the -re flag is passed to
+gem5 in the command line. This function is primarily for use with multisim.
+
+Code copied and adapted from main.py
+"""
+
+
+def override_re_outdir(new_outdir):
+    options = m5.options
+
+    stdout_file = Path(new_outdir) / "stdout.txt"
+    stderr_file = Path(new_outdir) / "stderr.txt"
+    if options.redirect_stdout:
+        redir_fd = os.open(stdout_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+        os.dup2(redir_fd, sys.stdout.fileno())
+        if not options.redirect_stderr:
+            os.dup2(redir_fd, sys.stderr.fileno())
+    if options.redirect_stderr:
+        redir_fd = os.open(stderr_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+        os.dup2(redir_fd, sys.stderr.fileno())

--- a/src/python/m5/main.py
+++ b/src/python/m5/main.py
@@ -409,30 +409,36 @@ def main():
     if not os.path.isdir(options.outdir):
         os.makedirs(options.outdir)
 
-    # These filenames are used only if the redirect_std* options are set
-    stdout_file = os.path.join(options.outdir, options.stdout_file)
-    stderr_file = os.path.join(options.outdir, options.stderr_file)
+    # simout.txt and simerr.txt for multisim are created in
+    # src/python/m5/core.py. We skip creating them here to avoid generating
+    # extra files.
+    if not (options.c and "multiprocessing" in options.c[0]):
+        # These filenames are used only if the redirect_std* options are set
+        stdout_file = os.path.join(options.outdir, options.stdout_file)
+        stderr_file = os.path.join(options.outdir, options.stderr_file)
 
-    if not options.silent_redirect:
-        # Print redirection notices here before doing any redirection
-        if options.redirect_stdout and not options.redirect_stderr:
-            print("Redirecting stdout and stderr to", stdout_file)
-        else:
-            if options.redirect_stdout:
-                print("Redirecting stdout to", stdout_file)
-            if options.redirect_stderr:
-                print("Redirecting stderr to", stderr_file)
-
-    # Now redirect stdout/stderr as desired
-    if options.redirect_stdout:
-        redir_fd = os.open(stdout_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
-        os.dup2(redir_fd, sys.stdout.fileno())
-        if not options.redirect_stderr:
+        if not options.silent_redirect:
+            # Print redirection notices here before doing any redirection
+            if options.redirect_stdout and not options.redirect_stderr:
+                print("Redirecting stdout and stderr to", stdout_file)
+            else:
+                if options.redirect_stdout:
+                    print("Redirecting stdout to", stdout_file)
+                if options.redirect_stderr:
+                    print("Redirecting stderr to", stderr_file)
+        # Now redirect stdout/stderr as desired
+        if options.redirect_stdout:
+            redir_fd = os.open(
+                stdout_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            )
+            os.dup2(redir_fd, sys.stdout.fileno())
+            if not options.redirect_stderr:
+                os.dup2(redir_fd, sys.stderr.fileno())
+        if options.redirect_stderr:
+            redir_fd = os.open(
+                stderr_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            )
             os.dup2(redir_fd, sys.stderr.fileno())
-
-    if options.redirect_stderr:
-        redir_fd = os.open(stderr_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
-        os.dup2(redir_fd, sys.stderr.fileno())
 
     done = False
 


### PR DESCRIPTION
Previously, when passing the -re option while using multisim, the files simerr.txt and simout.txt would be redirected into the m5out directory instead of the correct subdirectory. They would also have a name of the format
Spawn_gem5PoolWorker-some-integer_(simout|simerr).txt, which doesn't indicate which simulation the files correspond to.

This commit fixes these issues by redirecting simerr.txt and simout.txt into the correct subdirectory.

Change-Id: I0a25a9fd8dc672949f5f85fc5ca6452529301a73