### PR TITLE
tests,util: Extend SE mode m5-exit tests

### DIFF
--- a/tests/gem5/m5_util/README.md
+++ b/tests/gem5/m5_util/README.md
@@ -1,8 +1,9 @@
 # m5 Util
 
-These test the util m5 exit assembly instruction.
-To run these tests by themselves, you can run the following command in the tests directory:
+These test the util m5 exit magic instruction across different ISAs.
 
-```bash
-./main.py run gem5/m5_util --length=[length]
+To run these tests you can run the following command in the "tests" directory:
+
+```sh
+./main.py run gem5/m5_util -j`nproc`
 ```

--- a/tests/gem5/m5_util/configs/se-m5-exit.py
+++ b/tests/gem5/m5_util/configs/se-m5-exit.py
@@ -39,7 +39,7 @@ Usage
 `<isas>` can be one of `x86`, `arm`, or `riscv`.
 
 
-The `--resource-directory` argument is optional, and can be passed with a 
+The `--resource-directory` argument is optional, and can be passed with a
 <path> in order to specify where the downloaded resources should be cached.
 If not set, the downloaded resources are cached to the default location for
 gem5 binaries (typically "~/.cache/gem5/resources").

--- a/tests/gem5/m5_util/configs/se-m5-exit.py
+++ b/tests/gem5/m5_util/configs/se-m5-exit.py
@@ -39,10 +39,10 @@ Usage
 `<isas>` can be one of `x86`, `arm`, or `riscv`.
 
 
-The `--resource-directory` argument can be passed and along with path to the a
-directory the downloaded resources are to cached. If not set the downloaded
-resources are cached by the gem5 binary's default cache location defaults
-(typically "~/.cache/gem5/resources").
+The `--resource-directory` argument is optional, and can be passed with a 
+<path> in order to specify where the downloaded resources should be cached.
+If not set, the downloaded resources are cached to the default location for
+gem5 binaries (typically "~/.cache/gem5/resources").
 """
 
 import argparse

--- a/tests/gem5/m5_util/configs/se-m5-exit.py
+++ b/tests/gem5/m5_util/configs/se-m5-exit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Regents of the University of California
+# Copyright (c) 2021-2026 The Regents of the University of California
 # Copyright (c) 2022 Google Inc
 # All rights reserved.
 #
@@ -26,61 +26,99 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
-A run script for a very simple Syscall-Execution running simple binaries.
-The system has no cache heirarchy and is as "bare-bones" as you can get in
-gem5 while still being functinal.
+A script used to test the m5_exit magic instruction events function correctly
+for a given ISA.
+
+Usage
+-----
+
+```sh
+<gem5> test/gem5/m5_util/configs/se-m5-exit.py <isa>
+```
+
+`<isas>` can be one of `x86`, `arm`, or `riscv`.
+
+`<path-to-resources>` is the path to the directory where the resources are
+stored.
+
+The `--resource-directory` argument can be passed and along with path to the a
+directory the downloaded resources are to cached. If not set the downloaded
+resources are cached by the gem5 binary's default cache location defaults
+(typically "~/.cache/gem5/resources").
 """
 
 import argparse
-import importlib
 
-from m5.util import fatal
-
-from gem5.components.boards.mem_mode import MemMode
 from gem5.components.boards.simple_board import SimpleBoard
 from gem5.components.cachehierarchies.classic.no_cache import NoCache
 from gem5.components.memory import SingleChannelDDR3_1600
-from gem5.components.processors.base_cpu_core import BaseCPUCore
-from gem5.components.processors.base_cpu_processor import BaseCPUProcessor
-from gem5.components.processors.cpu_types import (
-    CPUTypes,
-    get_cpu_type_from_str,
-    get_cpu_types_str_set,
-)
-from gem5.components.processors.simple_core import SimpleCore
+from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.isas import (
     ISA,
     get_isa_from_str,
-    get_isas_str_set,
 )
-from gem5.resources.resource import Resource
+from gem5.resources.resource import (
+    BinaryResource,
+    obtain_resource,
+)
 from gem5.simulate.simulator import Simulator
 
+isa_resource_id_map = {
+    ISA.X86: "x86-m5-exit",
+    ISA.ARM: "arm-m5-exit",
+    ISA.RISCV: "riscv-m5-exit",
+}
+
+resource_id_version_map = {
+    "x86-m5-exit": "2.0.0",
+    "arm-m5-exit": "1.0.0",
+    "riscv-m5-exit": "1.0.0",
+}
+
+assert (
+    len(
+        {isa for isa in isa_resource_id_map.values()}
+        - {isa for isa in resource_id_version_map.keys()}
+    )
+    == 0
+), (
+    "The following resource IDs  are needed by a supported ISA but have no "
+    "version specified in `resource_id_version_map`:\n"
+    f"{isa_resource_id_map.values() - resource_id_version_map.keys()}"
+)
+
 parser = argparse.ArgumentParser(
-    description="A gem5 script for running simple binaries in SE mode."
+    description=(
+        "A gem5 script for checking the m5_exit magic instructions, functions "
+        "correctly in SE mode for a given ISA"
+    )
 )
 
 parser.add_argument(
-    "resource", type=str, help="The gem5 resource binary to run."
+    "isa",
+    type=str,
+    choices={isa.value for isa in isa_resource_id_map.keys()},
+    help="The ISA to run m5_exit on.",
 )
 
 parser.add_argument(
     "--resource-directory",
     type=str,
     required=False,
-    help="The directory in which resources will be downloaded or exist.",
+    help="The directory where downloaded resources are to be cached.",
 )
 
 args = parser.parse_args()
 
-# Setup the system.
+isa = get_isa_from_str(args.isa)
+
+
 cache_hierarchy = NoCache()
 memory = SingleChannelDDR3_1600()
-
 processor = SimpleProcessor(
     cpu_type=CPUTypes.ATOMIC,
-    isa=ISA.X86,
+    isa=isa,
     num_cores=1,
 )
 
@@ -91,16 +129,19 @@ motherboard = SimpleBoard(
     cache_hierarchy=cache_hierarchy,
 )
 
-# Set the workload
-binary = Resource(args.resource, resource_directory=args.resource_directory)
+binary = obtain_resource(
+    resource_id=isa_resource_id_map[isa],
+    resource_version=resource_id_version_map[isa_resource_id_map[isa]],
+    resource_directory=args.resource_directory,
+)
+
+assert isinstance(
+    binary, BinaryResource
+), "binary is not of type BinaryResource."
+
 motherboard.set_se_binary_workload(binary)
 
-# Run the simulation
 simulator = Simulator(board=motherboard)
 simulator.run()
 
-print(
-    "Exiting @ tick {} because {}.".format(
-        simulator.get_current_tick(), simulator.get_last_exit_event_cause()
-    )
-)
+print(f"Exit cause: '{simulator.get_last_exit_event_cause()}'.")

--- a/tests/gem5/m5_util/configs/se-m5-exit.py
+++ b/tests/gem5/m5_util/configs/se-m5-exit.py
@@ -38,8 +38,6 @@ Usage
 
 `<isas>` can be one of `x86`, `arm`, or `riscv`.
 
-`<path-to-resources>` is the path to the directory where the resources are
-stored.
 
 The `--resource-directory` argument can be passed and along with path to the a
 directory the downloaded resources are to cached. If not set the downloaded

--- a/tests/gem5/m5_util/configs/se-m5-exit.py
+++ b/tests/gem5/m5_util/configs/se-m5-exit.py
@@ -33,7 +33,7 @@ Usage
 -----
 
 ```sh
