### PR TITLE
mem-cache: Helper functions to allow dynamic configuration of partitioning policies

### DIFF
--- a/src/mem/cache/tags/partitioning_policies/max_capacity_pp.cc
+++ b/src/mem/cache/tags/partitioning_policies/max_capacity_pp.cc
@@ -52,8 +52,9 @@ namespace partitioning_policy
 
 MaxCapacityPartitioningPolicy::MaxCapacityPartitioningPolicy
     (const MaxCapacityPartitioningPolicyParams &params):
-    BasePartitioningPolicy(params), cacheSize(params.cache_size),
-    blkSize(params.blk_size), partitionIDs(params.partition_ids),
+    BasePartitioningPolicy(params),
+    totalBlockCount(params.cache_size / params.blk_size),
+    partitionIDs(params.partition_ids),
     capacities(params.capacities)
 {
     // check if ids and capacities vectors are the same length
@@ -61,9 +62,6 @@ MaxCapacityPartitioningPolicy::MaxCapacityPartitioningPolicy
         fatal("MaxCapacity Partitioning Policy configuration invalid: ids and "
             "capacities arrays are not equal lengths");
     }
-
-    // calculate total cache block count to use when creating allocation maps
-    const uint64_t total_block_cnt = this->cacheSize / this->blkSize;
 
     // check allocations and create map
     for (auto i = 0; i < this->partitionIDs.size(); i++) {
@@ -77,13 +75,13 @@ MaxCapacityPartitioningPolicy::MaxCapacityPartitioningPolicy
                 cap_frac);
         }
 
-        const uint64_t allocated_block_cnt = cap_frac * total_block_cnt;
+        const uint64_t allocated_block_cnt = cap_frac * totalBlockCount;
         partitionIdMaxCapacity.emplace(partition_id, allocated_block_cnt);
 
         DPRINTF(PartitionPolicy, "Configured MaxCapacity Partitioning Policy "
             "for PartitionID: %d to use portion of size %f (%d cache blocks "
             "of %d total)\n", partition_id, cap_frac, allocated_block_cnt,
-            total_block_cnt);
+            totalBlockCount);
 
     }
 }

--- a/src/mem/cache/tags/partitioning_policies/max_capacity_pp.cc
+++ b/src/mem/cache/tags/partitioning_policies/max_capacity_pp.cc
@@ -68,22 +68,28 @@ MaxCapacityPartitioningPolicy::MaxCapacityPartitioningPolicy
         const uint64_t partition_id = this->partitionIDs[i];
         const double cap_frac = capacities[i];
 
-        // check Capacity Fraction (cap_frac) is actually a fraction in [0,1]
-        if (!(cap_frac >= 0 && cap_frac <= 1)) {
-            fatal("MaxCapacity Partitioning Policy for PartitionID %d has "
-                "Capacity Fraction %f outside of [0,1] range", partition_id,
-                cap_frac);
-        }
-
-        const uint64_t allocated_block_cnt = cap_frac * totalBlockCount;
-        partitionIdMaxCapacity.emplace(partition_id, allocated_block_cnt);
-
-        DPRINTF(PartitionPolicy, "Configured MaxCapacity Partitioning Policy "
-            "for PartitionID: %d to use portion of size %f (%d cache blocks "
-            "of %d total)\n", partition_id, cap_frac, allocated_block_cnt,
-            totalBlockCount);
-
+        // Configure partition
+        configurePartition(partition_id, cap_frac);
     }
