### PR TITLE
python: clarify SimObject error message

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -1259,7 +1259,9 @@ class SimObject(metaclass=MetaSimObject):
         if not self._ccObject:
             # Make sure this object is in the configuration hierarchy
             if not self._parent and not isRoot(self):
-                raise RuntimeError("Attempt to instantiate orphan node")
+                raise RuntimeError(
+                    f"Attempt to instantiate orphan node {self}"
+                )
             # Cycles in the configuration hierarchy are not supported. This
             # will catch the resulting recursion and stop.
             self._ccObject = -1


### PR DESCRIPTION
This adds more detail to the error message that is thrown when an orphan node is instantiated.