### PR TITLE
misc: bump precommit asottile/pyupgrade to v3.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
       hooks:
           - id: black
     - repo: https://github.com/asottile/pyupgrade
-      rev: v3.19.0
+      rev: v3.19.1
       hooks:
           - id: pyupgrade
             # Python 3.8 is the earliest version supported.


### PR DESCRIPTION
This PR was opened because a number of unrelated commits were added to  https://github.com/gem5/gem5/pull/1880 when the target branch was changed from stable to develop.