### PR TITLE
dev: rework PCI to add type1 header

### DIFF
--- a/configs/example/gpufs/system/amdgpu.py
+++ b/configs/example/gpufs/system/amdgpu.py
@@ -227,4 +227,4 @@ def connectGPU(system, args):
 
     # Set bit 6 to enable atomic requestor, meaning this device can request
     # atomics from other PCI devices.
-    system.pc.south_bridge.gpu.PXCAPDevCtrl2 = 0x00000040
+    system.pc.south_bridge.gpu.PXCAPDevCtrl2 = 0x0040

--- a/src/dev/amdgpu/AMDGPU.py
+++ b/src/dev/amdgpu/AMDGPU.py
@@ -33,7 +33,7 @@ from m5.objects.Device import (
     DmaVirtDevice,
 )
 from m5.objects.PciDevice import (
-    PciDevice,
+    PciEndpoint,
     PciLegacyIoBar,
     PciMemBar,
     PciMemUpperBar,
@@ -49,7 +49,7 @@ from m5.proxy import *
 # This class requires a ROM binary and an MMIO trace to initialize the
 # device registers and memory. It is intended only to be used in full-system
 # simulation under Linux where the amdgpu driver is modprobed.
-class AMDGPUDevice(PciDevice):
+class AMDGPUDevice(PciEndpoint):
     type = "AMDGPUDevice"
     cxx_header = "dev/amdgpu/amdgpu_device.hh"
     cxx_class = "gem5::AMDGPUDevice"

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -60,7 +60,7 @@ class SDMAEngine;
  * sent to the corresponding IP block. BAR5 is the MMIO interface which writes
  * data values to registers controlling the IP blocks.
  */
-class AMDGPUDevice : public PciDevice
+class AMDGPUDevice : public PciEndpoint
 {
   private:
     /**
@@ -164,7 +164,7 @@ class AMDGPUDevice : public PciDevice
     AMDGPUDevice(const AMDGPUDeviceParams &p);
 
     /**
-     * Methods inherited from PciDevice
+     * Methods inherited from PciEndpoint
      */
     void intrPost();
 

--- a/src/dev/net/Ethernet.py
+++ b/src/dev/net/Ethernet.py
@@ -38,7 +38,7 @@
 
 from m5.defines import buildEnv
 from m5.objects.PciDevice import (
-    PciDevice,
+    PciEndpoint,
     PciIoBar,
     PciMemBar,
 )
@@ -163,7 +163,7 @@ class EtherDump(SimObject):
     maxlen = Param.Int(96, "max portion of packet data to dump")
 
 
-class EtherDevice(PciDevice):
+class EtherDevice(PciEndpoint):
     type = "EtherDevice"
     abstract = True
     cxx_header = "dev/net/etherdevice.hh"

--- a/src/dev/net/etherdevice.hh
+++ b/src/dev/net/etherdevice.hh
@@ -45,12 +45,12 @@ namespace gem5
 
 class EtherInt;
 
-class EtherDevice : public PciDevice
+class EtherDevice : public PciEndpoint
 {
   public:
     using Params = EtherDeviceParams;
     EtherDevice(const Params &params)
-        : PciDevice(params),
+        : PciEndpoint(params),
           etherDeviceStats(this)
     {}
 

--- a/src/dev/net/i8254xGBe.cc
+++ b/src/dev/net/i8254xGBe.cc
@@ -136,7 +136,7 @@ IGbE::~IGbE()
 void
 IGbE::init()
 {
-    PciDevice::init();
+    PciEndpoint::init();
 }
 
 Port &
@@ -152,7 +152,7 @@ IGbE::writeConfig(PacketPtr pkt)
 {
     int offset = pkt->getAddr() & PCI_CONFIG_SIZE;
     if (offset < PCI_DEVICE_SPECIFIC)
-        PciDevice::writeConfig(pkt);
+        PciEndpoint::writeConfig(pkt);
     else
         panic("Device specific PCI config space not implemented.\n");
 
@@ -2361,7 +2361,7 @@ IGbE::ethTxDone()
 void
 IGbE::serialize(CheckpointOut &cp) const
 {
-    PciDevice::serialize(cp);
+    PciEndpoint::serialize(cp);
 
     regs.serialize(cp);
     SERIALIZE_SCALAR(eeOpBits);
@@ -2412,7 +2412,7 @@ IGbE::serialize(CheckpointOut &cp) const
 void
 IGbE::unserialize(CheckpointIn &cp)
 {
-    PciDevice::unserialize(cp);
+    PciEndpoint::unserialize(cp);
 
     regs.unserialize(cp);
     UNSERIALIZE_SCALAR(eeOpBits);

--- a/src/dev/net/ns_gige.cc
+++ b/src/dev/net/ns_gige.cc
@@ -152,7 +152,7 @@ NSGigE::writeConfig(PacketPtr pkt)
 {
     int offset = pkt->getAddr() & PCI_CONFIG_SIZE;
     if (offset < PCI_DEVICE_SPECIFIC)
-        PciDevice::writeConfig(pkt);
+        PciEndpoint::writeConfig(pkt);
     else
         panic("Device specific PCI config space not implemented!\n");
 
@@ -161,7 +161,7 @@ NSGigE::writeConfig(PacketPtr pkt)
         // put in the IO to double check, an assertion will fail if we
         // need to properly implement it
       case PCI_COMMAND:
-        if (config.data[offset] & PCI_CMD_IOSE)
+        if (config().command & PCI_CMD_IOSE)
             ioEnable = true;
         else
             ioEnable = false;
@@ -2017,8 +2017,8 @@ NSGigE::drainResume()
 void
 NSGigE::serialize(CheckpointOut &cp) const
 {
-    // Serialize the PciDevice base class
-    PciDevice::serialize(cp);
+    // Serialize the PciEndpoint base class
+    PciEndpoint::serialize(cp);
 
     /*
      * Finalize any DMA events now.
@@ -2190,8 +2190,8 @@ NSGigE::serialize(CheckpointOut &cp) const
 void
 NSGigE::unserialize(CheckpointIn &cp)
 {
-    // Unserialize the PciDevice base class
-    PciDevice::unserialize(cp);
+    // Unserialize the PciEndpoint base class
+    PciEndpoint::unserialize(cp);
 
     UNSERIALIZE_SCALAR(regs.command);
     UNSERIALIZE_SCALAR(regs.config);

--- a/src/dev/net/sinic.cc
+++ b/src/dev/net/sinic.cc
@@ -198,7 +198,7 @@ Device::prepareWrite(ContextID cpu, int index)
 Tick
 Device::read(PacketPtr pkt)
 {
-    assert(config.command & PCI_CMD_MSE);
+    assert(config().command & PCI_CMD_MSE);
 
     Addr daddr = pkt->getAddr();
     assert(BARs[0]->range().contains(daddr));
@@ -289,7 +289,7 @@ Device::iprRead(Addr daddr, ContextID cpu, uint64_t &result)
 Tick
 Device::write(PacketPtr pkt)
 {
-    assert(config.command & PCI_CMD_MSE);
+    assert(config().command & PCI_CMD_MSE);
 
     Addr daddr = pkt->getAddr();
     assert(BARs[0]->range().contains(daddr));
@@ -1201,8 +1201,8 @@ Device::drainResume()
 void
 Base::serialize(CheckpointOut &cp) const
 {
-    // Serialize the PciDevice base class
-    PciDevice::serialize(cp);
+    // Serialize the PciEndpoint base class
+    PciEndpoint::serialize(cp);
 
     SERIALIZE_SCALAR(rxEnable);
     SERIALIZE_SCALAR(txEnable);
@@ -1222,8 +1222,8 @@ Base::serialize(CheckpointOut &cp) const
 void
 Base::unserialize(CheckpointIn &cp)
 {
-    // Unserialize the PciDevice base class
-    PciDevice::unserialize(cp);
+    // Unserialize the PciEndpoint base class
+    PciEndpoint::unserialize(cp);
 
     UNSERIALIZE_SCALAR(rxEnable);
     UNSERIALIZE_SCALAR(txEnable);
@@ -1248,7 +1248,7 @@ Device::serialize(CheckpointOut &cp) const
 {
     int count;
 
-    // Serialize the PciDevice base class
+    // Serialize the PciEndpoint base class
     Base::serialize(cp);
 
     if (rxState == rxCopy)
@@ -1361,7 +1361,7 @@ Device::serialize(CheckpointOut &cp) const
 void
 Device::unserialize(CheckpointIn &cp)
 {
-    // Unserialize the PciDevice base class
+    // Unserialize the PciEndpoint base class
     Base::unserialize(cp);
 
     /*

--- a/src/dev/pci/CopyEngine.py
+++ b/src/dev/pci/CopyEngine.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.PciDevice import (
-    PciDevice,
+    PciEndpoint,
     PciMemBar,
 )
 from m5.params import *
@@ -33,7 +33,7 @@ from m5.proxy import *
 from m5.SimObject import SimObject
 
 
-class CopyEngine(PciDevice):
+class CopyEngine(PciEndpoint):
     type = "CopyEngine"
     cxx_header = "dev/pci/copy_engine.hh"
     cxx_class = "gem5::CopyEngine"

--- a/src/dev/pci/PciDevice.py
+++ b/src/dev/pci/PciDevice.py
@@ -117,22 +117,9 @@ class PciDevice(DmaDevice):
     HeaderType = Param.UInt8(0, "PCI Header Type")
     BIST = Param.UInt8(0, "Built In Self Test")
 
-    BAR0 = Param.PciBar(PciBarNone(), "Base address register 0")
-    BAR1 = Param.PciBar(PciBarNone(), "Base address register 1")
-    BAR2 = Param.PciBar(PciBarNone(), "Base address register 2")
-    BAR3 = Param.PciBar(PciBarNone(), "Base address register 3")
-    BAR4 = Param.PciBar(PciBarNone(), "Base address register 4")
-    BAR5 = Param.PciBar(PciBarNone(), "Base address register 5")
-
-    CardbusCIS = Param.UInt32(0x00, "Cardbus Card Information Structure")
-    SubsystemID = Param.UInt16(0x00, "Subsystem ID")
-    SubsystemVendorID = Param.UInt16(0x00, "Subsystem Vendor ID")
-    ExpansionROM = Param.UInt32(0x00, "Expansion ROM Base Address")
     CapabilityPtr = Param.UInt8(0x00, "Capability List Pointer offset")
     InterruptLine = Param.UInt8(0x00, "Interrupt Line")
     InterruptPin = Param.UInt8(0x00, "Interrupt Pin")
-    MaximumLatency = Param.UInt8(0x00, "Maximum Latency")
-    MinimumGrant = Param.UInt8(0x00, "Minimum Grant")
 
     # Capabilities List structures for PCIe devices
     # PMCAP - PCI Power Management Capability
@@ -192,5 +179,67 @@ class PciDevice(DmaDevice):
     PXCAPLinkCap = Param.UInt32(0x00000000, "PCIe Link Capabilities")
     PXCAPLinkCtrl = Param.UInt16(0x0000, "PCIe Link Control")
     PXCAPLinkStatus = Param.UInt16(0x0000, "PCIe Link Status")
+    PXCAPSlotCap = Param.UInt32(0x00000000, "PCIe Slot Capabilities")
+    PXCAPSlotCtrl = Param.UInt16(0x0000, "PCIe Slot Control")
+    PXCAPSlotStatus = Param.UInt16(0x0000, "PCIe Slot Status")
+    PXCAPRootCap = Param.UInt16(0x0000, "PCIe Root Capabilities")
+    PXCAPRootCtrl = Param.UInt16(0x0000, "PCIe Root Control")
+    PXCAPRootStatus = Param.UInt32(0x00000000, "PCIe Root Status")
     PXCAPDevCap2 = Param.UInt32(0x00000000, "PCIe Device Capabilities 2")
-    PXCAPDevCtrl2 = Param.UInt32(0x00000000, "PCIe Device Control 2")
+    PXCAPDevCtrl2 = Param.UInt16(0x0000, "PCIe Device Control 2")
+    PXCAPDevStatus2 = Param.UInt16(0x0000, "PCIe Device Status 2")
+    PXCAPLinkCap2 = Param.UInt32(0x00000000, "PCIe Link Capabilities 2")
+    PXCAPLinkCtrl2 = Param.UInt16(0x0000, "PCIe Link Control 2")
+    PXCAPLinkStatus2 = Param.UInt16(0x0000, "PCIe Link Status 2")
+    PXCAPSlotCap2 = Param.UInt32(0x00000000, "PCIe Slot Capabilities 2")
+    PXCAPSlotCtrl2 = Param.UInt16(0x0000, "PCIe Slot Control 2")
+    PXCAPSlotStatus2 = Param.UInt16(0x0000, "PCIe Slot Status 2")
+
+
+class PciEndpoint(PciDevice):
+    type = "PciEndpoint"
+    cxx_class = "gem5::PciEndpoint"
+    cxx_header = "dev/pci/device.hh"
+    abstract = True
+
+    BAR0 = Param.PciBar(PciBarNone(), "Base address register 0")
+    BAR1 = Param.PciBar(PciBarNone(), "Base address register 1")
+    BAR2 = Param.PciBar(PciBarNone(), "Base address register 2")
+    BAR3 = Param.PciBar(PciBarNone(), "Base address register 3")
+    BAR4 = Param.PciBar(PciBarNone(), "Base address register 4")
+    BAR5 = Param.PciBar(PciBarNone(), "Base address register 5")
+
+    CardbusCIS = Param.UInt32(0x00, "Cardbus Card Information Structure")
+    SubsystemID = Param.UInt16(0x00, "Subsystem ID")
+    SubsystemVendorID = Param.UInt16(0x00, "Subsystem Vendor ID")
+    ExpansionROM = Param.UInt32(0x00, "Expansion ROM Base Address")
+    MaximumLatency = Param.UInt8(0x00, "Maximum Latency")
+    MinimumGrant = Param.UInt8(0x00, "Minimum Grant")
+
+
+class PciBridge(PciDevice):
+    type = "PciBridge"
+    cxx_class = "gem5::PciBridge"
+    cxx_header = "dev/pci/device.hh"
+    abstract = True
+
+    BAR0 = Param.PciBar(PciBarNone(), "Base address register 0")
+    BAR1 = Param.PciBar(PciBarNone(), "Base address register 1")
+
+    PrimaryBusNumber = Param.UInt8(0, "Primary bus number")
+    SecondaryBusNumber = Param.UInt8(0, "Secondary bus number")
+    SubordinateBusNumber = Param.UInt8(0, "Subordinate bus number")
+    SecondaryLatencyTimer = Param.UInt8(0, "Secondary Latency Timer")
+    IOBase = Param.UInt8(0, "I/O Base")
+    IOLimit = Param.UInt8(0, "I/O Limit")
+    SecondaryStatus = Param.UInt16(0, "Secondary status")
+    MemoryBase = Param.UInt16(0, "Memory base")
+    MemoryLimit = Param.UInt16(0, "Memory limit")
+    PrefetchableMemoryBase = Param.UInt16(0, "Prefetchable Memory Base")
+    PrefetchableMemoryLimit = Param.UInt16(0, "Prefetchable Memory Limit")
+    PrefetchableBaseUpper = Param.UInt32(0, "Prefetchable Base Upper")
+    PrefetchableLimitUpper = Param.UInt32(0, "Prefetchable Limit Upper")
+    IOBaseUpper = Param.UInt16(0, "I/O Base Upper")
+    IOLimitUpper = Param.UInt16(0, "I/O Limit Upper")
+    ExpansionROM = Param.UInt32(0, "Expansion ROM Base Address")
+    BridgeControl = Param.UInt16(0, "Bridge Control")

--- a/src/dev/pci/SConscript
+++ b/src/dev/pci/SConscript
@@ -42,9 +42,11 @@ Import('*')
 
 SimObject('PciDevice.py', sim_objects=[
     'PciBar', 'PciBarNone', 'PciIoBar', 'PciLegacyIoBar', 'PciMemBar',
-    'PciMemUpperBar', 'PciDevice'])
+    'PciMemUpperBar', 'PciDevice', 'PciEndpoint', 'PciBridge'])
 Source('device.cc')
 DebugFlag('PciDevice')
+DebugFlag('PciEndpoint')
+DebugFlag('PciBridge')
 
 SimObject('PciHost.py', sim_objects=['PciHost', 'GenericPciHost'])
 Source('host.cc')

--- a/src/dev/pci/copy_engine.cc
+++ b/src/dev/pci/copy_engine.cc
@@ -62,7 +62,7 @@ namespace gem5
 using namespace copy_engine_reg;
 
 CopyEngine::CopyEngine(const Params &p)
-    : PciDevice(p),
+    : PciEndpoint(p),
       copyEngineStats(this, p.ChanCnt)
 {
     // All Reg regs are initialized to 0 by default
@@ -120,7 +120,7 @@ CopyEngine::getPort(const std::string &if_name, PortID idx)
 {
     if (if_name != "dma") {
         // pass it along to our super class
-        return PciDevice::getPort(if_name, idx);
+        return PciEndpoint::getPort(if_name, idx);
     } else {
         if (idx >= static_cast<int>(chan.size())) {
             panic("CopyEngine::getPort: unknown index %d\n", idx);
@@ -651,7 +651,7 @@ CopyEngine::CopyEngineChannel::drain()
 void
 CopyEngine::serialize(CheckpointOut &cp) const
 {
-    PciDevice::serialize(cp);
+    PciEndpoint::serialize(cp);
     regs.serialize(cp);
     for (int x =0; x < chan.size(); x++)
         chan[x]->serializeSection(cp, csprintf("channel%d", x));
@@ -660,7 +660,7 @@ CopyEngine::serialize(CheckpointOut &cp) const
 void
 CopyEngine::unserialize(CheckpointIn &cp)
 {
-    PciDevice::unserialize(cp);
+    PciEndpoint::unserialize(cp);
     regs.unserialize(cp);
     for (int x = 0; x < chan.size(); x++)
         chan[x]->unserializeSection(cp, csprintf("channel%d", x));

--- a/src/dev/pci/copy_engine.hh
+++ b/src/dev/pci/copy_engine.hh
@@ -58,7 +58,7 @@
 namespace gem5
 {
 
-class CopyEngine : public PciDevice
+class CopyEngine : public PciEndpoint
 {
     class CopyEngineChannel : public Drainable, public Serializable
     {

--- a/src/dev/pci/device.cc
+++ b/src/dev/pci/device.cc
@@ -442,8 +442,21 @@ PciDevice::serialize(CheckpointOut &cp) const
     paramOut(cp, csprintf("pxcap.pxlcap"), uint32_t(pxcap.pxlcap));
     paramOut(cp, csprintf("pxcap.pxlc"), uint16_t(pxcap.pxlc));
     paramOut(cp, csprintf("pxcap.pxls"), uint16_t(pxcap.pxls));
+    paramOut(cp, csprintf("pxcap.pxscap"), uint32_t(pxcap.pxscap));
+    paramOut(cp, csprintf("pxcap.pxsc"), uint16_t(pxcap.pxsc));
+    paramOut(cp, csprintf("pxcap.pxss"), uint16_t(pxcap.pxss));
+    paramOut(cp, csprintf("pxcap.pxrcap"), uint16_t(pxcap.pxrcap));
+    paramOut(cp, csprintf("pxcap.pxrc"), uint16_t(pxcap.pxrc));
+    paramOut(cp, csprintf("pxcap.pxrs"), uint32_t(pxcap.pxrs));
     paramOut(cp, csprintf("pxcap.pxdcap2"), uint32_t(pxcap.pxdcap2));
-    paramOut(cp, csprintf("pxcap.pxdc2"), uint32_t(pxcap.pxdc2));
+    paramOut(cp, csprintf("pxcap.pxdc2"), uint16_t(pxcap.pxdc2));
+    paramOut(cp, csprintf("pxcap.pxds2"), uint16_t(pxcap.pxds2));
+    paramOut(cp, csprintf("pxcap.pxlcap2"), uint32_t(pxcap.pxlcap2));
+    paramOut(cp, csprintf("pxcap.pxlc2"), uint16_t(pxcap.pxlc2));
+    paramOut(cp, csprintf("pxcap.pxls2"), uint16_t(pxcap.pxls2));
+    paramOut(cp, csprintf("pxcap.pxscap2"), uint32_t(pxcap.pxscap2));
+    paramOut(cp, csprintf("pxcap.pxsc2"), uint16_t(pxcap.pxsc2));
+    paramOut(cp, csprintf("pxcap.pxss2"), uint16_t(pxcap.pxss2));
 }
 
 void
@@ -529,10 +542,36 @@ PciDevice::unserialize(CheckpointIn &cp)
     pxcap.pxlc = tmp16;
     paramIn(cp, csprintf("pxcap.pxls"), tmp16);
     pxcap.pxls = tmp16;
+    paramIn(cp, csprintf("pxcap.pxscap"), tmp32);
+    pxcap.pxscap = tmp32;
+    paramIn(cp, csprintf("pxcap.pxsc"), tmp16);
+    pxcap.pxsc = tmp16;
+    paramIn(cp, csprintf("pxcap.pxss"), tmp16);
+    pxcap.pxss = tmp16;
+    paramIn(cp, csprintf("pxcap.pxrcap"), tmp16);
+    pxcap.pxrcap = tmp16;
+    paramIn(cp, csprintf("pxcap.pxrc"), tmp16);
+    pxcap.pxrc = tmp16;
+    paramIn(cp, csprintf("pxcap.pxrs"), tmp32);
+    pxcap.pxrs = tmp32;
     paramIn(cp, csprintf("pxcap.pxdcap2"), tmp32);
     pxcap.pxdcap2 = tmp32;
-    paramIn(cp, csprintf("pxcap.pxdc2"), tmp32);
-    pxcap.pxdc2 = tmp32;
+    paramIn(cp, csprintf("pxcap.pxdc2"), tmp16);
+    pxcap.pxdc2 = tmp16;
+    paramIn(cp, csprintf("pxcap.pxds2"), tmp16);
+    pxcap.pxds2 = tmp16;
+    paramIn(cp, csprintf("pxcap.pxlcap2"), tmp32);
+    pxcap.pxlcap2 = tmp32;
+    paramIn(cp, csprintf("pxcap.pxlc2"), tmp16);
+    pxcap.pxlc2 = tmp16;
+    paramIn(cp, csprintf("pxcap.pxls2"), tmp16);
+    pxcap.pxls2 = tmp16;
+    paramIn(cp, csprintf("pxcap.pxscap2"), tmp32);
+    pxcap.pxscap2 = tmp32;
+    paramIn(cp, csprintf("pxcap.pxsc2"), tmp16);
+    pxcap.pxsc2 = tmp16;
+    paramIn(cp, csprintf("pxcap.pxss2"), tmp16);
+    pxcap.pxss2 = tmp16;
 }
 
 PciEndpoint::PciEndpoint(const PciEndpointParams &p)

--- a/src/dev/storage/Ide.py
+++ b/src/dev/storage/Ide.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.PciDevice import (
-    PciDevice,
+    PciEndpoint,
     PciIoBar,
 )
 from m5.params import *
@@ -45,7 +45,7 @@ class IdeDisk(SimObject):
     image = Param.DiskImage("Disk image")
 
 
-class IdeController(PciDevice):
+class IdeController(PciEndpoint):
     type = "IdeController"
     cxx_header = "dev/storage/ide_ctrl.hh"
     cxx_class = "gem5::IdeController"

--- a/src/dev/storage/ide_ctrl.hh
+++ b/src/dev/storage/ide_ctrl.hh
@@ -49,7 +49,7 @@ class IdeDisk;
  * Device model for an Intel PIIX4 IDE controller
  */
 
-class IdeController : public PciDevice
+class IdeController : public PciEndpoint
 {
   private:
     // Bus master IDE status register bit fields

--- a/src/dev/virtio/VirtIO.py
+++ b/src/dev/virtio/VirtIO.py
@@ -37,7 +37,7 @@
 
 from m5.objects.Device import PioDevice
 from m5.objects.PciDevice import (
-    PciDevice,
+    PciEndpoint,
     PciIoBar,
 )
 from m5.params import *
@@ -63,7 +63,7 @@ class VirtIODummyDevice(VirtIODeviceBase):
     cxx_class = "gem5::VirtIODummyDevice"
 
 
-class PciVirtIO(PciDevice):
+class PciVirtIO(PciEndpoint):
     type = "PciVirtIO"
     cxx_header = "dev/virtio/pci.hh"
     cxx_class = "gem5::PciVirtIO"

--- a/src/dev/virtio/pci.cc
+++ b/src/dev/virtio/pci.cc
@@ -47,11 +47,11 @@ namespace gem5
 {
 
 PciVirtIO::PciVirtIO(const Params &params)
-    : PciDevice(params), queueNotify(0), interruptDeliveryPending(false),
+    : PciEndpoint(params), queueNotify(0), interruptDeliveryPending(false),
       vio(*params.vio)
 {
     // Override the subsystem ID with the device ID from VirtIO
-    config.subsystemID = htole(vio.deviceId);
+    config().subsystemID = htole(vio.deviceId);
 
     // The kernel driver expects the BAR size to be an exact power of
     // two. Nothing else is supported. Therefore, we need to force

--- a/src/dev/virtio/pci.hh
+++ b/src/dev/virtio/pci.hh
@@ -47,7 +47,7 @@ namespace gem5
 
 struct PciVirtIOParams;
 
-class PciVirtIO : public PciDevice
+class PciVirtIO : public PciEndpoint
 {
   public:
     typedef PciVirtIOParams Params;

--- a/src/python/gem5/components/devices/gpus/viper_shader.py
+++ b/src/python/gem5/components/devices/gpus/viper_shader.py
@@ -273,7 +273,7 @@ class ViperShader(Shader):
 
         # Set bit 6 to enable atomic requestor, meaning this device can request
         # atomics from other PCI devices.
-        device.PXCAPDevCtrl2 = 0x00000040
+        device.PXCAPDevCtrl2 = 0x0040
 
         # If there are multiple GPUs in the system, make sure the VBIOS region
         # and the legacy IO bar do not overlap with the ranges from other GPUs.

--- a/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
@@ -81,7 +81,7 @@ board.set_kernel_disk_workload(
         "x86-ubuntu-18.04-img", resource_version="1.0.0"
     ),
     checkpoint=obtain_resource(
-        "x86-fs-test-checkpoint-v24-0", resource_version="3.0.0"
+        "x86-fs-test-checkpoint-v24-0", resource_version="4.0.0"
     ),
 )
 

--- a/util/cpt_upgraders/pci-config-pxcap.py
+++ b/util/cpt_upgraders/pci-config-pxcap.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 REDS institute of the HEIG-VD
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+# Rename config into _config in PciDevice and a new fields for pxcap
+def upgrader(cpt):
+    import re
+
+    for sec in cpt.sections():
+        # pmcap.pid is a unique option in PciDevice. So it allows to
+        # detect any PciDevice.
+        if cpt.has_option(sec, "pmcap.pid"):
+            cpt.set(sec, "_config.data", cpt.get(sec, "config.data"))
+            cpt.remove_option(sec, "config.data")
+            pxdc2 = cpt.getint(sec, "pxcap.pxdc2")
+            cpt.set(sec, "pxcap.pxdc2", str(pxdc2 & 0xFFFF))
+            cpt.set(sec, "pxcap.pxds2", str((pxdc2 >> 16) & 0xFFFF))
+
+            cpt.set(sec, "pxcap.pxscap", "0")
+            cpt.set(sec, "pxcap.pxsc", "0")
+            cpt.set(sec, "pxcap.pxss", "0")
+            cpt.set(sec, "pxcap.pxrcap", "0")
+            cpt.set(sec, "pxcap.pxrc", "0")
+            cpt.set(sec, "pxcap.pxrs", "0")
+            cpt.set(sec, "pxcap.pxlcap2", "0")
+            cpt.set(sec, "pxcap.pxlc2", "0")
+            cpt.set(sec, "pxcap.pxls2", "0")
+            cpt.set(sec, "pxcap.pxscap2", "0")
+            cpt.set(sec, "pxcap.pxsc2", "0")
+            cpt.set(sec, "pxcap.pxss2", "0")


### PR DESCRIPTION
This adds the possiblity to have PCI device with type 1 config header (PCI-to-PCI Bridge).

To achieve this, two classes are added `PciEndpoint` and `PciBridge` which inherit the current `PciDevice`:

  - `PciDevice` acts now on the common part of the configuration (based on PCIe 5.0 specification, the first 16 bytes + capability pointer + interrupt line/pin). This should not be inherited directly.
  - `PciEndpoint` replace `PciDevice` for all devices connected as an endpoint (GPU, network card, ...) and use the type 0 config header.
  - `PciBridge` add the possibility for PCI bridges using the type 1 config header.

I tried to stick to the current architecture to avoid big breaking changes. I'm open to any suggestion !

I also updated the `PXCAP` union for PCIe capabilities, which had a too big offset before the device capabilities 2 register (20 instead of 16) and also missing fields.

This is a first step into the bigger #1862 implementation.