### PR TITLE
arch-arm: Implement AT as standalone instructions

### DIFF
--- a/src/arch/arm/faults.cc
+++ b/src/arch/arm/faults.cc
@@ -1430,6 +1430,9 @@ DataAbort::annotate(AnnotationIDs id, uint64_t val)
       case OFA:
         faultAddr  = val;
         break;
+      case WnR:
+        write = val;
+        break;
       // Just ignore unknown ID's
       default:
         break;

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -141,6 +141,8 @@ class ArmFault : public FaultBase
                // the abort is triggered by a CMO. The faulting address is
                // then the address specified in the register argument of the
                // instruction and not the cacheline address (See FAR doc)
+        WnR,  // Write or Read. it should be forced to 1 when
+              // Cache maintainance and address translation instruction.
 
         // AArch64 only
         SF,    // DataAbort: width of the accessed register is SixtyFour

--- a/src/arch/arm/insts/misc64.hh
+++ b/src/arch/arm/insts/misc64.hh
@@ -39,6 +39,7 @@
 #define __ARCH_ARM_INSTS_MISC64_HH__
 
 #include "arch/arm/insts/static_inst.hh"
+#include "arch/arm/mmu.hh"
 #include "arch/arm/tlbi_op.hh"
 #include "arch/arm/types.hh"
 
@@ -337,6 +338,23 @@ class TlbiOp64 : public MiscRegRegImmOp64
 
     void performTlbi(ExecContext *xc,
                      ArmISA::MiscRegIndex idx, RegVal value) const;
+};
+
+class AtOp64 : public MiscRegRegImmOp64
+{
+  protected:
+    AtOp64(const char *mnem, ArmISA::ExtMachInst _machInst,
+             OpClass __opClass, ArmISA::MiscRegIndex _dest,
+             RegIndex _op1) :
+        MiscRegRegImmOp64(mnem, _machInst, __opClass, _dest, _op1)
+    {}
+
+    std::pair<Fault, uint64_t> performAt(ExecContext *xc,
+        ArmISA::MiscRegIndex idx, RegVal val) const;
+
+    std::pair<Fault, uint64_t> addressTranslation64(ThreadContext* tc,
+        ArmISA::MMU::ArmTranslationType tran_type,
+        BaseMMU::Mode mode, Request::Flags flags, RegVal val) const;
 };
 
 } // namespace gem5

--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -1293,46 +1293,6 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                 idx = MISCREG_CPSR;
             }
             break;
-          case MISCREG_AT_S1E1R_Xt:
-            addressTranslation64(MMU::S1E1Tran, BaseMMU::Read, 0, val);
-            return;
-          case MISCREG_AT_S1E1W_Xt:
-            addressTranslation64(MMU::S1E1Tran, BaseMMU::Write, 0, val);
-            return;
-          case MISCREG_AT_S1E0R_Xt:
-            addressTranslation64(MMU::S1E0Tran, BaseMMU::Read,
-                MMU::UserMode, val);
-            return;
-          case MISCREG_AT_S1E0W_Xt:
-            addressTranslation64(MMU::S1E0Tran, BaseMMU::Write,
-                MMU::UserMode, val);
-            return;
-          case MISCREG_AT_S1E2R_Xt:
-            addressTranslation64(MMU::S1E2Tran, BaseMMU::Read, 0, val);
-            return;
-          case MISCREG_AT_S1E2W_Xt:
-            addressTranslation64(MMU::S1E2Tran, BaseMMU::Write, 0, val);
-            return;
-          case MISCREG_AT_S12E1R_Xt:
-            addressTranslation64(MMU::S12E1Tran, BaseMMU::Read, 0, val);
-            return;
-          case MISCREG_AT_S12E1W_Xt:
-            addressTranslation64(MMU::S12E1Tran, BaseMMU::Write, 0, val);
-            return;
-          case MISCREG_AT_S12E0R_Xt:
-            addressTranslation64(MMU::S12E0Tran, BaseMMU::Read,
-                MMU::UserMode, val);
-            return;
-          case MISCREG_AT_S12E0W_Xt:
-            addressTranslation64(MMU::S12E0Tran, BaseMMU::Write,
-                MMU::UserMode, val);
-            return;
-          case MISCREG_AT_S1E3R_Xt:
-            addressTranslation64(MMU::S1E3Tran, BaseMMU::Read, 0, val);
-            return;
-          case MISCREG_AT_S1E3W_Xt:
-            addressTranslation64(MMU::S1E3Tran, BaseMMU::Write, 0, val);
-            return;
           case MISCREG_L2CTLR:
             warn("miscreg L2CTLR (%s) written with %#x. ignored...\n",
                  miscRegName[idx], uint32_t(val));
