### PR TITLE
scons: Fix scons 'readCommand' non-zero exits

### DIFF
--- a/site_scons/gem5_scons/util.py
+++ b/site_scons/gem5_scons/util.py
@@ -82,14 +82,18 @@ def readCommand(cmd, **kwargs):
     kwargs.setdefault("stdout", PIPE)
     kwargs.setdefault("stderr", STDOUT)
     kwargs.setdefault("close_fds", True)
-    try:
-        subp = Popen(cmd, **kwargs)
-    except Exception as e:
-        if no_exception:
-            return -1, exception
-        raise
 
-    output = subp.communicate()[0].decode("utf-8")
+    p = Popen(cmd, **kwargs)
+    return_code = p.wait()
+    output = p.communicate()[0].decode("utf-8")
+
+    if return_code != 0:
+        if no_exception:
+            return return_code, None
+        raise Exception(
+            f"Command '{cmd}' failed with return code {return_code}:\n{output}"
+        )
+
     return output
 
 


### PR DESCRIPTION
There appears to have been an assumption here that `Popen` would raise an exception if the command run returned non-zero. This is not the case. This commit fixes this by obtaining the return code and throwing an exception if it is non-zero.

This bug caused some minor issues as Exception handling code to handle the non-zero case elsewhere in Scons was never executed.