### PR TITLE
cpu: Add FastMemSimpleCPU model

### DIFF
--- a/src/arch/arm/ArmCPU.py
+++ b/src/arch/arm/ArmCPU.py
@@ -28,6 +28,7 @@ from m5.objects.ArmInterrupts import ArmInterrupts
 from m5.objects.ArmISA import ArmISA
 from m5.objects.ArmMMU import ArmMMU
 from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
+from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
 from m5.objects.BaseMinorCPU import BaseMinorCPU
 from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
 from m5.objects.BaseO3Checker import BaseO3Checker
@@ -48,6 +49,10 @@ class ArmAtomicSimpleCPU(BaseAtomicSimpleCPU, ArmCPU):
 
 
 class ArmNonCachingSimpleCPU(BaseNonCachingSimpleCPU, ArmCPU):
+    mmu = ArmMMU()
+
+
+class ArmFastMemSimpleCPU(BaseFastMemSimpleCPU, ArmCPU):
     mmu = ArmMMU()
 
 

--- a/src/arch/mips/MipsCPU.py
+++ b/src/arch/mips/MipsCPU.py
@@ -24,6 +24,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
+from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
 from m5.objects.BaseMinorCPU import BaseMinorCPU
 from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
 from m5.objects.BaseO3CPU import BaseO3CPU
@@ -46,6 +47,10 @@ class MipsAtomicSimpleCPU(BaseAtomicSimpleCPU, MipsCPU):
 
 
 class MipsNonCachingSimpleCPU(BaseNonCachingSimpleCPU, MipsCPU):
+    mmu = MipsMMU()
+
+
+class MipsFastMemSimpleCPU(BaseFastMemSimpleCPU, MipsCPU):
     mmu = MipsMMU()
 
 

--- a/src/arch/power/PowerCPU.py
+++ b/src/arch/power/PowerCPU.py
@@ -24,6 +24,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
+from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
 from m5.objects.BaseMinorCPU import BaseMinorCPU
 from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
 from m5.objects.BaseO3CPU import BaseO3CPU
@@ -46,6 +47,10 @@ class PowerAtomicSimpleCPU(BaseAtomicSimpleCPU, PowerCPU):
 
 
 class PowerNonCachingSimpleCPU(BaseNonCachingSimpleCPU, PowerCPU):
+    mmu = PowerMMU()
+
+
+class PowerFastMemSimpleCPU(BaseFastMemSimpleCPU, PowerCPU):
     mmu = PowerMMU()
 
 

--- a/src/arch/sparc/SparcCPU.py
+++ b/src/arch/sparc/SparcCPU.py
@@ -24,6 +24,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
+from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
 from m5.objects.BaseMinorCPU import BaseMinorCPU
 from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
 from m5.objects.BaseO3CPU import BaseO3CPU
@@ -46,6 +47,10 @@ class SparcAtomicSimpleCPU(BaseAtomicSimpleCPU, SparcCPU):
 
 
 class SparcNonCachingSimpleCPU(BaseNonCachingSimpleCPU, SparcCPU):
+    mmu = SparcMMU()
+
+
+class SparcFastMemSimpleCPU(BaseFastMemSimpleCPU, SparcCPU):
     mmu = SparcMMU()
 
 

--- a/src/arch/x86/X86CPU.py
+++ b/src/arch/x86/X86CPU.py
@@ -24,6 +24,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
+from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
 from m5.objects.BaseMinorCPU import BaseMinorCPU
 from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
 from m5.objects.BaseO3CPU import BaseO3CPU
@@ -49,6 +50,10 @@ class X86AtomicSimpleCPU(BaseAtomicSimpleCPU, X86CPU):
 
 
 class X86NonCachingSimpleCPU(BaseNonCachingSimpleCPU, X86CPU):
+    mmu = X86MMU()
+
+
+class X86FastMemSimpleCPU(BaseFastMemSimpleCPU, X86CPU):
     mmu = X86MMU()
 
 

