### PR TITLE
misc: Add 'ext' & 'tests' to vscode pythin extraPaths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "python.analysis.extraPaths": [
-        "src/python"
+        "src/python",
+        "ext",
+        "tests"
     ]
 }


### PR DESCRIPTION
'ext' is set as a Python source path for gem5, like 'src/python'. It helps vscode users to have vscode aware of this to better analytics and reduce warnings (most comminly "unable to resolve import).

'tests' isn't in the Python source path when compiling gem5 but it is when running `tests/main.py`. Though somewhat unideal as is lets vscode think files in 'src' can import from files in 'test', adding this helps vscode Python analytics parse the test files which reduces warnings and aids in betters navigation of the testing code. This is particularly helpful given the complexity of the testlib testing infrastructure.