### PR TITLE
arch-riscv: Fix CLINT mtime reset handling

### DIFF
--- a/src/dev/riscv/clint.cc
+++ b/src/dev/riscv/clint.cc
@@ -72,7 +72,7 @@ Clint::raiseInterruptPin(int id)
     // Increment mtime when received RTC signal
     uint64_t& mtime = registers.mtime.get();
     if (id == INT_RTC) {
-      mtime++;
+        mtime++;
     }
 
     for (int context_id = 0; context_id < nThread; context_id++) {

--- a/src/dev/riscv/clint.cc
+++ b/src/dev/riscv/clint.cc
@@ -53,7 +53,7 @@ Clint::Clint(const Params &params) :
     BasicPioDevice(params, params.pio_size),
     system(params.system),
     nThread(params.num_threads),
-    signal(params.name + ".signal", 0, this),
+    signal(params.name + ".signal", 0, this, INT_RTC),
     reset(params.name + ".reset"),
     resetMtimecmp(params.reset_mtimecmp),
     registers(params.name + ".registers", params.pio_addr, this,
@@ -69,9 +69,11 @@ Clint::Clint(const Params &params) :
 void
 Clint::raiseInterruptPin(int id)
 {
-    // Increment mtime
+    // Increment mtime when received RTC signal
     uint64_t& mtime = registers.mtime.get();
-    mtime++;
+    if (id == INT_RTC) {
+      mtime++;
+    }
 
     for (int context_id = 0; context_id < nThread; context_id++) {
 
@@ -261,7 +263,7 @@ Clint::doReset() {
         registers.msip[i].reset();
     }
     // We need to update the mtip interrupt bits when reset
-    raiseInterruptPin(0);
+    raiseInterruptPin(INT_RESET);
 }
 
 } // namespace gem5

--- a/src/dev/riscv/clint.hh
+++ b/src/dev/riscv/clint.hh
@@ -91,6 +91,13 @@ class Clint : public BasicPioDevice
     void raiseInterruptPin(int id);
     void lowerInterruptPin(int id) {}
 
+  // Interrupt ID
+  enum InterruptId
+  {
+      INT_RTC = 0, // received from RTC(signal port)
+      INT_RESET, // received from reset port
+  };
+
   // Register bank
   public:
 


### PR DESCRIPTION
The previous https://github.com/gem5/gem5/pull/1617 introduce the CLINT reset feature. When reset, we changed the mtime to 0 and keep mtimecmp unchanged by default, we also need to check mtime & mtimecmp regiter to update the MTI signal. However, the mtime register will be incremented to 1 by `raiseInterruptPin`.

In the PR, we introduced the interrupt ID for CLINT, the mtime will be incremented only if received the RTC signal