### PR TITLE
dev: Make unknown PCI device writes a warning

### DIFF
--- a/src/dev/pci/host.cc
+++ b/src/dev/pci/host.cc
@@ -168,9 +168,14 @@ GenericPciHost::write(PacketPtr pkt)
             pkt->getSize());
 
     PciDevice *const pci_dev(getDevice(dev_addr.first));
-    panic_if(!pci_dev,
-             "%02x:%02x.%i: Write to config space on non-existent PCI device\n",
-             dev_addr.first.bus, dev_addr.first.dev, dev_addr.first.func);
+    warn_if(!pci_dev,
+            "%02x:%02x.%i: Write to config space on non-existent PCI device\n",
+            dev_addr.first.bus, dev_addr.first.dev, dev_addr.first.func);
+
+    if (!pci_dev) {
+        pkt->makeAtomicResponse();
+        return 20000; // 20ns default from PciDevice.py
+    }
 
     // @todo Remove this after testing
     pkt->headerDelay = pkt->payloadDelay = 0;


### PR DESCRIPTION
This pops up in kernel 6.8.0. The device it is trying to write is currently unknown but does not cause problems ignoring the device, therefore change the panic to a warning and responding to the request with the default PCI latency.

Change-Id: I4c1229753a75a94a255d8cfd411ac7311283366b