### PR TITLE
fastmodel: Add tag for fastmodel

### DIFF
--- a/src/arch/arm/fastmodel/iris/isa.hh
+++ b/src/arch/arm/fastmodel/iris/isa.hh
@@ -40,7 +40,7 @@ namespace Iris
 class ISA : public BaseISA
 {
   public:
-    ISA(const Params &p) : BaseISA(p) {}
+    ISA(const Params &p) : BaseISA(p, "fastmodel") {}
 
     void serialize(CheckpointOut &cp) const override;
 


### PR DESCRIPTION
The previous PR #908 add the tag for each ISA to know what ISA stands for the checkpoint. Add the tag for fastmodel to fix compile issue with fastmodel

Change-Id: Ia18d4ed502c6f092ffc8f68ccc06dd8571599db9