### PR TITLE
port: Make binding-related functions virtual

### DIFF
--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -156,12 +156,12 @@ class RequestPort: public Port, public AtomicRequestProtocol,
      * Bind this request port to a response port. This also does the
      * mirror action and binds the response port to the request port.
      */
-    void bind(Port &peer) override;
+    virtual void bind(Port &peer) override;
 
     /**
      * Unbind this request port and the associated response port.
      */
-    void unbind() override;
+    virtual void unbind() override;
 
     /**
      * Determine if this request port is snooping or not. The default
@@ -391,8 +391,8 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
     /**
      * We let the request port do the work, so these don't do anything.
      */
-    void unbind() override {}
-    void bind(Port &peer) override {}
+    void virtual unbind() override {}
+    void virtual bind(Port &peer) override {}
 
   public:
     /* The atomic protocol. */

--- a/src/sim/signal.hh
+++ b/src/sim/signal.hh
@@ -76,7 +76,7 @@ class SignalSinkPort : public Port
     void onChange(OnChangeFunc func) { _onChange = std::move(func); }
 
     void
-    bind(Port &peer) override
+    virtual bind(Port &peer) override
     {
         _source = dynamic_cast<SignalSourcePort<State> *>(&peer);
         fatal_if(!_source, "Attempt to bind signal pin %s to "
@@ -86,7 +86,7 @@ class SignalSinkPort : public Port
         Port::bind(peer);
     }
     void
-    unbind() override
+    virtual unbind() override
     {
         _source = nullptr;
         Port::unbind();
@@ -127,7 +127,7 @@ class SignalSourcePort : public Port
     const State &state() const { return _state; }
 
     void
-    bind(Port &peer) override
+    virtual bind(Port &peer) override
     {
         sink = dynamic_cast<SignalSinkPort<State> *>(&peer);
         fatal_if(!sink, "Attempt to bind signal pin %s to "
@@ -135,7 +135,7 @@ class SignalSourcePort : public Port
         Port::bind(peer);
     }
     void
-    unbind() override
+    virtual unbind() override
     {
         sink = nullptr;
         Port::unbind();


### PR DESCRIPTION
It would be useful if developer can have logs, or put wrapped monitors in their derived ports when they are bound. This commit makes the binding-related functions of Request/Response Port and SignalPort virtual.

Change-Id: I55c65267eba14793f1c102ab048e2e3044974d0f