### PR TITLE
Speculative update for TAGE-SC-L

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -172,7 +172,9 @@ class SimpleIndirectPredictor(IndirectPredictor):
         "pipeline depth or a high value e.g. 256 to make it 'unlimited'.",
     )
     indirectGHRBits = Param.Unsigned(13, "Indirect GHR number of bits")
-    instShiftAmt = Param.Unsigned(2, "Number of bits to shift instructions by")
+    instShiftAmt = Param.Unsigned(
+        Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )
 
 
 class BranchPredictor(SimObject):
@@ -182,7 +184,15 @@ class BranchPredictor(SimObject):
     abstract = True
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
-    instShiftAmt = Param.Unsigned(2, "Number of bits to shift instructions by")
+    instShiftAmt = Param.Unsigned(
+        0,
+        "The `instShiftAmt` is intended for fixed size instruction sets "
+        "(Arm,RISC-V) to shift the FULL PC by `n` bits (e.g. 2 for 4 byte "
+        "instructions) as the two least significant bits are always zero and "
+        "therefore not useful for prediction. For variable size instruction "
+        "sets (x86) all bits are used and the `instShiftAmt` should be set "
+        "to 0.",
+    )
     requiresBTBHit = Param.Bool(
         False,
         "Requires the BTB to hit for returns and indirect branches. For an"
@@ -560,6 +570,10 @@ class StatisticalCorrector(SimObject):
     cxx_class = "gem5::branch_prediction::StatisticalCorrector"
     cxx_header = "cpu/pred/statistical_corrector.hh"
     abstract = True
+
+    instShiftAmt = Param.Unsigned(
+        Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )
 
     # Statistical corrector parameters
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -195,7 +195,8 @@ class BranchPredictor(SimObject):
         "to 0.",
     )
     speculativeHistUpdate = Param.Bool(
-        True, "Use speculative update for histories"
+        True,
+        "Use speculative update for histories",
     )
 
     requiresBTBHit = Param.Bool(
@@ -631,6 +632,11 @@ class StatisticalCorrector(SimObject):
 
     initialUpdateThresholdValue = Param.Int(
         0, "Initial pUpdate threshold counter value"
+    )
+
+    speculativeHistUpdate = Param.Bool(
+        Parent.speculativeHistUpdate,
+        "Use speculative update for the statistical corrector",
     )
 
 

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2022-2023 The University of Edinburgh
+# Copyright (c) 2024 Technical University of Munich
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -193,6 +194,10 @@ class BranchPredictor(SimObject):
         "sets (x86) all bits are used and the `instShiftAmt` should be set "
         "to 0.",
     )
+    speculativeHistUpdate = Param.Bool(
+        True, "Use speculative update for histories"
+    )
+
     requiresBTBHit = Param.Bool(
         False,
         "Requires the BTB to hit for returns and indirect branches. For an"
@@ -298,7 +303,7 @@ class TAGEBase(SimObject):
     noSkip = VectorParam.Bool([], "Vector of enabled TAGE tables")
 
     speculativeHistUpdate = Param.Bool(
-        True, "Use speculative update for histories"
+        Parent.speculativeHistUpdate, "Use speculative update for histories"
     )
 
 
@@ -378,8 +383,6 @@ class TAGE_SC_L_TAGE(TAGEBase):
     logUResetPeriod = 10
     initialTCounterValue = 1 << 9
     useAltOnNaBits = 5
-    # TODO No speculation implemented as of now
-    speculativeHistUpdate = False
 
     # This size does not set the final sizes of the tables (it is just used
     # for some calculations)
@@ -649,7 +652,9 @@ class TAGE_SC_L(LTAGE):
     cxx_header = "cpu/pred/tage_sc_l.hh"
     abstract = True
 
-    statistical_corrector = Param.StatisticalCorrector("Statistical Corrector")
+    statistical_corrector = Param.StatisticalCorrector(
+        "Statistical Corrector. Set to NULL to disable it"
+    )
 
 
 class TAGE_SC_L_64KB_LoopPredictor(TAGE_SC_L_LoopPredictor):
@@ -929,7 +934,6 @@ class MPP_TAGE(TAGEBase):
     logUResetPeriod = 10
     initialTCounterValue = 0
     numUseAltOnNa = 512
-    speculativeHistUpdate = False
 
 
 class MPP_LoopPredictor(LoopPredictor):
@@ -1048,6 +1052,7 @@ class MultiperspectivePerceptronTAGE64KB(MultiperspectivePerceptronTAGE):
     cxx_header = "cpu/pred/multiperspective_perceptron_tage_64KB.hh"
 
     budgetbits = 65536 * 8 + 2048
+    speculativeHistUpdate = False
 
     tage = MPP_TAGE()
     loop_predictor = MPP_LoopPredictor()
@@ -1098,6 +1103,7 @@ class MultiperspectivePerceptronTAGE8KB(MultiperspectivePerceptronTAGE):
     cxx_header = "cpu/pred/multiperspective_perceptron_tage_8KB.hh"
 
     budgetbits = 8192 * 8 + 2048
+    speculativeHistUpdate = False
 
     tage = MPP_TAGE_8KB()
     loop_predictor = MPP_LoopPredictor_8KB()

--- a/src/cpu/pred/ltage.hh
+++ b/src/cpu/pred/ltage.hh
@@ -85,9 +85,8 @@ class LTAGE : public TAGE
     void update(ThreadID tid, Addr pc, bool taken,
                 void * &bp_history, bool squashed,
                 const StaticInstPtr & inst, Addr target) override;
-    virtual void branchPlaceholder(ThreadID tid, Addr pc,
-                                   bool uncond, void * &bp_history) override;
-
+    void branchPlaceholder(ThreadID tid, Addr pc,
+                           bool uncond, void * &bp_history) override;
     void init() override;
 
   protected:

--- a/src/cpu/pred/multiperspective_perceptron_tage.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage.cc
@@ -341,7 +341,7 @@ MPP_StatisticalCorrector::scPredict(ThreadID tid, Addr branch_pc,
         bool cond_branch, StatisticalCorrector::BranchInfo* bi,
         bool prev_pred_taken, bool bias_bit, bool use_conf_ctr,
         int8_t conf_ctr, unsigned conf_bits, int hitBank, int altBank,
-        int64_t phist, int init_lsum)
+        int init_lsum)
 {
     bool pred_taken = prev_pred_taken;
     if (cond_branch) {
@@ -352,7 +352,7 @@ MPP_StatisticalCorrector::scPredict(ThreadID tid, Addr branch_pc,
 
         getBiasLSUM(branch_pc, bi, lsum);
 
-        int thres = gPredictions(tid, branch_pc, bi, lsum, phist);
+        int thres = gPredictions(tid, branch_pc, bi, lsum);
 
         // These will be needed at update time
         bi->lsum = lsum;
@@ -540,7 +540,7 @@ MultiperspectivePerceptronTAGE::lookup(ThreadID tid, Addr instPC,
             bi->scBranchInfo, pred_taken, false /* bias_bit: unused */,
             false /* use_tage_ctr: unused */, 0 /* conf_ctr: unused */,
             0 /* conf_bits: unused */, 0 /* hitBank: unused */,
-            0 /* altBank: unused */, tage->getPathHist(tid), init_lsum);
+            0 /* altBank: unused */, init_lsum);
     bi->predictedTaken = pred_taken;
     bi->lpBranchInfo->predTaken = pred_taken;
     return pred_taken;
@@ -550,7 +550,7 @@ MultiperspectivePerceptronTAGE::lookup(ThreadID tid, Addr instPC,
 void
 MPP_StatisticalCorrector::condBranchUpdate(ThreadID tid, Addr branch_pc,
         bool taken, StatisticalCorrector::BranchInfo *bi, Addr target,
-        bool bias_bit, int hitBank, int altBank, int64_t phist)
+        bool bias_bit, int hitBank, int altBank)
 {
     bool scPred = (bi->lsum >= 0);
 
@@ -584,7 +584,7 @@ MPP_StatisticalCorrector::condBranchUpdate(ThreadID tid, Addr branch_pc,
         ctrUpdate(bias[indBias], taken, scCountersWidth);
         ctrUpdate(biasSK[indBiasSK], taken, scCountersWidth);
 
-        gUpdates(tid, branch_pc, taken, bi, phist);
+        gUpdates(tid, branch_pc, taken, bi);
     }
 }
 
@@ -610,10 +610,11 @@ MultiperspectivePerceptronTAGE::update(ThreadID tid, Addr pc, bool taken,
     }
 
     if (bi->isUnconditional()) {
-        statisticalCorrector->scHistoryUpdate(pc, inst, taken,
-                bi->scBranchInfo, target);
         tage->updateHistories(tid, pc, false, taken, target,
                               inst, bi->tageBranchInfo);
+        statisticalCorrector->updateHistories(pc, false, inst, taken,
+                                              bi->scBranchInfo, target,
+                                              tage->getPathHist(tid, false));
     } else {
         tage->updateStats(taken, bi->tageBranchInfo);
         loopPredictor->updateStats(taken, bi->lpBranchInfo);
@@ -628,9 +629,10 @@ MultiperspectivePerceptronTAGE::update(ThreadID tid, Addr pc, bool taken,
             updatePartial(tid, *bi, taken);
         }
         statisticalCorrector->condBranchUpdate(tid, pc, taken,
-                bi->scBranchInfo, target, false /* bias_bit: unused */,
-                0 /* hitBank: unused */, 0 /* altBank: unused*/,
-                tage->getPathHist(tid));
+                                               bi->scBranchInfo, target,
+                                               false /* bias_bit: unused */,
+                                               0 /* hitBank: unused */,
+                                               0 /* altBank: unused*/);
 
         tage->condBranchUpdate(tid, pc, taken, bi->tageBranchInfo,
                                rng->random<int>(), target,
@@ -658,11 +660,12 @@ MultiperspectivePerceptronTAGE::update(ThreadID tid, Addr pc, bool taken,
                 }
             }
 
-            statisticalCorrector->scHistoryUpdate(pc, inst, taken,
-                    bi->scBranchInfo, target);
-
             tage->updateHistories(tid, pc, false, taken, target,
                                   inst, bi->tageBranchInfo);
+            statisticalCorrector->updateHistories(pc, false, inst, taken,
+                                                  bi->scBranchInfo, target,
+                                                  tage->getPathHist(tid,
+                                                                    false));
         }
     }
     delete bi;

--- a/src/cpu/pred/multiperspective_perceptron_tage.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage.hh
@@ -189,13 +189,13 @@ class MPP_StatisticalCorrector : public StatisticalCorrector
     bool scPredict(ThreadID tid, Addr branch_pc, bool cond_branch,
                    StatisticalCorrector::BranchInfo* bi, bool prev_pred_taken,
                    bool bias_bit, bool use_conf_ctr, int8_t conf_ctr,
-                   unsigned conf_bits, int hitBank, int altBank, int64_t phist,
+                   unsigned conf_bits, int hitBank, int altBank,
                    int init_lsum) override;
 
     void condBranchUpdate(ThreadID tid, Addr branch_pc, bool taken,
                           StatisticalCorrector::BranchInfo *bi,
-                          Addr target, bool b, int hitBank, int altBank,
-                          int64_t phist) override;
+                          Addr target, bool b, int hitBank,
+                          int altBank) override;
 
     virtual void getBiasLSUM(Addr branch_pc,
             StatisticalCorrector::BranchInfo *bi, int &lsum) const = 0;

