### PR TITLE
mem-ruby: Add missing option in ProtocolInfo

### DIFF
--- a/src/mem/ruby/protocol/MESI_Three_Level.slicc
+++ b/src/mem/ruby/protocol/MESI_Three_Level.slicc
@@ -1,4 +1,4 @@
-protocol "MESI_Three_Level" use_secondary_store_conditional;
+protocol "MESI_Three_Level" use_secondary_load_linked, use_secondary_store_conditional;
 include "MESI_Two_Level-msg.sm";
 include "MESI_Three_Level-msg.sm";
 include "MESI_Three_Level-L0cache.sm";

--- a/src/mem/ruby/protocol/MESI_Two_Level.slicc
+++ b/src/mem/ruby/protocol/MESI_Two_Level.slicc
@@ -1,4 +1,4 @@
-protocol "MESI_Two_Level";
+protocol "MESI_Two_Level" use_secondary_load_linked;
 include "MESI_Two_Level-msg.sm";
 include "MESI_Two_Level-L1cache.sm";
 include "MESI_Two_Level-L2cache.sm";

--- a/src/mem/ruby/slicc_interface/ProtocolInfo.hh
+++ b/src/mem/ruby/slicc_interface/ProtocolInfo.hh
@@ -45,19 +45,27 @@ class ProtocolInfo
 
   protected:
     const bool partialFuncReads;
+    const bool useSecondaryLoadLinked;
     const bool useSecondaryStoreConditional;
 
   public:
     ProtocolInfo(std::string name, bool partial_func_reads,
+                 bool use_secondary_load_linked,
                  bool use_secondary_store_conditional) :
         name(name),
         partialFuncReads(partial_func_reads),
+        useSecondaryLoadLinked(use_secondary_load_linked),
         useSecondaryStoreConditional(use_secondary_store_conditional)
     {
     }
 
     std::string getName() const { return name; }
     bool getPartialFuncReads() const { return partialFuncReads; }
+    bool
+    getUseSecondaryLoadLinked() const
+    {
+        return useSecondaryLoadLinked;
+    }
     bool
     getUseSecondaryStoreConditional() const
     {

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -959,12 +959,11 @@ Sequencer::makeRequest(PacketPtr pkt)
         //
         // The following logic works correctly with the semantics
         // of armV8 LDEX/STEX instructions.
+        const ProtocolInfo &protocol_info = m_ruby_system->getProtocolInfo();
 
         if (pkt->isWrite()) {
             DPRINTF(RubySequencer, "Issuing SC\n");
             primary_type = RubyRequestType_Store_Conditional;
-            const ProtocolInfo &protocol_info =
-                m_ruby_system->getProtocolInfo();
             if (protocol_info.getUseSecondaryStoreConditional()) {
                 secondary_type = RubyRequestType_Store_Conditional;
             } else {
@@ -974,11 +973,11 @@ Sequencer::makeRequest(PacketPtr pkt)
             DPRINTF(RubySequencer, "Issuing LL\n");
             assert(pkt->isRead());
             primary_type = RubyRequestType_Load_Linked;
-#if defined (PROTOCOL_MESI_Two_Level) || defined (PROTOCOL_MESI_Three_Level)
-            secondary_type = RubyRequestType_Load_Linked;
-#else
-            secondary_type = RubyRequestType_LD;
-#endif
+            if (protocol_info.getUseSecondaryLoadLinked()) {
+                secondary_type = RubyRequestType_Load_Linked;
+            } else {
+                secondary_type = RubyRequestType_LD;
+            }
         }
     } else if (pkt->req->isLockedRMW()) {
         //

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -75,6 +75,7 @@ class SLICC(Grammar):
         # Update slicc_interface/ProtocolInfo.cc/hh if updating this.
         self.options = {
             "partial_func_reads": False,
+            "use_secondary_load_linked": False,
             "use_secondary_store_conditional": False,
         }
 


### PR DESCRIPTION
After the support for multiple ruby protocols was added, the macros PROTOCOL_MESI_Two_Level and PROTOCOL_MESI_Three_Level were removed. These macros are still being used to determine if Load_Linked requests are sent to the protocol, an information required by the fix that addresses LL/SC livelock.
Replace the macros with a new option: useSecondaryLoadLinked.