### PR TITLE
arch-riscv: Add senvcfg CSR

### DIFF
--- a/src/arch/riscv/gdb-xml/riscv-32bit-csr.xml
+++ b/src/arch/riscv/gdb-xml/riscv-32bit-csr.xml
@@ -32,6 +32,7 @@
   <reg name="stval" bitsize="32"/>
   <reg name="sip" bitsize="32"/>
   <reg name="satp" bitsize="32"/>
+  <reg name="senvcfg" bitsize="32"/>
   <reg name="mvendorid" bitsize="32"/>
   <reg name="marchid" bitsize="32"/>
   <reg name="mimpid" bitsize="32"/>

--- a/src/arch/riscv/gdb-xml/riscv-64bit-csr.xml
+++ b/src/arch/riscv/gdb-xml/riscv-64bit-csr.xml
@@ -30,6 +30,7 @@
   <reg name="stval" bitsize="64"/>
   <reg name="sip" bitsize="64"/>
   <reg name="satp" bitsize="64"/>
+  <reg name="senvcfg" bitsize="64"/>
   <reg name="mvendorid" bitsize="64"/>
   <reg name="marchid" bitsize="64"/>
   <reg name="mimpid" bitsize="64"/>

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -185,6 +185,7 @@ namespace RiscvISA
     [MISCREG_SCAUSE]        = "SCAUSE",
     [MISCREG_STVAL]         = "STVAL",
     [MISCREG_SATP]          = "SATP",
+    [MISCREG_SENVCFG]       = "SENVCFG",
 
     [MISCREG_UTVEC]         = "UTVEC",
     [MISCREG_USCRATCH]      = "USCRATCH",
@@ -777,6 +778,11 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                     new_val.mode != AddrXlateMode::SV39)
                     new_val.mode = cur_val.mode;
                 setMiscRegNoEffect(idx, new_val);
+            }
+            break;
+          case MISCREG_SENVCFG:
+            {
+                setMiscRegNoEffect(idx, val + 1);
             }
             break;
           case MISCREG_TSELECT:

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -797,12 +797,7 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                     val);
                 }
 
