### PR TITLE
arch-arm: Fix inconsistency of rint().

### DIFF
--- a/src/arch/arm/insts/vfp.hh
+++ b/src/arch/arm/insts/vfp.hh
@@ -264,6 +264,9 @@ setFPExceptions(int exceptions) {
     feraiseexcept(exceptions);
 }
 
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+
 template <typename T>
 uint64_t
 vfpFpToFixed(T val, bool isSigned, uint8_t width, uint8_t imm, bool
@@ -547,6 +550,7 @@ vfpFpRint(T val, bool exact, bool defaultNan, bool useRmode = true,
     return val;
 };
 
+#pragma GCC pop_options
 
 float vfpUFixedToFpS(bool flush, bool defaultNan,
         uint64_t val, uint8_t width, uint8_t imm);


### PR DESCRIPTION
The behavior of rint() is different due to compiler optimizations. In vfp.hh, the output of rint() is correct in -O0, but error in -O3.

To fix this, vfpFpToFixed and vfpFpRint is forced to use -O0 by pragma.

Change-Id: I753aeb3aa61213ecbcc1009bb58d353a3863bf6e