### PR TITLE
arch-arm: setMiscRegs: Show CSPR.d in debug log on writes to CPSR

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -701,8 +701,9 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
             getMMUPtr(tc)->invalidateMiscReg();
         }
 
-        DPRINTF(Arm, "Updating CPSR from %#x to %#x f:%d i:%d a:%d mode:%#x\n",
-                miscRegs[idx], cpsr, cpsr.f, cpsr.i, cpsr.a, cpsr.mode);
+        DPRINTF(Arm, "Updating CPSR from %#x to %#x f:%d i:%d a:%d d:%d "
+                "mode:%#x\n", miscRegs[idx], cpsr, cpsr.f, cpsr.i, cpsr.a,
+                cpsr.d, cpsr.mode);
         PCState pc = tc->pcState().as<PCState>();
         pc.nextThumb(cpsr.t);
         pc.illegalExec(cpsr.il == 1);


### PR DESCRIPTION
The interrupt mask bits DAIF are typically all accessed together, so show all 4 of them on update. See, eg https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/DAIF--Interrupt-Mask-Bits

Change-Id: I122b1e9c1804b6077c1e91f35ee6fdd92a06f292