### PR TITLE
base: Make BaseGdbRegCache::data() non constant

### DIFF
--- a/src/arch/arm/remote_gdb.hh
+++ b/src/arch/arm/remote_gdb.hh
@@ -77,7 +77,7 @@ class RemoteGDB : public BaseRemoteGDB
           uint32_t fpscr;
         } r;
       public:
-        char *data() const override { return (char *)&r; }
+        char *data() override { return (char *)&r; }
         size_t size() const override { return sizeof(r); }
         void getRegs(ThreadContext*) override;
         void setRegs(ThreadContext*) const override;
@@ -103,7 +103,7 @@ class RemoteGDB : public BaseRemoteGDB
           uint32_t fpcr;
         } r;
       public:
-        char *data() const override { return (char *)&r; }
+        char *data() override { return (char *)&r; }
         size_t size() const override { return sizeof(r); }
         void getRegs(ThreadContext*) override;
         void setRegs(ThreadContext*) const override;

--- a/src/arch/mips/remote_gdb.hh
+++ b/src/arch/mips/remote_gdb.hh
@@ -66,7 +66,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint32_t fir;
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;

--- a/src/arch/power/remote_gdb.hh
+++ b/src/arch/power/remote_gdb.hh
@@ -68,7 +68,7 @@ class RemoteGDB : public BaseRemoteGDB
         } r;
 
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;
@@ -97,7 +97,7 @@ class RemoteGDB : public BaseRemoteGDB
         } r;
 
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;

--- a/src/arch/riscv/remote_gdb.hh
+++ b/src/arch/riscv/remote_gdb.hh
@@ -137,7 +137,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint32_t hip;
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;
@@ -220,7 +220,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint64_t hip;
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;

--- a/src/arch/sparc/remote_gdb.hh
+++ b/src/arch/sparc/remote_gdb.hh
@@ -66,7 +66,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint32_t csr;
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;
@@ -93,7 +93,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint64_t y;
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;

--- a/src/arch/x86/remote_gdb.hh
+++ b/src/arch/x86/remote_gdb.hh
@@ -83,7 +83,7 @@ class RemoteGDB : public BaseRemoteGDB
           uint32_t gs;
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;
@@ -131,7 +131,7 @@ class RemoteGDB : public BaseRemoteGDB
            */
         } r;
       public:
-        char *data() const { return (char *)&r; }
+        char *data() { return (char *)&r; }
         size_t size() const { return sizeof(r); }
         void getRegs(ThreadContext*);
         void setRegs(ThreadContext*) const;

--- a/src/base/remote_gdb.hh
+++ b/src/base/remote_gdb.hh
@@ -93,7 +93,7 @@ class BaseGdbRegCache
      *
      * @ingroup api_remote_gdb
      */
-    virtual char *data() const = 0;
+    virtual char *data() = 0;
 
     /**
      * Return the size of the raw buffer, in bytes


### PR DESCRIPTION
The method is defined as const but the caller will actually modify the content of the structure directly with the pointer in BaseRemoteGDB::cmdRegW. The member access in the const method are actually treated as const and will cause error if we use reinterpret_cast instead.

Remove the const tag to align the expectation of the virtual method.