### PR TITLE
mem-ruby: Fix issues in protocols due to multi-RubySystem

### DIFF
--- a/configs/learning_gem5/part3/msi_caches.py
+++ b/configs/learning_gem5/part3/msi_caches.py
@@ -103,7 +103,7 @@ class MyCacheSystem(RubySystem):
 
         # Set up a proxy port for the system_port. Used for load binaries and
         # other functional-only things.
-        self.sys_port_proxy = RubyPortProxy()
+        self.sys_port_proxy = RubyPortProxy(ruby_system=self)
         system.system_port = self.sys_port_proxy.in_ports
 
         # Connect the cpu's cache, interrupt, and TLB ports to Ruby

--- a/src/mem/ruby/common/WriteMask.hh
+++ b/src/mem/ruby/common/WriteMask.hh
@@ -87,6 +87,7 @@ class WriteMask
         assert(mSize == 0);
         assert(size > 0);
         mSize = size;
+        clear();
     }
 
     void

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -204,6 +204,7 @@ void functionalRead(Addr addr, Packet *pkt, WriteMask &mask) {
   CacheEntry cache_entry := getCacheEntry(addr);
   DPRINTF(RubySlicc, "functionalRead %x\n", addr);
   WriteMask read_mask;
+  read_mask.setBlockSize(mask.getBlockSize());
   bool dirty := false;
   bool from_tbe := false;
 

--- a/src/mem/ruby/protocol/chi/CHI-mem.sm
+++ b/src/mem/ruby/protocol/chi/CHI-mem.sm
@@ -292,6 +292,7 @@ machine(MachineType:Memory, "Memory controller interface") :
       //TODO additional handling of partial data ??
       if (is_valid(tbe)) {
         WriteMask read_mask;
+        read_mask.setBlockSize(mask.getBlockSize());
         read_mask.setMask(addressOffset(tbe.accAddr, tbe.addr), tbe.accSize);
         read_mask.andMask(tbe.dataBlkValid);
         if (read_mask.isEmpty() == false) {

--- a/src/mem/ruby/system/RubySystem.cc
+++ b/src/mem/ruby/system/RubySystem.cc
@@ -660,6 +660,7 @@ RubySystem::functionalRead(PacketPtr pkt)
     // Issue functional reads to all controllers found in a stable state
     // until we get a full copy of the line
     WriteMask bytes;
+    bytes.setBlockSize(getBlockSizeBytes());
     if (ctrl_rw != nullptr) {
         ctrl_rw->functionalRead(line_address, pkt, bytes);
         // if a RW controllter has the full line that's all uptodate

--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -773,9 +773,12 @@ $c_ident::init()
 
                     # For objects that require knowing the cache line size,
                     # set the value here.
-                    if vtype.c_ident in ("TBETable"):
+                    if vtype.c_ident in ("TBETable", "PerfectCacheMemory"):
                         block_size_func = "m_ruby_system->getBlockSizeBytes()"
                         code(f"(*{vid}).setBlockSize({block_size_func});")
+
+                    if vtype.c_ident in ("NetDest"):
+                        code(f"(*{vid}).setRubySystem(m_ruby_system);")
 
         for param in self.config_parameters:
             if param.type_ast.type.ident == "CacheMemory":

--- a/src/mem/slicc/symbols/Type.py
+++ b/src/mem/slicc/symbols/Type.py
@@ -274,6 +274,7 @@ $klass ${{self.c_ident}}$parent
                     code(f"\t\t, m_{dm.ident}(blockSize)")
 
             code("{")
+            code("        setRubySystem(rs);")
         elif self.isTBE:
             code("${{self.c_ident}}(int block_size)")
 


### PR DESCRIPTION
Starting with https://github.com/gem5/gem5/pull/1453 , some Ruby structures require a block size be set
and other require a pointer to the Ruby system. This fixes some cases
which were not covered by the per-checkin tests but seen in daily+
tests. In particular:

 - WriteMasks and PerfectCacheMemory must explicitly set a block size.
 - NetDest and RubyProxyPort require RubySystem pointer.
 - Classes inheriting Message now have a setRubySystem collecting all
   objects that need a RubySystem pointer and this should be called in
   the constructor of the Message.

This commit makes sure all of these happen. This should fix daily
arm_boot_tests and daily learning_gem5 tests.