### PR TITLE
cpu-o3: Replace integral constants by named constants in FU pool

### DIFF
--- a/src/cpu/o3/fu_pool.cc
+++ b/src/cpu/o3/fu_pool.cc
@@ -164,7 +164,7 @@ FUPool::getUnit(OpClass capability)
     //  If this pool doesn't have the specified capability,
     //  return this information to the caller
     if (!capabilityList[capability])
-        return -2;
+        return NoCapableFU;
 
     int fu_idx = fuPerCapList[capability].getFU();
     int start_idx = fu_idx;
@@ -175,7 +175,7 @@ FUPool::getUnit(OpClass capability)
         fu_idx = fuPerCapList[capability].getFU();
         if (fu_idx == start_idx) {
             // No FU available
-            return -1;
+            return NoFreeFU;
         }
     }
 


### PR DESCRIPTION
This replaces hardcoded integral values with more explicit constant names in the code allocating functional units to instructions.

This commit follows ba5886aee7a590f69bfe024c45c6afd08f21bec6 which should have read:

"If an instruction requires a functional unit that is not present in the model (e.g., because it is not present in the configuration), O3CPU treats it as a 1-cycle operation.

This commit changes the behavior to make the cpu panic when this happens. The cpu panics only if the instruction reaches the head of the ROB, meaning it is ok to have unsupported instructions on the wrong path.

Thanks to Chandana S. Deshpande (deshpande.s.chandana@gmail.com) for finding the issue."

Change-Id: I5e0a37e5fb8404cb5496bd2cb0a9a5baeae3b895