### PR TITLE
mem-ruby: Fix conflict between 117 and 1084

### DIFF
--- a/src/mem/ruby/protocol/chi/generic/CHIGenericController.cc
+++ b/src/mem/ruby/protocol/chi/generic/CHIGenericController.cc
@@ -57,6 +57,8 @@ namespace gem5
 namespace ruby
 {
 
+using namespace CHI;
+
 CHIGenericController::CHIGenericController(const Params &p)
   : AbstractController(p),
     reqOut(p.reqOut), snpOut(p.snpOut),
@@ -70,7 +72,8 @@ CHIGenericController::CHIGenericController(const Params &p)
 {
     m_machineID.type = MachineType_Cache;
     m_machineID.num = m_version;
-    p.ruby_system->registerAbstractController(this);
+    p.ruby_system->registerAbstractController(
+        this, std::make_unique<CHIProtocolInfo>());
     p.ruby_system->m_num_controllers[m_machineID.type]++;
     m_ruby_system = p.ruby_system;
 }

--- a/src/mem/ruby/protocol/chi/generic/CHIGenericController.hh
+++ b/src/mem/ruby/protocol/chi/generic/CHIGenericController.hh
@@ -50,10 +50,10 @@
 #include "params/CHIGenericController.hh"
 
 // Generated from SLICC
-#include "mem/ruby/protocol/CHIDataMsg.hh"
-#include "mem/ruby/protocol/CHIRequestMsg.hh"
-#include "mem/ruby/protocol/CHIResponseMsg.hh"
-#include "mem/ruby/protocol/Cache_Controller.hh"
+#include "mem/ruby/protocol/CHI/CHIDataMsg.hh"
+#include "mem/ruby/protocol/CHI/CHIRequestMsg.hh"
+#include "mem/ruby/protocol/CHI/CHIResponseMsg.hh"
+#include "mem/ruby/protocol/CHI/Cache_Controller.hh"
 
 namespace gem5
 {
@@ -125,9 +125,12 @@ class CHIGenericController : public AbstractController
         CHI_DAT = 3
     };
 
-    typedef std::shared_ptr<CHIRequestMsg> CHIRequestMsgPtr;
-    typedef std::shared_ptr<CHIResponseMsg> CHIResponseMsgPtr;
-    typedef std::shared_ptr<CHIDataMsg> CHIDataMsgPtr;
+    using CHIRequestMsg = CHI::CHIRequestMsg;
+    using CHIResponseMsg = CHI::CHIResponseMsg;
+    using CHIDataMsg = CHI::CHIDataMsg;
+    using CHIRequestMsgPtr = std::shared_ptr<CHIRequestMsg>;
+    using CHIResponseMsgPtr = std::shared_ptr<CHIResponseMsg>;
+    using CHIDataMsgPtr = std::shared_ptr<CHIDataMsg>;
 
     bool
     sendRequestMsg(CHIRequestMsgPtr msg)

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -38,16 +38,16 @@
 #include "mem/ruby/protocol/chi/tlm/controller.hh"
 
 #include "debug/TLM.hh"
-#include "mem/ruby/protocol/CHIDataMsg.hh"
-#include "mem/ruby/protocol/CHIRequestMsg.hh"
-#include "mem/ruby/protocol/CHIResponseMsg.hh"
+#include "mem/ruby/protocol/CHI/CHIDataMsg.hh"
+#include "mem/ruby/protocol/CHI/CHIRequestMsg.hh"
+#include "mem/ruby/protocol/CHI/CHIResponseMsg.hh"
 #include "mem/ruby/protocol/chi/tlm/utils.hh"
 
 namespace gem5 {
 
 namespace tlm::chi {
 
-using namespace ruby;
+using namespace ruby::CHI;
 
 CacheController::CacheController(const Params &p)
   : CHIGenericController(p)
@@ -97,7 +97,7 @@ bool
 CacheController::recvResponseMsg(const CHIResponseMsg *msg)
 {
 
-    if (msg->m_type == ruby::CHIResponseType_PCrdGrant) {
+    if (msg->m_type == CHIResponseType_PCrdGrant) {
         // P-credit grant does not refer to a specific transaction id
         pCreditGrant(msg);
         return true;
@@ -347,7 +347,7 @@ CacheController::sendDataMsg(ARM::CHI::Payload &payload,
         }
     }
 
-    data_msg->m_bitMask = WriteMask(byte_enabled.size(), byte_enabled);
+    data_msg->m_bitMask = ruby::WriteMask(byte_enabled.size(), byte_enabled);
 
     sendDataMsg(data_msg);
 }

--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -41,9 +41,9 @@
 #include <ARM/TLM/arm_chi.h>
 
 #include "mem/ruby/protocol/chi/generic/CHIGenericController.hh"
-#include "mem/ruby/protocol/CHIDataType.hh"
-#include "mem/ruby/protocol/CHIRequestType.hh"
-#include "mem/ruby/protocol/CHIResponseType.hh"
+#include "mem/ruby/protocol/CHI/CHIDataType.hh"
+#include "mem/ruby/protocol/CHI/CHIRequestType.hh"
+#include "mem/ruby/protocol/CHI/CHIResponseType.hh"
 #include "mem/ruby/protocol/RequestStatus.hh"
 #include "mem/ruby/protocol/WriteMask.hh"
 #include "params/TlmController.hh"
@@ -97,10 +97,10 @@ class CacheController : public ruby::CHIGenericController
     /** Set this to send data upstream */
     std::function<void(ARM::CHI::Payload* payload, ARM::CHI::Phase* phase)> bw;
 
-    bool recvRequestMsg(const ruby::CHIRequestMsg *msg) override;
-    bool recvSnoopMsg(const ruby::CHIRequestMsg *msg) override;
-    bool recvResponseMsg(const ruby::CHIResponseMsg *msg) override;
-    bool recvDataMsg(const ruby::CHIDataMsg *msg) override;
+    bool recvRequestMsg(const CHIRequestMsg *msg) override;
+    bool recvSnoopMsg(const CHIRequestMsg *msg) override;
+    bool recvResponseMsg(const CHIResponseMsg *msg) override;
+    bool recvDataMsg(const CHIDataMsg *msg) override;
 
     void sendMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
     using CHIGenericController::sendRequestMsg;
@@ -114,7 +114,7 @@ class CacheController : public ruby::CHIGenericController
     Addr reqAddr(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase) const;
     Addr reqSize(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase) const;
 
-    void pCreditGrant(const ruby::CHIResponseMsg *msg);
+    void pCreditGrant(const CHIResponseMsg *msg);
 
     struct Transaction
     {
@@ -135,12 +135,12 @@ class CacheController : public ruby::CHIGenericController
             ARM::CHI::Phase &_phase);
 
         virtual bool
-        handle(const ruby::CHIDataMsg *msg)
+        handle(const CHIDataMsg *msg)
         {
             panic("Unimplemented");
         }
 
-        virtual bool handle(const ruby::CHIResponseMsg *msg);
+        virtual bool handle(const CHIResponseMsg *msg);
 
         CacheController *controller;
         ARM::CHI::Payload *payload;
@@ -149,21 +149,21 @@ class CacheController : public ruby::CHIGenericController
     struct ReadTransaction : public Transaction
     {
         using Transaction::Transaction;
-        bool handle(const ruby::CHIDataMsg *msg) override;
-        bool handle(const ruby::CHIResponseMsg *msg) override;
-        bool forward(const ruby::CHIDataMsg *msg);
+        bool handle(const CHIDataMsg *msg) override;
+        bool handle(const CHIResponseMsg *msg) override;
+        bool forward(const CHIDataMsg *msg);
 
         uint8_t dataMsgCnt = 0;
     };
     struct DatalessTransaction : public Transaction
     {
         using Transaction::Transaction;
-        bool handle(const ruby::CHIResponseMsg *msg) override;
+        bool handle(const CHIResponseMsg *msg) override;
     };
     struct WriteTransaction : public Transaction
     {
         using Transaction::Transaction;
-        bool handle(const ruby::CHIResponseMsg *msg) override;
+        bool handle(const CHIResponseMsg *msg) override;
         bool recvComp = false;
         bool recvDBID = false;
     };

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -47,6 +47,7 @@ namespace tlm::chi {
 namespace {
 
 using namespace ARM::CHI;
+using namespace ruby::CHI;
 
 std::string
 reqOpcodeToName(ReqOpcode req_opcode)
@@ -242,30 +243,30 @@ transactionToString(const Payload &payload,
 
 namespace tlm_to_ruby {
 
-ruby::CHIRequestType
+CHIRequestType
 reqOpcode(ReqOpcode req)
 {
-    static std::unordered_map<uint8_t, ruby::CHIRequestType> translation_map = {
-        { REQ_OPCODE_READ_SHARED, ruby::CHIRequestType_ReadShared },
-        { REQ_OPCODE_READ_CLEAN, ruby::CHIRequestType_ReadOnce }, // TODO
-        { REQ_OPCODE_READ_ONCE, ruby::CHIRequestType_ReadOnce },
-        { REQ_OPCODE_READ_NO_SNP, ruby::CHIRequestType_ReadNoSnp }, // TODO
-        { REQ_OPCODE_READ_UNIQUE, ruby::CHIRequestType_ReadUnique },
-        { REQ_OPCODE_READ_NOT_SHARED_DIRTY, ruby::CHIRequestType_ReadNotSharedDirty },
-        { REQ_OPCODE_READ_PREFER_UNIQUE, ruby::CHIRequestType_ReadUnique }, // TODO
-        { REQ_OPCODE_MAKE_READ_UNIQUE, ruby::CHIRequestType_MakeReadUnique }, // TODO
+    static std::unordered_map<uint8_t, CHIRequestType> translation_map = {
+        { REQ_OPCODE_READ_SHARED, CHIRequestType_ReadShared },
+        { REQ_OPCODE_READ_CLEAN, CHIRequestType_ReadOnce }, // TODO
+        { REQ_OPCODE_READ_ONCE, CHIRequestType_ReadOnce },
+        { REQ_OPCODE_READ_NO_SNP, CHIRequestType_ReadNoSnp }, // TODO
+        { REQ_OPCODE_READ_UNIQUE, CHIRequestType_ReadUnique },
+        { REQ_OPCODE_READ_NOT_SHARED_DIRTY, CHIRequestType_ReadNotSharedDirty },
+        { REQ_OPCODE_READ_PREFER_UNIQUE, CHIRequestType_ReadUnique }, // TODO
+        { REQ_OPCODE_MAKE_READ_UNIQUE, CHIRequestType_MakeReadUnique }, // TODO
 
-        { REQ_OPCODE_CLEAN_UNIQUE, ruby::CHIRequestType_CleanUnique },
-        { REQ_OPCODE_MAKE_UNIQUE, ruby::CHIRequestType_CleanUnique }, // TODO
-        { REQ_OPCODE_EVICT, ruby::CHIRequestType_Evict },
-        { REQ_OPCODE_STASH_ONCE_SEP_SHARED, ruby::CHIRequestType_StashOnceShared }, // TODO
-        { REQ_OPCODE_STASH_ONCE_SEP_UNIQUE, ruby::CHIRequestType_StashOnceUnique },
-        { REQ_OPCODE_WRITE_NO_SNP_PTL, ruby::CHIRequestType_WriteUniquePtl },
-        { REQ_OPCODE_WRITE_NO_SNP_FULL, ruby::CHIRequestType_WriteUniqueFull },
-        { REQ_OPCODE_WRITE_UNIQUE_FULL, ruby::CHIRequestType_WriteUniqueFull },
-        { REQ_OPCODE_WRITE_UNIQUE_ZERO, ruby::CHIRequestType_WriteUniqueZero },
-        { REQ_OPCODE_WRITE_BACK_FULL, ruby::CHIRequestType_WriteBackFull },
-        { REQ_OPCODE_WRITE_EVICT_OR_EVICT, ruby::CHIRequestType_WriteEvictFull }, // TODO
+        { REQ_OPCODE_CLEAN_UNIQUE, CHIRequestType_CleanUnique },
+        { REQ_OPCODE_MAKE_UNIQUE, CHIRequestType_CleanUnique }, // TODO
+        { REQ_OPCODE_EVICT, CHIRequestType_Evict },
+        { REQ_OPCODE_STASH_ONCE_SEP_SHARED, CHIRequestType_StashOnceShared }, // TODO
+        { REQ_OPCODE_STASH_ONCE_SEP_UNIQUE, CHIRequestType_StashOnceUnique },
+        { REQ_OPCODE_WRITE_NO_SNP_PTL, CHIRequestType_WriteUniquePtl },
+        { REQ_OPCODE_WRITE_NO_SNP_FULL, CHIRequestType_WriteUniqueFull },
+        { REQ_OPCODE_WRITE_UNIQUE_FULL, CHIRequestType_WriteUniqueFull },
+        { REQ_OPCODE_WRITE_UNIQUE_ZERO, CHIRequestType_WriteUniqueZero },
+        { REQ_OPCODE_WRITE_BACK_FULL, CHIRequestType_WriteBackFull },
+        { REQ_OPCODE_WRITE_EVICT_OR_EVICT, CHIRequestType_WriteEvictFull }, // TODO
     };
 
     auto it = translation_map.find(req);
@@ -289,35 +290,35 @@ reqOpcode(ReqOpcode req)
     default: panic(""); \
     }
 
-ruby::CHIDataType
+CHIDataType
 datOpcode(DatOpcode dat, Resp resp)
 {
     switch (dat) {
       case DAT_OPCODE_NON_COPY_BACK_WR_DATA:
-        return ruby::CHIDataType_NCBWrData;
+        return CHIDataType_NCBWrData;
       case DAT_OPCODE_COPY_BACK_WR_DATA:
         switch (resp) {
-          case RESP_I: return ruby::CHIDataType_CBWrData_I;
-          case RESP_UC: return ruby::CHIDataType_CBWrData_UC;
-          case RESP_SC: return ruby::CHIDataType_CBWrData_SC;
-          case RESP_UD_PD: return ruby::CHIDataType_CBWrData_UD_PD;
+          case RESP_I: return CHIDataType_CBWrData_I;
+          case RESP_UC: return CHIDataType_CBWrData_UC;
+          case RESP_SC: return CHIDataType_CBWrData_SC;
+          case RESP_UD_PD: return CHIDataType_CBWrData_UD_PD;
           default: panic("");
         }
       case DAT_OPCODE_SNP_RESP_DATA:
-        RESP_CASE(ruby::CHIDataType_SnpRespData)
+        RESP_CASE(CHIDataType_SnpRespData)
       default:
         panic("Unsupported Translation: %s\n", datOpcodeToName(dat));
     }
 }
 
-ruby::CHIResponseType
+CHIResponseType
 rspOpcode(RspOpcode opc, Resp resp)
 {
     switch(opc) {
-      case RSP_OPCODE_COMP_ACK: return ruby::CHIResponseType_CompAck;
+      case RSP_OPCODE_COMP_ACK: return CHIResponseType_CompAck;
       case RSP_OPCODE_SNP_RESP:
         switch (resp) {
-          case RESP_I: return ruby::CHIResponseType_SnpResp_I;
+          case RESP_I: return CHIResponseType_SnpResp_I;
           default: panic("Invalid resp %d for %d\n", resp, opc);
         }
       default:
@@ -330,40 +331,40 @@ rspOpcode(RspOpcode opc, Resp resp)
 namespace ruby_to_tlm {
 
 uint8_t
-datOpcode(ruby::CHIDataType dat)
+datOpcode(CHIDataType dat)
 {
     switch (dat) {
-      case ruby::CHIDataType_CompData_I:
-      case ruby::CHIDataType_CompData_UC:
-      case ruby::CHIDataType_CompData_SC:
-      case ruby::CHIDataType_CompData_UD_PD:
-      case ruby::CHIDataType_CompData_SD_PD:
+      case CHIDataType_CompData_I:
+      case CHIDataType_CompData_UC:
+      case CHIDataType_CompData_SC:
+      case CHIDataType_CompData_UD_PD:
+      case CHIDataType_CompData_SD_PD:
         return 0x4;
-      case ruby::CHIDataType_DataSepResp_UC:
+      case CHIDataType_DataSepResp_UC:
         return 0xb;
-      case ruby::CHIDataType_CBWrData_UC:
-      case ruby::CHIDataType_CBWrData_SC:
-      case ruby::CHIDataType_CBWrData_UD_PD:
-      case ruby::CHIDataType_CBWrData_SD_PD:
-      case ruby::CHIDataType_CBWrData_I:
+      case CHIDataType_CBWrData_UC:
+      case CHIDataType_CBWrData_SC:
+      case CHIDataType_CBWrData_UD_PD:
+      case CHIDataType_CBWrData_SD_PD:
+      case CHIDataType_CBWrData_I:
         return 0x2;
-      case ruby::CHIDataType_NCBWrData:
+      case CHIDataType_NCBWrData:
         return 0x3;
-      case ruby::CHIDataType_SnpRespData_I:
-      case ruby::CHIDataType_SnpRespData_I_PD:
-      case ruby::CHIDataType_SnpRespData_SC:
-      case ruby::CHIDataType_SnpRespData_SC_PD:
-      case ruby::CHIDataType_SnpRespData_SD:
-      case ruby::CHIDataType_SnpRespData_UC:
-      case ruby::CHIDataType_SnpRespData_UD:
+      case CHIDataType_SnpRespData_I:
+      case CHIDataType_SnpRespData_I_PD:
+      case CHIDataType_SnpRespData_SC:
+      case CHIDataType_SnpRespData_SC_PD:
+      case CHIDataType_SnpRespData_SD:
+      case CHIDataType_SnpRespData_UC:
+      case CHIDataType_SnpRespData_UD:
         return 0x1;
-      case ruby::CHIDataType_SnpRespData_SC_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_SC_Fwded_SD_PD:
-      case ruby::CHIDataType_SnpRespData_SC_PD_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_SD_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_I_Fwded_SD_PD:
-      case ruby::CHIDataType_SnpRespData_I_PD_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_I_Fwded_SC:
+      case CHIDataType_SnpRespData_SC_Fwded_SC:
+      case CHIDataType_SnpRespData_SC_Fwded_SD_PD:
+      case CHIDataType_SnpRespData_SC_PD_Fwded_SC:
+      case CHIDataType_SnpRespData_SD_Fwded_SC:
+      case CHIDataType_SnpRespData_I_Fwded_SD_PD:
+      case CHIDataType_SnpRespData_I_PD_Fwded_SC:
+      case CHIDataType_SnpRespData_I_Fwded_SC:
         return 0x6;
       default:
         panic("Unrecognised data opcode: %d\n", dat);
@@ -371,16 +372,16 @@ datOpcode(ruby::CHIDataType dat)
 }
 
 uint8_t
-rspOpcode(ruby::CHIResponseType rsp)
+rspOpcode(CHIResponseType rsp)
 {
     switch (rsp) {
-      case ruby::CHIResponseType_Comp_UD_PD:
-      case ruby::CHIResponseType_Comp_UC:
-      case ruby::CHIResponseType_Comp_I:
+      case CHIResponseType_Comp_UD_PD:
+      case CHIResponseType_Comp_UC:
+      case CHIResponseType_Comp_I:
         return RSP_OPCODE_COMP;
-      case ruby::CHIResponseType_CompDBIDResp:
+      case CHIResponseType_CompDBIDResp:
         return RSP_OPCODE_COMP_DBID_RESP;
-      case ruby::CHIResponseType_RetryAck:
+      case CHIResponseType_RetryAck:
         return RSP_OPCODE_RETRY_ACK;
       default:
         panic("Unrecognised rsp opcode: %d\n", rsp);
@@ -388,18 +389,18 @@ rspOpcode(ruby::CHIResponseType rsp)
 }
 
 uint8_t
-snpOpcode(ruby::CHIRequestType snp)
+snpOpcode(CHIRequestType snp)
 {
     switch (snp) {
-      case ruby::CHIRequestType_SnpOnceFwd:
+      case CHIRequestType_SnpOnceFwd:
         return SNP_OPCODE_SNP_ONCE_FWD;
-      case ruby::CHIRequestType_SnpOnce:
+      case CHIRequestType_SnpOnce:
         return SNP_OPCODE_SNP_ONCE;
-      case ruby::CHIRequestType_SnpShared:
+      case CHIRequestType_SnpShared:
         return SNP_OPCODE_SNP_SHARED;
-      case ruby::CHIRequestType_SnpCleanInvalid:
+      case CHIRequestType_SnpCleanInvalid:
         return SNP_OPCODE_SNP_CLEAN_INVALID;
-      case ruby::CHIRequestType_SnpUnique:
+      case CHIRequestType_SnpUnique:
         return SNP_OPCODE_SNP_UNIQUE;
       default:
         panic("Unrecognised snp opcode: %d\n", snp);
@@ -407,62 +408,62 @@ snpOpcode(ruby::CHIRequestType snp)
 }
 
 Resp
-datResp(ruby::CHIDataType dat)
+datResp(CHIDataType dat)
 {
     switch (dat) {
-      case ruby::CHIDataType_SnpRespData_I:
-      case ruby::CHIDataType_CompData_I:
-      case ruby::CHIDataType_CBWrData_I:
+      case CHIDataType_SnpRespData_I:
+      case CHIDataType_CompData_I:
+      case CHIDataType_CBWrData_I:
         return RESP_I;
-      case ruby::CHIDataType_SnpRespData_SC:
-      case ruby::CHIDataType_CompData_SC:
-      case ruby::CHIDataType_CBWrData_SC:
+      case CHIDataType_SnpRespData_SC:
+      case CHIDataType_CompData_SC:
+      case CHIDataType_CBWrData_SC:
         return RESP_SC;
-      case ruby::CHIDataType_SnpRespData_UC:
-      case ruby::CHIDataType_CompData_UC:
-      case ruby::CHIDataType_CBWrData_UC:
-      case ruby::CHIDataType_DataSepResp_UC:
+      case CHIDataType_SnpRespData_UC:
+      case CHIDataType_CompData_UC:
+      case CHIDataType_CBWrData_UC:
+      case CHIDataType_DataSepResp_UC:
         return RESP_UC;
-      case ruby::CHIDataType_SnpRespData_UD:
+      case CHIDataType_SnpRespData_UD:
         return RESP_UD;
-      case ruby::CHIDataType_SnpRespData_SD:
+      case CHIDataType_SnpRespData_SD:
         return RESP_SD;
-      case ruby::CHIDataType_SnpRespData_I_PD:
+      case CHIDataType_SnpRespData_I_PD:
         return RESP_I_PD;
-      case ruby::CHIDataType_SnpRespData_SC_PD:
+      case CHIDataType_SnpRespData_SC_PD:
         return RESP_SC_PD;
-      case ruby::CHIDataType_CompData_UD_PD:
-      case ruby::CHIDataType_CBWrData_UD_PD:
+      case CHIDataType_CompData_UD_PD:
+      case CHIDataType_CBWrData_UD_PD:
         return RESP_UD_PD;
-      case ruby::CHIDataType_CompData_SD_PD:
-      case ruby::CHIDataType_CBWrData_SD_PD:
+      case CHIDataType_CompData_SD_PD:
+      case CHIDataType_CBWrData_SD_PD:
         return RESP_SD_PD;
       // TODO
-      case ruby::CHIDataType_SnpRespData_SC_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_SC_Fwded_SD_PD:
-      case ruby::CHIDataType_SnpRespData_SC_PD_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_SD_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_I_Fwded_SD_PD:
-      case ruby::CHIDataType_SnpRespData_I_PD_Fwded_SC:
-      case ruby::CHIDataType_SnpRespData_I_Fwded_SC:
+      case CHIDataType_SnpRespData_SC_Fwded_SC:
+      case CHIDataType_SnpRespData_SC_Fwded_SD_PD:
+      case CHIDataType_SnpRespData_SC_PD_Fwded_SC:
+      case CHIDataType_SnpRespData_SD_Fwded_SC:
+      case CHIDataType_SnpRespData_I_Fwded_SD_PD:
+      case CHIDataType_SnpRespData_I_PD_Fwded_SC:
+      case CHIDataType_SnpRespData_I_Fwded_SC:
       default:
         panic("Unrecognised data opcode: %d\n", dat);
     }
 }
 
 Resp
-rspResp(ruby::CHIResponseType rsp)
+rspResp(CHIResponseType rsp)
 {
     switch (rsp) {
-      case ruby::CHIResponseType_Comp_I:
+      case CHIResponseType_Comp_I:
         return RESP_I;
-      case ruby::CHIResponseType_Comp_UC:
+      case CHIResponseType_Comp_UC:
         return RESP_UC;
-      case ruby::CHIResponseType_Comp_UD_PD:
+      case CHIResponseType_Comp_UD_PD:
         return RESP_UD_PD;
-      case ruby::CHIResponseType_CompDBIDResp:
+      case CHIResponseType_CompDBIDResp:
         return RESP_I;
-      case ruby::CHIResponseType_RetryAck:
+      case CHIResponseType_RetryAck:
         // Just setup to zero
         return RESP_I;
       default:

--- a/src/mem/ruby/protocol/chi/tlm/utils.hh
+++ b/src/mem/ruby/protocol/chi/tlm/utils.hh
@@ -41,9 +41,9 @@
 #include <ARM/TLM/arm_chi.h>
 
 #include "base/types.hh"
-#include "mem/ruby/protocol/CHIDataType.hh"
-#include "mem/ruby/protocol/CHIRequestType.hh"
-#include "mem/ruby/protocol/CHIResponseType.hh"
+#include "mem/ruby/protocol/CHI/CHIDataType.hh"
+#include "mem/ruby/protocol/CHI/CHIRequestType.hh"
+#include "mem/ruby/protocol/CHI/CHIResponseType.hh"
 
 namespace gem5 {
 
@@ -54,20 +54,20 @@ std::string transactionToString(const ARM::CHI::Payload &payload,
 
 namespace tlm_to_ruby {
 
-ruby::CHIRequestType reqOpcode(ARM::CHI::ReqOpcode req);
-ruby::CHIDataType datOpcode(ARM::CHI::DatOpcode dat, ARM::CHI::Resp resp);
-ruby::CHIResponseType rspOpcode(ARM::CHI::RspOpcode res, ARM::CHI::Resp resp);
+ruby::CHI::CHIRequestType reqOpcode(ARM::CHI::ReqOpcode req);
+ruby::CHI::CHIDataType datOpcode(ARM::CHI::DatOpcode dat, ARM::CHI::Resp resp);
+ruby::CHI::CHIResponseType rspOpcode(ARM::CHI::RspOpcode res, ARM::CHI::Resp resp);
 
 }
 
 namespace ruby_to_tlm {
 
-uint8_t datOpcode(ruby::CHIDataType dat);
-uint8_t rspOpcode(ruby::CHIResponseType res);
-uint8_t snpOpcode(ruby::CHIRequestType snp);
+uint8_t datOpcode(ruby::CHI::CHIDataType dat);
+uint8_t rspOpcode(ruby::CHI::CHIResponseType res);
+uint8_t snpOpcode(ruby::CHI::CHIRequestType snp);
 
-ARM::CHI::Resp datResp(ruby::CHIDataType dat);
-ARM::CHI::Resp rspResp(ruby::CHIResponseType rsp);
+ARM::CHI::Resp datResp(ruby::CHI::CHIDataType dat);
+ARM::CHI::Resp rspResp(ruby::CHI::CHIResponseType rsp);
 
 }
 


### PR DESCRIPTION
This is fixing the conflict between the multi-ruby [1] and the CHI-TLM [2] PRs

[1]: https://github.com/gem5/gem5/pull/117
[2]: https://github.com/gem5/gem5/pull/1084

Change-Id: Ie9c6381c361ac344e22984d8a53ed03c387b0b43