### PR TITLE
util-docker,tests: Add compiler tests & Dockerfiles for GCC 14

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -13,8 +13,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                image: [gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-18, clang-version-17, clang-version-16, clang-version-15,
-                    clang-version-14, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
+                image: [gcc-version-14, gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-18, clang-version-17, clang-version-16,
+                    clang-version-15, clang-version-14, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
                 opts: [.opt, .fast]
         runs-on: [self-hosted, linux, x64]
         timeout-minutes: 2880 # 48 hours
@@ -32,7 +32,7 @@ jobs:
             matrix:
                 gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, MIPS, 'NULL', NULL_MESI_Two_Level,
                     NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86]
-                image: [gcc-version-13, clang-version-18]
+                image: [gcc-version-14, clang-version-18]
                 opts: [.opt]
         runs-on: [self-hosted, linux, x64]
         timeout-minutes: 2880 # 48 hours

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -125,7 +125,8 @@ group "gcc-compilers" {
     "gcc-version-10",
     "gcc-version-11",
     "gcc-version-12",
-    "gcc-version-13"
+    "gcc-version-13",
+    "gcc-version-14"
   ]
 }
 
@@ -167,6 +168,16 @@ target "gcc-version-13" {
   }
   context = "gcc-compiler"
   tags = ["${IMAGE_URI}/gcc-version-13:${TAG}"]
+}
+
+target "gcc-version-14" {
+  inherits = ["common"]
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v14 compiler."]
+  args = {
+    version = "14"
+  }
+  context = "gcc-compiler"
+  tags = ["${IMAGE_URI}/gcc-version-14:${TAG}"]
 }
 
 group "ubuntu-releases" {

--- a/util/dockerfiles/gcc-compiler/Dockerfile
+++ b/util/dockerfiles/gcc-compiler/Dockerfile
@@ -3,7 +3,7 @@ FROM  ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
 LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
 LABEL org.opencontainers.image.licenses=BSD-3-Clause
 
-ARG version=13 # Version of GCC to install in this image. Default is 13.
+ARG version=14 # Version of GCC to install in this image. Default is 14.
 
 RUN apt -y update && \
     apt -y install gcc-${version} g++-${version} && \


### PR DESCRIPTION
This commit adds gcc 14 to the compiler tests and Dockerfiles.