### PR TITLE
include algorithm in random.hh

### DIFF
--- a/src/base/random.hh
+++ b/src/base/random.hh
@@ -45,6 +45,7 @@
 #ifndef __BASE_RANDOM_HH__
 #define __BASE_RANDOM_HH__
 
+#include <algorithm>
 #include <random>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
This was seemingly left out in #1534 . The way it is right now it builds on some but not all distributions. Seems like at least Arch Linux is one where these things need to be explicitly included.

Without this it fails on line 59 of the file `src/base/random.cc` with the error message
`error: ‘remove_if’ is not a member of ‘std’; did you mean ‘remove_cv’?`
After adding this it at least built the ARM debug build successfully, haven't tested anything else
