### PR TITLE
learning-gem5: Add `ruby_system` param set to `RubyPortProxy`

### DIFF
--- a/configs/learning_gem5/part3/test_caches.py
+++ b/configs/learning_gem5/part3/test_caches.py
@@ -96,7 +96,7 @@ class TestCacheSystem(RubySystem):
 
         # Set up a proxy port for the system_port. Used for load binaries and
         # other functional-only things.
-        self.sys_port_proxy = RubyPortProxy()
+        self.sys_port_proxy = RubyPortProxy(ruby_system=self)
         system.system_port = self.sys_port_proxy.in_ports
 
         # Connect up the sequencers to the random tester


### PR DESCRIPTION
This missing parameter causing the Learning gem5 tests to fail.

**Note:** We need to update the website's learning gem5 examples to reflect this change.