--- a/src/cpu/simple/BaseFastMemSimpleCPU.py
+++ b/src/cpu/simple/BaseFastMemSimpleCPU.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google, Inc.
+# Copyright 2024 Barcelona Supercomputing Center.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -24,43 +24,24 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
-from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
-from m5.objects.BaseMinorCPU import BaseMinorCPU
-from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
-from m5.objects.BaseO3CPU import BaseO3CPU
-from m5.objects.BaseTimingSimpleCPU import BaseTimingSimpleCPU
-from m5.objects.RiscvDecoder import RiscvDecoder
-from m5.objects.RiscvInterrupts import RiscvInterrupts
-from m5.objects.RiscvISA import RiscvISA
-from m5.objects.RiscvMMU import RiscvMMU
+from m5.params import *
 
 
-class RiscvCPU:
-    ArchDecoder = RiscvDecoder
-    ArchMMU = RiscvMMU
-    ArchInterrupts = RiscvInterrupts
-    ArchISA = RiscvISA
+class BaseFastMemSimpleCPU(BaseAtomicSimpleCPU):
+    """FastMemSimpleCPU is based on the atomic CPU where the memory
+    system bypasses the caches and memory controllers resulting it in
+    faster simulations specifically for checkpointing.
 
+    """
 
-class RiscvAtomicSimpleCPU(BaseAtomicSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
+    type = "BaseFastMemSimpleCPU"
+    cxx_header = "cpu/simple/fastmem.hh"
+    cxx_class = "gem5::FastMemSimpleCPU"
 
+    @classmethod
+    def memory_mode(cls):
+        return "atomic_noncaching"
 
-class RiscvNonCachingSimpleCPU(BaseNonCachingSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvFastMemSimpleCPU(BaseFastMemSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvTimingSimpleCPU(BaseTimingSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvO3CPU(BaseO3CPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvMinorCPU(BaseMinorCPU, RiscvCPU):
-    mmu = RiscvMMU()
+    @classmethod
+    def support_take_over(cls):
+        return True

--- a/src/cpu/simple/FastMemSimpleCPU.py
+++ b/src/cpu/simple/FastMemSimpleCPU.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google, Inc.
+# Copyright 2024 Barcelona Supercomputing Center.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,44 +23,36 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects.BaseAtomicSimpleCPU import BaseAtomicSimpleCPU
-from m5.objects.BaseFastMemSimpleCPU import BaseFastMemSimpleCPU
-from m5.objects.BaseMinorCPU import BaseMinorCPU
-from m5.objects.BaseNonCachingSimpleCPU import BaseNonCachingSimpleCPU
-from m5.objects.BaseO3CPU import BaseO3CPU
-from m5.objects.BaseTimingSimpleCPU import BaseTimingSimpleCPU
-from m5.objects.RiscvDecoder import RiscvDecoder
-from m5.objects.RiscvInterrupts import RiscvInterrupts
-from m5.objects.RiscvISA import RiscvISA
-from m5.objects.RiscvMMU import RiscvMMU
+import m5.defines
 
+arch_vars = [
+    "USE_ARM_ISA",
+    "USE_MIPS_ISA",
+    "USE_POWER_ISA",
+    "USE_RISCV_ISA",
+    "USE_SPARC_ISA",
+    "USE_X86_ISA",
+]
 
-class RiscvCPU:
-    ArchDecoder = RiscvDecoder
-    ArchMMU = RiscvMMU
-    ArchInterrupts = RiscvInterrupts
-    ArchISA = RiscvISA
+enabled = list(filter(lambda var: m5.defines.buildEnv[var], arch_vars))
 
-
-class RiscvAtomicSimpleCPU(BaseAtomicSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvNonCachingSimpleCPU(BaseNonCachingSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvFastMemSimpleCPU(BaseFastMemSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvTimingSimpleCPU(BaseTimingSimpleCPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvO3CPU(BaseO3CPU, RiscvCPU):
-    mmu = RiscvMMU()
-
-
-class RiscvMinorCPU(BaseMinorCPU, RiscvCPU):
-    mmu = RiscvMMU()
+if len(enabled) == 1:
+    arch = enabled[0]
+    if arch == "USE_ARM_ISA":
+        from m5.objects.ArmCPU import ArmFastMemSimpleCPU as FastMemSimpleCPU
+    elif arch == "USE_MIPS_ISA":
+        from m5.objects.MipsCPU import MipsFastMemSimpleCPU as FastMemSimpleCPU
+    elif arch == "USE_POWER_ISA":
+        from m5.objects.PowerCPU import (
+            PowerFastMemSimpleCPU as FastMemSimpleCPU,
+        )
+    elif arch == "USE_RISCV_ISA":
+        from m5.objects.RiscvCPU import (
+            RiscvFastMemSimpleCPU as FastMemSimpleCPU,
+        )
+    elif arch == "USE_SPARC_ISA":
+        from m5.objects.SparcCPU import (
+            SparcFastMemSimpleCPU as FastMemSimpleCPU,
+        )
+    elif arch == "USE_X86_ISA":
+        from m5.objects.X86CPU import X86FastMemSimpleCPU as FastMemSimpleCPU

--- a/src/cpu/simple/SConscript
+++ b/src/cpu/simple/SConscript
@@ -39,6 +39,9 @@ if env['CONF']['BUILD_ISA']:
             sim_objects=['BaseNonCachingSimpleCPU'])
     Source('noncaching.cc')
 
+    SimObject('BaseFastMemSimpleCPU.py', sim_objects=['BaseFastMemSimpleCPU'])
+    Source('fastmem.cc')
+
     SimObject('BaseTimingSimpleCPU.py', sim_objects=['BaseTimingSimpleCPU'])
     Source('timing.cc')
 
@@ -51,3 +54,4 @@ if env['CONF']['BUILD_ISA']:
     SimObject('AtomicSimpleCPU.py', sim_objects=[])
     SimObject('NonCachingSimpleCPU.py', sim_objects=[])
     SimObject('TimingSimpleCPU.py', sim_objects=[])
+    SimObject('FastMemSimpleCPU.py', sim_objects=[])

--- a/src/cpu/simple/fastmem.cc
+++ b/src/cpu/simple/fastmem.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Barcelona Supercomputing Center.
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/simple/fastmem.hh"
+
+namespace gem5
+{
+
+FastMemSimpleCPU::FastMemSimpleCPU(
+      const BaseFastMemSimpleCPUParams &p)
+    : AtomicSimpleCPU(p)
+{
+    fatal_if(!FullSystem && p.workload.size() != 1,
+             "only one workload allowed");
+}
+
+void
+FastMemSimpleCPU::verifyMemoryMode() const
+{
+    if (!(system->isAtomicMode() && system->bypassCaches())) {
+        fatal("The direct CPU requires the memory system to be in the "
+              "'atomic_noncaching' mode.\n");
+    }
+}
+
+
+Tick
+FastMemSimpleCPU::sendPacket(RequestPort &port, const PacketPtr &pkt)
+{
+    if (system->isMemAddr(pkt->getAddr())) {
+        system->getPhysMem().access(pkt);
+        return 0;
+    } else {
+        return port.sendAtomic(pkt);
+    }
+}
+
+} // namespace gem5

--- a/src/cpu/simple/fastmem.hh
+++ b/src/cpu/simple/fastmem.hh
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Barcelona Supercomputing Center
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_SIMPLE_FASTMEM_HH__
+#define __CPU_SIMPLE_FASTMEM_HH__
+
+#include "cpu/simple/atomic.hh"
+#include "params/BaseFastMemSimpleCPU.hh"
+
+namespace gem5
+{
+
+class FastMemSimpleCPU : public AtomicSimpleCPU
+{
+  public:
+    FastMemSimpleCPU(const BaseFastMemSimpleCPUParams &params);
+
+  protected:
+    Tick sendPacket(RequestPort &port, const PacketPtr &pkt) override;
+    void verifyMemoryMode() const override;
+
+};
+
+} // namespace gem5
+
+#endif // __CPU_SIMPLE_FASTMEM_HH__


### PR DESCRIPTION
FastMemSimpleCPU doesnt use caches for memory access but instead accesses the memory directly.
This speeds up checkpointing considerably where accuracy of the simulation is not required.

In this PR, i have added the cpu model for all of the architectures.

@aarmejach 

Change-Id: Ia21757dad5a13b741b46d541f074fb6569098809