### PR TITLE
arch-arm: Make ESR_ELx a 64 bit register

### DIFF
--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -755,7 +755,8 @@ namespace ArmISA
         Bitfield<0>      f;
    EndBitUnion(PAR)
 
-   BitUnion32(ESR)
+   BitUnion64(ESR)
+        Bitfield<55, 32> iss2;
         Bitfield<31, 26> ec;
         Bitfield<25> il;
         Bitfield<24, 0> iss;


### PR DESCRIPTION
The ESR_EL1/2/3 register is now 64bit wide to accomodate to the ISS2 subfield.

Change-Id: I337a66a2db83ed7c52361e3411612476e1d4a7aa