### PR TITLE
arch-x86: break 32/64-bit LEA's input dependency on prior dest value

### DIFF
--- a/src/arch/x86/isa/microops/ldstop.isa
+++ b/src/arch/x86/isa/microops/ldstop.isa
@@ -720,8 +720,15 @@ let {{
                           "memDataSize": "dataSize" })
     header_output += MicroLeaDeclare.subst(iop)
     exec_output += MicroLeaExecute.subst(iop)
+    iop = InstObjParams("lea", "LeaBig", 'X86ISA::LdStOp',
+                        { "code": "Data = EA & mask(dataSize * 8);",
+                          "ea_code": "EA = " + segmentEAExpr,
+                          "memDataSize": "dataSize" })
+    header_output += MicroLeaDeclare.subst(iop)
+    exec_output += MicroLeaExecute.subst(iop)
 
-    class LeaOp(LdStOp):
+
+    class LeaOp(BigLdStOp):
         def __init__(self, data, segment, addr, disp = 0,
                 dataSize="env.dataSize", addressSize="env.addressSize"):
             super().__init__(data, segment, addr, disp,


### PR DESCRIPTION
Fix #1682. Treat LEA as a BigLdStOp. BigLdStOps (as well as other Big* x86 uops) do not have input dependencies on 32-/64-bit destinations. LEA will still have input dependencies on 16-bit destinations. (LEA cannot have an 8-bit destination.)

Change-Id: I5d0678e6bd79bfd6064941a89c6fe290750543c9