### PR TITLE
arch-riscv: fix tlb stats in timming mode

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -574,8 +574,8 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
              */
             Addr vaddr = req->getVaddr();
             vaddr = Addr(sext<VADDR_BITS>(vaddr));
-            Addr paddr = walker->tlb->translateWithTLB(vaddr, satp.asid,
-                                                       satp.mode, mode);
+            Addr paddr = walker->tlb->hiddenTranslateWithTLB(vaddr, satp.asid,
+                                                             satp.mode, mode);
             req->setPaddr(paddr);
 
             // do pmp check if any checking condition is met.

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -295,8 +295,8 @@ TLB::createPagefault(Addr vaddr, BaseMMU::Mode mode)
 }
 
 Addr
-TLB::translateWithTLB(Addr vaddr, uint16_t asid, Addr xmode,
-                      BaseMMU::Mode mode)
+TLB::hiddenTranslateWithTLB(Addr vaddr, uint16_t asid, Addr xmode,
+                            BaseMMU::Mode mode)
 {
     TlbEntry *e = lookup(getVPNFromVAddr(vaddr, xmode), asid, mode, true);
     assert(e != nullptr);

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -298,7 +298,7 @@ Addr
 TLB::translateWithTLB(Addr vaddr, uint16_t asid, Addr xmode,
                       BaseMMU::Mode mode)
 {
-    TlbEntry *e = lookup(getVPNFromVAddr(vaddr, xmode), asid, mode, false);
+    TlbEntry *e = lookup(getVPNFromVAddr(vaddr, xmode), asid, mode, true);
     assert(e != nullptr);
     return e->paddr << PageShift | (vaddr & mask(e->logBytes));
 }

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -131,8 +131,8 @@ class TLB : public BaseTLB
      */
     Port *getTableWalkerPort() override;
 
-    Addr translateWithTLB(Addr vaddr, uint16_t asid, Addr xmode,
-                          BaseMMU::Mode mode);
+    Addr hiddenTranslateWithTLB(Addr vaddr, uint16_t asid, Addr xmode,
+                                BaseMMU::Mode mode);
 
     Fault translateAtomic(const RequestPtr &req,
                           ThreadContext *tc, BaseMMU::Mode mode) override;


### PR DESCRIPTION
The previous #484 issue reported a bug where the TLB stats on RISC-V were incremented twice on misses by calling the `lookup` function twice with hidden argument set to `false`. The fix is only applied on atomic mode as the `translation` argument of `doTranslate` will not be `nullptr` in timing mode.

In that case, if the TLB lookup miss, the `doTranslate` function will start the walker and then return without doing anything more. Then later, when the pagetable walker found the corresponding PTE, it will insert it and call `translateWithTLB`. This function then call `lookup` again which will hit in any case (and crash if not due to the following
assert), but the hit count is incremented here too. 

This commit fix by setting the `hidden` argument of `lookup` to true.