### PR TITLE
arch-arm: Replace translateAtomic with translateFunctional in AT

### DIFF
--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -2593,7 +2593,7 @@ AtOp64::addressTranslation64(ThreadContext* tc,
         val, 0, flags,  Request::funcRequestorId,
         tc->pcState().instAddr(), tc->contextId());
 
-    Fault fault = getMMUPtr(tc)->translateAtomic(
+    Fault fault = getMMUPtr(tc)->translateFunctional(
         req, tc, mode, tran_type);
 
     PAR par = 0;


### PR DESCRIPTION
A previous PR mistakenly [1] replaced translateFunctional with translateAtomic. This commit is reverting that

[1]: https://github.com/gem5/gem5/pull/1697

Change-Id: I945c3fe59cea36732d9f30109b950d4114aa8fad