### PR TITLE
mem-ruby, scons: Add ProtocolInfo.hh files in build targets

### DIFF
--- a/src/mem/ruby/protocol/SConscript
+++ b/src/mem/ruby/protocol/SConscript
@@ -91,6 +91,14 @@ def slicc_emitter(target, source, env):
 
         files.update([output_dir.File(f) for f in sorted(slicc.files())])
 
+        # Dynamically determine protocol and add ProtocolInfo.hh to the list of
+        # files to be built
+        protocol_name = os.path.splitext(os.path.basename(filepath))[0]
+        protocol_file = output_dir.File(
+            f"{protocol_name}/{protocol_name}ProtocolInfo.hh"
+        )
+        files.update([protocol_file])
+
     return list(files), source
 
 

--- a/src/mem/ruby/protocol/SConscript
+++ b/src/mem/ruby/protocol/SConscript
@@ -93,9 +93,8 @@ def slicc_emitter(target, source, env):
 
         # Dynamically determine protocol and add ProtocolInfo.hh to the list of
         # files to be built
-        protocol_name = os.path.splitext(os.path.basename(filepath))[0]
         protocol_file = output_dir.File(
-            f"{protocol_name}/{protocol_name}ProtocolInfo.hh"
+            f"{slicc.protocol}/{slicc.protocol}ProtocolInfo.hh"
         )
         files.update([protocol_file])
 


### PR DESCRIPTION
- In the new MultiRuby system, the generated ProtocolInfo header files were not being correctly added to the build targets in SCons.

- As a result, when building gem5 with the --duplicate-sources option, these files were mistakenly deleted by SCons. This happened because SCons treated them as source files instead of generated build targets.

- This commit ensures that the ProtocolInfo header files are explicitly included in the build targets, preventing their unintended removal and fixing the build issue.