### PR TITLE
util-docker: Minor docker improvements/fixes

### DIFF
--- a/util/dockerfiles/clang-compiler/Dockerfile
+++ b/util/dockerfiles/clang-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies for gem5, with Clang 16."

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -37,9 +37,8 @@ variable "TAG" {
 
 # Common attributes across all targets. Note: these can be overwritten.
 target "common" {
-  # Here we are enabling multi-platform builds. We are compiling to ARM, X86,
-  # and RISC-V.
-  platforms = ["linux/amd64", "linux/arm64", "linux/riscv64"]
+  # Here we are enabling multi-platform builds. We are compiling to ARM, X86]
+  platforms = ["linux/amd64", "linux/arm64"]
   pull = true
 }
 

--- a/util/dockerfiles/gcc-compiler/Dockerfile
+++ b/util/dockerfiles/gcc-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+FROM  ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies for gem5, with GCC 13."

--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM --platform=${BUILDPLATFORM} ubuntu:20.04
+FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="This dockerfile contains all the dependences necessary to run GPU applications in gem5 using the gcn5 (Vega) APU model."

--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-FROM --platform=${BUILDPLATFORM} ubuntu:22.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="The Dockerfile in this directory is used to build applications to be run with GPU full system. Applications targeting AMD's ROCm GPU framework can be built using this docker (e.g., HIP, HSA, OpenCL, etc.)."

--- a/util/dockerfiles/sst/Dockerfile
+++ b/util/dockerfiles/sst/Dockerfile
@@ -23,7 +23,7 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile for using SST with gem5."

--- a/util/dockerfiles/systemc/Dockerfile
+++ b/util/dockerfiles/systemc/Dockerfile
@@ -23,7 +23,7 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-FROM --platform=${BUILDPLATFORM} ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile for using SystemC with gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause

--- a/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
@@ -23,7 +23,7 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-FROM --platform=${BUILDPLATFORM} ubuntu:22.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 22.04 docker image with all dependencies required for building and using gem5."

--- a/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
@@ -56,7 +56,8 @@ RUN apt -y update && apt -y upgrade && apt -y install \
     wget \
     cmake \
     doxygen \
-    vim
+    vim \
+    sudo
 
 # pre-commit, as installed via apt in 24.04, attempts to create a cache
 # directory at "${HOME}/.cache/pre-commit". If running docker with non-root,

--- a/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
@@ -23,7 +23,7 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-FROM --platform=${BUILDPLATFORM} ubuntu:24.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies required for building and using gem5."

--- a/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile
@@ -23,7 +23,7 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-FROM --platform=${BUILDPLATFORM} ubuntu:24.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with minimal dependencies required for building and using gem5."


### PR DESCRIPTION

1. Added `sudo` to Ubuntu 24.04 all dependency Dockerfile

Without this an admin user entering a container mirroring host user permissions can't run `sudo` within the container as it doesn't exist. They also can't install it as `apt install` requires `sudo`.

As 24.04_all-deps serves as the base images for other images, this change will be reflected in most other gem5 Docker images.

2. Fix multiplatform builds by removing `BUILDPLATFORM` platform fix.

This actually breaks multi-platform builds when using docker buildx via the docker-bake.hcl file. Removing this fixes and permits the multi-platform builds to be built.

3.Remove 'latex/riscv64' as Docker build target

It is unlikely anyone will be running these images on a RISC-V system anytime soon. They are costly in terms of space and also require RISC-V emulation to build which is very slow. This change has it so our multi-platform builds just target ARM and X86.