### PR TITLE
arch-arm,misc: Fix build errors

### DIFF
--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -57,7 +57,7 @@ namespace ArmISA {
 
 class TableWalker;
 class TLB;
-class TlbEntry;
+struct TlbEntry;
 class TLBIOp;
 class TlbTestInterface;
 

--- a/src/arch/arm/pagetable.hh
+++ b/src/arch/arm/pagetable.hh
@@ -500,7 +500,7 @@ struct TlbEntry : public ReplaceableEntry, Serializable
     }
 
     std::string
-    print() const
+    print() const override
     {
         return csprintf("%#x, asn %d vmn %d ppn %#x size: %#x ap:%d "
                         "ns:%d ss:%s g:%d xs: %d regime:%s", vpn << N, asid, vmid,


### PR DESCRIPTION
1. Add missing override to `print` function.
2. Change `TlbEntry` to struct in `ArmISA` class.

I honestly don't know what introduced these build errors but this fixes them.

This was found attempting to compile gem5 on MacOS (Apple Silicon) with clang v19.