### PR TITLE
fix wrong ruby-CHI base class name

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -359,7 +359,7 @@ class CHI_HNFController(Base_CHI_Cache_Controller):
         self.unify_repl_TBEs = False
 
 
-class CHI_MNController(Base_CHI_MiscNode_Controller):
+class CHI_MNController(CHI_MiscNode_Controller):
     """
     Default parameters for a Misc Node
     """


### PR DESCRIPTION
fix ruby-CHI base class name so it actually runs

previously was combined with PR #1797 