### PR TITLE
util-docker: Add qemu-riscv-env Dockerfile

### DIFF
--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -49,6 +49,7 @@ target "common" {
 # `docker buildx bake --push ubuntu-releases`.
 group "default" {
   targets=[
+    "qemu-riscv-env",
     "clang-compilers",
     "gcc-compilers",
     "ubuntu-releases",
@@ -59,6 +60,14 @@ group "default" {
     "devcontainer"
   ]
 }
+
+target "qemu-riscv-env" {
+  inherits = ["common"]
+  annotations = ["index,manifest:org.opencontainers.image.description=An image capable of running a RISC-V QEMU simulation. Used to build RISC-V disk images for gem5-resources."]
+  context = "qemu-riscv-env"
+  tags = ["${IMAGE_URI}/qemu-riscv-env:${TAG}"]
+}
+
 
 group "clang-compilers" {
   targets = [

--- a/util/dockerfiles/qemu-riscv-env/Dockerfile
+++ b/util/dockerfiles/qemu-riscv-env/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM ubuntu:24.04
+
+LABEL org.opencontainers.image.source=https://github.com/gem5/gem5
+LABEL org.opencontainers.image.licenses=BSD-3-Clause
+
+RUN apt -y update && apt -y install \
+    u-boot-qemu \
+    qemu-system-misc \
+    opensbi \
+    qemu-utils \
+    git \
+    wget \
+    unzip \
+    pipewire \
+    pipewire-audio-client-libraries


### PR DESCRIPTION
Adds "util/dockerfiles/qemu-riscv-env/Dockerfile"; used to build ghcr.io/gem5/qemu-riscv-env:latest using the build instructions outlined in the Docker bake file "util/dockerfiles/docker-bake.hcl".

This image contains the dependencies necessary to run a RISC-V QEMU emulation which is used to create RISC-V Disk Image resources.

Docker image can be obtained with `docker pull ghcr.io/gem5/qemu-riscv-env:latest`