### PR TITLE
util-docker: Minor housekeeping to Dockerfiles

### DIFF
--- a/util/dockerfiles/clang-compiler/Dockerfile
+++ b/util/dockerfiles/clang-compiler/Dockerfile
@@ -1,7 +1,6 @@
 FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies for gem5, with Clang 16."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ARG version=16 # Version of Clang to install in this image. Default is 16.

--- a/util/dockerfiles/devcontainer/Dockerfile
+++ b/util/dockerfiles/devcontainer/Dockerfile
@@ -42,7 +42,6 @@
 FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest as builder
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="This Dockerfile creates a devcontainer for gem5 development referenced in ./devcontainer/devcontainer.json. The devcontainer is a multi-platform container that can be built for x86, arm, and riscv and includes all dependencies required for gem5 development."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 RUN wget https://github.com/gem5/gem5/archive/refs/tags/v24.0.tar.gz && \

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -40,6 +40,7 @@ target "common" {
   # Here we are enabling multi-platform builds. We are compiling to ARM, X86]
   platforms = ["linux/amd64", "linux/arm64"]
   pull = true
+  dockerfile = "Dockerfile"
 }
 
 # A group of targets to be built. Note: groups can contain other groups.
@@ -71,7 +72,7 @@ group "clang-compilers" {
 
 target "clang-version-14" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a Clang v14 compiler."]
   args = {
     version = "14"
   }
@@ -81,7 +82,7 @@ target "clang-version-14" {
 
 target "clang-version-15" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a Clang v15 compiler."]
   args = {
     version = "15"
   }
@@ -91,7 +92,7 @@ target "clang-version-15" {
 
 target "clang-version-16" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a Clang v16 compiler."]
   args = {
     version = "16"
   }
@@ -101,7 +102,7 @@ target "clang-version-16" {
 
 target "clang-version-17" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a Clang v17 compiler."]
   args = {
     version = "17"
   }
@@ -111,7 +112,7 @@ target "clang-version-17" {
 
 target "clang-version-18" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a Clang v18 compiler."]
   args = {
     version = "18"
   }
@@ -130,7 +131,7 @@ group "gcc-compilers" {
 
 target "gcc-version-10" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v10 compiler"]
   args = {
     version = "10"
   }
@@ -140,7 +141,7 @@ target "gcc-version-10" {
 
 target "gcc-version-11" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v11 compiler."]
   args = {
     version = "11"
   }
@@ -150,7 +151,7 @@ target "gcc-version-11" {
 
 target "gcc-version-12" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v12 compiler."]
   args = {
     version = "12"
   }
@@ -160,7 +161,7 @@ target "gcc-version-12" {
 
 target "gcc-version-13" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v13 compiler."]
   args = {
     version = "13"
   }
@@ -178,59 +179,59 @@ group "ubuntu-releases" {
 
 target "ubuntu-24-04_all-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An Ubuntu 24.04 image with all dependencies required for building and running gem5."]
   context = "ubuntu-24.04_all-dependencies"
   tags = ["${IMAGE_URI}/ubuntu-24.04_all-dependencies:${TAG}"]
 }
 
 target "ubuntu-22-04_all-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An Ubuntu 22.04 image with all dependencies required for building and running gem5."]
   context = "ubuntu-22.04_all-dependencies"
   tags = ["${IMAGE_URI}/ubuntu-22.04_all-dependencies:${TAG}"]
 }
 
 target "ubuntu-24-04_min-dependencies" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An Ubuntu 24.04 image with the minimum dependencies required for building and running gem5."]
   context = "ubuntu-24.04_min-dependencies"
   tags = ["${IMAGE_URI}/ubuntu-24.04_min-dependencies:${TAG}"]
 }
 
 target "gcn-gpu" {
   inherits = ["common"]
-  platform = "linux/amd64" # Only build for x86.
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image used to build and run gem5 when simulating GPU in SE mode. Also used for creation of GPU SE workloads."]
+  platforms = ["linux/amd64"] # Only build for x86.
   context = "gcn-gpu"
   tags = ["${IMAGE_URI}/gcn-gpu:${TAG}"]
 }
 
 target "gpu-fs" {
   inherits = ["common"]
-  platform = "linux/amd64" # Only build for x86.
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image used to build applications to be run with GPU full system. Applications targeting AMD's ROCm GPU framework can be built using this image (e.g., HIP, HSA, OpenCL, etc.)."]
+  platforms = ["linux/amd64"] # Only build for x86.
   context = "gpu-fs"
   tags = ["${IMAGE_URI}/gpu-fs:${TAG}"]
 }
 
 target "sst" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image containing all the requirements for building and running gem5 in addition to SST. Used to test gem5-SST integration."]
   context = "sst"
   tags = ["${IMAGE_URI}/sst-env:${TAG}"]
 }
 
 target "systemc" {
   inherits = ["common"]
-  dockerfile = "Dockerfile"
+  annotations = ["index,manifest:org.opencontainers.image.description=An image containing all the requirements for building and running gem5 in addition to SystemC. Used to test gem5-SystemC integration."]
   context = "systemc"
   tags = ["${IMAGE_URI}/systemc-env:${TAG}"]
 }
 
 target "devcontainer" {
   inherits = ["common"]
+  annotations = ["index,manifest:org.opencontainers.image.description=A devcontainer image for gem5 development referenced in the repo's ./devcontainer/devcontainer.json file. Includes all dependencies required for gem5 development."]
   dependencies = ["devcontainer"]
-  dockerfile = "Dockerfile"
   context = "devcontainer"
   tags = ["${IMAGE_URI}/devcontainer:${TAG}"]
 }

--- a/util/dockerfiles/gcc-compiler/Dockerfile
+++ b/util/dockerfiles/gcc-compiler/Dockerfile
@@ -1,7 +1,6 @@
 FROM  ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies for gem5, with GCC 13."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ARG version=13 # Version of GCC to install in this image. Default is 13.

--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -27,7 +27,6 @@
 FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="This dockerfile contains all the dependences necessary to run GPU applications in gem5 using the gcn5 (Vega) APU model."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -30,7 +30,6 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="The Dockerfile in this directory is used to build applications to be run with GPU full system. Applications targeting AMD's ROCm GPU framework can be built using this docker (e.g., HIP, HSA, OpenCL, etc.)."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/util/dockerfiles/sst/Dockerfile
+++ b/util/dockerfiles/sst/Dockerfile
@@ -26,7 +26,6 @@
 FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile for using SST with gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 # Setting the environmental variables

--- a/util/dockerfiles/systemc/Dockerfile
+++ b/util/dockerfiles/systemc/Dockerfile
@@ -25,7 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 FROM ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile for using SystemC with gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV CXX="g++"

--- a/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile
@@ -26,7 +26,6 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 22.04 docker image with all dependencies required for building and using gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
@@ -26,7 +26,6 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with all dependencies required for building and using gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile
@@ -26,7 +26,7 @@
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
-LABEL org.opencontainers.image.description="A Dockerfile to build an Ubuntu 24.04 docker image with minimal dependencies required for building and using gem5."
+LABEL org.opencontainers.image.description="An Ubuntu 24.04 docker image with minimal dependencies required for building and using gem5."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
1. Moved description label to docker-bake.hcl. Image descriptions must be specified here. See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images
2. Moved specifying the 'Dockerfile' to 'common'.
3. Changed it so the gpu-fs and gcn-fpu images only built to linux/amd64. arm64 doesn't work.