### PR TITLE
tests: update gpu weekly test to test mis hip instead of fw hip

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -211,7 +211,7 @@ jobs:
                   path: tests/testing-results
                   retention-days: 7
 
-    gpu-test-pannotia-fw-hip:
+    gpu-test-pannotia-mis-hip:
         runs-on: [self-hosted, linux, x64]
         container: ghcr.io/gem5/gcn-gpu:latest
         timeout-minutes: 2160 # 36 hours
@@ -232,13 +232,13 @@ jobs:
 
             - name: Run Testlib GPU Tests
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --length=very-long -vvv -j $(nproc) --host gcn_gpu --uid SuiteUID:tests/gem5/gpu/test_gpu_pannotia.py:gpu-apu-se-pannotia-fw-hip-1k-128k-VEGA_X86-gcn_gpu-opt
+              run: ./main.py run --length=very-long -vvv -j $(nproc) --host gcn_gpu --uid SuiteUID:tests/gem5/gpu/test_gpu_pannotia.py:gpu-apu-se-pannotia-mis-hip-1k-128k-VEGA_X86-gcn_gpu-opt
 
             - name: Upload results
               if: success() || failure()
               uses: actions/upload-artifact@v4.0.0
               with:
-                  name: gpu_tests_pannotia_fw_hip_${{github.sha}}_RUN_${{github.run_id}}_ATTEMPT_${{github.run_attempt}}
+                  name: gpu_tests_pannotia_mis_hip_${{github.sha}}_RUN_${{github.run_id}}_ATTEMPT_${{github.run_attempt}}
                   path: tests/testing-results
                   retention-days: 7
 
@@ -278,6 +278,6 @@ jobs:
             - gpu-test-pannotia-bc
             - gpu-test-pannotia-color-maxmin
             - gpu-test-pannotia-color-max
-            - gpu-test-pannotia-fw-hip
+            - gpu-test-pannotia-mis-hip
         steps:
             - run: echo "This weekly tests have passed."

--- a/tests/gem5/gpu/test_gpu_pannotia.py
+++ b/tests/gem5/gpu/test_gpu_pannotia.py
@@ -42,7 +42,7 @@ binary_links = {
     "bc.gem5": "https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/bc.gem5",
     "color_max.gem5": "https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/color_max.gem5",
     "color_maxmin.gem5": "https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/color_maxmin.gem5",
-    "fw_hip.gem5": "https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/fw_hip.gem5",
+    "mis_hip.gem5": "https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/mis_hip.gem5",
 }
 
 dataset_links = {
@@ -128,45 +128,45 @@ gem5_verify_config(
 )
 
 
-gem5_verify_config(
-    name="gpu-apu-se-pannotia-fw-hip-1k-128k",
-    fixtures=(),
-    verifiers=(),
-    config=joinpath(config.base_dir, "configs", "example", "apu_se.py"),
-    config_args=[
-        "-n3",
-        "--mem-size=8GB",
-        "-c",
-        joinpath(binary_path, "fw_hip.gem5"),
-        "--options",
-        f'-f {joinpath(dataset_path, "1k_128k.gr")} -m default',
-    ],
-    valid_isas=(constants.vega_x86_tag,),
-    valid_hosts=(constants.host_gcn_gpu_tag,),
-    length=constants.very_long_tag,
-)
-
-# This test fails with
-# ERROR: hipMalloc row_d (size:-202182160) => hipErrorOutOfMemory
-# when mem-size is set to 64GiB.
-# The test passes with mem-size set to 8GiB.
 # gem5_verify_config(
-#     name="gpu-apu-se-pannotia-mis-hip-1k-128k",
+#     name="gpu-apu-se-pannotia-fw-hip-1k-128k",
 #     fixtures=(),
 #     verifiers=(),
 #     config=joinpath(config.base_dir, "configs", "example", "apu_se.py"),
 #     config_args=[
 #         "-n3",
-#         "--mem-size=8GiB",
+#         "--mem-size=8GB",
 #         "-c",
-#         joinpath(binary_path, "mis_hip.gem5"),
+#         joinpath(binary_path, "fw_hip.gem5"),
 #         "--options",
-#         f'{joinpath(dataset_path, "1k_128k.gr")} 0'
+#         f'-f {joinpath(dataset_path, "1k_128k.gr")} -m default',
 #     ],
 #     valid_isas=(constants.vega_x86_tag,),
 #     valid_hosts=(constants.host_gcn_gpu_tag,),
 #     length=constants.very_long_tag,
 # )
+
+# This test fails with
+# ERROR: hipMalloc row_d (size:-202182160) => hipErrorOutOfMemory
+# when mem-size is set to 64GiB.
+# The test passes with mem-size set to 8GiB.
+gem5_verify_config(
+    name="gpu-apu-se-pannotia-mis-hip-1k-128k",
+    fixtures=(),
+    verifiers=(),
+    config=joinpath(config.base_dir, "configs", "example", "apu_se.py"),
+    config_args=[
+        "-n3",
+        "--mem-size=8GiB",
+        "-c",
+        joinpath(binary_path, "mis_hip.gem5"),
+        "--options",
+        f'{joinpath(dataset_path, "1k_128k.gr")} 0',
+    ],
+    valid_isas=(constants.vega_x86_tag,),
+    valid_hosts=(constants.host_gcn_gpu_tag,),
+    length=constants.very_long_tag,
+)
 
 
 # gem5_verify_config(


### PR DESCRIPTION
I am moving this test because the fw tests fails on runners due to the following error 

```
File "/__w/gem5/gem5/tests/../ext/testlib/helper.py", line 207, in log_call
    raise subprocess.CalledProcessError(retval, cmdstr)
subprocess.CalledProcessError: Command '/__w/gem5/gem5/build/VEGA_X86/gem5.opt -d /tmp/gem5outesz2d05s -re --silent-redirect /__w/gem5/gem5/configs/example/apu_se.py -n3 --mem-size=8GB -c /__w/gem5/gem5/tests/gem5/gpu/../resources/gpu-pannotia/pannotia-bins/fw_hip.gem5 --options -f /__w/gem5/gem5/tests/gem5/gpu/../resources/gpu-pannotia/pannotia-datasets/1k_128k.gr -m default' died with &lt;Signals.SIGKILL: 9&gt;.
```

This looks like runners are killing the test due to lack of resources. This test did past locally so I changed the test with mis_hip.