### PR TITLE
mem, tests: SimObject tester for replacement policies

### DIFF
--- a/src/mem/cache/replacement_policies/ReplacementPolicies.py
+++ b/src/mem/cache/replacement_policies/ReplacementPolicies.py
@@ -175,3 +175,14 @@ class WeightedLRURP(LRURP):
     type = "WeightedLRURP"
     cxx_class = "gem5::replacement_policy::WeightedLRU"
     cxx_header = "mem/cache/replacement_policies/weighted_lru_rp.hh"
+
+
+class SimObjectUnitTester(SimObject):
+    type = "SimObjectUnitTester"
+    cxx_header = "mem/cache/replacement_policies/sim_object_unit_tester.hh"
+    cxx_class = "gem5::replacement_policy::SimObjectUnitTester"
+
+    replacement_policy = Param.BaseReplacementPolicy(
+        "Replacement policy to test"
+    )
+    num_entries = Param.Int("Total number of entries to instantiate")

--- a/src/mem/cache/replacement_policies/ReplacementPolicies.py
+++ b/src/mem/cache/replacement_policies/ReplacementPolicies.py
@@ -186,3 +186,15 @@ class SimObjectUnitTester(SimObject):
         "Replacement policy to test"
     )
     num_entries = Param.Int("Total number of entries to instantiate")
+    name = Param.String("Name of replacement policy")
+
+
+# class FIFOTester(SimObject):
+#     type = "FIFOTester"
+#     cxx_header = "mem/cache/replacement_policies/sim_object_unit_tester.hh"
+#     cxx_class = "gem5::replacement_policy::FIFOTester"
+
+# class LRUTester(SimObject):
+#     type = "LRUTester"
+#     cxx_header = "mem/cache/replacement_policies/sim_object_unit_tester.hh"
+#     cxx_class = "gem5::replacement_policy::LRUTester"

