### PR TITLE
DRAFT/REFERENCE: gem5 Bridge Driver with Read/Write Op Devices

### DIFF
--- a/util/gem5_bridge_all_ops/Makefile
+++ b/util/gem5_bridge_all_ops/Makefile
@@ -1,5 +1,5 @@
 DRIVER  := gem5_bridge
-SOURCES := gem5_bridge gem5_ops
+SOURCES := gem5_bridge gem5_ops gem5_poke
 GROUP   := gem5
 
 ifneq ($(KERNELRELEASE),)

--- a/util/gem5_bridge_all_ops/Makefile
+++ b/util/gem5_bridge_all_ops/Makefile
@@ -1,8 +1,10 @@
-DRIVER := gem5_bridge
-GROUP  := gem5
+DRIVER  := gem5_bridge
+SOURCES := gem5_bridge gem5_ops
+GROUP   := gem5
 
 ifneq ($(KERNELRELEASE),)
-obj-m += $(DRIVER).o
+obj-m := $(DRIVER).o
+$(DRIVER)-objs := $(addprefix ./src/,$(addsuffix .o,$(SOURCES)))
 
 # Build Parameters:
 # - GEM5OPS_BASE : base physical address of gem5ops MMIO range

--- a/util/gem5_bridge_all_ops/Makefile
+++ b/util/gem5_bridge_all_ops/Makefile
@@ -1,0 +1,40 @@
+DRIVER := gem5_bridge
+GROUP  := gem5
+
+ifneq ($(KERNELRELEASE),)
+obj-m += $(DRIVER).o
+
+# Build Parameters:
+# - GEM5OPS_BASE : base physical address of gem5ops MMIO range
+# - GEM5OPS_SIZE : size of gem5ops MMIO range
+ifneq ($(GEM5OPS_BASE),)
+ccflags-y += -DGEM5OPS_BASE=$(GEM5OPS_BASE)
+endif
+ifneq ($(GEM5OPS_SIZE),)
+ccflags-y += -DGEM5OPS_SIZE=$(GEM5OPS_SIZE)
+endif
+
+else
+PWD         ?= $(shell pwd)
+KVERSION    ?= $(shell uname -r)
+KMAKEDIR    ?= /lib/modules/$(KVERSION)/build
+MODLOADCONF ?= /etc/modules-load.d/$(GROUP).conf
+
+.PHONY: build
+build:
+	make -C $(KMAKEDIR) M=$(PWD) modules
+
+.PHONY: install
+install:
+	make -C $(KMAKEDIR) M=$(PWD) INSTALL_MOD_DIR=$(GROUP) modules_install
+	# May need to manually run `depmod --quick` after this
+
+.PHONY: autoload
+autoload:
+	echo $(DRIVER) >> $(MODLOADCONF)
+
+.PHONY: clean
+clean:
+	make -C $(KMAKEDIR) M=$(PWD) clean
+
+endif

--- a/util/gem5_bridge_all_ops/Makefile
+++ b/util/gem5_bridge_all_ops/Makefile
@@ -6,16 +6,6 @@ ifneq ($(KERNELRELEASE),)
 obj-m := $(DRIVER).o
 $(DRIVER)-objs := $(addprefix ./src/,$(addsuffix .o,$(SOURCES)))
 
-# Build Parameters:
-# - GEM5OPS_BASE : base physical address of gem5ops MMIO range
-# - GEM5OPS_SIZE : size of gem5ops MMIO range
-ifneq ($(GEM5OPS_BASE),)
-ccflags-y += -DGEM5OPS_BASE=$(GEM5OPS_BASE)
-endif
-ifneq ($(GEM5OPS_SIZE),)
-ccflags-y += -DGEM5OPS_SIZE=$(GEM5OPS_SIZE)
-endif
-
 else
 PWD         ?= $(shell pwd)
 KVERSION    ?= $(shell uname -r)
@@ -29,11 +19,7 @@ build:
 .PHONY: install
 install:
 	make -C $(KMAKEDIR) M=$(PWD) INSTALL_MOD_DIR=$(GROUP) modules_install
-	# May need to manually run `depmod --quick` after this
-
-.PHONY: autoload
-autoload:
-	echo $(DRIVER) >> $(MODLOADCONF)
+	# May need to manually run `depmod --quick` before running `modprobe`
 
 .PHONY: clean
 clean:

