### PR TITLE
arch-riscv: Fix misprediction of control flow instruction caused by vset{i}vl{i}

### DIFF
--- a/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
@@ -91,7 +91,7 @@ board.set_se_binary_workload(
     # the workload should be the same as the save-checkpoint script
     obtain_resource("riscv-hello"),
     checkpoint=obtain_resource(
-        "riscv-hello-example-checkpoint", resource_version="4.0.0"
+        "riscv-hello-example-checkpoint", resource_version="5.0.0"
     ),
 )
 

--- a/src/arch/riscv/decoder.hh
+++ b/src/arch/riscv/decoder.hh
@@ -65,6 +65,10 @@ class Decoder : public InstDecoder
     bool _enableZcd;
     Addr jvtEntry;
 
+    VTYPE vtype = (1ULL << 63); // vtype.vill = 1 at initial;
+    uint32_t vl = 0;
+    bool squashed = false;
+
     virtual StaticInstPtr decodeInst(ExtMachInst mach_inst);
 
     /// Decode a machine instruction.

--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -563,6 +563,7 @@ VlFFTrimVlMicroOp::execute(ExecContext *xc, trace::InstRecord *traceData) const
     }
 
     pc.vl(new_vl);
+    pc.new_vconf(true);
     xc->pcState(pc);
 
     return NoFault;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4839,6 +4839,7 @@ decode QUADRANT default Unknown::unknown() {
                         Rd_ud = new_vl;
                         VL = new_vl;
                         Vtype = new_vtype;
+                        IsVset = true;
                     }}, VSetVlDeclare, VSetVliBranchTarget
                       , SimdConfigOp, IsUncondControl
                       , IsIndirectControl);
@@ -4854,6 +4855,7 @@ decode QUADRANT default Unknown::unknown() {
                             Rd_ud = new_vl;
                             VL = new_vl;
                             Vtype = new_vtype;
+                            IsVset = true;
                         }}, VSetVlDeclare, VSetVlBranchTarget
                           , SimdConfigOp, IsUncondControl
                           , IsIndirectControl);
@@ -4868,6 +4870,7 @@ decode QUADRANT default Unknown::unknown() {
                             Rd_ud = new_vl;
                             VL = new_vl;
                             Vtype = new_vtype;
+                            IsVset = true;
                         }}, VSetiVliDeclare, VSetiVliBranchTarget
                           , SimdConfigOp, IsUncondControl
                           , IsDirectControl);

