### PR TITLE
arch-riscv: Fix vector instruction assertion caused by speculative execution

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -367,8 +367,6 @@ template<typename ElemType>
     %(set_reg_idx_arr)s;
     %(constructor)s;
     const int64_t vlmul = vtype_vlmul(_machInst.vtype8);
-    // Todo: move to Decode template
-    panic_if(vlmul == 3, "LMUL=8 is illegal for widening inst");
     // when LMUL setted as m1, need to split to 2 micro insts
     const uint32_t num_microops = 1 << std::max<int64_t>(0, vlmul + 1);
 
@@ -462,6 +460,8 @@ Fault
 
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if (vtype_vlmul(machInst.vtype8) == 3)
+        return std::make_shared<IllegalInstFault>("LMUL=8 is illegal for widening inst", machInst);
 
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);
@@ -747,6 +747,8 @@ Fault
 
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if (vtype_vlmul(machInst.vtype8) == 3)
+        return std::make_shared<IllegalInstFault>("LMUL=8 is illegal for widening inst", machInst);
 
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);
@@ -1884,6 +1886,8 @@ Fault
 
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if (vtype_vlmul(machInst.vtype8) == 3)
+        return std::make_shared<IllegalInstFault>("LMUL=8 is illegal for widening inst", machInst);
 
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1792,9 +1792,8 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-
-    panic_if(((1 << vlmul) * this->numFields) > 8,
-        "LMUL value is illegal for vlseg inst");
+    if (((1 << vlmul) * this->numFields) > 8)
+        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vlseg inst", machInst);
 
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);
@@ -1851,9 +1850,8 @@ Fault
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-
-    panic_if(((1 << vlmul) * this->numFields) > 8,
-        "LMUL value is illegal for vlseg inst");
+    if (((1 << vlmul) * this->numFields) > 8)
+        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vlseg inst", machInst);
 
     const std::vector<bool> byte_enable(mem_size, true);
     Fault fault = initiateMemRead(xc, EA, mem_size, memAccessFlags,
@@ -2040,8 +2038,8 @@ Fault
     %(ea_code)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-    panic_if(((1 << vlmul) * this->numFields) > 8,
-        "LMUL value is illegal for vsseg inst");
+    if (((1 << vlmul) * this->numFields) > 8)
+        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vsseg inst", machInst);
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
 
@@ -2097,9 +2095,8 @@ Fault
     %(ea_code)s;
 
     const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-        panic_if(((1 << vlmul) * this->numFields) > 8,
-            "LMUL value is illegal for vsseg inst");
-
+    if (((1 << vlmul) * this->numFields) > 8)
+        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vsseg inst", machInst);
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
 


### PR DESCRIPTION
Tihs PR fixed vector instruction assertion caused by speculative execution. #1645

The approach refers to the spike simulator.
https://github.com/riscv-software-src/riscv-isa-sim/blob/88fc84ded155a9e01987c4dfb7a77800e69b232b/riscv/v_ext_macros.h#L77

When lmul is found to be illegal, an instruction exception is triggered.

Change-Id: If4a8782e65ba80633df74aec8ad287f7d92b2dca