@@ -1594,57 +1554,6 @@ ISA::unserialize(CheckpointIn &cp)
 
     CPSR tmp_cpsr = miscRegs[MISCREG_CPSR];
     updateRegMap(tmp_cpsr);
-}
-
-void
-ISA::addressTranslation64(MMU::ArmTranslationType tran_type,
-    BaseMMU::Mode mode, Request::Flags flags, RegVal val)
-{
-    // If we're in timing mode then doing the translation in
-    // functional mode then we're slightly distorting performance
-    // results obtained from simulations. The translation should be
-    // done in the same mode the core is running in. NOTE: This
-    // can't be an atomic translation because that causes problems
-    // with unexpected atomic snoop requests.
-    warn_once("Doing AT (address translation) in functional mode! Fix Me!\n");
-
-    auto req = std::make_shared<Request>(
-        val, 0, flags,  Request::funcRequestorId,
-        tc->pcState().instAddr(), tc->contextId());
-
-    Fault fault = getMMUPtr(tc)->translateFunctional(
-        req, tc, mode, tran_type);
-
-    PAR par = 0;
-    if (fault == NoFault) {
-        Addr paddr = req->getPaddr();
-        uint64_t attr = getMMUPtr(tc)->getAttr();
-        uint64_t attr1 = attr >> 56;
-        if (!attr1 || attr1 ==0x44) {
-            attr |= 0x100;
-            attr &= ~ uint64_t(0x80);
-        }
-        par = (paddr & mask(47, 12)) | attr;
-        DPRINTF(MiscRegs,
-              "MISCREG: Translated addr %#x: PAR_EL1: %#xx\n",
-              val, par);
-    } else {
-        ArmFault *arm_fault = static_cast<ArmFault *>(fault.get());
-        arm_fault->update(tc);
-        // Set fault bit and FSR
-        FSR fsr = arm_fault->getFsr(tc);
-
-        par.f = 1; // F bit
-        par.fst = fsr.status; // FST
-        par.ptw = (arm_fault->iss() >> 7) & 0x1; // S1PTW
-        par.s = arm_fault->isStage2() ? 1 : 0; // S
-
-        DPRINTF(MiscRegs,
-                "MISCREG: Translated addr %#x fault fsr %#x: PAR: %#x\n",
-                val, fsr, par);
-    }
-    setMiscRegNoEffect(MISCREG_PAR_EL1, par);
-    return;
 }
 
 void

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -173,8 +173,6 @@ namespace ArmISA
       protected:
         void addressTranslation(MMU::ArmTranslationType tran_type,
             BaseMMU::Mode mode, Request::Flags flags, RegVal val);
-        void addressTranslation64(MMU::ArmTranslationType tran_type,
-            BaseMMU::Mode mode, Request::Flags flags, RegVal val);
 
       public:
         SelfDebug*

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -624,6 +624,21 @@ namespace Aarch64
                               TLBI_CASE_VARIANTS(MISCREG_TLBI_RVALE3OS)
                                 return new Tlbi64ShareableHub(
                                   machInst, miscReg, rt, dec.dvmEnabled);
