### PR TITLE
cpu: Add EpisodeCount debug flag

### DIFF
--- a/src/cpu/testers/gpu_ruby_test/SConscript
+++ b/src/cpu/testers/gpu_ruby_test/SConscript
@@ -53,3 +53,4 @@ Source('gpu_wavefront.cc')
 Source('tester_thread.cc')
 
 DebugFlag('ProtocolTest')
+DebugFlag('EpisodeCount')

--- a/src/cpu/testers/gpu_ruby_test/episode.cc
+++ b/src/cpu/testers/gpu_ruby_test/episode.cc
@@ -36,6 +36,7 @@
 
 #include "cpu/testers/gpu_ruby_test/protocol_tester.hh"
 #include "cpu/testers/gpu_ruby_test/tester_thread.hh"
+#include "debug/EpisodeCount.hh"
 
 namespace gem5
 {
@@ -62,7 +63,7 @@ Episode::Episode(ProtocolTester* _tester, TesterThread* _thread, int num_loads,
     initActions();
     isActive = true;
 
-    DPRINTFN("Episode %d\n", episodeId);
+    DPRINTF(EpisodeCount,"Episode %d\n", episodeId);
 }
 
 Episode::~Episode()


### PR DESCRIPTION
Updating the print statement to only print when the debug flag is specified.

Adding this change as the current gpu0random test is failing due to being killed by the runner. The test runs as expected when tested locally.

The test migh be getting killed due to having a very large output.