### PR TITLE
misc: Remove Serialize-related code in Random

### DIFF
--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -42,8 +42,6 @@
 
 #include <sstream>
 
-#include "base/logging.hh"
-
 namespace gem5
 {
 

--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -43,7 +43,6 @@
 #include <sstream>
 
 #include "base/logging.hh"
-#include "sim/serialize.hh"
 
 namespace gem5
 {
@@ -67,33 +66,6 @@ void
 Random::init(uint32_t s)
 {
     gen.seed(s);
-}
-
-void
-Random::serialize(CheckpointOut &cp) const
-{
-    panic("Currently not used anywhere.\n");
-
-    // get the state from the generator
-    std::ostringstream oss;
-    oss << gen;
-    std::string state = oss.str();
-    paramOut(cp, "mt_state", state);
-}
-
-void
-Random::unserialize(CheckpointIn &cp)
-{
-    panic("Currently not used anywhere.\n");
-
-    // the random generator state did not use to be part of the
-    // checkpoint state, so be forgiving in the unserialization and
-    // keep on going if the parameter is not there
-    std::string state;
-    if (optParamIn(cp, "mt_state", state)) {
-        std::istringstream iss(state);
-        iss >> gen;
-    }
 }
 
 Random random_mt;

--- a/src/base/random.hh
+++ b/src/base/random.hh
@@ -51,14 +51,11 @@
 
 #include "base/compiler.hh"
 #include "base/types.hh"
-#include "sim/serialize.hh"
 
 namespace gem5
 {
 
-class Checkpoint;
-
-class Random : public Serializable
+class Random
 {
 
   public:
@@ -115,9 +112,6 @@ class Random : public Serializable
         std::uniform_int_distribution<T> dist(min, max);
         return dist(gen);
     }
-
-    void serialize(CheckpointOut &cp) const override;
-    void unserialize(CheckpointIn &cp) override;
 };
 
 /**


### PR DESCRIPTION
The Random ser/des support has been non-existent since 2014.
Removing it will enable the Random class to be unit tested
without having a dependency on the src/sim code.