### PR TITLE
arch-riscv: sign-extend the PC when enter/leave trap handler

### DIFF
--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -160,7 +160,7 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
 
         // Set PC to fault handler address
         Addr addr = isa->getFaultHandlerAddr(tvec, _code, isInterrupt());
-        pc_state.set(addr);
+        pc_state.set(isa->rvSext(addr));
         tc->pcState(pc_state);
     } else {
         invokeSE(tc, inst);

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -124,10 +124,7 @@ class ISA : public BaseISA
     PCStateBase*
     newPCState(Addr new_inst_addr=0) const override
     {
-        if (_rvType == RV32) {
-            new_inst_addr = sext<32>(new_inst_addr);
-        }
-        return new PCState(new_inst_addr, _rvType);
+        return new PCState(rvSext(new_inst_addr), _rvType);
     }
 
   public:
@@ -196,6 +193,11 @@ class ISA : public BaseISA
 
     virtual Addr getFaultHandlerAddr(
         RegIndex idx, uint64_t cause, bool intr) const;
+
+    Addr rvSext(Addr addr) const
+    {
+        return (_rvType == RV32) ? sext<32>(addr) : addr;
+    }
 };
 
 } // namespace RiscvISA

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4852,7 +4852,7 @@ decode QUADRANT default Unknown::unknown() {
                             status.uie = status.upie;
                             status.upie = 1;
                             xc->setMiscReg(MISCREG_STATUS, status);
-                            NPC = xc->readMiscReg(MISCREG_UEPC);
+                            NPC = rvSext(xc->readMiscReg(MISCREG_UEPC));
                         }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
                     }
                     0x8: decode RS2 {
@@ -4878,7 +4878,7 @@ decode QUADRANT default Unknown::unknown() {
                                 status.spie = 1;
                                 status.spp = PRV_U;
                                 xc->setMiscReg(MISCREG_STATUS, status);
-                                NPC = xc->readMiscReg(MISCREG_SEPC);
+                                NPC = rvSext(xc->readMiscReg(MISCREG_SEPC));
                             }
                         }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
                         0x5: wfi({{
@@ -4948,7 +4948,7 @@ decode QUADRANT default Unknown::unknown() {
                             status.mpie = 1;
                             status.mpp = PRV_U;
                             xc->setMiscReg(MISCREG_STATUS, status);
-                            NPC = xc->readMiscReg(MISCREG_MEPC);
+                            NPC = rvSext(xc->readMiscReg(MISCREG_MEPC));
                         }
                     }}, IsSerializeAfter, IsNonSpeculative, IsReturn);
                 }


### PR DESCRIPTION
The PR https://github.com/gem5/gem5/pull/1316 changes the sign-extend address generation. We also need to sign-extend the address when setting the PC in enter/leave trap handler

Change-Id: I62d58a26dba0b0c64125fea8ac9376ebf55c4952