### PR TITLE
misc: Add "src/python" to vscode Python Analysis Paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "src/python"
+    ]
+}


### PR DESCRIPTION
This allows vscode to resolve python imported from "src/python". Warnings regarding these imports are numerous and the issue stops users of vscode to utilizubg features like navigating the codebase though "Go to Definition" queries on imported classes/functions.