### PR TITLE
ext: Fix GCC v13+ comp of systemc due to problematic overloaded-virtual warn

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -86,7 +86,7 @@ jobs:
 
     dramsys-tests:
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-22.04_all-dependencies:latest
+        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         timeout-minutes: 4320 # 3 days
         steps:
             - uses: actions/checkout@v4

--- a/src/systemc/ext/tlm_core/2/sockets/target_socket.hh
+++ b/src/systemc/ext/tlm_core/2/sockets/target_socket.hh
@@ -91,6 +91,17 @@ class tlm_base_target_socket :
     // - Binds the port of the target socket to the export of the initiator
     //   socket
     //
+
+#pragma GCC diagnostic push
+/**
+ * The following warning is disabled because the bind methods are overloaded
+ * in the derived class and the base class. In GCC v13+ this
+ * 'overloaded-virtual' warning is strict enough to trigger here (though the
+ * code is correct).
+ */
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
     virtual void
     bind(base_initiator_socket_type &s)
     {
@@ -133,6 +144,7 @@ class tlm_base_target_socket :
     }
 
     void operator () (fw_interface_type &s) { bind(s); }
+#pragma GCC diagnostic pop
 
     //
     // Forward to 'size()' of port class.


### PR DESCRIPTION
Fixes #1121 in line with the following suggesting:

https://github.com/gem5/gem5/issues/1121#issuecomment-2352743409