### PR TITLE
Fix riscv pcstate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cscope.out
 .*.swo
 m5out
 /src/doxygen/html
+/docs/_build
 /ext/dramsim2/DRAMSim2
 /ext/mcpat/regression/*/*.out
 /util/m5/*.o

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,22 @@
+# Version 24.1.0.1
+
+**[HOTFIX]** This hotfix release applies the following:
+
+* Generalization of the class types in CHI RNF/MN generators thus fixing an issue with missing attributes when using the CHI protocol.
+PR: <https://github.com/gem5/gem5/pull/1851>.
+* Add Sphinx documentation for the gem5 standard library.
+This is largely generated from Python docstrings.
+See "docs/README" for more information on building and deploying Sphinx documentation.
+PR: <https://github.com/gem5/gem5/pull/335>.
+* Add missing `RubySystem` member and related methods in `PerfectCacheMemory`'s entries.
+This was causing assertions to trigger in "src/mem/ruby/commonNetDest.cc".
+PR: <https://github.com/gem5/gem5/pull/1864>.
+* Add `useSecondaryLoadLinked` function to "src/mem/ruby/slicc_interface/ProtocolInfo.hh".
+This fixes a bug which was introduced after the removal of the `PROTOCOL_MESI_Two_Level` and `PROTOCOL_MESI_Three_Level` MACROs in v24.1.0.0.
+These MACROs were being used to infer if `Load_Linked` requests are sent to the Ruby protocol or not.
+The `useSecondaryLoadLinked` function has been introduced to specify this directly where needed.
+PR: <https://github.com/gem5/gem5/pull/1865>.
+
 # Version 24.1
 
 ## User facing changes

--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -601,7 +601,7 @@ class CHI_RNF(CHI_Node):
     @classmethod
     def generate(cls, options, ruby_system, cpus):
         rnfs = [
-            CHI_RNF(
+            cls(
                 [cpu],
                 ruby_system,
                 L1ICache(size=options.l1i_size, assoc=options.l1i_assoc),
@@ -724,7 +724,7 @@ class CHI_MN(CHI_Node):
         """
         Creates one Misc Node
         """
-        return [CHI_MN(ruby_system, [cpu.l1d for cpu in cpus])]
+        return [cls(ruby_system, [cpu.l1d for cpu in cpus])]
 
 
 class CHI_SNF_Base(CHI_Node):

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README
+++ b/docs/README
@@ -1,0 +1,37 @@
+# How to build Sphinx documentation
+
+In order to build documentation for the standard library, first install sphinx. Run these commands in the `gem5` directory.
+
+```bash
+python3 -m venv build/
+source build/bin/activate
+pip install sphinx
+
+```
+
+Next, build gem5, then cd to the `docs` directory.
+
+```bash
+scons build/ALL/gem5.opt
+cd docs
+```
+
+In the `docs` directory, run `../build/ALL/gem5.opt gem5-sphinx-apidoc -o . ../src/python/gem5 -F -e` in order to generate the RST files.
+
+To generate the documentation, run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html`
+
+In order to view this documentation as a website, run the following commands while still in the `docs` directory:
+
+```bash
+cd _build/html
+python3 -m http.server 8000
+```
+
+If you want to use a different Sphinx theme, follow these steps:
+
+- Install the desired theme, e.g., `pip install sphinx-rtd-theme`
+- Update the `html_theme` in `docs/conf.py` by setting `html_theme = "sphinx_rtd_theme"`
+- Run `SPHINXBUILD="../build/ALL/gem5.opt gem5-sphinx" make html` in the `docs` directory to apply the changes.
+
+Note: We are aware that some modules currently display a blank page in the documentation.
+This will be addressed in the future.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,42 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "gem5"
+copyright = ""
+author = ""
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "build/lib64/python3.8/site-packages",
+    "build/lib/python3.8/site-packages",
+]
+
+language = "en"
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]
+
+# -- Options for todo extension ----------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#configuration
+
+todo_include_todos = True

--- a/docs/gem5-sphinx
+++ b/docs/gem5-sphinx
@@ -1,0 +1,1 @@
+import sphinx.__main__

--- a/docs/gem5-sphinx-apidoc
+++ b/docs/gem5-sphinx-apidoc
@@ -1,0 +1,14 @@
+import re
+import sys
+
+extensions = ['myst_parser']
+
+source_suffix = {
+    '.md': 'markdown',
+    '.py': 'markdown'
+}
+
+from sphinx.ext.apidoc import main
+if __name__ == '__m5_main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())

--- a/src/Doxyfile
+++ b/src/Doxyfile
@@ -31,7 +31,7 @@ PROJECT_NAME           = gem5
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = v24.1.0.0
+PROJECT_NUMBER         = v24.1.0.1
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/src/arch/riscv/pcstate.hh
+++ b/src/arch/riscv/pcstate.hh
@@ -70,6 +70,7 @@ class PCState : public GenericISA::UPCState<4>
 
   public:
     PCState(const PCState &other) : Base(other),
+        _compressed(other._compressed),
         _rvType(other._rvType), _vtype(other._vtype), _vl(other._vl)
     {}
     PCState &operator=(const PCState &other) = default;

--- a/src/base/version.cc
+++ b/src/base/version.cc
@@ -32,6 +32,6 @@ namespace gem5
 /**
  * @ingroup api_base_utils
  */
