### PR TITLE
arch-riscv: Change RISC-V Interrupts::nmi_cause to protected

### DIFF
--- a/src/arch/riscv/interrupts.hh
+++ b/src/arch/riscv/interrupts.hh
@@ -61,9 +61,11 @@ class Interrupts : public BaseInterrupts
   private:
     std::bitset<NumInterruptTypes> ip;
     std::bitset<NumInterruptTypes> ie;
-    int nmi_cause;
 
     std::vector<gem5::IntSinkPin<Interrupts>*> localInterruptPins;
+  protected:
+    int nmi_cause;
+
   public:
     using Params = RiscvInterruptsParams;
 


### PR DESCRIPTION
The change allow derived Interrupts class to use field without create new one