### PR TITLE
mem-ruby: set RubySystem pointer during TBE alloc

### DIFF
--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -831,13 +831,13 @@ $c_ident::init()
                         comment = f"Type {vtype.ident} default"
                         code('*$vid = ${{vtype["default"]}}; // $comment')
 
-                    # For objects that require knowing the cache line size,
+                    # For objects that require a pointer to RubySystem,
                     # set the value here.
-                    if vtype.c_ident in ("TBETable"):
-                        block_size_func = "m_ruby_system->getBlockSizeBytes()"
-                        code(f"(*{vid}).setBlockSize({block_size_func});")
-
-                    if vtype.c_ident in ("NetDest", "PerfectCacheMemory"):
+                    if vtype.c_ident in (
+                        "NetDest",
+                        "PerfectCacheMemory",
+                        "TBETable",
+                    ):
                         code(f"(*{vid}).setRubySystem(m_ruby_system);")
 
         for param in self.config_parameters:
@@ -1271,7 +1271,6 @@ void
 $c_ident::set_tbe(${{self.TBEType.c_ident}}*& m_tbe_ptr, ${{self.TBEType.c_ident}}* m_new_tbe)
 {
   m_tbe_ptr = m_new_tbe;
-  m_tbe_ptr->setRubySystem(m_ruby_system);
 }
 
 void


### PR DESCRIPTION
Currently the RubySystem pointer is set when set_tbe is performed, which effectively clears the NetDest objects from the TBE (if any). This is fine if the TBE has been just allocated before set_tbe is called (no NetDest info in the TBE). However, the CHI protocol has an action (RestoreFromHazard) that performs a set_tbe over a TBE that had already been set, i.e., it already has valid NetDest data.

This patch sets the RubySystem pointer when the TBE is allocated, which is more natural and follows the style already adopted in the PerfectCacheMemory class (#1864).