### PR TITLE
arch-arm: Rewrite the ArmTLB storage to use an AssociativeCache

### DIFF
--- a/src/arch/arm/ArmMMU.py
+++ b/src/arch/arm/ArmMMU.py
@@ -72,7 +72,9 @@ class ArmMMU(BaseMMU):
     cxx_header = "arch/arm/mmu.hh"
 
     # L2 TLBs
-    l2_shared = ArmTLB(entry_type="unified", size=1280, partial_levels=["L2"])
+    l2_shared = ArmTLB(
+        entry_type="unified", size=1280, assoc=5, partial_levels=["L2"]
+    )
 
     # L1 TLBs
     itb = ArmTLB(entry_type="instruction", next_level=Parent.l2_shared)

--- a/src/arch/arm/ArmTLB.py
+++ b/src/arch/arm/ArmTLB.py
@@ -36,6 +36,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.BaseTLB import BaseTLB
+from m5.objects.ReplacementPolicies import LRURP
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject
@@ -71,6 +72,16 @@ class ArmTLB(BaseTLB):
     cxx_header = "arch/arm/tlb.hh"
     sys = Param.System(Parent.any, "system object parameter")
     size = Param.Int(64, "TLB size")
+    assoc = Param.Int(
+        Self.size, "Associativity of the TLB. Fully Associative by default"
+    )
+    indexing_policy = Param.TLBIndexingPolicy(
+        TLBSetAssociative(assoc=Parent.assoc, num_entries=Parent.size),
+        "Indexing policy of the TLB",
+    )
+    replacement_policy = Param.BaseReplacementPolicy(
+        LRURP(), "Replacement policy of the TLB"
+    )
     is_stage2 = Param.Bool(False, "Is this a stage 2 TLB?")
 
     partial_levels = VectorParam.ArmLookupLevel(

--- a/src/arch/arm/ArmTLB.py
+++ b/src/arch/arm/ArmTLB.py
@@ -1,6 +1,6 @@
 # -*- mode:python -*-
 
-# Copyright (c) 2009, 2013, 2015, 2021 Arm Limited
+# Copyright (c) 2009, 2013, 2015, 2021, 2024 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -43,6 +43,26 @@ from m5.SimObject import SimObject
 
 class ArmLookupLevel(Enum):
     vals = ["L0", "L1", "L2", "L3"]
+
+
+class TLBIndexingPolicy(SimObject):
+    type = "TLBIndexingPolicy"
+    abstract = True
+    cxx_class = "gem5::IndexingPolicyTemplate<gem5::ArmISA::TLBTypes>"
+    cxx_header = "arch/arm/pagetable.hh"
+    cxx_template_params = ["class Types"]
+
+    # Get the size from the parent (cache)
+    num_entries = Param.Int(Parent.size, "number of TLB entries")
+
+    # Get the associativity
+    assoc = Param.Int(Parent.assoc, "associativity")
+
+
+class TLBSetAssociative(TLBIndexingPolicy):
+    type = "TLBSetAssociative"
+    cxx_class = "gem5::ArmISA::TLBSetAssociative"
+    cxx_header = "arch/arm/pagetable.hh"
 
 
 class ArmTLB(BaseTLB):

--- a/src/arch/arm/SConscript
+++ b/src/arch/arm/SConscript
@@ -38,104 +38,127 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+Import("*")
 
-Source('insts/fplib.cc')
+Source("insts/fplib.cc")
 
-if env['CONF']['USE_ARM_ISA']:
-    env.TagImplies('arm isa', 'gem5 lib')
+if env["CONF"]["USE_ARM_ISA"]:
+    env.TagImplies("arm isa", "gem5 lib")
 
 # The GTest function does not have a 'tags' parameter. We therefore apply this
 # guard to ensure this test is only built when ARM is compiled.
 #
 # Note: This will need reconfigured for multi-isa. E.g., if this is
 # incorporated: https://gem5-review.googlesource.com/c/public/gem5/+/52491
-if env['CONF']['USE_ARM_ISA']:
-    GTest('aapcs64.test', 'aapcs64.test.cc',
-          '../../base/debug.cc',
-          '../../cpu/reg_class.cc',
-          '../../sim/bufval.cc', '../../sim/cur_tick.cc',
-          'regs/int.cc')
-    GTest('matrix.test', 'matrix.test.cc')
-Source('decoder.cc', tags='arm isa')
-Source('faults.cc', tags='arm isa')
-Source('htm.cc', tags='arm isa')
-Source('insts/branch.cc', tags='arm isa')
-Source('insts/branch64.cc', tags='arm isa')
-Source('insts/data64.cc', tags='arm isa')
-Source('insts/macromem.cc', tags='arm isa')
-Source('insts/mem.cc', tags='arm isa')
-Source('insts/mem64.cc', tags='arm isa')
-Source('insts/misc.cc', tags='arm isa')
-Source('insts/misc64.cc', tags='arm isa')
-Source('insts/pred_inst.cc', tags='arm isa')
-Source('insts/pseudo.cc', tags='arm isa')
-Source('insts/sme.cc', tags='arm isa')
-Source('insts/static_inst.cc', tags='arm isa')
-Source('insts/sve.cc', tags='arm isa')
-Source('insts/sve_mem.cc', tags='arm isa')
-Source('insts/vfp.cc', tags='arm isa')
-Source('insts/crypto.cc', tags='arm isa')
-Source('insts/tme64.cc', tags='arm isa')
-if env['CONF']['PROTOCOL'] == 'MESI_Three_Level_HTM':
-    Source('insts/tme64ruby.cc', tags='arm isa')
+if env["CONF"]["USE_ARM_ISA"]:
+    GTest(
+        "aapcs64.test",
+        "aapcs64.test.cc",
+        "../../base/debug.cc",
+        "../../cpu/reg_class.cc",
+        "../../sim/bufval.cc",
+        "../../sim/cur_tick.cc",
+        "regs/int.cc",
+    )
+    GTest("matrix.test", "matrix.test.cc")
+Source("decoder.cc", tags="arm isa")
+Source("faults.cc", tags="arm isa")
+Source("htm.cc", tags="arm isa")
+Source("insts/branch.cc", tags="arm isa")
+Source("insts/branch64.cc", tags="arm isa")
+Source("insts/data64.cc", tags="arm isa")
+Source("insts/macromem.cc", tags="arm isa")
+Source("insts/mem.cc", tags="arm isa")
+Source("insts/mem64.cc", tags="arm isa")
+Source("insts/misc.cc", tags="arm isa")
+Source("insts/misc64.cc", tags="arm isa")
+Source("insts/pred_inst.cc", tags="arm isa")
+Source("insts/pseudo.cc", tags="arm isa")
+Source("insts/sme.cc", tags="arm isa")
+Source("insts/static_inst.cc", tags="arm isa")
+Source("insts/sve.cc", tags="arm isa")
+Source("insts/sve_mem.cc", tags="arm isa")
+Source("insts/vfp.cc", tags="arm isa")
+Source("insts/crypto.cc", tags="arm isa")
+Source("insts/tme64.cc", tags="arm isa")
+if env["CONF"]["PROTOCOL"] == "MESI_Three_Level_HTM":
+    Source("insts/tme64ruby.cc", tags="arm isa")
 else:
-    Source('insts/tme64classic.cc', tags='arm isa')
-Source('interrupts.cc', tags='arm isa')
-Source('isa.cc', tags='arm isa')
-Source('isa_device.cc', tags='arm isa')
-Source('linux/process.cc', tags='arm isa')
-Source('linux/se_workload.cc', tags='arm isa')
-Source('linux/fs_workload.cc', tags='arm isa')
-Source('freebsd/fs_workload.cc', tags='arm isa')
-Source('freebsd/se_workload.cc', tags='arm isa')
-Source('fs_workload.cc', tags='arm isa')
-Source('regs/int.cc', tags='arm isa')
-Source('regs/misc.cc', tags='arm isa')
-Source('mmu.cc', tags='arm isa')
-Source('mpam.cc', tags='arm isa')
-Source('nativetrace.cc', tags='arm isa')
-Source('pagetable.cc', tags='arm isa')
-Source('pauth_helpers.cc', tags='arm isa')
-Source('pmu.cc', tags='arm isa')
-Source('process.cc', tags='arm isa')
-Source('qarma.cc', tags='arm isa')
-Source('remote_gdb.cc', tags='arm isa')
-Source('reg_abi.cc', tags='arm isa')
-Source('semihosting.cc', tags='arm isa')
-Source('system.cc', tags='arm isa')
-Source('table_walker.cc', tags='arm isa')
-Source('self_debug.cc', tags='arm isa')
-Source('stage2_lookup.cc', tags='arm isa')
-Source('tlb.cc', tags='arm isa')
-Source('tlbi_op.cc', tags='arm isa')
-Source('utility.cc', tags='arm isa')
+    Source("insts/tme64classic.cc", tags="arm isa")
+Source("interrupts.cc", tags="arm isa")
+Source("isa.cc", tags="arm isa")
+Source("isa_device.cc", tags="arm isa")
+Source("linux/process.cc", tags="arm isa")
+Source("linux/se_workload.cc", tags="arm isa")
+Source("linux/fs_workload.cc", tags="arm isa")
+Source("freebsd/fs_workload.cc", tags="arm isa")
+Source("freebsd/se_workload.cc", tags="arm isa")
+Source("fs_workload.cc", tags="arm isa")
+Source("regs/int.cc", tags="arm isa")
+Source("regs/misc.cc", tags="arm isa")
+Source("mmu.cc", tags="arm isa")
+Source("mpam.cc", tags="arm isa")
+Source("nativetrace.cc", tags="arm isa")
+Source("pagetable.cc", tags="arm isa")
+Source("pauth_helpers.cc", tags="arm isa")
+Source("pmu.cc", tags="arm isa")
+Source("process.cc", tags="arm isa")
+Source("qarma.cc", tags="arm isa")
+Source("remote_gdb.cc", tags="arm isa")
+Source("reg_abi.cc", tags="arm isa")
+Source("semihosting.cc", tags="arm isa")
+Source("system.cc", tags="arm isa")
+Source("table_walker.cc", tags="arm isa")
+Source("self_debug.cc", tags="arm isa")
+Source("stage2_lookup.cc", tags="arm isa")
+Source("tlb.cc", tags="arm isa")
+Source("tlbi_op.cc", tags="arm isa")
+Source("utility.cc", tags="arm isa")
 
-SimObject('ArmDecoder.py', sim_objects=['ArmDecoder'], tags='arm isa')
-SimObject('ArmFsWorkload.py', sim_objects=[
-    'ArmFsWorkload', 'ArmFsLinux', 'ArmFsFreebsd'],
-    enums=['ArmMachineType'], tags='arm isa')
-SimObject('ArmInterrupts.py', sim_objects=['ArmInterrupts'], tags='arm isa')
-SimObject('ArmISA.py', sim_objects=['ArmISA'], enums=['DecoderFlavor'],
-    tags='arm isa')
-SimObject('ArmMMU.py', sim_objects=['ArmTableWalker', 'ArmMMU'],
-    tags='arm isa')
-SimObject('ArmNativeTrace.py', sim_objects=['ArmNativeTrace'], tags='arm isa')
-SimObject('ArmSemihosting.py', sim_objects=['ArmSemihosting'], tags='arm isa')
-SimObject('ArmSeWorkload.py', sim_objects=[
-    'ArmSEWorkload', 'ArmEmuLinux', 'ArmEmuFreebsd'], tags='arm isa')
-SimObject('ArmSystem.py', sim_objects=['ArmSystem', 'ArmRelease'],
-    enums=['ArmExtension'], tags='arm isa')
-SimObject('ArmTLB.py', sim_objects=['ArmTLB'], enums=['ArmLookupLevel'],
-    tags='arm isa')
-SimObject('ArmPMU.py', sim_objects=['ArmPMU'], tags='arm isa')
+SimObject("ArmDecoder.py", sim_objects=["ArmDecoder"], tags="arm isa")
+SimObject(
+    "ArmFsWorkload.py",
+    sim_objects=["ArmFsWorkload", "ArmFsLinux", "ArmFsFreebsd"],
+    enums=["ArmMachineType"],
+    tags="arm isa",
+)
+SimObject("ArmInterrupts.py", sim_objects=["ArmInterrupts"], tags="arm isa")
+SimObject(
+    "ArmISA.py",
+    sim_objects=["ArmISA"],
+    enums=["DecoderFlavor"],
+    tags="arm isa",
+)
+SimObject(
+    "ArmMMU.py", sim_objects=["ArmTableWalker", "ArmMMU"], tags="arm isa"
+)
+SimObject("ArmNativeTrace.py", sim_objects=["ArmNativeTrace"], tags="arm isa")
+SimObject("ArmSemihosting.py", sim_objects=["ArmSemihosting"], tags="arm isa")
+SimObject(
+    "ArmSeWorkload.py",
+    sim_objects=["ArmSEWorkload", "ArmEmuLinux", "ArmEmuFreebsd"],
+    tags="arm isa",
+)
+SimObject(
+    "ArmSystem.py",
+    sim_objects=["ArmSystem", "ArmRelease"],
+    enums=["ArmExtension"],
+    tags="arm isa",
+)
+SimObject(
+    "ArmTLB.py",
+    sim_objects=["ArmTLB", "TLBIndexingPolicy", "TLBSetAssociative"],
+    enums=["ArmLookupLevel"],
+    tags="arm isa",
+)
+SimObject("ArmPMU.py", sim_objects=["ArmPMU"], tags="arm isa")
 
-SimObject('ArmCPU.py', sim_objects=[], tags='arm isa')
+SimObject("ArmCPU.py", sim_objects=[], tags="arm isa")
 
-DebugFlag('Arm', tags='arm isa')
-DebugFlag('ArmTme', 'Transactional Memory Extension', tags='arm isa')
-DebugFlag('MPAM', 'MPAM debug flag', tags='arm isa')
-DebugFlag('PMUVerbose', "Performance Monitor", tags='arm isa')
+DebugFlag("Arm", tags="arm isa")
+DebugFlag("ArmTme", "Transactional Memory Extension", tags="arm isa")
+DebugFlag("MPAM", "MPAM debug flag", tags="arm isa")
+DebugFlag("PMUVerbose", "Performance Monitor", tags="arm isa")
 
 # Add files generated by the ISA description.
-ISADesc('isa/main.isa', decoder_splits=3, exec_splits=6, tags='arm isa')
+ISADesc("isa/main.isa", decoder_splits=3, exec_splits=6, tags="arm isa")

--- a/src/arch/arm/faults.cc
+++ b/src/arch/arm/faults.cc
@@ -1067,8 +1067,8 @@ AbortFault<T>::invoke(ThreadContext *tc, const StaticInstPtr &inst)
             tc->setMiscReg(T::FsrIndex, fsr);
             tc->setMiscReg(T::FarIndex, faultAddr);
         }
