### PR TITLE
mem-ruby: Fix two NetDest locals using default constructor

### DIFF
--- a/src/mem/ruby/network/garnet/NetworkInterface.cc
+++ b/src/mem/ruby/network/garnet/NetworkInterface.cc
@@ -404,7 +404,7 @@ NetworkInterface::flitisizeMessage(MsgPtr msg_ptr, int vnet)
 
         Message *new_net_msg_ptr = new_msg_ptr.get();
         if (dest_nodes.size() > 1) {
-            NetDest personal_dest;
+            NetDest personal_dest(m_net_ptr->getRubySystem());
             for (int m = 0; m < (int) MachineType_NUM; m++) {
                 if ((destID >= MachineType_base_number((MachineType) m)) &&
                     destID < MachineType_base_number((MachineType) (m+1))) {

--- a/src/mem/ruby/slicc_interface/AbstractController.cc
+++ b/src/mem/ruby/slicc_interface/AbstractController.cc
@@ -502,7 +502,7 @@ AbstractController::broadcast(MachineType type)
     assert(m_ruby_system != nullptr);
     NodeID type_count = m_ruby_system->MachineType_base_count(type);
 
-    NetDest dest;
+    NetDest dest(m_ruby_system);
     for (NodeID i = 0; i < type_count; i++) {
         MachineID mach = {type, i};
         dest.add(mach);


### PR DESCRIPTION
Two NetDest locally declared variables are using default constructor instead of constructor with RubySystem pointer. This will cause asserts when (1) garnet is used or (2) a protocol that uses `broadcast()` is built.

Fix these two by passing the appropriate RubySystem pointers.