### PR TITLE
cpu-o3: Clear thread state in time buffers on thread exit

### DIFF
--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -225,6 +225,25 @@ struct TimeStruct
     bool iewUnblock[MaxThreads];
 };
 
+/**
+ * Remove instructions belonging to given thread from the
+ * given comm struct's instruction array. Automatically
+ * updates the array size.
+ */
+template <class CommStruct>
+void
+removeCommThreadInsts(ThreadID tid, CommStruct& comm_struct)
+{
+    auto has_tid = [tid] (const auto &inst) -> bool {
+        return inst && inst->threadNumber == tid;
+    };
+    DynInstPtr *last = std::remove_if(comm_struct.insts,
+                                      comm_struct.insts + comm_struct.size,
+                                      has_tid);
+    std::fill(last, comm_struct.insts + comm_struct.size, nullptr);
+    comm_struct.size = last - comm_struct.insts;
+}
+
 } // namespace o3
 } // namespace gem5
 

--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -116,14 +116,14 @@ struct TimeStruct
         std::unique_ptr<PCStateBase> nextPC;
         DynInstPtr mispredictInst;
         DynInstPtr squashInst;
-        InstSeqNum doneSeqNum;
-        Addr mispredPC;
-        uint64_t branchAddr;
-        unsigned branchCount;
-        bool squash;
-        bool predIncorrect;
-        bool branchMispredict;
-        bool branchTaken;
+        InstSeqNum doneSeqNum = 0;
+        Addr mispredPC = 0;
+        uint64_t branchAddr = 0;
+        unsigned branchCount = 0;
+        bool squash = false;
+        bool predIncorrect = false;
+        bool branchMispredict = false;
+        bool branchTaken = false;
     };
 
     DecodeComm decodeInfo[MaxThreads];
@@ -135,18 +135,18 @@ struct TimeStruct
     struct IewComm
     {
         // Also eventually include skid buffer space.
-        unsigned freeIQEntries;
-        unsigned freeLQEntries;
-        unsigned freeSQEntries;
-        unsigned dispatchedToLQ;
-        unsigned dispatchedToSQ;
+        unsigned freeIQEntries = 0;
+        unsigned freeLQEntries = 0;
+        unsigned freeSQEntries = 0;
+        unsigned dispatchedToLQ = 0;
+        unsigned dispatchedToSQ = 0;
 
-        unsigned iqCount;
-        unsigned ldstqCount;
+        unsigned iqCount = 0;
+        unsigned ldstqCount = 0;
 
-        unsigned dispatched;
-        bool usedIQ;
-        bool usedLSQ;
+        unsigned dispatched = 0;
+        bool usedIQ = false;
+        bool usedLSQ = false;
     };
 
     IewComm iewInfo[MaxThreads];
@@ -183,35 +183,35 @@ struct TimeStruct
 
         /// Communication specifically to the IQ to tell the IQ that it can
         /// schedule a non-speculative instruction.
-        InstSeqNum nonSpecSeqNum; // *I
+        InstSeqNum nonSpecSeqNum = 0; // *I
 
         /// Represents the instruction that has either been retired or
         /// squashed.  Similar to having a single bus that broadcasts the
         /// retired or squashed sequence number.
-        InstSeqNum doneSeqNum; // *F, I
+        InstSeqNum doneSeqNum = 0; // *F, I
 
         /// Tell Rename how many free entries it has in the ROB
-        unsigned freeROBEntries; // *R
+        unsigned freeROBEntries = 0; // *R
 
-        bool squash; // *F, D, R, I
-        bool robSquashing; // *F, D, R, I
+        bool squash = false; // *F, D, R, I
+        bool robSquashing = false; // *F, D, R, I
 
         /// Rename should re-read number of free rob entries
-        bool usedROB; // *R
+        bool usedROB = false; // *R
 
         /// Notify Rename that the ROB is empty
-        bool emptyROB; // *R
+        bool emptyROB = false; // *R
 
         /// Was the branch taken or not
-        bool branchTaken; // *F
+        bool branchTaken = false; // *F
         /// If an interrupt is pending and fetch should stall
-        bool interruptPending; // *F
+        bool interruptPending = false; // *F
         /// If the interrupt ended up being cleared before being handled
-        bool clearInterrupt; // *F
+        bool clearInterrupt = false; // *F
 
         /// Hack for now to send back an strictly ordered access to
         /// the IEW stage.
