### PR TITLE
gpu-compute: Fix '64kB' to '64KiB' in gpu-compute

### DIFF
--- a/src/gpu-compute/GPU.py
+++ b/src/gpu-compute/GPU.py
@@ -310,7 +310,7 @@ class Shader(ClockedObject):
         """Insert rel packet into
                                          ruby at kernel end""",
     )
-    globalmem = Param.MemorySize("64kB", "Memory size")
+    globalmem = Param.MemorySize("64KiB", "Memory size")
     timing = Param.Bool(False, "timing memory accesses")
 
     cpu_pointer = Param.BaseCPU(NULL, "pointer to base CPU")

--- a/src/gpu-compute/LdsState.py
+++ b/src/gpu-compute/LdsState.py
@@ -38,7 +38,7 @@ class LdsState(ClockedObject):
     cxx_class = "gem5::LdsState"
     cxx_header = "gpu-compute/lds_state.hh"
     size = Param.Int(65536, "the size of the LDS")
-    range = Param.AddrRange("64kB", "address space of the LDS")
+    range = Param.AddrRange("64KiB", "address space of the LDS")
     bankConflictPenalty = Param.Int(
         1, "penalty per LDS bank conflict when accessing data"
     )


### PR DESCRIPTION
64kB, in these cases, will cast to 64KiB regardless. To improve readability and understanding of these objects, this patch changes there SI Prefix (kB -> KiB).