### PR TITLE
mem-ruby: Fix functional access in MI_example

### DIFF
--- a/src/mem/ruby/protocol/MI_example-cache.sm
+++ b/src/mem/ruby/protocol/MI_example-cache.sm
@@ -52,8 +52,8 @@ machine(MachineType:L1Cache, "MI Example L1 Cache")
     I, AccessPermission:Invalid, desc="Not Present/Invalid";
     II, AccessPermission:Busy, desc="Not Present/Invalid, issued PUT";
     M, AccessPermission:Read_Write, desc="Modified";
-    MI, AccessPermission:Busy, desc="Modified, issued PUT";
-    MII, AccessPermission:Busy, desc="Modified, issued PUTX, received nack";
+    MI, AccessPermission:Maybe_Stale, desc="Modified, issued PUT";
+    MII, AccessPermission:Read_Write, desc="Modified, issued PUTX, received nack";
 
     IS, AccessPermission:Busy, desc="Issued request for LOAD/IFETCH";
     IM, AccessPermission:Busy, desc="Issued request for STORE/ATOMIC";


### PR DESCRIPTION
In MI_example, when in MI state the block "Maybe_Stale" as in this
controller may have the most up to date value or it could be in the
network. For MII it is guaranteed that this controller has the most up
to date value because it received a PUTX_NACK.

This fixes one of the daily test failures.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>