### PR TITLE
arch-riscv: Add support for Zicbop extension

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1214,9 +1214,38 @@ decode QUADRANT default Unknown::unknown() {
                         }});
                     }
                 }
-                0x6: ori({{
-                    Rd = rvSext(Rs1 | imm);
-                }}, uint64_t);
+                0x6: decode RD {
+                    0x00: decode RS2 {
+                        0x0: Load::prefetch_i({{
+                                uint64_t temp = Mem_ub; temp = temp;
+                            }}, offset_code = {{
+                                offset = IMM7 << 5;
+                            }}, mem_flags = [PREFETCH],
+                            inst_flags = IsInstPrefetch
+                        );
+                        0x1: Load::prefetch_r({{
+                                uint64_t temp = Mem_ub; temp = temp;
+                            }}, offset_code = {{
+                                offset = IMM7 << 5;
+                            }}, mem_flags = [PREFETCH],
+                            inst_flags = IsDataPrefetch
+                        );
+                        0x3: Load::prefetch_w({{
+                                uint64_t temp = Mem_ub; temp = temp;
+                            }}, offset_code = {{
+                                offset = IMM7 << 5;
+                            }}, mem_flags = [PF_EXCLUSIVE],
+                            inst_flags = IsDataPrefetch
+                        );
+                        // Remaining ori instruction coding space
+                        default: ori_hint({{
+                            Rd = rvSext(Rs1 | imm);
+                        }}, uint64_t);
+                    }
+                    default: ori({{
+                        Rd = rvSext(Rs1 | imm);
+                    }}, uint64_t);
+                }
                 0x7: andi({{
                     Rd = rvSext(Rs1 & imm);
                 }}, uint64_t);

--- a/src/arch/riscv/isa/formats/mem.isa
+++ b/src/arch/riscv/isa/formats/mem.isa
@@ -104,12 +104,15 @@ def LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
 
     # select templates
 
+    is_prefetch = "prefetch" in name
+
     fullExecTemplate = eval(exec_template_base + 'Execute')
     initiateAccTemplate = eval(exec_template_base + 'InitiateAcc')
-    completeAccTemplate = eval(exec_template_base + 'CompleteAcc')
+    completeAccTemplate = eval('PrefetchCompleteAcc') if is_prefetch else \
+        eval(exec_template_base + 'CompleteAcc')
 
     # (header_output, decoder_output, decode_block, exec_output)
-    return (LoadStoreDeclare.subst(iop),
+    return (PrefetchDeclare.subst(iop) if is_prefetch else LoadStoreDeclare.subst(iop),
         LoadStoreConstructor.subst(iop),
         decode_template.subst(iop),
         fullExecTemplate.subst(iop) +
@@ -293,6 +296,45 @@ def template CacheBlockBasedStoreInitiateAcc {{
 }};
 
 def template CacheBlockBasedStoreCompleteAcc {{
+    Fault
+    %(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
+        trace::InstRecord *traceData) const
+    {
+        return NoFault;
+    }
+}};
+
+def template PrefetchDeclare {{
+    /**
+     * Static instruction class for "%(mnemonic)s".
+     */
+    class %(class_name)s : public %(base_class)s
+    {
+      private:
+        %(reg_idx_arr_decl)s;
+
+      public:
+        /// Constructor.
+        %(class_name)s(ExtMachInst machInst);
+
+        Fault execute(ExecContext *, trace::InstRecord *) const override;
+        Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
+        Fault completeAcc(PacketPtr, ExecContext *,
+                          trace::InstRecord *) const override;
+        std::string
+        generateDisassembly(Addr pc,
+                            const loader::SymbolTable *symtab) const override
+        {
+            std::stringstream ss;
+            ss << mnemonic << ' ' <<
+                offset << '(' << registerName(srcRegIdx(0)) << ')';
+            return ss.str();
+        }
+    };
+}};
+
+
+def template PrefetchCompleteAcc {{
     Fault
     %(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
         trace::InstRecord *traceData) const


### PR DESCRIPTION
This PR add support for RISC-V [Zicbop](https://github.com/riscv/riscv-CMOs/blob/master/cmobase/Zicbop.adoc) extension.

Change-Id: I13b044cf84608fb09b760348366ffad659a00427