### PR TITLE
Fix bug in SysBridge + XBar and Add option for external memory addresses

### DIFF
--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -86,6 +86,15 @@ class System(SimObject):
         [], "Ranges that constitute main memory"
     )
 
+    external_memory_ranges = VectorParam.AddrRange(
+        [],
+        "Ranges that are valid physical address but not part of physmem. "
+        "These are considered to be coherent addresses, not for I/O or "
+        "devices. This is used for external memory controllers which are "
+        "owned by a different instance of a `System` object (e.g., remote) "
+        "memory.",
+    )
+
     # The ranges backed by a shadowed ROM
     shadow_rom_ranges = VectorParam.AddrRange(
         [], "Ranges  backed by a shadowed ROM"

--- a/src/sim/system.cc
+++ b/src/sim/system.cc
@@ -166,6 +166,8 @@ int System::numSystemsRunning = 0;
 
 System::System(const Params &p)
     : SimObject(p), _systemPort("system_port"),
+      externalMemRanges(p.external_memory_ranges.begin(),
+                         p.external_memory_ranges.end()),
       multiThread(p.multi_thread),
       init_param(p.init_param),
       physProxy(_systemPort, p.cache_line_size),
@@ -287,7 +289,18 @@ System::memSize() const
 bool
 System::isMemAddr(Addr addr) const
 {
-    return physmem.isMemAddr(addr);
+    if (physmem.isMemAddr(addr)) {
+        return true;
+    } else {
+        // Check the external memory ranges as well
+        for (const auto& range : externalMemRanges) {
+            if (range.contains(addr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }
 
 void

--- a/src/sim/system.hh
+++ b/src/sim/system.hh
@@ -111,6 +111,11 @@ class System : public SimObject, public PCEventScope
     std::unordered_map<RequestorID, std::vector<memory::AbstractMemory *>>
         deviceMemMap;
 
+    // List of address ranges that are have valid physical addresses but
+    // don't appear in the physical memory map. Note that these are assumed
+    // to be coherent addresses, not I/O or device addresses
+    AddrRangeList externalMemRanges;
+
   public:
 
     class Threads


### PR DESCRIPTION
Jason made these commits to enable disaggregated memory in gem5. The first commit fixes a panic thrown out when using a system bridge after a coherent crossbar. The second commit adds a new parameter to the System object. This allows physical addresses not managed by the System to go through the normal memory system. See commit descriptions for more details.