### PR TITLE
util: bump Jinja2 from 3.1.4 to 3.1.5

### DIFF
--- a/util/gem5-resources-manager/requirements.txt
+++ b/util/gem5-resources-manager/requirements.txt
@@ -12,7 +12,7 @@ Flask==2.3.2
 idna==3.7
 importlib-metadata==6.6.0
 itsdangerous==2.1.2
-Jinja2==3.1.4
+Jinja2==3.1.5
 jsonschema==4.17.3
 Markdown==3.4.3
 MarkupSafe==2.1.3


### PR DESCRIPTION
This PR was opened because changing the target branch of https://github.com/gem5/gem5/pull/1881 from stable to develop added unrelated commits.