### PR TITLE
arch-vega: Fix LDS/buffer load/store x2,x3,x4

### DIFF
--- a/src/arch/amdgpu/vega/insts/ds.cc
+++ b/src/arch/amdgpu/vega/insts/ds.cc
@@ -4557,11 +4557,11 @@ namespace VegaISA
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (gpuDynInst->exec_mask[lane]) {
                 (reinterpret_cast<VecElemU32*>(
-                    gpuDynInst->d_data))[lane * 4] = data0[lane];
+                    gpuDynInst->d_data))[lane * 3] = data0[lane];
                 (reinterpret_cast<VecElemU32*>(
-                    gpuDynInst->d_data))[lane * 4 + 1] = data1[lane];
+                    gpuDynInst->d_data))[lane * 3 + 1] = data1[lane];
                 (reinterpret_cast<VecElemU32*>(
-                    gpuDynInst->d_data))[lane * 4 + 2] = data2[lane];
+                    gpuDynInst->d_data))[lane * 3 + 2] = data2[lane];
             }
         }
 
@@ -4702,11 +4702,11 @@ namespace VegaISA
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (gpuDynInst->exec_mask[lane]) {
                 vdst0[lane] = (reinterpret_cast<VecElemU32*>(
-                    gpuDynInst->d_data))[lane * 4];
+                    gpuDynInst->d_data))[lane * 3];
                 vdst1[lane] = (reinterpret_cast<VecElemU32*>(
-                    gpuDynInst->d_data))[lane * 4 + 1];
+                    gpuDynInst->d_data))[lane * 3 + 1];
                 vdst2[lane] = (reinterpret_cast<VecElemU32*>(
-                    gpuDynInst->d_data))[lane * 4 + 2];
+                    gpuDynInst->d_data))[lane * 3 + 2];
             }
         }
 

--- a/src/arch/amdgpu/vega/insts/mubuf.cc
+++ b/src/arch/amdgpu/vega/insts/mubuf.cc
@@ -1782,9 +1782,9 @@ namespace VegaISA
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (gpuDynInst->exec_mask[lane]) {
-                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane * 4]
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane * 2]
                     = data0[lane];
-                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane*4 + 1]
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane*2 + 1]
                     = data1[lane];
             }
         }
@@ -1878,11 +1878,11 @@ namespace VegaISA
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (gpuDynInst->exec_mask[lane]) {
-                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane * 4]
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane * 3]
                     = data0[lane];
-                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane*4 + 1]
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane*3 + 1]
                     = data1[lane];
-                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane*4 + 2]
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->d_data))[lane*3 + 2]
                     = data2[lane];
             }
         }


### PR DESCRIPTION
These instructions have the wrong index values when writing to the GPUDynInst d_data field, which expects data to be contiguous in the d_data buffer. This results in loads/stores being mis-aligned with zeros padding the empty space.

Set the correct index values (see flat.cc for example) so that the data values are in the correct locations. This should help fix issues with nanoGPT and MNIST spotted during the ISCA tutorial.