### PR TITLE
sim: Update multisim to use Process instead of Pool

### DIFF
--- a/src/python/gem5/utils/multisim/multisim.py
+++ b/src/python/gem5/utils/multisim/multisim.py
@@ -53,8 +53,8 @@ import importlib
 import multiprocessing
 import signal
 import time
+from multiprocessing import Lock
 from pathlib import Path
-from threading import Lock
 from typing import (
     Optional,
     Set,

--- a/src/python/gem5/utils/multisim/multisim.py
+++ b/src/python/gem5/utils/multisim/multisim.py
@@ -209,7 +209,7 @@ def run(module_path: Path, processes: Optional[int] = None) -> None:
     active_processes = []
     remaining_ids = list(ids).copy()
     process_lock = Lock()
-    from gem5.utils.multiprocessing import Process
+    from ..multiprocessing import Process
 
     def handle_exit(signum, frame):
         """Signal handler to clean up processes on termination."""
@@ -246,6 +246,9 @@ def run(module_path: Path, processes: Optional[int] = None) -> None:
             # Wait for active processes to finish
             time.sleep(1)  # Avoid busy-waiting
             with process_lock:
+                # Using list comprehension to remove finished processes
+                # as using `remove` in a loop over the list will cause
+                # the list to be modified during iteration.
                 active_processes = [
                     process
                     for process in active_processes

--- a/src/python/gem5/utils/multisim/multisim.py
+++ b/src/python/gem5/utils/multisim/multisim.py
@@ -210,7 +210,13 @@ def run(module_path: Path, processes: Optional[int] = None) -> None:
     # module path (the config script specifying all simulations using MultiSim)
     # but a different ID. The ID is used to select the correct simulator to
     # run.
-    pool.starmap(_run, zip([module_path for _ in range(len(ids))], tuple(ids)))
+    try:
+        pool.starmap(
+            _run, zip([module_path for _ in range(len(ids))], tuple(ids))
+        )
+    finally:
+        pool.close()
+        pool.join()
 
 
 def set_num_processes(num_processes: int) -> None:

--- a/src/python/gem5/utils/multisim/multisim.py
+++ b/src/python/gem5/utils/multisim/multisim.py
@@ -207,7 +207,6 @@ def run(module_path: Path, processes: Optional[int] = None) -> None:
     while remaining_ids or active_processes:
         while remaining_ids and len(active_processes) < max_num_processes:
             id_to_run = remaining_ids.pop()
-            print(f"Running {id_to_run}")
             process = Process(
                 target=_run, args=(module_path, id_to_run), name=id_to_run
             )
@@ -216,7 +215,6 @@ def run(module_path: Path, processes: Optional[int] = None) -> None:
         for process in active_processes:
             if not process.is_alive():
                 active_processes.remove(process)
-    print("All simulations complete.")
 
 
 def set_num_processes(num_processes: int) -> None:


### PR DESCRIPTION
- Using `Multiprocessing.Pool` in multisim was causing errors when number of jobs were > 4x the number pf processes as a worker thread was being used to run a gem5 simulation after already running one.

- This change updates the multisim code to manually spawn the processes and handle them. 