### PR TITLE
arch-arm: gic_v3_redistributor: Fix GICR_IGRPMODR0 update bug

### DIFF
--- a/src/dev/arm/gic_v3_redistributor.cc
+++ b/src/dev/arm/gic_v3_redistributor.cc
@@ -620,7 +620,7 @@ Gicv3Redistributor::write(Addr addr, uint64_t data, size_t size,
                       continue;
                   }
 
-                  irqGrpmod[int_id] = data & (1 << int_id);
+                  irqGrpmod[int_id] = bits(data, int_id);
               }
           }
 


### PR DESCRIPTION
In the GICv3 spec IHI0069H.b, each interrupt has a group modifier bit that determines if the interrupt is taken in group 0 (Secure), or group 1 (Non-secure).

The group bits can be set through the distributor or redistributor interfaces.

IRQs 0..31 can be set via the redistributor reg GICR_IGRPMODR0. IRQs 0..1020 can be set via the distributor regs GICD_IGRPMODR<n>.

In gem5, the group bits are stored in irqGrpMod, a vector<uint8_t>. In all places except the line in this patch, gem5 only writes or checks for the 0 or 1 values in this vector (so arguably it should be vector<bool>.)

The existing redistributor code erroneously does the following, which masks out the bit we're interested in setting, but then stores the masked (but not shifted!) bit directly to irqGrpMod:

```
irqGrpmod[int_id] = data & (1 << int_id);
```

To see why this is wrong, imagine `int_id = 10`, then `data & (1<<10) == 0x400` and storing that to `irqGrpmod[int_id]` will truncate 0x400 to a uint8_t and store the value 0.

Instead, we should extract the bit at position `int_id` like how it's done in Gicv3Distributor::write for GICD_IGRPMODR.contains(addr)

Change-Id: Ie831b7794a56e036c9c56489b565a777938c4284