### PR TITLE
dev-amdgpu, gpu-compute, mem-ruby: Add support for writeback L2 in GPU

### DIFF
--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -685,11 +685,17 @@ class ComputeUnit : public ClockedObject
             Packet::SenderState *saved;
             // kernel id to be used in handling I-Cache invalidate response
             int kernId;
-
+            bool isKernDispatch;
             SenderState(Wavefront *_wavefront, Packet::SenderState
                     *sender_state=nullptr, int _kernId=-1)
                 : wavefront(_wavefront), saved(sender_state),
-                kernId(_kernId){ }
+                kernId(_kernId), isKernDispatch(false){ }
+
+            SenderState(Wavefront *_wavefront, bool _isKernDispatch,
+                    Packet::SenderState *sender_state=nullptr, int _kernId=-1)
+                : wavefront(_wavefront), saved(sender_state),
+                kernId(_kernId), isKernDispatch(_isKernDispatch){ }
+
         };
 
         class MemReqEvent : public Event

--- a/src/gpu-compute/gpu_command_processor.hh
+++ b/src/gpu-compute/gpu_command_processor.hh
@@ -85,11 +85,26 @@ class GPUCommandProcessor : public DmaVirtDevice
     Shader* shader();
     GPUComputeDriver* driver();
 
+    struct KernelDispatchData
+    {
+        AMDKernelCode *akc;
+        void *raw_pkt;
+        uint32_t queue_id;
+        Addr host_pkt_addr;
+        PacketPtr readPkt;
+    };
+
+    std::list<struct KernelDispatchData> kernelDispatchList;
+
     enum AgentCmd
     {
       Nop = 0,
       Steal = 1
     };
+
+    void performTimingRead(PacketPtr pkt);
+
+    void completeTimingRead();
 
     void submitAgentDispatchPkt(void *raw_pkt, uint32_t queue_id,
                            Addr host_pkt_addr);

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -473,6 +473,8 @@ class Request : public Extensible<Request>
     /** The cause for HTM transaction abort */
     HtmFailureFaultCause _htmAbortCause = HtmFailureFaultCause::INVALID;
 
+    bool _isGPUFuncAccess;
+
   public:
 
     /**
@@ -493,6 +495,7 @@ class Request : public Extensible<Request>
         _flags.set(flags);
         privateFlags.set(VALID_PADDR|VALID_SIZE);
         _byteEnable = std::vector<bool>(size, true);
+        _isGPUFuncAccess = false;
     }
 
     Request(Addr vaddr, unsigned size, Flags flags,
@@ -502,6 +505,7 @@ class Request : public Extensible<Request>
         setVirt(vaddr, size, flags, id, pc, std::move(atomic_op));
         setContext(cid);
         _byteEnable = std::vector<bool>(size, true);
+        _isGPUFuncAccess = false;
     }
 
     Request(const Request& other)
@@ -1124,6 +1128,17 @@ class Request : public Extensible<Request>
     bool isCacheInvalidate() const { return _flags.isSet(INVALIDATE); }
     bool isCacheMaintenance() const { return _flags.isSet(CLEAN|INVALIDATE); }
     /** @} */
+
+    void
+    setGPUFuncAccess(bool flag) {
+        _isGPUFuncAccess = flag;
+    }
+
+    bool
+    getGPUFuncAccess()
+    {
+        return _isGPUFuncAccess;
+    }
 };
 
 } // namespace gem5

--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -832,17 +832,14 @@ machine(MachineType:TCC, "TCC Cache")
       out_msg.Type := CoherenceResponseType:CPUPrbResp;  // TCC, L3  respond in same way to probes
       out_msg.Sender := machineID;
       out_msg.Destination.add(mapAddressToMachine(address, MachineType:Directory));
