### PR TITLE
 mem-cache: Do not require p.size and p.entry_size in IP template 

### DIFF
--- a/src/mem/cache/tags/Tags.py
+++ b/src/mem/cache/tags/Tags.py
@@ -46,12 +46,6 @@ class TaggedIndexingPolicy(SimObject):
     cxx_header = "mem/cache/tags/tagged_entry.hh"
     cxx_template_params = ["class Types"]
 
-    # Get the size from the parent (cache)
-    size = Param.MemorySize(Parent.size, "capacity in bytes")
-
-    # Get the entry size from the parent (tags)
-    entry_size = Param.Int(Parent.entry_size, "entry size in bytes")
-
     # Get the associativity
     assoc = Param.Int(Parent.assoc, "associativity")
 
@@ -60,6 +54,12 @@ class TaggedSetAssociative(TaggedIndexingPolicy):
     type = "TaggedSetAssociative"
     cxx_class = "gem5::TaggedSetAssociative"
     cxx_header = "mem/cache/tags/tagged_entry.hh"
+
+    # Get the size from the parent (cache)
+    size = Param.MemorySize(Parent.size, "capacity in bytes")
+
+    # Get the entry size from the parent (tags)
+    entry_size = Param.Int(Parent.entry_size, "entry size in bytes")
 
 
 class BaseTags(ClockedObject):

--- a/src/mem/cache/tags/indexing_policies/IndexingPolicies.py
+++ b/src/mem/cache/tags/indexing_policies/IndexingPolicies.py
@@ -49,12 +49,6 @@ class BaseIndexingPolicy(SimObject):
     cxx_header = "mem/cache/tags/indexing_policies/base.hh"
     cxx_template_params = ["class Types"]
 
-    # Get the size from the parent (cache)
-    size = Param.MemorySize(Parent.size, "capacity in bytes")
-
-    # Get the entry size from the parent (tags)
-    entry_size = Param.Int(Parent.entry_size, "entry size in bytes")
-
     # Get the associativity
     assoc = Param.Int(Parent.assoc, "associativity")
 
@@ -64,8 +58,20 @@ class SetAssociative(BaseIndexingPolicy):
     cxx_class = "gem5::SetAssociative"
     cxx_header = "mem/cache/tags/indexing_policies/set_associative.hh"
 
+    # Get the size from the parent (cache)
+    size = Param.MemorySize(Parent.size, "capacity in bytes")
+
+    # Get the entry size from the parent (tags)
+    entry_size = Param.Int(Parent.entry_size, "entry size in bytes")
+
 
 class SkewedAssociative(BaseIndexingPolicy):
     type = "SkewedAssociative"
     cxx_class = "gem5::SkewedAssociative"
     cxx_header = "mem/cache/tags/indexing_policies/skewed_associative.hh"
+
+    # Get the size from the parent (cache)
+    size = Param.MemorySize(Parent.size, "capacity in bytes")
+
+    # Get the entry size from the parent (tags)
+    entry_size = Param.Int(Parent.entry_size, "entry size in bytes")

--- a/src/mem/cache/tags/indexing_policies/base.hh
+++ b/src/mem/cache/tags/indexing_policies/base.hh
@@ -109,14 +109,16 @@ class IndexingPolicyTemplate : public SimObject
     /**
      * Construct and initialize this policy.
      */
-    IndexingPolicyTemplate(const Params &p)
+    IndexingPolicyTemplate(const Params &p,
+                           uint32_t num_entries,
+                           int set_shift)
       : SimObject(p), assoc(p.assoc),
-        numSets(p.size / (p.entry_size * assoc)),
-        setShift(floorLog2(p.entry_size)), setMask(numSets - 1), sets(numSets),
+        numSets(num_entries / assoc),
+        setShift(set_shift), setMask(numSets - 1), sets(numSets),
         tagShift(setShift + floorLog2(numSets))
     {
-        fatal_if(!isPowerOf2(numSets), "# of sets must be non-zero and a power " \
-                 "of 2");
+        fatal_if(!isPowerOf2(numSets),
+            "# of sets must be non-zero and a power of 2");
         fatal_if(assoc <= 0, "associativity must be greater than zero");
 
         // Make space for the entries

--- a/src/mem/cache/tags/indexing_policies/set_associative.cc
+++ b/src/mem/cache/tags/indexing_policies/set_associative.cc
@@ -52,7 +52,7 @@ namespace gem5
 {
 
 SetAssociative::SetAssociative(const Params &p)
-    : BaseIndexingPolicy(p)
+    : BaseIndexingPolicy(p, p.size / p.entry_size, floorLog2(p.entry_size))
 {
 }
 

--- a/src/mem/cache/tags/indexing_policies/skewed_associative.cc
+++ b/src/mem/cache/tags/indexing_policies/skewed_associative.cc
@@ -42,7 +42,8 @@ namespace gem5
 {
 
 SkewedAssociative::SkewedAssociative(const Params &p)
-    : BaseIndexingPolicy(p), msbShift(floorLog2(numSets) - 1)
+    : BaseIndexingPolicy(p, p.size / p.entry_size, floorLog2(p.entry_size)),
+      msbShift(floorLog2(numSets) - 1)
 {
     if (assoc > NUM_SKEWING_FUNCTIONS) {
         warn_once("Associativity higher than number of skewing functions. " \

--- a/src/mem/cache/tags/tagged_entry.hh
+++ b/src/mem/cache/tags/tagged_entry.hh
@@ -85,7 +85,7 @@ class TaggedSetAssociative : public TaggedIndexingPolicy
   public:
     PARAMS(TaggedSetAssociative);
     TaggedSetAssociative(const Params &p)
-      : TaggedIndexingPolicy(p)
+      : TaggedIndexingPolicy(p, p.size / p.entry_size, floorLog2(p.entry_size))
     {}
 
     std::vector<ReplaceableEntry*>


### PR DESCRIPTION
This PR is adjusting the constructor to relax template
requirements. In this way child classes are free to provide
their own way of calculating the number of entries and the
shifting required to extract the set

Why do we need this?
Up to this patch we have been configuring the indexing policy
by setting up the cache/table size (in bytes) and the entry size.
Those parameters make a lot of sense in caching structures
where:

a) We want to configure the caching structure using
the amount of storage (in bytes) provided (e.g. 4kB of Cache)
b) the content of a single entry is addressable therefore
we need the entry size to know how many bits in the indexing
process we need to shift to extract the set

In those cases the number of cache entries is derived from the formula

num_entries = size / entry_size

The adoption of the IndexingPolicy for different kinds
of caching structures (e.g. prefetcher tables) make this
way of configuring the IP a bit quirky.

For some tables directly setting the number of entries is a far more
intuitive way of configuring the IP, instead of allocating the desired
number of entries by working things out with the formula above