### PR TITLE
arch-vega,gpu-compute: Fix architected flat scratch

### DIFF
--- a/src/arch/amdgpu/vega/gpu_mem_helpers.hh
+++ b/src/arch/amdgpu/vega/gpu_mem_helpers.hh
@@ -133,7 +133,10 @@ template<int N>
 inline void
 initScratchReqHelper(GPUDynInstPtr gpuDynInst, MemCmd mem_req_type)
 {
-    int req_size = N * sizeof(VegaISA::VecElemU32);
+    // This function should be used for 1+ DWORD scratch accesses. 1+ DWORD
+    // scratch accesses are special in that they send multiple single DWORD
+    // requests in a swizzled manner to memory.
+    int req_size = sizeof(VegaISA::VecElemU32);
     int block_size = gpuDynInst->computeUnit()->cacheLineSize();
 
     gpuDynInst->resetEntireStatusVector();

--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -384,8 +384,12 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
                 // the FLAT_SCRATCH register pair to the scratch backing
                 // memory: https://llvm.org/docs/AMDGPUUsage.html#flat-scratch
                 if (task->gfxVersion() == GfxVersion::gfx942) {
+                    uint32_t scratchPerWI =
+                        task->amdQueue.scratch_workitem_byte_size;
+
                     archFlatScratchAddr =
-                        task->amdQueue.scratch_backing_memory_location;
+                        task->amdQueue.scratch_backing_memory_location
+                        + (scratchPerWI * 64 * wfId);
 
                     DPRINTF(GPUInitAbi, "CU%d: WF[%d][%d]: wave[%d] "
                             "Setting architected flat scratch = %x\n",


### PR DESCRIPTION
There are several issues with architected flat scratch. Since this was written, new documentation in the RDNA3 ISA manual explains the address calculations better. This commit updates the following:

1) The memory request helper for scratch accesses of >1 DWORD has incorrect request size causing a misalignment assert.
2) Scratch base should be different per-wave and currently is per-shader and clobbering data due to having the same addresses for every wave.
3) Offsets in calcAddr can be negative. Use signed types.
4) Element size should always be 4. Based on RDNA3 ISA manual. No need to calculate payload size every time.
5) Add some asserts based on the text in RDNA3 ISA manual, Section 11.2.

This fixes PyTorch examples from the ISCA'24 tutorial for MI300X (recall that MI200 was fixed in #1916).