### PR TITLE
python: Add warning message for set_workload being called twice

### DIFF
--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -110,6 +110,7 @@ class AbstractBoard:
         # is defined. Whether or not the board is to be run in FS mode is
         # determined by which kind of workload is set.
         self._is_fs = None
+        self._is_workload_set = False
 
         # This variable is used to record the checkpoint directory which is
         # set when declaring the board's workload and then used by the
@@ -210,6 +211,12 @@ class AbstractBoard:
                 "function is run."
             )
         return self._is_fs
+
+    def set_is_workload_set(self, is_set: bool) -> None:
+        self._is_workload_set = is_set
+
+    def is_workload_set(self) -> bool:
+        return self._is_workload_set
 
     def set_workload(self, workload: WorkloadResource) -> None:
         """

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -75,8 +75,6 @@ class KernelDiskWorkload:
         * This assumes the Linux kernel is used.
     """
 
-    _is_workload_set = False
-
     @abstractmethod
     def get_default_kernel_args(self) -> List[str]:
         """
@@ -183,9 +181,9 @@ class KernelDiskWorkload:
         # Abstract board. This function will not work otherwise.
         assert isinstance(self, AbstractBoard)
 
-        if self._is_workload_set:
+        if self.is_workload_set():
             warn("Workload has been set more than once!")
-        self._is_workload_set = True
+        self.set_is_workload_set(True)
 
         # Set the disk device
         self._disk_device = disk_device

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -33,6 +33,7 @@ from typing import (
     Union,
 )
 
+import m5
 from m5.util import warn
 
 from ...resources.resource import (

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -33,7 +33,7 @@ from typing import (
     Union,
 )
 
-import m5
+from m5.util import warn
 
 from ...resources.resource import (
     BootloaderResource,
@@ -186,6 +186,9 @@ class KernelDiskWorkload:
         # If we are setting a workload of this type, we need to run as a
         # full-system simulation.
         self._set_fullsystem(True)
+
+        if self.workload.object_file:
+            warn("Workload has been set more than once!")
 
         # Set the kernel to use.
         self.workload.object_file = kernel.get_local_path()

--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -75,6 +75,8 @@ class KernelDiskWorkload:
         * This assumes the Linux kernel is used.
     """
 
+    _is_workload_set = False
+
     @abstractmethod
     def get_default_kernel_args(self) -> List[str]:
         """
@@ -181,15 +183,16 @@ class KernelDiskWorkload:
         # Abstract board. This function will not work otherwise.
         assert isinstance(self, AbstractBoard)
 
+        if self._is_workload_set:
+            warn("Workload has been set more than once!")
+        self._is_workload_set = True
+
         # Set the disk device
         self._disk_device = disk_device
 
         # If we are setting a workload of this type, we need to run as a
         # full-system simulation.
         self._set_fullsystem(True)
-
-        if self.workload.object_file:
-            warn("Workload has been set more than once!")
 
         # Set the kernel to use.
         self.workload.object_file = kernel.get_local_path()

--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -145,7 +145,6 @@ class SEBinaryWorkload:
             #
             # A better API for this which avoids `isinstance` checks would be
             # welcome.
-
             for core in self.get_processor()._all_cores():
                 core.set_workload(process)
         else:

--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -68,6 +68,8 @@ class SEBinaryWorkload:
         for multi-core setups, multi-program workloads are not presently supported.
     """
 
+    _is_workload_set = False
+
     def set_se_binary_workload(
         self,
         binary: BinaryResource,
@@ -100,6 +102,10 @@ class SEBinaryWorkload:
         # We assume this this is in a multiple-inheritance setup with an
         # Abstract board. This function will not work otherwise.
         assert isinstance(self, AbstractBoard)
+
+        if self._is_workload_set:
+            warn("Workload has been set more than once!")
+        self._is_workload_set = True
 
         # If we are setting a workload of this type, we need to run as a
         # SE-mode simulation.
@@ -141,20 +147,10 @@ class SEBinaryWorkload:
             #
             # A better API for this which avoids `isinstance` checks would be
             # welcome.
-            if any(
-                core.is_workload_set()
-                for core in self.get_processor()._all_cores()
-            ):
-                warn("Workload has been set more than once!")
 
             for core in self.get_processor()._all_cores():
                 core.set_workload(process)
         else:
-            if any(
-                core.is_workload_set()
-                for core in self.get_processor().get_cores()
-            ):
-                warn("Workload has been set more than once!")
             for core in self.get_processor().get_cores():
                 core.set_workload(process)
 

--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -68,8 +68,6 @@ class SEBinaryWorkload:
         for multi-core setups, multi-program workloads are not presently supported.
     """
 
-    _is_workload_set = False
-
     def set_se_binary_workload(
         self,
         binary: BinaryResource,
@@ -103,9 +101,9 @@ class SEBinaryWorkload:
         # Abstract board. This function will not work otherwise.
         assert isinstance(self, AbstractBoard)
 
-        if self._is_workload_set:
+        if self.is_workload_set():
             warn("Workload has been set more than once!")
-        self._is_workload_set = True
+        self.set_is_workload_set(True)
 
         # If we are setting a workload of this type, we need to run as a
         # SE-mode simulation.

--- a/src/python/gem5/components/boards/se_binary_workload.py
+++ b/src/python/gem5/components/boards/se_binary_workload.py
@@ -141,9 +141,20 @@ class SEBinaryWorkload:
             #
             # A better API for this which avoids `isinstance` checks would be
             # welcome.
+            if any(
+                core.is_workload_set()
+                for core in self.get_processor()._all_cores()
+            ):
+                warn("Workload has been set more than once!")
+
             for core in self.get_processor()._all_cores():
                 core.set_workload(process)
         else:
+            if any(
+                core.is_workload_set()
+                for core in self.get_processor().get_cores()
+            ):
+                warn("Workload has been set more than once!")
             for core in self.get_processor().get_cores():
                 core.set_workload(process)
 

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -135,11 +135,6 @@ class BaseCPUCore(AbstractCore):
     def set_workload(self, process: Process) -> None:
         self.core.workload = process
 
-    def is_workload_set(self) -> bool:
-        if self.core.workload:
-            return True
-        return False
-
     @overrides(AbstractCore)
     def set_switched_out(self, value: bool) -> None:
         self.core.switched_out = value

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -135,6 +135,11 @@ class BaseCPUCore(AbstractCore):
     def set_workload(self, process: Process) -> None:
         self.core.workload = process
 
+    def is_workload_set(self) -> bool:
+        if self.core.workload:
+            return True
+        return False
+
     @overrides(AbstractCore)
     def set_switched_out(self, value: bool) -> None:
         self.core.switched_out = value


### PR DESCRIPTION
This commit adds a warning message for when set_workload is called twice, as users typically do not mean to do this.