### PR TITLE
arch-riscv: Fix incorrect vector slide instructions and statically filter redundant uops

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -192,9 +192,11 @@ std::string VectorSlideMicroInst::generateDisassembly(Addr pc,
     std::stringstream ss;
     ss << mnemonic << ' ' << registerName(destRegIdx(0)) <<  ", ";
     if (machInst.funct3 == 0x3) {
-      ss  << registerName(srcRegIdx(0)) << ", " << machInst.vecimm;
+      ss  << registerName(srcRegIdx(0)) << ", "
+        << registerName(srcRegIdx(1)) << ", " << machInst.vecimm;
     } else {
-      ss  << registerName(srcRegIdx(1)) << ", " << registerName(srcRegIdx(0));
+      ss  << registerName(srcRegIdx(1)) << ", "
+        << registerName(srcRegIdx(2)) << ", " << registerName(srcRegIdx(0));
     }
     if (machInst.vm == 0) ss << ", v0.t";
     return ss.str();
@@ -860,10 +862,12 @@ VCpyVsMicroInst::generateDisassembly(Addr pc,
 
 VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                                  uint32_t _numVdPins, uint32_t _elen,
-                                 uint32_t _vlen, bool _hasVdOffset)
+                                 uint32_t _vlen, bool _hasVdOffset,
+                                 bool _copyVs, uint32_t _vsIdx)
     : VectorArithMicroInst("vpinvd_v_micro", _machInst, SimdMiscOp, 0,
                            _microIdx, _elen, _vlen)
     , hasVdOffset(_hasVdOffset)
+    , copyVs(_copyVs)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -882,6 +886,10 @@ VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
     RegId Vd = destRegIdx(0);
     Vd.setNumPinnedWrites(_numVdPins);
     setDestRegIdx(0, Vd);
+
+    if (copyVs) {
+        setSrcRegIdx(_numSrcRegs++, vecRegClass[_vsIdx]);
+    }
 }
 
 Fault
@@ -901,7 +909,7 @@ VPinVdMicroInst::execute(ExecContext* xc, trace::InstRecord* traceData) const
     // tail/mask policy: both undisturbed if one is, 1s if none
     vreg_t& vd = *(vreg_t *)xc->getWritableRegOperand(this, 0);
     if (!machInst.vtype8.vta || (!machInst.vm && !machInst.vtype8.vma)
-                             || hasVdOffset) {
+                            || hasVdOffset) {
         vreg_t old_vd;
         xc->getRegOperand(this, 0, &old_vd);
         vd = old_vd;
@@ -910,7 +918,14 @@ VPinVdMicroInst::execute(ExecContext* xc, trace::InstRecord* traceData) const
     }
 
     if (traceData) {
-        traceData->setData(vecRegClass, &vd);
+        traceData->setData(vecRegClass, xc->getWritableRegOperand(this, 0));
+    }
+
+    if (copyVs) {
+        vreg_t& vs = *(vreg_t *)xc->getWritableRegOperand(this, 1);
+        vreg_t old_vs;
+        xc->getRegOperand(this, 1, &old_vs);
+        vs = old_vs;
     }
 
     return NoFault;

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -128,6 +128,8 @@ class VectorMacroInst : public RiscvMacroInst
     uint8_t vtype;
     uint32_t elen;
     uint32_t vlen;
+    int oldDstIdx = -1;
+    int vmsrcIdx = -1;
 
     VectorMacroInst(const char* mnem, ExtMachInst _machInst,
                    OpClass __opClass, uint32_t _elen, uint32_t _vlen)
@@ -149,6 +151,8 @@ protected:
     uint8_t vtype;
     uint32_t elen;
     uint32_t vlen;
+    int oldDstIdx = -1;
+    int vmsrcIdx = -1;
 
     VectorMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
       uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
@@ -259,13 +263,14 @@ class VectorSlideMicroInst : public VectorMicroInst
   protected:
     uint32_t vdIdx;
     uint32_t vs2Idx;
+    uint32_t vs3Idx;
     VectorSlideMicroInst(const char *mnem, ExtMachInst _machInst,
                          OpClass __opClass, uint32_t _microVl,
                          uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx,
-                         uint32_t _elen, uint32_t _vlen)
+                         uint32_t _vs3Idx, uint32_t _elen, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
                           _elen, _vlen)
-        , vdIdx(_vdIdx), vs2Idx(_vs2Idx)
+        , vdIdx(_vdIdx), vs2Idx(_vs2Idx), vs3Idx(_vs3Idx)
     {}
 
     std::string generateDisassembly(
@@ -753,13 +758,15 @@ class VPinVdMicroInst : public VectorArithMicroInst
 {
     private:
         RegId srcRegIdxArr[1];
-        RegId destRegIdxArr[1];
-        bool hasVdOffset;
+        RegId destRegIdxArr[2];
+        const bool hasVdOffset;
+        const bool copyVs;
 
     public:
         VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                         uint32_t _numVdPins, uint32_t _elen, uint32_t _vlen,
-                        bool _hasVdOffset=false);
+                        bool _hasVdOffset=false, bool _copyVs = false,
+                        uint32_t _vsIdx = 0);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -642,43 +642,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
@@ -736,43 +743,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
@@ -827,43 +841,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
@@ -918,43 +939,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
@@ -1194,13 +1222,16 @@ decode QUADRANT default Unknown::unknown() {
                 format ROp {
                     0x0c: decode RS2 {
                         0x00: clz({{
-                            Rd = (machInst.rv_type == RV32) ? clz32(Rs1) : clz64(Rs1);
+                            Rd = (machInst.rv_type == RV32)
+                                ? clz32(Rs1) : clz64(Rs1);
                         }});
                         0x01: ctz({{
-                            Rd = (machInst.rv_type == RV32) ? ctz32(Rs1) : ctz64(Rs1);
+                            Rd = (machInst.rv_type == RV32)
+                                ? ctz32(Rs1) : ctz64(Rs1);
                         }});
                         0x02: cpop({{
-                            Rd = (machInst.rv_type == RV32) ? popCount(Rs1<31:0>) : popCount(Rs1);
+                            Rd = (machInst.rv_type == RV32)
+                                ? popCount(Rs1<31:0>) : popCount(Rs1);
                         }});
                         0x04: sext_b({{
                             Rd = sext<8>(Rs1_ub);
@@ -1346,10 +1377,12 @@ decode QUADRANT default Unknown::unknown() {
                     0x1: decode FS3 {
                         0x0: slliw({{
                             Rd_sd = Rs1_sw << imm;
-                        }}, imm_type = uint64_t, imm_code = {{ imm = SHAMT5; }});
+                        }}, imm_type = uint64_t,
+                        imm_code = {{ imm = SHAMT5; }});
                         0x1: slli_uw({{
                             Rd = ((uint64_t)(Rs1_uw)) << imm;
-                        }}, imm_type = uint64_t, imm_code = {{ imm = SHAMT6; }});
+                        }}, imm_type = uint64_t,
+                        imm_code = {{ imm = SHAMT6; }});
                         0xc: decode FS2 {
                             0x0: clzw({{
                                 Rd = clz32(Rs1);
@@ -1365,13 +1398,17 @@ decode QUADRANT default Unknown::unknown() {
                     0x5: decode FS3 {
                         0x0: srliw({{
                             Rd_sd = (int32_t)(Rs1_uw >> imm);
-                        }}, imm_type = uint64_t, imm_code = {{ imm = SHAMT5; }});
+                        }}, imm_type = uint64_t,
+                        imm_code = {{ imm = SHAMT5; }});
                         0x8: sraiw({{
                             Rd_sd = Rs1_sw >> imm;
-                        }}, imm_type = uint64_t, imm_code = {{ imm = SHAMT5; }});
+                        }}, imm_type = uint64_t,
+                        imm_code = {{ imm = SHAMT5; }});
                         0xc: roriw({{
-                            Rd = (int32_t) ((Rs1_uw >> imm) | (Rs1_uw << ((32 - imm) & (32 - 1))));
-                        }}, imm_type = uint64_t, imm_code = {{ imm = SHAMT5; }});
+                            Rd = (int32_t) ((Rs1_uw >> imm)
+                                | (Rs1_uw << ((32 - imm) & (32 - 1))));
+                        }}, imm_type = uint64_t,
+                        imm_code = {{ imm = SHAMT5; }});
                     }
                 }
             }