-      if (getState(tbe, cache_entry, address) == State:V || getState(tbe, cache_entry, address) == State:I) {
-        out_msg.Dirty := false;
-      } else {
-        out_msg.Dirty := true;
-      }
       if (getState(tbe, cache_entry, address) == State:V || getState(tbe, cache_entry, address) == State:M || getState(tbe, cache_entry, address) == State:W) {
         out_msg.Hit := true;
+        out_msg.Dirty := true;
         out_msg.DataBlk := cache_entry.DataBlk;
         out_msg.MessageSize := MessageSizeType:Response_Data;
       } else {
 	    out_msg.Hit := false;
+        out_msg.Dirty := false;
         out_msg.MessageSize := MessageSizeType:Response_Control;
       }
       out_msg.Ntsl := true;

--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -73,6 +73,7 @@ machine(MachineType:TCC, "TCC Cache")
     // Probes
     PrbInv,                 desc="Invalidating probe";
     InvCache,               desc="Invalidating probe from TCP";
+    PrbDowngrade,	        desc="Downgrading probe";
     // Coming from Memory Controller
     WBAck,                  desc="writethrough ack from memory";
     Bypass,                 desc="Bypass the entire L2 cache";
@@ -348,7 +349,14 @@ machine(MachineType:TCC, "TCC Cache")
         DPRINTF(RubySlicc, "%s\n", in_msg);
         Entry cache_entry := getCacheEntry(in_msg.addr);
         TBE tbe := TBEs.lookup(in_msg.addr);
-        trigger(Event:PrbInv, in_msg.addr, cache_entry, tbe);
+        if (in_msg.Type == ProbeRequestType:PrbInv) {
+          // Invalidate data and send it downstream
+          trigger(Event:PrbInv, in_msg.addr, cache_entry, tbe);
+        } else {
+          // If data present in cache, then downgrade it and send it
+          // downstream
+          trigger(Event:PrbDowngrade, in_msg.addr, cache_entry, tbe);
+        }
       }
     }
   }
@@ -818,6 +826,31 @@ machine(MachineType:TCC, "TCC Cache")
     }
   }
 