+}
+
+void
+MaxCapacityPartitioningPolicy::configurePartition(uint64_t partition_id,
+                                                  double cap_frac)
+{
+    // check Capacity Fraction (cap_frac) is actually a fraction in [0,1]
+    panic_if(!(cap_frac >= 0 && cap_frac <= 1),
+             "MaxCapacity Partitioning Policy for PartitionID %d has "
+             "Capacity Fraction %f outside of [0,1] range", partition_id,
+             cap_frac);
+
+    const uint64_t allocated_block_cnt = cap_frac * totalBlockCount;
+    partitionIdMaxCapacity.emplace(partition_id, allocated_block_cnt);
+
+    DPRINTF(PartitionPolicy, "Configured MaxCapacity Partitioning Policy "
+        "for PartitionID: %d to use portion of size %f (%d cache blocks "
+        "of %d total)\n", partition_id, cap_frac, allocated_block_cnt,
+        totalBlockCount);
 }
 
 void

--- a/src/mem/cache/tags/partitioning_policies/max_capacity_pp.hh
+++ b/src/mem/cache/tags/partitioning_policies/max_capacity_pp.hh
@@ -81,14 +81,9 @@ class MaxCapacityPartitioningPolicy : public BasePartitioningPolicy
 
   private:
     /**
-    * Cache size in number of bytes
+    * Total number of cache blocks
     */
-    const uint64_t cacheSize;
-
-    /**
-    * Cache block size in number of bytes
-    */
-    const uint64_t blkSize;
+    const uint64_t totalBlockCount;
 
     /**
     * Vector of partitionIDs the policy operates on

--- a/src/mem/cache/tags/partitioning_policies/max_capacity_pp.hh
+++ b/src/mem/cache/tags/partitioning_policies/max_capacity_pp.hh
@@ -79,6 +79,14 @@ class MaxCapacityPartitioningPolicy : public BasePartitioningPolicy
     void
     notifyRelease(const uint64_t partition_id) override;
 
+    /**
+    * Set the maximum capacity (as a fraction) for the provided partition
+    *
+    * param partion_id partition to be configured
+    * param cap_frac max capacity for the partition (0 < cap_frac < 1)
+    */
+    void configurePartition(uint64_t partition_id, double cap_frac);
+
   private:
     /**
     * Total number of cache blocks

--- a/src/mem/cache/tags/partitioning_policies/way_pp.cc
+++ b/src/mem/cache/tags/partitioning_policies/way_pp.cc
@@ -70,7 +70,7 @@ WayPartitioningPolicy::WayPartitioningPolicy
                 "associativity is %d", alloc_id, way, cache_assoc);
 
             if (this->partitionIdWays[alloc_id].count(way) == 0) {
-                this->partitionIdWays[alloc_id].emplace(way);
+                addWayToPartition(alloc_id, way);
             } else {
                 // do not add duplicate allocation to policy and warn
                 warn("Duplicate Way Partitioning Policy allocation for "
@@ -84,6 +84,18 @@ WayPartitioningPolicy::WayPartitioningPolicy
             "for PartitionID: %d \n", allocation->getWays().size(),
             alloc_id);
     }
+}
+
+void
+WayPartitioningPolicy::addWayToPartition(uint64_t partition_id, unsigned way)
+{
+    partitionIdWays[partition_id].emplace(way);
+}
+
+void
+WayPartitioningPolicy::removeWayToPartition(uint64_t partition_id, unsigned way)
+{
+    partitionIdWays[partition_id].erase(way);
 }
 
 void

--- a/src/mem/cache/tags/partitioning_policies/way_pp.hh
+++ b/src/mem/cache/tags/partitioning_policies/way_pp.hh
@@ -85,6 +85,9 @@ class WayPartitioningPolicy : public BasePartitioningPolicy
     void
     notifyRelease(const uint64_t partition_id) override {};
 
+    void addWayToPartition(uint64_t partition_id, unsigned way);
+    void removeWayToPartition(uint64_t partition_id, unsigned way);
+
   private:
     /**
     * Map of policied PartitionIDs and their associated cache ways


### PR DESCRIPTION
This PR is doing a simple refactoring of some partitioning policies. It moves existing functionalities
within PP methods so that they can be called multiple times throughout the simulation.
Therefore allowing a dynamic adjustment of the partitioning scheme