### PR TITLE
mem-ruby: Remove unused variables/mark [maybe unused]

### DIFF
--- a/src/mem/ruby/common/DataBlock.cc
+++ b/src/mem/ruby/common/DataBlock.cc
@@ -60,7 +60,6 @@ DataBlock::DataBlock(const DataBlock &cp)
     m_data = new uint8_t[m_block_size];
     memcpy(m_data, cp.m_data, m_block_size);
     m_alloc = true;
-    m_block_size = m_block_size;
     // If this data block is involved in an atomic operation, the effect
     // of applying the atomic operations on the data block are recorded in
     // m_atomicLog. If so, we must copy over every entry in the change log

--- a/src/mem/ruby/slicc_interface/Message.hh
+++ b/src/mem/ruby/slicc_interface/Message.hh
@@ -66,8 +66,7 @@ class Message
         : m_block_size(block_size),
           m_time(curTime),
           m_LastEnqueueTime(curTime),
-          m_DelayedTicks(0), m_msg_counter(0),
-          p_ruby_system(rs)
+          m_DelayedTicks(0), m_msg_counter(0)
     { }
 
     Message(const Message &other) = default;
@@ -135,9 +134,6 @@ class Message
     // Variables for required network traversal
     int incoming_link;
     int vnet;
-
-    // Needed to call MacheinType_base_count/level
-    const RubySystem *p_ruby_system = nullptr;
 };
 
 inline bool

--- a/src/mem/ruby/structures/BankedArray.hh
+++ b/src/mem/ruby/structures/BankedArray.hh
@@ -51,7 +51,6 @@ class BankedArray
     Tick clockPeriod = 0;
     unsigned int bankBits;
     unsigned int startIndexBit;
-    RubySystem *m_ruby_system;
 
     class AccessRecord
     {


### PR DESCRIPTION
PR https://github.com/gem5/gem5/pull/1453 left some unused variables in the ruby code that triggered
"unused variable" warnings found compiling ALL/gem5.opt to use the CHI
protocol. These have been removed.

`p_ruby_system` in the `Message` class also triggered an unused
variable warning but is, in fact, used. The `[[maybe_unused]]`
annotation is not suitable here as though I found changing it from
a private to a protected class variable solved the issue.