### PR TITLE
tests,misc: Remove `edited` from PR Action trigger list

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -5,7 +5,7 @@ name: CI Tests
 
 on:
     pull_request:
-        types: [opened, edited, synchronize, ready_for_review]
+        types: [opened, synchronize, ready_for_review]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref || github.run_id }}


### PR DESCRIPTION
`edited` is what forces a re-run of our tests when the PR title is updated and other minor metadata stuff. I believe all changes to the code are covered by the remainder. `synchronize` is means the PR is triggered with the when the this PR is from (in this case my forked gem5 repo) is synced with the PR branch here. This covers the vast majority of cases we care about. `opended` covers for the case where the PR is created and `ready_for_review` for when something moves out of a draft.