### PR TITLE
cpu-o3: Use the generic cache library to build store sets

### DIFF
--- a/configs/common/cores/arm/O3_ARM_v7a.py
+++ b/configs/common/cores/arm/O3_ARM_v7a.py
@@ -138,7 +138,7 @@ class O3_ARM_v7a_3(ArmO3CPU):
     SQEntries = 16
     LSQDepCheckShift = 0
     LFSTSize = 1024
-    SSITSize = 1024
+    SSITSize = "1024"
     decodeToFetchDelay = 1
     renameToFetchDelay = 1
     iewToFetchDelay = 1

--- a/configs/common/cores/arm/ex5_big.py
+++ b/configs/common/cores/arm/ex5_big.py
@@ -135,7 +135,7 @@ class ex5_big(ArmO3CPU):
     SQEntries = 16
     LSQDepCheckShift = 0
     LFSTSize = 1024
-    SSITSize = 1024
+    SSITSize = "1024"
     decodeToFetchDelay = 1
     renameToFetchDelay = 1
     iewToFetchDelay = 1

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -42,8 +42,11 @@ from m5.objects.BaseCPU import BaseCPU
 # from m5.objects.O3Checker import O3Checker
 from m5.objects.BranchPredictor import *
 from m5.objects.FUPool import *
+from m5.objects.IndexingPolicies import *
+from m5.objects.ReplacementPolicies import *
 from m5.params import *
 from m5.proxy import *
+from m5.SimObject import *
 
 
 class SMTFetchPolicy(ScopedEnum):
@@ -153,7 +156,19 @@ class BaseO3CPU(BaseCPU):
         "should be invalidated",
     )
     LFSTSize = Param.Unsigned(1024, "Last fetched store table size")
-    SSITSize = Param.Unsigned(1024, "Store set ID table size")
+    SSITSize = Param.MemorySize("1024", "Store set ID table size")
+    SSITAssoc = Param.Unsigned(1, "SSIT table associativity")
+    SSITReplPolicy = Param.BaseReplacementPolicy(
+        LRURP(), "SSIT replacement policy"
+    )
+    SSITIndexingPolicy = Param.BaseIndexingPolicy(
+        SetAssociative(
+            size=Parent.SSITSize * 4,
+            assoc=Parent.SSITAssoc,
+            entry_size=4,
+        ),
+        "SSIT indexing policy",
+    )
 
     numRobs = Param.Unsigned(1, "Number of Reorder Buffers")
 

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -33,8 +33,9 @@ Import('*')
 if env['CONF']['BUILD_ISA']:
     SimObject('FUPool.py', sim_objects=['FUPool'])
     SimObject('FuncUnitConfig.py', sim_objects=[])
-    SimObject('BaseO3CPU.py', sim_objects=['BaseO3CPU'], enums=[
-        'SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
+    SimObject('BaseO3CPU.py',
+        sim_objects=['BaseO3CPU'],
+        enums=['SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
 
     Source('commit.cc')
     Source('cpu.cc')

--- a/src/mem/cache/tags/indexing_policies/base.hh
+++ b/src/mem/cache/tags/indexing_policies/base.hh
@@ -110,8 +110,8 @@ class IndexingPolicyTemplate : public SimObject
      * Construct and initialize this policy.
      */
     IndexingPolicyTemplate(const Params &p,
-                           uint32_t num_entries,
-                           int set_shift)
+                           const uint32_t num_entries,
+                           const uint32_t set_shift)
       : SimObject(p), assoc(p.assoc),
         numSets(num_entries / assoc),
         setShift(set_shift), setMask(numSets - 1), sets(numSets),


### PR DESCRIPTION
This allows us to build an associative store set structure and also experiment with various replacement policies for the store set.

Change-Id: I18ddad2346b82423c01ef9117a5d3d85f7039be7