### PR TITLE
arch-arm: Do not compute purifyTaggedAddr in checkPermissions

### DIFF
--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -507,9 +507,6 @@ MMU::checkPermissions64(TlbEntry *te, const RequestPtr &req, Mode mode,
     }
 
     Addr vaddr_tainted = req->getVaddr();
-    Addr vaddr = purifyTaggedAddr(vaddr_tainted, tc, state.exceptionLevel,
-        static_cast<TCR>(state.ttbcr), mode==Execute, state);
-
     Request::Flags flags = req->getFlags();
     bool is_fetch  = (mode == Execute);
     // Cache clean operations require read permissions to the specified VA
@@ -534,7 +531,7 @@ MMU::checkPermissions64(TlbEntry *te, const RequestPtr &req, Mode mode,
     // strongly ordered memory
     if (!is_fetch) {
         if (te->mtype != TlbEntry::MemoryType::Normal) {
-            if (vaddr & mask(flags & AlignmentMask)) {
+            if (vaddr_tainted & mask(flags & AlignmentMask)) {
                 stats.alignFaults++;
                 return std::make_shared<DataAbort>(
                     vaddr_tainted,


### PR DESCRIPTION
purifyTaggedAddr is known to be an expensive computation regardless of the memoization we do, as it sits in the critical path from a host performance point of view (instruction fetch).
In checkPermissions64 we compute it without really needing the tag purification. The only place where it is used is to check for PCAlignment, but the alignment checks the 3LSBs whereas a potential tag would be stored in the most significant ones

Change-Id: I9f39db658c3575dcbacb5351813ff9bb3775046d