### PR TITLE
arch-x86: add LRU cache eviction in `decoder.hh`

### DIFF
--- a/src/arch/SConscript
+++ b/src/arch/SConscript
@@ -237,3 +237,4 @@ CompoundFlag('Registers', [ 'IntRegs', 'FloatRegs', 'VecRegs', 'VecPredRegs',
 DebugFlag('Decoder', "Decoder debug output")
 DebugFlag('Faults', "Information about faults, exceptions, interrupts, etc")
 DebugFlag('TLBVerbose')
+DebugFlag('decode_LRU')


### PR DESCRIPTION
In `decoder.hh` the `addrCacheMap` and the `instCacheMap` can grow unbound as there are no limits on their sizes. This change adds a size limit and implements an LRU cache eviction for the `addrCacheMap` and the `instCacheMap`.