### PR TITLE
arch-riscv: Implement SVNAPOT Extension

### DIFF
--- a/src/arch/riscv/RiscvISA.py
+++ b/src/arch/riscv/RiscvISA.py
@@ -160,5 +160,6 @@ class RiscvISA(BaseISA):
         isa_string += "_Zba"  # Address Generation
         isa_string += "_Zbb"  # Basic Bit Manipulation
         isa_string += "_Zbs"  # Single-bit Instructions
+        isa_string += "_svnapot"
 
         return isa_string

--- a/src/arch/riscv/page_size.hh
+++ b/src/arch/riscv/page_size.hh
@@ -52,6 +52,7 @@ namespace RiscvISA
 
 const Addr PageShift = 12;
 const Addr PageBytes = 1ULL << PageShift;
+const Addr NapotShift = 4;
 
 } // namespace RiscvISA
 } // namespace gem5

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -62,6 +62,8 @@ const Addr LEVEL_BITS  = 9;
 const Addr LEVEL_MASK  = (1 << LEVEL_BITS) - 1;
 
 BitUnion64(PTESv39)
+    Bitfield<63> n;
+    Bitfield<62, 54> reserved;
     Bitfield<53, 10> ppn;
     Bitfield<53, 28> ppn2;
     Bitfield<27, 19> ppn1;

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -369,6 +369,12 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                                 "PTE has misaligned PPN, raising PF\n");
                         fault = pageFault(true);
                     }
+                    if (pte.n && (pte.ppn0 & mask(NapotShift)) != 8) {
+                            DPRINTF(Develop,
+                                "SVNAPOT PTE has wrong encoding, \
+                                 raising PF\n");
+                            fault = pageFault(true);
+                    }
                 }
 
                 if (fault == NoFault) {
@@ -404,7 +410,11 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                                  level, entry.vaddr);
 
                         // step 8
-                        entry.logBytes = PageShift + (level * LEVEL_BITS);
+                        // Check if N (contig bit) is set, if yes we have
+                        // a 64K page mapping (SVNAPOT Extension)
+                        assert(!(pte.n) || level == 0);
+                        entry.logBytes = (pte.n) ? PageShift + NapotShift :
+                                            PageShift + (level * LEVEL_BITS);
                         entry.paddr = pte.ppn;
                         entry.vaddr &= ~((1 << entry.logBytes) - 1);
                         entry.pte = pte;
@@ -420,7 +430,10 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                             walker->pagewalkerstats.num_2mb_walks++;
                         }
                         if (level == 0) {
-                            walker->pagewalkerstats.num_4kb_walks++;
+                            if (pte.n)
+                                walker->pagewalkerstats.num_64kb_walks++;
+                            else
+                                walker->pagewalkerstats.num_4kb_walks++;
                         }
                         DPRINTF(PageTableWalker,
                                 "#1 leaf node at level %d, with vpn %#x\n",
@@ -680,6 +693,8 @@ Walker::PagewalkerStats::PagewalkerStats(statistics::Group *parent)
   : statistics::Group(parent),
     ADD_STAT(num_4kb_walks, statistics::units::Count::get(),
              "Completed page walks with 4KB pages"),
+    ADD_STAT(num_64kb_walks, statistics::units::Count::get(),
+             "Completed page walks with 64KB pages"),
     ADD_STAT(num_2mb_walks, statistics::units::Count::get(),
              "Completed page walks with 2MB pages")
 {

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -370,7 +370,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         fault = pageFault(true);
                     }
                     if (pte.n && (pte.ppn0 & mask(NapotShift)) != 8) {
-                            DPRINTF(Develop,
+                            DPRINTF(PageTableWalker,
                                 "SVNAPOT PTE has wrong encoding, \
                                  raising PF\n");
                             fault = pageFault(true);

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -199,6 +199,7 @@ namespace RiscvISA
             PagewalkerStats(statistics::Group *parent);
 
             statistics::Scalar num_4kb_walks;
+            statistics::Scalar num_64kb_walks;
             statistics::Scalar num_2mb_walks;
 
         } pagewalkerstats;


### PR DESCRIPTION
This commit introduces support for the RISC-V SVNAPOT Extension, which enables the use of contiguous 4K pages by combining them into a 64KB page, thereby increasing the reach of the TLB.

I tested this on Linux 6.9 with transparent huge pages enabled. To support THP for 64KB pages, I applied this [patch](https://lore.kernel.org/kvm-riscv/20240508191931.46060-5-alexghiti@rivosinc.com/T/). Additionally, I verified its functionality using glibc tunables, specifically `glibc.malloc.hugetlb=$(( 64 << 10 ))`.