### PR TITLE
learning-gem5,tests: Update learning-gem5 Ruby Test ref

### DIFF
--- a/tests/gem5/learning_gem5/ref/test
+++ b/tests/gem5/learning_gem5/ref/test
@@ -1,3 +1,3 @@
 Global frequency set at 1000000000 ticks per second
 Beginning simulation!
-Exiting @ tick 9981 because Ruby Tester completed
+Exiting @ tick 9831 because Ruby Tester completed


### PR DESCRIPTION
The Daily tests have been failing as the learning-gem5 Ruby test now exits at tick 9831 instead of tick 9981.

**Note**: The cause of this change is currently unknown. I'm not sure if this is symptomatic of something bigger but for now I only observe this bug failure and this patch at least silences the error.