### PR TITLE
sim: Make SignalSinkPort::set virtual

### DIFF
--- a/src/sim/signal.hh
+++ b/src/sim/signal.hh
@@ -51,12 +51,11 @@ class SignalSinkPort : public Port
     SignalSourcePort<State> *_source = nullptr;
 
     State _state = {};
-    OnChangeFunc _onChange;
 
   protected:
     // if bypass_on_change is specified true, it will not call the _onChange
     // function. Only _state will be updated if needed.
-    void
+    virtual void
     set(const State &new_state, const bool bypass_on_change = false)
     {
         if (new_state == _state)
@@ -66,6 +65,8 @@ class SignalSinkPort : public Port
         if (!bypass_on_change && _onChange)
             _onChange(_state);
     }
+
+    OnChangeFunc _onChange;
 
   public:
     SignalSinkPort(const std::string &_name, PortID _id=InvalidPortID) :


### PR DESCRIPTION
We are implementing derived classes of SignalSinkPort that does some additional logic after it's triggered (set() invoked by SignalSourcePort peer), and before executing the callback that a device provides (in onChange_). The logic is like additional logging, or providing debugging features. However, set() itself directly calls the onChange_ callback.

Making the set() virtual could provide the flexibility to achieve this feature.

Change-Id: Iaa3fd6bd76f0b60c17b651561a7567517a364360