-        DPRINTF(Faults, "Abort Fault source=%#x fsr=%#x faultAddr=%#x "\
-                "tranMethod=%#x\n", source, fsr, faultAddr, tranMethod);
+        DPRINTF(Faults, "Abort Fault source=%#x fsr=%#x faultAddr=%#x\n",
+                source, fsr, faultAddr);
     } else {  // AArch64
         // Set the FAR register.  Nothing else to do if we are in AArch64 state
         // because the syndrome register has already been set inside invoke64()
@@ -1092,11 +1092,11 @@ template<class T>
 void
 AbortFault<T>::update(ThreadContext *tc)
 {
-    if (tranMethod == ArmFault::UnknownTran) {
-        tranMethod = longDescFormatInUse(tc) ? ArmFault::LpaeTran
-                                             : ArmFault::VmsaTran;
+    if (tranMethod == TranMethod::UnknownTran) {
+        tranMethod = longDescFormatInUse(tc) ? TranMethod::LpaeTran
+                                             : TranMethod::VmsaTran;
 
-        if ((tranMethod == ArmFault::VmsaTran) && this->routeToMonitor(tc)) {
+        if ((tranMethod == TranMethod::VmsaTran) && this->routeToMonitor(tc)) {
             // See ARM ARM B3-1416
             bool override_LPAE = false;
             TTBCR ttbcr_s = tc->readMiscReg(MISCREG_TTBCR_S);
@@ -1109,7 +1109,7 @@ AbortFault<T>::update(ThreadContext *tc)
                         "override detected.\n");
             }
             if (override_LPAE)
-                tranMethod = ArmFault::LpaeTran;
+                tranMethod = TranMethod::LpaeTran;
         }
     }
 
@@ -1139,8 +1139,8 @@ AbortFault<T>::getFaultStatusCode(ThreadContext *tc) const
 
     if (!this->to64) {
         // AArch32
-        assert(tranMethod != ArmFault::UnknownTran);
-        if (tranMethod == ArmFault::LpaeTran) {
+        assert(tranMethod != TranMethod::UnknownTran);
+        if (tranMethod == TranMethod::LpaeTran) {
             fsc = ArmFault::longDescFaultSources[source];
         } else {
             fsc = ArmFault::shortDescFaultSources[source];
@@ -1162,8 +1162,8 @@ AbortFault<T>::getFsr(ThreadContext *tc) const
     auto fsc = getFaultStatusCode(tc);
 
     // AArch32
-    assert(tranMethod != ArmFault::UnknownTran);
-    if (tranMethod == ArmFault::LpaeTran) {
+    assert(tranMethod != TranMethod::UnknownTran);
+    if (tranMethod == TranMethod::LpaeTran) {
         fsr.status = fsc;
         fsr.lpae   = 1;
     } else {

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -473,7 +473,7 @@ class AbortFault : public ArmFaultVals<T>
      */
     Addr OVAddr;
     bool write;
-    TlbEntry::DomainType domain;
+    DomainType domain;
     uint8_t source;
     uint8_t srcEncoded;
     bool stage2;
@@ -482,7 +482,7 @@ class AbortFault : public ArmFaultVals<T>
     ArmFault::DebugType debugType;
 
   public:
-    AbortFault(Addr _faultAddr, bool _write, TlbEntry::DomainType _domain,
+    AbortFault(Addr _faultAddr, bool _write, DomainType _domain,
                uint8_t _source, bool _stage2,
                TranMethod _tranMethod = TranMethod::UnknownTran,
                ArmFault::DebugType _debug = ArmFault::NODEBUG) :
@@ -518,7 +518,7 @@ class PrefetchAbort : public AbortFault<PrefetchAbort>
     PrefetchAbort(Addr _addr, uint8_t _source, bool _stage2 = false,
                   TranMethod _tran_method = TranMethod::UnknownTran,
                   ArmFault::DebugType _debug = ArmFault::NODEBUG) :
-        AbortFault<PrefetchAbort>(_addr, false, TlbEntry::DomainType::NoAccess,
+        AbortFault<PrefetchAbort>(_addr, false, DomainType::NoAccess,
                 _source, _stage2, _tran_method, _debug)
     {}
 
@@ -549,7 +549,7 @@ class DataAbort : public AbortFault<DataAbort>
     bool sf;
     bool ar;
 
-    DataAbort(Addr _addr, TlbEntry::DomainType _domain, bool _write, uint8_t _source,
+    DataAbort(Addr _addr, DomainType _domain, bool _write, uint8_t _source,
               bool _stage2=false,
               TranMethod _tran_method=TranMethod::UnknownTran,
               ArmFault::DebugType _debug_type=ArmFault::NODEBUG) :
@@ -577,7 +577,7 @@ class VirtualDataAbort : public AbortFault<VirtualDataAbort>
     static const MiscRegIndex FarIndex  = MISCREG_DFAR;
     static const MiscRegIndex HFarIndex = MISCREG_HDFAR;
 
-    VirtualDataAbort(Addr _addr, TlbEntry::DomainType _domain, bool _write,
+    VirtualDataAbort(Addr _addr, DomainType _domain, bool _write,
                      uint8_t _source) :
         AbortFault<VirtualDataAbort>(_addr, _write, _domain, _source, false)
     {}

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -147,13 +147,6 @@ class ArmFault : public FaultBase
         AR     // DataAbort: Acquire/Release semantics
     };
 
-    enum TranMethod
-    {
-        LpaeTran,
-        VmsaTran,
-        UnknownTran
-    };
-
     enum DebugType
     {
         NODEBUG = 0,
@@ -485,13 +478,13 @@ class AbortFault : public ArmFaultVals<T>
     uint8_t srcEncoded;
     bool stage2;
     bool s1ptw;
-    ArmFault::TranMethod tranMethod;
+    TranMethod tranMethod;
     ArmFault::DebugType debugType;
 
   public:
     AbortFault(Addr _faultAddr, bool _write, TlbEntry::DomainType _domain,
                uint8_t _source, bool _stage2,
-               ArmFault::TranMethod _tranMethod = ArmFault::UnknownTran,
+               TranMethod _tranMethod = TranMethod::UnknownTran,
                ArmFault::DebugType _debug = ArmFault::NODEBUG) :
         faultAddr(_faultAddr), OVAddr(0), write(_write),
         domain(_domain), source(_source), srcEncoded(0),
@@ -523,10 +516,10 @@ class PrefetchAbort : public AbortFault<PrefetchAbort>
     static const MiscRegIndex HFarIndex = MISCREG_HIFAR;
 
     PrefetchAbort(Addr _addr, uint8_t _source, bool _stage2 = false,
-                  ArmFault::TranMethod _tranMethod = ArmFault::UnknownTran,
+                  TranMethod _tran_method = TranMethod::UnknownTran,
                   ArmFault::DebugType _debug = ArmFault::NODEBUG) :
         AbortFault<PrefetchAbort>(_addr, false, TlbEntry::DomainType::NoAccess,
-                _source, _stage2, _tranMethod, _debug)
+                _source, _stage2, _tran_method, _debug)
     {}
 
     // @todo: external aborts should be routed if SCR.EA == 1
@@ -558,10 +551,10 @@ class DataAbort : public AbortFault<DataAbort>
 
     DataAbort(Addr _addr, TlbEntry::DomainType _domain, bool _write, uint8_t _source,
               bool _stage2=false,
-              ArmFault::TranMethod _tranMethod=ArmFault::UnknownTran,
+              TranMethod _tran_method=TranMethod::UnknownTran,
               ArmFault::DebugType _debug_type=ArmFault::NODEBUG) :
         AbortFault<DataAbort>(_addr, _write, _domain, _source, _stage2,
-                              _tranMethod, _debug_type),
+                              _tran_method, _debug_type),
         isv(false), sas (0), sse(0), srt(0), cm(0), sf(false), ar(false)
     {}
 

--- a/src/arch/arm/insts/static_inst.cc
+++ b/src/arch/arm/insts/static_inst.cc
@@ -646,7 +646,7 @@ ArmStaticInst::softwareBreakpoint32(ExecContext *xc, uint16_t imm) const
         return std::make_shared<PrefetchAbort>(readPC(xc),
                                                ArmFault::DebugEvent,
                                                false,
-                                               ArmFault::UnknownTran,
+                                               TranMethod::UnknownTran,
                                                ArmFault::BRKPOINT);
     }
 }

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -235,7 +235,7 @@ class Interrupts : public BaseInterrupts
             return std::make_shared<SystemError>();
         if (hcr.va && takeVirtualInt(INT_VIRT_ABT))
             return std::make_shared<VirtualDataAbort>(
-                0, TlbEntry::DomainType::NoAccess, false,
+                0, DomainType::NoAccess, false,
                 ArmFault::AsynchronousExternalAbort);
         if (interrupts[INT_RST])
             return std::make_shared<Reset>();

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -185,7 +185,7 @@ MMU::translateFunctional(ThreadContext *tc, Addr va, Addr &pa)
 
     auto tlb = getTlb(BaseMMU::Read, state.directToStage2);
 
-    TlbEntry::Lookup lookup_data;
+    TlbEntry::KeyType lookup_data;
 
     lookup_data.va = va;
     lookup_data.asn = state.asid;
@@ -1475,7 +1475,7 @@ MMU::lookup(Addr va, uint16_t asid, vmid_t vmid, SecurityState ss,
 {
     TLB *tlb = getTlb(mode, stage2);
 
-    TlbEntry::Lookup lookup_data;
+    TlbEntry::KeyType lookup_data;
 
     lookup_data.va = va;
     lookup_data.asn = asid;

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -207,7 +207,7 @@ MMU::testAndFinalize(const RequestPtr &req,
 {
     // If we don't have a valid tlb entry it means virtual memory
     // is not enabled
-    auto domain = te ? te-> domain : TlbEntry::DomainType::NoAccess;
+    auto domain = te ? te-> domain : DomainType::NoAccess;
 
     mpam::tagRequest(tc, req, mode == Execute);
 
@@ -277,7 +277,7 @@ MMU::translateSe(const RequestPtr &req, ThreadContext *tc, Mode mode,
                 // LPAE is always disabled in SE mode
                 return std::make_shared<DataAbort>(
                     vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess, is_write,
+                    DomainType::NoAccess, is_write,
                     ArmFault::AlignmentFault, state.isStage2,
                     TranMethod::VmsaTran);
             }
@@ -343,7 +343,7 @@ MMU::checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
             if (vaddr & mask(flags & AlignmentMask)) {
                 stats.alignFaults++;
                 return std::make_shared<DataAbort>(
-                    vaddr, TlbEntry::DomainType::NoAccess, is_write,
+                    vaddr, DomainType::NoAccess, is_write,
                     ArmFault::AlignmentFault, state.isStage2,
                     tran_method);
             }
@@ -538,7 +538,7 @@ MMU::checkPermissions64(TlbEntry *te, const RequestPtr &req, Mode mode,
                 stats.alignFaults++;
                 return std::make_shared<DataAbort>(
                     vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess,
+                    DomainType::NoAccess,
                     is_atomic ? false : is_write,
                     ArmFault::AlignmentFault, state.isStage2,
                     TranMethod::LpaeTran);
@@ -831,7 +831,7 @@ MMU::translateMmuOff(ThreadContext *tc, const RequestPtr &req, Mode mode,
                     TranMethod::LpaeTran);
             else
                 f = std::make_shared<DataAbort>( vaddr,
-                    TlbEntry::DomainType::NoAccess,
+                    DomainType::NoAccess,
                     is_atomic ? false : mode==Write,
                     ArmFault::AddressSizeLL, state.isStage2,
                     TranMethod::LpaeTran);
@@ -934,7 +934,7 @@ MMU::translateMmuOn(ThreadContext* tc, const RequestPtr &req, Mode mode,
                 bool is_write  = (mode == Write);
                 return std::make_shared<DataAbort>(
                     vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess, is_write,
+                    DomainType::NoAccess, is_write,
                     ArmFault::AlignmentFault, state.isStage2,
                     tran_method);
         }
@@ -996,7 +996,7 @@ MMU::translateFs(const RequestPtr &req, ThreadContext *tc, Mode mode,
                 stats.alignFaults++;
                 return std::make_shared<DataAbort>(
                     vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess, is_write,
+                    DomainType::NoAccess, is_write,
                     ArmFault::AlignmentFault, state.isStage2,
                     tran_method);
             }
@@ -1590,7 +1590,7 @@ MMU::setTestInterface(SimObject *_ti)
 
 Fault
 MMU::testTranslation(const RequestPtr &req, Mode mode,
-                     TlbEntry::DomainType domain, CachedState &state) const
+                     DomainType domain, CachedState &state) const
 {
     if (!test || !req->hasSize() || req->getSize() == 0 ||
         req->isCacheMaintenance()) {

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -42,7 +42,6 @@
 #define __ARCH_ARM_MMU_HH__
 
 #include "arch/arm/page_size.hh"
-#include "arch/arm/tlb.hh"
 #include "arch/arm/utility.hh"
 #include "arch/generic/mmu.hh"
 #include "base/memoizer.hh"
@@ -57,23 +56,18 @@ namespace gem5
 namespace ArmISA {
 
 class TableWalker;
+class TLB;
+class TlbEntry;
+class TLBIOp;
+class TlbTestInterface;
 
 class MMU : public BaseMMU
 {
   protected:
     using LookupLevel = enums::ArmLookupLevel;
 
-    ArmISA::TLB *
-    getDTBPtr() const
-    {
-        return static_cast<ArmISA::TLB *>(dtb);
-    }
-
-    ArmISA::TLB *
-    getITBPtr() const
-    {
-        return static_cast<ArmISA::TLB *>(itb);
-    }
+    ArmISA::TLB * getDTBPtr() const;
+    ArmISA::TLB * getITBPtr() const;
 
     TLB * getTlb(BaseMMU::Mode mode, bool stage2) const;
     TableWalker * getTableWalker(BaseMMU::Mode mode, bool stage2) const;
@@ -298,73 +292,13 @@ class MMU : public BaseMMU
 
     void invalidateMiscReg();
 
-    template <typename OP>
-    void
-    flush(const OP &tlbi_op)
-    {
-        if (tlbi_op.stage1Flush()) {
-            flushStage1(tlbi_op);
-        }
+    void flush(const TLBIOp &tlbi_op);
+    void flushStage1(const TLBIOp &tlbi_op);
+    void flushStage2(const TLBIOp &tlbi_op);
+    void iflush(const TLBIOp &tlbi_op);
+    void dflush(const TLBIOp &tlbi_op);
 
-        if (tlbi_op.stage2Flush()) {
-            flushStage2(tlbi_op);
-        }
-    }
-
-    template <typename OP>
-    void
-    flushStage1(const OP &tlbi_op)
-    {
-        for (auto tlb : instruction) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-        for (auto tlb : data) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-        for (auto tlb : unified) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-    }
-
-    template <typename OP>
-    void
-    flushStage2(const OP &tlbi_op)
-    {
-        itbStage2->flush(tlbi_op);
-        dtbStage2->flush(tlbi_op);
-    }
-
-    template <typename OP>
-    void
-    iflush(const OP &tlbi_op)
-    {
-        for (auto tlb : instruction) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-        for (auto tlb : unified) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-    }
-
-    template <typename OP>
-    void
-    dflush(const OP &tlbi_op)
-    {
-        for (auto tlb : data) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-        for (auto tlb : unified) {
-            static_cast<TLB*>(tlb)->flush(tlbi_op);
-        }
-    }
-
-    void
-    flushAll() override
-    {
-        BaseMMU::flushAll();
-        itbStage2->flushAll();
-        dtbStage2->flushAll();
-    }
+    void flushAll() override;
 
     uint64_t
     getAttr() const

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -46,6 +46,7 @@
 #include "arch/arm/utility.hh"
 #include "arch/generic/mmu.hh"
 #include "base/memoizer.hh"
+#include "base/statistics.hh"
 #include "enums/ArmLookupLevel.hh"
 
 #include "params/ArmMMU.hh"
@@ -270,7 +271,7 @@ class MMU : public BaseMMU
         CachedState &state);
     Fault translateMmuOn(ThreadContext *tc, const RequestPtr &req, Mode mode,
         Translation *translation, bool &delay, bool timing, bool functional,
-        Addr vaddr, ArmFault::TranMethod tranMethod,
+        Addr vaddr, TranMethod tran_method,
         CachedState &state);
 
     Fault translateFs(const RequestPtr &req, ThreadContext *tc, Mode mode,

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -463,7 +463,7 @@ class MMU : public BaseMMU
     void setTestInterface(SimObject *ti);
 
     Fault testTranslation(const RequestPtr &req, Mode mode,
-                          TlbEntry::DomainType domain, CachedState &state) const;
+                          DomainType domain, CachedState &state) const;
 
   protected:
     bool checkWalkCache() const;

--- a/src/arch/arm/pagetable.cc
+++ b/src/arch/arm/pagetable.cc
@@ -489,5 +489,14 @@ getPageTableOps(GrainSize trans_granule)
     }
 }
 
+TLBTypes::KeyType::KeyType(const TlbEntry &entry)
+  : va(entry.vpn << entry.N), pageSize(entry.N), size(0),
+    asn(entry.asid), ignoreAsn(false),
+    vmid(entry.vmid), ss(entry.ss),
+    functional(false),
+    targetRegime(entry.regime),
+    mode(BaseMMU::Read)
+{}
+
 } // namespace ArmISA
 } // namespace gem5

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012-2013, 2021, 2023-2024 Arm Limited
+ * Copyright (c) 2010, 2012-2013, 2021, 2023-2024 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -49,6 +49,7 @@
 #include "arch/generic/mmu.hh"
 #include "enums/TypeTLB.hh"
 #include "enums/ArmLookupLevel.hh"
+#include "mem/cache/replacement_policies/replaceable_entry.hh"
 #include "sim/serialize.hh"
 
 namespace gem5
@@ -162,7 +163,7 @@ struct V8PageTableOps64k : public PageTableOps
 };
 
 // ITB/DTB table entry
-struct TlbEntry : public Serializable
+struct TlbEntry : public ReplaceableEntry, Serializable
 {
   public:
     typedef enums::ArmLookupLevel LookupLevel;
@@ -296,6 +297,46 @@ struct TlbEntry : public Serializable
         // no restrictions by default, hap = 0x3
 
         // @todo Check the memory type
+    }
+    TlbEntry(const TlbEntry &rhs) = default;
+    TlbEntry& operator=(TlbEntry rhs)
+    {
+        swap(rhs);
+        return *this;
+    }
+
+    void
+    swap(TlbEntry &rhs)
+    {
+        std::swap(pfn, rhs.pfn);
+        std::swap(size, rhs.size);
+        std::swap(vpn, rhs.vpn);
+        std::swap(attributes, rhs.attributes);
+        std::swap(lookupLevel, rhs.lookupLevel);
+        std::swap(asid, rhs.asid);
+        std::swap(vmid, rhs.vmid);
+        std::swap(tg, rhs.tg);
+        std::swap(N, rhs.N);
+        std::swap(innerAttrs, rhs.innerAttrs);
+        std::swap(outerAttrs, rhs.outerAttrs);
+        std::swap(ap, rhs.ap);
+        std::swap(hap, rhs.hap);
+        std::swap(domain, rhs.domain);
+        std::swap(mtype, rhs.mtype);
+        std::swap(longDescFormat, rhs.longDescFormat);
+        std::swap(global, rhs.global);
+        std::swap(valid, rhs.valid);
+        std::swap(ns, rhs.ns);
+        std::swap(ss, rhs.ss);
+        std::swap(regime, rhs.regime);
+        std::swap(type, rhs.type);
+        std::swap(partial, rhs.partial);
+        std::swap(nonCacheable, rhs.nonCacheable);
+        std::swap(shareable, rhs.shareable);
+        std::swap(outerShareable, rhs.outerShareable);
+        std::swap(xn, rhs.xn);
+        std::swap(pxn, rhs.pxn);
+        std::swap(xs, rhs.xs);
     }
 
     void

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -177,6 +177,16 @@ struct TlbEntry : public ReplaceableEntry, Serializable
 
     struct Lookup
     {
+        Lookup() = default;
+        explicit Lookup(const TlbEntry &entry)
+          : va(entry.vpn << entry.N), pageSize(entry.N), size(0),
+            asn(entry.asid), ignoreAsn(false),
+            vmid(entry.vmid), ss(entry.ss),
+            functional(false),
+            targetRegime(entry.regime),
+            mode(BaseMMU::Read)
+        {}
+
         // virtual address
         Addr va = 0;
         // page size

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -179,6 +179,8 @@ struct TlbEntry : public ReplaceableEntry, Serializable
     {
         // virtual address
         Addr va = 0;
+        // page size
+        Addr pageSize = Grain4KB;
         // lookup size:
         // * != 0 -> this is a range based lookup.
         //           end_address = va + size

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -358,6 +358,9 @@ struct TlbEntry : public ReplaceableEntry, Serializable
         valid = false;
     }
 
+    /** Need for compliance with the AssociativeCache interface */
+    void insert(const Lookup &lookup) {}
+
     void
     updateVaddr(Addr new_vaddr)
     {

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -361,6 +361,9 @@ struct TlbEntry : public ReplaceableEntry, Serializable
     /** Need for compliance with the AssociativeCache interface */
     void insert(const Lookup &lookup) {}
 
+    /** Need for compliance with the AssociativeCache interface */
+    bool isValid() const { return valid; }
+
     void
     updateVaddr(Addr new_vaddr)
     {

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012-2013, 2021, 2023-2024 ARM Limited
+ * Copyright (c) 2010, 2012-2013, 2021, 2023-2024 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -233,7 +233,7 @@ struct TlbEntry : public ReplaceableEntry, Serializable
 {
   public:
     using LookupLevel = enums::ArmLookupLevel;
-    using Lookup = TLBTypes::KeyType;
+    using KeyType = TLBTypes::KeyType;
     using IndexingPolicy = TLBIndexingPolicy;
 
     enum class MemoryType : std::uint8_t
@@ -389,7 +389,7 @@ struct TlbEntry : public ReplaceableEntry, Serializable
     }
 
     /** Need for compliance with the AssociativeCache interface */
-    void insert(const Lookup &lookup) {}
+    void insert(const KeyType &key) {}
 
     /** Need for compliance with the AssociativeCache interface */
     bool isValid() const { return valid; }
@@ -407,32 +407,32 @@ struct TlbEntry : public ReplaceableEntry, Serializable
     }
 
     bool
-    matchAddress(const Lookup &lookup) const
+    matchAddress(const KeyType &key) const
     {
         Addr page_addr = vpn << N;
-        if (lookup.size) {
+        if (key.size) {
             // This is a range based loookup
-            return lookup.va <= page_addr + size &&
-                   lookup.va + lookup.size > page_addr;
+            return key.va <= page_addr + size &&
+                   key.va + key.size > page_addr;
         } else {
             // This is a normal lookup
-            return lookup.va >= page_addr && lookup.va <= page_addr + size;
+            return key.va >= page_addr && key.va <= page_addr + size;
         }
     }
 
     bool
-    match(const Lookup &lookup) const
+    match(const KeyType &key) const
     {
         bool match = false;
-        if (valid && matchAddress(lookup) && lookup.ss == ss)
+        if (valid && matchAddress(key) && key.ss == ss)
         {
-            match = checkRegime(lookup.targetRegime);
+            match = checkRegime(key.targetRegime);
 
-            if (match && !lookup.ignoreAsn) {
-                match = global || (lookup.asn == asid);
+            if (match && !key.ignoreAsn) {
+                match = global || (key.asn == asid);
             }
-            if (match && useVMID(lookup.targetRegime)) {
-                match = lookup.vmid == vmid;
+            if (match && useVMID(key.targetRegime)) {
+                match = key.vmid == vmid;
             }
         }
         return match;

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -351,6 +351,13 @@ struct TlbEntry : public ReplaceableEntry, Serializable
         std::swap(xs, rhs.xs);
     }
 
+    /** Need for compliance with the AssociativeCache interface */
+    void
+    invalidate()
+    {
+        valid = false;
+    }
+
     void
     updateVaddr(Addr new_vaddr)
     {

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -174,14 +174,6 @@ struct TlbEntry : public Serializable
         Normal
     };
 
-    enum class DomainType : std::uint8_t
-    {
-        NoAccess = 0,
-        Client,
-        Reserved,
-        Manager
-    };
-
     struct Lookup
     {
         // virtual address

--- a/src/arch/arm/self_debug.cc
+++ b/src/arch/arm/self_debug.cc
@@ -145,7 +145,7 @@ SelfDebug::triggerWatchpointException(ThreadContext *tc, Addr vaddr,
         ArmFault::DebugType d = cm? ArmFault::WPOINT_CM:
                                     ArmFault::WPOINT_NOCM;
         return std::make_shared<DataAbort>(vaddr,
-                                           TlbEntry::DomainType::NoAccess,
+                                           DomainType::NoAccess,
                                            write, ArmFault::DebugEvent, cm,
                                            TranMethod::UnknownTran, d);
     } else {

--- a/src/arch/arm/self_debug.cc
+++ b/src/arch/arm/self_debug.cc
@@ -110,7 +110,7 @@ SelfDebug::triggerException(ThreadContext *tc, Addr vaddr)
     if (to32) {
         return std::make_shared<PrefetchAbort>(vaddr,
                                    ArmFault::DebugEvent, false,
-                                   ArmFault::UnknownTran,
+                                   TranMethod::UnknownTran,
                                    ArmFault::BRKPOINT);
     } else {
         return std::make_shared<HardwareBreakpoint>(vaddr, 0x22);
@@ -147,7 +147,7 @@ SelfDebug::triggerWatchpointException(ThreadContext *tc, Addr vaddr,
         return std::make_shared<DataAbort>(vaddr,
                                            TlbEntry::DomainType::NoAccess,
                                            write, ArmFault::DebugEvent, cm,
-                                           ArmFault::UnknownTran, d);
+                                           TranMethod::UnknownTran, d);
     } else {
         return std::make_shared<Watchpoint>(0, vaddr, write, cm);
     }

--- a/src/arch/arm/self_debug.hh
+++ b/src/arch/arm/self_debug.hh
@@ -40,7 +40,6 @@
 #define __ARCH_ARM_SELF_DEBUG_HH__
 
 
-#include "arch/arm/faults.hh"
 #include "arch/arm/regs/misc.hh"
 #include "arch/arm/system.hh"
 #include "arch/arm/types.hh"

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -644,7 +644,7 @@ TableWalker::processWalk()
             else
                 return std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess,
+                    DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::VmsaTran);
@@ -665,7 +665,7 @@ TableWalker::processWalk()
             else
                 return std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess,
+                    DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::VmsaTran);
@@ -762,7 +762,7 @@ TableWalker::processWalkLPAE()
                 else
                     return std::make_shared<DataAbort>(
                         currState->vaddr_tainted,
-                        TlbEntry::DomainType::NoAccess,
+                        DomainType::NoAccess,
                         is_atomic ? false : currState->isWrite,
                         ArmFault::TranslationLL + LookupLevel::L1,
                         isStage2,
@@ -788,7 +788,7 @@ TableWalker::processWalkLPAE()
                 else
                     return std::make_shared<DataAbort>(
                         currState->vaddr_tainted,
-                        TlbEntry::DomainType::NoAccess,
+                        DomainType::NoAccess,
                         is_atomic ? false : currState->isWrite,
                         ArmFault::TranslationLL + LookupLevel::L1,
                         isStage2,
@@ -813,7 +813,7 @@ TableWalker::processWalkLPAE()
             else
                 return std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess,
+                    DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1,
                     isStage2, TranMethod::LpaeTran);
@@ -1078,7 +1078,7 @@ TableWalker::processWalkAArch64()
         } else {
             return std::make_shared<DataAbort>(
                 currState->vaddr_tainted,
-                TlbEntry::DomainType::NoAccess,
+                DomainType::NoAccess,
                 is_atomic ? false : currState->isWrite,
                 ArmFault::TranslationLL + LookupLevel::L0,
                 isStage2, TranMethod::LpaeTran);
@@ -1115,7 +1115,7 @@ TableWalker::processWalkAArch64()
         else
             return std::make_shared<DataAbort>(
                 currState->vaddr_tainted,
-                TlbEntry::DomainType::NoAccess,
+                DomainType::NoAccess,
                 is_atomic ? false : currState->isWrite,
                 ArmFault::AddressSizeLL + start_lookup_level,
                 isStage2,
@@ -1692,7 +1692,7 @@ TableWalker::doL1Descriptor()
             currState->fault =
                 std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
-                    TlbEntry::DomainType::NoAccess,
+                    DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::VmsaTran);
@@ -1762,7 +1762,7 @@ TableWalker::generateLongDescFault(ArmFault::FaultSource src)
     } else {
         return std::make_shared<DataAbort>(
             currState->vaddr_tainted,
-            TlbEntry::DomainType::NoAccess,
+            DomainType::NoAccess,
             currState->req->isAtomic() ? false : currState->isWrite,
             src + currState->longDesc.lookupLevel,
             isStage2,
@@ -1973,7 +1973,7 @@ TableWalker::doL2Descriptor()
 
         currState->fault = std::make_shared<DataAbort>(
             currState->vaddr_tainted,
-            TlbEntry::DomainType::NoAccess,
+            DomainType::NoAccess,
             is_atomic ? false : currState->isWrite,
             ArmFault::AccessFlagLL + LookupLevel::L2, isStage2,
             TranMethod::VmsaTran);
@@ -2427,7 +2427,7 @@ TableWalker::pendingChange()
 }
 
 Fault
-TableWalker::testWalk(const RequestPtr &walk_req, TlbEntry::DomainType domain,
+TableWalker::testWalk(const RequestPtr &walk_req, DomainType domain,
                       LookupLevel lookup_level)
 {
     if (!test) {

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -2312,7 +2312,7 @@ TableWalker::insertPartialTableEntry(LongDescriptor &descriptor)
             descriptor.getRawData());
 
     // Insert the entry into the TLBs
-    tlb->multiInsert(te);
+    tlb->multiInsert(TlbEntry::KeyType(te), te);
 }
 
 void
@@ -2386,7 +2386,7 @@ TableWalker::insertTableEntry(DescriptorBase &descriptor, bool long_descriptor)
             descriptor.getRawData());
 
     // Insert the entry into the TLBs
-    tlb->multiInsert(te);
+    tlb->multiInsert(TlbEntry::KeyType(te), te);
     if (!currState->timing) {
         currState->tc  = NULL;
         currState->req = NULL;

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -640,14 +640,14 @@ TableWalker::processWalk()
                     currState->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1,
                     isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
             else
                 return std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
                     TlbEntry::DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
         }
         ttbr = currState->tc->readMiscReg(snsBankedIndex(
             MISCREG_TTBR0, currState->tc,
@@ -661,14 +661,14 @@ TableWalker::processWalk()
                     currState->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1,
                     isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
             else
                 return std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
                     TlbEntry::DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
         }
         ttbr = ttbr1;
         currState->ttbcr.n = 0;
@@ -758,7 +758,7 @@ TableWalker::processWalkLPAE()
                         currState->vaddr_tainted,
                         ArmFault::TranslationLL + LookupLevel::L1,
                         isStage2,
-                        ArmFault::LpaeTran);
+                        TranMethod::LpaeTran);
                 else
                     return std::make_shared<DataAbort>(
                         currState->vaddr_tainted,
@@ -766,7 +766,7 @@ TableWalker::processWalkLPAE()
                         is_atomic ? false : currState->isWrite,
                         ArmFault::TranslationLL + LookupLevel::L1,
                         isStage2,
-                        ArmFault::LpaeTran);
+                        TranMethod::LpaeTran);
             }
             ttbr = currState->tc->readMiscReg(snsBankedIndex(
                 MISCREG_TTBR0, currState->tc,
@@ -784,7 +784,7 @@ TableWalker::processWalkLPAE()
                         currState->vaddr_tainted,
                         ArmFault::TranslationLL + LookupLevel::L1,
                         isStage2,
-                        ArmFault::LpaeTran);
+                        TranMethod::LpaeTran);
                 else
                     return std::make_shared<DataAbort>(
                         currState->vaddr_tainted,
@@ -792,7 +792,7 @@ TableWalker::processWalkLPAE()
                         is_atomic ? false : currState->isWrite,
                         ArmFault::TranslationLL + LookupLevel::L1,
                         isStage2,
-                        ArmFault::LpaeTran);
+                        TranMethod::LpaeTran);
             }
             ttbr = currState->tc->readMiscReg(snsBankedIndex(
                 MISCREG_TTBR1, currState->tc,
@@ -809,14 +809,14 @@ TableWalker::processWalkLPAE()
                     currState->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1,
                     isStage2,
-                    ArmFault::LpaeTran);
+                    TranMethod::LpaeTran);
             else
                 return std::make_shared<DataAbort>(
                     currState->vaddr_tainted,
                     TlbEntry::DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1,
-                    isStage2, ArmFault::LpaeTran);
+                    isStage2, TranMethod::LpaeTran);
         }
 
     }
@@ -1074,14 +1074,14 @@ TableWalker::processWalkAArch64()
             return std::make_shared<PrefetchAbort>(
                 currState->vaddr_tainted,
                 ArmFault::TranslationLL + LookupLevel::L0, isStage2,
-                ArmFault::LpaeTran);
+                TranMethod::LpaeTran);
         } else {
             return std::make_shared<DataAbort>(
                 currState->vaddr_tainted,
                 TlbEntry::DomainType::NoAccess,
                 is_atomic ? false : currState->isWrite,
                 ArmFault::TranslationLL + LookupLevel::L0,
-                isStage2, ArmFault::LpaeTran);
+                isStage2, TranMethod::LpaeTran);
         }
     }
 
@@ -1111,7 +1111,7 @@ TableWalker::processWalkAArch64()
                 currState->vaddr_tainted,
                 ArmFault::AddressSizeLL + start_lookup_level,
                 isStage2,
-                ArmFault::LpaeTran);
+                TranMethod::LpaeTran);
         else
             return std::make_shared<DataAbort>(
                 currState->vaddr_tainted,
@@ -1119,7 +1119,7 @@ TableWalker::processWalkAArch64()
                 is_atomic ? false : currState->isWrite,
                 ArmFault::AddressSizeLL + start_lookup_level,
                 isStage2,
-                ArmFault::LpaeTran);
+                TranMethod::LpaeTran);
     }
 
     Request::Flags flag = Request::PT_WALK;
