### PR TITLE
arch-arm: Do FEAT_VHE redirection for TCR2_EL1 register

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -254,6 +254,8 @@ ISA::redirectRegVHE(int misc_reg)
         return currEL() == EL2 ? MISCREG_TTBR1_EL2 : misc_reg;
       case MISCREG_TCR_EL1:
         return currEL() == EL2 ? MISCREG_TCR_EL2 : misc_reg;
+      case MISCREG_TCR2_EL1:
+        return currEL() == EL2 ? MISCREG_TCR2_EL2 : misc_reg;
       case MISCREG_AFSR0_EL1:
         return currEL() == EL2 ? MISCREG_AFSR0_EL2 : misc_reg;
       case MISCREG_AFSR1_EL1:


### PR DESCRIPTION
While we were redirecting TCR2_EL12 accesses to TCR2_EL1, we were not forwarding TCR2_EL1 access to TCR2_EL2 when in host

Change-Id: I2822a81bd13ec4f8d7ef30aa181baf7eb7f0b8fc