### PR TITLE
cpu-o3: Add Matrix OpDesc to the O3 Default FU

### DIFF
--- a/src/cpu/o3/FUPool.py
+++ b/src/cpu/o3/FUPool.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 ARM Limited
+# Copyright (c) 2017, 2024 Arm Limited
 # All rights reserved
 #
 # The license below extends only to copyright in the software and shall
@@ -57,6 +57,7 @@ class DefaultFUPool(FUPool):
         FP_MultDiv(),
         ReadPort(),
         SIMD_Unit(),
+        Matrix_Unit(),
         PredALU(),
         WritePort(),
         RdWrPort(),

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -113,6 +113,15 @@ class SIMD_Unit(FUDesc):
     count = 4
 
 
+class Matrix_Unit(FUDesc):
+    opList = [
+        OpDesc(opClass="Matrix"),
+        OpDesc(opClass="MatrixMov"),
+        OpDesc(opClass="MatrixOP"),
+    ]
+    count = 1
+
+
 class PredALU(FUDesc):
     opList = [OpDesc(opClass="SimdPredAlu")]
     count = 1


### PR DESCRIPTION
There was a bug exposed by a recent PR [1] where until recently the O3 CPU was executing an instruction even if it did not have the required functional unit in the FU pool.

We are adding the matrix descriptors to the Default FU pool in the O3 cpu so that no panic is encountered upon executing of a matrix instruction

[1]: https://github.com/gem5/gem5/pull/1516

Change-Id: I04250255a2cbb2ee6f3ef204b62bc2c1ee2d4d2c

Reviewed-by: Richard Cooper <richard.cooper@arm.com>