@@ -1687,7 +1687,7 @@ TableWalker::doL1Descriptor()
                     currState->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1,
                     isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
         else
             currState->fault =
                 std::make_shared<DataAbort>(
@@ -1695,7 +1695,7 @@ TableWalker::doL1Descriptor()
                     TlbEntry::DomainType::NoAccess,
                     is_atomic ? false : currState->isWrite,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
         return;
       case L1Descriptor::Section:
         if (currState->sctlr.afe && bits(currState->l1Desc.ap(), 0) == 0) {
@@ -1710,7 +1710,7 @@ TableWalker::doL1Descriptor()
                 is_atomic ? false : currState->isWrite,
                 ArmFault::AccessFlagLL + LookupLevel::L1,
                 isStage2,
-                ArmFault::VmsaTran);
+                TranMethod::VmsaTran);
         }
         if (currState->l1Desc.supersection()) {
             panic("Haven't implemented supersections\n");
@@ -1758,7 +1758,7 @@ TableWalker::generateLongDescFault(ArmFault::FaultSource src)
             currState->vaddr_tainted,
             src + currState->longDesc.lookupLevel,
             isStage2,
-            ArmFault::LpaeTran);
+            TranMethod::LpaeTran);
     } else {
         return std::make_shared<DataAbort>(
             currState->vaddr_tainted,
@@ -1766,7 +1766,7 @@ TableWalker::generateLongDescFault(ArmFault::FaultSource src)
             currState->req->isAtomic() ? false : currState->isWrite,
             src + currState->longDesc.lookupLevel,
             isStage2,
-            ArmFault::LpaeTran);
+            TranMethod::LpaeTran);
     }
 }
 
