### PR TITLE
scons: Fix -Werror=undef err with homebrew's protobuf on macOS

### DIFF
--- a/src/proto/SConsopts
+++ b/src/proto/SConsopts
@@ -76,3 +76,4 @@ if main['CONF']['HAVE_PROTOBUF']:
     # explanded to 0 but since we use -Wundef they end up generating
     # warnings.
     main.Append(CCFLAGS='-DPROTOBUF_INLINE_NOT_IN_HEADERS=0')
+    main.Append(CCFLAGS='-DPROTOBUF_ENABLE_DEBUG_LOGGING_MAY_LEAK_PII=0')


### PR DESCRIPTION
This issue has been fixed upstream in
https://github.com/protocolbuffers/protobuf/commit/12eadfdfd9e6603f but hasn't yet been picked up by homebrew.

With this, gem5 compiles (with warnings) out-of-box on macOS 15 with Apple clang 16.

Change-Id: I6cb3fce068dcd231362fa33bf7fd549745fbd7c4