### PR TITLE
arch-riscv: fix reg dep autoref on vslide with vcpy micro

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1475,7 +1475,7 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd + vdIdx]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + vs2Idx]"
+    src2_reg_id = "vecRegClass[VecMemInternalReg0 + vs2Idx]"
     src1_ireg_id = "intRegClass[_machInst.rs1]"
     src1_freg_id = "floatRegClass[_machInst.rs1]"
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2313,6 +2313,10 @@ template<typename ElemType>
     }
 
     for (uint32_t i = 0; i < ceil((float) this->vl/micro_vlmax); i++) {
+        microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen, vlen);
+        microop->setFlag(IsDelayedCommit);
+        this->microops.push_back(microop);
+
         microop = new VPinVdMicroInst(machInst, i, i+1, elen, vlen, true);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
@@ -2358,6 +2362,10 @@ template<typename ElemType>
     }
 
     for (uint32_t i = 0; i < ceil((float) this->vl / micro_vlmax); i++) {
+        microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen, vlen);
+        microop->setFlag(IsDelayedCommit);
+        this->microops.push_back(microop);
+
         microop = new VPinVdMicroInst(machInst, i, num_microops-i, elen, vlen,
                                       false);
         microop->setFlag(IsDelayedCommit);


### PR DESCRIPTION
Vector slide instructions can have the same register group as source and destination. 
Because we are pinning the destination this will provoke an auto-reference in the dependency graph. 

The solution is to use the `vcpy` micro. This way we use the `vtmp` register group as source and pin the destination without issues.