### PR TITLE
mem: fix warning message for when memory size > 4GiB

### DIFF
--- a/src/mem/mem_interface.hh
+++ b/src/mem/mem_interface.hh
@@ -131,7 +131,7 @@ class MemInterface : public AbstractMemory
      * ranks and banks, the burst size, and the row buffer size.
      */
     const uint32_t burstSize;
-    const uint32_t deviceSize;
+    const uint64_t deviceSize;
     const uint32_t deviceRowBufferSize;
     const uint32_t devicesPerRank;
     const uint32_t rowBufferSize;


### PR DESCRIPTION
This PR fixes the bug described in issue 1860, where a warning occurs when memory size is set to greater than 4GiB. It does this by changing the type of the variable deviceSize in src/mem/mem_interface.hh from uint32_t to uint64_t.

I was not able to reproduce the bug using configuration scripts adapted from those in `configs/example/gem5_library`, but I am still creating this PR so it is here if we need it.