### PR TITLE
arch-riscv: Use getValidAddr to get zero-extend address in RV32 mode

### DIFF
--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -147,6 +147,12 @@ class TLB : public BaseTLB
     Addr
     getValidAddr(Addr vaddr, ThreadContext *tc, BaseMMU::Mode mode)
     {
+      /**
+        * For RV32, we follow what the specification said:
+        * When mapping between narrower and wider addresses,
+        * RISC-V zero-extends a narrower physical address to a
+        * wider size.
+        */
         ISA* isa = static_cast<ISA*>(tc->getIsaPtr());
         if (isa->rvType() == RV32) {
             return bits(vaddr, 31, 0);


### PR DESCRIPTION
Previous PR #1758 implements the generic getValidAddr to get pure vaddr without any tags or sign-extend bits.

In RISC-V implementation, the getValidAddr will zero-extend address in RV32 mode and use it to do TLB translation. Use getValidAddr to get zero-extend vaddr can reduce zero-extend repetition

Change-Id: I2273ce48bccb873790103ba0fcdb0b48de9ced4c