### PR TITLE
tests: modify gem5/learning-gem5 ref file to fix failure

### DIFF
--- a/tests/gem5/learning_gem5/ref/test
+++ b/tests/gem5/learning_gem5/ref/test
@@ -1,3 +1,3 @@
 Global frequency set at 1000000000 ticks per second
 Beginning simulation!
-Exiting @ tick 9831 because Ruby Tester completed
+Exiting @ tick 10011 because Ruby Tester completed


### PR DESCRIPTION
The test `ruby_test_test-ALL-x86_64-opt-MatchStdout` is currently failing because the reference file doesn't match the actual output. This PR changes the reference file to match.