### PR TITLE
base: Fix failing compiler tests

### DIFF
--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -42,6 +42,8 @@
 
 #include <sstream>
 
+#include <algorithm>
+
 namespace gem5
 {
 

--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -40,9 +40,8 @@
 
 #include "base/random.hh"
 
-#include <sstream>
-
 #include <algorithm>
+#include <sstream>
 
 namespace gem5
 {


### PR DESCRIPTION
This PR adds `#include <algorithm>` to `src/base/random.cc`. This should fix some of the failing compiler tests.