### PR TITLE
base: Introduce registerExtraLog() in Logger

### DIFF
--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -52,15 +52,11 @@ namespace {
 class ExitLogger : public Logger
 {
   public:
-    using Logger::Logger;
-
-  protected:
-    void
-    log(const Loc &loc, std::string s) override
+    ExitLogger(const char *prefix) : Logger(prefix)
     {
-        std::stringstream ss;
-        ccprintf(ss, "Memory Usage: %ld KBytes\n", memUsage());
-        Logger::log(loc, s + ss.str());
+        registerExtraLog([]() {
+            return csprintf("Memory Usage: %ld KBytes\n", memUsage());
+        });
     }
 };
 

--- a/src/base/logging.test.cc
+++ b/src/base/logging.test.cc
@@ -157,6 +157,27 @@ TEST_F(LoggingFixture, DisabledPrint)
     ASSERT_EQ(gtestLogOutput.str(), "");
 }
 
+/** Test print with extra logs. */
+TEST_F(LoggingFixture, PrintWithExtraLogs)
+{
+    Logger logger("test: ");
+
+    logger.registerExtraLog([]() { return "Extra log 1\n"; });
+
+    gtestLogOutput.str("");
+    logger.print(Logger::Loc("File", 10), "message");
+    ASSERT_EQ(gtestLogOutput.str(), "File:10: test: message\nExtra log 1\n");
+
+    logger.registerExtraLog([]() { return "Extra log 2"; });
+    logger.registerExtraLog([]() { return "Extra log 3"; });
+
+    gtestLogOutput.str("");
+    logger.print(Logger::Loc("File", 10), "message");
+    ASSERT_EQ(
+        gtestLogOutput.str(),
+        "File:10: test: message\nExtra log 1\nExtra log 2\nExtra log 3\n");
+}
+
 /** Test printing with the warn logger, enabled and disabled. */
 TEST_F(LoggingFixture, WarnLoggerPrint)
 {


### PR DESCRIPTION
We may want to register extra logs when logging in gem5. For example, log CPU PC when gem5 panic / gem5 fatal.

To achieve this, I introduce extraLog and registerExtraLog() in Logger class. We can attach custom logs after the log message. For example:

Logger::getPanic().registerExtraLog([]() { return getCPUPC(); });

In the existing ExitLogger, we can also put the memory usage printing message in extraLog

Change-Id: I4daa175c6e4eeeee1234ccccffffddddeeeeeeee