### PR TITLE
arch, cpu: Add generic getValidAddr to correct exetrace symbol table

### DIFF
--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -373,6 +373,20 @@ MMU::translateSe(const RequestPtr &req, ThreadContext *tc, Mode mode,
     }
 }
 
+Addr
+MMU::getValidAddr(Addr vaddr, ThreadContext *tc, Mode mode)
+{
+    auto& state = updateMiscReg(tc, NormalTran, false);
+    Addr purified_vaddr = 0;
+    if (state.aarch64) {
+        purified_vaddr = purifyTaggedAddr(vaddr, tc, state.exceptionLevel,
+            static_cast<TCR>(state.ttbcr), mode==Execute, state);
+    } else {
+        purified_vaddr = vaddr;
+    }
+    return purified_vaddr;
+}
+
 Fault
 MMU::checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
                       bool stage2)

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -276,6 +276,8 @@ class MMU : public BaseMMU
             Translation *translation, bool &delay, bool timing,
             CachedState &state);
 
+    Addr getValidAddr(Addr vaddr, ThreadContext *tc, Mode mode) override;
+
     Fault translateComplete(const RequestPtr &req, ThreadContext *tc,
             Translation *translation, Mode mode, ArmTranslationType tran_type,
             bool call_from_s2);

--- a/src/arch/generic/mmu.cc
+++ b/src/arch/generic/mmu.cc
@@ -128,6 +128,12 @@ BaseMMU::translateFunctional(const RequestPtr &req, ThreadContext *tc,
     return getTlb(mode)->translateFunctional(req, tc, mode);
 }
 
+Addr
+BaseMMU::getValidAddr(Addr vaddr, ThreadContext *tc, Mode mode)
+{
+    return vaddr;
+}
+
 Fault
 BaseMMU::finalizePhysical(const RequestPtr &req, ThreadContext *tc,
                           BaseMMU::Mode mode) const

--- a/src/arch/generic/mmu.hh
+++ b/src/arch/generic/mmu.hh
@@ -125,6 +125,8 @@ class BaseMMU : public SimObject
     translateFunctional(const RequestPtr &req, ThreadContext *tc,
                         Mode mode);
 
+    virtual Addr getValidAddr(Addr vaddr, ThreadContext *tc, Mode mode);
+
     class MMUTranslationGen : public TranslationGen
     {
       private:

--- a/src/arch/riscv/mmu.hh
+++ b/src/arch/riscv/mmu.hh
@@ -68,6 +68,15 @@ class MMU : public BaseMMU
         getPMP()->pmpReset();
     }
 
+    Addr
+    getValidAddr(Addr vaddr, ThreadContext *tc, Mode mode) override
+    {
+        if (mode == BaseMMU::Execute) {
+            return static_cast<TLB*>(itb)->getValidAddr(vaddr, tc, mode);
+        }
+        return static_cast<TLB*>(dtb)->getValidAddr(vaddr, tc, mode);
+    }
+
     TranslationGenPtr
     translateFunctional(Addr start, Addr size, ThreadContext *tc,
             Mode mode, Request::Flags flags) override

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -144,6 +144,15 @@ class TLB : public BaseTLB
     Fault finalizePhysical(const RequestPtr &req, ThreadContext *tc,
                            BaseMMU::Mode mode) const override;
 
+    Addr
+    getValidAddr(Addr vaddr, ThreadContext *tc, BaseMMU::Mode mode)
+    {
+        ISA* isa = static_cast<ISA*>(tc->getIsaPtr());
+        if (isa->rvType() == RV32) {
+            return bits(vaddr, 31, 0);
+        }
+        return vaddr;
+    }
     /**
      * Perform the tlb lookup
      * @param vpn The virtual page number extracted from the address.

--- a/src/cpu/exetrace.cc
+++ b/src/cpu/exetrace.cc
@@ -43,6 +43,7 @@
 #include <iomanip>
 #include <sstream>
 
+#include "arch/generic/mmu.hh"
 #include "base/loader/symtab.hh"
 #include "cpu/base.hh"
 #include "cpu/static_inst.hh"
@@ -75,7 +76,8 @@ ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)
     if (debug::ExecThread)
         outs << "T" << thread->threadId() << " : ";
 
-    Addr cur_pc = pc->instAddr();
+    Addr cur_pc = thread->getMMUPtr()->getValidAddr(
+        pc->instAddr(), thread, BaseMMU::Execute);
     loader::SymbolTable::const_iterator it;
     ccprintf(outs, "%#x", cur_pc);
     if (debug::ExecSymbol && (!FullSystem || !in_user_mode) &&


### PR DESCRIPTION
The getValidAddr is the method get virtual address with valid bits. It is useful to get the correct symbol table via valid virtual address.

For ARM, we have `purifyTaggedAddr` to get the right virtual address. For RISC-V, we only get lower 32 bits in RV32 mode to get the right symbol table.

Change-Id: I33ad7bec6e7ea4ec82cb1b3a7f521432c6d735b6