### PR TITLE
mem-ruby: remove incorrect actions in MOESI_CMP_directory

### DIFF
--- a/src/mem/ruby/protocol/MOESI_CMP_directory-L2cache.sm
+++ b/src/mem/ruby/protocol/MOESI_CMP_directory-L2cache.sm
@@ -2900,14 +2900,12 @@ machine(MachineType:L2Cache, "Token protocol")
 
   transition({MI, OI}, Writeback_Ack, I) {
     qq_sendDataFromTBEToMemory;
-    removeFromDir;
     s_deallocateTBE;
     n_popResponseQueue;
     wa_wakeUpDependents;
   }
 
   transition(MII, Writeback_Nack, I) {
-    removeFromDir;
     s_deallocateTBE;
     n_popResponseQueue;
     wa_wakeUpDependents;
@@ -2927,7 +2925,6 @@ machine(MachineType:L2Cache, "Token protocol")
 
   transition(MII, Writeback_Ack, I) {
     f_sendUnblock;
-    removeFromDir;
     s_deallocateTBE;
     n_popResponseQueue;
     wa_wakeUpDependents;


### PR DESCRIPTION
The states MI, OI, and MII in L2 don't have a DirEntry allocated, since they're preceded by states that own the block and therefore use CacheEntry instead of DirEntry. In fact, MI, OI, and MII don't even have a CacheEntry allocated, at this point everything is already deallocated except for the TBE entry.

Remove 'removeFromDir' action from a few transitions coming from these states. After the changes to enable support for multiple Ruby protocols, these spurious actions cause assertion failure in NetDest.cc.