### PR TITLE
arch-riscv: Implement CLINT reset feature

### DIFF
--- a/src/dev/riscv/Clint.py
+++ b/src/dev/riscv/Clint.py
@@ -35,6 +35,7 @@
 
 from m5.objects.Device import BasicPioDevice
 from m5.objects.IntPin import IntSinkPin
+from m5.objects.ResetPort import ResetResponsePort
 from m5.params import *
 from m5.proxy import *
 from m5.util.fdthelper import *
@@ -55,6 +56,13 @@ class Clint(BasicPioDevice):
     int_pin = IntSinkPin("Pin to receive RTC signal")
     pio_size = Param.Addr(0xC000, "PIO Size")
     num_threads = Param.Int("Number of threads in the system.")
+    reset = ResetResponsePort("Reset")
+    reset_mtimecmp = Param.Bool(
+        False, "Change mtimecmp to `mtimecmp_reset_value` when reset"
+    )
+    mtimecmp_reset_value = Param.UInt64(
+        0xFFFFFFFFFFFFFFFF, "mtimecmp reset value"
+    )
 
     def generateDeviceTree(self, state):
         node = self.generateBasicPioDeviceNode(

--- a/src/dev/riscv/clint.hh
+++ b/src/dev/riscv/clint.hh
@@ -74,6 +74,8 @@ class Clint : public BasicPioDevice
     System *system;
     int nThread;
     IntSinkPin<Clint> signal;
+    SignalSinkPort<bool> reset;
+    bool resetMtimecmp;
 
   public:
     typedef ClintParams Params;
@@ -112,11 +114,14 @@ class Clint : public BasicPioDevice
         Register64 mtime = {"mtime", 0};
         std::vector<RegisterRaz> reserved;
 
-        ClintRegisters(const std::string &name, Addr base, Clint* clint) :
+        ClintRegisters(const std::string &name, Addr base, Clint* clint,
+                       uint64_t mtimecmp_reset_value) :
           RegisterBankLE(name, base),
-          clint(clint) {}
+          clint(clint),
+          mtimecmpResetValue(mtimecmp_reset_value) {}
 
         Clint *clint;
+        uint64_t mtimecmpResetValue;
 
         void init();
 
@@ -143,6 +148,10 @@ class Clint : public BasicPioDevice
                    PortID idx=InvalidPortID) override;
     void serialize(CheckpointOut &cp) const override;
     void unserialize(CheckpointIn &cp) override;
+
+  // CLINT reset
+  public:
+    void doReset();
 
 };
 


### PR DESCRIPTION
When reset, registers are change
msip: cleared to zero
mtimecmp: unknown state, cloud be origin values or change to any values mtime: cleared to zero

Spec:
https://github.com/riscv/riscv-aclint/blob/main/riscv-aclint.adoc https://sifive.cdn.prismic.io/sifive/1a82e600-1f93-4f41-b2d8-86ed8b16acba_fu740-c000-manual-v1p6.pdf

Change-Id: I3c50b41eb765ad9cd7a8a03c427bd0011195de5c