### PR TITLE
arch-arm: Fix bug in VQRSHL.

### DIFF
--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -2551,6 +2551,8 @@ let {{
                 destElem = (srcElem1 >> shiftAmt);
             }
             destElem += rBit;
+        } else if (shiftAmt == 0) {
+            destElem = srcElem1;
         } else {
             if (shiftAmt >= sizeof(Element) * 8) {
                 if (srcElem1 != 0) {


### PR DESCRIPTION
If shiftAmt is 0, bits raise assert, causing core dump.

Change-Id: Ic4285f51a866ffc017645655e98674ca69a15a40