### PR TITLE
Add Python interface to get port actual name

### DIFF
--- a/src/sim/python.cc
+++ b/src/sim/python.cc
@@ -42,6 +42,7 @@ sim_pybind(pybind11::module_ &m_internal)
     pybind11::class_<
         Port, std::unique_ptr<Port, pybind11::nodelete>>(m, "Port")
         .def("bind", &Port::bind)
+        .def("name", &Port::name)
         ;
 }
 EmbeddedPyBind embed_("sim", &sim_pybind);


### PR DESCRIPTION
In our usecase, we'd like to intercept some gadgets in some gem5 ports, and register them to a Python-level collection. The registered name is the string from C++ constructor argument (portName), and it would be great if we can access that from Python-level as well. This commit enable this by exporting a py-binded method to access the portName.

Change-Id: I93398697536f27a52d3a1dd0e658fcb321b9e293