@@ -1953,14 +1953,14 @@ TableWalker::doL2Descriptor()
                     currState->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L2,
                     isStage2,
-                    ArmFault::VmsaTran);
+                    TranMethod::VmsaTran);
         else
             currState->fault = std::make_shared<DataAbort>(
                 currState->vaddr_tainted, currState->l1Desc.domain(),
                 is_atomic ? false : currState->isWrite,
                 ArmFault::TranslationLL + LookupLevel::L2,
                 isStage2,
-                ArmFault::VmsaTran);
+                TranMethod::VmsaTran);
         return;
     }
 
@@ -1976,7 +1976,7 @@ TableWalker::doL2Descriptor()
             TlbEntry::DomainType::NoAccess,
             is_atomic ? false : currState->isWrite,
             ArmFault::AccessFlagLL + LookupLevel::L2, isStage2,
-            ArmFault::VmsaTran);
+            TranMethod::VmsaTran);
     }
 
     insertTableEntry(currState->l2Desc, false);

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -79,7 +79,7 @@ class TableWalker : public ClockedObject
         LookupLevel lookupLevel;
 
         virtual Addr pfn() const = 0;
-        virtual TlbEntry::DomainType domain() const = 0;
+        virtual DomainType domain() const = 0;
         virtual bool xn() const = 0;
         virtual uint8_t ap() const = 0;
         virtual bool global(WalkerState *currState) const = 0;
