### PR TITLE
cpu-o3: Add Crypto OpDesc to the O3 Default FU

### DIFF
--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010, 2017, 2020 ARM Limited
+# Copyright (c) 2010, 2017, 2020, 2024 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -109,6 +109,14 @@ class SIMD_Unit(FUDesc):
         OpDesc(opClass="SimdExt"),
         OpDesc(opClass="SimdFloatExt"),
         OpDesc(opClass="SimdConfig"),
+        OpDesc(opClass="SimdAes"),
+        OpDesc(opClass="SimdAesMix"),
+        OpDesc(opClass="SimdSha1Hash"),
+        OpDesc(opClass="SimdSha1Hash2"),
+        OpDesc(opClass="SimdSha256Hash"),
+        OpDesc(opClass="SimdSha256Hash2"),
+        OpDesc(opClass="SimdShaSigma2"),
+        OpDesc(opClass="SimdShaSigma3"),
     ]
     count = 4
 


### PR DESCRIPTION
There was a bug exposed by a recent PR [1] where until recently the O3 CPU was executing an instruction even if it did not have the required functional unit in the FU pool.

We are adding the crypto descriptors to the Default FU pool in the O3 cpu so that no panic is encountered upon executing of a crypto instruction

[1]: https://github.com/gem5/gem5/pull/1516

Change-Id: Ifaf2f8e4780dfb8ba825a99a02dd587f011dbd23

Reviewed-by: Richard Cooper <richard.cooper@arm.com>