### PR TITLE
arch-arm,util-m5: Change arm64's default m5 call type to addr

### DIFF
--- a/util/m5/src/abi/arm64/SConsopts
+++ b/util/m5/src/abi/arm64/SConsopts
@@ -29,8 +29,8 @@ env['ABI'] = 'arm64'
 get_abi_opt('CROSS_COMPILE', 'aarch64-linux-gnu-')
 get_abi_opt('QEMU_ARCH', 'aarch64')
 
-env['CALL_TYPE']['inst'].impl('m5op.S', 'verify_inst.cc', default=True)
-env['CALL_TYPE']['addr'].impl('m5op_addr.S')
+env['CALL_TYPE']['inst'].impl('m5op.S', 'verify_inst.cc')
+env['CALL_TYPE']['addr'].impl('m5op_addr.S', default=True)
 env['CALL_TYPE']['semi'].impl('m5op_semi.S', 'verify_semi.cc')
 
 env.Append(CXXFLAGS='-DM5OP_ADDR=0x10010000')


### PR DESCRIPTION
As of PR #977, gem5 has a defined M5OPS_ADDR for arm64, even if it is constrained to certain conditions. With that change and the arm64 board KVM support (#725), it seems like interaction with the m5 utility under arm64 will most commonly occur in KVM -- where instruction-mode does not work -- and thus address-mode becomes more desirable as the default.

This also makes m5's behavior in arm64 consistent with x86, the only other architecture that supports address-mode operations.