+  action(pd_sendProbeResponseDowngrade, "pd", desc="send probe downgrade") {
+    enqueue(responseToNB_out, ResponseMsg, 1) {
+      out_msg.addr := address;
+      out_msg.Type := CoherenceResponseType:CPUPrbResp;  // TCC, L3  respond in same way to probes
+      out_msg.Sender := machineID;
+      out_msg.Destination.add(mapAddressToMachine(address, MachineType:Directory));
+      if (getState(tbe, cache_entry, address) == State:V || getState(tbe, cache_entry, address) == State:I) {
+        out_msg.Dirty := false;
+      } else {
+        out_msg.Dirty := true;
+      }
+      if (getState(tbe, cache_entry, address) == State:V || getState(tbe, cache_entry, address) == State:M || getState(tbe, cache_entry, address) == State:W) {
+        out_msg.Hit := true;
+        out_msg.DataBlk := cache_entry.DataBlk;
+        out_msg.MessageSize := MessageSizeType:Response_Data;
+      } else {
+	    out_msg.Hit := false;
+        out_msg.MessageSize := MessageSizeType:Response_Control;
+      }
+      out_msg.Ntsl := true;
+      out_msg.State := CoherenceState:NA;
+    }
+  }
+
+
   action(pi_sendProbeResponseInv, "pi", desc="send probe ack inv, no data") {
     enqueue(responseToNB_out, ResponseMsg, 1) {
       out_msg.addr := address;
@@ -1213,6 +1246,25 @@ machine(MachineType:TCC, "TCC Cache")
     i_invL2;
     ir_invL2Resp;
     p_popRequestQueue;
+  }
+
+  transition(I, PrbDowngrade) {TagArrayRead} {
+    pd_sendProbeResponseDowngrade;
+    pp_popProbeQueue;
+  }
+
+  transition(V, PrbDowngrade) {TagArrayRead} {
+    pd_sendProbeResponseDowngrade;
+    pp_popProbeQueue;
+  }
+
+  transition({M, W}, PrbDowngrade, V) {TagArrayRead, TagArrayWrite} {
+    pd_sendProbeResponseDowngrade;
+    pp_popProbeQueue;
+  }
+
+  transition({A, IV, WI, WIB}, PrbDowngrade) {TagArrayRead, TagArrayWrite} {
+    st_stallAndWaitRequest;
   }
 
   transition({I, V}, PrbInv, I) {TagArrayRead, TagArrayWrite} {

--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -180,8 +180,11 @@ machine(MachineType:TCC, "TCC Cache")
 
   void functionalRead(Addr addr, Packet *pkt) {
     TBE tbe := TBEs.lookup(addr);
+    Entry cache_entry := getCacheEntry(addr);
     if(is_valid(tbe)) {
       testAndRead(addr, tbe.DataBlk, pkt);
+    } else if (is_valid(cache_entry)) {
+      testAndRead(addr, cache_entry.DataBlk, pkt);
     } else {
       functionalMemoryRead(pkt);
     }

--- a/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
@@ -173,8 +173,11 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
 
   void functionalRead(Addr addr, Packet *pkt) {
     TBE tbe := TBEs.lookup(addr);
+    Entry cache_entry := getCacheEntry(addr);
     if(is_valid(tbe)) {
       testAndRead(addr, tbe.DataBlk, pkt);
+    } else if (is_valid(cache_entry)) {
+      testAndRead(addr, cache_entry.DataBlk, pkt);
     } else {
       functionalMemoryRead(pkt);
     }

--- a/src/mem/ruby/protocol/MOESI_AMD_Base-dir.sm
+++ b/src/mem/ruby/protocol/MOESI_AMD_Base-dir.sm
@@ -107,7 +107,7 @@ machine(MachineType:Directory, "AMD Baseline protocol")
 
     // probe responses
     CPUPrbResp,            desc="Probe Response Msg";
-    CPUPrbRespHit,	       desc="Probe Response Msg and Data";
+    CPUPrbRespWB,	       desc="Probe Response Msg and Data";
 
     ProbeAcksComplete,  desc="Probe Acks Complete";
 
@@ -367,8 +367,8 @@ machine(MachineType:Directory, "AMD Baseline protocol")
         TBE tbe := TBEs.lookup(in_msg.addr);
         CacheEntry entry := static_cast(CacheEntry, "pointer", L3CacheMemory.lookup(in_msg.addr));
         if (in_msg.Type == CoherenceResponseType:CPUPrbResp) {
-          if (in_msg.Hit == true) {
-            trigger(Event:CPUPrbRespHit, in_msg.addr, entry, tbe);
+          if (in_msg.Hit == true && L2isWB) {
+            trigger(Event:CPUPrbRespWB, in_msg.addr, entry, tbe);
           } else {
             trigger(Event:CPUPrbResp, in_msg.addr, entry, tbe);
           }
@@ -622,35 +622,6 @@ machine(MachineType:Directory, "AMD Baseline protocol")
         out_msg.Sender := machineID;
         out_msg.MessageSize := MessageSizeType:Writeback_Data;
         out_msg.DataBlk := in_msg.DataBlk;
-      }
-    }
-  }
-
-  action(qdrt_queueDmaRdReqTrig, "qdrt", desc="Read data from memory for DMA") {
-    peek(triggerQueue_in, TriggerMsg) {
-      if (L3CacheMemory.isTagPresent(address)) {
-        enqueue(L3TriggerQueue_out, TriggerMsg, l3_hit_latency) {
-          out_msg.addr := address;
-          out_msg.Type := TriggerType:L3Hit;
-        }
-        CacheEntry entry := static_cast(CacheEntry, "pointer", L3CacheMemory.lookup(address));
-
-        // tbe.DataBlk may have partial data (e.g., for DMA writes). Make sure
-        // not to clobber the data before merging it with the L3 cache data.
-        DataBlock tmpBlk := entry.DataBlk;
-        tmpBlk.copyPartial(tbe.DataBlk, tbe.writeMask);
-        tbe.DataBlk := tmpBlk;
-
-        tbe.L3Hit := true;
-        tbe.MemData := true;
-        L3CacheMemory.deallocate(address);
-      } else {
-        enqueue(memQueue_out, MemoryMsg, to_memory_controller_latency) {
-          out_msg.addr := address;
-          out_msg.Type := MemoryRequestType:MEMORY_READ;
-          out_msg.Sender := machineID;
-          out_msg.MessageSize := MessageSizeType:Request_Control;
-        }
       }
     }
   }
@@ -1147,6 +1118,7 @@ machine(MachineType:Directory, "AMD Baseline protocol")
 
   action(mt_writeMemDataToTBE, "mt", desc="write Mem data to TBE") {
     peek(memQueue_in, MemoryMsg) {
+      DPRINTF(RubySlicc, "%s\n", in_msg);
       if (tbe.wtData == true) {
         // Keep the write-through data based on mask, but use the memory block
         // for the masked-off data. If we received a probe with data, the mask
@@ -1163,14 +1135,18 @@ machine(MachineType:Directory, "AMD Baseline protocol")
   }
 
 
-  action(y_writeProbeDataToTBEWB, "yw", desc="write Probe Data to TBE") {
+  action(yw_writeProbeDataToTBEWB, "yw", desc="write Probe Data to TBE") {
     peek(responseNetwork_in, ResponseMsg) {
-      tbe.DataBlk := in_msg.DataBlk;
-      tbe.Dirty := in_msg.Dirty;
-      tbe.LastSender := in_msg.Sender;
-      tbe.Cached := true;
+      DPRINTF(RubySlicc, "%s\n", in_msg);
+      if (tbe.Dirty == false) {
+        tbe.DataBlk := in_msg.DataBlk;
+        tbe.Dirty := in_msg.Dirty;
+        tbe.LastSender := in_msg.Sender;
+        tbe.Cached := true;
+        tbe.MemData := true;
+      }
+    }
   }
-}
 
   action(y_writeProbeDataToTBE, "y", desc="write Probe Data to TBE") {
     peek(responseNetwork_in, ResponseMsg) {
@@ -1389,9 +1365,10 @@ machine(MachineType:Directory, "AMD Baseline protocol")
 
   // transitions from U
   transition(U, DmaReadWB, BL2) {
-   atd_allocateTBEforDMA; // Allocate a TBE
-   pr_profileL3HitMiss;
-   scd_probeShrCoreDataForDma; // Send probes to the Ruby Network
+    atd_allocateTBEforDMA; // Allocate a TBE
+    qdr_queueDmaRdReq;
+    pr_profileL3HitMiss;
+    scd_probeShrCoreDataForDma; // Send probes to the Ruby Network
   }
 
   transition(U, DmaRead, BDR_PM) {L3TagArrayRead} {
@@ -1637,9 +1614,20 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     pr_popResponseQueue;
   }
 
-  transition(BL2, CPUPrbRespHit, BL2_Pm) {
+  transition({BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, BP}, CPUPrbRespWB) {
+    y_writeProbeDataToTBE;
+    x_decrementAcks;
+    o_checkForCompletion;
+    pr_popResponseQueue;
+  }
+
+  transition(BL2, L3Hit, BL2_Pm) {
+    ptl_popTriggerQueue;
+  }
+
+  transition({BL2, BL2_Pm}, CPUPrbRespWB, BL2_Pm) {
     // Blocked on L2 and waiting for probes
-    y_writeProbeDataToTBEWB;
+    yw_writeProbeDataToTBEWB;
     x_decrementAcks;
     o_checkForCompletion;
     pr_popResponseQueue;
@@ -1656,8 +1644,6 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     // We probed all the TCC dirs but didn't find the memory
     // Send out memory request
     // Transition to waiting on memory
-    qdrt_queueDmaRdReqTrig;
-    pr_profileL3HitMiss; //Must come after qdrt_queueDmaRdReqTrig
     pt_popTriggerQueue;
   }
 
@@ -1665,11 +1651,19 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     // We were waiting for all probes to come back now that they have we can unblock
     // Send WBAck back to TCC
     dd_sendResponseDmaData;
-    w_sendResponseWBAck;
     wada_wakeUpAllDependentsAddr;
     dt_deallocateTBE;
     pd_popDmaRequestQueue;
     pt_popTriggerQueue;
+  }
+
+  transition(BL2, MemData, BL2_Pm) {
+    mt_writeMemDataToTBE;
+    pm_popMemQueue;
+  }
+
+  transition({BL2_Pm, U}, MemData) {
+    pm_popMemQueue;
   }
 
   transition(BL2_M, MemData, U) {

--- a/src/mem/ruby/protocol/MOESI_AMD_Base-dir.sm
+++ b/src/mem/ruby/protocol/MOESI_AMD_Base-dir.sm
@@ -84,7 +84,9 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     BM_Pm, AccessPermission:Backing_Store,      desc="blocked waiting for probes, already got memory";
     B_Pm, AccessPermission:Backing_Store,       desc="blocked waiting for probes, already got memory";
     B, AccessPermission:Backing_Store,          desc="sent response, Blocked til ack";
-
+    BL2, AccessPermission:Backing_Store,	    desc="Blocked checking for data in L2";
+    BL2_Pm, AccessPermission:Backing_Store,	    desc="Blocked waiting for probes, already got memory";
+    BL2_M, AccessPermission:Backing_Store,	    desc="Blocked waiting for memory";
     F, AccessPermission:Busy, desc="sent Flus, blocked till ack";
   }
 
@@ -105,6 +107,7 @@ machine(MachineType:Directory, "AMD Baseline protocol")
 
     // probe responses
     CPUPrbResp,            desc="Probe Response Msg";
+    CPUPrbRespHit,	       desc="Probe Response Msg and Data";
 
     ProbeAcksComplete,  desc="Probe Acks Complete";
 
@@ -121,6 +124,7 @@ machine(MachineType:Directory, "AMD Baseline protocol")
 
     // DMA
     DmaRead,            desc="DMA read";
+    DmaReadWB,		    desc="DMA read write back";
     DmaWrite,           desc="DMA write";
 
     // Flush
@@ -300,7 +304,11 @@ machine(MachineType:Directory, "AMD Baseline protocol")
         TBE tbe := TBEs.lookup(in_msg.LineAddress);
         CacheEntry entry := static_cast(CacheEntry, "pointer", L3CacheMemory.lookup(in_msg.LineAddress));
         if (in_msg.Type == DMARequestType:READ) {
-          trigger(Event:DmaRead, in_msg.LineAddress, entry, tbe);
+          if (L2isWB) {
+            trigger(Event:DmaReadWB, in_msg.LineAddress, entry, tbe);
+          } else {
+            trigger(Event:DmaRead, in_msg.LineAddress, entry, tbe);
+          }
         } else if (in_msg.Type == DMARequestType:WRITE) {
           trigger(Event:DmaWrite, in_msg.LineAddress, entry, tbe);
         } else {
@@ -359,7 +367,11 @@ machine(MachineType:Directory, "AMD Baseline protocol")
         TBE tbe := TBEs.lookup(in_msg.addr);
         CacheEntry entry := static_cast(CacheEntry, "pointer", L3CacheMemory.lookup(in_msg.addr));
         if (in_msg.Type == CoherenceResponseType:CPUPrbResp) {
-          trigger(Event:CPUPrbResp, in_msg.addr, entry, tbe);
+          if (in_msg.Hit == true) {
+            trigger(Event:CPUPrbRespHit, in_msg.addr, entry, tbe);
+          } else {
+            trigger(Event:CPUPrbResp, in_msg.addr, entry, tbe);
+          }
         } else if (in_msg.Type == CoherenceResponseType:StaleNotif) {
             trigger(Event:StaleWB, in_msg.addr, entry, tbe);
         } else {
@@ -614,6 +626,35 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     }
   }
 
+  action(qdrt_queueDmaRdReqTrig, "qdrt", desc="Read data from memory for DMA") {
+    peek(triggerQueue_in, TriggerMsg) {
+      if (L3CacheMemory.isTagPresent(address)) {
+        enqueue(L3TriggerQueue_out, TriggerMsg, l3_hit_latency) {
+          out_msg.addr := address;
+          out_msg.Type := TriggerType:L3Hit;
+        }
+        CacheEntry entry := static_cast(CacheEntry, "pointer", L3CacheMemory.lookup(address));
+
+        // tbe.DataBlk may have partial data (e.g., for DMA writes). Make sure
+        // not to clobber the data before merging it with the L3 cache data.
+        DataBlock tmpBlk := entry.DataBlk;
+        tmpBlk.copyPartial(tbe.DataBlk, tbe.writeMask);
+        tbe.DataBlk := tmpBlk;
+
+        tbe.L3Hit := true;
+        tbe.MemData := true;
+        L3CacheMemory.deallocate(address);
+      } else {
+        enqueue(memQueue_out, MemoryMsg, to_memory_controller_latency) {
+          out_msg.addr := address;
+          out_msg.Type := MemoryRequestType:MEMORY_READ;
+          out_msg.Sender := machineID;
+          out_msg.MessageSize := MessageSizeType:Request_Control;
+        }
+      }
+    }
+  }
+
   action(qdr_queueDmaRdReq, "qdr", desc="Read data from memory for DMA") {
     peek(dmaRequestQueue_in, DMARequestMsg) {
       if (L3CacheMemory.isTagPresent(address)) {
@@ -822,6 +863,12 @@ machine(MachineType:Directory, "AMD Baseline protocol")
         // We don't need to notify TCC about reads
         if (!noTCCdir) {
           probe_dests.add(mapAddressToRange(address, MachineType:TCCdir,
+                                            TCC_select_low_bit,
+                                            TCC_select_num_bits));
+        }
+
+        if (GPUonly && L2isWB) {
+          probe_dests.add(mapAddressToRange(address, MachineType:TCC,
                                             TCC_select_low_bit,
                                             TCC_select_num_bits));
         }
@@ -1115,6 +1162,16 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     }
   }
 
+
+  action(y_writeProbeDataToTBEWB, "yw", desc="write Probe Data to TBE") {
+    peek(responseNetwork_in, ResponseMsg) {
+      tbe.DataBlk := in_msg.DataBlk;
+      tbe.Dirty := in_msg.Dirty;
+      tbe.LastSender := in_msg.Sender;
+      tbe.Cached := true;
+  }
+}
+
   action(y_writeProbeDataToTBE, "y", desc="write Probe Data to TBE") {
     peek(responseNetwork_in, ResponseMsg) {
       if (in_msg.Dirty) {
@@ -1315,22 +1372,28 @@ machine(MachineType:Directory, "AMD Baseline protocol")
   */
 
   // TRANSITIONS
-  transition({BL, BDR_M, BDW_M, BS_M, BM_M, B_M, BP, BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, B}, {RdBlkS, RdBlkM, RdBlk, CtoD}) {
+  transition({BL, BL2, BL2_Pm, BL2_M, BDR_M, BDW_M, BS_M, BM_M, B_M, BP, BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, B}, {RdBlkS, RdBlkM, RdBlk, CtoD}) {
       st_stallAndWaitRequest;
   }
 
-  // It may be possible to save multiple invalidations here!
-  transition({BL, BS_M, BM_M, B_M, BP, BS_PM, BM_PM, B_PM, BS_Pm, BM_Pm, B_Pm, B}, {Atomic, WriteThrough}) {
+    // It may be possible to save multiple invalidations here!
+  transition({BL, BL2, BL2_Pm, BL2_M, BS_M, BM_M, B_M, BP, BS_PM, BM_PM, B_PM, BS_Pm, BM_Pm, B_Pm, B}, {Atomic, WriteThrough}) {
       st_stallAndWaitRequest;
   }
 
   // The exit state is always going to be U, so wakeUpDependents logic should be covered in all the
   // transitions which are flowing into U.
-  transition({BL, BDR_M, BDW_M, BS_M, BM_M, B_M, BP, BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, B}, {DmaRead,DmaWrite}){
+  transition({BL, BL2, BL2_Pm, BL2_M, BDR_M, BDW_M, BS_M, BM_M, B_M, BP, BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, B}, {DmaRead, DmaReadWB, DmaWrite}){
     sd_stallAndWaitRequest;
   }
 
   // transitions from U
+  transition(U, DmaReadWB, BL2) {
+   atd_allocateTBEforDMA; // Allocate a TBE
+   pr_profileL3HitMiss;
+   scd_probeShrCoreDataForDma; // Send probes to the Ruby Network
+  }
+
   transition(U, DmaRead, BDR_PM) {L3TagArrayRead} {
     atd_allocateTBEforDMA;
     qdr_queueDmaRdReq;
@@ -1567,11 +1630,56 @@ machine(MachineType:Directory, "AMD Baseline protocol")
     ptl_popTriggerQueue;
   }
 
-  transition({BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, BP}, CPUPrbResp) {
+  transition({BDR_PM, BDW_PM, BS_PM, BM_PM, B_PM, BDR_Pm, BDW_Pm, BS_Pm, BM_Pm, B_Pm, BP, BL2}, CPUPrbResp) {
     y_writeProbeDataToTBE;
     x_decrementAcks;
     o_checkForCompletion;
     pr_popResponseQueue;
+  }
+
+  transition(BL2, CPUPrbRespHit, BL2_Pm) {
+    // Blocked on L2 and waiting for probes
+    y_writeProbeDataToTBEWB;
+    x_decrementAcks;
+    o_checkForCompletion;
+    pr_popResponseQueue;
+  }
+
+  transition(BL2_Pm, CPUPrbResp) {
+    // Blocked on L2 probes, got the memory
+    x_decrementAcks;
+    o_checkForCompletion;
+    pr_popResponseQueue;
+  }
+
+  transition(BL2, ProbeAcksComplete, BL2_M) {
+    // We probed all the TCC dirs but didn't find the memory
+    // Send out memory request
+    // Transition to waiting on memory
+    qdrt_queueDmaRdReqTrig;
+    pr_profileL3HitMiss; //Must come after qdrt_queueDmaRdReqTrig
+    pt_popTriggerQueue;
+  }
+
+  transition(BL2_Pm, ProbeAcksComplete, U) {
+    // We were waiting for all probes to come back now that they have we can unblock
+    // Send WBAck back to TCC
+    dd_sendResponseDmaData;
+    w_sendResponseWBAck;
+    wada_wakeUpAllDependentsAddr;
+    dt_deallocateTBE;
+    pd_popDmaRequestQueue;
+    pt_popTriggerQueue;
+  }
+
+  transition(BL2_M, MemData, U) {
+    // Got the memory we were waiting for. We can unblock now.
+    mt_writeMemDataToTBE;
+    dd_sendResponseDmaData;
+    wada_wakeUpAllDependentsAddr;
+    pd_popDmaRequestQueue;
+    dt_deallocateTBE;
+    pm_popMemQueue;
   }
 
   transition(BDR_PM, ProbeAcksComplete, BDR_M) {

--- a/src/mem/ruby/system/RubySystem.cc
+++ b/src/mem/ruby/system/RubySystem.cc
@@ -560,7 +560,8 @@ RubySystem::functionalRead(PacketPtr pkt)
     // it only if it's not in the cache hierarchy at all.
     int num_controllers = netCntrls[request_net_id].size();
     if (num_invalid == (num_controllers - 1) && num_backing_store == 1) {
-        DPRINTF(RubySystem, "only copy in Backing_Store memory, read from it\n");
+        DPRINTF(RubySystem,
+                "only copy in Backing_Store memory, read from it\n");
         ctrl_backing_store->functionalRead(line_address, pkt);
         return true;
     } else if (num_ro > 0 || num_rw >= 1) {


### PR DESCRIPTION
Previously, GPU L2 caches could be configured in either writeback or writethrough mode when used in an APU. However, in a CPU+dGPU system, only writethrough worked. This is mainly because in CPU+dGPU system, the CPU sends either PCI or SDMA requests to transfer data from the GPU memory to CPU. When L2 cache is configured to be writeback, the dirty data resides in L2 when CPU transfers data from GPU memory. This leads to the wrong version being transferred. A similar issue also crops up when the GPU command processor reads kernel information before kernel dispatch, only to incorrect data. This PR contains a set of commits that fix both these issues.