### PR TITLE
arch-riscv: Move static GDB methods to RemoteGDB virtual methods

### DIFF
--- a/src/arch/riscv/remote_gdb.cc
+++ b/src/arch/riscv/remote_gdb.cc
@@ -159,22 +159,6 @@ namespace gem5
 
 using namespace RiscvISA;
 
-static RiscvType
-getRvType(ThreadContext* tc)
-{
-    auto isa = dynamic_cast<ISA*>(tc->getIsaPtr());
-    panic_if(!isa, "Cannot derive rv_type from non-riscv isa");
-    return isa->rvType();
-}
-
-static PrivilegeModeSet
-getPrivilegeModeSet(ThreadContext* tc)
-{
-    auto isa = dynamic_cast<ISA*>(tc->getIsaPtr());
-    panic_if(!isa, "Cannot derive rv_type from non-riscv isa");
-    return isa->getPrivilegeModeSet();
-}
-
 template <typename xint>
 static void
 setRegNoEffectWithMask(
@@ -205,6 +189,22 @@ RemoteGDB::RemoteGDB(System *_system, ListenSocketConfig _listen_config)
     : BaseRemoteGDB(_system, _listen_config),
     regCache32(this), regCache64(this)
 {
+}
+
+RiscvType
+RemoteGDB::getRvType(ThreadContext* tc)
+{
+    auto isa = dynamic_cast<ISA*>(tc->getIsaPtr());
+    panic_if(!isa, "Cannot derive rv_type from non-riscv isa");
+    return isa->rvType();
+}
+
+PrivilegeModeSet
+RemoteGDB::getPrivilegeModeSet(ThreadContext* tc)
+{
+    auto isa = dynamic_cast<ISA*>(tc->getIsaPtr());
+    panic_if(!isa, "Cannot derive rv_type from non-riscv isa");
+    return isa->getPrivilegeModeSet();
 }
 
 bool
@@ -251,7 +251,11 @@ void
 RemoteGDB::Riscv32GdbRegCache::getRegs(ThreadContext *context)
 {
     DPRINTF(GDBAcc, "getregs in remotegdb, size %lu\n", size());
-    PrivilegeModeSet pms = getPrivilegeModeSet(context);
+    RemoteGDB* rv_gdb = dynamic_cast<RemoteGDB*>(gdb);
+    PrivilegeModeSet pms = enums::MSU;
+    if (rv_gdb != nullptr) {
+      pms = rv_gdb->getPrivilegeModeSet(context);
+    }
     auto& RVxCSRMasks = CSRMasks[RV32][pms];
 
     // General registers
@@ -366,7 +370,11 @@ void
 RemoteGDB::Riscv32GdbRegCache::setRegs(ThreadContext *context) const
 {
     DPRINTF(GDBAcc, "setregs in remotegdb \n");
-    PrivilegeModeSet pms = getPrivilegeModeSet(context);
+    RemoteGDB* rv_gdb = dynamic_cast<RemoteGDB*>(gdb);
+    PrivilegeModeSet pms = enums::MSU;
+    if (rv_gdb != nullptr) {
+      pms = rv_gdb->getPrivilegeModeSet(context);
+    }
     for (int i = 0; i < int_reg::NumArchRegs; i++)
         context->setReg(intRegClass[i], r.gpr[i]);
     context->pcState(r.pc);
@@ -448,7 +456,11 @@ void
 RemoteGDB::Riscv64GdbRegCache::getRegs(ThreadContext *context)
 {
     DPRINTF(GDBAcc, "getregs in remotegdb, size %lu\n", size());
-    PrivilegeModeSet pms = getPrivilegeModeSet(context);
+    RemoteGDB* rv_gdb = dynamic_cast<RemoteGDB*>(gdb);
+    PrivilegeModeSet pms = enums::MSU;
+    if (rv_gdb != nullptr) {
+      pms = rv_gdb->getPrivilegeModeSet(context);
+    }
     auto& RVxCSRMasks = CSRMasks[RV64][pms];
 
     // General registers
@@ -557,7 +569,11 @@ void
 RemoteGDB::Riscv64GdbRegCache::setRegs(ThreadContext *context) const
 {
     DPRINTF(GDBAcc, "setregs in remotegdb \n");
-    PrivilegeModeSet pms = getPrivilegeModeSet(context);
+    RemoteGDB* rv_gdb = dynamic_cast<RemoteGDB*>(gdb);
+    PrivilegeModeSet pms = enums::MSU;
+    if (rv_gdb != nullptr) {
+      pms = rv_gdb->getPrivilegeModeSet(context);
+    }
     for (int i = 0; i < int_reg::NumArchRegs; i++)
         context->setReg(intRegClass[i], r.gpr[i]);
     context->pcState(r.pc);

--- a/src/arch/riscv/remote_gdb.hh
+++ b/src/arch/riscv/remote_gdb.hh
@@ -35,8 +35,10 @@
 
 #include <string>
 
+#include "arch/riscv/isa.hh"
 #include "arch/riscv/regs/float.hh"
 #include "arch/riscv/regs/int.hh"
+#include "arch/riscv/regs/misc.hh"
 #include "base/remote_gdb.hh"
 
 namespace gem5
@@ -250,6 +252,10 @@ class RemoteGDB : public BaseRemoteGDB
      */
     bool getXferFeaturesRead(const std::string &annex,
                              std::string &output) override;
+
+    virtual RiscvType getRvType(ThreadContext* tc);
+
+    virtual PrivilegeModeSet getPrivilegeModeSet(ThreadContext* tc);
 };
 
 } // namespace RiscvISA


### PR DESCRIPTION
Move getRvType & getPrivilegeModeSet static methods into RiscvISA::RemoteGDB virtual methods allows the derived RiscvISA::RemoteGDB to override it without change a lot of methods in base methods

Change-Id: I3cbb9cf1fdee4a298e903bb4a0a5683c042b749d