### PR TITLE
mem-cache: fixed incorrect x-o lookup address in BOP

### DIFF
--- a/src/mem/cache/prefetch/bop.cc
+++ b/src/mem/cache/prefetch/bop.cc
@@ -217,16 +217,16 @@ BOP::tag(Addr addr) const
 }
 
 bool
-BOP::testRR(Addr addr) const
+BOP::testRR(Addr addr_tag) const
 {
     for (auto& it : rrLeft) {
-        if (it == addr) {
+        if (it == addr_tag) {
             return true;
         }
     }
 
     for (auto& it : rrRight) {
-        if (it == addr) {
+        if (it == addr_tag) {
             return true;
         }
     }

--- a/src/mem/cache/prefetch/bop.cc
+++ b/src/mem/cache/prefetch/bop.cc
@@ -1,4 +1,16 @@
 /**
+ * Copyright (c) 2025 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2018 Metempsy Technology Consulting
  * Copyright (c) 2024 Samsung Electronics
  * All rights reserved.
@@ -223,18 +235,16 @@ BOP::testRR(Addr addr) const
 }
 
 void
-BOP::bestOffsetLearning(Addr addr_tag)
+BOP::bestOffsetLearning(Addr addr)
 {
     Addr offset_tag = (*offsetsListIterator).first;
 
     /*
-     * Compute the lookup tag for the RR table. Since addr_tag is a tag value,
-     * and not an address, subtracting the offset from addr_tag may result in
-     * integer underflow. Therefore, we first convert the tag back to address
-     * by right shifting it, and then subtract the offset. This gives us a
-     * new lookup address which we use to compute the lookup tag
+     * Compute the lookup tag for the RR table. As tags are generated using
+     * lower 12 bits we subtract offset from the full address rather than the
+     * tag to avoid integer underflow.
      */
-    Addr lookup_tag = tag((addr_tag << lBlkSize) - (offset_tag << lBlkSize));
+    Addr lookup_tag = tag((addr) - (offset_tag << lBlkSize));
 
     // There was a hit in the RR table, increment the score for this offset
     if (testRR(lookup_tag)) {

--- a/src/mem/cache/prefetch/bop.hh
+++ b/src/mem/cache/prefetch/bop.hh
@@ -1,4 +1,16 @@
 /**
+ * Copyright (c) 2025 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2018 Metempsy Technology Consulting
  * Copyright (c) 2024 Samsung Electronics
  * All rights reserved.
@@ -146,8 +158,11 @@ class BOP : public Queued
         bool testRR(Addr) const;
 
         /** Learning phase of the BOP. Update the intermediate values of the
-            round and update the best offset if found */
-        void bestOffsetLearning(Addr);
+         * round and update the best offset if found
+         * @param addr: full address used to compute X-O tag to determine
+         *              offset efficacy.
+        */
+        void bestOffsetLearning(Addr addr);
 
         /** Update the RR right table after a prefetch fill */
         void notifyFill(const CacheAccessProbeArg &arg) override;

--- a/src/mem/cache/prefetch/bop.hh
+++ b/src/mem/cache/prefetch/bop.hh
@@ -154,8 +154,10 @@ class BOP : public Queued
         Addr tag(Addr addr) const;
 
         /** Test if @X-O is hitting in the RR table to update the
-            offset score */
-        bool testRR(Addr) const;
+         *  offset score
+         *  @param addr_tag: tag searched for within the RR
+        */
+        bool testRR(Addr addr_tag) const;
 
         /** Learning phase of the BOP. Update the intermediate values of the
          * round and update the best offset if found


### PR DESCRIPTION
Current BOP implementation (after https://github.com/gem5/gem5/pull/1403) performes an
address - offset calculation expecting the address to be a tag.
It is however being passed as a full address leading to incorrect values being calculated.
This is causing the prefetcher to be disabled or use poor performing offsets.