### PR TITLE
sim: Remove cyclic dependency of SimObjects and probes

### DIFF
--- a/src/cpu/o3/probe/elastic_trace.hh
+++ b/src/cpu/o3/probe/elastic_trace.hh
@@ -59,7 +59,7 @@
 #include "proto/packet.pb.h"
 #include "proto/protoio.hh"
 #include "sim/eventq.hh"
-#include "sim/probe/probe.hh"
+#include "sim/probe/probe_listener_object.hh"
 
 namespace gem5
 {

--- a/src/cpu/o3/probe/simple_trace.hh
+++ b/src/cpu/o3/probe/simple_trace.hh
@@ -46,7 +46,7 @@
 
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "params/SimpleTrace.hh"
-#include "sim/probe/probe.hh"
+#include "sim/probe/probe_listener_object.hh"
 
 namespace gem5
 {

--- a/src/cpu/probes/inst_tracker.hh
+++ b/src/cpu/probes/inst_tracker.hh
@@ -34,7 +34,7 @@
 #include "debug/InstTracker.hh"
 #include "params/GlobalInstTracker.hh"
 #include "params/LocalInstTracker.hh"
-#include "sim/probe/probe.hh"
+#include "sim/probe/probe_listener_object.hh"
 #include "sim/sim_exit.hh"
 
 namespace gem5

--- a/src/cpu/probes/pc_count_tracker.hh
+++ b/src/cpu/probes/pc_count_tracker.hh
@@ -33,7 +33,7 @@
 
 #include "cpu/probes/pc_count_tracker_manager.hh"
 #include "params/PcCountTracker.hh"
-#include "sim/probe/probe.hh"
+#include "sim/probe/probe_listener_object.hh"
 
 namespace gem5
 {

--- a/src/cpu/simple/probes/looppoint_analysis.hh
+++ b/src/cpu/simple/probes/looppoint_analysis.hh
@@ -36,8 +36,8 @@
 
 // m5 includes
 #include "arch/generic/pcstate.hh"
-#include "cpu/probes/pc_count_pair.hh"
 #include "cpu/simple_thread.hh"
+#include "sim/probe/probe_listener_object.hh"
 #include "sim/sim_exit.hh"
 
 // class includes

--- a/src/cpu/simple/probes/simpoint.hh
+++ b/src/cpu/simple/probes/simpoint.hh
@@ -43,7 +43,7 @@
 #include "base/output.hh"
 #include "cpu/simple_thread.hh"
 #include "params/SimPoint.hh"
-#include "sim/probe/probe.hh"
+#include "sim/probe/probe_listener_object.hh"
 
 namespace gem5
 {

--- a/src/sim/power/power_model.hh
+++ b/src/sim/power/power_model.hh
@@ -44,6 +44,7 @@
 #include "params/PowerModel.hh"
 #include "params/PowerModelState.hh"
 #include "sim/probe/probe.hh"
+#include "sim/sim_object.hh"
 
 namespace gem5
 {

--- a/src/sim/probe/Probe.py
+++ b/src/sim/probe/Probe.py
@@ -42,7 +42,7 @@ from m5.SimObject import SimObject
 
 class ProbeListenerObject(SimObject):
     type = "ProbeListenerObject"
-    cxx_header = "sim/probe/probe.hh"
+    cxx_header = "sim/probe/probe_listener_object.hh"
     cxx_class = "gem5::ProbeListenerObject"
 
     manager = Param.SimObject(Parent.any, "ProbeManager")

--- a/src/sim/probe/SConscript
+++ b/src/sim/probe/SConscript
@@ -39,4 +39,5 @@ Import('*')
 
 SimObject('Probe.py', sim_objects=['ProbeListenerObject'])
 Source('probe.cc')
+Source('probe_listener_object.cc')
 DebugFlag('ProbeVerbose')

--- a/src/sim/probe/probe.cc
+++ b/src/sim/probe/probe.cc
@@ -84,7 +84,7 @@ bool
 ProbeManager::addListener(std::string point_name, ProbeListener &listener)
 {
     DPRINTFR(ProbeVerbose, "Probes: Call to addListener to \"%s\" on %s.\n",
-        point_name, object->name());
+        point_name, name());
     bool added = false;
     for (auto p = points.begin(); p != points.end(); ++p) {
         if ((*p)->getName() == point_name) {
@@ -94,7 +94,7 @@ ProbeManager::addListener(std::string point_name, ProbeListener &listener)
     }
     if (!added) {
         DPRINTFR(ProbeVerbose, "Probes: Call to addListener to \"%s\" on "
-            "%s failed, no such point.\n", point_name, object->name());
+            "%s failed, no such point.\n", point_name, name());
     }
     return added;
 }
@@ -103,7 +103,7 @@ bool
 ProbeManager::removeListener(std::string point_name, ProbeListener &listener)
 {
     DPRINTFR(ProbeVerbose, "Probes: Call to removeListener from \"%s\" on "
-        "%s.\n", point_name, object->name());
+        "%s.\n", point_name, name());
     bool removed = false;
     for (auto p = points.begin(); p != points.end(); ++p) {
         if ((*p)->getName() == point_name) {
@@ -113,7 +113,7 @@ ProbeManager::removeListener(std::string point_name, ProbeListener &listener)
     }
     if (!removed) {
         DPRINTFR(ProbeVerbose, "Probes: Call to removeListener from \"%s\" "
-            "on %s failed, no such point.\n", point_name, object->name());
+            "on %s failed, no such point.\n", point_name, name());
     }
     return removed;
 }
@@ -122,12 +122,12 @@ void
 ProbeManager::addPoint(ProbePoint &point)
 {
     DPRINTFR(ProbeVerbose, "Probes: Call to addPoint \"%s\" to %s.\n",
-        point.getName(), object->name());
+        point.getName(), name());
 
     for (auto p = points.begin(); p != points.end(); ++p) {
         if ((*p)->getName() == point.getName()) {
             DPRINTFR(ProbeVerbose, "Probes: Call to addPoint \"%s\" to %s "
-                "failed, already added.\n", point.getName(), object->name());
+                "failed, already added.\n", point.getName(), name());
             return;
         }
     }

--- a/src/sim/probe/probe.hh
+++ b/src/sim/probe/probe.hh
@@ -68,6 +68,7 @@
 #include <vector>
 
 #include "base/compiler.hh"
+#include "base/named.hh"
 #include "base/trace.hh"
 #include "sim/sim_object.hh"
 
@@ -160,18 +161,14 @@ class ProbePoint
  * ProbeManager is a conduit class that lives on each SimObject,
  *  and is used to match up probe listeners with probe points.
  */
-class ProbeManager
+class ProbeManager : public Named
 {
   private:
-    /** Required for sensible debug messages.*/
-    GEM5_CLASS_VAR_USED const SimObject *object;
     /** Vector for name look-up. */
     std::vector<ProbePoint *> points;
 
   public:
-    ProbeManager(SimObject *obj)
-        : object(obj)
-    {}
+    ProbeManager(const std::string &obj_name) : Named(obj_name) {}
     virtual ~ProbeManager() {}
 
     /**

--- a/src/sim/probe/probe.hh
+++ b/src/sim/probe/probe.hh
@@ -50,9 +50,6 @@
  *                      a probe point event occurs. Multiple ProbeListeners
  *                      can be added to each ProbePoint.
  *
- * ProbeListenerObject: a wrapper around a SimObject that can connect to
- *                      another SimObject on which it will add ProbeListeners.
- *
  * ProbeManager:        used to match up ProbeListeners and ProbePoints.
  *                      At <b>simulation init</b> this is handled by
  *                      regProbePoints followed by regProbeListeners being
@@ -70,7 +67,6 @@
 #include "base/compiler.hh"
 #include "base/named.hh"
 #include "base/trace.hh"
-#include "sim/sim_object.hh"
 
 namespace gem5
 {
@@ -78,7 +74,6 @@ namespace gem5
 /** Forward declare the ProbeManager. */
 class ProbeManager;
 class ProbeListener;
-struct ProbeListenerObjectParams;
 
 /**
  * Name space containing shared probe point declarations.
@@ -95,27 +90,6 @@ namespace probing
  * for example pmu.hh.
  */
 }
-
-/**
- * This class is a minimal wrapper around SimObject. It is used to declare
- * a python derived object that can be added as a ProbeListener to any other
- * SimObject.
- *
- * It instantiates manager from a call to Parent.any.
- * The vector of listeners is used simply to hold onto listeners until the
- * ProbeListenerObject is destroyed.
- */
-class ProbeListenerObject : public SimObject
-{
-  protected:
-    ProbeManager *manager;
-    std::vector<ProbeListener *> listeners;
-
-  public:
-    ProbeListenerObject(const ProbeListenerObjectParams &params);
-    virtual ~ProbeListenerObject();
-    ProbeManager* getProbeManager() { return manager; }
-};
 
 /**
  * ProbeListener base class; here to simplify things like containers

--- a/src/sim/sim_object.cc
+++ b/src/sim/sim_object.cc
@@ -61,7 +61,7 @@ SimObject::SimObject(const Params &p)
       _params(p)
 {
     simObjectList.push_back(this);
-    probeManager = new ProbeManager(this);
+    probeManager = new ProbeManager(name());
 }
 
 SimObject::~SimObject()


### PR DESCRIPTION
Remove SimObject pointer from ProbeManager, as it is only used to get the SimObject's name for improved debugging messages. This adds an unnecessary dependency, and since the name should not change throughout execution, it can be stored on construction instead by inheriting from the Named class.

Finally, we move the ProbeListenerObject class to its own file, as it was adding a cyclic dependency that complicated creating unit tests for SimObjects.