### PR TITLE
mem-ruby: Fix Atomic transitions in VIPER protocol

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCC.sm
@@ -933,14 +933,18 @@ machine(MachineType:TCC, "TCC Cache")
   }
 
   action(pa_performAtomic, "pa", desc="Perform atomic") {
-    peek(coreRequestNetwork_in, CPURequestMsg) {
-      if ((is_valid(tbe) && tbe.atomicDataReturn) || in_msg.Type == CoherenceRequestType:AtomicReturn) {
-        cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask, false);
-      } else {
-        // Set the isAtomicNoReturn flag to ensure that logs are not
-        // generated erroneously
-        assert((is_valid(tbe) && tbe.atomicDataNoReturn) || in_msg.Type == CoherenceRequestType:AtomicNoReturn);
-        cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask, true);
+    if (is_valid(tbe) && tbe.atomicDataReturn) {
+       cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask, false);
+    } else if (is_valid(tbe) && tbe.atomicDataNoReturn) {
+       cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask, true);
+    } else {
+      peek(coreRequestNetwork_in, CPURequestMsg) {
+        if (in_msg.Type == CoherenceRequestType:AtomicReturn) {
+           cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask, false);
+        } else {
+          assert(in_msg.Type == CoherenceRequestType:AtomicNoReturn);
+          cache_entry.DataBlk.atomicPartial(cache_entry.DataBlk, cache_entry.writeMask, true);
+        }
       }
     }
   }

--- a/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
@@ -917,8 +917,18 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
   // store followed by a load. Thus, complete the store without affecting
   // TBE or line state.
   // TCC_AckWB only snoops TBE
-  transition({V, I, IV, A}, TCC_AckWB) {
+  transition({V, I, IV}, TCC_AckWB) {
     wd_wtDone;
+    pr_popResponseQueue;
+  }
+
+  transition(A, TCC_AckWB, I) {TagArrayRead, DataArrayRead, DataArrayWrite} {
+    a_allocate;
+    w_writeCache;
+    ad_atomicDone;
+    ic_invCache;
+    wada_wakeUpAllDependentsAddr;
+    d_deallocateTBE;
     pr_popResponseQueue;
   }
 


### PR DESCRIPTION
This PR fixes two bugs in the GPU VIPER protocol when globally coherent atomic requests are issued. First, a segfault happens when the cache line in TCC moves from V/I to a transient state but later runs transitions back to I. The segfault happens because the pa_performAtomic action tries to access a request queue that has already dequeued the message. The fix changes the action to use the TBE entry instead of peeking into the queue. If the cacheline does not allocate a TBE or move to a transient state, it performs the peek instead. The second fix completes the cache line's transition to I in the TCP upon receiving an ack from the TCC when it is configured to be in write-back mode