### PR TITLE
arch-arm: Add a method to determine External Abort

### DIFF
--- a/src/arch/arm/faults.cc
+++ b/src/arch/arm/faults.cc
@@ -1227,6 +1227,17 @@ AbortFault<T>::isMMUFault() const
 
 template<class T>
 bool
+AbortFault<T>::isExternalAbort() const
+{
+    return
+        (source == ArmFault::SynchronousExternalAbort)  ||
+        (source == ArmFault::AsynchronousExternalAbort) ||
+        ((source >= ArmFault::SynchExtAbtOnTranslTableWalkLL) &&
+         (source < ArmFault::SynchExtAbtOnTranslTableWalkLL + 4));
+}
+
+template<class T>
+bool
 AbortFault<T>::getFaultVAddr(Addr &va) const
 {
     va = (stage2 ?  OVAddr : faultAddr);
@@ -1368,6 +1379,7 @@ DataAbort::iss() const
     iss.wnr = write;
     iss.s1ptw = s1ptw;
     iss.cm = cm;
+    iss.ea = isExternalAbort();
 
     // ISS is valid if not caused by a stage 1 page table walk, and when taken
     // to AArch64 only when directed to EL2

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -254,6 +254,7 @@ class ArmFault : public FaultBase
     virtual void setSyndrome(ThreadContext *tc, MiscRegIndex syndrome_reg);
     virtual bool getFaultVAddr(Addr &va) const { return false; }
     OperatingMode getToMode() const { return toMode; }
+    virtual bool isExternalAbort() const { return false; }
 };
 
 template<typename T>
@@ -511,6 +512,7 @@ class AbortFault : public ArmFaultVals<T>
     void annotate(ArmFault::AnnotationIDs id, uint64_t val) override;
     void setSyndrome(ThreadContext *tc, MiscRegIndex syndrome_reg) override;
     bool isMMUFault() const;
+    bool isExternalAbort() const override;
 };
 
 class PrefetchAbort : public AbortFault<PrefetchAbort>

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -227,7 +227,7 @@ class ArmFault : public FaultBase
                   nullStaticInstPtr);
     void invoke64(ThreadContext *tc, const StaticInstPtr &inst =
                   nullStaticInstPtr);
-    void update(ThreadContext *tc);
+    virtual void update(ThreadContext *tc);
     bool isResetSPSR(){ return bStep; }
 
     bool vectorCatch(ThreadContext *tc, const StaticInstPtr &inst);
@@ -502,6 +502,7 @@ class AbortFault : public ArmFaultVals<T>
 
     void invoke(ThreadContext *tc, const StaticInstPtr &inst =
                 nullStaticInstPtr) override;
+    void update(ThreadContext *tc) override;
 
     FSR getFsr(ThreadContext *tc) const override;
     uint8_t getFaultStatusCode(ThreadContext *tc) const;


### PR DESCRIPTION
- Add `isExternalAbort()` in `AbortFault<T>` to determine external abort.
- Add `virtual isExternalAbort()` in `ArmFault` so the method can be
used in base class.
- Set iss.ea by `isExternalAbort()`