-        bool strictlyOrdered; // *I
+        bool strictlyOrdered = false; // *I
 
     };
 

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -295,6 +295,11 @@ Commit::clearStates(ThreadID tid)
     pc[tid].reset(cpu->tcBase(tid)->getIsaPtr()->newPCState());
     lastCommitedSeqNum[tid] = 0;
     squashAfterInst[tid] = NULL;
+
+    // Clear out any of this thread's instructions being sent to prior stages.
+    for (int i = -cpu->timeBuffer.getPast();
+         i <= cpu->timeBuffer.getFuture(); ++i)
+        cpu->timeBuffer[i].commitInfo[i] = {};
 }
 
 void Commit::drain() { drainPending = true; }

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -651,15 +651,6 @@ CPU::removeThread(ThreadID tid)
     rename.clearStates(tid);
     iew.clearStates(tid);
 
-    // Flush out any old data from the time buffers.
-    for (int i = 0; i < timeBuffer.getSize(); ++i) {
-        timeBuffer.advance();
-        fetchQueue.advance();
-        decodeQueue.advance();
-        renameQueue.advance();
-        iewQueue.advance();
-    }
-
     // at this step, all instructions in the pipeline should be already
     // either committed successfully or squashed. All thread-specific
     // queues in the pipeline must be empty.

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -98,6 +98,22 @@ Decode::clearStates(ThreadID tid)
 {
     decodeStatus[tid] = Idle;
     stalls[tid].rename = false;
+
+    // Clear out any of this thread's instructions being sent to rename.
+    for (int i = -cpu->decodeQueue.getPast();
+         i <= cpu->decodeQueue.getFuture(); ++i) {
+        DecodeStruct& decode_struct = cpu->decodeQueue[i];
+        removeCommThreadInsts(tid, decode_struct);
+    }
+
+    // Clear out any of this thread's instructions being sent to fetch.
+    for (int i = -cpu->timeBuffer.getPast();
+         i <= cpu->timeBuffer.getFuture(); ++i) {
+        TimeStruct& time_struct = cpu->timeBuffer[i];
+        time_struct.decodeInfo[tid] = {};
+        time_struct.decodeBlock[tid] = false;
+        time_struct.decodeUnblock[tid] = false;
+    }
 }
 
 void

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -286,6 +286,13 @@ Fetch::clearStates(ThreadID tid)
 
     // TODO not sure what to do with priorityList for now
     // priorityList.push_back(tid);
+
+    // Clear out any of this thread's instructions being sent to decode.
+    for (int i = -cpu->fetchQueue.getPast();
+         i <= cpu->fetchQueue.getFuture(); ++i) {
+        FetchStruct& fetch_struct = cpu->fetchQueue[i];
+        removeCommThreadInsts(tid, fetch_struct);
+    }
 }
 
 void

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -245,6 +245,22 @@ Rename::clearStates(ThreadID tid)
     storesInProgress[tid] = 0;
 
     serializeOnNextInst[tid] = false;
+
+    // Clear out any of this thread's instructions being sent to IEW.
+    for (int i = -cpu->renameQueue.getPast();
+         i <= cpu->renameQueue.getFuture(); ++i) {
+        RenameStruct& rename_struct = cpu->renameQueue[i];
+        removeCommThreadInsts(tid, rename_struct);
+    }
+
+    // Clear out any of this thread's instructions being sent to decode.
+    for (int i = -cpu->timeBuffer.getPast();
+         i <= cpu->timeBuffer.getFuture(); ++i) {
+        TimeStruct& time_struct = cpu->timeBuffer[i];
+        time_struct.renameInfo[tid] = {};
+        time_struct.renameBlock[tid] = false;
+        time_struct.renameUnblock[tid] = false;
+    }
 }
 
 void

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -245,6 +245,18 @@ class TimeBuffer
     {
         return size;
     }
+
+    int
+    getPast() const
+    {
+        return past;
+    }
+
+    int
+    getFuture() const
+    {
+        return future;
+    }
 };
 
 } // namespace gem5


### PR DESCRIPTION
Fix #1049. Clear only thread-specific state from the O3 CPU time buffers, rather than clearing *all* state for *all* threads.

Specifically, this patch adds a `clearStates()` method for all O3 time buffer structs in src/cpu/o3/comm.hh. Upon thread exit, `CPU::removeThread()` now invokes this method for all structs in each time buffer, rather than flushing out the time buffers (which nukes the states for all threads, not just the exiting one).