### PR TITLE
arch-riscv: Implement resumable non-maskable interrupt(Smrnmi)

### DIFF
--- a/src/arch/riscv/RiscvISA.py
+++ b/src/arch/riscv/RiscvISA.py
@@ -121,6 +121,9 @@ class RiscvISA(BaseISA):
         "c.fsdsp is overlap with them."
         "Refs: https://github.com/riscv/riscv-isa-manual/blob/main/src/zc.adoc",
     )
+    enable_Smrnmi = Param.Bool(
+        False, "Resumable non-maskable interrupt in FS mode"
+    )
 
     wfi_resume_on_pending = Param.Bool(
         False,

--- a/src/arch/riscv/RiscvInterrupts.py
+++ b/src/arch/riscv/RiscvInterrupts.py
@@ -31,7 +31,10 @@
 from m5.citations import add_citation
 from m5.objects.BaseInterrupts import BaseInterrupts
 from m5.objects.IntPin import VectorIntSinkPin
-from m5.params import VectorParam
+from m5.params import (
+    Param,
+    VectorParam,
+)
 
 
 class RiscvInterrupts(BaseInterrupts):
@@ -43,6 +46,7 @@ class RiscvInterrupts(BaseInterrupts):
     local_interrupt_ids = VectorParam.Unsigned(
         [], "list of local interrupt ids"
     )
+    nmi_cause = Param.Int(0, "Non-maskable interrupt(NMI) cause")
 
 
 add_citation(

--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -69,12 +69,15 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         PrivilegeMode prv = PRV_M;
         MISA misa = tc->readMiscRegNoEffect(MISCREG_ISA);
         STATUS status = tc->readMiscReg(MISCREG_STATUS);
+        NSTATUS nstatus = tc->readMiscReg(MISCREG_MNSTATUS);
+        auto* isa = static_cast<RiscvISA::ISA*>(tc->getIsaPtr());
+        bool is_rnmi = isResumableNonMaskableInterrupt(isa);
 
         // According to riscv-privileged-v1.11, if a NMI occurs at the middle
         // of a M-mode trap handler, the state (epc/cause) will be overwritten
-        // and is not necessary recoverable. There's nothing we can do here so
-        // we'll just warn our user that the CPU state might be broken.
-        warn_if(isNonMaskableInterrupt() && pp == PRV_M && status.mie == 0,
+        // and is not necessary recoverable unless smrnmi enabled.
+        warn_if(!isa->enableSmrnmi() && isNonMaskableInterrupt() &&
+                pp == PRV_M && status.mie == 0,
                 "NMI overwriting M-mode trap handler state");
 
         // Set fault handler privilege mode
@@ -123,14 +126,18 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
             status.sie = 0;
             break;
           case PRV_M:
-            cause = MISCREG_MCAUSE;
-            epc = MISCREG_MEPC;
+            cause = is_rnmi ? MISCREG_MNCAUSE : MISCREG_MCAUSE;
+            epc = is_rnmi ? MISCREG_MNEPC : MISCREG_MEPC;
             tvec = isNonMaskableInterrupt() ? MISCREG_NMIVEC : MISCREG_MTVEC;
             tval = MISCREG_MTVAL;
 
-            status.mpp = pp;
-            status.mpie = status.mie;
-            status.mie = 0;
+            if (is_rnmi) {
+                nstatus.mnpp = pp;
+            } else {
+                status.mpp = pp;
+                status.mpie = status.mie;
+                status.mie = 0;
+            }
             break;
           default:
             panic("Unknown privilege mode %d.", prv);
@@ -146,7 +153,11 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         tc->setMiscReg(epc, tc->pcState().instAddr());
         tc->setMiscReg(tval, trap_value());
         tc->setMiscReg(MISCREG_PRV, prv);
-        tc->setMiscReg(MISCREG_STATUS, status);
+        if (is_rnmi) {
+            tc->setMiscReg(MISCREG_MNSTATUS, nstatus);
+        } else {
+            tc->setMiscReg(MISCREG_STATUS, status);
+        }
         // Temporarily mask NMI while we're in NMI handler. Otherweise, the
         // checkNonMaskableInterrupt will always return true and we'll be
         // stucked in an infinite loop.
@@ -155,7 +166,6 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         }
 
         // Clear load reservation address
-        auto isa = static_cast<RiscvISA::ISA*>(tc->getIsaPtr());
         isa->clearLoadReservation(tc->contextId());
 
         // Set PC to fault handler address

--- a/src/arch/riscv/faults.hh
+++ b/src/arch/riscv/faults.hh
@@ -173,6 +173,10 @@ class RiscvFault : public FaultBase
     {
         return _fault_type == FaultType::NON_MASKABLE_INTERRUPT;
     }
+    bool isResumableNonMaskableInterrupt(ISA* isa) const
+    {
+        return isa->enableSmrnmi() && isNonMaskableInterrupt();
+    }
     ExceptionCode exception() const { return _code; }
     virtual RegVal trap_value() const { return 0; }
 
@@ -206,10 +210,14 @@ class NonMaskableInterruptFault : public RiscvFault
 {
   public:
     NonMaskableInterruptFault()
+        : NonMaskableInterruptFault(0) {}
+    NonMaskableInterruptFault(ExceptionCode c)
         : RiscvFault("non_maskable_interrupt",
                      FaultType::NON_MASKABLE_INTERRUPT,
-                     static_cast<ExceptionCode>(0))
+                     c)
     {}
+    NonMaskableInterruptFault(int c)
+        : NonMaskableInterruptFault(static_cast<ExceptionCode>(c)) {}
 };
 
 class InstFault : public RiscvFault

--- a/src/arch/riscv/interrupts.cc
+++ b/src/arch/riscv/interrupts.cc
@@ -38,7 +38,8 @@ namespace RiscvISA
 
 Interrupts::Interrupts(const Params &p) : BaseInterrupts(p),
                                           ip(0),
-                                          ie(0)
+                                          ie(0),
+                                          nmi_cause(p.nmi_cause)
 {
     for (uint8_t i = 0;
         i < p.port_local_interrupt_pins_connection_count;
@@ -131,7 +132,7 @@ Interrupts::getInterrupt()
 {
     assert(checkInterrupts());
     if (checkNonMaskableInterrupt())
-        return std::make_shared<NonMaskableInterruptFault>();
+        return std::make_shared<NonMaskableInterruptFault>(nmi_cause);
     std::bitset<NumInterruptTypes> mask = globalMask();
     if (((ISA*) tc->getIsaPtr())->rvType() == RV64) {
         const std::vector<int> interrupt_order {

--- a/src/arch/riscv/interrupts.hh
+++ b/src/arch/riscv/interrupts.hh
@@ -61,6 +61,7 @@ class Interrupts : public BaseInterrupts
   private:
     std::bitset<NumInterruptTypes> ip;
     std::bitset<NumInterruptTypes> ie;
+    int nmi_cause;
 
     std::vector<gem5::IntSinkPin<Interrupts>*> localInterruptPins;
   public:
@@ -79,6 +80,10 @@ class Interrupts : public BaseInterrupts
     bool checkInterrupt(int num) const { return ip[num] && ie[num]; }
     bool checkInterrupts() const override
     {
+        ISA* isa = static_cast<ISA*>(tc->getIsaPtr());
+        if (isa->enableSmrnmi() && tc->readMiscReg(MISCREG_NMIE) == 0) {
+            return false;
+        }
         return checkNonMaskableInterrupt() || (ip & ie & globalMask()).any();
     }
 

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -116,6 +116,12 @@ class ISA : public BaseISA
      */
     bool _enableZcd;
 
+    /**
+     * Resumable non-maskable interrupt
+     * Set true to make NMI recoverable
+     */
+    bool _enableSmrnmi;
+
   public:
     using Params = RiscvISAParams;
 
@@ -190,6 +196,8 @@ class ISA : public BaseISA
     bool resumeOnPending() { return _wfiResumeOnPending; }
 
     bool enableZcd() { return _enableZcd; }
+
+    bool enableSmrnmi() { return _enableSmrnmi; }
 
     virtual Addr getFaultHandlerAddr(
         RegIndex idx, uint64_t cause, bool intr) const;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5033,6 +5033,8 @@ decode QUADRANT default Unknown::unknown() {
                         xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
                     }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
                     0x18: mret({{
+                        auto isa = dynamic_cast<RiscvISA::ISA*>(
+                            xc->tcBase()->getIsaPtr());
                         if (xc->readMiscReg(MISCREG_PRV) != PRV_M) {
                             return std::make_shared<IllegalInstFault>(
                                         "mret at lower privilege", machInst);
@@ -5040,12 +5042,42 @@ decode QUADRANT default Unknown::unknown() {
                         } else {
                             STATUS status = xc->readMiscReg(MISCREG_STATUS);
                             xc->setMiscReg(MISCREG_PRV, status.mpp);
-                            xc->setMiscReg(MISCREG_NMIE, 1);
+                            // Always enable NMIE if smrnmi is not enabled
+                            if (!isa->enableSmrnmi()) {
+                                xc->setMiscReg(MISCREG_NMIE, 1);
+                            }
                             status.mie = status.mpie;
                             status.mpie = 1;
                             status.mpp = PRV_U;
                             xc->setMiscReg(MISCREG_STATUS, status);
                             NPC = rvSext(xc->readMiscReg(MISCREG_MEPC));
+                        }
+                    }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
+                    0x38: mnret({{
+                        auto isa = dynamic_cast<RiscvISA::ISA*>(
+                            xc->tcBase()->getIsaPtr());
+                        if (!isa->enableSmrnmi()) {
+                            return std::make_shared<IllegalInstFault>(
+                                        "mnret requires smrnmi enabled.",
+                                        machInst);
+                        }
+                        if (xc->readMiscReg(MISCREG_PRV) != PRV_M) {
+                            return std::make_shared<IllegalInstFault>(
+                                        "mnret at lower privilege", machInst);
+                            NPC = NPC;
+                        } else {
+                            NSTATUS nstatus = xc->readMiscReg(
+                                MISCREG_MNSTATUS);
+                            STATUS status = xc->readMiscReg(MISCREG_STATUS);
+                            xc->setMiscReg(MISCREG_PRV, nstatus.mnpp);
+                            if (nstatus.mnpp != PRV_M) {
+                                status.mprv = 0;
+                            }
+                            nstatus.nmie = 1;
+                            nstatus.mnpp = PRV_U;
+                            xc->setMiscReg(MISCREG_MNSTATUS, nstatus);
+                            xc->setMiscReg(MISCREG_STATUS, status);
+                            NPC = rvSext(xc->readMiscReg(MISCREG_MNEPC));
                         }
                     }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
                 }

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -356,6 +356,13 @@ def template CSRExecute {{
                     machInst);
         }
 
+        if (csr_data_it->second.requireSmrnmi && !isa->enableSmrnmi()) {
+            return std::make_shared<IllegalInstFault>(
+                    csprintf("%s requires Smrnmi enabled\n",
+                             csrName),
+                    machInst);
+        }
+
         %(op_decl)s;
         %(op_rd)s;
 

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -211,6 +211,12 @@ enum MiscRegIndex
     // non-maskable-interrupt-pending: NMI version of xIP
     MISCREG_NMIP,
 
+    // Resumable Non-Maskable Interrupts
+    MISCREG_MNSCRATCH,
+    MISCREG_MNEPC,
+    MISCREG_MNCAUSE,
+    MISCREG_MNSTATUS,
+
     // the following MicsRegIndex are RV32 only
     MISCREG_MSTATUSH,
 
@@ -510,7 +516,12 @@ enum CSRIndex
     CSR_VCSR         = 0x00F,
     CSR_VL           = 0xC20,
     CSR_VTYPE        = 0xC21,
-    CSR_VLENB        = 0xC22
+    CSR_VLENB        = 0xC22,
+
+    CSR_MNSCRATCH    = 0x740,
+    CSR_MNEPC        = 0x741,
+    CSR_MNCAUSE      = 0x742,
+    CSR_MNSTATUS     = 0x744,
 };
 
 struct CSRMetadata
@@ -519,6 +530,7 @@ struct CSRMetadata
     const int physIndex;
     const uint64_t rvTypes;
     const uint64_t isaExts;
+    const bool requireSmrnmi = false;
 };
 
 template <typename... T>
@@ -1181,7 +1193,20 @@ const std::unordered_map<int, CSRMetadata> CSRData = {
     {CSR_VTYPE,
         {"vtype", MISCREG_VTYPE, rvTypeFlags(RV64, RV32), isaExtsFlags('v')}},
     {CSR_VLENB,
-        {"VLENB", MISCREG_VLENB, rvTypeFlags(RV64, RV32), isaExtsFlags('v')}}
+        {"VLENB", MISCREG_VLENB, rvTypeFlags(RV64, RV32), isaExtsFlags('v')}},
+
+    {CSR_MNSCRATCH,
+        {"mnscratch", MISCREG_MNSCRATCH, rvTypeFlags(RV64, RV32),
+         isaExtsFlags(), true}},
+    {CSR_MNEPC,
+        {"mnepc", MISCREG_MNEPC, rvTypeFlags(RV64, RV32), isaExtsFlags(),
+         true}},
+    {CSR_MNCAUSE,
+        {"mncause", MISCREG_MNCAUSE, rvTypeFlags(RV64, RV32), isaExtsFlags(),
+         true}},
+    {CSR_MNSTATUS,
+        {"mnstatus", MISCREG_MNSTATUS, rvTypeFlags(RV64, RV32),
+         isaExtsFlags(), true}}
 };
 
 /**
@@ -1214,6 +1239,17 @@ BitUnion64(STATUS)
     Bitfield<1> sie;
     Bitfield<0> uie;
 EndBitUnion(STATUS)
+
+/**
+ * These fields are specified in the RISC-V Instruction Set Manual.
+ * Resumable Non-Maskable Interrupts. The main register that
+ * uses these fields is the MNSTATUS register
+ */
+BitUnion64(NSTATUS)
+    Bitfield<12, 11> mnpp;
+    Bitfield<7> mnv;
+    Bitfield<3> nmie;
+EndBitUnion(NSTATUS)
 
 /**
  * These fields are specified in the RISC-V Instruction Set Manual, Volume II,

--- a/util/cpt_upgraders/riscv-smrnmi.py
+++ b/util/cpt_upgraders/riscv-smrnmi.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2024 Arm Limited
+# All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2023 Barcelona Supercomputing Center (BSC)
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+def upgrader(cpt):
+    """
+    Add Smrnmi misc registers in the checkpoint
+    """
+
+    import re
+
+    for sec in cpt.sections():
+        # Search for all ISA sections
+        if (
+            re.search(r".*processor.*\.core.*\.isa$", sec)
+            and cpt.get(sec, "isaName") == "riscv"
+        ):
+            # Updating Snmrnm misc registers (dummy values)
+            mr = cpt.get(sec, "miscRegFile").split()
+            if len(mr) == 168:
+                print(
+                    "MISCREG_* Smrnmi registers already seem "
+                    "to be inserted."
+                )
+            else:
+                # Add dummy value for MISCREG_MNSCRATCH
+                mr.insert(131, 0)
+                # Add dummy value for MISCREG_MNEPC
+                mr.insert(131, 0)
+                # Add dummy value for MISCREG_MNCAUSE
+                mr.insert(131, 0)
+                # Add dummy value for MISCREG_MNSTATUS
+                mr.insert(131, 0)
+                cpt.set(sec, "miscRegFile", " ".join(str(x) for x in mr))
+
+
+legacy_version = 18


### PR DESCRIPTION
In previous CL(https://gem5-review.googlesource.com/c/public/gem5/+/52363) allows the gem5 platform handle RISC-V NMI interrupt. The change makes the NMI resumable following the spec.

Changes in the PR:
1. Support customized nmi_cause idi
2. The default of MISCREG_NMIE is 0 if smrnmi is enabled
3. All interrupts will be disable if Smrnmi extension is enabled and MISCREG_NMIE is 0
4. mret won't set MISCREG_NMIE to 1 if smrnmi is enabled
5. Keep using MISCREG_NMIVEC for NMI trap handler
6. Add mnscratch, mnepc, mncause and mnstatus
7. Add new instruction mnret

Spec: https://github.com/riscv/riscv-isa-manual/blob/main/src/rnmi.adoc

Change-Id: I0cd03ffbcc83131e9d0527eda4a52d39dcd0dbae