### PR TITLE
Clear mstatus.mprv when xret leaving M-mode

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4971,6 +4971,7 @@ decode QUADRANT default Unknown::unknown() {
                                 NPC = NPC;
                             } else {
                                 xc->setMiscReg(MISCREG_PRV, status.spp);
+                                status.mprv = 0;
                                 status.sie = status.spie;
                                 status.spie = 1;
                                 status.spp = PRV_U;
@@ -5041,6 +5042,9 @@ decode QUADRANT default Unknown::unknown() {
                             NPC = NPC;
                         } else {
                             STATUS status = xc->readMiscReg(MISCREG_STATUS);
+                            if (status.mpp != PRV_M) {
+                                status.mprv = 0;
+                            }
                             xc->setMiscReg(MISCREG_PRV, status.mpp);
                             // Always enable NMIE if smrnmi is not enabled
                             if (!isa->enableSmrnmi()) {


### PR DESCRIPTION
From privilege spec 20211203 section 3.1.6.3
```
An MRET or SRET instruction that changes the privilege mode to a mode less privileged than M also sets MPRV=0.
```

Change-Id: Ib64a613ef0ab63d24797db39ce5f471040ee326f