### PR TITLE
base,arch-arm: Add GEM5_NO_OPTIMIZE; use in ARM's vfp.hh

### DIFF
--- a/src/arch/arm/insts/vfp.hh
+++ b/src/arch/arm/insts/vfp.hh
@@ -264,11 +264,9 @@ setFPExceptions(int exceptions) {
     feraiseexcept(exceptions);
 }
 
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-
 template <typename T>
 uint64_t
+GEM5_NO_OPTIMIZE
 vfpFpToFixed(T val, bool isSigned, uint8_t width, uint8_t imm, bool
              useRmode = true, VfpRoundingMode roundMode = VfpRoundZero,
              bool aarch64 = false)
@@ -440,6 +438,7 @@ vfpFpToFixed(T val, bool isSigned, uint8_t width, uint8_t imm, bool
 
 template <typename T>
 T
+GEM5_NO_OPTIMIZE
 vfpFpRint(T val, bool exact, bool defaultNan, bool useRmode = true,
           VfpRoundingMode roundMode = VfpRoundZero)
 {
@@ -550,7 +549,6 @@ vfpFpRint(T val, bool exact, bool defaultNan, bool useRmode = true,
     return val;
 };
 
-#pragma GCC pop_options
 
 float vfpUFixedToFpS(bool flush, bool defaultNan,
         uint64_t val, uint8_t width, uint8_t imm);

--- a/src/base/compiler.hh
+++ b/src/base/compiler.hh
@@ -131,6 +131,16 @@ do { [[maybe_unused]] int i[] = { 0, ((void)(__VA_ARGS__), 0)... }; } while (0)
 #  error "Don't know what to do for your compiler."
 #endif
 
+
+// GEM5_NO_OPTIMIZE can be used to prevent the compiler from optimizing a
+// function. Clang and GCC have different ways of doing this, so we need to
+// check which compiler is being used.
+#if defined(__clang__)
+#  define GEM5_NO_OPTIMIZE __attribute__((optnone))
+#else
+#  define GEM5_NO_OPTIMIZE __attribute__((optimize("O0")))
+#endif
+
 // When a member variable may be unused, mark it with GEM5_CLASS_VAR_USED. This
 // needs to be limitted to clang only since clang warns on these unused
 // variables, and g++ will actually warn if you use this attribute since it


### PR DESCRIPTION
GCC and CLANG have different annotations for declaring code should not
be optimized. Adding GEM5_NO_OPTIMZE provides gem5 developers a MACRO
that works in both cases.

This change replaces the GCC pragmas in vfp.hh with GEM5_NO_OPTIMIZE
as this solution didn't work with clang.