@@ -2201,7 +2238,8 @@ decode QUADRANT default Unknown::unknown() {
                         }});
                         0x30: rolw({{
                             int shamt = Rs2 & (32 - 1);
-                            Rd = (int32_t) ((Rs1_uw << shamt) | (Rs1_uw >> ((32 - shamt) & (32 - 1))));
+                            Rd = (int32_t) ((Rs1_uw << shamt)
+                                | (Rs1_uw >> ((32 - shamt) & (32 - 1))));
                         }});
                     }
                     0x2: decode FUNCT7 {
@@ -2232,7 +2270,8 @@ decode QUADRANT default Unknown::unknown() {
                         }});
                         0x30: rorw({{
                             int shamt = Rs2 & (32 - 1);
-                            Rd = (int32_t) ((Rs1_uw >> shamt) | (Rs1_uw << ((32 - shamt) & (32 - 1))));
+                            Rd = (int32_t) ((Rs1_uw >> shamt)
+                                | (Rs1_uw << ((32 - shamt) & (32 - 1))));
                         }});
                     }
                     0x6:  decode FUNCT7 {
@@ -2664,13 +2703,15 @@ decode QUADRANT default Unknown::unknown() {
                     0x4: fround_s({{
                         RM_REQUIRED;
                         freg_t fd;
-                        fd = freg(f32_roundToInt(f32(freg(Fs1_bits)), rm, false));
+                        fd = freg(f32_roundToInt(
+                            f32(freg(Fs1_bits)), rm, false));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
                     0x5: froundnx_s({{
                         RM_REQUIRED;
                         freg_t fd;
-                        fd = freg(f32_roundToInt(f32(freg(Fs1_bits)), rm, true));
+                        fd = freg(f32_roundToInt(
+                            f32(freg(Fs1_bits)), rm, true));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
                 }
@@ -2690,13 +2731,15 @@ decode QUADRANT default Unknown::unknown() {
                     0x4: fround_d({{
                         RM_REQUIRED;
                         freg_t fd;
-                        fd = freg(f64_roundToInt(f64(freg(Fs1_bits)), rm, false));
+                        fd = freg(f64_roundToInt(
+                            f64(freg(Fs1_bits)), rm, false));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
                     0x5: froundnx_d({{
                         RM_REQUIRED;
                         freg_t fd;
-                        fd = freg(f64_roundToInt(f64(freg(Fs1_bits)), rm, true));
+                        fd = freg(f64_roundToInt(
+                            f64(freg(Fs1_bits)), rm, true));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
                 }
@@ -2716,13 +2759,15 @@ decode QUADRANT default Unknown::unknown() {
                     0x4: fround_h({{
                         RM_REQUIRED;
                         freg_t fd;
-                        fd = freg(f16_roundToInt(f16(freg(Fs1_bits)), rm, false));
+                        fd = freg(f16_roundToInt(
+                            f16(freg(Fs1_bits)), rm, false));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
                     0x5: froundnx_h({{
                         RM_REQUIRED;
                         freg_t fd;
-                        fd = freg(f16_roundToInt(f16(freg(Fs1_bits)), rm, true));
+                        fd = freg(f16_roundToInt(
+                            f16(freg(Fs1_bits)), rm, true));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
                 }
@@ -2767,10 +2812,12 @@ decode QUADRANT default Unknown::unknown() {
                         Rd = f32_eq(f32(freg(Fs1_bits)), f32(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                     0x4: fleq_s({{
-                        Rd = f32_le_quiet(f32(freg(Fs1_bits)), f32(freg(Fs2_bits)));
+                        Rd = f32_le_quiet(f32(freg(Fs1_bits)),
+                            f32(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                     0x5: fltq_s({{
-                        Rd = f32_lt_quiet(f32(freg(Fs1_bits)), f32(freg(Fs2_bits)));
+                        Rd = f32_lt_quiet(f32(freg(Fs1_bits)),
+                            f32(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                 }
                 0x51: decode ROUND_MODE {
@@ -2784,10 +2831,12 @@ decode QUADRANT default Unknown::unknown() {
                         Rd = f64_eq(f64(freg(Fs1_bits)), f64(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                     0x4: fleq_d({{
-                        Rd = f64_le_quiet(f64(freg(Fs1_bits)), f64(freg(Fs2_bits)));
+                        Rd = f64_le_quiet(f64(freg(Fs1_bits)),
+                            f64(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                     0x5: fltq_d({{
-                        Rd = f64_lt_quiet(f64(freg(Fs1_bits)), f64(freg(Fs2_bits)));
+                        Rd = f64_lt_quiet(f64(freg(Fs1_bits)),
+                            f64(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                 }
                 0x52: decode ROUND_MODE {
@@ -2801,10 +2850,12 @@ decode QUADRANT default Unknown::unknown() {
                         Rd = f16_eq(f16(freg(Fs1_bits)), f16(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                     0x4: fleq_h({{
-                        Rd = f16_le_quiet(f16(freg(Fs1_bits)), f16(freg(Fs2_bits)));
+                        Rd = f16_le_quiet(f16(freg(Fs1_bits)),
+                            f16(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                     0x5: fltq_h({{
-                        Rd = f16_lt_quiet(f16(freg(Fs1_bits)), f16(freg(Fs2_bits)));
+                        Rd = f16_lt_quiet(f16(freg(Fs1_bits)),
+                            f16(freg(Fs2_bits)));
                     }}, FloatCmpOp);
                 }
                 0x59: decode ROUND_MODE {
@@ -2892,24 +2943,28 @@ decode QUADRANT default Unknown::unknown() {
 
                             /* Shift the fraction into place.  */
                             if (shift >= 64) {
-                                /* The fraction is shifted out entirely.  */
+                                /* The fraction is shifted out entirely. */
                                 frac = 0;
                             } else  if ((shift >= 0) && (shift < 64)) {
-                                /* The number is so large we must shift the fraction left.  */
+                                /* The number is so large we must shift the
+                                fraction left.  */
                                 frac <<= shift;
                             } else if ((shift > -64) && (shift < 0)) {
-                                /* Normal case -- shift right and notice if bits shift out.  */
+                                /* Normal case -- shift right and notice if
+                                bits shift out. */
                                 inexact = (frac << (64 + shift)) != 0;
                                 frac >>= -shift;
                             } else {
-                                /* The fraction is shifted out entirely.  */
+                                /* The fraction is shifted out entirely. */
                                 frac = 0;
                                 inexact = true;
                             }
 
                             /* Handle overflows */
-                            if (true_exp > 31 || frac > (sign ? 0x80000000ull : 0x7fffffff)) {
-                                /* Overflow, for which this operation raises invalid.  */
+                            if (true_exp > 31 || frac
+                                > (sign ? 0x80000000ull : 0x7fffffff)) {
+                                /* Overflow, for which this operation raises
+                                invalid. */
                                 invalid = true;
                                 inexact = false;  /* invalid takes precedence */
                             }
@@ -2921,8 +2976,9 @@ decode QUADRANT default Unknown::unknown() {
                         }
 
                         Rd = sext<32>(frac);
-                        softfloat_exceptionFlags = (inexact ? softfloat_flag_inexact : 0) |
-                                    (invalid ? softfloat_flag_invalid : 0)
+                        softfloat_exceptionFlags =
+                            (inexact ? softfloat_flag_inexact : 0) |
+                            (invalid ? softfloat_flag_invalid : 0);
                     }}, FloatCvtOp);
                 }
                 0x62: decode CONV_SGN {
@@ -3092,7 +3148,8 @@ decode QUADRANT default Unknown::unknown() {
                         0x01: fli_s({{
                             static const uint32_t imm[32] = {
                                 [0b00000] = 0xbf800000,  /* -1.0 */
-                                [0b00001] = 0x00800000,  /* minimum positive normal */
+                                [0b00001] = 0x00800000,  /* minimum positive
+                                    normal */
                                 [0b00010] = 0x37800000,  /* 1.0 * 2^-16 */
                                 [0b00011] = 0x38000000,  /* 1.0 * 2^-15 */
                                 [0b00100] = 0x3b800000,  /* 1.0 * 2^-8  */
@@ -3141,13 +3198,20 @@ decode QUADRANT default Unknown::unknown() {
                     0x01: fli_d({{
                         static const uint64_t imm[32] = {
                             [0b00000] = 0xbff0000000000000ull,  /* -1.0 */
-                            [0b00001] = 0x0010000000000000ull,  /* minimum positive normal */
-                            [0b00010] = 0x3ef0000000000000ull,  /* 1.0 * 2^-16 */
-                            [0b00011] = 0x3f00000000000000ull,  /* 1.0 * 2^-15 */
-                            [0b00100] = 0x3f70000000000000ull,  /* 1.0 * 2^-8  */
-                            [0b00101] = 0x3f80000000000000ull,  /* 1.0 * 2^-7  */
-                            [0b00110] = 0x3fb0000000000000ull,  /* 1.0 * 2^-4  */
-                            [0b00111] = 0x3fc0000000000000ull,  /* 1.0 * 2^-3  */
+                            [0b00001] = 0x0010000000000000ull,  /* minimum
+                                positive normal */
+                            [0b00010] = 0x3ef0000000000000ull,  /* 1.0
+                                * 2^-16 */
+                            [0b00011] = 0x3f00000000000000ull,  /* 1.0
+                                * 2^-15 */
+                            [0b00100] = 0x3f70000000000000ull,  /* 1.0
+                                * 2^-8  */
+                            [0b00101] = 0x3f80000000000000ull,  /* 1.0
+                                * 2^-7  */
+                            [0b00110] = 0x3fb0000000000000ull,  /* 1.0
+                                * 2^-4  */
+                            [0b00111] = 0x3fc0000000000000ull,  /* 1.0
+                                * 2^-3  */
                             [0b01000] = 0x3fd0000000000000ull,  /* 0.25 */
                             [0b01001] = 0x3fd4000000000000ull,  /* 0.3125 */
                             [0b01010] = 0x3fd8000000000000ull,  /* 0.375 */
@@ -3215,7 +3279,8 @@ decode QUADRANT default Unknown::unknown() {
                             [0b11010] = 0x5800,  /* 2^7 */
                             [0b11011] = 0x5c00,  /* 2^8 */
                             [0b11100] = 0x7800,  /* 2^15 */
-                            [0b11101] = 0x7c00,  /* +inf (2^16 is not expressible) */
+                            [0b11101] = 0x7c00,  /* +inf (2^16 is not
+                                expressible) */
                             [0b11110] = 0x7c00,  /* +inf */
                             [0b11111] = defaultNaNF16UI
                         };
@@ -4195,67 +4260,106 @@ decode QUADRANT default Unknown::unknown() {
                         }
                     }
                 }}, OPIVI, SimdMiscOp);
-                0x0e: VectorSlideUpFormat::vslideup_vi({{
-                    const int offset = (int)(uint64_t)(SIMM5);
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vdIdx - vs2Idx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int elemOffset = vdOffset + vdIdx * microVlmax;
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            if (this->vm || elem_mask(v0, i + elemOffset)) {
-                                Vd_vu[i + vdOffset] = Vs2_vu[i + vs2Offset];
+                0x0e: VectorSlideUpVIFormat::vslideup_vi({{
+                    int offset = (int)(uint64_t)(SIMM5);
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeft = microVlmax * (vs2Idx + 1) + offset;
+                    bool copyAll = vs3WindowLeft >= vdWindowLeft
+                        && vs3WindowLeft < vdWindowRight;
+
+                    RiscvISA::vreg_t old_vd;
+                    xc->getRegOperand(this, oldDstIdx, &old_vd);
+                    tmp_d0 = old_vd;
+
+                    if (copyAll) {
+                        int backLen = vdWindowRight - vs3WindowLeft;
+                        int frontLen = microVlmax - backLen;
+                        int vdOffset = 0;
+                        for (int i = 0; vdOffset < frontLen
+                            && vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs2_vu[i + backLen];
+                            }
+                        }
+                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
+                            }
+                        }
+                    } else {
+                        int vs2WindowLeft = microVlmax * vs2Idx + offset;
+                        bool copyBack = vs2Idx == 0 && vs2WindowLeft
+                            >= vdWindowLeft && vs2WindowLeft < vdWindowRight;
+                        if (copyBack) {
+                            int backLen = vdWindowRight - vs2WindowLeft;
+                            int vdOffset = microVlmax - backLen;
+                            for (int i = 0; i < backLen && vdOffset < microVl;
+                                vdOffset++, i++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdOffset + vdWindowLeft)) {
+                                    Vd_vu[vdOffset] = Vs2_vu[i];
+                                }
                             }
                         }
                     }
                 }}, OPIVI, SimdMiscOp);
-                0x0f: VectorSlideDownFormat::vslidedown_vi({{
-                    const int offset = (int)(uint64_t)(SIMM5);
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vs2Idx - vdIdx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    const int numVs2s = vtype_regs_per_group(vtype);
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const bool needZeroTail = numVs2s == vs2Idx + 1;
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int elemIdxBase = vdIdx * microVlmax;
-                        vreg_t resVreg;
-                        auto res = resVreg.as<vu>();
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            res[i + vdOffset] = Vs2_vu[i + vs2Offset];
-                        }
-                        if (needZeroTail) {
-                            for (int i = upperBound + vdOffset;
-                                i < microVlmax; i++) {
-                                res[i] = 0;
+                0x0f: VectorSlideDownVIFormat::vslidedown_vi({{
+                    int offset = (int)(uint64_t)(SIMM5);
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int offsetWindow = offset % microVlmax;
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeftSlide = microVlmax * vs3Idx - offset;
+                    int vs3WindowRightSlide = microVlmax * (vs3Idx + 1)
+                        - offset;
+                    bool copyFrontFromVs2 = vs3WindowLeftSlide > vdWindowLeft
+                        && vs3WindowLeftSlide <= vdWindowRight;
+                    bool copyFrontFromVs3 = lastUopForVd && vs3WindowRightSlide
+                        > vdWindowLeft && vs3WindowRightSlide <= vdWindowRight;
+                    bool needZeroTail = lastUopForVd && vs3WindowRightSlide
+                        <= vdWindowLeft;
+                    int vdOffset = 0;
+
+                    COPY_OLD_VD(oldDstIdx);
+
+                    if (copyFrontFromVs2) {
+                        int frontLen = vs3WindowLeftSlide - vdWindowLeft;
+                        for (; vdOffset < frontLen && vdOffset < microVl;
+                            vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] =
+                                    Vs2_vu[vdOffset + offsetWindow];
                             }
                         }
-                        for (int i = vdOffset; i < microVl ; i++) {
-                            if (vm || elem_mask(v0, i + elemIdxBase)) {
-                                Vd_vu[i] = res[i];
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
+                            }
+                        }
+                    } else {
+                        if (copyFrontFromVs3) {
+                            int frontLen = vs3WindowRightSlide - vdWindowLeft;
+                            for (; vdOffset < frontLen && vdOffset < microVl;
+                                vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] =
+                                        Vs3_vu[vdOffset + offsetWindow];
+                                }
+                            }
+                        }
+                        if (copyFrontFromVs3 || needZeroTail) {
+                            for (; vdOffset < microVl; vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] = 0;
+                                }
                             }
                         }
                     }
@@ -4454,66 +4558,99 @@ decode QUADRANT default Unknown::unknown() {
                     }}, OPIVX, SimdAluOp);
                 }
                 0x0e: VectorSlideUpFormat::vslideup_vx({{
-                    const int offset = (int)Rs1_vu;
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vdIdx - vs2Idx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int elemOffset = vdOffset + vdIdx * microVlmax;
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            if (this->vm || elem_mask(v0, i + elemOffset)) {
-                                Vd_vu[i + vdOffset] = Vs2_vu[i + vs2Offset];
+                    int offset = (int)Rs1_vu;
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeft = microVlmax * (vs2Idx + 1) + offset;
+                    bool copyAll = vs3WindowLeft >= vdWindowLeft
+                        && vs3WindowLeft < vdWindowRight;
+
+                    if (copyAll) {
+                        int backLen = vdWindowRight - vs3WindowLeft;
+                        int frontLen = microVlmax - backLen;
+                        int vdOffset = 0;
+                        for (int i = 0; vdOffset < frontLen
+                            && vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs2_vu[i + backLen];
+                            }
+                        }
+                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
+                            }
+                        }
+                    } else {
+                        int vs2WindowLeft = microVlmax * vs2Idx + offset;
+                        bool copyBack = vs2Idx == 0 && vs2WindowLeft
+                            >= vdWindowLeft && vs2WindowLeft < vdWindowRight;
+                        if (copyBack) {
+                            int backLen = vdWindowRight - vs2WindowLeft;
+                            int vdOffset = microVlmax - backLen;
+                            for (int i = 0; i < backLen && vdOffset < microVl;
+                                vdOffset++, i++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdOffset + vdWindowLeft)) {
+                                    Vd_vu[vdOffset] = Vs2_vu[i];
+                                }
                             }
                         }
                     }
                 }}, OPIVX, SimdMiscOp);
                 0x0f: VectorSlideDownFormat::vslidedown_vx({{
-                    const int offset = (int)Rs1_vu;
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vs2Idx - vdIdx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    const int numVs2s = vtype_regs_per_group(vtype);
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const bool needZeroTail = numVs2s == vs2Idx + 1;
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int elemIdxBase = vdIdx * microVlmax;
-                        vreg_t resVreg;
-                        auto res = resVreg.as<vu>();
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            res[i + vdOffset] = Vs2_vu[i + vs2Offset];
-                        }
-                        if (needZeroTail) {
-                            for (int i = upperBound + vdOffset;
-                                i < microVlmax; i++) {
-                                res[i] = 0;
+                    int offset = (int)Rs1_vu;
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int offsetWindow = offset % microVlmax;
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeftSlide = microVlmax * vs3Idx - offset;
+                    int vs3WindowRightSlide = microVlmax * (vs3Idx + 1)
+                        - offset;
+                    bool copyFrontFromVs2 = vs3WindowLeftSlide > vdWindowLeft
+                        && vs3WindowLeftSlide <= vdWindowRight;
+                    bool copyFrontFromVs3 = lastUopForVd && vs3WindowRightSlide
+                        > vdWindowLeft && vs3WindowRightSlide <= vdWindowRight;
+                    bool needZeroTail = lastUopForVd && vs3WindowRightSlide
+                        <= vdWindowLeft;
+                    int vdOffset = 0;
+
+                    if (copyFrontFromVs2) {
+                        int frontLen = vs3WindowLeftSlide - vdWindowLeft;
+                        for (; vdOffset < frontLen && vdOffset < microVl;
+                            vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] =
+                                    Vs2_vu[vdOffset + offsetWindow];
                             }
                         }
-                        for (int i = vdOffset; i < microVl ; i++) {
-                            if (vm || elem_mask(v0, i + elemIdxBase)) {
-                                Vd_vu[i] = res[i];
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
+                            }
+                        }
+                    } else {
+                        if (copyFrontFromVs3) {
+                            int frontLen = vs3WindowRightSlide - vdWindowLeft;
+                            for (; vdOffset < frontLen && vdOffset < microVl;
+                                vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] =
+                                        Vs3_vu[vdOffset + offsetWindow];
+                                }
+                            }
+                        }
+                        if (copyFrontFromVs3 || needZeroTail) {
+                            for (; vdOffset < microVl; vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] = 0;
+                                }
                             }
                         }
                     }
@@ -4760,75 +4897,113 @@ decode QUADRANT default Unknown::unknown() {
                     }}, OPFVF, SimdFloatExtOp);
                 }
                 0x0e: VectorFloatSlideUpFormat::vfslide1up_vf({{
-                    const int offset = 1;
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vdIdx - vs2Idx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int elemOffset = vdOffset + vdIdx * microVlmax;
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            if (this->vm || elem_mask(v0, i + elemOffset)) {
-                                Vd_vu[i + vdOffset] = Vs2_vu[i + vs2Offset];
+                    int offset = 1;
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeft = microVlmax * (vs2Idx + 1) + offset;
+                    bool copyAll = vs3WindowLeft >= vdWindowLeft
+                        && vs3WindowLeft < vdWindowRight;
+
+                    COPY_OLD_VD(oldDstIdx);
+
+                    if (copyAll) {
+                        int backLen = vdWindowRight - vs3WindowLeft;
+                        int frontLen = microVlmax - backLen;
+                        int vdOffset = 0;
+                        for (int i = 0; vdOffset < frontLen
+                            && vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        // TODO: dirty code
-                        if (vdIdx == 0 && vs2Idx == 0 &&
-                                (this->vm || elem_mask(v0, 0))) {
-                            tmp_d0.as<vu>()[0] = Rs1_vu;
+                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
+                            }
                         }
+                    } else {
+                        int vs2WindowLeft = microVlmax * vs2Idx + offset;
+                        bool copyBack = vs2Idx == 0 && vs2WindowLeft
+                            >= vdWindowLeft && vs2WindowLeft < vdWindowRight;
+                        if (copyBack) {
+                            int backLen = vdWindowRight - vs2WindowLeft;
+                            int vdOffset = microVlmax - backLen;
+                            for (int i = 0; i < backLen && vdOffset < microVl;
+                                vdOffset++, i++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdOffset + vdWindowLeft)) {
+                                    Vd_vu[vdOffset] = Vs2_vu[i];
+                                }
+                            }
+                        }
+                    }
+                    if (vdIdx == 0) {
+                        auto fd = ftype_freg<et>(freg(Fs1_bits));
+                        Vd_vu[0] = fd.v;
                     }
                 }}, OPFVF, SimdMiscOp);
                 0x0f: VectorFloatSlideDownFormat::vfslide1down_vf({{
-                    const int offset = 1;
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vs2Idx - vdIdx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    const int numVs2s = vtype_regs_per_group(vtype);
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const bool needZeroTail = numVs2s == vs2Idx + 1;
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int elemIdxBase = vdIdx * microVlmax;
-                        vreg_t resVreg;
-                        auto res = resVreg.as<vu>();
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            res[i + vdOffset] = Vs2_vu[i + vs2Offset];
-                        }
-                        if (needZeroTail) {
-                            for (int i = upperBound + vdOffset;
-                                i < microVlmax; i++) {
-                                res[i] = 0;
+                    int offset = 1;
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int offsetWindow = offset % microVlmax;
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeftSlide = microVlmax * vs3Idx - offset;
+                    int vs3WindowRightSlide = microVlmax * (vs3Idx + 1)
+                        - offset;
+                    bool copyFrontFromVs2 = vs3WindowLeftSlide > vdWindowLeft
+                        && vs3WindowLeftSlide <= vdWindowRight;
+                    bool copyFrontFromVs3 = lastUopForVd && vs3WindowRightSlide
+                        > vdWindowLeft && vs3WindowRightSlide <= vdWindowRight;
+                    bool needZeroTail = lastUopForVd && vs3WindowRightSlide
+                        <= vdWindowLeft;
+                    int vdOffset = 0;
+
+                    COPY_OLD_VD(oldDstIdx);
+
+                    if (copyFrontFromVs2) {
+                        int frontLen = vs3WindowLeftSlide - vdWindowLeft;
+                        for (; vdOffset < frontLen && vdOffset < microVl;
+                            vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] =
+                                    Vs2_vu[vdOffset + offsetWindow];
                             }
                         }
-                        for (int i = vdOffset; i < microVl ; i++) {
-                            if (vm || elem_mask(v0, i + elemIdxBase)) {
-                                Vd_vu[i] = (i + elemIdxBase != machInst.vl - 1)
-                                    ? res[i]
-                                    : Rs1_vu;
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
                             }
                         }
+                    } else {
+                        if (copyFrontFromVs3) {
+                            int frontLen = vs3WindowRightSlide - vdWindowLeft;
+                            for (; vdOffset < frontLen && vdOffset < microVl;
+                                vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] =
+                                        Vs3_vu[vdOffset + offsetWindow];
+                                }
+                            }
+                        }
+                        if (copyFrontFromVs3 || needZeroTail) {
+                            for (; vdOffset < microVl; vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] = 0;
+                                }
+                            }
+                        }
+                    }
+                    if (lastUop) {
+                        auto fd = ftype_freg<et>(freg(Fs1_bits));
+                        Vd_vu[microVl - 1] = fd.v;
                     }
                 }}, OPFVF, SimdMiscOp);
                 // VRFUNARY0
@@ -5038,76 +5213,112 @@ decode QUADRANT default Unknown::unknown() {
                         Vd_vi[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
                 }
-                0x0e: VectorSlideUpFormat::vslide1up_vx({{
-                    const int offset = 1;
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vdIdx - vs2Idx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int elemOffset = vdOffset + vdIdx * microVlmax;
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            if (this->vm || elem_mask(v0, i + elemOffset)) {
-                                Vd_vu[i + vdOffset] = Vs2_vu[i + vs2Offset];
+                0x0e: VectorSlide1UpFormat::vslide1up_vx({{
+                    int offset = 1;
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeft = microVlmax * (vs2Idx + 1) + offset;
+                    bool copyAll = vs3WindowLeft >= vdWindowLeft
+                        && vs3WindowLeft < vdWindowRight;
+
+                    COPY_OLD_VD(oldDstIdx);
+
+                    if (copyAll) {
+                        int backLen = vdWindowRight - vs3WindowLeft;
+                        int frontLen = microVlmax - backLen;
+                        int vdOffset = 0;
+                        for (int i = 0; vdOffset < frontLen
+                            && vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        // TODO: dirty code
-                        if (vdIdx == 0 && vs2Idx == 0 &&
-                                (this->vm || elem_mask(v0, 0))) {
-                            tmp_d0.as<vu>()[0] = Rs1_vu;
+                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdOffset + vdWindowLeft)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
+                            }
+                        }
+                    } else {
+                        int vs2WindowLeft = microVlmax * vs2Idx + offset;
+                        bool copyBack = vs2Idx == 0 && vs2WindowLeft
+                            >= vdWindowLeft && vs2WindowLeft < vdWindowRight;
+                        if (copyBack) {
+                            int backLen = vdWindowRight - vs2WindowLeft;
+                            int vdOffset = microVlmax - backLen;
+                            for (int i = 0; i < backLen && vdOffset < microVl;
+                                vdOffset++, i++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdOffset + vdWindowLeft)) {
+                                    Vd_vu[vdOffset] = Vs2_vu[i];
+                                }
+                            }
                         }
                     }
+                    if (vdIdx == 0) {
+                        Vd_vu[0] = Rs1_vu;
+                    }
                 }}, OPIVX, SimdMiscOp);
-                0x0f: VectorSlideDownFormat::vslide1down_vx({{
-                    const int offset = 1;
-                    const int microVlmax = vtype_VLMAX(machInst.vtype8,
-                        vlen, true);
-                    const int vregOffset = vs2Idx - vdIdx;
-                    const int offsetInVreg = offset - vregOffset * microVlmax;
-                    const int numVs2s = vtype_regs_per_group(vtype);
-                    if (std::abs(offsetInVreg) < uint32_t(microVlmax)) {
-                        const bool needZeroTail = numVs2s == vs2Idx + 1;
-                        const int upperBound = (offsetInVreg >= 0)
-                            ? microVlmax - offsetInVreg
-                            : microVlmax + offsetInVreg;
-                        const int vdOffset = (offsetInVreg >= 0)
-                            ? 0
-                            : -offsetInVreg;
-                        const int vs2Offset = (offsetInVreg >= 0)
-                            ? offsetInVreg
-                            : 0;
-                        const int elemIdxBase = vdIdx * microVlmax;
-                        vreg_t resVreg;
-                        auto res = resVreg.as<vu>();
-                        for (int i = 0;
-                            i < upperBound && i + vdOffset < microVl;
-                            i++) {
-                            res[i + vdOffset] = Vs2_vu[i + vs2Offset];
-                        }
-                        if (needZeroTail) {
-                            for (int i = upperBound + vdOffset;
-                                i < microVlmax; i++) {
-                                res[i] = 0;
+                0x0f: VectorSlide1DownFormat::vslide1down_vx({{
+                    int offset = 1;
+                    int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+                    int offsetWindow = offset % microVlmax;
+                    int vdWindowLeft = microVlmax * vdIdx;
+                    int vdWindowRight = microVlmax * (vdIdx + 1);
+                    int vs3WindowLeftSlide = microVlmax * vs3Idx - offset;
+                    int vs3WindowRightSlide = microVlmax * (vs3Idx + 1)
+                        - offset;
+                    bool copyFrontFromVs2 = vs3WindowLeftSlide > vdWindowLeft
+                        && vs3WindowLeftSlide <= vdWindowRight;
+                    bool copyFrontFromVs3 = lastUopForVd && vs3WindowRightSlide
+                        > vdWindowLeft && vs3WindowRightSlide <= vdWindowRight;
+                    bool needZeroTail = lastUopForVd && vs3WindowRightSlide
+                        <= vdWindowLeft;
+                    int vdOffset = 0;
+
+                    COPY_OLD_VD(oldDstIdx);
+
+                    if (copyFrontFromVs2) {
+                        int frontLen = vs3WindowLeftSlide - vdWindowLeft;
+                        for (; vdOffset < frontLen && vdOffset < microVl;
+                            vdOffset++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] =
+                                    Vs2_vu[vdOffset + offsetWindow];
                             }
                         }
-                        for (int i = vdOffset; i < microVl ; i++) {
-                            if (vm || elem_mask(v0, i + elemIdxBase)) {
-                                Vd_vu[i] = (i + elemIdxBase != machInst.vl - 1)
-                                    ? res[i]
-                                    : Rs1_vu;
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
+                            if (this->vm || elem_mask(v0,
+                                vdWindowLeft + vdOffset)) {
+                                Vd_vu[vdOffset] = Vs3_vu[i];
                             }
                         }
+                    } else {
+                        if (copyFrontFromVs3) {
+                            int frontLen = vs3WindowRightSlide - vdWindowLeft;
+                            for (; vdOffset < frontLen && vdOffset < microVl;
+                                vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] =
+                                        Vs3_vu[vdOffset + offsetWindow];
+                                }
+                            }
+                        }
+                        if (copyFrontFromVs3 || needZeroTail) {
+                            for (; vdOffset < microVl; vdOffset++) {
+                                if (this->vm || elem_mask(v0,
+                                    vdWindowLeft + vdOffset)) {
+                                    Vd_vu[vdOffset] = 0;
+                                }
+                            }
+                        }
+                    }
+                    if (lastUop) {
+                        Vd_vu[microVl - 1] = Rs1_vu;
                     }
                 }}, OPIVX, SimdMiscOp);
                 // VRXUNARY0

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -36,10 +36,11 @@ let {{
     def setSrcWrapper(srcRegId):
         return "setSrcRegIdx(_numSrcRegs++, " + srcRegId + ");\n"
     def tailMaskCondSetSrcWrapper(setSrcRegCode):
-        return f'''
-        if (!_machInst.vtype8.vta || (!_machInst.vm && !_machInst.vtype8.vma))
-            {setSrcRegCode}
-        '''
+        return "if (!_machInst.vtype8.vta || (!_machInst.vm " \
+            + "&& !_machInst.vtype8.vma)) {\n" \
+            + "oldDstIdx = _numSrcRegs;\n" \
+            + setSrcRegCode \
+            + "}\n"
     def setSrcVm():
         return "if (!this->vm)\n" + \
                "    setSrcRegIdx(_numSrcRegs++, vecRegClass[0]);"
@@ -1456,7 +1457,7 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
 let {{
 
 def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
-        decode_template, micro_execute_template):
+        decode_template, micro_execute_template, offset_code=''):
     macroop_class_name = 'VectorSlideMacroInst'
     microop_class_name = 'VectorSlideMicroInst'
     # Make sure flags are in lists (convert to lists if not).
@@ -1472,29 +1473,34 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
         Name,
         macroop_class_name,
        {'code': code,
-        'declare_varith_template': varith_macro_declare},
+        'declare_varith_template': varith_macro_declare,
+        'offset_code': offset_code},
         flags
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd + vdIdx]"
-    src2_reg_id = "vecRegClass[VecMemInternalReg0 + vs2Idx]"
+
+    set_src_reg_idx = ""
+
+    src2_reg_id = "vecRegClass[(_copyVs ? VecMemInternalReg0 " \
+        + ": _machInst.vs2) + vs2Idx]"
+    src3_reg_id = "vecRegClass[(_copyVs ? VecMemInternalReg0 " \
+        + ": _machInst.vs2) + vs3Idx]"
     src1_ireg_id = "intRegClass[_machInst.rs1]"
     src1_freg_id = "floatRegClass[_machInst.rs1]"
 
-    num_src_regs = 0
-
-    set_src_reg_idx = ""
-    if category in ["OPIVX", "OPMVX"]:
+    if category == "OPIVX":
         set_src_reg_idx += setSrcWrapper(src1_ireg_id)
-        num_src_regs += 1
     elif category in ["OPFVF"]:
         set_src_reg_idx += setSrcWrapper(src1_freg_id)
-        num_src_regs += 1
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    num_src_regs += 1
+    set_src_reg_idx += setSrcWrapper(src3_reg_id)
+
+    if name not in ["vslideup_vx", "vslidedown_vx"]:
+        set_src_reg_idx += tailMaskCondSetSrcWrapper( \
+            setSrcWrapper(dest_reg_id))
+
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
-    vm_decl_rd = vmDeclAndReadData()
-    set_src_reg_idx += setSrcVm()
     set_vlenb = setVlenb()
 
     if decode_template is VectorIntDecodeBlock:
@@ -1510,7 +1516,6 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
-         'vm_decl_rd': vm_decl_rd,
          'declare_varith_template': varith_micro_declare},
         flags)
 
@@ -1535,6 +1540,26 @@ def format VectorSlideUpFormat(code, category, *flags) {{
             micro_execute_template = VectorSlideMicroExecute)
 }};
 
+def format VectorSlide1UpFormat(code, category, *flags) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        VectorSlideBase(name, Name, category, code,
+            flags,
+            macro_construtor = VectorSlideUpImmediateMacroConstructor,
+            decode_template = VectorIntDecodeBlock,
+            micro_execute_template = VectorSlideMicroExecute,
+            offset_code = 'int offset = 1')
+}};
+
+def format VectorSlideUpVIFormat(code, category, *flags) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        VectorSlideBase(name, Name, category, code,
+            flags,
+            macro_construtor = VectorSlideUpImmediateMacroConstructor,
+            decode_template = VectorIntDecodeBlock,
+            micro_execute_template = VectorSlideMicroExecute,
+            offset_code = 'int offset = (int)(uint64_t)(SIMM5);')
+}};
+
 def format VectorSlideDownFormat(code, category, *flags) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         VectorSlideBase(name, Name, category, code,
@@ -1544,20 +1569,42 @@ def format VectorSlideDownFormat(code, category, *flags) {{
             micro_execute_template = VectorSlideMicroExecute)
 }};
 
+def format VectorSlide1DownFormat(code, category, *flags) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        VectorSlideBase(name, Name, category, code,
+            flags,
+            macro_construtor = VectorSlideDownImmediateMacroConstructor,
+            decode_template = VectorIntDecodeBlock,
+            micro_execute_template = VectorSlideMicroExecute,
+            offset_code = 'int offset = 1')
+}};
+
+def format VectorSlideDownVIFormat(code, category, *flags) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        VectorSlideBase(name, Name, category, code,
+            flags,
+            macro_construtor = VectorSlideDownImmediateMacroConstructor,
+            decode_template = VectorIntDecodeBlock,
+            micro_execute_template = VectorSlideMicroExecute,
+            offset_code = 'int offset = (int)(uint64_t)(SIMM5);')
+}};
+
 def format VectorFloatSlideUpFormat(code, category, *flags) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         VectorSlideBase(name, Name, category, code,
             flags,
-            macro_construtor = VectorSlideUpMacroConstructor,
+            macro_construtor = VectorSlideUpImmediateMacroConstructor,
             decode_template = VectorFloatDecodeBlock,
-            micro_execute_template = VectorFloatSlideMicroExecute)
+            micro_execute_template = VectorFloatSlideMicroExecute,
+            offset_code = 'int offset = 1')
 }};
 
 def format VectorFloatSlideDownFormat(code, category, *flags) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         VectorSlideBase(name, Name, category, code,
             flags,
-            macro_construtor = VectorSlideDownMacroConstructor,
+            macro_construtor = VectorSlideDownImmediateMacroConstructor,
             decode_template = VectorFloatDecodeBlock,
-            micro_execute_template = VectorFloatSlideMicroExecute)
+            micro_execute_template = VectorFloatSlideMicroExecute,
+            offset_code = 'int offset = 1')
 }};

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2586,7 +2586,7 @@ Fault
 
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);
-  
+
     bool set_dirty = true;
     bool check_vill = true;
     Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -40,6 +40,20 @@ output header {{
         tmp_d0.set(0xff);                                                 \
     }                                                                     \
 
+#define SET_VM_SRC() \
+    if (!_machInst.vm) { \
+        vmsrcIdx = _numSrcRegs; \
+        setSrcRegIdx(_numSrcRegs++, vecRegClass[0]); \
+    }
+
+#define VM_REQUIRED() \
+    [[maybe_unused]] RiscvISA::vreg_t tmp_v0; \
+    [[maybe_unused]] uint8_t *v0; \
+    if(!machInst.vm) { \
+        xc->getRegOperand(this, vmsrcIdx, &tmp_v0); \
+        v0 = tmp_v0.as<uint8_t>(); \
+    }
+
 #define VRM_REQUIRED                                                         \
         uint_fast8_t frm = xc->readMiscReg(MISCREG_FRM);                     \
         if (frm > 4)                                                         \
@@ -2400,24 +2414,92 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
 
-    for (uint32_t i = 0; i < ceil((float) this->vl/micro_vlmax); i++) {
-        microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen, vlen);
-        microop->setFlag(IsDelayedCommit);
-        this->microops.push_back(microop);
+    uint32_t vs2_end = machInst.vs2 + num_microops - 1;
+    uint32_t vd_end = machInst.vd + num_microops - 1;
+    bool overlap = (machInst.vs2 >= machInst.vd && machInst.vs2 <= vd_end)
+        || (vs2_end >= machInst.vd && vs2_end <= vd_end);
+    bool need_pin = overlap || num_microops > 2;
 
-        microop = new VPinVdMicroInst(machInst, i, i+1, elen, vlen, true);
+    for (int i = 0; need_pin && i < ceil((float) this->vl/micro_vlmax); i++) {
+        microop = new VPinVdMicroInst(machInst, i, std::max(i, 1), elen, vlen,
+                                      true, overlap, machInst.vs2 + i);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
 
-    // Todo static filter out useless uop
     int micro_idx = 0;
+    uint32_t vsIdxMax =
+        (1 << std::max<int64_t>(0, vtype_vlmul(_machInst.vtype8))) - 1;
+
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        for (int j = 0; j <= i; ++j) {
+        for (int j = 0; j <= std::max(i - 1, 0); ++j) {
+            uint32_t vs2Idx = j;
+            uint32_t vs3Idx = (j == vsIdxMax) ? j : j + 1;
+
             microop = new %(class_name)sMicro<ElemType>(
-                _machInst, micro_vl, micro_idx++, i, j, _elen, _vlen);
+                _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
+                _vlen, true, j == (std::max(i - 1, 0) - 1), false, overlap);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
+        }
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+    }
+    this->microops.front()->setFirstMicroop();
+    this->microops.back()->setLastMicroop();
+}
+
+%(declare_varith_template)s;
+
+}};
+
+def template VectorSlideUpImmediateMacroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
+{
+    %(set_reg_idx_arr)s;
+    %(constructor)s;
+    const uint32_t num_microops = vtype_regs_per_group(vtype);
+    int32_t tmp_vl = this->vl;
+    const int32_t micro_vlmax = vtype_VLMAX(_machInst.vtype8, vlen, true);
+    int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
+    StaticInstPtr microop;
+
+    if (micro_vl == 0) {
+        microop = new VectorNopMicroInst(_machInst);
+        this->microops.push_back(microop);
+    }
+
+    %(offset_code)s;
+
+    int micro_idx = 0;
+    uint32_t vsIdxMax = (1 << std::max<int64_t>(0,
+        vtype_vlmul(_machInst.vtype8))) - 1;
+
+    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+        for (int j = 0; j <= std::max(i - 1, 0); ++j) {
+            uint32_t vs2Idx = j;
+            uint32_t vs3Idx = (j == vsIdxMax) ? j : j + 1;
+
+            int vdWindowLeft = micro_vlmax * i;
+            int vdWindowRight = micro_vlmax * (i + 1);
+            int vs2WindowLeft = micro_vlmax * j + offset;
+            int vs3WindowLeft = micro_vlmax * (j + 1) + offset;
+            bool copyAll = vs3WindowLeft >= vdWindowLeft && vs3WindowLeft
+                < vdWindowRight;
+            bool copyBack = j == 0 && vs2WindowLeft >= vdWindowLeft
+                && vs2WindowLeft < vdWindowRight;
+            // Static filter out useless uop
+            if (copyAll || copyBack || j == std::max(i - 1, 0)) {
+                microop = new %(class_name)sMicro<ElemType>(
+                    _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
+                    _vlen, true, j == (std::max(i - 1, 0) - 1));
+                microop->setDelayedCommit();
+                this->microops.push_back(microop);
+                break;
+            }
         }
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
@@ -2438,7 +2520,7 @@ template<typename ElemType>
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
-    const uint32_t num_microops = vtype_regs_per_group(vtype);
+    const int num_microops = vtype_regs_per_group(vtype);
     int32_t tmp_vl = this->vl;
     const int32_t micro_vlmax = vtype_VLMAX(_machInst.vtype8, vlen, true);
     int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
@@ -2449,25 +2531,98 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
 
-    for (uint32_t i = 0; i < ceil((float) this->vl / micro_vlmax); i++) {
-        microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen, vlen);
-        microop->setFlag(IsDelayedCommit);
-        this->microops.push_back(microop);
+    uint32_t vs2_end = machInst.vs2 + num_microops - 1;
+    uint32_t vd_end = machInst.vd + num_microops - 1;
+    bool overlap = (machInst.vs2 >= machInst.vd && machInst.vs2 <= vd_end)
+        || (vs2_end >= machInst.vd && vs2_end <= vd_end);
+    bool need_pin = overlap || num_microops > 2;
 
-        microop = new VPinVdMicroInst(machInst, i, num_microops-i, elen, vlen,
-                                      false);
+    for (int i = 0; need_pin && i < ceil((float) this->vl / micro_vlmax);
+        i++) {
+        microop = new VPinVdMicroInst(machInst, i,
+            std::max(num_microops-i-1, 1), elen, vlen, false, overlap,
+            machInst.vs2 + i);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
 
-    // Todo static filter out useless uop
     int micro_idx = 0;
+    uint32_t vsIdxMax = (1 << std::max<int64_t>(0,
+        vtype_vlmul(_machInst.vtype8))) - 1;
+
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        for (int j = i; j < num_microops; ++j) {
+        for (int j = i; j < std::max(num_microops-1, 1) || i == j; ++j) {
+            uint32_t vs2Idx = j;
+            uint32_t vs3Idx = (j == vsIdxMax) ? j : j + 1;
+
             microop = new %(class_name)sMicro<ElemType>(
-                _machInst, micro_vl, micro_idx++, i, j, _elen, _vlen);
+                _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
+                _vlen, false, j >= (num_microops - 2), false, overlap);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
+        }
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+    }
+    this->microops.front()->setFirstMicroop();
+    this->microops.back()->setLastMicroop();
+}
+
+%(declare_varith_template)s;
+
+}};
+
+def template VectorSlideDownImmediateMacroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
+{
+    %(set_reg_idx_arr)s;
+    %(constructor)s;
+    const int num_microops = vtype_regs_per_group(vtype);
+    int32_t tmp_vl = this->vl;
+    const int32_t micro_vlmax = vtype_VLMAX(_machInst.vtype8, vlen, true);
+    int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
+    StaticInstPtr microop;
+
+    if (micro_vl == 0) {
+        microop = new VectorNopMicroInst(_machInst);
+        this->microops.push_back(microop);
+    }
+
+    %(offset_code)s;
+
+    int micro_idx = 0;
+    uint32_t vsIdxMax = (1 << std::max<int64_t>(0,
+        vtype_vlmul(_machInst.vtype8))) - 1;
+
+    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+        for (int j = i; j < std::max(num_microops-1, 1) || i == j; ++j) {
+            uint32_t vs2Idx = j;
+            uint32_t vs3Idx = (j == vsIdxMax) ? j : j + 1;
+
+            int vdWindowLeft = micro_vlmax * i;
+            int vdWindowRight = micro_vlmax * (i + 1);
+            int vs3WindowLeftSlide = micro_vlmax * vs3Idx - offset;
+            int vs3WindowRightSlide = micro_vlmax * (vs3Idx + 1) - offset;
+            bool copyFrontFromVs2 = vs3WindowLeftSlide > vdWindowLeft
+                && vs3WindowLeftSlide <= vdWindowRight;
+            bool lastUopForVd = j >= (num_microops - 2);
+            bool copyFrontFromVs3 = lastUopForVd && vs3WindowRightSlide
+                > vdWindowLeft && vs3WindowRightSlide <= vdWindowRight;
+            bool needZeroTail = lastUopForVd && vs3WindowRightSlide
+                <= vdWindowLeft;
+            // Static filter out useless uop
+            if (copyFrontFromVs2 || copyFrontFromVs3 || needZeroTail) {
+                microop = new %(class_name)sMicro<ElemType>(
+                    _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
+                    _vlen, false, lastUopForVd,
+                    i == (num_microops - 1) || micro_vl < micro_vlmax);
+                microop->setDelayedCommit();
+                this->microops.push_back(microop);
+                break;
+            }
         }
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
@@ -2487,13 +2642,17 @@ class %(class_name)s : public %(base_class)s
 private:
     // vs2, vs1, vm for *.vv, *.vx
     // vs2, vm for *.vi
-    RegId srcRegIdxArr[3];
+    RegId srcRegIdxArr[5];
     RegId destRegIdxArr[1];
     bool vm;
+    bool lastUopForVd;
+    bool lastUop;
+    bool slideUp;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-        uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx, uint32_t _elen,
-        uint32_t _vlen);
+        uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx,
+        uint32_t _vs3Idx, uint32_t _elen, uint32_t _vlen, bool _slideUp,
+        bool _lastUopForVd, bool _lastUop=false, bool _copyVs = false);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2505,9 +2664,13 @@ def template VectorSlideMicroConstructor {{
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
         uint32_t _microVl, uint32_t _microIdx, uint32_t _vdIdx,
-        uint32_t _vs2Idx, uint32_t _elen, uint32_t _vlen)
+        uint32_t _vs2Idx, uint32_t _vs3Idx, uint32_t _elen, uint32_t _vlen,
+        bool _slideUp, bool _lastUopForVd, bool _lastUop, bool _copyVs)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
-        _microIdx, _vdIdx, _vs2Idx, _elen, _vlen)
+        _microIdx, _vdIdx, _vs2Idx, _vs3Idx, _elen, _vlen),
+      lastUopForVd(_lastUopForVd),
+      lastUop(_lastUop),
+      slideUp(_slideUp)
 {
     this->vm = _machInst.vm;
     %(set_reg_idx_arr)s;
@@ -2515,6 +2678,7 @@ template<typename ElemType>
     _numDestRegs = 0;
     %(set_dest_reg_idx)s;
     %(set_src_reg_idx)s;
+    SET_VM_SRC();
 }
 
 %(declare_varith_template)s;
@@ -2540,6 +2704,22 @@ Fault
     if (machInst.vill)
         return std::make_shared<IllegalInstFault>("VILL is set", machInst);
 
+    uint32_t num_microops = vtype_regs_per_group(vtype);
+    if (slideUp || num_microops > 1) {
+        uint32_t vs2_end = machInst.vs2 + num_microops - 1;
+        uint32_t vd_end = machInst.vd + num_microops - 1;
+        bool overlap = (machInst.vs2 >= machInst.vd && machInst.vs2 <= vd_end)
+            || (vs2_end >= machInst.vd && vs2_end <= vd_end);
+        if (overlap && slideUp) {
+            return std::make_shared<IllegalInstFault>(
+                "Regs overlap is not allowed for vslideup", machInst);
+        } else if (overlap && !slideUp) {
+            return std::make_shared<IllegalInstFault>(
+                "Regs overlap is not allowed for vslidedown when lmul > 1",
+                machInst);
+        }
+    }
+
     status.vs = VPUStatus::DIRTY;
     xc->setMiscReg(MISCREG_STATUS, status);
 
@@ -2549,7 +2729,7 @@ Fault
 
     [[maybe_unused]]const uint32_t vlmax = vtype_VLMAX(vtype, vlen);
 
-    %(vm_decl_rd)s;
+    VM_REQUIRED();
     %(code)s;
     %(op_wb)s;
 
@@ -2588,7 +2768,7 @@ Fault
 
     [[maybe_unused]]const uint32_t vlmax = vtype_VLMAX(vtype, vlen);
 
-    %(vm_decl_rd)s;
+    VM_REQUIRED();
     %(code)s;
     %(op_wb)s;
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2564,10 +2564,6 @@ Fault
     using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
     using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
 
-
-    if (machInst.vill)
-        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
-
     uint32_t num_microops = vtype_regs_per_group(vtype);
     if (slideUp || num_microops > 1) {
         uint32_t vs2_end = machInst.vs2 + num_microops - 1;
@@ -2583,9 +2579,6 @@ Fault
                 machInst);
         }
     }
-
-    status.vs = VPUStatus::DIRTY;
-    xc->setMiscReg(MISCREG_STATUS, status);
 
     bool set_dirty = true;
     bool check_vill = true;


### PR DESCRIPTION
This PR fixed incorrect vector slide instructions mentioned in #1667.

And statically filter redundant uops for vslideup.vi/vslidedown.vi/vslide1up.vx /vsilde1down.vx/vfslide1up.vf/vfslide1down.vf instructions to improve performance.

Change-Id: I1ba36f216f0bb55372206a94b7f8108acc674f5a