### PR TITLE
util-docker: Add RISCV to Ubuntu all-deps Docker platforms

### DIFF
--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -190,6 +190,7 @@ group "ubuntu-releases" {
 
 target "ubuntu-24-04_all-dependencies" {
   inherits = ["common"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/riscv64"]
   annotations = ["index,manifest:org.opencontainers.image.description=An Ubuntu 24.04 image with all dependencies required for building and running gem5."]
   context = "ubuntu-24.04_all-dependencies"
   tags = ["${IMAGE_URI}/ubuntu-24.04_all-dependencies:${TAG}"]


### PR DESCRIPTION
I have re-implemented building this image to target RISC-V in addition to X86 and ARM. I have found it makes for quite a good cross compilation tool.