### PR TITLE
mem-cache: Fix use-after-free in MSHR handling

### DIFF
--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -721,8 +721,8 @@ Cache::serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt, CacheBlk *blk)
         // don't need to respond now, so pop it off to prevent the loop
         // below from generating another response.
         assert(initial_tgt->pkt->cmd == MemCmd::LockedRMWReadReq);
-        mshr->popTarget();
         delete initial_tgt->pkt;
+        mshr->popTarget();
         initial_tgt = nullptr;
     }
 


### PR DESCRIPTION
Found the error while running valgrind. In the code, when popping the MSHR target it will delete the data pointed to by `initial_tgt`. This change just swaps the order.

Valgrind output (just the first line):
==1267085== Invalid read of size 8
==1267085==    at 0x256BF8D: gem5::Cache::serviceMSHRTargets(gem5::MSHR*, gem5::Packet*, gem5::CacheBlk*) (cache.cc:725)