+                              // AT instructions
+                              case MISCREG_AT_S1E1R_Xt:
+                              case MISCREG_AT_S1E1W_Xt:
+                              case MISCREG_AT_S1E0R_Xt:
+                              case MISCREG_AT_S1E0W_Xt:
+                              case MISCREG_AT_S1E2R_Xt:
+                              case MISCREG_AT_S1E2W_Xt:
+                              case MISCREG_AT_S12E1R_Xt:
+                              case MISCREG_AT_S12E1W_Xt:
+                              case MISCREG_AT_S12E0R_Xt:
+                              case MISCREG_AT_S12E0W_Xt:
+                              case MISCREG_AT_S1E3R_Xt:
+                              case MISCREG_AT_S1E3W_Xt:
+                                return new At64Hub(machInst, miscReg,
+                                  MiscRegIndex::MISCREG_PAR_EL1, rt);
                               default:
                                 return new Msr64(machInst, miscReg, rt);
                             }

--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -401,6 +401,20 @@ let {{
     exec_output += DvmInitiateAcc.subst(msrTlbiSIop)
     exec_output += DvmCompleteAcc.subst(msrTlbiSIop)
 
+    atCode = msr_check_code + '''
+        uint64_t par_result;
+        std::tie(fault, par_result) = performAt(xc, flat_idx, XOp1);
+        MiscDest_ud = XOp1;
+        MiscDest2_ud = par_result;
+    '''
+    msrAtIop = ArmInstObjParams("msr", "At64Hub", "AtOp64",
+        {
+            "code" : atCode
+        })
+    header_output += AtDeclare.subst(msrAtIop)
+    decoder_output += AtConstructor.subst(msrAtIop)
+    exec_output += BasicExecute.subst(msrAtIop)
+
     msrNZCVCode = '''
         CPSR cpsr = XOp1;
         CondCodesNZ = cpsr.nz;

--- a/src/arch/arm/isa/operands.isa
+++ b/src/arch/arm/isa/operands.isa
@@ -1,5 +1,5 @@
 // -*- mode:c++ -*-
-// Copyright (c) 2010-2014, 2016-2018, 2021-2022 Arm Limited
+// Copyright (c) 2010-2014, 2016-2018, 2021-2022, 2024 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -470,6 +470,7 @@ def operands {{
 
     #Abstracted control reg operands
     'MiscDest': CntrlReg('dest'),
+    'MiscDest2': CntrlReg('dest2'),
     'MiscOp1': CntrlReg('op1'),
     'MiscNsBankedDest': CntrlNsBankedReg('dest'),
     'MiscNsBankedOp1': CntrlNsBankedReg('op1'),

--- a/src/arch/arm/isa/templates/misc64.isa
+++ b/src/arch/arm/isa/templates/misc64.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2011,2017-2022 Arm Limited
+// Copyright (c) 2011,2017-2022,2024 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -303,6 +303,22 @@ class %(class_name)s : public %(base_class)s
 };
 }};
 
+def template AtDeclare {{
+class %(class_name)s : public %(base_class)s
+{
+  private:
+    ArmISA::MiscRegIndex dest2;
+    %(reg_idx_arr_decl)s;
+
+  public:
+    // Constructor
+    %(class_name)s(ExtMachInst machInst, MiscRegIndex _dest,
+            MiscRegIndex _dest2, RegIndex _op1);
+
+    Fault execute(ExecContext *, trace::InstRecord *) const override;
+};
+}};
+
 def template DvmDeclare {{
     /**
      * Static instruction class for "%(mnemonic)s".
@@ -336,6 +352,18 @@ def template DvmTlbiConstructor {{
         if (dvmEnabled) {
             flags[IsLoad] = true;
         }
+    }
+}};
+
+def template AtConstructor {{
+    %(class_name)s::%(class_name)s(ExtMachInst machInst, MiscRegIndex _dest,
+                                   MiscRegIndex _dest2, RegIndex _op1) :
+        %(base_class)s("%(mnemonic)s", machInst, %(op_class)s,
+                       _dest, _op1),
+        dest2(_dest2)
+    {
+        %(set_reg_idx_arr)s;
+        %(constructor)s;
     }
 }};
 


### PR DESCRIPTION
Moving the address translation logic outside of the ISA::setMiscReg will allow it to return and potentially invoke a fault
upon execution of the AT instruction. This change affects AArch64 mode only