### PR TITLE
arch-riscv: Change the packed data of GdbRegCache to protected

### DIFF
--- a/src/arch/riscv/remote_gdb.hh
+++ b/src/arch/riscv/remote_gdb.hh
@@ -63,7 +63,7 @@ class RemoteGDB : public BaseRemoteGDB
     class Riscv32GdbRegCache : public BaseGdbRegCache
     {
       using BaseGdbRegCache::BaseGdbRegCache;
-      private:
+      protected:
         /**
          * RISC-V Register Cache
          * Order and sizes of registers found in ext/gdb-xml/riscv.xml
@@ -149,7 +149,7 @@ class RemoteGDB : public BaseRemoteGDB
     class Riscv64GdbRegCache : public BaseGdbRegCache
     {
       using BaseGdbRegCache::BaseGdbRegCache;
-      private:
+      protected:
         /**
          * RISC-V Register Cache
          * Order and sizes of registers found in ext/gdb-xml/riscv.xml


### PR DESCRIPTION
Change it to protected to enable access the packed data from derived RiscvGdbRegCache class

Change-Id: Ib33732642914ad367773c3fa45adaf6dfdeb248d