@@ -209,10 +209,10 @@ class TableWalker : public ClockedObject
         }
 
         /** Domain Client/Manager: ARM DDI 0406B: B3-31 */
-        TlbEntry::DomainType
+        DomainType
         domain() const override
         {
-            return static_cast<TlbEntry::DomainType>(bits(data, 8, 5));
+            return static_cast<DomainType>(bits(data, 8, 5));
         }
 
         /** Address of L2 descriptor if it exists */
@@ -316,7 +316,7 @@ class TableWalker : public ClockedObject
             return "Inserting L2 Descriptor into TLB\n";
         }
 
-        TlbEntry::DomainType
+        DomainType
         domain() const override
         {
             return l1Parent->domain();
@@ -744,11 +744,11 @@ class TableWalker : public ClockedObject
             return ((!rw) << 2) | (user << 1);
         }
 
-        TlbEntry::DomainType
+        DomainType
         domain() const override
         {
             // Long-desc. format only supports Client domain
-            return TlbEntry::DomainType::Client;
+            return DomainType::Client;
         }
 
         /** Attribute index */
@@ -1249,7 +1249,7 @@ class TableWalker : public ClockedObject
 
     void setTestInterface(TlbTestInterface *ti);
 
-    Fault testWalk(const RequestPtr &walk_req, TlbEntry::DomainType domain,
+    Fault testWalk(const RequestPtr &walk_req, DomainType domain,
                    LookupLevel lookup_level);
 };
 

