### PR TITLE
systemc: Disable 'overloaded-virtual' warn for clang

### DIFF
--- a/src/systemc/ext/core/sc_export.hh
+++ b/src/systemc/ext/core/sc_export.hh
@@ -78,7 +78,7 @@ class sc_export : public sc_export_base
  * code is correct).
  * Please check section 9.3 of SystemC 2.3.1 release note for more details.
  */
-#if defined(__GNUC__) && (__GNUC__ >= 13)
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 13))
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
     void operator () (IF &i) { bind(i); }

--- a/src/systemc/ext/core/sc_port.hh
+++ b/src/systemc/ext/core/sc_port.hh
@@ -126,7 +126,7 @@ class sc_port_b : public sc_port_base
  * code is correct).
  * Please check section 9.3 of SystemC 2.3.1 release note for more details.
  */
-#if defined(__GNUC__) && (__GNUC__ >= 13)
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 13))
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
     void operator () (IF &i) { bind(i); }

--- a/src/systemc/ext/tlm_core/2/sockets/initiator_socket.hh
+++ b/src/systemc/ext/tlm_core/2/sockets/initiator_socket.hh
@@ -105,7 +105,7 @@ class tlm_base_initiator_socket :
  * code is correct).
  * Please check section 9.3 of SystemC 2.3.1 release note for more details.
  */
-#if defined(__GNUC__) && (__GNUC__ >= 13)
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 13))
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
     virtual void

--- a/src/systemc/ext/tlm_core/2/sockets/target_socket.hh
+++ b/src/systemc/ext/tlm_core/2/sockets/target_socket.hh
@@ -100,7 +100,7 @@ class tlm_base_target_socket :
  * code is correct).
  * Please check section 9.3 of SystemC 2.3.1 release note for more details.
  */
-#if defined(__GNUC__) && (__GNUC__ >= 13)
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 13))
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
     virtual void


### PR DESCRIPTION
We need to extend the warning disable even for clang compiler.

Fixes #1658