### PR TITLE
Fix-append-kernel-arg-risv

### DIFF
--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -541,6 +541,17 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
             else:
                 self.workload.kernel_addr = 0x0
                 self.workload.entry_point = 0x80000000
+
+            # Set up the device tree. We need to wait until pre-instantiate to
+            # do this since the workload could change until this point.
+            # Default DTB address if bbl is built with --with-dts option
+            self.workload.dtb_addr = 0x87E00000
+
+            self.generate_device_tree(m5.options.outdir)
+            self.workload.dtb_filename = os.path.join(
+                m5.options.outdir, "device.dtb"
+            )
+
         super()._pre_instantiate(full_system=full_system)
 
     @overrides(KernelDiskWorkload)
@@ -556,14 +567,6 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         # workload are set, we can generate the device tree file.
         self._setup_io_devices()
         self._setup_pma()
-
-        # Default DTB address if bbl is built with --with-dts option
-        self.workload.dtb_addr = 0x87E00000
-
-        self.generate_device_tree(m5.options.outdir)
-        self.workload.dtb_filename = os.path.join(
-            m5.options.outdir, "device.dtb"
-        )
 
     @overrides(KernelDiskWorkload)
     def get_default_kernel_args(self) -> List[str]:


### PR DESCRIPTION
Previously, the device tree was being generated when the workload was
initially set in `set_kernel_disk_workload` (when the disk image was
set). However, this meant that if you changed the kernel boot parameters
after the initial call they would not show up in the dtb file. The
RISC-V kernel picks up the parameters from the dtb file, not what is
passed in via the gem5 workload.

The solution is to generate the dtb file in `_pre_instantiate` instead
of in `_add_disk_to_board`

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>