### PR TITLE
fix delayed execution bug when using classic cache model

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -359,7 +359,7 @@ class CHI_HNFController(Base_CHI_Cache_Controller):
         self.unify_repl_TBEs = False
 
 
-class CHI_MNController(Base_CHI_MiscNode_Controller):
+class CHI_MNController(CHI_MiscNode_Controller):
     """
     Default parameters for a Misc Node
     """

--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -359,7 +359,7 @@ class CHI_HNFController(Base_CHI_Cache_Controller):
         self.unify_repl_TBEs = False
 
 
-class CHI_MNController(CHI_MiscNode_Controller):
+class CHI_MNController(Base_CHI_MiscNode_Controller):
     """
     Default parameters for a Misc Node
     """

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -807,7 +807,7 @@ Cache::serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt, CacheBlk *blk)
                 // responseLatency is the latency of the return path
                 // from lower level caches/memory to an upper level cache or
                 // the core.
-                completion_time += clockEdge(responseLatency) +
+                completion_time += curTick() + responseLatency +
                     (transfer_offset ? pkt->payloadDelay : 0);
 
                 assert(!tgt_pkt->req->isUncacheable());

--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -807,7 +807,7 @@ Cache::serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt, CacheBlk *blk)
                 // responseLatency is the latency of the return path
                 // from lower level caches/memory to an upper level cache or
                 // the core.
-                completion_time += curTick() + responseLatency +
+                completion_time += curTick() + responseLatency * clockPeriod() +
                     (transfer_offset ? pkt->payloadDelay : 0);
 
                 assert(!tgt_pkt->req->isUncacheable());


### PR DESCRIPTION
### 1. what is this bug?

some instructions have unintended 1 cpu cycle delay when being ready for execution when instrucitons are waiting on data load from l1d cache

and for a bonus, fixes a bug where you couldn't run ruby-CHI cache model in develop branch due to wrong class name

### 2. when does it happen?

when multiple instructions are dependent in single cache line load. Only first instructions gets executed while others have unintended 1 cycle delay when cache line is ready.

This happens only when you're using classic cache model. This doesn't happend when using Ruby

### 3. how can i reproduce?

Use `configs/deprecated/example/se.py` and dummy assembly code (aka code) to demonstrate this issue. Running the code with ref cache setting and ruby-CHI setting will show that this issue shows only on ref cache setting, and after applying this PR, issue disappears on ref cache model.

here is the [link](https://github.com/2channelkrt/gem5-bug-report) for the code and script to run ref cache model and ruby-CHI cache model. clone that repo anywhere you like.

`binary/` dir has sample assembly code and compiled binary to be run on simulation to produce the bug. If you look at the assembly code, it's simple: lots of nops, and 3 `ldr` instruction starting at line 3210.

    ldr x1, =DataStart
    ldr x2, =DataStart
    ldr x3, =DataStart

these three loads requests line read on same cache line; and put on hold until data is available. By executing this code and looking at the log, you can see that on ref cache model, only `ldr x1` gets executed and latter two is executed on next cycle while all three `ldr` is executed on same cycle when using ruby-CHI cache model.

`runscript/` dir has the script to run ref cache model (`ref.sh`) and ruby-CHI cache model (`chi.sh`). just change value of `gem5_dir` of each script to match your gem5 directory and run each script once.

When you run each script, you will get the result directory `m5out-ref` and `m5out-chi`, and in each dir, you'll get debug log file `ref-out.txt` and `chi-out.txt` for each run. Open up these debug log, and look for the timestamp below. following is how to read the timestamp

example timestamp:
[sn:105786] 53110400 53157600 118 **// first ldr instruction**
[sn:105787] 53110400 53158000 119 **// second ldr instruction**
[sn:105788] 53110400 53158000 119 **// third ldr instruction**

[sn:105788] : instruction sequence number
first number (53157600) : tick when instruction calls mem read
second number (53157600) : tick when mem read complete and instruction gets executed
third number (118) : number of cpu cycle elapsed (assuming 2.5GHz CPU core clock)

**If you're running on `stable` branch:**

**ref before fix**

[sn:105786] 53110400 53157600 118
[sn:105787] 53110400 53158000 119
[sn:105788] 53110400 53158000 119

**ref after fix**

[sn:105859] 52748000 52795200 118
[sn:105860] 52748000 52795200 118
[sn:105861] 52748000 52795200 118

**chi before, after fix**

[sn:105333] 67030800 67090400 149
[sn:105334] 67030800 67090400 149
[sn:105335] 67030800 67090400 149

**If you're running on `develop` branch:**

**ref before fix**

[sn:105786] 53110400 53157600 118
[sn:105787] 53110400 53158000 119
[sn:105788] 53110400 53158000 119

**ref after fix**

[sn:105859] 52748000 52795200 118
[sn:105860] 52748000 52795200 118
[sn:105861] 52748000 52795200 118

chi before fix(doesn't run because of class naming scheme)

**chi after fix**

[sn:105333] 66974000 67033600 149
[sn:105334] 66974000 67033600 149
[sn:105335] 66974000 67033600 149

as you can see, before fix, first `ldr` instruction from ref-cache model takes 118 cycle while latter two takes 119 cycles. after fix, this bug disappears

### 4. Ok. what is going on here?

following is the simplified timeline of what's happening in the simulation. Let's say 3 `ldr` instructions are instruction a, b, and c.

**before fix**

tick 300

- cache load done. resp latency : 1
- inst a,b,c queued to release at next cpu cycle  + resp latency  = (tick 800)

tick 400 (cpu clock edge)
- cpu executes

tick 800(cpu clock edge)
- inst a released, checking for any more instruction... yes. scheduling inst b at tick 801
- cpu executes, **finds inst a released.**

tick 801
- inst b released, checking for any more instruction... yes. scheduling inst c at tick 802

tick 802
- inst c released. checking for any more instruction... no

tick 1200(cpu clock edge)
- cpu executes, **finds inst b, c released**

==============

**after fix**

tick 300
- cache load done. resp latency : 1
- inst a,b,c queued to release at curTime + resp latency = (tick 700)

tick 400 (cpu clock edge)
- cpu executes

tick 700
- inst a released, checking for any more instruction... yes. scheduling inst b at tick 701

tick 701
- inst b released, checking for any more instruction... yes. scheduling inst c at tick 702

tick 702
- inst c released, checking for any more instruction... no

tick 800(cpu clock edge)
- cpu executes, **finds inst a,b,c released.**

==============

**ruby-cache (resp latency isn't implemented in code, though parameter exists)**

tick 300
- cache load done. resp latency : 1
- inst a,b,c queued to release at next clock edge (tick 400)

tick 400 (cpu clock edge)
- cpu executes
- inst a released, checking for any more instruction... yes. scheduling inst b at tick 401

tick 401
- inst b released, checking for any more instruction... yes. scheduling inst c at tick 402

tick 402
- inst c released, checking for any more instruction... no

tick 800(cpu clock edge)
- cpu executes, **finds inst a,b,c released.**

so basically, order of `releasing the ready instruction` and `cpu execution` is the problem. So I changed the tick timing of the release of instructions, so instructions are released on time regardless of the order. This solution might seem like a XY problem, but all tests passed, and my benchmarks run without problem with meaningful perfomrance difference.