### PR TITLE
systemc: Disable 'overloaded-virtual' warn for systemc bind funcs

### DIFF
--- a/src/systemc/ext/core/sc_export.hh
+++ b/src/systemc/ext/core/sc_export.hh
@@ -70,6 +70,17 @@ class sc_export : public sc_export_base
 
     virtual const char *kind() const override { return "sc_export"; }
 
+#pragma GCC diagnostic push
+/**
+ * The following warning is disabled because the bind methods are overloaded
+ * in the derived class and the base class. In GCC v13+ this
+ * 'overloaded-virtual' warning is strict enough to trigger here (though the
+ * code is correct).
+ * Please check section 9.3 of SystemC 2.3.1 release note for more details.
+ */
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
     void operator () (IF &i) { bind(i); }
     virtual void
     bind(IF &i)
@@ -80,6 +91,7 @@ class sc_export : public sc_export_base
         }
         interface = &i;
     }
+#pragma GCC diagnostic pop
     operator IF & ()
     {
         if (!interface)

--- a/src/systemc/ext/core/sc_port.hh
+++ b/src/systemc/ext/core/sc_port.hh
@@ -114,19 +114,27 @@ class sc_port_base : public sc_object
     virtual sc_port_policy _portPolicy() const = 0;
 };
 
-// The overloaded virtual is intended in SystemC, so we'll disable the warning.
-// Please check section 9.3 of SystemC 2.3.1 release note for more details.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 template <class IF>
 class sc_port_b : public sc_port_base
 {
   public:
+#pragma GCC diagnostic push
+/**
+ * The following warning is disabled because the bind methods are overloaded
+ * in the derived class and the base class. In GCC v13+ this
+ * 'overloaded-virtual' warning is strict enough to trigger here (though the
+ * code is correct).
+ * Please check section 9.3 of SystemC 2.3.1 release note for more details.
+ */
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
     void operator () (IF &i) { bind(i); }
     void operator () (sc_port_b<IF> &p) { bind(p); }
 
     virtual void bind(IF &i) { sc_port_base::bind(i); }
     virtual void bind(sc_port_b<IF> &p) { sc_port_base::bind(p); }
+#pragma GCC diagnostic pop
 
     IF *
     operator -> ()
@@ -248,7 +256,6 @@ class sc_port_b : public sc_port_base
     sc_port_b(const sc_port_b<IF> &) {}
     sc_port_b<IF> &operator = (const sc_port_b<IF> &) { return *this; }
 };
-#pragma GCC diagnostic pop
 
 template <class IF, int N=1, sc_port_policy P=SC_ONE_OR_MORE_BOUND>
 class sc_port : public sc_port_b<IF>

--- a/src/systemc/ext/tlm_core/2/sockets/initiator_socket.hh
+++ b/src/systemc/ext/tlm_core/2/sockets/initiator_socket.hh
@@ -51,10 +51,6 @@ template <unsigned int BUSWIDTH, typename FW_IF, typename BW_IF, int N,
           sc_core::sc_port_policy POL>
 class tlm_base_target_socket;
 
-// The overloaded virtual is intended in SystemC, so we'll disable the warning.
-// Please check section 9.3 of SystemC 2.3.1 release note for more details.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 template <unsigned int BUSWIDTH=32, typename FW_IF=tlm_fw_transport_if<>,
           typename BW_IF=tlm_bw_transport_if<>, int N=1,
           sc_core::sc_port_policy POL=sc_core::SC_ONE_OR_MORE_BOUND>
@@ -100,6 +96,18 @@ class tlm_base_initiator_socket :
     // - Binds the port of the target socket to the export of the initiator
     //   socket
     //
+
+#pragma GCC diagnostic push
+/**
+ * The following warning is disabled because the bind methods are overloaded
+ * in the derived class and the base class. In GCC v13+ this
+ * 'overloaded-virtual' warning is strict enough to trigger here (though the
+ * code is correct).
+ * Please check section 9.3 of SystemC 2.3.1 release note for more details.
+ */
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
     virtual void
     bind(base_target_socket_type &s)
     {
@@ -132,6 +140,7 @@ class tlm_base_initiator_socket :
     //
     virtual void bind(bw_interface_type &ifs) { (get_base_export())(ifs); }
     void operator() (bw_interface_type &s) { bind(s); }
+#pragma GCC diagnostic pop
 
     // Implementation of tlm_base_socket_if functions
     virtual sc_core::sc_port_base &get_port_base() { return *this; }
@@ -174,7 +183,6 @@ class tlm_base_initiator_socket :
   protected:
     export_type m_export;
 };
-#pragma GCC diagnostic pop
 
 //
 // Convenience socket classes

--- a/src/systemc/ext/tlm_core/2/sockets/target_socket.hh
+++ b/src/systemc/ext/tlm_core/2/sockets/target_socket.hh
@@ -98,6 +98,7 @@ class tlm_base_target_socket :
  * in the derived class and the base class. In GCC v13+ this
  * 'overloaded-virtual' warning is strict enough to trigger here (though the
  * code is correct).
+ * Please check section 9.3 of SystemC 2.3.1 release note for more details.
  */
 #if defined(__GNUC__) && (__GNUC__ >= 13)
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"


### PR DESCRIPTION
For GCC >=v13 systemc was breaking due to the overloaded virtual warning check.

Issue: gem5#1121

Change-Id: I68872f58d0bbe5430976163ba7316bbd2e403ec8