### PR TITLE
mem-ruby: Fix missing RubySystem in PerfectCacheMemory's entries

### DIFF
--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -833,11 +833,11 @@ $c_ident::init()
 
                     # For objects that require knowing the cache line size,
                     # set the value here.
-                    if vtype.c_ident in ("TBETable", "PerfectCacheMemory"):
+                    if vtype.c_ident in ("TBETable"):
                         block_size_func = "m_ruby_system->getBlockSizeBytes()"
                         code(f"(*{vid}).setBlockSize({block_size_func});")
 
-                    if vtype.c_ident in ("NetDest"):
+                    if vtype.c_ident in ("NetDest", "PerfectCacheMemory"):
                         code(f"(*{vid}).setRubySystem(m_ruby_system);")
 
         for param in self.config_parameters:


### PR DESCRIPTION
MOESI_CMP_directory protocol crashes with one of the several assertions in NetDest.cc. It happens because the entry type used to instantiate a PerfectCacheMemory object in MOESI_CMP_directory-L2cache.sm contains a NetDest object, so it requires a RubySystem object to be manually set for it.

Instead of just receiving the block size, change PerfectCacheMemory to receive a RubySystem object and use it to set the block size and call ENTRY::setRubySystem if the entries require it.