### PR TITLE
mem-ruby: Fix replacement policy in GPU_VIPER

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -1162,7 +1162,6 @@ machine(MachineType:TCC, "TCC Cache")
   transition(I, WrVicBlkBack, W) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     p_profileMiss;
     a_allocateBlock;
-    ut_updateTag;
     swb_sendWBAck;
     wdb_writeDirtyBytes;
     p_popRequestQueue;
@@ -1257,7 +1256,6 @@ machine(MachineType:TCC, "TCC Cache")
 
   transition(IV, Data, V) {TagArrayRead, TagArrayWrite, DataArrayWrite} {
     a_allocateBlock;
-    ut_updateTag;
     wcb_writeCacheBlock;
     sdr_sendDataResponse;
     wada_wakeUpAllDependentsAddr;


### PR DESCRIPTION
The current GPU_VIPER protocol's TCC cache update the MRU information
twice with calling a_allocateBlock and ut_updateTag which affects the
LIP and RRIP replacement polies. Remove ut_updateTag fixes the LIP and
RRIP replacement polies.

Change-Id: I79ad9392593e00425a7fe8828048465b2c2c2e1f