--- a/src/arch/arm/tlb.cc
+++ b/src/arch/arm/tlb.cc
@@ -264,6 +264,7 @@ TLB::insert(TlbEntry &entry)
         table[i] = table[i-1];
     table[0] = entry;
 
+    observedPageSizes.insert(entry.N);
     stats.inserts++;
     ppRefills->notify(1);
 }
@@ -314,12 +315,14 @@ TLB::flushAll()
     }
 
     stats.flushTlb++;
+    observedPageSizes.clear();
 }
 
 void
 TLB::flush(const TLBIOp& tlbi_op)
 {
     int x = 0;
+    bool valid_entry = false;
     TlbEntry *te;
     while (x < size) {
         te = &table[x];
@@ -328,10 +331,13 @@ TLB::flush(const TLBIOp& tlbi_op)
             te->valid = false;
             stats.flushedEntries++;
         }
+        valid_entry = valid_entry || te->valid;
         ++x;
     }
 
     stats.flushTlb++;
+    if (!valid_entry)
+        observedPageSizes.clear();
 }
 
 void

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -156,6 +156,16 @@ class TLB : public BaseTLB
     int rangeMRU; //On lookup, only move entries ahead when outside rangeMRU
     vmid_t vmid;
 
+    /** Set of observed page sizes in the TLB
+     * We update the set conservatively, therefore allowing
+     * false positives but not false negatives.
+     * This means there could be a stored page size with
+     * no matching TLB entry (e.g. it has been invalidated),
+     * but if the page size is not in the set, we are certain
+     * there is no associated TLB with that size
+     */
+    std::set<Addr> observedPageSizes;
+
   public:
     using Params = ArmTLBParams;
     using Lookup = TlbEntry::Lookup;

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -79,7 +79,7 @@ class TlbTestInterface
      */
     virtual Fault translationCheck(const RequestPtr &req, bool is_priv,
                                    BaseMMU::Mode mode,
-                                   TlbEntry::DomainType domain) = 0;
+                                   DomainType domain) = 0;
 
     /**
      * Check if a page table walker access should be forced to fail.
@@ -95,7 +95,7 @@ class TlbTestInterface
     virtual Fault walkCheck(const RequestPtr &walk_req,
                             Addr va, bool is_secure,
                             Addr is_priv, BaseMMU::Mode mode,
-                            TlbEntry::DomainType domain,
+                            DomainType domain,
                             enums::ArmLookupLevel lookup_level) = 0;
 };
 

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -168,7 +168,7 @@ class TLB : public BaseTLB
 
   public:
     using Params = ArmTLBParams;
-    using Lookup = TlbEntry::Lookup;
+    using Lookup = TlbEntry::KeyType;
     using LookupLevel = enums::ArmLookupLevel;
 
     TLB(const Params &p);

--- a/src/arch/arm/tlbi_op.cc
+++ b/src/arch/arm/tlbi_op.cc
@@ -206,10 +206,10 @@ TLBIALLN::matchEntry(TlbEntry* te, vmid_t vmid) const
         te->checkRegime(targetRegime);
 }
 
-TlbEntry::Lookup
+TlbEntry::KeyType
 TLBIMVAA::lookupGen(vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data;
+    TlbEntry::KeyType lookup_data;
     lookup_data.va = sext<56>(addr);
     lookup_data.ignoreAsn = true;
     lookup_data.vmid = vmid;
@@ -234,15 +234,15 @@ TLBIMVAA::operator()(ThreadContext* tc)
 bool
 TLBIMVAA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    TlbEntry::KeyType lookup_data = lookupGen(vmid);
 
     return te->match(lookup_data) && (!lastLevel || !te->partial);
 }
 
-TlbEntry::Lookup
+TlbEntry::KeyType
 TLBIMVA::lookupGen(vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data;
+    TlbEntry::KeyType lookup_data;
     lookup_data.va = sext<56>(addr);
     lookup_data.asn = asid;
     lookup_data.ignoreAsn = false;
@@ -269,7 +269,7 @@ TLBIMVA::operator()(ThreadContext* tc)
 bool
 TLBIMVA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    TlbEntry::KeyType lookup_data = lookupGen(vmid);
 
     return te->match(lookup_data) && (!lastLevel || !te->partial);
 }
@@ -309,10 +309,10 @@ TLBIIPA::operator()(ThreadContext* tc)
     }
 }
 
-TlbEntry::Lookup
+TlbEntry::KeyType
 TLBIIPA::lookupGen(vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data;
+    TlbEntry::KeyType lookup_data;
     lookup_data.va = szext<56>(addr);
     lookup_data.ignoreAsn = true;
     lookup_data.vmid = vmid;
@@ -326,7 +326,7 @@ TLBIIPA::lookupGen(vmid_t vmid) const
 bool
 TLBIIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    TlbEntry::KeyType lookup_data = lookupGen(vmid);
 
     return te->match(lookup_data) && (!lastLevel || !te->partial) &&
         ipaSpace == te->ipaSpace;
@@ -335,7 +335,7 @@ TLBIIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
 bool
 TLBIRMVA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    TlbEntry::KeyType lookup_data = lookupGen(vmid);
     lookup_data.size = rangeSize();
 
     auto addr_match = te->match(lookup_data) && (!lastLevel || !te->partial);
@@ -351,7 +351,7 @@ TLBIRMVA::matchEntry(TlbEntry* te, vmid_t vmid) const
 bool
 TLBIRMVAA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    TlbEntry::KeyType lookup_data = lookupGen(vmid);
     lookup_data.size = rangeSize();
 
     auto addr_match = te->match(lookup_data) && (!lastLevel || !te->partial);
@@ -367,7 +367,7 @@ TLBIRMVAA::matchEntry(TlbEntry* te, vmid_t vmid) const
 bool
 TLBIRIPA::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    TlbEntry::Lookup lookup_data = lookupGen(vmid);
+    TlbEntry::KeyType lookup_data = lookupGen(vmid);
     lookup_data.size = rangeSize();
 
     auto addr_match = te->match(lookup_data) && (!lastLevel || !te->partial);

--- a/src/arch/arm/tlbi_op.hh
+++ b/src/arch/arm/tlbi_op.hh
@@ -279,7 +279,7 @@ class TLBIALLN : public TLBIOp
 class TLBIMVAA : public TLBIOp
 {
   protected:
-    TlbEntry::Lookup lookupGen(vmid_t vmid) const;
+    TlbEntry::KeyType lookupGen(vmid_t vmid) const;
   public:
     TLBIMVAA(TranslationRegime _target_regime, SecurityState _ss,
              Addr _addr, bool last_level, Attr _attr=Attr::None)
@@ -299,7 +299,7 @@ class TLBIMVAA : public TLBIOp
 class TLBIMVA : public TLBIOp
 {
   protected:
-    TlbEntry::Lookup lookupGen(vmid_t vmid) const;
+    TlbEntry::KeyType lookupGen(vmid_t vmid) const;
 
   public:
     TLBIMVA(TranslationRegime _target_regime, SecurityState _ss,
@@ -405,7 +405,7 @@ class TLBIRange
 class TLBIIPA : public TLBIOp
 {
   protected:
-    TlbEntry::Lookup lookupGen(vmid_t vmid) const;
+    TlbEntry::KeyType lookupGen(vmid_t vmid) const;
   public:
     TLBIIPA(TranslationRegime _target_regime, SecurityState _ss, Addr _addr,
             bool last_level, Attr _attr=Attr::None)

--- a/src/arch/arm/types.hh
+++ b/src/arch/arm/types.hh
@@ -282,6 +282,13 @@ namespace ArmISA
         Secure
     };
 
+    enum class TranMethod
+    {
+        LpaeTran,
+        VmsaTran,
+        UnknownTran
+    };
+
     enum ExceptionLevel
     {
         EL0 = 0,

--- a/src/arch/arm/types.hh
+++ b/src/arch/arm/types.hh
@@ -289,6 +289,14 @@ namespace ArmISA
         UnknownTran
     };
 
+    enum class DomainType : std::uint8_t
+    {
+        NoAccess = 0,
+        Client,
+        Reserved,
+        Manager
+    };
+
     enum ExceptionLevel
     {
         EL0 = 0,


### PR DESCRIPTION
With this PR we replace the TlbEntry storage within the TLB from an
array of entries with a custom hardcoded FA indexing policy and LRU
replacement policy, into the flexible SetAssociative cache.