### PR TITLE
python: infer fs/se mode from workload for boards with both

### DIFF
--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -116,9 +116,6 @@ class AbstractBoard:
         # Simulator module.
         self._checkpoint = None
 
-        # Setup the board and memory system's memory ranges.
-        self._setup_memory_ranges()
-
         # A private variable to record whether `_connect_things` has been
         # been called.
         self._connect_things_called = False
@@ -189,8 +186,6 @@ class AbstractBoard:
         :param is_fs: Set whether the board is to be run in FS mode or SE mode.
         """
         self._is_fs = is_fs
-        # Setup board properties unique to the board being constructed.
-        self._setup_board()
 
     def is_fullsystem(self) -> bool:
         """
@@ -386,6 +381,12 @@ class AbstractBoard:
     def _pre_instantiate(self):
         """To be called immediately before ``m5.instantiate``. This is where
         ``_connect_things`` is executed by default."""
+
+        # Setup the board and memory system's memory ranges.
+        self._setup_memory_ranges()
+
+        # Setup board properties unique to the board being constructed.
+        self._setup_board()
 
         # Connect the memory, processor, and cache hierarchy.
         self._connect_things()

--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -119,9 +119,6 @@ class AbstractBoard:
         # Setup the board and memory system's memory ranges.
         self._setup_memory_ranges()
 
-        # Setup board properties unique to the board being constructed.
-        self._setup_board()
-
         # A private variable to record whether `_connect_things` has been
         # been called.
         self._connect_things_called = False
@@ -192,6 +189,8 @@ class AbstractBoard:
         :param is_fs: Set whether the board is to be run in FS mode or SE mode.
         """
         self._is_fs = is_fs
+        # Setup board properties unique to the board being constructed.
+        self._setup_board()
 
     def is_fullsystem(self) -> bool:
         """

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -123,11 +123,16 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
             self.multi_proc = True
 
     @overrides(AbstractBoard)
-    def _setup_board(self) -> None:
-        # This board is expected to run full-system simulation.
-        # Loading ArmFsLinux() from `src/arch/arm/ArmFsWorkload.py`
-        self.workload = ArmFsLinux()
+    def _set_fullsystem(self, is_fs: bool) -> None:
+        self._is_fs = is_fs
 
+        if self._is_fs:
+            # This board is expected to run full-system simulation.
+            # Loading ArmFsLinux() from `src/arch/arm/ArmFsWorkload.py`
+            self.workload = ArmFsLinux()
+
+    @overrides(AbstractBoard)
+    def _setup_board(self) -> None:
         # We are fixing the following variable for the ArmSystem to work. The
         # security extension is checked while generating the dtb file in
         # realview. This board does not have security extension enabled.

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -96,9 +96,14 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload):
             )
 
     @overrides(AbstractSystemBoard)
-    def _setup_board(self) -> None:
-        self.workload = RiscvBootloaderKernelWorkload()
+    def _set_fullsystem(self, is_fs: bool) -> None:
+        self._is_fs = is_fs
 
+        if self._is_fs:
+            self.workload = RiscvBootloaderKernelWorkload()
+
+    @overrides(AbstractSystemBoard)
+    def _setup_board(self) -> None:
         # Contains a CLINT, PLIC, UART, and some functions for the dtb, etc.
         self.platform = HiFive()
         # Note: This only works with single threaded cores.

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -92,11 +92,16 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload):
             )
 
     @overrides(AbstractSystemBoard)
+    def _set_fullsystem(self, is_fs: bool) -> None:
+        self._is_fs = is_fs
+
+        if self._is_fs:
+            self.pc = Pc()
+
+            self.workload = X86FsLinux()
+
+    @overrides(AbstractSystemBoard)
     def _setup_board(self) -> None:
-        self.pc = Pc()
-
-        self.workload = X86FsLinux()
-
         # North Bridge
         self.iobus = IOXBar()
 

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -142,10 +142,15 @@ class RISCVMatchedBoard(
         )
 
     @overrides(AbstractSystemBoard)
-    def _setup_board(self) -> None:
-        if self._fs:
+    def _set_fullsystem(self, is_fs: bool) -> None:
+        self._is_fs = is_fs
+
+        if self._is_fs:
             self.workload = RiscvBootloaderKernelWorkload()
 
+    @overrides(AbstractSystemBoard)
+    def _setup_board(self) -> None:
+        if self._fs:
             # Contains a CLINT, PLIC, UART, and some functions for the dtb, etc.
             self.platform = HiFive()
             # Note: This only works with single threaded cores.


### PR DESCRIPTION
This commit modifies abstract_board.py so that boards that support both SE and FS mode (have both set_se_binary_workload and set_kernel_disk_workload) can infer which to use based on the workload that is set.