### PR TITLE
base: Remove DPRINTF_UNCONDITIONAL

### DIFF
--- a/src/base/trace.hh
+++ b/src/base/trace.hh
@@ -195,7 +195,6 @@ struct StringWrap
  * \def DPRINTFV(x, ...)
  * \def DPRINTFN(...)
  * \def DPRINTFNR(...)
- * \def DPRINTF_UNCONDITIONAL(x, ...) (deprecated)
  *
  * @ingroup api_trace
  * @{
@@ -248,16 +247,6 @@ struct StringWrap
             (::gem5::Tick)-1, "", __VA_ARGS__); \
     }                                                                \
 } while (0)
-
-#define DPRINTF_UNCONDITIONAL(x, ...)                      \
-    GEM5_DEPRECATED_MACRO_STMT(DPRINTF_UNCONDITIONAL,      \
-    do {                                                   \
-        if (TRACING_ON) {                                  \
-            ::gem5::trace::getDebugLogger()->dprintf_flag(         \
-                ::gem5::curTick(), name(), #x, __VA_ARGS__);       \
-        }                                                  \
-    } while (0),                                           \
-    "Use DPRINTFN or DPRINTF with a debug flag instead.")
 
 /** @} */ // end of api_trace
 

--- a/src/base/trace.test.cc
+++ b/src/base/trace.test.cc
@@ -633,34 +633,6 @@ TEST(TraceTest, MacroDPRINTFNR)
 #endif
 }
 
-/** Test DPRINTF_UNCONDITIONAL with tracing on. */
-TEST(TraceTest, MacroDPRINTF_UNCONDITIONAL)
-{
-    StringWrap name("Foo");
-
-    // Flag enabled
-    trace::enable();
-    EXPECT_TRUE(debug::changeFlag("TraceTestDebugFlag", true));
-    EXPECT_TRUE(debug::changeFlag("FmtFlag", true));
-    DPRINTF_UNCONDITIONAL(TraceTestDebugFlag, "Test message");
-#if TRACING_ON
-    ASSERT_EQ(getString(trace::output()),
-        "      0: TraceTestDebugFlag: Foo: Test message");
-#else
-    ASSERT_EQ(getString(trace::output()), "");
-#endif
-
-    // Flag disabled
-    trace::disable();
-    EXPECT_TRUE(debug::changeFlag("TraceTestDebugFlag", false));
-    DPRINTF_UNCONDITIONAL(TraceTestDebugFlag, "Test message");
-#if TRACING_ON
-    ASSERT_EQ(getString(trace::output()), "      0: Foo: Test message");
-#else
-    ASSERT_EQ(getString(trace::output()), "");
-#endif
-}
-
 /**
  * Test that there is a global name() to fall through when a locally scoped
  * name() is not defined.


### PR DESCRIPTION
This macro has been marked as deprecated since 2021. Wrap its deprecation process up.