### PR TITLE
cpu,arch,arch-riscv: Check wake up signal when post interrupt

### DIFF
--- a/src/arch/generic/interrupts.hh
+++ b/src/arch/generic/interrupts.hh
@@ -89,6 +89,12 @@ class BaseInterrupts : public SimObject
     {
         panic("Interrupts::clearAll unimplemented!\n");
     }
+
+    virtual bool
+    isWakeUp() const
+    {
+        return true;
+    }
 };
 
 } // namespace gem5

--- a/src/arch/riscv/interrupts.hh
+++ b/src/arch/riscv/interrupts.hh
@@ -95,6 +95,11 @@ class Interrupts : public BaseInterrupts
 
     void clearAll() override;
 
+    bool isWakeUp() const override
+    {
+        return checkNonMaskableInterrupt() || (ip & ie).any();
+    }
+
     uint64_t readIP() const { return (uint64_t)ip.to_ulong(); }
     uint64_t readIE() const { return (uint64_t)ie.to_ulong(); }
     void setIP(const uint64_t& val) { ip = val; }

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -240,7 +240,11 @@ BaseCPU::postInterrupt(ThreadID tid, int int_num, int index)
     // Only wake up syscall emulation if it is not waiting on a futex.
     // This is to model the fact that instructions such as ARM SEV
     // should wake up a WFE sleep, but not a futex syscall WAIT.
-    if (FullSystem || !system->futexMap.is_waiting(threadContexts[tid]))
+    //
+    // For RISC-V, the WFI sleep wake up is implementation defined.
+    // The SiFive WFI wake up the hart only if mip & mie != 0
+    if ((FullSystem && interrupts[tid]->isWakeUp()) ||
+        !system->futexMap.is_waiting(threadContexts[tid]))
         wakeup(tid);
 }
 


### PR DESCRIPTION
The RISC-V doesn't not draft about how to handle wake up from interrupt signal. In SiFive U74 core, the hart will wake up if there is any enabled pending interrupt.

[1] Section 14.3.1 https://sifive.cdn.prismic.io/sifive/ad5577a0-9a00-45c9-a5d0-424a3d586060_u74_core_complex_manual_21G3.pdf