--- a/src/arch/riscv/isa/formats/vector_conf.isa
+++ b/src/arch/riscv/isa/formats/vector_conf.isa
@@ -39,12 +39,16 @@ def format VConfOp(code, write_code, declare_class, branch_class, *flags) {{
         flags
     )
     declareTemplate = eval(declare_class)
-    branchTargetTemplate = eval(branch_class)
 
     header_output = declareTemplate.subst(iop)
     decoder_output = VConfConstructor.subst(iop)
     decode_block = VConfDecodeBlock.subst(iop)
-    exec_output = VConfExecute.subst(iop) + branchTargetTemplate.subst(iop)
+
+    if "vsetivli" in name:
+        branchTargetTemplate = eval(branch_class)
+        exec_output = VConfExecute.subst(iop) + branchTargetTemplate.subst(iop)
+    else:
+        exec_output = VConfExecute.subst(iop)
 }};
 
 def template VSetVlDeclare {{
@@ -63,10 +67,7 @@ def template VSetVlDeclare {{
         /// Constructor.
         %(class_name)s(ExtMachInst machInst, uint32_t elen, uint32_t vlen);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
-        std::unique_ptr<PCStateBase> branchTarget(
-                ThreadContext *tc) const override;
 
-        using StaticInst::branchTarget;
         using %(base_class)s::generateDisassembly;
 
     };
@@ -203,54 +204,9 @@ def template VSetiVliBranchTarget {{
 
         std::unique_ptr<PCState> npc(dynamic_cast<PCState*>(rpc.clone()));
         npc->set(rvSext(npc->pc() + 4));
+        npc->new_vconf(true);
         npc->vtype(new_vtype);
         npc->vl(new_vl);
         return npc;
-    }
-}};
-
-def template VSetVliBranchTarget {{
-    std::unique_ptr<PCStateBase>
-    %(class_name)s::branchTarget(ThreadContext *tc) const
-    {
-        PCStateBase *pc_ptr = tc->pcState().clone();
-
-        uint64_t rd_bits = machInst.rd;
-        uint64_t rs1_bits = machInst.rs1;
-        uint64_t requested_vl = tc->getReg(srcRegIdx(0));
-        uint64_t requested_vtype = zimm11;
-
-        VTYPE new_vtype = getNewVtype(
-            pc_ptr->as<PCState>().vtype(), requested_vtype);
-        uint32_t vlmax = new_vtype.vill ? 0 : getVlmax(new_vtype, vlen);
-        uint32_t new_vl = getNewVL(
-            pc_ptr->as<PCState>().vl(), requested_vl, vlmax, rd_bits, rs1_bits);
-
-        pc_ptr->as<PCState>().vtype(new_vtype);
-        pc_ptr->as<PCState>().vl(new_vl);
-        return std::unique_ptr<PCStateBase>{pc_ptr};
-    }
-}};
-
-def template VSetVlBranchTarget {{
-    std::unique_ptr<PCStateBase>
-    %(class_name)s::branchTarget(ThreadContext *tc) const
-    {
-        PCStateBase *pc_ptr = tc->pcState().clone();
-
-        uint64_t rd_bits = machInst.rd;
-        uint64_t rs1_bits = machInst.rs1;
-        uint64_t requested_vl = tc->getReg(srcRegIdx(0));
-        uint64_t requested_vtype = tc->getReg(srcRegIdx(1));
-
-        VTYPE new_vtype = getNewVtype(
-            pc_ptr->as<PCState>().vtype(), requested_vtype);
-        uint32_t vlmax = new_vtype.vill ? 0 : getVlmax(new_vtype, vlen);
-        uint32_t new_vl = getNewVL(
-            pc_ptr->as<PCState>().vl(), requested_vl, vlmax, rd_bits, rs1_bits);
-
-        pc_ptr->as<PCState>().vtype(new_vtype);
-        pc_ptr->as<PCState>().vl(new_vl);
-        return std::unique_ptr<PCStateBase>{pc_ptr};
     }
 }};

--- a/src/arch/riscv/isa/operands.isa
+++ b/src/arch/riscv/isa/operands.isa
@@ -115,4 +115,5 @@ def operands {{
     'ZcmtSecondFetch': PCStateOp(
         'bl', 'zcmtSecondFetch', (None, None, 'IsControl'), 13),
     'ZcmtPC': PCStateOp('ud', 'zcmtPc', (None, None, 'IsControl'), 13),
+    'IsVset': PCStateOp('ub', 'new_vconf', (None, None, 'IsControl'), 13),
 }};

--- a/src/arch/riscv/pcstate.hh
+++ b/src/arch/riscv/pcstate.hh
@@ -65,6 +65,7 @@ class PCState : public GenericISA::UPCState<4>
 
     bool _compressed = false;
     RiscvType _rvType = RV64;
+    bool _new_vconf = false;
     VTYPE _vtype = (1ULL << 63); // vtype.vill = 1 at initial;
     uint32_t _vl = 0;
     bool _zcmtSecondFetch = false;
@@ -73,8 +74,8 @@ class PCState : public GenericISA::UPCState<4>
   public:
     PCState(const PCState &other) : Base(other),
         _compressed(other._compressed),
-        _rvType(other._rvType), _vtype(other._vtype), _vl(other._vl),
-        _zcmtSecondFetch(other._zcmtSecondFetch), _zcmtPc(other._zcmtPc)
+        _rvType(other._rvType), _new_vconf(other._new_vconf), _vtype(other._vtype),
+        _vl(other._vl), _zcmtSecondFetch(other._zcmtSecondFetch), _zcmtPc(other._zcmtPc)
     {}
     PCState &operator=(const PCState &other) = default;
     PCState() = default;
@@ -94,6 +95,7 @@ class PCState : public GenericISA::UPCState<4>
         auto &pcstate = other.as<PCState>();
         _compressed = pcstate._compressed;
         _rvType = pcstate._rvType;
+        _new_vconf = pcstate._new_vconf;
         _vtype = pcstate._vtype;
         _vl = pcstate._vl;
         _zcmtSecondFetch = pcstate._zcmtSecondFetch;
@@ -105,6 +107,9 @@ class PCState : public GenericISA::UPCState<4>
 
     void rvType(RiscvType rvType) { _rvType = rvType; }
     RiscvType rvType() const { return _rvType; }
+
+    void new_vconf(bool v) { _new_vconf = v; }
+    bool new_vconf() const { return _new_vconf; }
 
     void vtype(VTYPE v) { _vtype = v; }
     VTYPE vtype() const { return _vtype; }
@@ -131,8 +136,8 @@ class PCState : public GenericISA::UPCState<4>
     {
         auto &opc = other.as<PCState>();
         return Base::equals(other) &&
-            _vtype == opc._vtype &&
-            _vl == opc._vl &&
+            (_new_vconf == opc._new_vconf) &&
+            (!_new_vconf || (_vtype == opc._vtype && _vl == opc._vl)) &&
             _zcmtSecondFetch == opc._zcmtSecondFetch &&
             _zcmtPc == opc._zcmtPc;
     }
@@ -142,6 +147,7 @@ class PCState : public GenericISA::UPCState<4>
     {
         Base::serialize(cp);
         SERIALIZE_SCALAR(_rvType);
+        SERIALIZE_SCALAR(_new_vconf);
         SERIALIZE_SCALAR(_vtype);
         SERIALIZE_SCALAR(_vl);
         SERIALIZE_SCALAR(_compressed);
@@ -154,6 +160,7 @@ class PCState : public GenericISA::UPCState<4>
     {
         Base::unserialize(cp);
         UNSERIALIZE_SCALAR(_rvType);
+        UNSERIALIZE_SCALAR(_new_vconf);
         UNSERIALIZE_SCALAR(_vtype);
         UNSERIALIZE_SCALAR(_vl);
         UNSERIALIZE_SCALAR(_compressed);

--- a/util/cpt_upgraders/riscv-pcstate.py
+++ b/util/cpt_upgraders/riscv-pcstate.py
@@ -61,3 +61,6 @@ def upgrader(cpt):
 
             if cpt.get(sec, "_compressed", fallback="") == "":
                 cpt.set(sec, "_compressed", "false")
+
+            if cpt.get(sec, "_new_vconf", fallback="") == "":
+                cpt.set(sec, "_new_vconf", "false")

--- a/util/cpt_upgraders/riscv-vconf.py
+++ b/util/cpt_upgraders/riscv-vconf.py
@@ -36,28 +36,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 def upgrader(cpt):
-    # Update the RISC-V pcstate to match the new version of
-    # PCState
+    # Update the RISC-V pcstate to add the new_vconf flag
 
     import re
 
     for sec in cpt.sections():
         res = re.search(r"(.*processor.*\.core.*)\.xc.*", sec)
         if res and cpt.get(res.groups()[0] + ".isa", "isaName") == "riscv":
-            # Only update for RISCV XCs
-            if cpt.get(sec, "_rvType", fallback="") == "":
-                cpt.set(sec, "_rvType", "1")
 
-            if cpt.get(sec, "_vlenb", fallback="") == "":
-                cpt.set(sec, "_vlenb", "32")
-
-            if cpt.get(sec, "_vtype", fallback="") == "":
-                cpt.set(sec, "_vtype", str(1 << 63))
-
-            if cpt.get(sec, "_vl", fallback="") == "":
-                cpt.set(sec, "_vl", "0")
-
-            if cpt.get(sec, "_compressed", fallback="") == "":
-                cpt.set(sec, "_compressed", "false")
+            if cpt.get(sec, "_new_vconf", fallback="") == "":
+                cpt.set(sec, "_new_vconf", "false")


### PR DESCRIPTION
This PR fixed the bug mentioned in #1708.

In the new implementation, the BPU only predicts vl&vtype for vset{i}vl{i} instructions. Other control flow instructions will not be predicted by the BPU for vl and vtype, because it is meaningless. The new implementation adds `new_conf` flag in pcstate and `vl/vtype` registers in decoder. This is used to filter the prediction of `vl&vtype` by other control flow instructions. When a flush occurs, the `vl/vtype` registers in the decoder are restored.

When checking pcstate at IEW stage, `vl&vtype` are only checked for instructions with new_vconf = 1. It means that vl and vtype are only checked for vset{i}vl{i} instructions.

Here is a simple picture describing the new changes：
![绘图1](https://github.com/user-attachments/assets/210e1d34-00d2-4111-a389-e1306d8f25e1)

The following picture is the new pipeline of the test case from #1708. No more flush after warmup.
![截屏2024-10-24 下午4 08 02](https://github.com/user-attachments/assets/9942b2ef-73f2-463b-a982-74950f0e726a)

Change-Id: I7d3df0328d5757f6b3506743200d5b154dee367f