### PR TITLE
util-docker: Fix gpu dpcker images

### DIFF
--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -199,16 +199,16 @@ target "ubuntu-24-04_min-dependencies" {
 }
 
 target "gcn-gpu" {
-  inherits = ["common"]
-  annotations = ["index,manifest:org.opencontainers.image.description=An image used to build and run gem5 when simulating GPU in SE mode. Also used for creation of GPU SE workloads."]
+  dockerfile = "Dockerfile"
+  pull=true
   platforms = ["linux/amd64"] # Only build for x86.
   context = "gcn-gpu"
   tags = ["${IMAGE_URI}/gcn-gpu:${TAG}"]
 }
 
 target "gpu-fs" {
-  inherits = ["common"]
-  annotations = ["index,manifest:org.opencontainers.image.description=An image used to build applications to be run with GPU full system. Applications targeting AMD's ROCm GPU framework can be built using this image (e.g., HIP, HSA, OpenCL, etc.)."]
+  dockerfile = "Dockerfile"
+  pull=true
   platforms = ["linux/amd64"] # Only build for x86.
   context = "gpu-fs"
   tags = ["${IMAGE_URI}/gpu-fs:${TAG}"]

--- a/util/dockerfiles/gcn-gpu/Dockerfile
+++ b/util/dockerfiles/gcn-gpu/Dockerfile
@@ -27,6 +27,7 @@
 FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
+LABEL org.opencontainers.image.description="An image used to build and run gem5 when simulating GPU in SE mode. Also used for creation of GPU SE workloads."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -30,6 +30,7 @@
 FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
+LABEL org.opencontainers.image.description="An image used to build applications to be run with GPU full system. A pplications targeting AMD's ROCm GPU framework can be built using this image (e.g., HIP, HSA, OpencL, etc.)."
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Two faults:

1. You can't give description the docker-bake file for single platform builds. They must be in the Dockerfile..
2. The gpu docker image def in docker-bake.hcl was not overriding the "common" setttings as previously thought. This was causing builds to something build the wrong platform and vairous other weird bugs. This has been fixed in this patch.