### PR TITLE
arch-x86: fix pack micro-op implementation

### DIFF
--- a/src/arch/x86/isa/microops/mediaop.isa
+++ b/src/arch/x86/isa/microops/mediaop.isa
@@ -389,17 +389,20 @@ let {{
                     bits(FpSrcReg1_uqw, (i + 1) * srcBits - 1,
                                         (i + 0) * srcBits);
                 unsigned signBit = bits(picked, srcBits - 1);
-                uint64_t overflow = bits(picked, srcBits - 1, destBits - 1);
 
                 // Handle saturation.
                 if (signBit) {
-                    if (overflow != mask(srcBits - destBits + 1)) {
-                        if (signedOp())
+                    if (signedOp()) {
+                        uint64_t overflow = bits(picked, srcBits - 1,
+                                                 destBits - 1);
+                        if (overflow != mask(srcBits - destBits + 1)) {
                             picked = (1ULL << (destBits - 1));
-                        else
-                            picked = 0;
+                        }
+                    } else {
+                        picked = 0;
                     }
                 } else {
+                    uint64_t overflow = bits(picked, srcBits - 1, destBits);
                     if (overflow != 0) {
                         if (signedOp())
                             picked = mask(destBits - 1);


### PR DESCRIPTION
Fix #1951. This patch fixes two bugs in the pack x86 micro-op implementation. The pack micro-op packs signed 2n-bit inputs into signed or unsigned n-bit outputs with saturation, i.e., if the 2n-bit value is out of the range that can be represented by the signed or unsigned n-bit value, it is replaced with -128/127 or 0/255.

Bug 1: a signed 2n-bit input that fits into one signed byte is not clamped to 0 before being copied to an unsigned n-bit output. This is because the checks when the input is negative were performed out of order.

Bug 2: a signed 2n-bit input in the range 128 to 255 (i.e., it fits in one unsigned byte and the 7th bit is set) is "clamped" to 255 despite fitting in one unsigned byte.

This patch fixes the logic errors resulting in both bugs.

Change-Id: I2c1c59e84463c8b4def808f34bd9be4f24989b5f