### PR TITLE
arch-arm: Move generateTrap from MiscRegOp to ArmStaticInst

### DIFF
--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -128,22 +128,6 @@ MiscRegOp64::generateTrap(ExceptionLevel el) const
     return generateTrap(el, ExceptionClass::TRAPPED_MSR_MRS_64, iss());
 }
 
-Fault
-MiscRegOp64::generateTrap(ExceptionLevel el, ExceptionClass ec,
-        uint32_t iss) const
-{
-    switch (el) {
-      case EL1:
-        return std::make_shared<SupervisorTrap>(getEMI(), iss, ec);
-      case EL2:
-        return std::make_shared<HypervisorTrap>(getEMI(), iss, ec);
-      case EL3:
-        return std::make_shared<SecureMonitorTrap>(getEMI(), iss, ec);
-      default:
-        panic("Invalid EL: %d\n", el);
-    }
-}
-
 RegVal
 MiscRegImmOp64::miscRegImm() const
 {

--- a/src/arch/arm/insts/misc64.hh
+++ b/src/arch/arm/insts/misc64.hh
@@ -174,9 +174,8 @@ class MiscRegOp64 : public ArmISA::ArmStaticInst
 
     bool miscRead() const { return _miscRead; }
 
+    using ArmISA::ArmStaticInst::generateTrap;
     Fault generateTrap(ArmISA::ExceptionLevel el) const;
-    Fault generateTrap(ArmISA::ExceptionLevel el,
-            ArmISA::ExceptionClass ec, uint32_t iss) const;
 };
 
 class MiscRegImmOp64 : public MiscRegOp64

--- a/src/arch/arm/insts/static_inst.cc
+++ b/src/arch/arm/insts/static_inst.cc
@@ -1367,6 +1367,21 @@ ArmStaticInst::getCurSmeVecLenInBits(ThreadContext *tc)
     return isa->getCurSmeVecLenInBits();
 }
 
+Fault
+ArmStaticInst::generateTrap(ExceptionLevel el, ExceptionClass ec,
+        uint32_t iss) const
+{
+    switch (el) {
+      case EL1:
+        return std::make_shared<SupervisorTrap>(getEMI(), iss, ec);
+      case EL2:
+        return std::make_shared<HypervisorTrap>(getEMI(), iss, ec);
+      case EL3:
+        return std::make_shared<SecureMonitorTrap>(getEMI(), iss, ec);
+      default:
+        panic("Invalid EL: %d\n", el);
+    }
+}
 
 } // namespace ArmISA
 } // namespace gem5

--- a/src/arch/arm/insts/static_inst.hh
+++ b/src/arch/arm/insts/static_inst.hh
@@ -633,6 +633,10 @@ class ArmStaticInst : public StaticInst
         return std::make_shared<UndefinedInstruction>(
             machInst, false, mnemonic, disabled);
     }
+
+    Fault
+    generateTrap(ArmISA::ExceptionLevel el,
+                 ArmISA::ExceptionClass ec, uint32_t iss) const;
 };
 
 } // namespace ArmISA


### PR DESCRIPTION
System(Misc) register accesses are not the only trappable instructions.
We move the exception generation logic (generateTrap) from the
MiscRegOp64 to the base ArmStaticInst