### PR TITLE
cpu: Incorrect BP update for atomic core

### DIFF
--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -516,15 +516,16 @@ BaseSimpleCPU::advancePC(const Fault &fault)
         // instruction in flight at the same time.
         const InstSeqNum cur_sn(0);
 
-        if (*t_info.predPC == thread->pcState()) {
-            // Correctly predicted branch
-            branchPred->update(cur_sn, curThread);
-        } else {
+        if (*t_info.predPC != thread->pcState()) {
+
             // Mis-predicted branch
             branchPred->squash(cur_sn, thread->pcState(), branching,
-                    curThread);
+                                curThread);
             ++t_info.execContextStats.numBranchMispred;
         }
+        // Update the branch predictor, this is done whether the
+        // prediction was correct or not.
+        branchPred->update(cur_sn, curThread);
     }
 }
 


### PR DESCRIPTION
In the atomic core the branch predictor was not correctly updated upon misprediction. On misprediction, the history was only squashed but not committed.
It has only a small impact on the accuracy because most of the time a subsequent correctly predicted branch calls the update function and both branches will be commited. However, in case of two subsequent mispredictions the earlier one which is already corrected with be squashed again and the update is lost.