### PR TITLE
misc: edit pre-commit.ci yaml to target develop for autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,3 +102,6 @@ repos:
             language: system
             stages: [commit-msg]
             description: The gem5 commit message checker hook.
+
+ci:
+    autoupdate_branch: develop


### PR DESCRIPTION
This PR modifies the .pre-commit-config.yaml to target the develop branch for autoupdates instead of the stable branch.