### PR TITLE
sim-se: Fix "<bad format>" in ioctl call

### DIFF
--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -807,7 +807,7 @@ ioctlFunc(SyscallDesc *desc, ThreadContext *tc,
      * For lack of a better return code, return ENOTTY. Ideally, we should
      * return something better here, but at least we issue the warning.
      */
-    warn("Unsupported ioctl call (return ENOTTY): ioctl(%d, 0x%x, ...) @ \n",
+    warn("Unsupported ioctl call (return ENOTTY): ioctl(%d, 0x%x, ...) @ %s\n",
          tgt_fd, req, tc->pcState());
     return -ENOTTY;
 }


### PR DESCRIPTION
This could be easily triggered when running musl-linked programs in SE mode.

---

For this program:

```c
#include <stdio.h>

int main() {
    printf("Hello, world!\n");
}
```

Compiled with `musl-gcc hello.c -static -o hello` in Ubuntu 22.04.

Original:

```shell
**** REAL SIMULATION ****
src/sim/simulate.cc:199: info: Entering event queue @ 0.  Starting simulation...
src/sim/syscall_emul.hh:810: warn: Unsupported ioctl call (return ENOTTY): ioctl(1, 0x5413, ...) @
<bad format>
Hello, world!
```

This patch:

```shell
**** REAL SIMULATION ****
src/sim/simulate.cc:199: info: Entering event queue @ 0.  Starting simulation...
src/sim/syscall_emul.hh:810: warn: Unsupported ioctl call (return ENOTTY): ioctl(1, 0x5413, ...) @ (0x401b42=>0x401b4a).(0=>1)
Hello, world!
```