### PR TITLE
arch-arm: Fix DC IVAC for Secure EL2

### DIFF
--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -525,11 +525,9 @@ let {{
            EA = XBase;
            faultAddr = EA;
            HCR hcr = Hcr64;
-           SCR scr = Scr64;
            CPSR cpsr = Cpsr;
            ExceptionLevel el = (ExceptionLevel) (uint8_t) cpsr.el;
-           if (el == EL1 && ArmSystem::haveEL(xc->tcBase(), EL2) &&
-               hcr.vm && (scr.ns || !ArmSystem::haveEL(xc->tcBase(), EL3))) {
+           if (el == EL1 && EL2Enabled(xc->tcBase()) && hcr.vm) {
                memAccessFlags = memAccessFlags | Request::CLEAN;
            }
            System *sys = xc->tcBase()->getSystemPtr();


### PR DESCRIPTION
According to the Arm architecture reference manual:

"When the value of HCR_EL2.VM is 1, data cache invalidate instructions executed at EL1 perform a data cache clean and invalidate"

This behaviour should be exteded to secure mode now that Secure EL2 is supported

Change-Id: I8b4733e6336a0fd5577f4ef35c0bae5408f91194