### PR TITLE
scons: Fix build failures with ASAN enabled.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -691,6 +691,25 @@ for variant_path in variant_paths:
             env.Append(CXXFLAGS=['-stdlib=libc++'])
             env.Append(LIBS=['c++'])
 
+    if sys.platform == 'cygwin':
+        # cygwin has some header file issues...
+        env.Append(CCFLAGS=["-Wno-uninitialized"])
+
+
+    if not GetOption('no_compress_debug'):
+        with gem5_scons.Configure(env) as conf:
+            if not conf.CheckCxxFlag('-gz'):
+                warning("Can't enable object file debug section compression")
+            if not conf.CheckLinkFlag('-gz'):
+                warning("Can't enable executable debug section compression")
+
+    if env['USE_PYTHON']:
+        config_embedded_python(env)
+        gem5py_env = env.Clone()
+    else:
+        gem5py_env = env.Clone()
+        config_embedded_python(gem5py_env)
+
     # Add sanitizers flags
     sanitizers=[]
     if GetOption('with_ubsan'):
@@ -760,25 +779,6 @@ for variant_path in variant_paths:
         else:
             warning("Don't know how to enable %s sanitizer(s) for your "
                     "compiler." % sanitizers)
-
-    if sys.platform == 'cygwin':
-        # cygwin has some header file issues...
-        env.Append(CCFLAGS=["-Wno-uninitialized"])
-
-
-    if not GetOption('no_compress_debug'):
-        with gem5_scons.Configure(env) as conf:
-            if not conf.CheckCxxFlag('-gz'):
-                warning("Can't enable object file debug section compression")
-            if not conf.CheckLinkFlag('-gz'):
-                warning("Can't enable executable debug section compression")
-
-    if env['USE_PYTHON']:
-        config_embedded_python(env)
-        gem5py_env = env.Clone()
-    else:
-        gem5py_env = env.Clone()
-        config_embedded_python(gem5py_env)
 
     # Bare minimum environment that only includes python
     gem5py_env.Append(CCFLAGS=['${GEM5PY_CCFLAGS_EXTRA}'])


### PR DESCRIPTION
Currently gem5 will not build on some platforms with the address sanitizer enabled (`scons --with-asan ...`).

As part of the build process, Scons builds a custom Python interpreter (`gem5py`) which wraps the same version of Python that will be embedded in the gem5 binary. This custom interpreter is used later in the build process.

Currently, when ASAN is enabled, `gem5py` will also be built with ASAN enabled. Any memory leaks in `gem5py`, or its payload, will then cause the build to fail when the custom interpreter is used. This patch updates the SConstruct file to build the gem5py without ASAN even when ASAN is enabled for the gem5 binary itself.

Change-Id: Ibebfa06a29f4f62990663ae17790c205505880f8