--- a/util/gem5_bridge_all_ops/gem5_bridge.c
+++ b/util/gem5_bridge_all_ops/gem5_bridge.c
@@ -1,0 +1,165 @@
+#include <linux/err.h>
+#include <linux/init.h>
+#include <linux/io.h>
+#include <linux/kernel.h>
+#include <linux/miscdevice.h>
+#include <linux/mm.h>
+#include <linux/module.h>
+#include <linux/string.h>
+#include <linux/uaccess.h>
+
+/* ========================================================================= *
+ * Constants
+ * ========================================================================= */
+
+/* Device information */
+#define DEV_NAME "gem5_bridge"
+#define DEV_MODE ((umode_t)0666) /* All users have RW access to this device */
+
+/* Physical address for base of gem5ops MMIO range */
+#ifndef GEM5OPS_BASE
+#define GEM5OPS_BASE 0xffff0000 /* default, also used for x86 */
+#endif
+
+/* Size of gem5ops MMIO range */
+#ifndef GEM5OPS_SIZE
+#define GEM5OPS_SIZE 0x10000
+#endif
+
+/* ========================================================================= *
+ * Global Variables
+ * ========================================================================= */
+
+static void __iomem *gem5_bridge_mmio;
+
+/* ========================================================================= *
+ * File Operations
+ * ========================================================================= */
+
+static int gem5_bridge_open(struct inode *inode, struct file *file)
+{
+    pr_info("gem5_bridge_open: SUCCESS!\n");
+    return 0;
+}
+
+static int gem5_bridge_release(struct inode *inode, struct file *file)
+{
+    pr_info("gem5_bridge_release: SUCCESS!\n");
+    return 0;
+}
+
+static int gem5_bridge_mmap(struct file *file, struct vm_area_struct *vma)
+{
+    unsigned long vm_size = vma->vm_end - vma->vm_start + vma->vm_pgoff;
+    unsigned long gem5_bridge_pfn = GEM5OPS_BASE >> PAGE_SHIFT;
+
+    if (vm_size > GEM5OPS_SIZE) {
+        pr_info("gem5_bridge_mmap: requested memory range is too large\n");
+        return -EINVAL;
+    }
+
+    /* Map the virtual memory area to our gem5 ops MMIO range */
+    if (io_remap_pfn_range(
+            vma, vma->vm_start, gem5_bridge_pfn, vm_size, vma->vm_page_prot
+    )) {
+        pr_info("gem5_bridge_mmap: failed to remap vm area to phys addr\n");
+        return -EAGAIN;
+    }
+
+    pr_info("gem5_bridge_mmap: SUCCESS!\n");
+    return 0;
+}
+
+#if 0 /* !!! DISABLED !!! */
+/* This function is disabled, but still included to show how one can directly
+ * cause this driver to trigger MMIO traps. Included so far is the ability to
+ * detect when "exit" has been written to the device node and, once detected,
+ * a memory request is made to the address that gem5 will detect as an m5exit
+ * operation. Currently, there is no implementation of the m5op arguments which
+ * prevents this from being functional in this state as the delay argument will
+ * be undefined and could cause the simulation to crash. */
+static ssize_t gem5_bridge_write(struct file *file, const char *ubuf,
+                                    size_t count, loff_t *offp)
+{
+    static char kbuf[1024];
+
+    if (copy_from_user(kbuf, ubuf, count) > 0) {
+        pr_err("gem5_bridge_write: unknown error when copying user buffer\n");
+        return -EINVAL; /* @TODO: find better error code */
+    }
+
+    if (!strncmp(kbuf, "exit", 5)) {
+        pr_info("gem5_bridge_write: EXIT command\n");
+        /* @TODO: setup arguments, right now it does not work */
+        /* Kernel may have been built for 32-bit addresses, in which case we
+         * do not have access to `ioread64`. However, we know that this MMIO
+         * access will reach KVM and it will expect a 64-bit request so we
+         * just force it explicitly here. */
+        *(volatile u64 __force *)(gem5_bridge_mmio + 0x2100);
+    } else {
+        pr_err("gem5_bridge_write: unknown command = %s\n", ubuf);
+        return -EINVAL;
+    }
+
+    pr_info("gem5_bridge_write: SUCCESS!\n");
+    return count;
+}
+#endif /* !!! DISABLED !!! */
+
+static struct file_operations gem5_bridge_fops = {
+    .owner      = THIS_MODULE,
+    .open       = gem5_bridge_open,
+    .release    = gem5_bridge_release,
+    .mmap       = gem5_bridge_mmap,
+//    .write      = gem5_bridge_write,
+};
+
+/* ========================================================================= *
+ * Module Initialization + Destruction
+ * ========================================================================= */
+
+static struct miscdevice gem5_bridge_miscdevice = {
+    .minor = MISC_DYNAMIC_MINOR,
+    .name = DEV_NAME,
+    .mode = DEV_MODE,
+    .fops = &gem5_bridge_fops,
+};
+
+static int __init gem5_bridge_init(void)
+{
+    /* Make virtual mapping to physical MMIO address */
+    gem5_bridge_mmio = ioremap(GEM5OPS_BASE, GEM5OPS_SIZE);
+    if (gem5_bridge_mmio < 0) {
+        pr_err("gem5_bridge_init: failed to map gem5ops MMIO range\n");
+        goto error_mmio;
+    }
+
+    /* Register misc device */
+    if (misc_register(&gem5_bridge_miscdevice) < 0) {
+        pr_err("gem5_bridge_init: failed to register misc device\n");
+        goto error_misc_register;
+    }
+
+    pr_info("gem5_bridge_init: SUCCESS!\n");
+    return 0;
+
+error_misc_register:
+    iounmap(gem5_bridge_mmio);
+error_mmio:
+    return -1;
+}
+
+static void __exit gem5_bridge_exit(void)
+{
+    /* Undo all allocations and registrations in reverse order */
+    misc_deregister(&gem5_bridge_miscdevice);
+    iounmap(gem5_bridge_mmio);
+    pr_info("gem5_bridge_exit: SUCCESS!\n");
+}
+
+module_init(gem5_bridge_init);
+module_exit(gem5_bridge_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Noah Krim");
+MODULE_DESCRIPTION("Diver that provides user-space mapping to MMIO range");

--- a/util/gem5_bridge_all_ops/gem5_bridge.c
+++ b/util/gem5_bridge_all_ops/gem5_bridge.c
@@ -1,12 +1,42 @@
+#include <linux/cdev.h>
+#include <linux/device.h>
 #include <linux/err.h>
+#include <linux/fs.h>
 #include <linux/init.h>
 #include <linux/io.h>
+#include <linux/kdev_t.h>
 #include <linux/kernel.h>
-#include <linux/miscdevice.h>
+#include <linux/kstrtox.h>
 #include <linux/mm.h>
 #include <linux/module.h>
 #include <linux/string.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
+
+/* ========================================================================= *
+ * gem5_bridge Device Configuration
+ * ========================================================================= */
+
+struct gem5_bridge_dev_config
+{
+    /* @TODO: Still needs required fields for functionality */
+    const char *name;
+    u8 opcode;
+    int num_args;
+};
+static struct gem5_bridge_dev_config config_list[] = {
+    { .name = "bridge" /* bridge has no config, can only mmap */ },
+    { .name = "exit", .opcode=0x21, .num_args = 1 },
+};
+enum gem5_bridge_op
+{
+    /* Op enum values must match connected device indices in `config_list` */
+    GEM5_EXIT = 1,
+};
+
+/* Just helpful for printing */
+#define PATH "/dev/gem5/"
+
 
 /* ========================================================================= *
  * Constants
@@ -15,6 +45,7 @@
 /* Device information */
 #define DEV_NAME "gem5_bridge"
 #define DEV_MODE ((umode_t)0666) /* All users have RW access to this device */
+#define DEV_COUNT ARRAY_SIZE(config_list)
 
 /* Physical address for base of gem5ops MMIO range */
 #ifndef GEM5OPS_BASE
@@ -26,11 +57,69 @@
 #define GEM5OPS_SIZE 0x10000
 #endif
 
+
 /* ========================================================================= *
  * Global Variables
  * ========================================================================= */
 
+/* gem5 bridge */
 static void __iomem *gem5_bridge_mmio;
+static u16 gem5_bridge_nextop;
+
+/* Device information */
+static dev_t dev_number;
+static struct class *dev_class;
+static struct cdev cdev_list[DEV_COUNT];
+
+
+/* ========================================================================= *
+ * Utility
+ * ========================================================================= */
+
+static int gem5_bridge_search(const char *dev_name) {
+    int i;
+    for (i = 0; i < DEV_COUNT; ++i) {
+        if (!strcmp(dev_name, config_list[i].name)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/* Returns a pointer to the first buffer position after the parsed ints,
+ * or NULL on error */
+static char *gem5_bridge_parse_ints(int numargs, char *buff, uint64_t *outargs)
+{
+    int i;
+    char *bufp = buff; /* Need a local pointer that can be modified */
+    char *tok;
+    for (i = 0; i < numargs; ++i) {
+        do {
+            if (!bufp[0]) /* End of buffer */
+                break;
+            tok = strsep(&bufp, " ");
+        } while (!tok[0]); /* Skip long chains of whitespace */
+        if (kstrtou64(tok, 10, &outargs[i]) < 0) {
+            pr_err("%s: failed parsing int from \"%s\"\n", __func__, tok);
+            return NULL;
+        }
+    }
+    if (i < numargs)
+        return NULL;
+    return bufp;
+}
+
+/* Kernel may have been built for 32-bit addresses, in which case we
+ * do not have access to `ioread64`. However, we know that this MMIO
+ * access will reach KVM and it will expect a 64-bit request so we
+ * just force it explicitly here. */
+#define POKE \
+    *(volatile u64 __force *)(gem5_bridge_mmio + (gem5_bridge_nextop << 8))
+
+static void gem5_bridge_poke_int(int a) {
+    POKE;
+}
+
 
 /* ========================================================================= *
  * File Operations
@@ -38,39 +127,51 @@ static void __iomem *gem5_bridge_mmio;
 
 static int gem5_bridge_open(struct inode *inode, struct file *file)
 {
-    pr_info("gem5_bridge_open: SUCCESS!\n");
+    pr_info("%s: SUCCESS!\n", __func__);
     return 0;
 }
 
 static int gem5_bridge_release(struct inode *inode, struct file *file)
 {
-    pr_info("gem5_bridge_release: SUCCESS!\n");
+    pr_info("%s: SUCCESS!\n", __func__);
     return 0;
 }
 
-static int gem5_bridge_mmap(struct file *file, struct vm_area_struct *vma)
+static int gem5_bridge_mmap(struct file *filp, struct vm_area_struct *vma)
 {
     unsigned long vm_size = vma->vm_end - vma->vm_start + vma->vm_pgoff;
     unsigned long gem5_bridge_pfn = GEM5OPS_BASE >> PAGE_SHIFT;
+    const char *file_name = filp->f_path.dentry->d_iname;
+    int dev_i = gem5_bridge_search(file_name);
+
+    if (dev_i < 0) {
+        pr_err("%s: unsupported device node "PATH"%s\n", __func__, file_name);
+        return -EINVAL;
+    }
+
+    if (dev_i != 0) {
+        pr_err("%s: mmap unsupported for "PATH"%s, only works with /dev/%s\n",
+                __func__, config_list[dev_i].name, config_list[0].name);
+        return -EINVAL;
+    }
 
     if (vm_size > GEM5OPS_SIZE) {
-        pr_info("gem5_bridge_mmap: requested memory range is too large\n");
+        pr_err("%s: requested memory range is too large\n", __func__);
         return -EINVAL;
     }
 
     /* Map the virtual memory area to our gem5 ops MMIO range */
-    if (io_remap_pfn_range(
-            vma, vma->vm_start, gem5_bridge_pfn, vm_size, vma->vm_page_prot
-    )) {
-        pr_info("gem5_bridge_mmap: failed to remap vm area to phys addr\n");
+    if (io_remap_pfn_range(vma, vma->vm_start, gem5_bridge_pfn,
+                            vm_size, vma->vm_page_prot))
+    {
+        pr_err("%s: failed to remap vm area to phys addr\n", __func__);
         return -EAGAIN;
     }
 
-    pr_info("gem5_bridge_mmap: SUCCESS!\n");
+    pr_info("%s: SUCCESS!\n", __func__);
     return 0;
 }
 
-#if 0 /* !!! DISABLED !!! */
 /* This function is disabled, but still included to show how one can directly
  * cause this driver to trigger MMIO traps. Included so far is the ability to
  * detect when "exit" has been written to the device node and, once detected,
@@ -78,83 +179,163 @@ static int gem5_bridge_mmap(struct file *file, struct vm_area_struct *vma)
  * operation. Currently, there is no implementation of the m5op arguments which
  * prevents this from being functional in this state as the delay argument will
  * be undefined and could cause the simulation to crash. */
-static ssize_t gem5_bridge_write(struct file *file, const char *ubuf,
+#define WRITE_BUFF_SIZE 1024
+static ssize_t gem5_bridge_write(struct file *filp, const char *ubuff,
                                     size_t count, loff_t *offp)
 {
-    static char kbuf[1024];
+    static char kbuff[WRITE_BUFF_SIZE];
+    static u64 intargs[2];
+    char *kbufp = kbuff;
 
-    if (copy_from_user(kbuf, ubuf, count) > 0) {
-        pr_err("gem5_bridge_write: unknown error when copying user buffer\n");
-        return -EINVAL; /* @TODO: find better error code */
-    }
+    const char *file_name = filp->f_path.dentry->d_iname;
+    int dev_i = gem5_bridge_search(file_name);
 
-    if (!strncmp(kbuf, "exit", 5)) {
-        pr_info("gem5_bridge_write: EXIT command\n");
-        /* @TODO: setup arguments, right now it does not work */
-        /* Kernel may have been built for 32-bit addresses, in which case we
-         * do not have access to `ioread64`. However, we know that this MMIO
-         * access will reach KVM and it will expect a 64-bit request so we
-         * just force it explicitly here. */
-        *(volatile u64 __force *)(gem5_bridge_mmio + 0x2100);
-    } else {
-        pr_err("gem5_bridge_write: unknown command = %s\n", ubuf);
+    if (count >= WRITE_BUFF_SIZE) {
+        pr_err("%s: write content reaches or exceeds buffer size of %d\n",
+                __func__, WRITE_BUFF_SIZE);
         return -EINVAL;
     }
 
-    pr_info("gem5_bridge_write: SUCCESS!\n");
+    if (copy_from_user(kbuff, ubuff, count) > 0) {
+        pr_err("%s: unknown error when copying user buffer\n", __func__);
+        return -EINVAL; /* @TODO: find better error code */
+    }
+
+    if (dev_i < 0) {
+        pr_err("%s: unsupported device node "PATH"%s\n", __func__, file_name);
+        return -EINVAL;
+    }
+
+    switch ((enum gem5_bridge_op)dev_i) {
+    case GEM5_EXIT:
+        kbufp = gem5_bridge_parse_ints(1, kbufp, intargs);
+        pr_info("%s: op=exit, args=%llu\n", __func__, intargs[0]);
+        gem5_bridge_nextop = config_list[dev_i].opcode;
+        gem5_bridge_poke_int(intargs[0]);
+        break;
+    default:
+        pr_err("%s: write unsupported for "PATH"%s",
+                __func__, config_list[dev_i].name);
+        return -EINVAL;
+    }
+
+    pr_info("%s: SUCCESS!\n", __func__);
     return count;
 }
-#endif /* !!! DISABLED !!! */
 
 static struct file_operations gem5_bridge_fops = {
     .owner      = THIS_MODULE,
     .open       = gem5_bridge_open,
     .release    = gem5_bridge_release,
     .mmap       = gem5_bridge_mmap,
-//    .write      = gem5_bridge_write,
+    .write      = gem5_bridge_write,
 };
+
 
 /* ========================================================================= *
  * Module Initialization + Destruction
  * ========================================================================= */
 
-static struct miscdevice gem5_bridge_miscdevice = {
-    .minor = MISC_DYNAMIC_MINOR,
-    .name = DEV_NAME,
-    .mode = DEV_MODE,
-    .fops = &gem5_bridge_fops,
-};
+static int gem5_bridge_uevent(struct device *dev, struct kobj_uevent_env *env)
+{
+    add_uevent_var(env, "DEVMODE=%#o", DEV_MODE);
+    return 0;
+}
 
 static int __init gem5_bridge_init(void)
 {
+    int error;
+    int cdev_i;
+    dev_t cdev_number;
+    struct device *devp;
+
     /* Make virtual mapping to physical MMIO address */
     gem5_bridge_mmio = ioremap(GEM5OPS_BASE, GEM5OPS_SIZE);
     if (gem5_bridge_mmio < 0) {
-        pr_err("gem5_bridge_init: failed to map gem5ops MMIO range\n");
-        goto error_mmio;
+        pr_err("%s: failed to map gem5ops MMIO range\n", __func__);
+        goto error_ioremap;
     }
 
     /* Register misc device */
-    if (misc_register(&gem5_bridge_miscdevice) < 0) {
-        pr_err("gem5_bridge_init: failed to register misc device\n");
-        goto error_misc_register;
+    error = alloc_chrdev_region(&dev_number, 0, DEV_COUNT, DEV_NAME);
+    if (error < 0) {
+        pr_err("%s: failed to allocate device major number\n", __func__);
+        goto error_alloc_chrdev_region;
     }
 
-    pr_info("gem5_bridge_init: SUCCESS!\n");
+    /* Create device class */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
+    dev_class = class_create(DEV_NAME);
+#else
+    dev_class = class_create(THIS_MODULE, DEV_NAME);
+#endif
+    if (IS_ERR(dev_class)) {
+        pr_err("%s: failed to create device class\n", __func__);
+        goto error_class_create;
+    }
+
+    /* Map udev event that sets access permissions on our devices */
+    dev_class->dev_uevent = gem5_bridge_uevent;
+
+    /* Create all character devices */
+    for (cdev_i = 0; cdev_i < DEV_COUNT; ++cdev_i) {
+        /* Create cdev struct for this device */
+        cdev_number = MKDEV(MAJOR(dev_number), cdev_i);
+        cdev_init(&cdev_list[cdev_i], &gem5_bridge_fops);
+        error = cdev_add(&cdev_list[cdev_i], cdev_number, 1);
+        if (error < 0) {
+            pr_err("%s: failed to init/add character device: %s\n",
+                    __func__, config_list[cdev_i].name);
+            goto error_cdev_add;
+        }
+
+        /* Create device */
+        devp = device_create(dev_class, NULL, cdev_number, NULL,
+                             "gem5/%s", config_list[cdev_i].name);
+        if (IS_ERR(devp)) {
+            pr_err("%s: failed to create device: %s\n",
+                    __func__, config_list[cdev_i].name);
+            goto error_device_create;
+        }
+    }
+
+    pr_info("%s: SUCCESS!\n", __func__);
     return 0;
 
-error_misc_register:
+error_device_create:
+    /* Delete the last device's cdev */
+    cdev_del(&cdev_list[cdev_i]);
+error_cdev_add:
+    /* Go back and delete all previously created devices */
+    for (--cdev_i; cdev_i >= 0; --cdev_i) {
+        cdev_number = MKDEV(MAJOR(dev_number), cdev_i);
+        device_destroy(dev_class, cdev_number);
+        cdev_del(&cdev_list[cdev_i]);
+    }
+    class_destroy(dev_class);
+error_class_create:
+    unregister_chrdev_region(dev_number, DEV_COUNT);
+error_alloc_chrdev_region:
     iounmap(gem5_bridge_mmio);
-error_mmio:
+error_ioremap:
     return -1;
 }
 
 static void __exit gem5_bridge_exit(void)
 {
+    int cdev_i;
+    dev_t cdev_number;
+
     /* Undo all allocations and registrations in reverse order */
-    misc_deregister(&gem5_bridge_miscdevice);
+    for (cdev_i = 0; cdev_i < DEV_COUNT; ++cdev_i) {
+        cdev_number = MKDEV(MAJOR(dev_number), cdev_i);
+        device_destroy(dev_class, cdev_number);
+        cdev_del(&cdev_list[cdev_i]);
+    }
+    class_destroy(dev_class);
+    unregister_chrdev_region(dev_number, DEV_COUNT);
     iounmap(gem5_bridge_mmio);
-    pr_info("gem5_bridge_exit: SUCCESS!\n");
+    pr_info("%s: SUCCESS!\n", __func__);
 }
 
 module_init(gem5_bridge_init);

--- a/util/gem5_bridge_all_ops/src/gem5_bridge.c
+++ b/util/gem5_bridge_all_ops/src/gem5_bridge.c
@@ -145,7 +145,7 @@ static ssize_t gem5_bridge_read(struct file *filp, char *ubuff,
 
     /* Run this op's read function */
     result = op->read(op, kbuff, len, offp);
-    if (result < 0) {
+    if (result < 0 || result > len) {
         pr_err("%s: read failed for "PATH"%s\n", __func__, op->name);
         kvfree(kbuff);
         return result; /* propogate the error */
@@ -194,7 +194,7 @@ static ssize_t gem5_bridge_write(struct file *filp, const char *ubuff,
 
     /* Run this op's write function */
     result = op->write(op, kbuff, len, offp);
-    if (result < 0) {
+    if (result < 0 || result > len) {
         pr_err("%s: write failed for "PATH"%s\n", __func__, op->name);
         kvfree(kbuff);
         return result; /* propogate the error */

--- a/util/gem5_bridge_all_ops/src/gem5_bridge.c
+++ b/util/gem5_bridge_all_ops/src/gem5_bridge.c
@@ -1,3 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-Only
+/*
+ * Copyright (c) 2024 The Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <linux/cdev.h>
 #include <linux/device.h>
 #include <linux/err.h>
@@ -308,7 +337,7 @@ module_exit(gem5_bridge_exit);
  * FOOTER
  * ========================================================================= */
 
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("Dual BSD/GPL");
 MODULE_AUTHOR("Noah Krim");
 MODULE_DESCRIPTION(
     "Driver that facilitates gem5 op calls via MMIO accesses"

--- a/util/gem5_bridge_all_ops/src/gem5_bridge.h
+++ b/util/gem5_bridge_all_ops/src/gem5_bridge.h
@@ -1,0 +1,17 @@
+#ifndef GEM5_BRIDGE_H
+#define GEM5_BRIDGE_H
+
+/* Physical address for base of gem5ops MMIO range */
+#ifndef GEM5OPS_BASE
+#define GEM5OPS_BASE 0xffff0000 /* default, also used for x86 */
+#endif
+
+/* Size of gem5ops MMIO range */
+#ifndef GEM5OPS_SIZE
+#define GEM5OPS_SIZE 0x10000
+#endif
+
+/* MMIO virtual address for poking out of KVM */
+extern void __iomem *gem5_bridge_mmio;
+
+#endif /* GEM5_BRIDGE_H */

--- a/util/gem5_bridge_all_ops/src/gem5_bridge.h
+++ b/util/gem5_bridge_all_ops/src/gem5_bridge.h
@@ -1,5 +1,34 @@
-#ifndef GEM5_BRIDGE_H
-#define GEM5_BRIDGE_H
+/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-Only */
+/*
+ * Copyright (c) 2024 The Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GEM5_BRIDGE_H__
+#define __GEM5_BRIDGE_H__
 
 /* Physical address for base of gem5ops MMIO range */
 #ifndef GEM5OPS_BASE
@@ -14,4 +43,4 @@
 /* MMIO virtual address for poking out of KVM */
 extern void __iomem *gem5_bridge_mmio;
 
-#endif /* GEM5_BRIDGE_H */
+#endif /* __GEM5_BRIDGE_H__ */

--- a/util/gem5_bridge_all_ops/src/gem5_bridge.h
+++ b/util/gem5_bridge_all_ops/src/gem5_bridge.h
@@ -30,15 +30,9 @@
 #ifndef __GEM5_BRIDGE_H__
 #define __GEM5_BRIDGE_H__
 
-/* Physical address for base of gem5ops MMIO range */
-#ifndef GEM5OPS_BASE
-#define GEM5OPS_BASE 0xffff0000 /* default, also used for x86 */
-#endif
-
-/* Size of gem5ops MMIO range */
-#ifndef GEM5OPS_SIZE
-#define GEM5OPS_SIZE 0x10000
-#endif
+/* Driver parameters */
+extern unsigned long gem5_bridge_baseaddr; /* Physical base addr for MMIO */
+extern unsigned long gem5_bridge_rangesize; /* Size of MMIO range */
 
 /* MMIO virtual address for poking out of KVM */
 extern void __iomem *gem5_bridge_mmio;

--- a/util/gem5_bridge_all_ops/src/gem5_ops.c
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.c
@@ -52,15 +52,7 @@ static ssize_t set_write_file_dest(struct gem5_op *op, char *buff,
 static ssize_t write_file(struct gem5_op *op, char *buff, size_t len,
                             loff_t *offp);
 
-static ssize_t op_nil(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp);
-static ssize_t op_int1(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp);
-static ssize_t op_int2(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp);
-static ssize_t op_int6(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp);
-static ssize_t op_int1_str1(struct gem5_op *op, char *buff, size_t len,
+static ssize_t op_args(struct gem5_op *op, char *buff, size_t len,
                             loff_t *offp);
 
 
@@ -71,46 +63,106 @@ static ssize_t op_int1_str1(struct gem5_op *op, char *buff, size_t len,
 struct gem5_op op_list[] =
 {
     /* Always keep "bridge" as first op, used as backcompat with m5 binary */
-    { .name = "bridge",         /* no opcode */ /* hard-coded mmap */ },
+    { .name = "bridge",
+        /* no opcode */ /* hard-coded mmap */ },
 
     /* Used to read the return value from gem5 for normal write-arg ops */
-    { .name = "retval",         /* no opcode */ .read  = read_retval },
+    { .name = "retval",
+        /* no opcode */ .read  = read_retval },
 
     /* Special device for setting destination path of writefile op */
-    { .name = "writefiledest",  /* no opcode */ .write = set_write_file_dest },
+    { .name = "writefiledest",
+        /* no opcode */ .write = set_write_file_dest },
 
-    { .name = "arm",            .opcode = 0x00, .write = op_int1 },
-    { .name = "quiesce",        .opcode = 0x01, .write = op_nil },
-    { .name = "quiescens",      .opcode = 0x02, .write = op_int1 },
-    { .name = "quiescecycle",   .opcode = 0x03, .write = op_int1 },
-    { .name = "quiescetime",    .opcode = 0x04, .write = op_nil },
-    { .name = "rpns",           .opcode = 0x07, .write = op_nil },
-    { .name = "wakecpu",        .opcode = 0x09, .write = op_int1 },
+    /* Opcode [0x00, 0x0f] */
+    { .name = "arm",
+        .opcode = 0x00, .write = op_args,
+        .argc = 1, .argt = {INT_A} },
+    { .name = "quiesce",
+        .opcode = 0x01, .write = op_args,
+        .argc = 0 },
+    { .name = "quiescens",
+        .opcode = 0x02, .write = op_args,
+        .argc = 1, .argt = {INT_A} },
+    { .name = "quiescecycle",
+        .opcode = 0x03, .write = op_args,
+        .argc = 1, .argt = {INT_A} },
+    { .name = "quiescetime",
+        .opcode = 0x04, .write = op_args,
+        .argc = 0 },
+    { .name = "rpns",
+        .opcode = 0x07, .write = op_args,
+        .argc = 0 },
+    { .name = "wakecpu",
+        .opcode = 0x09, .write = op_args,
+        .argc = 1, .argt = {INT_A} },
 
-    { .name = "exit",           .opcode = 0x21, .write = op_int1 },
-    { .name = "fail",           .opcode = 0x22, .write = op_int2 },
-    { .name = "sum",            .opcode = 0x23, .write = op_int6 },
+    /* Opcode [0x20, 0x2f] */
+    { .name = "exit",
+        .opcode = 0x21, .write = op_args,
+        .argc = 1, .argt = {INT_A} },
+    { .name = "fail",
+        .opcode = 0x22, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "sum",
+        .opcode = 0x23, .write = op_args,
+        .argc = 6, .argt = {INT_A, INT_A, INT_A, INT_A, INT_A, INT_A} },
 
-    { .name = "initparam",      .opcode = 0x30, .write = op_int2 },
-    { .name = "loadsymbol",     .opcode = 0x31, .write = op_nil },
+    /* Opcode [0x30, 0x3f] */
+    { .name = "initparam",
+        .opcode = 0x30, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "loadsymbol",
+        .opcode = 0x31, .write = op_args,
+        .argc = 0 },
 
-    { .name = "resetstats",     .opcode = 0x40, .write = op_int2 },
-    { .name = "dumpstats",      .opcode = 0x41, .write = op_int2 },
-    { .name = "dumpresetstats", .opcode = 0x42, .write = op_int2 },
-    { .name = "checkpoint",     .opcode = 0x43, .write = op_int2 },
-    { .name = "writefile",      .opcode = 0x4F, .write = write_file },
+    /* Opcode [0x40, 0x4f] */
+    { .name = "resetstats",
+        .opcode = 0x40, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "dumpstats",
+        .opcode = 0x41, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "dumpresetstats",
+        .opcode = 0x42, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "checkpoint",
+        .opcode = 0x43, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "writefile",
+        .opcode = 0x4F, .write = write_file },
 
-    { .name = "readfile",       .opcode = 0x50, .read  = read_file },
-    { .name = "debugbreak",     .opcode = 0x51, .write = op_nil },
-    { .name = "switchcpu",      .opcode = 0x52, .write = op_nil },
-    { .name = "addsymbol",      .opcode = 0x53, .write = op_int1_str1 },
-    { .name = "panic",          .opcode = 0x54, .write = op_nil },
-    { .name = "workbegin",      .opcode = 0x5a, .write = op_int2 },
-    { .name = "workend",        .opcode = 0x5b, .write = op_int2 },
+    /* Opcode [0x50, 0x5f] */
+    { .name = "readfile",
+        .opcode = 0x50, .read  = read_file },
+    { .name = "debugbreak",
+        .opcode = 0x51, .write = op_args,
+        .argc = 0 },
+    { .name = "switchcpu",
+        .opcode = 0x52, .write = op_args,
+        .argc = 0 },
+    { .name = "addsymbol",
+        .opcode = 0x53, .write = op_args,
+        .argc = 2, .argt = {INT_A, STR_A} },
+    { .name = "panic",
+        .opcode = 0x54, .write = op_args,
+        .argc = 0 },
+    { .name = "workbegin",
+        .opcode = 0x5a, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
+    { .name = "workend",
+        .opcode = 0x5b, .write = op_args,
+        .argc = 2, .argt = {INT_A, INT_A} },
 
-    { .name = "disttogglesync", .opcode = 0x62, .write = op_nil },
+    /* Opcode [0x60, 0x6f] */
+    { .name = "disttogglesync",
+        .opcode = 0x62, .write = op_args,
+        .argc = 0 },
 
-    { .name = "workload",       .opcode = 0x70, .write = op_nil },
+    /* Opcode [0x60, 0x6f] */
+    { .name = "workload",
+        .opcode = 0x70, .write = op_args,
+        .argc = 0 },
 };
 const int op_count = ARRAY_SIZE(op_list);
 
@@ -260,79 +312,64 @@ static ssize_t write_file(struct gem5_op *op, char *buff, size_t len,
  * Op Function Definitions - General
  * ========================================================================= */
 
-static ssize_t op_nil(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp)
+static void op_args_error(struct gem5_op *op)
 {
-    gem5_poke_opcode = op->opcode;
-    (void)POKE0();
-    return len; /* unconditionally consume entire input */
+    char err_usage_buff[128], *errstr = err_usage_buff;
+    int arg_i;
+
+    if (op->argc == 0) {
+        errstr += snprintf(errstr, 8, " <none>");
+    } else {
+        for (arg_i = 0; arg_i < op->argc; ++arg_i) {
+            switch (op->argt[arg_i]) {
+                case STR_A:
+                    errstr += snprintf(errstr, 8, " <str>");
+                    break;
+                case INT_A:
+                    errstr += snprintf(errstr, 8, " <int>");
+                    break;
+                default:
+                    errstr += snprintf(errstr, 8, " <???>");
+            }
+        }
+    }
+
+    pr_err("%s: argument error on arg %d\n", __func__, arg_i);
+    pr_err("    expected args of the form:%s\n", err_usage_buff);
 }
 
-static ssize_t op_int1(struct gem5_op *op, char *buff, size_t len,
+static ssize_t op_args(struct gem5_op *op, char *buff, size_t len,
                             loff_t *offp)
 {
-    u64 arg0;
-    int err = parse_arg_int(&buff, &arg0);
-    if (err) {
-        ARG_PARSE_ERR("<int>");
-        return -EINVAL;
+    u64 args[GEM5_OPS_MAXARGS] = { 0 };
+    char *argstr;
+    int arg_i;
+    int err;
+
+    for (arg_i = 0; arg_i < op->argc; ++arg_i) {
+        /* Parse args tokens as described by op */
+        switch (op->argt[arg_i]) {
+            case STR_A:
+                err = parse_arg_str(&buff, &argstr);
+                args[arg_i] = (u64)argstr; /* store pointer as u64 */
+                break;
+            case INT_A:
+                err = parse_arg_int(&buff, &args[arg_i]);
+                break;
+            default:
+                pr_err("%s: unrecognized arg type\n", __func__);
+                return -EINVAL;
+        }
+
+        /* Report arg usage errors */
+        if (err) {
+            op_args_error(op);
+            return -EINVAL;
+        }
     }
 
     gem5_poke_opcode = op->opcode;
-    (void)POKE1(arg0);
-    return len; /* unconditionally consume entire input */
-}
-
-static ssize_t op_int2(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp)
-{
-    u64 arg0, arg1;
-    int err = parse_arg_int(&buff, &arg0)
-            | parse_arg_int(&buff, &arg1);
-    if (err) {
-        ARG_PARSE_ERR("<int> <int>");
-        return -EINVAL;
-    }
-
-    gem5_poke_opcode = op->opcode;
-    (void)POKE2(arg0, arg1);
-    return len; /* unconditionally consume entire input */
-}
-
-static ssize_t op_int6(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp)
-{
-    u64 arg0, arg1, arg2, arg3, arg4, arg5;
-    int err = parse_arg_int(&buff, &arg0)
-            | parse_arg_int(&buff, &arg1)
-            | parse_arg_int(&buff, &arg2)
-            | parse_arg_int(&buff, &arg3)
-            | parse_arg_int(&buff, &arg4)
-            | parse_arg_int(&buff, &arg5);
-    if (err) {
-        ARG_PARSE_ERR("<int> <int> <int> <int> <int> <int>");
-        return -EINVAL;
-    }
-
-    gem5_poke_opcode = op->opcode;
-    (void)POKE6(arg0, arg1, arg2, arg3, arg4, arg5);
-    return len; /* unconditionally consume entire input */
-}
-
-static ssize_t op_int1_str1(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *offp)
-{
-    u64 arg0;
-    char *arg1;
-    int err = parse_arg_int(&buff, &arg0)
-            | parse_arg_str(&buff, &arg1);
-    if (err) {
-        ARG_PARSE_ERR("<int> <string>");
-        return -EINVAL;
-    }
-
-    gem5_poke_opcode = op->opcode;
-    (void)POKE2(arg0, (u64)arg1);
+    (void)POKE6(args[0], args[1], args[2], args[3], args[4], args[5]);
     return len; /* unconditionally consume entire input */
 }
 

--- a/util/gem5_bridge_all_ops/src/gem5_ops.c
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.c
@@ -1,0 +1,137 @@
+#include <linux/kernel.h>
+#include <linux/kstrtox.h>
+#include <linux/module.h>
+#include <linux/string.h>
+
+#include "gem5_bridge.h"
+#include "gem5_ops.h"
+
+/* ========================================================================= *
+ * Op Function Forward Declarations
+ * ========================================================================= */
+
+// static int read_file(struct gem5_op *op, char *buff);
+// static int write_file(struct gem5_op *op, char *buff);
+static int op_args_int(struct gem5_op *op, char *buff);
+
+
+/* ========================================================================= *
+ * Op Configurations
+ * ========================================================================= */
+
+struct gem5_op op_list[] =
+{
+    /* Always keep "bridge" as first op */
+    { .name = "bridge",    /* no opcode */ /* hard-coded mmap */ },
+
+    { .name = "exit",      .opcode = 0x21, .write = op_args_int },
+
+//    { .name = "writefile", .opcode = 0x4F, .read  = read_file },
+//    { .name = "readfile",  .opcode = 0x50, .read  = read_file },
+};
+const int op_count = ARRAY_SIZE(op_list);
+
+
+/* ========================================================================= *
+ * Utility
+ * ========================================================================= */
+
+struct gem5_op *gem5_op_search(const char *dev_name)
+{
+    int i;
+    for (i = 0; i < op_count; ++i) {
+        if (!strcmp(dev_name, op_list[i].name)) {
+            return &op_list[i];
+        }
+    }
+    return NULL;
+}
+
+/* Takes a pointer to a string, extracts the first space-delimited token and
+ * has outstr point to it. Advances bufp to the location after the end of this
+ * token. */
+static int parse_arg_str(char **bufp, char **outstr)
+{
+    /* Extract token */
+    *outstr = NULL;
+    do {
+        if (!(*bufp) || !(*bufp)[0]) /* End of buffer */
+            break;
+        *outstr = strsep(bufp, " \t\n");
+    } while ((*outstr) && !(*outstr)[0]); /* Skip long chains of whitespace */
+
+    if (!(*outstr) || !(*outstr)[0]) {
+        pr_err("%s: missing argument\n", __func__);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+/* Calls parse_arg_str to extract a token and then converts it to u64. */
+static int parse_arg_int(char **bufp, u64 *outint)
+{
+    char *argstr;
+    if (parse_arg_str(bufp, &argstr) < 0) {
+        pr_err("%s: failed to get argument string\n", __func__);
+        return -EINVAL;
+    }
+
+    /* Convert to int */
+    if (kstrtou64(argstr, 10, outint) < 0) {
+        pr_err("%s: failed parsing int from \"%s\"\n", __func__, argstr);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+/* We want to directly do a 64-bit read to our calculated memory address.
+ * There is an ioread64() function, but this would both taint the register
+ * state and may be disabled since KVM configuration tends to have 32-bit
+ * addresses, which prevents ioread64() from being available in the kernel
+ * headers. */
+static u16 poke_opcode; /* Global variable for setting poke target */
+#define POKE \
+    *(volatile u64 __force *)(gem5_bridge_mmio + (poke_opcode << 8))
+
+/* Necessary macro to ensure argument loading is not elided by the compiler
+ * while also doing best effort to not taint the argument registers. */
+#define UNUSED(_type, _var)                                          \
+do {                                                                 \
+    volatile _type dummy = _var; /* Ensure argument is not elided */ \
+    (void)dummy;                 /* Silence unused var warnings */   \
+} while (0)
+
+
+/* ========================================================================= *
+ * Op Function Definitions
+ * ========================================================================= */
+
+static noinline void poke_int(u64 a)
+{
+    UNUSED(u64, a);
+    POKE;
+}
+static int op_args_int(struct gem5_op *op, char *buff)
+{
+    u64 arg0;
+    int err = 0;
+    err |= parse_arg_int(&buff, &arg0);
+
+    if (err) {
+        pr_err("%s: failed parsing args, expected the form \"%s\"\n",
+                __func__, "<int>");
+        return -EINVAL;
+    }
+
+    poke_opcode = op->opcode;
+    poke_int(arg0);
+
+    pr_info("%s: SUCCESS!\n", __func__);
+    return 0;
+}
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Noah Krim");
+MODULE_DESCRIPTION("Supports gem5_bridge by defining gem5 op functionality");

--- a/util/gem5_bridge_all_ops/src/gem5_ops.c
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.c
@@ -1,6 +1,7 @@
 #include <linux/kernel.h>
 #include <linux/kstrtox.h>
 #include <linux/module.h>
+#include <linux/slab.h>
 #include <linux/string.h>
 
 #include "gem5_bridge.h"
@@ -10,10 +11,26 @@
  * Op Function Forward Declarations
  * ========================================================================= */
 
+static ssize_t read_retval(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
 static ssize_t read_file(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *off);
-static ssize_t op_int(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *off);
+                            loff_t *offp);
+
+static ssize_t set_write_file_dest(struct gem5_op *op, char *buff,
+                            size_t len, loff_t *offp);
+static ssize_t write_file(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
+
+static ssize_t op_nil(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
+static ssize_t op_int1(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
+static ssize_t op_int2(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
+static ssize_t op_int6(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
+static ssize_t op_int1_str1(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp);
 
 
 /* ========================================================================= *
@@ -22,12 +39,47 @@ static ssize_t op_int(struct gem5_op *op, char *buff, size_t len,
 
 struct gem5_op op_list[] =
 {
-    /* Always keep "bridge" as first op */
-    { .name = "bridge", /* no opcode */ /* hard-coded mmap */ },
+    /* Always keep "bridge" as first op, used as backcompat with m5 binary */
+    { .name = "bridge",         /* no opcode */ /* hard-coded mmap */ },
 
-    { .name = "exit",           .opcode = 0x21, .write = op_int },
+    /* Used to read the return value from gem5 for normal write-arg ops */
+    { .name = "retval",         /* no opcode */ .read  = read_retval },
 
-    { .name = "readfile",       .opcode = 0x50, .read = read_file },
+    /* Special device for setting destination path of writefile op */
+    { .name = "writefiledest",  /* no opcode */ .write = set_write_file_dest },
+
+    { .name = "arm",            .opcode = 0x00, .write = op_int1 },
+    { .name = "quiesce",        .opcode = 0x01, .write = op_nil },
+    { .name = "quiescens",      .opcode = 0x02, .write = op_int1 },
+    { .name = "quiescecycle",   .opcode = 0x03, .write = op_int1 },
+    { .name = "quiescetime",    .opcode = 0x04, .write = op_nil },
+    { .name = "rpns",           .opcode = 0x07, .write = op_nil },
+    { .name = "wakecpu",        .opcode = 0x09, .write = op_int1 },
+
+    { .name = "exit",           .opcode = 0x21, .write = op_int1 },
+    { .name = "fail",           .opcode = 0x22, .write = op_int2 },
+    { .name = "sum",            .opcode = 0x23, .write = op_int6 },
+
+    { .name = "initparam",      .opcode = 0x30, .write = op_int2 },
+    { .name = "loadsymbol",     .opcode = 0x31, .write = op_nil },
+
+    { .name = "resetstats",     .opcode = 0x40, .write = op_int2 },
+    { .name = "dumpstats",      .opcode = 0x41, .write = op_int2 },
+    { .name = "dumpresetstats", .opcode = 0x42, .write = op_int2 },
+    { .name = "checkpoint",     .opcode = 0x43, .write = op_int2 },
+    { .name = "writefile",      .opcode = 0x4F, .write = write_file },
+
+    { .name = "readfile",       .opcode = 0x50, .read  = read_file },
+    { .name = "debugbreak",     .opcode = 0x51, .write = op_nil },
+    { .name = "switchcpu",      .opcode = 0x52, .write = op_nil },
+    { .name = "addsymbol",      .opcode = 0x53, .write = op_int1_str1 },
+    { .name = "panic",          .opcode = 0x54, .write = op_nil },
+    { .name = "workbegin",      .opcode = 0x5a, .write = op_int2 },
+    { .name = "workend",        .opcode = 0x5b, .write = op_int2 },
+
+    { .name = "disttogglesync", .opcode = 0x62, .write = op_nil },
+
+    { .name = "workload",       .opcode = 0x70, .write = op_nil },
 };
 const int op_count = ARRAY_SIZE(op_list);
 
@@ -36,7 +88,8 @@ const int op_count = ARRAY_SIZE(op_list);
  * Utility
  * ========================================================================= */
 
-struct gem5_op *gem5_op_search(const char *dev_name)
+/* Linear search for op struct associated with the given device */
+struct gem5_op *gem5_ops_search(const char *dev_name)
 {
     int i;
     for (i = 0; i < op_count; ++i) {
@@ -86,6 +139,17 @@ static int parse_arg_int(char **bufp, u64 *outint)
     return 0;
 }
 
+
+/* ========================================================================= *
+ * MMIO Poking Functions
+ * ========================================================================= */
+
+/* @NOTE: At this point, I am uncertain if the below approach is better than
+ *        linking against or including raw assembly, as was done before. One
+ *        benefit is that the architecure-specific aspects are drastically
+ *        reduced. On the other hand, there is a lot of compiler massaging
+ *        which is inherently not guaranteed. */
+
 /* We want to directly do a 64-bit write to our calculated memory address.
  * There is an iowrite64() function, but this would both taint the register
  * state and may be disabled since KVM configuration tends to have 32-bit
@@ -108,51 +172,74 @@ do {                                                                 \
     (void)dummy;                 /* Silence unused var warnings */   \
 } while (0)
 
+/* Location to store op result from asm, accessible via /dev/gem5/retval */
+static u64 gem5_ops_retval;
 /* Assembly fragment to explicitly return the value placed in the result
  * register by gem5 while executing the op. */
-u64 __retval; /* Dummy var for storing op result from assembly */
 #if defined(__x86_64__)
-    #define ASM_RETVAL asm("movq %%rax, %0" : "=r" (__retval) :: "%rax")
+    /* 64-bit x86 */
+    #define ASM_RETVAL asm("movq %%rax, %0" : "=r" (gem5_ops_retval) :: "%rax")
+#elif defined(__i386__)
+    /* 32-bit x86 */
+    #define ASM_RETVAL asm("movq %%eax, %0" : "=r" (gem5_ops_retval) :: "%eax")
 #elif defined(__aarch64__)
-    #define ASM_RETVAL asm("mov %0, x0" : "=r" (__retval) :: "x0")
+    /* 64-bit ARM */
+    #define ASM_RETVAL asm("mov %0, x0" : "=r" (gem5_ops_retval) :: "x0")
+#elif defined(__arm__) || defined(__thumb__) || defined(_M_ARM)
+    /* 32-bit ARM */
+    #define ASM_RETVAL asm("mov %0, r0" : "=r" (gem5_ops_retval) :: "r0")
 #else
     #define ASM_RETVAL pr_err("%s: unsupported architecture\n", __func__)
 #endif
-#define RET          \
-do {                 \
-    ASM_RETVAL;      \
-    return __retval; \
+#define RET                 \
+do {                        \
+    ASM_RETVAL;             \
+    return gem5_ops_retval; \
 } while (0)
 
+/* In these poke functions, the `noinline` attribute and `USED_*` macros are
+ * required to ensure that calling convention is invoked predictably. This
+ * enables gem5 to consistently extract arguments from the thread context. */
 
-/* ========================================================================= *
- * MMIO Poking Functions
- * ========================================================================= */
-
-/*
 static noinline u64 poke_nil(void)
 {
     POKE; RET;
 }
-*/
 
-static noinline u64 poke_int(u64 a)
+static noinline u64 poke_int1(u64 a)
 {
     USED_INT(a);
     POKE; RET;
 }
 
-/*
-static noinline u64 poke_int_int(u64 a, u64 b)
+static noinline u64 poke_int2(u64 a, u64 b)
 {
     USED_INT(a); USED_INT(b);
     POKE; RET;
 }
-*/
 
-static noinline u64 poke_str_int_int(char *a, u64 b, u64 c)
+static noinline u64 poke_int6(u64 a, u64 b, u64 c, u64 d, u64 e, u64 f)
+{
+    USED_INT(a); USED_INT(b); USED_INT(c);
+    USED_INT(d); USED_INT(e); USED_INT(f);
+    POKE; RET;
+}
+
+static noinline u64 poke_int1_str1(u64 a, char *b)
+{
+    USED_INT(a); USED_STR(b);
+    POKE; RET;
+}
+
+static noinline u64 poke_str1_int2(char *a, u64 b, u64 c)
 {
     USED_STR(a); USED_INT(b); USED_INT(c);
+    POKE; RET;
+}
+
+static noinline u64 poke_str1_int2_str1(char *a, u64 b, u64 c, char *d)
+{
+    USED_STR(a); USED_INT(b); USED_INT(c); USED_STR(d);
     POKE; RET;
 }
 
@@ -161,17 +248,79 @@ static noinline u64 poke_str_int_int(char *a, u64 b, u64 c)
  * Op Function Definitions - Specialized
  * ========================================================================= */
 
+static ssize_t read_retval(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp)
+{
+    ssize_t bytes_read;
+
+    /* Return EOF if after the first read, detected by non-zero offset */
+    if (*offp > 0)
+        return 0;
+
+    bytes_read = snprintf(buff, len, "%llu\n", gem5_ops_retval);
+    if ((size_t)bytes_read >= len) {
+        pr_err("%s: buffer size cannot fit retval\n", __func__);
+        return -EINVAL;
+    }
+
+    *offp += bytes_read;
+    return bytes_read;
+}
+
 static ssize_t read_file(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *off)
+                            loff_t *offp)
 {
     ssize_t bytes_read = 0;
 
     poke_opcode = op->opcode;
-    bytes_read = poke_str_int_int(buff, len, *off);
+    bytes_read = poke_str1_int2(buff, len, *offp);
 
-    if (bytes_read > 0)
-        *off += bytes_read;
+    if (bytes_read > 0) /* only push offset on success */
+        *offp += bytes_read;
     return bytes_read;
+}
+
+
+static char *write_file_dest = NULL;
+static ssize_t set_write_file_dest(struct gem5_op *op, char *buff, size_t len,
+                                    loff_t *off)
+{
+    char *arg;
+    if (parse_arg_str(&buff, &arg) < 0) {
+        pr_err("%s: failed parsing arg, expected a host destination path\n",
+                __func__);
+        return -EINVAL;
+    }
+
+    if (write_file_dest)
+        kfree(write_file_dest);
+    write_file_dest = kstrndup(arg, len, GFP_KERNEL);
+    if (!write_file_dest) {
+        pr_err("%s: failed parsing arg, expected a host destination path\n",
+                __func__);
+        return -ENOMEM;
+    }
+
+    return len; /* unconditionally consume entire input */
+}
+
+static ssize_t write_file(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *off)
+{
+    ssize_t bytes_written = 0;
+
+    if (!write_file_dest) {
+        pr_err("%s: need to set destination path by writing to %s\n",
+                __func__, "/dev/gem5/writefiledest");
+        return -EINVAL;
+    }
+
+    poke_opcode = op->opcode;
+    bytes_written = poke_str1_int2_str1(buff, len, *off, write_file_dest);
+
+    if (bytes_written > 0) /* only push offset on success */
+        *off += bytes_written;
+    return bytes_written;
 }
 
 
@@ -179,38 +328,84 @@ static ssize_t read_file(struct gem5_op *op, char *buff, size_t len,
  * Op Function Definitions - General
  * ========================================================================= */
 
-#define OP_ARG_ERR(_err, _argfmt)                                     \
-    if (_err) {                                                       \
-        pr_err("%s: failed parsing args, expected the form \"%s\"\n", \
-                __func__, _argfmt);                                   \
-        return -EINVAL;                                               \
-    }
+#define OP_ARG_ERR(argfmt)                                        \
+do {                                                              \
+    pr_err("%s: failed parsing args, expected the form \"%s\"\n", \
+            __func__, argfmt);                                    \
+    return -EINVAL;                                               \
+} while (0)
 
-static ssize_t op_int(struct gem5_op *op, char *buff, size_t len, loff_t *off)
+static ssize_t op_nil(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp)
+{
+    poke_opcode = op->opcode;
+    (void)poke_nil();
+    return len; /* unconditionally consume entire input */
+}
+
+static ssize_t op_int1(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp)
 {
     u64 arg0;
     int err = parse_arg_int(&buff, &arg0);
-    OP_ARG_ERR(err, "<int>");
+    if (err) OP_ARG_ERR("<int>");
 
     poke_opcode = op->opcode;
-    (void)poke_int(arg0);
+    (void)poke_int1(arg0);
     return len; /* unconditionally consume entire input */
 }
-/*
-static ssize_t op_int_int(struct gem5_op *op, char *buff, size_t len,
-                            loff_t *off)
+
+static ssize_t op_int2(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp)
 {
     u64 arg0, arg1;
     int err = parse_arg_int(&buff, &arg0)
             | parse_arg_int(&buff, &arg1);
-    OP_ARG_ERR(err, "<int> <int>");
+    if (err) OP_ARG_ERR("<int> <int>");
 
     poke_opcode = op->opcode;
-    (void)poke_int_int(arg0, arg1);
-    return len;
+    (void)poke_int2(arg0, arg1);
+    return len; /* unconditionally consume entire input */
 }
-*/
+
+static ssize_t op_int6(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp)
+{
+    u64 arg0, arg1, arg2, arg3, arg4, arg5;
+    int err = parse_arg_int(&buff, &arg0)
+            | parse_arg_int(&buff, &arg1)
+            | parse_arg_int(&buff, &arg2)
+            | parse_arg_int(&buff, &arg3)
+            | parse_arg_int(&buff, &arg4)
+            | parse_arg_int(&buff, &arg5);
+    if (err) OP_ARG_ERR("<int> <int> <int> <int> <int> <int>");
+
+    poke_opcode = op->opcode;
+    (void)poke_int6(arg0, arg1, arg2, arg3, arg4, arg5);
+    return len; /* unconditionally consume entire input */
+}
+
+static ssize_t op_int1_str1(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *offp)
+{
+    u64 arg0;
+    char *arg1;
+    int err = parse_arg_int(&buff, &arg0)
+            | parse_arg_str(&buff, &arg1);
+    if (err) OP_ARG_ERR("<int> <string>");
+
+    poke_opcode = op->opcode;
+    (void)poke_int1_str1(arg0, arg1);
+    return len; /* unconditionally consume entire input */
+}
+
+
+/* ========================================================================= *
+ * FOOTER
+ * ========================================================================= */
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Noah Krim");
-MODULE_DESCRIPTION("Supports gem5_bridge by defining gem5 op functionality");
+MODULE_DESCRIPTION(
+    "Supports gem5_bridge by implementing gem5 op ABI and functionality"
+);

--- a/util/gem5_bridge_all_ops/src/gem5_ops.c
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.c
@@ -1,3 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-Only
+/*
+ * Copyright (c) 2024 The Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <linux/kernel.h>
 #include <linux/kstrtox.h>
 #include <linux/module.h>
@@ -404,7 +433,7 @@ static ssize_t op_int1_str1(struct gem5_op *op, char *buff, size_t len,
  * FOOTER
  * ========================================================================= */
 
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("Dual BSD/GPL");
 MODULE_AUTHOR("Noah Krim");
 MODULE_DESCRIPTION(
     "Supports gem5_bridge by implementing gem5 op ABI and functionality"

--- a/util/gem5_bridge_all_ops/src/gem5_ops.h
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.h
@@ -39,13 +39,25 @@ typedef ssize_t (*read_f)(struct gem5_op *op, char *buff, size_t len,
 typedef ssize_t (*write_f)(struct gem5_op *op, char *buff, size_t len,
                             loff_t *off);
 
+/* Op arg enum */
+enum gem5_op_arg
+{
+    NIL_A=0,
+    STR_A,
+    INT_A,
+};
+
 /* Op configuration struct */
+#define GEM5_OPS_MAXARGS 6
 struct gem5_op
 {
     const char *name;
     u8 opcode;
     read_f read;
     write_f write;
+    /* Only for generic ops using op_args() */
+    int argc;
+    enum gem5_op_arg argt[GEM5_OPS_MAXARGS];
 };
 
 /* Exported op configuration list */

--- a/util/gem5_bridge_all_ops/src/gem5_ops.h
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.h
@@ -24,6 +24,6 @@ extern struct gem5_op op_list[];
 extern const int op_count;
 
 /* Utility funcitons */
-struct gem5_op *gem5_op_search(const char *dev_name);
+struct gem5_op *gem5_ops_search(const char *dev_name);
 
 #endif /* GEM5_OPS_H */

--- a/util/gem5_bridge_all_ops/src/gem5_ops.h
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.h
@@ -5,8 +5,10 @@
 
 /* Types for op function pointers */
 struct gem5_op; /* Forward decl */
-typedef int (*read_f)(struct gem5_op *op, char *kbuff);
-typedef int (*write_f)(struct gem5_op *op, char *kbuff);
+typedef ssize_t (*read_f)(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *off);
+typedef ssize_t (*write_f)(struct gem5_op *op, char *buff, size_t len,
+                            loff_t *off);
 
 /* Op configuration struct */
 struct gem5_op

--- a/util/gem5_bridge_all_ops/src/gem5_ops.h
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.h
@@ -1,0 +1,27 @@
+#ifndef GEM5_OPS_H
+#define GEM5_OPS_H
+
+#include <linux/types.h>
+
+/* Types for op function pointers */
+struct gem5_op; /* Forward decl */
+typedef int (*read_f)(struct gem5_op *op, char *kbuff);
+typedef int (*write_f)(struct gem5_op *op, char *kbuff);
+
+/* Op configuration struct */
+struct gem5_op
+{
+    const char *name;
+    u8 opcode;
+    read_f read;
+    write_f write;
+};
+
+/* Exported op configuration list */
+extern struct gem5_op op_list[];
+extern const int op_count;
+
+/* Utility funcitons */
+struct gem5_op *gem5_op_search(const char *dev_name);
+
+#endif /* GEM5_OPS_H */

--- a/util/gem5_bridge_all_ops/src/gem5_ops.h
+++ b/util/gem5_bridge_all_ops/src/gem5_ops.h
@@ -1,5 +1,34 @@
-#ifndef GEM5_OPS_H
-#define GEM5_OPS_H
+/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-Only */
+/*
+ * Copyright (c) 2024 The Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GEM5_OPS_H__
+#define __GEM5_OPS_H__
 
 #include <linux/types.h>
 
@@ -26,4 +55,4 @@ extern const int op_count;
 /* Utility funcitons */
 struct gem5_op *gem5_ops_search(const char *dev_name);
 
-#endif /* GEM5_OPS_H */
+#endif /* __GEM5_OPS_H__ */

--- a/util/gem5_bridge_all_ops/src/gem5_poke.c
+++ b/util/gem5_bridge_all_ops/src/gem5_poke.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-Only
+/*
+ * Copyright (c) 2024 The Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <linux/kernel.h>
+
+#include "gem5_bridge.h"
+#include "gem5_poke.h"
+
+u64 gem5_poke_opcode;
+u64 gem5_poke_retval;
+
+u64 noinline gem5_poke_func(u64 a, u64 b, u64 c, u64 d, u64 e, u64 f)
+{
+#if defined(__x86_64__)
+    /* 64-bit x86 */
+    asm volatile(
+        /* Assembly to build and access poke addr, extracting retval */
+        "movq %[mmio], %%r10 \n"
+        "movq %[opcode], %%r11 \n"
+        "shl  $8, %%r11 \n"
+        "movq (%%r10, %%r11, 1), %%rax \n"
+        "movq %%rax, %[retval] \n"
+        /* Output variables */
+          : [retval] "=m" (gem5_poke_retval)
+        /* Input variables */
+          : [mmio] "m" (gem5_bridge_mmio), [opcode] "m" (gem5_poke_opcode)
+        /* Clobbers from this asm fragment */
+          : "%rax", "%r10", "%r11",
+        /* Clobbers to prevent changing calling-convention arg registers */
+            "%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9"
+    );
+#elif defined(__aarch64__)
+    /* 64-bit ARM */
+    asm volatile(
+        /* Assembly to build and access poke addr, extracting retval */
+        "ldr x10, %[mmio] \n"
+        "ldr x11, %[opcode] \n"
+        "lsl x11, x11, #8 \n"
+        "ldr x0, [x10, x11] \n"
+        "str x0, %[retval] \n"
+        /* Output variables */
+          : [retval] "=m" (gem5_poke_retval)
+        /* Input variables */
+          : [mmio] "m" (gem5_bridge_mmio), [opcode] "m" (gem5_poke_opcode)
+        /* Clobbers from this asm fragment */
+          : "x0", "x10", "x11",
+        /* Clobbers to prevent changing calling-convention arg registers */
+            /* "x0", */ "x1", "x2", "x3", "x4", "x5"
+    );
+#else
+    pr_err("%s: unsupported architecture\n", __func__);
+#endif
+
+    return gem5_poke_retval;
+}

--- a/util/gem5_bridge_all_ops/src/gem5_poke.h
+++ b/util/gem5_bridge_all_ops/src/gem5_poke.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-Only */
+/*
+ * Copyright (c) 2024 The Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GEM5_POKE_H__
+#define __GEM5_POKE_H__
+
+/* Global variable for setting poke target */
+extern u64 gem5_poke_opcode;
+
+/* Location to store op result, accessible via /dev/gem5/retval */
+extern u64 gem5_poke_retval;
+
+/* C declarations for calling / linking to driver source */
+u64 noinline gem5_poke_func(u64 a, u64 b, u64 c, u64 d, u64 e, u64 f);
+#define POKE0() \
+    gem5_poke_func(0, 0, 0, 0, 0, 0)
+#define POKE1(a) \
+    gem5_poke_func((u64)(a), 0, 0, 0, 0, 0)
+#define POKE2(a, b) \
+    gem5_poke_func((u64)(a), (u64)(b), 0, 0, 0, 0)
+#define POKE3(a, b, c) \
+    gem5_poke_func((u64)(a), (u64)(b), (u64)(c), 0, 0, 0)
+#define POKE4(a, b, c, d) \
+    gem5_poke_func((u64)(a), (u64)(b), (u64)(c), (u64)(d), 0, 0)
+#define POKE5(a, b, c, d, e) \
+    gem5_poke_func((u64)(a), (u64)(b), (u64)(c), (u64)(d), (u64)(e), 0)
+#define POKE6(a, b, c, d, e, f) \
+    gem5_poke_func((u64)(a), (u64)(b), (u64)(c), (u64)(d), (u64)(e), (u64)(f))
+
+#endif /* __GEM5_POKE_H__ */

--- a/util/m5/src/m5_mmap.c
+++ b/util/m5/src/m5_mmap.c
@@ -57,7 +57,7 @@ void *m5_mem = NULL;
 #endif
 uint64_t m5op_addr = M5OP_ADDR;
 
-const char *m5_mmap_dev = "/dev/mem";
+const char *m5_mmap_dev = "/dev/gem5_bridge";
 
 void
 map_m5_mem()
@@ -79,8 +79,7 @@ map_m5_mem()
         exit(1);
     }
 
-    m5_mem = mmap(NULL, 0x10000, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
-                  m5op_addr);
+    m5_mem = mmap(NULL, 0x10000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     close(fd);
 
     if (!m5_mem) {

--- a/util/m5/src/m5_mmap.c
+++ b/util/m5/src/m5_mmap.c
@@ -58,6 +58,7 @@ void *m5_mem = NULL;
 uint64_t m5op_addr = M5OP_ADDR;
 
 const char *m5_mmap_dev = "/dev/gem5/bridge";
+const char *m5_mmap_dev_fallback = "/dev/mem";
 
 void
 map_m5_mem()
@@ -76,7 +77,19 @@ map_m5_mem()
     fd = open(m5_mmap_dev, O_RDWR | O_SYNC);
     if (fd == -1) {
         fprintf(stderr, "Can't open %s: %s\n", m5_mmap_dev, strerror(errno));
-        exit(1);
+        fprintf(stderr, "--> Make sure the gem5_bridge device driver has "
+                        "been properly inserted into the kernel. Otherwise, "
+                        "sudo access required to perform address-mode ops.\n");
+
+        /* Fallback device */
+        fd = open(m5_mmap_dev_fallback, O_RDWR | O_SYNC);
+        if (fd == -1) {
+            fprintf(stderr, "Can't open %s: %s\n",
+                    m5_mmap_dev_fallback, strerror(errno));
+            fprintf(stderr, "--> Make sure this utility has sudo access to "
+                            "use fallback device.\n");
+            exit(1);
+        }
     }
 
     m5_mem = mmap(NULL, 0x10000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);

--- a/util/m5/src/m5_mmap.c
+++ b/util/m5/src/m5_mmap.c
@@ -57,7 +57,7 @@ void *m5_mem = NULL;
 #endif
 uint64_t m5op_addr = M5OP_ADDR;
 
-const char *m5_mmap_dev = "/dev/gem5_bridge";
+const char *m5_mmap_dev = "/dev/gem5/bridge";
 
 void
 map_m5_mem()


### PR DESCRIPTION
This PR should not be merged as-is and is primarily included as a reference for how to augment the `gem5_bridge` driver introduced in PR:https://github.com/gem5/gem5/pull/1480

The code in this PR is a copy of a former implementation of the above PR, where many of these features were omitted for the sake of a simpler and more direct implementation. This implementation, on the other hand, offers a suite of devices under `/dev/gem5`. The mappable device used by the `m5` utility is `/dev/gem5/bridge` and then there are additional devices for each gem5op that produce the same behavior as calls to the `m5` utility.

Besides `readfile` and `writefile`, all ops can be triggered by writing a string of arguments to them. `readfile` can be read from directly, and `writefile` can be written to directly after defining a destination target through `/dev/gem5/writefiledest`. Here are a few usage examples:

```
echo "0" > /dev/gem5/exit
echo "1 2 3 4 5 6" > /dev/gem5/sum && cat /dev/gem5/retval
cat /dev/gem5/readfile > file.txt
echo "path/to/target.txt" > /dev/gem5/writefiledest && cat source.txt > /dev/gem5/writefile
```

Though this is replicating the behavior of the `m5` utility, it offers a new platform for experimenting with gem5ops interfaces. The implementation of these ops is done mostly as a proof of concept.

Beyond the complexity and thus maintenance concerns of this implementation, calls to this driver are less desirable during workloads as they perform extra transitions into the kernel. The `m5` utility, when linked to the workload program, can incur just a single transition to mmap to the gem5_bridge device at the start of the program, and then all pokes that trigger the ops will happen in user space, reducing the overhead of the ops that would appear in the workload statistics. Additionally, introducing magic-instruction ops into the driver would be another layer of complexity but would be a requirement for replacing the `m5` utility.