### PR TITLE
arch-x86: Add YMM Registers to X86KvmCPU and Floating Point Register File

### DIFF
--- a/src/arch/x86/kvm/x86_cpu.cc
+++ b/src/arch/x86/kvm/x86_cpu.cc
@@ -116,7 +116,7 @@ struct GEM5_PACKED FXSave
     uint64_t reserved[12];
 };
 
-// for the upper 128 bits of 16 ymm registers 
+// for the upper 128 bits of 16 ymm registers
 struct GEM5_PACKED AVXState {
     uint8_t ymmh[16][16];
 };
@@ -880,10 +880,10 @@ X86KvmCPU::updateKvmStateSRegs()
 void
 X86KvmCPU::updateKvmStateAVXCommon(ThreadContext *tc, const kvm_xsave &kxsave)
 {
-    // Like updateKvmStateFPUCommon, updateKvmStateAVXCommon is called by 
-    // updateKvmStateFPU function 
+    // Like updateKvmStateFPUCommon, updateKvmStateAVXCommon is called by
+    // updateKvmStateFPU function
     // Setting Kvm's ymm reg values to gem5's ymm reg values
-    const AVXState *avx = (const AVXState*)((const char*)kxsave.region 
+    const AVXState *avx = (const AVXState*)((const char*)kxsave.region
                             + sizeof(FXSave) + sizeof(XSaveHeader));
 
     for (int i = 0; i < 16; i++) {
@@ -1148,16 +1148,16 @@ X86KvmCPU::updateThreadContextSRegs(const struct kvm_sregs &sregs)
 #undef APPLY_DTABLE
 }
 
-void 
-X86KvmCPU::updateThreadContextAVXCommon(ThreadContext *tc, 
-                                        const struct kvm_xsave &kxsave) 
+void
+X86KvmCPU::updateThreadContextAVXCommon(ThreadContext *tc,
+                                        const struct kvm_xsave &kxsave)
 {
-    // Setting gem5's ymm reg values to Kvm's ymm reg values 
-    XSaveHeader& xsave_hdr = * (XSaveHeader *) ((char *) &kxsave 
+    // Setting gem5's ymm reg values to Kvm's ymm reg values
+    XSaveHeader& xsave_hdr = * (XSaveHeader *) ((char *) &kxsave
                                 + sizeof(FXSave));
-    
+
     if (xsave_hdr.xstate_bv.avx) {
-        const AVXState *avx = (const AVXState*)((const char*)kxsave.region 
+        const AVXState *avx = (const AVXState*)((const char*)kxsave.region
                                 + sizeof(FXSave) + sizeof(XSaveHeader));
 
         for (int i = 0; i < 16; i++) {

--- a/src/arch/x86/kvm/x86_cpu.cc
+++ b/src/arch/x86/kvm/x86_cpu.cc
@@ -112,7 +112,7 @@ struct GEM5_PACKED FXSave
 
     uint8_t fpr[8][16];
     uint8_t xmm[16][16];
-
+    
     uint64_t reserved[12];
 };
 
@@ -882,9 +882,10 @@ X86KvmCPU::updateKvmStateAVXCommon(ThreadContext *tc, const kvm_xsave &kxsave)
 {
     // Like updateKvmStateFPUCommon, updateKvmStateAVXCommon is called by
     // updateKvmStateFPU function
-    // Setting Kvm's ymm reg values to gem5's ymm reg values
-    const AVXState *avx = (const AVXState*)((const char*)kxsave.region
-                            + sizeof(FXSave) + sizeof(XSaveHeader));
+    // Setting KVM's YMM reg values to gem5's YMM reg values
+    const AVXState *avx = (const AVXState*)((const char*)
+                            kxsave.region[sizeof(FXSave) 
+                            + sizeof(XSaveHeader)]);
 
     for (int i = 0; i < 16; i++) {
         *(uint64_t *)&avx->ymmh[i][0] = tc->getReg(float_reg::ymmHigh(i));
@@ -968,15 +969,13 @@ X86KvmCPU::updateKvmStateFPUXSave()
      * Development Manual) directly follows the legacy xsave region
      * (i.e., the FPU/SSE state). The first 8 bytes of the xsave header
      * hold a state-component bitmap called xstate_bv. We need to set
-     * the state component bits corresponding to the FPU and SSE
+     * the state component bits corresponding to the FPU, SSE, and AVX
      * states.
      */
     XSaveHeader& xsave_hdr =
       * (XSaveHeader *) ((char *) &kxsave + sizeof(FXSave));
     xsave_hdr.xstate_bv.fpu = 1;
     xsave_hdr.xstate_bv.sse = 1;
-
-    // enable avx bitmap and run the AVX state update function
     xsave_hdr.xstate_bv.avx = 1;
     updateKvmStateAVXCommon(tc, kxsave);
 
@@ -1152,13 +1151,14 @@ void
 X86KvmCPU::updateThreadContextAVXCommon(ThreadContext *tc,
                                         const struct kvm_xsave &kxsave)
 {
-    // Setting gem5's ymm reg values to Kvm's ymm reg values
+    // Setting gem5's YMM reg values to KVM's YMM reg values
     XSaveHeader& xsave_hdr = * (XSaveHeader *) ((char *) &kxsave
                                 + sizeof(FXSave));
 
     if (xsave_hdr.xstate_bv.avx) {
-        const AVXState *avx = (const AVXState*)((const char*)kxsave.region
-                                + sizeof(FXSave) + sizeof(XSaveHeader));
+        const AVXState *avx = (const AVXState*)((const char*)
+                                kxsave.region[sizeof(FXSave) 
+                                + sizeof(XSaveHeader)]);
 
         for (int i = 0; i < 16; i++) {
             tc->setReg(float_reg::ymmLow(i), *(uint64_t *)&avx->ymmh[i][0]);

--- a/src/arch/x86/kvm/x86_cpu.cc
+++ b/src/arch/x86/kvm/x86_cpu.cc
@@ -112,7 +112,7 @@ struct GEM5_PACKED FXSave
 
     uint8_t fpr[8][16];
     uint8_t xmm[16][16];
-    
+
     uint64_t reserved[12];
 };
 
@@ -884,7 +884,7 @@ X86KvmCPU::updateKvmStateAVXCommon(ThreadContext *tc, const kvm_xsave &kxsave)
     // updateKvmStateFPU function
     // Setting KVM's YMM reg values to gem5's YMM reg values
     const AVXState *avx = (const AVXState*)((const char*)
-                            kxsave.region[sizeof(FXSave) 
+                            kxsave.region[sizeof(FXSave)
                             + sizeof(XSaveHeader)]);
 
     for (int i = 0; i < 16; i++) {
@@ -1157,7 +1157,7 @@ X86KvmCPU::updateThreadContextAVXCommon(ThreadContext *tc,
 
     if (xsave_hdr.xstate_bv.avx) {
         const AVXState *avx = (const AVXState*)((const char*)
-                                kxsave.region[sizeof(FXSave) 
+                                kxsave.region[sizeof(FXSave)
                                 + sizeof(XSaveHeader)]);
 
         for (int i = 0; i < 16; i++) {

--- a/src/arch/x86/kvm/x86_cpu.cc
+++ b/src/arch/x86/kvm/x86_cpu.cc
@@ -888,8 +888,8 @@ X86KvmCPU::updateKvmStateAVXCommon(ThreadContext *tc, const kvm_xsave &kxsave)
                             + sizeof(XSaveHeader)]);
 
     for (int i = 0; i < 16; i++) {
-        *(uint64_t *)&avx->ymmh[i][0] = tc->getReg(float_reg::ymmHigh(i));
-        *(uint64_t *)&avx->ymmh[i][8] = tc->getReg(float_reg::ymmLow(i));
+        *(uint64_t *)&avx->ymmh[i][0] = tc->getReg(float_reg::ymmLow(i));
+        *(uint64_t *)&avx->ymmh[i][8] = tc->getReg(float_reg::ymmHigh(i));
     }
 }
 

--- a/src/arch/x86/kvm/x86_cpu.hh
+++ b/src/arch/x86/kvm/x86_cpu.hh
@@ -219,6 +219,9 @@ class X86KvmCPU : public BaseKvmCPU
     void updateKvmStateMSRs();
     /** Update XCR registers */
     void updateKvmStateXCRs();
+    /** Update AVX state */
+    void updateKvmStateAVXCommon(ThreadContext *tc, const kvm_xsave &kxsave);
+
     /** @} */
 
     /**
@@ -240,6 +243,9 @@ class X86KvmCPU : public BaseKvmCPU
     void updateThreadContextMSRs();
     /** Update XCR registers */
     void updateThreadContextXCRs();
+    /** Update AVX state */
+    void updateThreadContextAVXCommon(ThreadContext *tc, const struct kvm_xsave &kxsave);
+
     /** @} */
 
     /** Transfer gem5's CPUID values into the virtual CPU. */

--- a/src/arch/x86/regs/float.cc
+++ b/src/arch/x86/regs/float.cc
@@ -63,6 +63,12 @@ FlatFloatRegClassOps::regName(const RegId &id) const
         return ss.str();
     }
     reg_idx -= NumXMMRegs * 2;
+    if (reg_idx < NumXMMRegs * 2) {
+        ccprintf(ss, "%%ymm%d_%s", reg_idx / 2,
+                (reg_idx % 2) ? "high": "low");
+        return ss.str();
+    }
+    reg_idx -= NumXMMRegs * 2;
     if (reg_idx < NumMicroFpRegs) {
         ccprintf(ss, "%%ufp%d", reg_idx);
         return ss.str();

--- a/src/arch/x86/regs/float.cc
+++ b/src/arch/x86/regs/float.cc
@@ -68,7 +68,7 @@ FlatFloatRegClassOps::regName(const RegId &id) const
                 (reg_idx % 2) ? "high": "low");
         return ss.str();
     }
-    reg_idx -= NumXMMRegs * 2;
+    reg_idx -= NumYMMRegs * 2;
     if (reg_idx < NumMicroFpRegs) {
         ccprintf(ss, "%%ufp%d", reg_idx);
         return ss.str();

--- a/src/arch/x86/regs/float.hh
+++ b/src/arch/x86/regs/float.hh
@@ -106,7 +106,41 @@ enum FloatRegIndex
     _Xmm15LowIdx,
     _Xmm15HighIdx,
 
-    MicrofpBase = XmmBase + 2 * NumXMMRegs,
+    YmmBase = XmmBase + 2 * NumXMMRegs,
+    _Ymm0LowIdx = YmmBase,
+    _Ymm0HighIdx,
+    _Ymm1LowIdx,
+    _Ymm1HighIdx,
+    _Ymm2LowIdx,
+    _Ymm2HighIdx,
+    _Ymm3LowIdx,
+    _Ymm3HighIdx,
+    _Ymm4LowIdx,
+    _Ymm4HighIdx,
+    _Ymm5LowIdx,
+    _Ymm5HighIdx,
+    _Ymm6LowIdx,
+    _Ymm6HighIdx,
+    _Ymm7LowIdx,
+    _Ymm7HighIdx,
+    _Ymm8LowIdx,
+    _Ymm8HighIdx,
+    _Ymm9LowIdx,
+    _Ymm9HighIdx,
+    _Ymm10LowIdx,
+    _Ymm10HighIdx,
+    _Ymm11LowIdx,
+    _Ymm11HighIdx,
+    _Ymm12LowIdx,
+    _Ymm12HighIdx,
+    _Ymm13LowIdx,
+    _Ymm13HighIdx,
+    _Ymm14LowIdx,
+    _Ymm14HighIdx,
+    _Ymm15LowIdx,
+    _Ymm15HighIdx,
+
+    MicrofpBase = YmmBase + 2 * NumXMMRegs,
     _Microfp0Idx = MicrofpBase,
     _Microfp1Idx,
     _Microfp2Idx,
@@ -177,6 +211,24 @@ static inline RegId
 xmmHigh(int index)
 {
     return floatRegClass[XmmBase + 2 * index + 1];
+}
+
+static inline RegId
+ymm(int index)
+{
+    return floatRegClass[YmmBase + index];
+}
+
+static inline RegId
+ymmLow(int index)
+{
+    return floatRegClass[YmmBase + 2 * index];
+}
+
+static inline RegId
+ymmHigh(int index)
+{
+    return floatRegClass[YmmBase + 2 * index + 1];
 }
 
 static inline RegId

--- a/src/arch/x86/regs/float.hh
+++ b/src/arch/x86/regs/float.hh
@@ -140,7 +140,7 @@ enum FloatRegIndex
     _Ymm15LowIdx,
     _Ymm15HighIdx,
 
-    MicrofpBase = YmmBase + 2 * NumXMMRegs,
+    MicrofpBase = YmmBase + 2 * NumYMMRegs,
     _Microfp0Idx = MicrofpBase,
     _Microfp1Idx,
     _Microfp2Idx,
@@ -211,12 +211,6 @@ static inline RegId
 xmmHigh(int index)
 {
     return floatRegClass[XmmBase + 2 * index + 1];
-}
-
-static inline RegId
-ymm(int index)
-{
-    return floatRegClass[YmmBase + index];
 }
 
 static inline RegId

--- a/src/arch/x86/x86_traits.hh
+++ b/src/arch/x86/x86_traits.hh
@@ -51,6 +51,7 @@ namespace X86ISA
 
     const int NumMMXRegs = 8;
     const int NumXMMRegs = 16;
+    const int NumYMMRegs = 16;
     const int NumMicroFpRegs = 8;
 
     const int NumCRegs = 16;


### PR DESCRIPTION
Co-authored with @xuann6.

When KvmCPU executes AVX instructions and is interrupted by a checkpoint, YMM registers are not correctly saved and restored. 

This PR adds YMM registers to the x86 Floating Point Register File and helper functions for accessing YMM to automatically serialize YMM registers during checkpointing. YMM registers follow the same format as existing XMM registers in the Floating Point Register File. 

This PR adds a struct called AVXState containing a 16x16 byte array to represent the 16 128-bit YMM registers in KvmCPU. Along with existing Floating Point Unit (FPU) update functions, thread context is updated to save the AVXState to the x86 YMM registers, and KVM state is updated to restore AVXState from x86 YMM registers. 

The KVM YMM registers are accessed according to the Intel Developer's Manual Chapter 13.5.3 AVX State. They are located in the XSAVE region below the XSAVE Header and XMM registers. 

Overall, this provides checkpointing support for YMM registers of AVX State in KvmCPU, described in issue #958. 