-                if ((wpri_mask & val) != 0) {
-                    warn("Ignoring write to WPRI bit(s) in senvcfg CSR.\n"
-                    "The attempted write was:\n %" PRIu64 "\n", val);
-                } else {
-                    setMiscRegNoEffect(idx, val);
-                }
+                setMiscRegNoEffect(idx, val & ~wpri_mask);
             }
             break;
           case MISCREG_TSELECT:

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -782,7 +782,27 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
             break;
           case MISCREG_SENVCFG:
             {
-                setMiscRegNoEffect(idx, val + 1);
+                // panic on write to bitfields that aren't implemented in gem5
+                SENVCFG panic_mask = 0;
+                panic_mask.pmm = 3;
+
+                SENVCFG wpri_mask = 0;
+                wpri_mask.wpri_1 = ~wpri_mask.wpri_1;
+                wpri_mask.wpri_2 = ~wpri_mask.wpri_2;
+                wpri_mask.wpri_3 = ~wpri_mask.wpri_3;
+
+                if ((panic_mask & val) != 0) {
+                    panic("Tried to write to an unimplemented bitfield in the "
+                    "senvcfg CSR!\nThe attempted write was:\n %" PRIu64 "\n",
+                    val);
+                }
+
+                if ((wpri_mask & val) != 0) {
+                    warn("Ignoring write to WPRI bit(s) in senvcfg CSR.\n"
+                    "The attempted write was:\n %" PRIu64 "\n", val);
+                } else {
+                    setMiscRegNoEffect(idx, val);
+                }
             }
             break;
           case MISCREG_TSELECT:

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1003,16 +1003,84 @@ decode QUADRANT default Unknown::unknown() {
             0x2: decode FUNCT12 {
                 format CBMOp {
                     0x0: cbo_inval({{
-                        Mem = 0;
-                    }}, mem_flags=[INVALIDATE, DST_POC]);
+                        SENVCFG senvcfg = xc->readMiscReg(MISCREG_SENVCFG);
+                        auto pm = (PrivilegeMode)xc->readMiscReg(
+                                MISCREG_PRV);
+
+                        if (pm == PRV_U) {
+                            if (senvcfg.cbie == 0) {
+                                return std::make_shared<IllegalInstFault>(
+                                        "Can't execute cbo.clean in current "
+                                        "privilege mode!", machInst);
+                            }
+                            else if (senvcfg.cbie == 1){ //flush
+                                Mem = 0;
+                            }
+                            else if (senvcfg.cbie == 3) { // invalidate
+                                Mem = 0;
+                            } else { //sebvcfg.cbie == 2, reserved
+                                return std::make_shared<IllegalInstFault>(
+                                        "Invalid value for senvcfg.cbie!",
+                                        machInst);
+                            }
+                        } else if (pm == PRV_M){ // all invalidate
+                            Mem = 0;
+                        } else if (pm == PRV_S) {
+                            // whether it's a flush or invalidate depends on
+                            // menvcfg (01 and 11 respectively)
+                            Mem = 0;
+                        }
+                    }}, mem_flags = [INVALIDATE, DST_POC]);
+                        // mem_flags might need a conditional to add CLEAN
+                        // in certain cases; unsure of syntax for that
+
                     0x1: cbo_clean({{
-                        Mem = 0;
+                        SENVCFG senvcfg = xc->readMiscReg(MISCREG_SENVCFG);
+                        auto pm = (PrivilegeMode)xc->readMiscReg(
+                                MISCREG_PRV);
+
+                        if (pm == PRV_U && !senvcfg.cbcfe){
+                            return std::make_shared<IllegalInstFault>(
+                                        "Can't execute cbo.clean in current "
+                                        "privilege mode!", machInst);
+                        // the specification has more conditions/privilege
+                        // modes to check, but menvcfg and henvcfg are not
+                        // implemented
+                        } else {
+                            Mem = 0;
+                        }
                     }}, mem_flags=[CLEAN, DST_POC]);
                     0x2: cbo_flush({{
-                        Mem = 0;
+                        SENVCFG senvcfg = xc->readMiscReg(MISCREG_SENVCFG);
+                        auto pm = (PrivilegeMode)xc->readMiscReg(
+                                MISCREG_PRV);
+
+                        if (pm == PRV_U && !senvcfg.cbcfe){
+                            return std::make_shared<IllegalInstFault>(
+                                        "Can't execute cbo.flush in current "
+                                        "privilege mode!", machInst);
+                        // the specification has more conditions/privilege
+                        // modes to check, but menvcfg and henvcfg are not
+                        // implemented
+                        } else {
+                            Mem = 0;
+                        }
                     }}, mem_flags=[CLEAN, INVALIDATE, DST_POC]);
                     0x4: cbo_zero({{
-                        Mem = 0;
+                        SENVCFG senvcfg = xc->readMiscReg(MISCREG_SENVCFG);
+                        auto pm = (PrivilegeMode)xc->readMiscReg(
+                                MISCREG_PRV);
+
+                        if (pm == PRV_U && !senvcfg.cbze){
+                            return std::make_shared<IllegalInstFault>(
+                                        "Can't execute cbo.zero in current "
+                                        "privilege mode!", machInst);
+                        // the specification has more conditions/privilege
+                        // modes to check, but menvcfg and henvcfg are not
+                        // implemented
+                        } else {
+                            Mem = 0;
+                        }
                     }}, mem_flags=[CACHE_BLOCK_ZERO]);
                 }
             }

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -1265,6 +1265,20 @@ BitUnion64(INTERRUPT)
     Bitfield<0> usi;
 EndBitUnion(INTERRUPT)
 