--- a/src/cpu/pred/multiperspective_perceptron_tage.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage.hh
@@ -134,8 +134,10 @@ class MPP_StatisticalCorrector : public StatisticalCorrector
 
     struct MPP_SCThreadHistory : public StatisticalCorrector::SCThreadHistory
     {
-        MPP_SCThreadHistory() : globalHist(0), historyStack(16, 0),
-            historyStackPointer(0) {}
+        MPP_SCThreadHistory(unsigned instShiftAmt)
+            : SCThreadHistory(instShiftAmt),
+              globalHist(0), historyStack(16, 0),
+              historyStackPointer(0) {}
         int64_t globalHist; // global history
         std::vector<int64_t> historyStack;
         unsigned int historyStackPointer;

--- a/src/cpu/pred/multiperspective_perceptron_tage_64KB.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage_64KB.cc
@@ -77,7 +77,7 @@ MPP_StatisticalCorrector_64KB::makeThreadHistory()
 
 void
 MPP_StatisticalCorrector_64KB::getBiasLSUM(Addr branch_pc,
-        StatisticalCorrector::BranchInfo* bi, int &lsum) const
+        StatisticalCorrector::BranchInfo *bi, int &lsum) const
 {
     int8_t ctr = bias[getIndBias(branch_pc, bi, false /* unused */)];
     lsum += 2.09 * ctr;
@@ -87,7 +87,7 @@ MPP_StatisticalCorrector_64KB::getBiasLSUM(Addr branch_pc,
 
 int
 MPP_StatisticalCorrector_64KB::gPredictions(ThreadID tid, Addr branch_pc,
-        StatisticalCorrector::BranchInfo* bi, int & lsum, int64_t phist)
+        StatisticalCorrector::BranchInfo *bi, int &lsum)
 {
     MPP_SCThreadHistory *sh = static_cast<MPP_SCThreadHistory *>(scHistory);
     unsigned int pc = branch_pc;
@@ -118,7 +118,7 @@ MPP_StatisticalCorrector_64KB::gPredictions(ThreadID tid, Addr branch_pc,
 
 void
 MPP_StatisticalCorrector_64KB::gUpdates(ThreadID tid, Addr pc, bool taken,
-        StatisticalCorrector::BranchInfo* bi, int64_t phist)
+        StatisticalCorrector::BranchInfo *bi)
 {
     MPP_SCThreadHistory *sh = static_cast<MPP_SCThreadHistory *>(scHistory);
 
@@ -141,7 +141,7 @@ MPP_StatisticalCorrector_64KB::gUpdates(ThreadID tid, Addr pc, bool taken,
 void
 MPP_StatisticalCorrector_64KB::scHistoryUpdate(Addr branch_pc,
         const StaticInstPtr &inst, bool taken,
-        StatisticalCorrector::BranchInfo *bi, Addr corrTarget)
+        Addr corrTarget, int64_t phist)
 {
     int brtype = inst->isDirectCtrl() ? 0 : 2;
     if (! inst->isUncondCtrl()) {
@@ -159,8 +159,8 @@ MPP_StatisticalCorrector_64KB::scHistoryUpdate(Addr branch_pc,
     sh->updateHistoryStack(corrTarget, taken, inst->isCall(),
                            inst->isReturn());
 
-    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken, bi,
-                                          corrTarget);
+    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken,
+                                          corrTarget, phist);
 }
 
 size_t

--- a/src/cpu/pred/multiperspective_perceptron_tage_64KB.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage_64KB.cc
@@ -64,7 +64,7 @@ MPP_StatisticalCorrector_64KB::MPP_StatisticalCorrector_64KB(
 MPP_StatisticalCorrector_64KB::SCThreadHistory*
 MPP_StatisticalCorrector_64KB::makeThreadHistory()
 {
-    MPP_SCThreadHistory *sh = new MPP_SCThreadHistory();
+    MPP_SCThreadHistory *sh = new MPP_SCThreadHistory(instShiftAmt);
 
     sh->setNumOrdinalHistories(3);
     sh->initLocalHistory(1, numEntriesFirstLocalHistories, 4);

--- a/src/cpu/pred/multiperspective_perceptron_tage_64KB.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage_64KB.hh
@@ -70,14 +70,13 @@ class MPP_StatisticalCorrector_64KB : public MPP_StatisticalCorrector
 
     StatisticalCorrector::SCThreadHistory *makeThreadHistory() override;
     int gPredictions(ThreadID tid, Addr branch_pc,
-            StatisticalCorrector::BranchInfo* bi, int &lsum, int64_t phist)
-            override;
+            StatisticalCorrector::BranchInfo *bi, int &lsum) override;
     void getBiasLSUM(Addr branch_pc,
             StatisticalCorrector::BranchInfo *bi, int &lsum) const override;
     void gUpdates(ThreadID tid, Addr pc, bool taken,
-            StatisticalCorrector::BranchInfo* bi, int64_t phist) override;
+            StatisticalCorrector::BranchInfo *bi) override;
     void scHistoryUpdate(Addr branch_pc, const StaticInstPtr &inst, bool taken,
-            StatisticalCorrector::BranchInfo *bi, Addr corrTarget) override;
+            Addr corrTarget, int64_t phist) override;
   public:
     MPP_StatisticalCorrector_64KB(
             const MPP_StatisticalCorrector_64KBParams &p);

--- a/src/cpu/pred/multiperspective_perceptron_tage_8KB.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage_8KB.cc
@@ -54,7 +54,7 @@ MPP_StatisticalCorrector_8KB::MPP_StatisticalCorrector_8KB(
 MPP_StatisticalCorrector_8KB::SCThreadHistory*
 MPP_StatisticalCorrector_8KB::makeThreadHistory()
 {
-    MPP_SCThreadHistory *sh = new MPP_SCThreadHistory();
+    MPP_SCThreadHistory *sh = new MPP_SCThreadHistory(instShiftAmt);
 
     sh->setNumOrdinalHistories(1);
     sh->initLocalHistory(1, numEntriesFirstLocalHistories, 4);

--- a/src/cpu/pred/multiperspective_perceptron_tage_8KB.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage_8KB.cc
@@ -64,7 +64,7 @@ MPP_StatisticalCorrector_8KB::makeThreadHistory()
 
 void
 MPP_StatisticalCorrector_8KB::getBiasLSUM(Addr branch_pc,
-        StatisticalCorrector::BranchInfo* bi, int &lsum) const
+        StatisticalCorrector::BranchInfo *bi, int &lsum) const
 {
     int8_t ctr = bias[getIndBias(branch_pc, bi, false /* unused */)];
     lsum += 2 * ctr + 1;
@@ -74,7 +74,7 @@ MPP_StatisticalCorrector_8KB::getBiasLSUM(Addr branch_pc,
 
 int
 MPP_StatisticalCorrector_8KB::gPredictions(ThreadID tid, Addr branch_pc,
-        StatisticalCorrector::BranchInfo* bi, int & lsum, int64_t phist)
+        StatisticalCorrector::BranchInfo *bi, int &lsum)
 {
     MPP_SCThreadHistory *sh = static_cast<MPP_SCThreadHistory *>(scHistory);
     unsigned int pc = branch_pc;
@@ -97,7 +97,7 @@ MPP_StatisticalCorrector_8KB::gPredictions(ThreadID tid, Addr branch_pc,
 
 void
 MPP_StatisticalCorrector_8KB::gUpdates(ThreadID tid, Addr pc, bool taken,
-        StatisticalCorrector::BranchInfo* bi, int64_t phist)
+        StatisticalCorrector::BranchInfo *bi)
 {
     MPP_SCThreadHistory *sh = static_cast<MPP_SCThreadHistory *>(scHistory);
 
@@ -113,8 +113,7 @@ MPP_StatisticalCorrector_8KB::gUpdates(ThreadID tid, Addr pc, bool taken,
 
 void
 MPP_StatisticalCorrector_8KB::scHistoryUpdate(Addr branch_pc,
-        const StaticInstPtr &inst, bool taken,
-        StatisticalCorrector::BranchInfo *bi, Addr corrTarget)
+        const StaticInstPtr &inst, bool taken, Addr corrTarget, int64_t phist)
 {
     int brtype = inst->isDirectCtrl() ? 0 : 2;
     if (! inst->isUncondCtrl()) {
@@ -129,8 +128,8 @@ MPP_StatisticalCorrector_8KB::scHistoryUpdate(Addr branch_pc,
     sh->updateHistoryStack(corrTarget, taken, inst->isCall(),
                            inst->isReturn());
 
-    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken, bi,
-                                          corrTarget);
+    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken,
+                                          corrTarget, phist);
 }
 
 size_t

--- a/src/cpu/pred/multiperspective_perceptron_tage_8KB.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage_8KB.hh
@@ -69,14 +69,13 @@ class MPP_StatisticalCorrector_8KB : public MPP_StatisticalCorrector
 {
     StatisticalCorrector::SCThreadHistory *makeThreadHistory() override;
     int gPredictions(ThreadID tid, Addr branch_pc,
-            StatisticalCorrector::BranchInfo* bi, int &lsum, int64_t phist)
-            override;
+            StatisticalCorrector::BranchInfo *bi, int &lsum) override;
     void getBiasLSUM(Addr branch_pc,
             StatisticalCorrector::BranchInfo *bi, int &lsum) const override;
     void gUpdates(ThreadID tid, Addr pc, bool taken,
-            StatisticalCorrector::BranchInfo* bi, int64_t phist) override;
+            StatisticalCorrector::BranchInfo *bi) override;
     void scHistoryUpdate(Addr branch_pc, const StaticInstPtr &inst, bool taken,
-            StatisticalCorrector::BranchInfo *bi, Addr corrTarget) override;
+            Addr corrTarget, int64_t phist) override;
   public:
     MPP_StatisticalCorrector_8KB(const MPP_StatisticalCorrector_8KBParams &p);
     size_t getSizeInBits() const override;

--- a/src/cpu/pred/statistical_corrector.cc
+++ b/src/cpu/pred/statistical_corrector.cc
@@ -70,6 +70,7 @@ StatisticalCorrector::StatisticalCorrector(
     pUpdateThresholdWidth(p.pUpdateThresholdWidth),
     extraWeightsWidth(p.extraWeightsWidth),
     scCountersWidth(p.scCountersWidth),
+    instShiftAmt(p.instShiftAmt),
     firstH(0),
     secondH(0),
     stats(this)
@@ -156,34 +157,41 @@ unsigned
 StatisticalCorrector::getIndBias(Addr branch_pc, BranchInfo* bi,
                                  bool bias) const
 {
-    return (((((branch_pc ^(branch_pc >>2))<<1) ^ (bi->lowConf & bias)) <<1)
-            +  bi->predBeforeSC) & ((1<<logBias) -1);
+    Addr shifted_pc = branch_pc >> instShiftAmt;
+    return (((((shifted_pc ^ (shifted_pc >> 2)) << 1)
+            ^ (bi->lowConf & bias)) << 1) +  bi->predBeforeSC)
+            & ((1 << logBias) - 1);
 }
 
 unsigned
 StatisticalCorrector::getIndBiasSK(Addr branch_pc, BranchInfo* bi) const
 {
-    return (((((branch_pc ^ (branch_pc >> (logBias-2)))<<1) ^
-           (bi->highConf))<<1) + bi->predBeforeSC) & ((1<<logBias) -1);
+    Addr shifted_pc = branch_pc >> instShiftAmt;
+    return (((((shifted_pc ^ (shifted_pc >> (logBias - 2))) << 1)
+            ^ bi->highConf) << 1) + bi->predBeforeSC)
+            & ((1 << logBias) - 1);
 }
 
 unsigned
 StatisticalCorrector::getIndUpd(Addr branch_pc) const
 {
-    return ((branch_pc ^ (branch_pc >>2)) & ((1 << (logSizeUp)) - 1));
+    Addr shifted_pc = branch_pc >> instShiftAmt;
+    return ((shifted_pc ^ (shifted_pc >> 2)) & ((1 << logSizeUp) - 1));
 }
 
 unsigned
 StatisticalCorrector::getIndUpds(Addr branch_pc) const
 {
-    return ((branch_pc ^ (branch_pc >>2)) & ((1 << (logSizeUps)) - 1));
+    Addr shifted_pc = branch_pc >> instShiftAmt;
+    return ((shifted_pc ^ (shifted_pc >> 2)) & ((1 << logSizeUps) - 1));
 }
 
 int64_t
 StatisticalCorrector::gIndex(Addr branch_pc, int64_t bhist, int logs, int nbr,
                              int i)
 {
-    return (((int64_t) branch_pc) ^ bhist ^ (bhist >> (8 - i)) ^
+    return (((int64_t) branch_pc >> instShiftAmt) ^
+             bhist ^ (bhist >> (8 - i)) ^
             (bhist >> (16 - 2 * i)) ^ (bhist >> (24 - 3 * i)) ^
             (bhist >> (32 - 3 * i)) ^ (bhist >> (40 - 4 * i))) &
            ((1 << (logs - gIndexLogsSubstr(nbr, i))) - 1);

--- a/src/cpu/pred/statistical_corrector.cc
+++ b/src/cpu/pred/statistical_corrector.cc
@@ -99,7 +99,7 @@ StatisticalCorrector::makeBranchInfo()
 StatisticalCorrector::SCThreadHistory*
 StatisticalCorrector::makeThreadHistory()
 {
-    return new SCThreadHistory();
+    return new SCThreadHistory(instShiftAmt);
 }
 
 void

--- a/src/cpu/pred/statistical_corrector.cc
+++ b/src/cpu/pred/statistical_corrector.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Metempsy Technology Consulting
+ * Copyright (c) 2024 Technical University of Munich
  * All rights reserved.
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
@@ -71,6 +72,7 @@ StatisticalCorrector::StatisticalCorrector(
     extraWeightsWidth(p.extraWeightsWidth),
     scCountersWidth(p.scCountersWidth),
     instShiftAmt(p.instShiftAmt),
+    speculativeHistUpdate(p.speculativeHistUpdate),
     firstH(0),
     secondH(0),
     stats(this)
@@ -133,8 +135,10 @@ StatisticalCorrector::initBias()
 
 void
 StatisticalCorrector::initGEHLTable(unsigned numLenghts,
-    std::vector<int> lengths, std::vector<int8_t> * & table,
-    unsigned logNumEntries, std::vector<int8_t> & w, int8_t wInitValue)
+                                    std::vector<int> lengths,
+                                    std::vector<int8_t> *&table,
+                                    unsigned logNumEntries,
+                                    std::vector<int8_t> &w, int8_t wInitValue)
 {
     assert(lengths.size() == numLenghts);
     if (numLenghts == 0) {
@@ -164,7 +168,7 @@ StatisticalCorrector::getIndBias(Addr branch_pc, BranchInfo* bi,
 }
 
 unsigned
-StatisticalCorrector::getIndBiasSK(Addr branch_pc, BranchInfo* bi) const
+StatisticalCorrector::getIndBiasSK(Addr branch_pc, BranchInfo *bi) const
 {
     Addr shifted_pc = branch_pc >> instShiftAmt;
     return (((((shifted_pc ^ (shifted_pc >> (logBias - 2))) << 1)
@@ -199,8 +203,9 @@ StatisticalCorrector::gIndex(Addr branch_pc, int64_t bhist, int logs, int nbr,
 
 int
 StatisticalCorrector::gPredict(Addr branch_pc, int64_t hist,
-        std::vector<int> & length, std::vector<int8_t> * tab, int nbr,
-        int logs, std::vector<int8_t> & w)
+                               std::vector<int> &length,
+                               std::vector<int8_t> *tab, int nbr, int logs,
+                               std::vector<int8_t> &w)
 {
     int percsum = 0;
     for (int i = 0; i < nbr; i++) {
@@ -215,9 +220,9 @@ StatisticalCorrector::gPredict(Addr branch_pc, int64_t hist,
 
 void
 StatisticalCorrector::gUpdate(Addr branch_pc, bool taken, int64_t hist,
-                   std::vector<int> & length, std::vector<int8_t> * tab,
-                   int nbr, int logs, std::vector<int8_t> & w,
-                   BranchInfo* bi)
+                              std::vector<int> &length,
+                              std::vector<int8_t> *tab, int nbr, int logs,
+                              std::vector<int8_t> &w, BranchInfo *bi)
 {
     int percsum = 0;
     for (int i = 0; i < nbr; i++) {
@@ -236,34 +241,26 @@ StatisticalCorrector::gUpdate(Addr branch_pc, bool taken, int64_t hist,
 
 bool
 StatisticalCorrector::scPredict(ThreadID tid, Addr branch_pc, bool cond_branch,
-                     BranchInfo* bi, bool prev_pred_taken, bool bias_bit,
-                     bool use_conf_ctr, int8_t conf_ctr, unsigned conf_bits,
-                     int hitBank, int altBank, int64_t phist, int init_lsum)
+                                BranchInfo *bi, bool prev_pred_taken,
+                                bool bias_bit, bool use_conf_ctr,
+                                int8_t conf_ctr, unsigned conf_bits,
+                                int hitBank, int altBank, int init_lsum)
 {
     bool pred_taken = prev_pred_taken;
     if (cond_branch) {
 
         bi->predBeforeSC = prev_pred_taken;
-
-        // first calc/update the confidences from the TAGE prediction
-        if (use_conf_ctr) {
-            bi->lowConf = (abs(2 * conf_ctr + 1) == 1);
-            bi->medConf = (abs(2 * conf_ctr + 1) == 5);
-            bi->highConf = (abs(2 * conf_ctr + 1) >= (1<<conf_bits) - 1);
-        }
-
         int lsum = init_lsum;
 
-        int8_t ctr = bias[getIndBias(branch_pc, bi, bias_bit)];
-        lsum += (2 * ctr + 1);
-        ctr = biasSK[getIndBiasSK(branch_pc, bi)];
-        lsum += (2 * ctr + 1);
-        ctr = biasBank[getIndBiasBank(branch_pc, bi, hitBank, altBank)];
-        lsum += (2 * ctr + 1);
+        lsum += calcBias(branch_pc, bi, bias_bit,
+                         use_conf_ctr, conf_ctr, conf_bits, hitBank, altBank);
 
-        lsum = (1 + (wb[getIndUpds(branch_pc)] >= 0)) * lsum;
+        // Record the history state to be able to recover
+        // The gPredictions function will use the recorded state to
+        // make the predictions
+        scRecordHistState(branch_pc, bi);
 
-        int thres = gPredictions(tid, branch_pc, bi, lsum, phist);
+        int thres = gPredictions(tid, branch_pc, bi, lsum);
 
         // These will be needed at update time
         bi->lsum = lsum;
@@ -299,18 +296,73 @@ StatisticalCorrector::scPredict(ThreadID tid, Addr branch_pc, bool cond_branch,
     return pred_taken;
 }
 
+int
+StatisticalCorrector::calcBias(Addr branch_pc, BranchInfo *bi, bool bias_bit,
+                               bool use_conf_ctr, int8_t conf_ctr,
+                               unsigned conf_bits, int hitBank, int altBank)
+{
+    // first calc/update the confidences from the TAGE prediction
+    if (use_conf_ctr) {
+        bi->lowConf = (abs(2 * conf_ctr + 1) == 1);
+        bi->medConf = (abs(2 * conf_ctr + 1) == 5);
+        bi->highConf = (abs(2 * conf_ctr + 1) >= (1<<conf_bits) - 1);
+    }
+
+    int lsum = 0;
+
+    int8_t ctr = bias[getIndBias(branch_pc, bi, bias_bit)];
+    lsum += (2 * ctr + 1);
+    ctr = biasSK[getIndBiasSK(branch_pc, bi)];
+    lsum += (2 * ctr + 1);
+    ctr = biasBank[getIndBiasBank(branch_pc, bi, hitBank, altBank)];
+    lsum += (2 * ctr + 1);
+
+    lsum = (1 + (wb[getIndUpds(branch_pc)] >= 0)) * lsum;
+    return lsum;
+}
+
+
+void
+StatisticalCorrector::updateHistories(Addr branch_pc, bool speculative,
+                                      const StaticInstPtr &inst, bool taken,
+                                      BranchInfo *bi, Addr target,
+                                      int64_t phist)
+{
+    if (speculative != speculativeHistUpdate) {
+        return;
+    }
+
+    // If this is the first time we see this branch record the current
+    // state of the history to be able to recover.
+    if (speculativeHistUpdate && (!bi->modified)) {
+        scRecordHistState(branch_pc, bi);
+    }
+
+    // In case the branch already updated the history
+    // we need to revert the previous update first.
+    if (bi->modified) {
+        scRestoreHistState(bi);
+    }
+
+    // Update the SC histories
+    scHistoryUpdate(branch_pc, inst, taken, target, phist);
+    bi->modified = true;
+}
+
 void
 StatisticalCorrector::scHistoryUpdate(Addr branch_pc,
-        const StaticInstPtr &inst, bool taken, BranchInfo * tage_bi,
-        Addr corrTarget)
+                                      const StaticInstPtr &inst, bool taken,
+                                      Addr target, int64_t phist)
 {
+    // Update the path history from TAGE
+    scHistory->pHist = phist;
     int brtype = inst->isDirectCtrl() ? 0 : 2;
     if (! inst->isUncondCtrl()) {
         ++brtype;
     }
     // Non speculative SC histories update
     if (brtype & 1) {
-        if (corrTarget < branch_pc) {
+        if (target < branch_pc) {
             //This branch corresponds to a loop
             if (!taken) {
                 //exit of the "loop"
@@ -323,16 +375,50 @@ StatisticalCorrector::scHistoryUpdate(Addr branch_pc,
         }
 
         scHistory->bwHist = (scHistory->bwHist << 1) +
-                                (taken & (corrTarget < branch_pc));
+                                (taken & (target < branch_pc));
         scHistory->updateLocalHistory(1, branch_pc, taken);
     }
 }
 
 void
-StatisticalCorrector::condBranchUpdate(ThreadID tid, Addr branch_pc,
-        bool taken, BranchInfo *bi, Addr corrTarget, bool b, int hitBank,
-        int altBank, int64_t phist)
+StatisticalCorrector::scRecordHistState(Addr branch_pc, BranchInfo *bi)
 {
+    bi->pc = branch_pc;
+    bi->bwHist = scHistory->bwHist;
+    bi->imliCount = scHistory->imliCount;
+    bi->pHist = scHistory->pHist;
+    bi->localHistories[1] = scHistory->getLocalHistory(1, branch_pc);
+}
+
+bool
+StatisticalCorrector::scRestoreHistState(BranchInfo *bi)
+{
+    if (!bi->modified) {
+        return false;
+    }
+    scHistory->bwHist = bi->bwHist;
+    scHistory->imliCount = bi->imliCount;
+    scHistory->setLocalHistory(1, bi->pc, bi->localHistories[1]);
+    return true;
+}
+
+
+void
+StatisticalCorrector::condBranchUpdate(ThreadID tid, Addr branch_pc,
+                                       bool taken, BranchInfo *bi,
+                                       Addr corrTarget, bool b, int hitBank,
+                                       int altBank)
+{
+
+    if (speculativeHistUpdate) {
+        // For speculative updates we recalculate the lsum as it might
+        // have changed since the last update
+
+        bi->lsum = calcBias(branch_pc, bi, b, false/* was already recorded*/,
+                            0, 0, hitBank, altBank);
+        bi->thres = gPredictions(tid, branch_pc, bi, bi->lsum);
+    }
+
     bool scPred = (bi->lsum >= 0);
 
     if (bi->predBeforeSC != scPred) {
@@ -383,7 +469,7 @@ StatisticalCorrector::condBranchUpdate(ThreadID tid, Addr branch_pc,
         ctrUpdate(biasSK[indBiasSK], taken, scCountersWidth);
         ctrUpdate(biasBank[indBiasBank], taken, scCountersWidth);
 
-        gUpdates(tid, branch_pc, taken, bi, phist);
+        gUpdates(tid, branch_pc, taken, bi);
     }
 }
 

--- a/src/cpu/pred/statistical_corrector.hh
+++ b/src/cpu/pred/statistical_corrector.hh
@@ -128,7 +128,9 @@ class StatisticalCorrector : public SimObject
 
         unsigned getEntry(Addr pc, unsigned idx)
         {
-            return (pc ^ (pc >> shifts[idx])) & (localHistories[idx].size()-1);
+            Addr shifted_pc = pc >> instShiftAmt;
+            return (shifted_pc ^ (shifted_pc >> shifts[idx]))
+                 & (localHistories[idx].size()-1);
         }
     };
 
@@ -185,6 +187,8 @@ class StatisticalCorrector : public SimObject
     const unsigned extraWeightsWidth;
 
     const unsigned scCountersWidth;
+
+    const unsigned instShiftAmt;
 
     int8_t firstH;
     int8_t secondH;

--- a/src/cpu/pred/statistical_corrector.hh
+++ b/src/cpu/pred/statistical_corrector.hh
@@ -74,11 +74,14 @@ class StatisticalCorrector : public SimObject
     // histories used for the statistical corrector
     struct SCThreadHistory
     {
-        SCThreadHistory() {
+        SCThreadHistory(unsigned instShiftAmt)
+          : instShiftAmt(instShiftAmt)
+        {
             bwHist = 0;
             numOrdinalHistories = 0;
             imliCount = 0;
         }
+        const unsigned instShiftAmt;
         int64_t bwHist;  // backward global history
         int64_t imliCount;
 

--- a/src/cpu/pred/statistical_corrector.hh
+++ b/src/cpu/pred/statistical_corrector.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Metempsy Technology Consulting
+ * Copyright (c) 2024 Technical University of Munich
  * All rights reserved.
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
@@ -80,13 +81,16 @@ class StatisticalCorrector : public SimObject
             bwHist = 0;
             numOrdinalHistories = 0;
             imliCount = 0;
+            pHist = 0;
         }
         const unsigned instShiftAmt;
         int64_t bwHist;  // backward global history
         int64_t imliCount;
+        int64_t pHist;   // path history from TAGE
 
         void setNumOrdinalHistories(unsigned num)
         {
+            assert(num < MaxOrdinalHistories);
             numOrdinalHistories = num;
             assert(num > 0);
             shifts.resize(num);
@@ -106,6 +110,13 @@ class StatisticalCorrector : public SimObject
             assert((ordinal >= 1) && (ordinal <= numOrdinalHistories));
             unsigned idx = ordinal - 1;
             return localHistories[idx][getEntry(pc, idx)];
+        }
+
+        void setLocalHistory(int ordinal, Addr pc, int64_t value)
+        {
+            assert((ordinal >= 1) && (ordinal <= numOrdinalHistories));
+            unsigned idx = ordinal - 1;
+            localHistories[idx][getEntry(pc, idx)] = value;
         }
 
         void updateLocalHistory(
@@ -193,6 +204,11 @@ class StatisticalCorrector : public SimObject
 
     const unsigned instShiftAmt;
 
+    // Enable speculative updates of the SC histories
+    const bool speculativeHistUpdate;
+    // Maximum number of ordinal histories
+    static const int MaxOrdinalHistories = 4;
+
     int8_t firstH;
     int8_t secondH;
 
@@ -208,7 +224,9 @@ class StatisticalCorrector : public SimObject
     {
         BranchInfo() : lowConf(false), highConf(false), altConf(false),
               medConf(false), scPred(false), lsum(0), thres(0),
-              predBeforeSC(false), usedScPred(false)
+              predBeforeSC(false), usedScPred(false),
+              modified(false), pc(0), bwHist(0), imliCount(0), pHist(0),
+              globalHist(0), imHist(0)
         {}
 
         // confidences calculated on tage and used on the statistical
@@ -223,6 +241,19 @@ class StatisticalCorrector : public SimObject
         int thres;
         bool predBeforeSC;
         bool usedScPred;
+
+        // Variables to take a checkpoint of the SC history state
+        // and restore it after a misprediction
+        bool modified;     // indicator when the SC history was modified
+        Addr pc;
+        int64_t bwHist;    // backward global history
+        int64_t imliCount; // inner most loop interation count
+        int64_t pHist;     // path history from TAGE
+        int64_t localHistories[MaxOrdinalHistories] = {0};
+        // 8KB SC another global history
+        int64_t globalHist;
+        // 64KB SC uses multiple imliCount
+        int64_t imHist;
     };
 
     StatisticalCorrector(const StatisticalCorrectorParams &p);
@@ -233,23 +264,27 @@ class StatisticalCorrector : public SimObject
     virtual void initBias();
 
     virtual bool scPredict(
-        ThreadID tid, Addr branch_pc, bool cond_branch, BranchInfo* bi,
+        ThreadID tid, Addr branch_pc, bool cond_branch, BranchInfo *bi,
         bool prev_pred_taken, bool bias_bit, bool use_conf_ctr,
         int8_t conf_ctr, unsigned conf_bits, int hitBank, int altBank,
-        int64_t phist, int init_lsum = 0);
+        int init_lsum = 0);
 
-    virtual unsigned getIndBias(Addr branch_pc, BranchInfo* bi, bool b) const;
+    virtual unsigned getIndBias(Addr branch_pc, BranchInfo *bi, bool b) const;
 
-    virtual unsigned getIndBiasSK(Addr branch_pc, BranchInfo* bi) const;
+    virtual unsigned getIndBiasSK(Addr branch_pc, BranchInfo *bi) const;
 
-    virtual unsigned getIndBiasBank( Addr branch_pc, BranchInfo* bi,
-        int hitBank, int altBank) const = 0;
+    virtual unsigned getIndBiasBank(
+        Addr branch_pc, BranchInfo *bi, int hitBank, int altBank) const = 0;
 
     virtual unsigned getIndUpd(Addr branch_pc) const;
     unsigned getIndUpds(Addr branch_pc) const;
 
-    virtual int gPredictions(ThreadID tid, Addr branch_pc, BranchInfo* bi,
-        int & lsum, int64_t phist) = 0;
+    virtual int gPredictions(
+        ThreadID tid, Addr branch_pc, BranchInfo *bi, int &lsum) = 0;
+
+    int calcBias(
+        Addr branch_pc, BranchInfo *bi, bool bias_bit, bool use_conf_ctr,
+        int8_t conf_ctr, unsigned conf_bits, int hitBank, int altBank);
 
     int64_t gIndex(Addr branch_pc, int64_t bhist, int logs, int nbr, int i);
 
@@ -261,28 +296,36 @@ class StatisticalCorrector : public SimObject
         std::vector<int8_t> & w);
 
     virtual void gUpdate(
-        Addr branch_pc, bool taken, int64_t hist, std::vector<int> & length,
-        std::vector<int8_t> * tab, int nbr, int logs,
-        std::vector<int8_t> & w, BranchInfo* bi);
+        Addr branch_pc, bool taken, int64_t hist, std::vector<int> &length,
+        std::vector<int8_t> *tab, int nbr, int logs,
+        std::vector<int8_t> &w, BranchInfo *bi);
 
     void initGEHLTable(
         unsigned numLenghts, std::vector<int> lengths,
-        std::vector<int8_t> * & table, unsigned logNumEntries,
-        std::vector<int8_t> & w, int8_t wInitValue);
+        std::vector<int8_t> *&table, unsigned logNumEntries,
+        std::vector<int8_t> &w, int8_t wInitValue);
 
     virtual void scHistoryUpdate(
-        Addr branch_pc, const StaticInstPtr &inst , bool taken,
-        BranchInfo * tage_bi, Addr corrTarget);
+        Addr branch_pc, const StaticInstPtr &inst,
+        bool taken, Addr target, int64_t phist);
 
-    virtual void gUpdates( ThreadID tid, Addr pc, bool taken, BranchInfo* bi,
-        int64_t phist) = 0;
+    void updateHistories(
+        Addr branch_pc, bool speculative,
+        const StaticInstPtr &inst , bool taken,
+        BranchInfo *bi, Addr target, int64_t phist);
+
+    virtual void scRecordHistState(Addr branch_pc, BranchInfo *bi);
+    virtual bool scRestoreHistState(BranchInfo *bi);
+
+    virtual void gUpdates(
+        ThreadID tid, Addr pc, bool taken, BranchInfo *bi) = 0;
 
     void init() override;
     void updateStats(bool taken, BranchInfo *bi);
 
     virtual void condBranchUpdate(ThreadID tid, Addr branch_pc, bool taken,
                           BranchInfo *bi, Addr corrTarget, bool bias_bit,
-                          int hitBank, int altBank, int64_t phist);
+                          int hitBank, int altBank);
 
     virtual size_t getSizeInBits() const;
 };

--- a/src/cpu/pred/tage.hh
+++ b/src/cpu/pred/tage.hh
@@ -104,15 +104,15 @@ class TAGE: public BPredUnit
 
     // Base class methods.
     bool lookup(ThreadID tid, Addr pc, void* &bp_history) override;
-    void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
-                         Addr target, const StaticInstPtr &inst,
+    void updateHistories(ThreadID tid, Addr pc, bool uncond,
+                         bool taken, Addr target, const StaticInstPtr &inst,
                          void * &bp_history) override;
     void update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
                 bool squashed, const StaticInstPtr &inst,
                 Addr target) override;
-    virtual void squash(ThreadID tid, void * &bp_history) override;
-    virtual void branchPlaceholder(ThreadID tid, Addr pc,
-                                   bool uncond, void * &bp_history) override;
+    void squash(ThreadID tid, void * &bp_history) override;
+    void branchPlaceholder(ThreadID tid, Addr pc,
+                           bool uncond, void * &bp_history) override;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/tage_base.cc
+++ b/src/cpu/pred/tage_base.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 The University of Wisconsin
+ * Copyright (c) 2024 Technical University of Munich
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
  * Informatique et en Automatique  / French National Research Institute
@@ -601,7 +602,6 @@ TAGEBase::updatePathAndGlobalHistory(ThreadID tid, int brtype, bool taken,
     bi->nGhist = 1;
     // Update the global history
     updateGHist(tid, bi->ghist, bi->nGhist);
-    bi->modified = true;
 }
 
 
@@ -646,6 +646,7 @@ TAGEBase::updateHistories(ThreadID tid, Addr branch_pc, bool speculative,
     // TAGE implementations.
     updatePathAndGlobalHistory(tid, branchTypeExtra(inst), taken,
                                branch_pc, target, bi);
+    bi->modified = true;
 
     DPRINTF(Tage, "Updating global histories with branch:%lx; taken?:%d, "
             "path Hist: %x; pointer:%d\n", branch_pc, taken,
@@ -700,6 +701,15 @@ TAGEBase::restoreHistState(ThreadID tid, BranchInfo* bi)
     }
     bi->nGhist = 0;
     bi->modified = false;
+}
+
+int
+TAGEBase::calcNewPathHist(ThreadID tid, Addr pc, int cur_phist) const
+{
+    int pathbit = ((pc >> instShiftAmt) & 1);
+    cur_phist = (cur_phist << 1) + pathbit;
+    cur_phist = (cur_phist & ((1ULL << pathHistBits) - 1));
+    return cur_phist;
 }
 
 void

--- a/src/cpu/pred/tage_base.hh
+++ b/src/cpu/pred/tage_base.hh
@@ -504,6 +504,8 @@ class TAGEBase : public SimObject
         // Speculative path history
         // (LSB of branch address)
         int pathHist;
+        // Non-speculative path history
+        int nonSpecPathHist;
 
         // Speculative branch direction
         // history (circular buffer)

--- a/src/cpu/pred/tage_base.hh
+++ b/src/cpu/pred/tage_base.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 The University of Wisconsin
+ * Copyright (c) 2024 Technical University of Munich
  *
  * Copyright (c) 2006 INRIA (Institut National de Recherche en
  * Informatique et en Automatique  / French National Research Institute
@@ -474,7 +475,8 @@ class TAGEBase : public SimObject
     unsigned getGHR(ThreadID tid) const;
     int8_t getCtr(int hitBank, int hitBankIndex) const;
     unsigned getTageCtrBits() const;
-    int getPathHist(ThreadID tid) const;
+    int getPathHist(ThreadID tid, bool speculative=true) const;
+    int calcNewPathHist(ThreadID tid, Addr pc, int cur_phist) const;
     bool isSpeculativeUpdateEnabled() const;
     size_t getSizeInBits() const;
 

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2024 Technical University of Munich
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -239,10 +240,21 @@ TAGE_SC_L_TAGE::bindex(Addr pc) const
             ((1ULL << (logTagTableSizes[0])) - 1));
 }
 
+int
+TAGE_SC_L_TAGE::branchTypeExtra(const StaticInstPtr& inst)
+{
+    int brtype = inst->isDirectCtrl() ? 0 : 2;
+    if (! inst->isUncondCtrl()) {
+        ++brtype;
+    }
+    return brtype;
+}
+
 void
-TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
-    ThreadID tid, int brtype, bool taken, Addr branch_pc, Addr target,
-    TAGEBase::BranchInfo *bi)
+TAGE_SC_L_TAGE::updatePathAndGlobalHistory(ThreadID tid, int brtype,
+                                           bool taken, Addr branch_pc,
+                                           Addr target,
+                                           TAGEBase::BranchInfo* bi)
 {
     ThreadHistory& tHist = threadHistory[tid];
     // TAGE update
@@ -266,41 +278,11 @@ TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
             tHist.pathHist = (tHist.pathHist & ((1ULL << pathHistBits) - 1));
         }
     }
-
+    // Record the update to be able to squash it later
+    bi->ghist = tmp;
+    bi->nGhist = maxt;
     updateGHist(tid, tmp, maxt);
     bi->modified = true;
-}
-
-void
-TAGE_SC_L_TAGE::updateHistories(ThreadID tid, Addr branch_pc,
-                                bool speculative, bool taken,
-                                Addr target, const StaticInstPtr &inst,
-                                TAGEBase::BranchInfo* bi)
-{
-    if (speculative != speculativeHistUpdate) {
-        return;
-    }
-    // speculation is not implemented
-    assert(! speculative);
-
-    ThreadHistory& tHist = threadHistory[tid];
-
-    int brtype = inst->isDirectCtrl() ? 0 : 2;
-    if (! inst->isUncondCtrl()) {
-        ++brtype;
-    }
-    updatePathAndGlobalHistory(tid, brtype, taken, branch_pc, target, bi);
-
-    DPRINTF(TageSCL, "Updating global histories with branch:%lx; taken?:%d, "
-            "path Hist: %x; pointer:%d\n", branch_pc, taken, tHist.pathHist,
-            tHist.ptGhist);
-}
-
-void
-TAGE_SC_L_TAGE::squash(ThreadID tid, bool taken, Addr target,
-                       const StaticInstPtr &inst, TAGEBase::BranchInfo *bi)
-{
-    fatal("Speculation is not implemented");
 }
 
 void
@@ -400,19 +382,21 @@ TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
     bi->scBranchInfo->altConf = tage_scl_bi->altConf;
     bi->scBranchInfo->medConf = tage_scl_bi->medConf;
 
-    bool use_tage_ctr = bi->tageBranchInfo->hitBank > 0;
-    int8_t tage_ctr = use_tage_ctr ?
-        tage->getCtr(tage_scl_bi->hitBank, tage_scl_bi->hitBankIndex) : 0;
-    bool bias = (bi->tageBranchInfo->longestMatchPred !=
-                 bi->tageBranchInfo->altTaken);
+    if (statisticalCorrector) {
+        bool use_tage_ctr = bi->tageBranchInfo->hitBank > 0;
+        int8_t tage_ctr = use_tage_ctr ?
+            tage->getCtr(tage_scl_bi->hitBank, tage_scl_bi->hitBankIndex) : 0;
+        bool bias = (bi->tageBranchInfo->longestMatchPred !=
+                    bi->tageBranchInfo->altTaken);
 
-    pred_taken = statisticalCorrector->scPredict(tid, pc, cond_branch,
-            bi->scBranchInfo, pred_taken, bias, use_tage_ctr, tage_ctr,
-            tage->getTageCtrBits(), bi->tageBranchInfo->hitBank,
-            bi->tageBranchInfo->altBank, tage->getPathHist(tid));
+        pred_taken = statisticalCorrector->scPredict(tid, pc, cond_branch,
+                bi->scBranchInfo, pred_taken, bias, use_tage_ctr, tage_ctr,
+                tage->getTageCtrBits(), bi->tageBranchInfo->hitBank,
+                bi->tageBranchInfo->altBank, tage->getPathHist(tid));
 
-    if (bi->scBranchInfo->usedScPred) {
-        bi->tageBranchInfo->provider = SC;
+        if (bi->scBranchInfo->usedScPred) {
+            bi->tageBranchInfo->provider = SC;
+        }
     }
 
     // record final prediction
@@ -451,13 +435,15 @@ TAGE_SC_L::update(ThreadID tid, Addr pc, bool taken, void *&bp_history,
 
         loopPredictor->updateStats(taken, bi->lpBranchInfo);
 
-        statisticalCorrector->updateStats(taken, bi->scBranchInfo);
+        if (statisticalCorrector) {
+            statisticalCorrector->updateStats(taken, bi->scBranchInfo);
 
-        bool bias = (bi->tageBranchInfo->longestMatchPred !=
-                     bi->tageBranchInfo->altTaken);
-        statisticalCorrector->condBranchUpdate(tid, pc, taken,
-            bi->scBranchInfo, target, bias, bi->tageBranchInfo->hitBank,
-            bi->tageBranchInfo->altBank, tage->getPathHist(tid));
+            bool bias = (bi->tageBranchInfo->longestMatchPred !=
+                        bi->tageBranchInfo->altTaken);
+            statisticalCorrector->condBranchUpdate(tid, pc, taken,
+                bi->scBranchInfo, target, bias, bi->tageBranchInfo->hitBank,
+                bi->tageBranchInfo->altBank, tage->getPathHist(tid));
+        }
 
         loopPredictor->condBranchUpdate(tid, pc, taken,
                 bi->tageBranchInfo->tagePred, bi->lpBranchInfo, instShiftAmt);
@@ -466,17 +452,17 @@ TAGE_SC_L::update(ThreadID tid, Addr pc, bool taken, void *&bp_history,
                                nrand, target, bi->lpBranchInfo->predTaken);
     }
 
-    if (!tage->isSpeculativeUpdateEnabled()) {
+    if (statisticalCorrector) {
         statisticalCorrector->scHistoryUpdate(pc, inst, taken,
-                                              bi->scBranchInfo, target);
-
-        tage->updateHistories(tid, pc, false, taken, target,
-                              inst, bi->tageBranchInfo);
+                                            bi->scBranchInfo, target);
     }
 
+    tage->updateHistories(tid, pc, false, taken, target,
+                            inst, bi->tageBranchInfo);
     delete bi;
     bp_history = nullptr;
 }
+
 
 } // namespace branch_prediction
 } // namespace gem5

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -140,6 +140,7 @@ TAGE_SC_L_TAGE::calculateIndicesAndTags(
     ThreadID tid, Addr pc, TAGEBase::BranchInfo* bi)
 {
     // computes the table addresses and the partial tags
+    Addr shifted_pc = pc >> instShiftAmt;
 
     for (int i = 1; i <= nHistoryTables; i += 2) {
         tableIndices[i] = gindex(tid, pc, i);
@@ -152,7 +153,7 @@ TAGE_SC_L_TAGE::calculateIndicesAndTags(
         bi->tableTags[i+1] = tableTags[i+1];
     }
 
-    Addr t = (pc ^ (threadHistory[tid].pathHist &
+    Addr t = (shifted_pc ^ (threadHistory[tid].pathHist &
                     ((1 << histLengths[firstLongTagTable]) - 1)))
              % longTagsTageFactor;
 
@@ -165,7 +166,8 @@ TAGE_SC_L_TAGE::calculateIndicesAndTags(
         }
     }
 
-    t = (pc ^ (threadHistory[tid].pathHist & ((1 << histLengths[1]) - 1)))
+    t = (shifted_pc ^ (threadHistory[tid].pathHist &
+                    ((1 << histLengths[1]) - 1)))
         % shortTagsTageFactor;
 
     for (int i = 1; i <= firstLongTagTable - 1; i++) {
@@ -193,11 +195,10 @@ TAGE_SC_L_TAGE::gindex(ThreadID tid, Addr pc, int bank) const
     int index;
     int hlen = (histLengths[bank] > pathHistBits) ? pathHistBits :
                                                     histLengths[bank];
-    unsigned int shortPc = pc;
+    unsigned int shifted_pc = pc >> instShiftAmt;
 
-    // pc is not shifted by instShiftAmt in this implementation
-    index = shortPc ^
-            (shortPc >> ((int) abs(logTagTableSizes[bank] - bank) + 1)) ^
+    index = shifted_pc ^
+            (shifted_pc >> ((int) abs(logTagTableSizes[bank] - bank) + 1)) ^
             threadHistory[tid].computeIndices[bank].comp ^
             F(threadHistory[tid].pathHist, hlen, bank);
 
@@ -233,7 +234,8 @@ TAGE_SC_L_TAGE::F(int a, int size, int bank) const
 int
 TAGE_SC_L_TAGE::bindex(Addr pc) const
 {
-    return ((pc ^ (pc >> instShiftAmt)) &
+    Addr shifted_pc = pc >> instShiftAmt;
+    return ((shifted_pc ^ (shifted_pc >> 2)) &
             ((1ULL << (logTagTableSizes[0])) - 1));
 }
 
@@ -244,12 +246,12 @@ TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
 {
     ThreadHistory& tHist = threadHistory[tid];
     // TAGE update
-    int tmp = ((branch_pc ^ (branch_pc >> instShiftAmt))) ^ taken;
-    int path = branch_pc ^ (branch_pc >> instShiftAmt)
-                         ^ (branch_pc >> (instShiftAmt+2));
+    Addr shifted_pc = branch_pc >> instShiftAmt;
+    int tmp = ((shifted_pc ^ (shifted_pc >> 2))) ^ taken;
+    int path = shifted_pc ^ (shifted_pc >> 2) ^ (shifted_pc >> 4);
     if ((brtype == 3) & taken) {
-         tmp = (tmp ^ (target >> instShiftAmt));
-         path = path ^ (target >> instShiftAmt) ^ (target >> (instShiftAmt+2));
+         tmp = (tmp ^ (target >> 2));
+         path = path ^ (target >> 2) ^ (target >> 4);
     }
 
     // some branch types use 3 bits in global history, the others just 2

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -172,10 +172,13 @@ class TAGE_SC_L: public LTAGE
 
     bool predict(
         ThreadID tid, Addr branch_pc, bool cond_branch, void* &b) override;
+    void squash(ThreadID tid, void * &bp_history) override;
     void update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
                 bool squashed, const StaticInstPtr & inst,
                 Addr target) override;
-
+    void updateHistories(ThreadID tid, Addr pc, bool uncond,
+                         bool taken, Addr target, const StaticInstPtr &inst,
+                         void * &bp_history) override;
     void branchPlaceholder(ThreadID tid, Addr pc,
                                 bool uncond, void * &bp_history) override
     { panic("Not implemented for this BP!\n"); }

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2024 Technical University of Munich
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -121,10 +122,6 @@ class TAGE_SC_L_TAGE : public TAGEBase
 
     unsigned getUseAltIdx(TAGEBase::BranchInfo* bi, Addr branch_pc) override;
 
-    void updateHistories(ThreadID tid, Addr branch_pc, bool speculative,
-                         bool taken, Addr target, const StaticInstPtr & inst,
-                         TAGEBase::BranchInfo* bi) override;
-
     int bindex(Addr pc_in) const override;
     int gindex(ThreadID tid, Addr pc, int bank) const override;
     virtual int gindex_ext(int index, int bank) const = 0;
@@ -132,12 +129,10 @@ class TAGE_SC_L_TAGE : public TAGEBase
 
     virtual uint16_t gtag(ThreadID tid, Addr pc, int bank) const override = 0;
 
-    void squash(ThreadID tid, bool taken, Addr target,
-                const StaticInstPtr &inst, TAGEBase::BranchInfo *bi) override;
-
-    void updatePathAndGlobalHistory(
-        ThreadID tid, int brtype, bool taken,
-        Addr branch_pc, Addr target, TAGEBase::BranchInfo* bi) override;
+    int branchTypeExtra(const StaticInstPtr& inst) override;
+    void updatePathAndGlobalHistory(ThreadID tid, int brtype, bool taken,
+                                    Addr branch_pc, Addr target,
+                                    TAGEBase::BranchInfo* bi) override;
 
     void adjustAlloc(bool & alloc, bool taken, bool pred_taken) override;
 

--- a/src/cpu/pred/tage_sc_l_64KB.cc
+++ b/src/cpu/pred/tage_sc_l_64KB.cc
@@ -75,7 +75,7 @@ TAGE_SC_L_64KB_StatisticalCorrector::TAGE_SC_L_64KB_StatisticalCorrector(
 TAGE_SC_L_64KB_StatisticalCorrector::SCThreadHistory*
 TAGE_SC_L_64KB_StatisticalCorrector::makeThreadHistory()
 {
-    SC_64KB_ThreadHistory *sh = new SC_64KB_ThreadHistory();
+    SC_64KB_ThreadHistory *sh = new SC_64KB_ThreadHistory(instShiftAmt);
 
     sh->setNumOrdinalHistories(3);
     sh->initLocalHistory(1, numEntriesFirstLocalHistories, 2);

--- a/src/cpu/pred/tage_sc_l_64KB.cc
+++ b/src/cpu/pred/tage_sc_l_64KB.cc
@@ -90,9 +90,14 @@ unsigned
 TAGE_SC_L_64KB_StatisticalCorrector::getIndBiasBank(Addr branch_pc,
         BranchInfo* bi, int hitBank, int altBank) const
 {
-    return (bi->predBeforeSC + (((hitBank+1)/4)<<4) + (bi->highConf<<1) +
-            (bi->lowConf <<2) + ((altBank!=0)<<3) +
-            ((branch_pc^(branch_pc>>2))<<7)) & ((1<<logBias) -1);
+    Addr shifted_pc = branch_pc >> instShiftAmt;
+    return (bi->predBeforeSC
+            + (((hitBank + 1) / 4) << 4)
+            + (bi->highConf << 1)
+            + (bi->lowConf << 2)
+            + ((altBank != 0) << 3)
+            + ((shifted_pc ^ (shifted_pc >> 2)) << 7))
+         & ((1 << logBias) -1);
 }
 
 int
@@ -103,7 +108,7 @@ TAGE_SC_L_64KB_StatisticalCorrector::gPredictions(ThreadID tid, Addr branch_pc,
         static_cast<SC_64KB_ThreadHistory *>(scHistory);
 
     lsum += gPredict(
-        (branch_pc << 1) + bi->predBeforeSC, sh->bwHist, bwm,
+        ((branch_pc >> instShiftAmt) << 1) + bi->predBeforeSC, sh->bwHist, bwm,
         bwgehl, bwnb, logBwnb, wbw);
 
     lsum += gPredict(
@@ -206,7 +211,8 @@ uint16_t
 TAGE_SC_L_TAGE_64KB::gtag(ThreadID tid, Addr pc, int bank) const
 {
     // very similar to the TAGE implementation, but w/o shifting the pc
-    int tag = pc ^ threadHistory[tid].computeTags[0][bank].comp ^
+    Addr shifted_pc = pc >> instShiftAmt;
+    int tag = shifted_pc ^ threadHistory[tid].computeTags[0][bank].comp ^
               (threadHistory[tid].computeTags[1][bank].comp << 1);
 
     return (tag & ((1ULL << tagTableTagWidths[bank]) - 1));

--- a/src/cpu/pred/tage_sc_l_64KB.cc
+++ b/src/cpu/pred/tage_sc_l_64KB.cc
@@ -88,7 +88,9 @@ TAGE_SC_L_64KB_StatisticalCorrector::makeThreadHistory()
 
 unsigned
 TAGE_SC_L_64KB_StatisticalCorrector::getIndBiasBank(Addr branch_pc,
-        BranchInfo* bi, int hitBank, int altBank) const
+                                                    BranchInfo *bi,
+                                                    int hitBank,
+                                                    int altBank) const
 {
     Addr shifted_pc = branch_pc >> instShiftAmt;
     return (bi->predBeforeSC
@@ -102,36 +104,33 @@ TAGE_SC_L_64KB_StatisticalCorrector::getIndBiasBank(Addr branch_pc,
 
 int
 TAGE_SC_L_64KB_StatisticalCorrector::gPredictions(ThreadID tid, Addr branch_pc,
-        BranchInfo* bi, int & lsum, int64_t pathHist)
+                                                  BranchInfo *bi, int &lsum)
 {
-    SC_64KB_ThreadHistory *sh =
-        static_cast<SC_64KB_ThreadHistory *>(scHistory);
-
     lsum += gPredict(
-        ((branch_pc >> instShiftAmt) << 1) + bi->predBeforeSC, sh->bwHist, bwm,
+        ((branch_pc >> instShiftAmt) << 1) + bi->predBeforeSC, bi->bwHist, bwm,
         bwgehl, bwnb, logBwnb, wbw);
 
     lsum += gPredict(
-        branch_pc, pathHist, pm, pgehl, pnb, logPnb, wp);
+        branch_pc, bi->pHist, pm, pgehl, pnb, logPnb, wp);
 
     lsum += gPredict(
-        branch_pc, sh->getLocalHistory(1, branch_pc), lm,
+        branch_pc, bi->localHistories[1], lm,
         lgehl, lnb, logLnb, wl);
 
     lsum += gPredict(
-        branch_pc, sh->getLocalHistory(2, branch_pc), sm,
+        branch_pc, bi->localHistories[2], sm,
         sgehl, snb, logSnb, ws);
 
     lsum += gPredict(
-        branch_pc, sh->getLocalHistory(3, branch_pc), tm,
+        branch_pc, bi->localHistories[3], tm,
         tgehl, tnb, logTnb, wt);
 
     lsum += gPredict(
-        branch_pc, sh->imHist[scHistory->imliCount], imm,
+        branch_pc, bi->imHist, imm,
         imgehl, imnb, logImnb, wim);
 
     lsum += gPredict(
-        branch_pc, sh->imliCount, im, igehl, inb, logInb, wi);
+        branch_pc, bi->imliCount, im, igehl, inb, logInb, wi);
 
     int thres = (updateThreshold>>3) + pUpdateThreshold[getIndUpd(branch_pc)]
       + 12*((wb[getIndUpds(branch_pc)] >= 0) + (wp[getIndUpds(branch_pc)] >= 0)
@@ -150,8 +149,9 @@ TAGE_SC_L_64KB_StatisticalCorrector::gIndexLogsSubstr(int nbr, int i)
 
 void
 TAGE_SC_L_64KB_StatisticalCorrector::scHistoryUpdate(Addr branch_pc,
-        const StaticInstPtr &inst, bool taken, BranchInfo* tage_bi,
-        Addr corrTarget)
+                                                     const StaticInstPtr &inst,
+                                                     bool taken, Addr target,
+                                                     int64_t phist)
 {
     int brtype = inst->isDirectCtrl() ? 0 : 2;
     if (! inst->isUncondCtrl()) {
@@ -168,36 +168,57 @@ TAGE_SC_L_64KB_StatisticalCorrector::scHistoryUpdate(Addr branch_pc,
         sh->updateLocalHistory(3, branch_pc, taken);
     }
 
-    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken, tage_bi,
-                                          corrTarget);
+    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken,
+                                          target, phist);
+}
+
+void
+TAGE_SC_L_64KB_StatisticalCorrector::scRecordHistState(Addr branch_pc,
+                                                       BranchInfo *bi)
+{
+    StatisticalCorrector::scRecordHistState(branch_pc, bi);
+    auto sh = static_cast<SC_64KB_ThreadHistory *>(scHistory);
+    bi->imHist = sh->imHist[sh->imliCount];
+    bi->localHistories[2] = sh->getLocalHistory(2, branch_pc);
+    bi->localHistories[3] = sh->getLocalHistory(3, branch_pc);
+}
+
+bool
+TAGE_SC_L_64KB_StatisticalCorrector::scRestoreHistState(BranchInfo *bi)
+{
+    if (!StatisticalCorrector::scRestoreHistState(bi)) {
+        return false;
+    }
+    auto sh = static_cast<SC_64KB_ThreadHistory *>(scHistory);
+    sh->imHist[sh->imliCount] = bi->imHist;
+    sh->setLocalHistory(2, bi->pc, bi->localHistories[2]);
+    sh->setLocalHistory(3, bi->pc, bi->localHistories[3]);
+    return true;
 }
 
 void
 TAGE_SC_L_64KB_StatisticalCorrector::gUpdates(ThreadID tid, Addr pc,
-        bool taken, BranchInfo* bi, int64_t phist)
+                                              bool taken, BranchInfo *bi)
 {
-    SC_64KB_ThreadHistory *sh =
-        static_cast<SC_64KB_ThreadHistory *>(scHistory);
-
-    gUpdate((pc << 1) + bi->predBeforeSC, taken, sh->bwHist, bwm,
+    gUpdate((pc << 1) + bi->predBeforeSC, taken, bi->bwHist, bwm,
             bwgehl, bwnb, logBwnb, wbw, bi);
 
-    gUpdate(pc, taken, phist, pm,
+    gUpdate(pc, taken, bi->pHist, pm,
             pgehl, pnb, logPnb, wp, bi);
 
-    gUpdate(pc, taken, sh->getLocalHistory(1, pc), lm,
+    gUpdate(pc, taken, bi->localHistories[1], lm,
             lgehl, lnb, logLnb, wl, bi);
 
-    gUpdate(pc, taken, sh->getLocalHistory(2, pc), sm,
+    gUpdate(pc, taken, bi->localHistories[2], sm,
             sgehl, snb, logSnb, ws, bi);
 
-    gUpdate(pc, taken, sh->getLocalHistory(3, pc), tm,
+    gUpdate(pc, taken, bi->localHistories[3], tm,
             tgehl, tnb, logTnb, wt, bi);
 
-    gUpdate(pc, taken, sh->imHist[scHistory->imliCount], imm,
+    gUpdate(pc, taken, bi->imHist, imm,
             imgehl, imnb, logImnb, wim, bi);
 
-    gUpdate(pc, taken, sh->imliCount, im,
+    gUpdate(pc, taken, bi->imliCount, im,
             igehl, inb, logInb, wi, bi);
 }
 
@@ -219,8 +240,8 @@ TAGE_SC_L_TAGE_64KB::gtag(ThreadID tid, Addr pc, int bank) const
 }
 
 void
-TAGE_SC_L_TAGE_64KB::handleAllocAndUReset(
-    bool alloc, bool taken, TAGEBase::BranchInfo* bi, int nrand)
+TAGE_SC_L_TAGE_64KB::handleAllocAndUReset(bool alloc, bool taken,
+                                          TAGEBase::BranchInfo *bi, int nrand)
 {
     if (! alloc) {
         return;
@@ -268,7 +289,7 @@ TAGE_SC_L_TAGE_64KB::handleAllocAndUReset(
 
 void
 TAGE_SC_L_TAGE_64KB::handleTAGEUpdate(Addr branch_pc, bool taken,
-                                 TAGEBase::BranchInfo* bi)
+                                      TAGEBase::BranchInfo *bi)
 {
     if (bi->hitBank > 0) {
         if (abs (2 * gtable[bi->hitBank][bi->hitBankIndex].ctr + 1) == 1) {

--- a/src/cpu/pred/tage_sc_l_64KB.hh
+++ b/src/cpu/pred/tage_sc_l_64KB.hh
@@ -67,10 +67,10 @@ class TAGE_SC_L_TAGE_64KB : public TAGE_SC_L_TAGE
     uint16_t gtag(ThreadID tid, Addr pc, int bank) const override;
 
     void handleAllocAndUReset(
-        bool alloc, bool taken, TAGEBase::BranchInfo* bi, int nrand) override;
+        bool alloc, bool taken, TAGEBase::BranchInfo *bi, int nrand) override;
 
     void handleTAGEUpdate(
-        Addr branch_pc, bool taken, TAGEBase::BranchInfo* bi) override;
+        Addr branch_pc, bool taken, TAGEBase::BranchInfo *bi) override;
 };
 
 class TAGE_SC_L_64KB_StatisticalCorrector : public StatisticalCorrector
@@ -120,19 +120,20 @@ class TAGE_SC_L_64KB_StatisticalCorrector : public StatisticalCorrector
     TAGE_SC_L_64KB_StatisticalCorrector(
         const TAGE_SC_L_64KB_StatisticalCorrectorParams &p);
 
-    unsigned getIndBiasBank(Addr branch_pc, BranchInfo* bi, int hitBank,
-        int altBank) const override;
+    unsigned getIndBiasBank(Addr branch_pc, BranchInfo *bi, int hitBank,
+                            int altBank) const override;
 
-    int gPredictions(ThreadID tid, Addr branch_pc, BranchInfo* bi,
-                     int & lsum, int64_t phist) override;
+    int gPredictions(ThreadID tid, Addr branch_pc, BranchInfo *bi,
+                     int &lsum) override;
 
     int gIndexLogsSubstr(int nbr, int i) override;
 
     void scHistoryUpdate(Addr branch_pc, const StaticInstPtr &inst, bool taken,
-                         BranchInfo * tage_bi, Addr corrTarget) override;
+                         Addr target, int64_t phist) override;
+    void scRecordHistState(Addr branch_pc, BranchInfo *bi) override;
+    bool scRestoreHistState(BranchInfo *bi) override;
 
-    void gUpdates(ThreadID tid, Addr pc, bool taken, BranchInfo* bi,
-            int64_t phist) override;
+    void gUpdates(ThreadID tid, Addr pc, bool taken, BranchInfo *bi) override;
 };
 
 class TAGE_SC_L_64KB : public TAGE_SC_L

--- a/src/cpu/pred/tage_sc_l_64KB.hh
+++ b/src/cpu/pred/tage_sc_l_64KB.hh
@@ -108,6 +108,9 @@ class TAGE_SC_L_64KB_StatisticalCorrector : public StatisticalCorrector
 
     struct SC_64KB_ThreadHistory : public SCThreadHistory
     {
+        SC_64KB_ThreadHistory(unsigned instShiftAmt)
+            : SCThreadHistory(instShiftAmt) {}
+
         std::vector<int64_t> imHist;
     };
 

--- a/src/cpu/pred/tage_sc_l_8KB.cc
+++ b/src/cpu/pred/tage_sc_l_8KB.cc
@@ -71,7 +71,9 @@ TAGE_SC_L_8KB_StatisticalCorrector::makeThreadHistory()
 
 unsigned
 TAGE_SC_L_8KB_StatisticalCorrector::getIndBiasBank(Addr branch_pc,
-        BranchInfo* bi, int hitBank, int altBank) const
+                                                   BranchInfo *bi,
+                                                   int hitBank,
+                                                   int altBank) const
 {
     return (bi->predBeforeSC
          + (((hitBank + 1) / 4) << 4)
@@ -83,22 +85,21 @@ TAGE_SC_L_8KB_StatisticalCorrector::getIndBiasBank(Addr branch_pc,
 
 int
 TAGE_SC_L_8KB_StatisticalCorrector::gPredictions(
-    ThreadID tid, Addr branch_pc, BranchInfo* bi, int & lsum, int64_t phist)
+    ThreadID tid, Addr branch_pc, BranchInfo *bi, int &lsum)
 {
-    SC_8KB_ThreadHistory *sh = static_cast<SC_8KB_ThreadHistory *>(scHistory);
     lsum += gPredict(
-        branch_pc, sh->globalHist, gm, ggehl, gnb, logGnb, wg);
+        branch_pc, bi->globalHist, gm, ggehl, gnb, logGnb, wg);
 
     lsum += gPredict(
-        branch_pc, sh->bwHist, bwm, bwgehl, bwnb, logBwnb, wbw);
+        branch_pc, bi->bwHist, bwm, bwgehl, bwnb, logBwnb, wbw);
 
     // only 1 local history here
     lsum += gPredict(
-        branch_pc, sh->getLocalHistory(1, branch_pc), lm,
+        branch_pc, bi->localHistories[1], lm,
         lgehl, lnb, logLnb, wl);
 
     lsum += gPredict(
-        branch_pc, sh->imliCount, im, igehl, inb, logInb, wi);
+        branch_pc, bi->imliCount, im, igehl, inb, logInb, wi);
 
     int thres = (updateThreshold>>3)+pUpdateThreshold[getIndUpd(branch_pc)];
 
@@ -112,8 +113,9 @@ int TAGE_SC_L_8KB_StatisticalCorrector::gIndexLogsSubstr(int nbr, int i)
 
 void
 TAGE_SC_L_8KB_StatisticalCorrector::scHistoryUpdate(Addr branch_pc,
-    const StaticInstPtr &inst, bool taken, BranchInfo *tage_bi,
-    Addr corrTarget)
+                                                    const StaticInstPtr &inst,
+                                                    bool taken, Addr target,
+                                                    int64_t phist)
 {
     int brtype = inst->isDirectCtrl() ? 0 : 2;
     if (! inst->isUncondCtrl()) {
@@ -126,20 +128,39 @@ TAGE_SC_L_8KB_StatisticalCorrector::scHistoryUpdate(Addr branch_pc,
         sh->globalHist = (sh->globalHist << 1) + taken;
     }
 
-    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken, tage_bi,
-                                          corrTarget);
+    StatisticalCorrector::scHistoryUpdate(branch_pc, inst, taken,
+                                          target, phist);
+}
+
+void
+TAGE_SC_L_8KB_StatisticalCorrector::scRecordHistState(Addr branch_pc,
+                                                      BranchInfo *bi)
+{
+    StatisticalCorrector::scRecordHistState(branch_pc, bi);
+    auto sh = static_cast<SC_8KB_ThreadHistory *>(scHistory);
+    bi->globalHist = sh->globalHist;
+}
+
+bool
+TAGE_SC_L_8KB_StatisticalCorrector::scRestoreHistState(BranchInfo *bi)
+{
+    if (!StatisticalCorrector::scRestoreHistState(bi)) {
+        return false;
+    }
+    auto sh = static_cast<SC_8KB_ThreadHistory *>(scHistory);
+    sh->globalHist = bi->globalHist;
+    return true;
 }
 
 void
 TAGE_SC_L_8KB_StatisticalCorrector::gUpdates(ThreadID tid, Addr pc, bool taken,
-        BranchInfo* bi, int64_t phist)
+                                             BranchInfo *bi)
 {
-    SC_8KB_ThreadHistory *sh = static_cast<SC_8KB_ThreadHistory *>(scHistory);
-    gUpdate(pc, taken, sh->globalHist, gm, ggehl, gnb, logGnb, wg, bi);
-    gUpdate(pc, taken, sh->bwHist, bwm, bwgehl, bwnb, logBwnb, wbw, bi);
-    gUpdate(pc, taken, sh->getLocalHistory(1, pc), lm, lgehl, lnb, logLnb, wl,
+    gUpdate(pc, taken, bi->globalHist, gm, ggehl, gnb, logGnb, wg, bi);
+    gUpdate(pc, taken, bi->bwHist, bwm, bwgehl, bwnb, logBwnb, wbw, bi);
+    gUpdate(pc, taken, bi->localHistories[1], lm, lgehl, lnb, logLnb, wl,
             bi);
-    gUpdate(pc, taken, sh->imliCount, im, igehl, inb, logInb, wi, bi);
+    gUpdate(pc, taken, bi->imliCount, im, igehl, inb, logInb, wi, bi);
 }
 
 TAGE_SC_L_8KB::TAGE_SC_L_8KB(const TAGE_SC_L_8KBParams &params)
@@ -148,7 +169,7 @@ TAGE_SC_L_8KB::TAGE_SC_L_8KB(const TAGE_SC_L_8KBParams &params)
 }
 
 void
-TAGE_SC_L_TAGE_8KB::initFoldedHistories(ThreadHistory & history)
+TAGE_SC_L_TAGE_8KB::initFoldedHistories(ThreadHistory &history)
 {
     // Some hardcoded values are used here
     // (they do not seem to depend on any parameter)
@@ -191,8 +212,8 @@ TAGE_SC_L_TAGE_8KB::gtag(ThreadID tid, Addr pc, int bank) const
 }
 
 void
-TAGE_SC_L_TAGE_8KB::handleAllocAndUReset(
-    bool alloc, bool taken, TAGEBase::BranchInfo* bi, int nrand)
+TAGE_SC_L_TAGE_8KB::handleAllocAndUReset(bool alloc, bool taken,
+                                         TAGEBase::BranchInfo *bi, int nrand)
 {
     if (!alloc) {
         return;
@@ -251,7 +272,7 @@ TAGE_SC_L_TAGE_8KB::handleAllocAndUReset(
 }
 
 void
-TAGE_SC_L_TAGE_8KB::resetUctr(uint8_t & u)
+TAGE_SC_L_TAGE_8KB::resetUctr(uint8_t &u)
 {
     // On real HW it should be u >>= 1 instead of if > 0 then u--
     if (u > 0) {
@@ -261,7 +282,7 @@ TAGE_SC_L_TAGE_8KB::resetUctr(uint8_t & u)
 
 void
 TAGE_SC_L_TAGE_8KB::handleTAGEUpdate(Addr branch_pc, bool taken,
-                                     TAGEBase::BranchInfo* bi)
+                                     TAGEBase::BranchInfo *bi)
 {
     if (bi->hitBank > 0) {
         if (abs (2 * gtable[bi->hitBank][bi->hitBankIndex].ctr + 1) == 1) {

--- a/src/cpu/pred/tage_sc_l_8KB.cc
+++ b/src/cpu/pred/tage_sc_l_8KB.cc
@@ -73,8 +73,12 @@ unsigned
 TAGE_SC_L_8KB_StatisticalCorrector::getIndBiasBank(Addr branch_pc,
         BranchInfo* bi, int hitBank, int altBank) const
 {
-    return (bi->predBeforeSC + (((hitBank+1)/4)<<4) + (bi->highConf<<1) +
-            (bi->lowConf <<2) +((altBank!=0)<<3)) & ((1<<logBias) -1);
+    return (bi->predBeforeSC
+         + (((hitBank + 1) / 4) << 4)
+         + (bi->highConf << 1)
+         + (bi->lowConf << 2)
+         + ((altBank != 0) << 3))
+         & ((1 << logBias) -1);
 }
 
 int
@@ -170,8 +174,9 @@ TAGE_SC_L_TAGE_8KB::gindex_ext(int index, int bank) const
 uint16_t
 TAGE_SC_L_TAGE_8KB::gtag(ThreadID tid, Addr pc, int bank) const
 {
-    int tag = (threadHistory[tid].computeIndices[bank - 1].comp << 2) ^ pc ^
-              (pc >> instShiftAmt) ^
+    Addr shifted_pc = pc >> instShiftAmt;
+    int tag = (threadHistory[tid].computeIndices[bank - 1].comp << 2)
+            ^ shifted_pc ^ (shifted_pc >> 2) ^
               threadHistory[tid].computeIndices[bank].comp;
     int hlen = (histLengths[bank] > pathHistBits) ? pathHistBits :
                                                     histLengths[bank];

--- a/src/cpu/pred/tage_sc_l_8KB.cc
+++ b/src/cpu/pred/tage_sc_l_8KB.cc
@@ -63,7 +63,7 @@ TAGE_SC_L_8KB_StatisticalCorrector::TAGE_SC_L_8KB_StatisticalCorrector(
 TAGE_SC_L_8KB_StatisticalCorrector::SCThreadHistory *
 TAGE_SC_L_8KB_StatisticalCorrector::makeThreadHistory()
 {
-    SC_8KB_ThreadHistory *sh = new SC_8KB_ThreadHistory();
+    SC_8KB_ThreadHistory *sh = new SC_8KB_ThreadHistory(instShiftAmt);
     sh->setNumOrdinalHistories(1);
     sh->initLocalHistory(1, numEntriesFirstLocalHistories, 2);
     return sh;

--- a/src/cpu/pred/tage_sc_l_8KB.hh
+++ b/src/cpu/pred/tage_sc_l_8KB.hh
@@ -84,9 +84,8 @@ class TAGE_SC_L_8KB_StatisticalCorrector : public StatisticalCorrector
 
     struct SC_8KB_ThreadHistory : public SCThreadHistory
     {
-        SC_8KB_ThreadHistory() {
-            globalHist = 0;
-        }
+        SC_8KB_ThreadHistory(unsigned instShiftAmt)
+            : SCThreadHistory(instShiftAmt), globalHist(0) {}
         int64_t globalHist; // global history
     };
 

--- a/src/cpu/pred/tage_sc_l_8KB.hh
+++ b/src/cpu/pred/tage_sc_l_8KB.hh
@@ -59,16 +59,16 @@ class TAGE_SC_L_TAGE_8KB : public TAGE_SC_L_TAGE
     TAGE_SC_L_TAGE_8KB(const TAGE_SC_L_TAGE_8KBParams &p) : TAGE_SC_L_TAGE(p)
     {}
 
-    void initFoldedHistories(ThreadHistory & history) override;
+    void initFoldedHistories(ThreadHistory &history) override;
     int gindex_ext(int index, int bank) const override;
 
     uint16_t gtag(ThreadID tid, Addr pc, int bank) const override;
 
-    void handleAllocAndUReset(
-        bool alloc, bool taken, TAGEBase::BranchInfo* bi, int nrand) override;
+    void handleAllocAndUReset(bool alloc, bool taken, TAGEBase::BranchInfo *bi,
+                              int nrand) override;
 
-    void handleTAGEUpdate(
-        Addr branch_pc, bool taken, TAGEBase::BranchInfo* bi) override;
+    void handleTAGEUpdate(Addr branch_pc, bool taken,
+                          TAGEBase::BranchInfo *bi) override;
 
     void resetUctr(uint8_t & u) override;
 };
@@ -95,20 +95,20 @@ class TAGE_SC_L_8KB_StatisticalCorrector : public StatisticalCorrector
     TAGE_SC_L_8KB_StatisticalCorrector(
         const TAGE_SC_L_8KB_StatisticalCorrectorParams &p);
 
-    unsigned getIndBiasBank( Addr branch_pc, BranchInfo* bi, int hitBank,
-        int altBank) const override;
+    unsigned getIndBiasBank(Addr branch_pc, BranchInfo *bi, int hitBank,
+                            int altBank) const override;
 
-    int gPredictions( ThreadID tid, Addr branch_pc,
-        BranchInfo* bi, int & lsum, int64_t phist) override;
+    int gPredictions(ThreadID tid, Addr branch_pc, BranchInfo *bi,
+                     int &lsum) override;
 
     int gIndexLogsSubstr(int nbr, int i) override;
 
-    void scHistoryUpdate(
-        Addr branch_pc, const StaticInstPtr &inst, bool taken,
-        BranchInfo * tage_bi, Addr corrTarget) override;
+    void scHistoryUpdate(Addr branch_pc, const StaticInstPtr &inst, bool taken,
+                         Addr target, int64_t phist) override;
+    void scRecordHistState(Addr branch_pc, BranchInfo *bi) override;
+    bool scRestoreHistState(BranchInfo *bi) override;
 
-    void gUpdates(ThreadID tid, Addr pc, bool taken, BranchInfo* bi,
-        int64_t phist) override;
+    void gUpdates(ThreadID tid, Addr pc, bool taken, BranchInfo *bi) override;
 };
 
 class TAGE_SC_L_8KB : public TAGE_SC_L


### PR DESCRIPTION
__NOTE: The last commit will be removed after testing__

As pointed out in [this ](https://github.com/orgs/gem5/discussions/1341) recent discussion. TAGE-SC-L does not support speculative updates.
This commit adds initial support for speculative updates in TAGE and the statistical corrector.
I have tested it on three different workloads and compared it against the original code from Seznec obtained from the branch prediction championship. It's pretty close, but I probably have not caught all corner cases. 

The last commit in this PR contains the reference code. Before merging, I'll remove this commit, but I kept it for others to try with additional workloads.
Note: To correlate the results against the original code, the `instShiftAmt` of the branch predictor must be set to 0.

The plot shows the reference code with the atomic core (It only works with the atomic core as the original code does not support speculative updates) and the gem5 implementation with the atomic core.
Furthermore, with the O3 core with and without speculative updates.
The O3 core with speculative updates behaves about the same as the two atomic cores.


![image](https://github.com/user-attachments/assets/919ed4c8-dd55-4976-bd5b-c0500bf24d44)
