### PR TITLE
stdlib: Add interface to set binary in fs mode

### DIFF
--- a/src/python/gem5/components/boards/kernel_disk_workload.py
+++ b/src/python/gem5/components/boards/kernel_disk_workload.py
@@ -37,6 +37,7 @@ import m5
 from m5.util import warn
 
 from ...resources.resource import (
+    BinaryResource,
     BootloaderResource,
     CheckpointResource,
     DiskImageResource,
@@ -215,21 +216,7 @@ class KernelDiskWorkload:
         if readfile:
             self.readfile = readfile
         elif readfile_contents:
-            # We hash the contents of the readfile and append it to the
-            # readfile name. This is to ensure that we don't overwrite the
-            # readfile if the contents are different.
-            readfile_contents_hash = hex(
-                hash(tuple(bytes(readfile_contents, "utf-8")))
-            )
-            self.readfile = os.path.join(
-                m5.options.outdir, ("readfile_" + readfile_contents_hash)
-            )
-
-        # Add the contents to the readfile, if specified.
-        if readfile_contents:
-            file = open(self.readfile, "w+")
-            file.write(readfile_contents)
-            file.close()
+            self._set_readfile_contents(readfile_contents)
 
         self._add_disk_to_board(disk_image=disk_image)
 
@@ -257,3 +244,47 @@ class KernelDiskWorkload:
         :param arg: The kernel argument to append.
         """
         self.workload.command_line += f" {arg}"
+
+    def _set_readfile_contents(self, readfile_contents: str) -> None:
+        # We hash the contents of the readfile and append it to the
+        # readfile name. This is to ensure that we don't overwrite the
+        # readfile if the contents are different.
+        readfile_contents_hash = hex(
+            hash(tuple(bytes(readfile_contents, "utf-8")))
+        )
+        self.readfile = os.path.join(
+            m5.options.outdir, ("readfile_" + readfile_contents_hash)
+        )
+
+        file = open(self.readfile, "w+")
+        file.write(readfile_contents)
+        file.close()
+
+    def set_binary_to_run(self, application: BinaryResource, args: List[str]):
+        """
+        Set the binary to run on the board.
+
+        The binary could be an application or any executable script.
+        Note: this will override the readfile or readfile_contents set in the
+        set_kernel_disk_workload function.
+
+        :param application: The binary to run.
+        :param args: The arguments to pass to the binary.
+        """
+        if self.readfile:
+            warn(
+                "Setting a binary to run will override the readfile "
+                "set in the set_kernel_disk_workload function."
+            )
+        from base64 import b64encode
+
+        with open(application.get_local_path(), "rb") as binfile:
+            encodedBin = b64encode(binfile.read()).decode()
+
+        application_command = (
+            f'echo "{encodedBin}" | base64 -d > myapp\n'
+            "chmod +x myapp\n"
+            f"./myapp {args}\n"
+        )
+
+        self._set_readfile_contents(application_command)


### PR DESCRIPTION
This change adds a `set_binary_to_run` function in the `KernelDiskWorkload` mixin. This function allows you to pass a binary that will be executed after boot when booting in FS mode. With this change, you can write code something like below to run a binary from the host on the simulated guest.

```python
board.set_workload(obtain_resource("x86-ubuntu-24.04-boot-no-systemd"))
board.set_binary_to_run(BinaryResource("/bin/ls"), "-l")
```

This will copy the file `/bin/ls` from the host to the gem5 guest and execute it with the `-l` argument.

Note: This function should only be used for testing. **This is not intended for use in experiments as it will make the experiments very difficult to reproduce!**

Inspiration/code from Matt Poremba.
See https://github.com/gem5/gem5/pull/1636