-<gem5> test/gem5/m5_util/configs/se-m5-exit.py <isa>
+<gem5> test/gem5/m5_util/configs/se-m5-exit.py <isa> --resource-directory <path>
 ```
 
 `<isas>` can be one of `x86`, `arm`, or `riscv`.

--- a/tests/gem5/m5_util/test_exit.py
+++ b/tests/gem5/m5_util/test_exit.py
@@ -10,6 +10,7 @@
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
 #
+# Copyright (c) 2026 The Regents of the University of California
 # Copyright (c) 2017 Mark D. Hill and David A. Wood
 # All rights reserved.
 #
@@ -37,39 +38,47 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
-Test file for the util m5 exit assembly instruction.
+Tests the m5-exit magic instruction in SE mode for X86, RISCV and ARM.
 """
 
 import re
+from pathlib import Path
 
-from testlib import *
-
-m5_exit_regex = re.compile(
-    r"Exiting @ tick \d* because m5_exit instruction encountered"
+from testlib import (
+    config,
+    constants,
+    gem5_verify_config,
+    verifier,
 )
 
-if config.bin_path:
-    resource_path = config.bin_path
-else:
-    resource_path = joinpath(absdirpath(__file__), "..", "resources")
+m5_exit_regex = re.compile(r"Exit cause: 'm5_exit instruction encountered'")
 
-a = verifier.MatchRegex(m5_exit_regex)
-gem5_verify_config(
-    name="m5_exit_test",
-    verifiers=[a],
-    fixtures=(),
-    config=joinpath(
-        config.base_dir,
-        "tests",
-        "gem5",
-        "m5_util",
-        "configs",
-        "simple_binary_run.py",
-    ),
-    config_args=[
-        "x86-m5-exit",
-        "--resource-directory",
-        resource_path,
-    ],
-    valid_isas=(constants.all_compiled_tag,),
+resource_directory = (
+    config.bin_path
+    if config.bin_path
+    else str(Path(Path(__file__).parent, "resources"))
 )
+
+exit_cause_verifier = verifier.MatchRegex(
+    re.compile(r"Exit cause: 'm5_exit instruction encountered'")
+)
+
+for isa in ["x86", "arm", "riscv"]:
+    gem5_verify_config(
+        name=f"m5-inst-exit-{isa}-se-mode",
+        verifiers=(exit_cause_verifier,),
+        fixtures=tuple(),
+        config=str(
+            Path(
+                Path(__file__).parent,
+                "configs",
+                "se-m5-exit.py",
+            )
+        ),
+        config_args=[
+            isa,
+            f"--resource-directory='{resource_directory}'",
+        ],
+        valid_isas=(constants.all_compiled_tag,),
+        length=constants.quick_tag,
+    )

--- a/tests/gem5/m5_util/test_exit.py
+++ b/tests/gem5/m5_util/test_exit.py
@@ -77,7 +77,7 @@ for isa in ["x86", "arm", "riscv"]:
         ),
         config_args=[
             isa,
-            f"--resource-directory='{resource_directory}'",
+            f"--resource-directory={resource_directory}",
         ],
         valid_isas=(constants.all_compiled_tag,),
         length=constants.quick_tag,


### PR DESCRIPTION
These tests expand the m5-exit tests to target other ISAs using magic instructions and address approaches.

The motivating factor in creating these tests was to verify https://github.com/gem5/gem5/pull/1583