+
+// From the RISCV specification version 20240411, volume 2,
+// section 10.1.10, page 98
+BitUnion64(SENVCFG)
+    Bitfield<63,34> wpri_1;
+    Bitfield<33,32> pmm;
+    Bitfield<31,8> wpri_2;
+    Bitfield<7> cbze;
+    Bitfield<6> cbcfe;
+    Bitfield<5,4> cbie;
+    Bitfield<3,1> wpri_3;
+    Bitfield<0> fiom;
+EndBitUnion(SENVCFG)
+
 const off_t MXL_OFFSETS[enums::Num_RiscvType] = {
     [RV32] = (sizeof(uint32_t) * 8 - 2),
     [RV64] = (sizeof(uint64_t) * 8 - 2),

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -183,6 +183,7 @@ enum MiscRegIndex
     MISCREG_SCAUSE,
     MISCREG_STVAL,
     MISCREG_SATP,
+    MISCREG_SENVCFG,
 
     MISCREG_UTVEC,
     MISCREG_USCRATCH,
@@ -360,6 +361,7 @@ enum CSRIndex
     CSR_STVAL = 0x143,
     CSR_SIP = 0x144,
     CSR_SATP = 0x180,
+    CSR_SENVCFG = 0x10A, // 20240411 RISCV spec, volume 2
 
     CSR_MVENDORID = 0xF11,
     CSR_MARCHID = 0xF12,
@@ -777,6 +779,9 @@ const std::unordered_map<int, CSRMetadata> CSRData = {
         {"sip", MISCREG_SIP, rvTypeFlags(RV64, RV32), isaExtsFlags('s')}},
     {CSR_SATP,
         {"satp", MISCREG_SATP, rvTypeFlags(RV64, RV32), isaExtsFlags('s')}},
+    {CSR_SENVCFG,
+        {"senvcfg", MISCREG_SENVCFG, rvTypeFlags(RV64, RV32),
+         isaExtsFlags('s')}},
 
     {CSR_MVENDORID,
         {"mvendorid", MISCREG_VENDORID, rvTypeFlags(RV64, RV32),

--- a/src/arch/riscv/remote_gdb.cc
+++ b/src/arch/riscv/remote_gdb.cc
@@ -327,6 +327,8 @@ RemoteGDB::Riscv32GdbRegCache::getRegs(ThreadContext *context)
         CSRData.at(CSR_SIP).physIndex) & RVxCSRMasks.at(CSR_SIP);
     r.satp = context->readMiscRegNoEffect(
         CSRData.at(CSR_SATP).physIndex);
+    r.senvcfg = context->readMiscRegNoEffect(
+        CSRData.at(CSR_SENVCFG).physIndex);
 
     // M mode CSR
     r.mvendorid = context->readMiscRegNoEffect(
@@ -426,6 +428,8 @@ RemoteGDB::Riscv32GdbRegCache::setRegs(ThreadContext *context) const
         CSRData.at(CSR_STVAL).physIndex, r.stval);
     context->setMiscRegNoEffect(
         CSRData.at(CSR_SATP).physIndex, r.satp);
+    context->setMiscRegNoEffect(
+        CSRData.at(CSR_SENVCFG).physIndex, r.senvcfg);
 
     // M mode CSR
     setRegWithMask(context, RV32, pms, CSR_MSTATUS, r.mstatus);
@@ -528,6 +532,8 @@ RemoteGDB::Riscv64GdbRegCache::getRegs(ThreadContext *context)
         CSRData.at(CSR_SIP).physIndex) & RVxCSRMasks.at(CSR_SIP);
     r.satp = context->readMiscRegNoEffect(
         CSRData.at(CSR_SATP).physIndex);
+    r.senvcfg = context->readMiscRegNoEffect(
+        CSRData.at(CSR_SENVCFG).physIndex);
 
     // M mode CSR
     r.mvendorid = context->readMiscRegNoEffect(
@@ -625,7 +631,8 @@ RemoteGDB::Riscv64GdbRegCache::setRegs(ThreadContext *context) const
         CSRData.at(CSR_STVAL).physIndex, r.stval);
     context->setMiscRegNoEffect(
         CSRData.at(CSR_SATP).physIndex, r.satp);
-
+    context->setMiscRegNoEffect(
+        CSRData.at(CSR_SENVCFG).physIndex, r.senvcfg);
     // M mode CSR
     setRegWithMask(context, RV64, pms, CSR_MSTATUS, r.mstatus);
     setRegNoEffectWithMask(context, RV64, pms, CSR_MISA, r.misa);

--- a/src/arch/riscv/remote_gdb.hh
+++ b/src/arch/riscv/remote_gdb.hh
@@ -108,6 +108,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint32_t stval;
             uint32_t sip;
             uint32_t satp;
+            uint32_t senvcfg;
             uint32_t mvendorid;
             uint32_t marchid;
             uint32_t mimpid;
@@ -192,6 +193,7 @@ class RemoteGDB : public BaseRemoteGDB
             uint64_t stval;
             uint64_t sip;
             uint64_t satp;
+            uint64_t senvcfg;
             uint64_t mvendorid;
             uint64_t marchid;
             uint64_t mimpid;


### PR DESCRIPTION
This commit adds the senvcfg control status register, which fixes the 6.11.3 kernel crash documented in issue 1674. I have not added a bitfield and its implementation in isa.cc only uses setMiscRegNoEffect, so this implementation is missing some components.