### PR TITLE
arch-x86, sim-se: move mmap end downward in case of large stacks

### DIFF
--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -114,7 +114,7 @@ X86_64Process::X86_64Process(const ProcessParams &params,
     Addr stack_base = 0x7FFFFFFFF000ULL;
     Addr max_stack_size = params.maxStackSize;
     Addr next_thread_stack_base = stack_base - max_stack_size;
-    Addr mmap_end = 0x7FFFF7FFF000ULL;
+    Addr mmap_end = std::min<Addr>(0x7FFFF7FFF000ULL, next_thread_stack_base);
 
     memState = std::make_shared<MemState>(
             this, brk_point, stack_base, max_stack_size,


### PR DESCRIPTION
Fix #1809. Shift the mmap end to a lower address in case the process has a large max stack size, to avoid overlapping the stack with the mmap memory range.

Change-Id: Idae343dbbe851a7510463ff141c03f1847e36328