### PR TITLE
configs: Generalize class types in CHI RNF/MN generators

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -601,7 +601,7 @@ class CHI_RNF(CHI_Node):
     @classmethod
     def generate(cls, options, ruby_system, cpus):
         rnfs = [
-            CHI_RNF(
+            cls(
                 [cpu],
                 ruby_system,
                 L1ICache(size=options.l1i_size, assoc=options.l1i_assoc),
@@ -724,7 +724,7 @@ class CHI_MN(CHI_Node):
         """
         Creates one Misc Node
         """
-        return [CHI_MN(ruby_system, [cpu.l1d for cpu in cpus])]
+        return [cls(ruby_system, [cpu.l1d for cpu in cpus])]
 
 
 class CHI_SNF_Base(CHI_Node):


### PR DESCRIPTION
Classes CHI_RNF and CHI_MN can be specialized to override base class/subclass attributes, like it happens in CustomMesh with router_list (see configs/example/noc_config/2x4.py). To avoid missing these attributes, it is needed to generalize the class types when instantiating the objects in the recently added generators.