### PR TITLE
mem,ruby: Adding SimObject name to SLICC errors.

### DIFF
--- a/src/mem/slicc/ast/AST.py
+++ b/src/mem/slicc/ast/AST.py
@@ -59,7 +59,7 @@ class AST(PairContainer):
         code = self.slicc.codeFormatter()
         code(
             """
-panic("Runtime Error at ${{self.location}}: %s.\\n", $message);
+panic("Runtime Error at ${{self.location}}: %s for machine %s.\\n", $message, name());
 """
         )
         return code


### PR DESCRIPTION
This change adds the name of the SimObject to panic errors generated from SLICC. This is useful in debugging SLICC errors.