-const char *gem5Version = "24.1.0.0";
+const char *gem5Version = "24.1.0.1";
 
 } // namespace gem5

--- a/src/mem/ruby/protocol/MESI_Three_Level.slicc
+++ b/src/mem/ruby/protocol/MESI_Three_Level.slicc
@@ -1,4 +1,4 @@
-protocol "MESI_Three_Level" use_secondary_store_conditional;
+protocol "MESI_Three_Level" use_secondary_load_linked, use_secondary_store_conditional;
 include "MESI_Two_Level-msg.sm";
 include "MESI_Three_Level-msg.sm";
 include "MESI_Three_Level-L0cache.sm";

--- a/src/mem/ruby/protocol/MESI_Two_Level.slicc
+++ b/src/mem/ruby/protocol/MESI_Two_Level.slicc
@@ -1,4 +1,4 @@
-protocol "MESI_Two_Level";
+protocol "MESI_Two_Level" use_secondary_load_linked;
 include "MESI_Two_Level-msg.sm";
 include "MESI_Two_Level-L1cache.sm";
 include "MESI_Two_Level-L2cache.sm";

--- a/src/mem/ruby/slicc_interface/ProtocolInfo.hh
+++ b/src/mem/ruby/slicc_interface/ProtocolInfo.hh
@@ -45,19 +45,27 @@ class ProtocolInfo
 
   protected:
     const bool partialFuncReads;
+    const bool useSecondaryLoadLinked;
     const bool useSecondaryStoreConditional;
 
   public:
     ProtocolInfo(std::string name, bool partial_func_reads,
+                 bool use_secondary_load_linked,
                  bool use_secondary_store_conditional) :
         name(name),
         partialFuncReads(partial_func_reads),
+        useSecondaryLoadLinked(use_secondary_load_linked),
         useSecondaryStoreConditional(use_secondary_store_conditional)
     {
     }
 
     std::string getName() const { return name; }
     bool getPartialFuncReads() const { return partialFuncReads; }
+    bool
+    getUseSecondaryLoadLinked() const
+    {
+        return useSecondaryLoadLinked;
+    }
     bool
     getUseSecondaryStoreConditional() const
     {

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -959,12 +959,11 @@ Sequencer::makeRequest(PacketPtr pkt)
         //
         // The following logic works correctly with the semantics
         // of armV8 LDEX/STEX instructions.
+        const ProtocolInfo &protocol_info = m_ruby_system->getProtocolInfo();
 
         if (pkt->isWrite()) {
             DPRINTF(RubySequencer, "Issuing SC\n");
             primary_type = RubyRequestType_Store_Conditional;
-            const ProtocolInfo &protocol_info =
-                m_ruby_system->getProtocolInfo();
             if (protocol_info.getUseSecondaryStoreConditional()) {
                 secondary_type = RubyRequestType_Store_Conditional;
             } else {
@@ -974,11 +973,11 @@ Sequencer::makeRequest(PacketPtr pkt)
             DPRINTF(RubySequencer, "Issuing LL\n");
             assert(pkt->isRead());
             primary_type = RubyRequestType_Load_Linked;
-#if defined (PROTOCOL_MESI_Two_Level) || defined (PROTOCOL_MESI_Three_Level)
-            secondary_type = RubyRequestType_Load_Linked;
-#else
-            secondary_type = RubyRequestType_LD;
-#endif
+            if (protocol_info.getUseSecondaryLoadLinked()) {
+                secondary_type = RubyRequestType_Load_Linked;
+            } else {
+                secondary_type = RubyRequestType_LD;
+            }
         }
     } else if (pkt->req->isLockedRMW()) {
         //

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -75,6 +75,7 @@ class SLICC(Grammar):
         # Update slicc_interface/ProtocolInfo.cc/hh if updating this.
         self.options = {
             "partial_func_reads": False,
+            "use_secondary_load_linked": False,
             "use_secondary_store_conditional": False,
         }
 

--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -833,11 +833,11 @@ $c_ident::init()
 
                     # For objects that require knowing the cache line size,
                     # set the value here.
-                    if vtype.c_ident in ("TBETable", "PerfectCacheMemory"):
+                    if vtype.c_ident in ("TBETable"):
                         block_size_func = "m_ruby_system->getBlockSizeBytes()"
                         code(f"(*{vid}).setBlockSize({block_size_func});")
 
-                    if vtype.c_ident in ("NetDest"):
+                    if vtype.c_ident in ("NetDest", "PerfectCacheMemory"):
                         code(f"(*{vid}).setRubySystem(m_ruby_system);")
 
         for param in self.config_parameters:


### PR DESCRIPTION
To fix issue [#1405](https://github.com/gem5/gem5/issues/1405)
The missing copy of the `_compressed` flag in the RISC-V `PCState` constructor caused incorrect instruction length handling, leading to BTB training issues. This commit ensures the `_compressed` flag is correctly copied during object construction.