### PR TITLE
arch-riscv: fix viota

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -957,6 +957,8 @@ Fault
 %(class_name)s<ElemType>::execute(ExecContext* xc,
                                   trace::InstRecord* traceData) const
 {
+    if (isFirstMicroop())
+        *cnt = 0;
     using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
     using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
 


### PR DESCRIPTION
This commit fixs a bug in the viota instuction.

I ran some RISC-V vector tests on Gem5, and the logs are as shown below.

```
 222000:  system.cpu          : A0 T0 : 0x800002be    : vsetvli t1, t0, e8, mf8, tu, mu : SimdConfig :  D=0x0000000000000004  flags=(IsInteger|IsVector|IsControl|IsIndirectControl|IsUncondControl)
 224000:  system.cpu.[tid:0]  : Reading vector register vector[21] (21) as [2b7f5ff0_5d11fd9e_9a0a6039_3b0b5015_f5891b42_6a56b990_3a19699a_f8ac6e0d].
 224000:  system.cpu.[tid:0]  : Reading vector register vector[8] (8) as [cc8c67ad_62d4b3b1_ee3002a3_7a51035f_acef6523_ed27cf7d_2735ba00_f850670a].
 224000:  system.cpu          : A0 T0 : 0x800002c2    : viota_m v8, v21           
 224000:  system.cpu          : A0 T0 : 0x800002c2. 0 : viota_m_micro v8, v21      : SimdAlu :  D=[00010202_62d4b3b1_ee3002a3_7a51035f_acef6523_ed27cf7d_2735ba00_f850670a]  flags=(IsVector|IsMicroop|IsDelayedCommit|IsLastMicroop|IsFirstMicroop)
```

```
 286000:  system.cpu          : A0 T0 : 0x800003de    : vsetvli t1, t0, e8, mf8, tu, mu : SimdConfig :  D=0x0000000000000004  flags=(IsInteger|IsVector|IsControl|IsIndirectControl|IsUncondControl)
 288000:  system.cpu.[tid:0]  : Reading vector register vector[21] (21) as [2b7f5ff0_5d11fd9e_9a0a6039_3b0b5015_f5891b42_6a56b990_3a19699a_f8ac6e0d].
 288000:  system.cpu.[tid:0]  : Reading vector register vector[8] (8) as [cc8c67ad_62d4b3b1_ee3002a3_7a51035f_acef6523_ed27cf7d_2735ba00_f850670a].
 288000:  system.cpu          : A0 T0 : 0x800003e2    : viota_m v8, v21           
 288000:  system.cpu          : A0 T0 : 0x800003e2. 0 : viota_m_micro v8, v21      : SimdAlu :  D=[03040505_62d4b3b1_ee3002a3_7a51035f_acef6523_ed27cf7d_2735ba00_f850670a]  flags=(IsVector|IsMicroop|IsDelayedCommit|IsLastMicroop|IsFirstMicroop)
```

The two different instructions can be referenced to the same StaticInstPtr because the decoder behaves as shown in [the section of the code](https://github.com/gem5/gem5/blob/stable/src/arch/riscv/decoder.cc#L98-L100).

So every first micro-op should reset the cnt variable in the macro-op.

Change-Id: Id311a05cfed41b01e16fd7256d9baa166aee49da