### PR TITLE
arch-arm: Simplify FEAT_PAN implementation

### DIFF
--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -379,12 +379,6 @@ class MMU : public BaseMMU
                           ExceptionLevel el,
                           TCR tcr, bool is_inst, CachedState& state);
 
-    bool checkPAN(ThreadContext *tc, uint8_t ap, const RequestPtr &req,
-                  Mode mode, const bool is_priv, CachedState &state);
-
-    bool faultPAN(ThreadContext *tc, uint8_t ap, const RequestPtr &req,
-                  Mode mode, const bool is_priv, CachedState &state);
-
     std::pair<bool, bool> s1PermBits64(
         TlbEntry *te, const RequestPtr &req, Mode mode,
         ThreadContext *tc, CachedState &state, bool r, bool w, bool x);


### PR DESCRIPTION
By moving the check to the upper level permission method, we actually simplify the logic, aligning with the Arm pseudocode:

1) We don't need to check the EL regime anymore as it is covered by the hasUnprivRegime (EL10 and EL20)

2) We don't check the access type (Execute vs Read/Write) since the condition will simply override pr and pw (and not px)

Change-Id: I70de3345316005f5e18eae2b4be8fb08e608c22e