--- a/src/mem/cache/replacement_policies/fifo_rp.hh
+++ b/src/mem/cache/replacement_policies/fifo_rp.hh
@@ -49,6 +49,7 @@ namespace replacement_policy
 
 class FIFO : public Base
 {
+  friend class SimObjectUnitTester;
   protected:
     /** FIFO-specific implementation of replacement data. */
     struct FIFOReplData : ReplacementData

--- a/src/mem/cache/replacement_policies/fifo_rp.hh
+++ b/src/mem/cache/replacement_policies/fifo_rp.hh
@@ -49,7 +49,9 @@ namespace replacement_policy
 
 class FIFO : public Base
 {
+  friend class FIFOTester;
   friend class SimObjectUnitTester;
+
   protected:
     /** FIFO-specific implementation of replacement data. */
     struct FIFOReplData : ReplacementData

--- a/src/mem/cache/replacement_policies/lru_rp.hh
+++ b/src/mem/cache/replacement_policies/lru_rp.hh
@@ -47,6 +47,8 @@ namespace replacement_policy
 
 class LRU : public Base
 {
+  friend class LRUTester;
+  friend class SimObjectUnitTester;
   protected:
     /** LRU-specific implementation of replacement data. */
     struct LRUReplData : ReplacementData

--- a/src/mem/cache/replacement_policies/sim_object_unit_tester.cc
+++ b/src/mem/cache/replacement_policies/sim_object_unit_tester.cc
@@ -1,0 +1,99 @@
+#include "mem/cache/replacement_policies/sim_object_unit_tester.hh"
+
+#include <iostream>
+
+#include "base/trace.hh"
+#include "mem/cache/replacement_policies/fifo_rp.hh"
+#include "mem/cache/replacement_policies/replaceable_entry.hh"
+
+namespace gem5
+{
+namespace replacement_policy
+{
+
+SimObjectUnitTester::SimObjectUnitTester(
+  const SimObjectUnitTesterParams& params):
+  SimObject(params),
+  nextEvent([this](){ processNextEvent(); }, name() + "nextEvent"),
+  replacement_policy(params.replacement_policy),
+  numEntries(params.num_entries)
+{}
+
+void
+SimObjectUnitTester::processNextEvent()
+{
+  std::cout << "tick: " << curTick() <<
+  ", Hello from SimObjectUnitTester::processNextEvent!" << std::endl;
+
+  // create a new entry and put it in candidates
+  ReplaceableEntry* temp = new ReplaceableEntry();
+  temp->replacementData = replacement_policy->instantiateEntry();
+  replacement_policy->reset(temp->replacementData); // record insertion tick
+  // std::cout<< "Inserted tick: " <<
+  //std::static_pointer_cast<FIFO::FIFOReplData>(temp->replacementData)
+  //->tickInserted <<std::endl;
+  candidates.push_back(temp);
+
+  if (numEntries > 0){
+    schedule(nextEvent, curTick() + 500);
+    numEntries--;
+  }
+  else {
+    // FIFO* tmp;
+    bool correct = checkCorrectness(/*tmp*/);
+    // free memory
+    for (const auto& candidate : candidates) {
+      delete candidate;
+    }
+    if (correct){
+      exit(0);
+    }
+    exit(1);
+  }
+}
+
+bool
+SimObjectUnitTester::checkCorrectness(/*FIFO* */){
+  ReplaceableEntry* victim = replacement_policy->getVictim(candidates);
+  if (std::static_pointer_cast<FIFO::FIFOReplData>(
+    victim ->replacementData)->tickInserted != 1){
+
+    std::cout<<"tick: "<<std::static_pointer_cast<FIFO::FIFOReplData>(
+      victim ->replacementData)->tickInserted <<std::endl;
+    return false;
+  }
+  return true;
+}
+
+  // template <>
+  // bool
+  // SimObjectUnitTester::checkCorrectness<FIFO>(){
+  //   ReplaceableEntry* victim = replacement_policy->getVictim(candidates);
+  //   if (std::static_pointer_cast<FIFO::FIFOReplData>(victim
+  //->replacementData)->tickInserted != 1){
+  //     std::cout<<"tick: "<<std::static_pointer_cast<FIFO::FIFOReplData>
+  //(victim ->replacementData)->tickInserted <<std::endl;
+  //     return false;
+  //   }
+  //   return true;
+  // }
+
+  // template <>
+  // bool
+  // SimObjectUnitTester::checkCorrectness<Base>(){
+  //   return false;
+  // }
+
+
+void
+SimObjectUnitTester::startup()
+{
+  panic_if(curTick() != 0, "startup() called at a tick other than 0");
+  panic_if(nextEvent.scheduled(),
+  "nextEvent scheduled before startup() called! ");
+  schedule(nextEvent, curTick() + 500);
+}
+
+} //namespace replacement_policy
+
+} // namespace gem5

--- a/src/mem/cache/replacement_policies/sim_object_unit_tester.hh
+++ b/src/mem/cache/replacement_policies/sim_object_unit_tester.hh
@@ -1,0 +1,44 @@
+#ifndef __MEM_CACHE_REPLACEMENT_POLICIES_SIM_OBJECT_UNIT_TESTER_HH__
+#define __MEM_CACHE_REPLACEMENT_POLICIES_SIM_OBJECT_UNIT_TESTER_HH__
+
+#include "mem/cache/replacement_policies/base.hh"
+#include "mem/cache/replacement_policies/fifo_rp.hh"
+#include "mem/cache/replacement_policies/lru_rp.hh"
+#include "mem/cache/replacement_policies/replaceable_entry.hh"
+#include "params/SimObjectUnitTester.hh"
+#include "sim/eventq.hh"
+#include "sim/sim_object.hh"
+
+// For now, focus on implementing something for the FIFO replacement policy
+namespace gem5
+{
+
+namespace replacement_policy{
+
+class SimObjectUnitTester : public SimObject
+{
+  private:
+  EventFunctionWrapper nextEvent;
+  // the type of ReplacementCandidates is std::vector<ReplaceableEntry*>
+  ReplacementCandidates candidates;
+  replacement_policy::Base* replacement_policy;
+  int numEntries;
+
+  void processNextEvent();
+  bool checkCorrectness(/*FIFO* */);
+  // bool checkCorrectness(LRU*);
+  // bool checkCorrectness(Base*);
+
+  // template<class T>
+  // bool checkCorrectness();
+
+public:
+  SimObjectUnitTester(const SimObjectUnitTesterParams& params);
+  virtual void startup() override;
+};
+
+} //namespace replacement_policy
+
+} //namespace gem5
+
+#endif // __SIM_OBJECT_UNIT_TESTER_SIM_OBJECT_UNIT_TESTER_HH__

--- a/src/mem/cache/replacement_policies/sim_object_unit_tester.hh
+++ b/src/mem/cache/replacement_policies/sim_object_unit_tester.hh
@@ -18,24 +18,43 @@ namespace replacement_policy{
 class SimObjectUnitTester : public SimObject
 {
   private:
-  EventFunctionWrapper nextEvent;
+    EventFunctionWrapper nextEvent;
+  protected:
   // the type of ReplacementCandidates is std::vector<ReplaceableEntry*>
   ReplacementCandidates candidates;
-  replacement_policy::Base* replacement_policy;
+  replacement_policy::Base* replacementPolicy;
   int numEntries;
+  std::string replacementPolicyName;
 
   void processNextEvent();
-  bool checkCorrectness(/*FIFO* */);
-  // bool checkCorrectness(LRU*);
-  // bool checkCorrectness(Base*);
 
-  // template<class T>
-  // bool checkCorrectness();
+  bool checkCorrectness(FIFO*);
+  bool checkCorrectness(LRU*);
+  // bool checkCorrectnessFIFO();
+  // bool checkCorrectnessLRU();
+  bool checkCorrectness(Base*);
+
+  // virtual bool checkCorrectness();
+
+  void freeCandidates();
 
 public:
   SimObjectUnitTester(const SimObjectUnitTesterParams& params);
   virtual void startup() override;
 };
+
+
+// class FIFOTester : public SimObjectUnitTester{
+//   private:
+//     virtual bool checkCorrectness() override;
+// };
+
+// class LRUTester : public SimObjectUnitTester{
+//   private:
+//     virtual bool checkCorrectness() override;
+// };
+
+
 
 } //namespace replacement_policy
 

--- a/tests/gem5/sim-object-unit-tester/README.md
+++ b/tests/gem5/sim-object-unit-tester/README.md
@@ -1,0 +1,4 @@
+To run this suite of tests, run the following command in the tests directory:
+```
+./main.py run -vvv  gem5/sim-object-unit-tester/ -j 20
+```

--- a/tests/gem5/sim-object-unit-tester/configs/first.py
+++ b/tests/gem5/sim-object-unit-tester/configs/first.py
@@ -1,0 +1,19 @@
+import m5
+from m5.objects.ReplacementPolicies import (
+    FIFORP,
+    SimObjectUnitTester,
+)
+from m5.objects.Root import Root
+
+# , GoodByeSimObject
+
+
+root = Root(full_system=False)
+root.unit_tester = SimObjectUnitTester(num_entries=2)
+root.unit_tester.replacement_policy = FIFORP()
+# root.unit_tester.goodbye_object = GoodByeSimObject()
+
+m5.instantiate()
+exit_event = m5.simulate()
+
+print(f"Exited simulation because: {exit_event.getCause()}")

--- a/tests/gem5/sim-object-unit-tester/configs/lru.py
+++ b/tests/gem5/sim-object-unit-tester/configs/lru.py
@@ -1,6 +1,6 @@
 import m5
 from m5.objects.ReplacementPolicies import (
-    FIFORP,
+    LRURP,
     SimObjectUnitTester,
 )
 from m5.objects.Root import Root
@@ -9,9 +9,9 @@ from m5.objects.Root import Root
 
 
 root = Root(full_system=False)
-root.unit_tester = SimObjectUnitTester(num_entries=2)
-root.unit_tester.replacement_policy = FIFORP()
-root.unit_tester.name = "FIFO"
+root.unit_tester = SimObjectUnitTester(num_entries=3)
+root.unit_tester.replacement_policy = LRURP()
+root.unit_tester.name = "LRU"
 # root.unit_tester.goodbye_object = GoodByeSimObject()
 
 m5.instantiate()

--- a/tests/gem5/sim-object-unit-tester/test_sim_object_unit_test.py
+++ b/tests/gem5/sim-object-unit-tester/test_sim_object_unit_test.py
@@ -42,3 +42,20 @@ gem5_verify_config(
     valid_isas=(constants.all_compiled_tag,),
     length=constants.quick_tag,
 )
+
+gem5_verify_config(
+    name="lru",
+    fixtures=(),
+    verifiers=[],
+    config=joinpath(
+        config.base_dir,
+        "tests",
+        "gem5",
+        "sim-object-unit-tester",
+        "configs",
+        "lru.py",
+    ),
+    config_args=[],
+    valid_isas=(constants.all_compiled_tag,),
+    length=constants.quick_tag,
+)

--- a/tests/gem5/sim-object-unit-tester/test_sim_object_unit_test.py
+++ b/tests/gem5/sim-object-unit-tester/test_sim_object_unit_test.py
@@ -1,6 +1,4 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2018 Inria
+# Copyright (c) 2024 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,27 +24,21 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from testlib import *
 
-SimObject('ReplacementPolicies.py', sim_objects=[
-    'BaseReplacementPolicy', 'DuelingRP', 'FIFORP', 'SecondChanceRP',
-    'LFURP', 'LRURP', 'BIPRP', 'MRURP', 'RandomRP', 'BRRIPRP', 'SHiPRP',
-    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP',
-    "SimObjectUnitTester"])
-
-Source('bip_rp.cc')
-Source('brrip_rp.cc')
-Source('dueling_rp.cc')
-Source('fifo_rp.cc')
-Source('lfu_rp.cc')
-Source('lru_rp.cc')
-Source('mru_rp.cc')
-Source('random_rp.cc')
-Source('second_chance_rp.cc')
-Source('ship_rp.cc')
-Source('tree_plru_rp.cc')
-Source('weighted_lru_rp.cc')
-Source("sim_object_unit_tester.cc")
-
-
-GTest('replaceable_entry.test', 'replaceable_entry.test.cc')
+gem5_verify_config(
+    name="first",
+    fixtures=(),
+    verifiers=[],
+    config=joinpath(
+        config.base_dir,
+        "tests",
+        "gem5",
+        "sim-object-unit-tester",
+        "configs",
+        "first.py",
+    ),
+    config_args=[],
+    valid_isas=(constants.all_compiled_tag,),
+    length=constants.quick_tag,
+)


### PR DESCRIPTION
This PR adds a SimObject that tests the FIFO replacement policy. It initializes several entries, evicts an entry, and checks that the evicted entry was the first to be created, indicating that the replacement policy behaves correctly.

I am still working on getting this change to work with several replacement policies.