### PR TITLE
configs: `exec` -> `importlib` for Ruby.py  dynamic imports

### DIFF
--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -38,6 +38,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+from importlib import import_module
 
 import m5
 from m5.defines import buildEnv
@@ -125,9 +126,8 @@ def define_options(parser):
         help="Recycle latency for ruby controller input buffers",
     )
 
-    protocol = buildEnv["PROTOCOL"]
-    exec(f"from . import {protocol}")
-    eval(f"{protocol}.define_options(parser)")
+    import_module(f"ruby.{buildEnv["PROTOCOL"]}").define_options(parser)
+
     Network.define_options(parser)
 
 
@@ -246,16 +246,17 @@ def create_system(
     if cpus is None:
         cpus = system.cpu
 
-    protocol = buildEnv["PROTOCOL"]
-    exec(f"from . import {protocol}")
     try:
-        (cpu_sequencers, dir_cntrls, topology) = eval(
-            "%s.create_system(options, full_system, system, dma_ports,\
-                                    bootmem, ruby, cpus)"
-            % protocol
+        (cpu_sequencers, dir_cntrls, topology) = import_module(
+            f"ruby.{buildEnv["PROTOCOL"]}"
+        ).create_system(
+            options, full_system, system, dma_ports, bootmem, ruby, cpus
         )
     except:
-        print(f"Error: could not create sytem for ruby protocol {protocol}")
+        print(
+            "Error: could not create sytem for ruby protocol "
+            f"{buildEnv["PROTOCOL"]}"
+        )
         raise
 
     # Create the network topology

--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -126,7 +126,7 @@ def define_options(parser):
         help="Recycle latency for ruby controller input buffers",
     )
 
-    import_module(f"ruby.{buildEnv["PROTOCOL"]}").define_options(parser)
+    import_module(f"ruby.{buildEnv['PROTOCOL']}").define_options(parser)
 
     Network.define_options(parser)
 
@@ -248,14 +248,14 @@ def create_system(
 
     try:
         (cpu_sequencers, dir_cntrls, topology) = import_module(
-            f"ruby.{buildEnv["PROTOCOL"]}"
+            f"ruby.{buildEnv['PROTOCOL']}"
         ).create_system(
             options, full_system, system, dma_ports, bootmem, ruby, cpus
         )
     except:
         print(
             "Error: could not create sytem for ruby protocol "
-            f"{buildEnv["PROTOCOL"]}"
+            f"{buildEnv['PROTOCOL']}"
         )
         raise
 


### PR DESCRIPTION
On my Mac systems (ARM-Apple Silicon)  I was getting an import error for config scripts that utilized "configs/ruby/Ruby.py" when importing the correct Ruby protocol.

For example, when executing

```shell
scons build/VEGA_X86/gem5.opt -j `nproc`
./build/VEGA_X86/gem5.opt configs/example/ruby_gpu_random_test.py \
  --WB_L2 --test-length 5000000 --num-dmas 0`
```

I got the following error:

```shell
NameError: name 'GPU_VIPER' is not defined

At:
  <string>(1): <module>
  /Users/bobbyrbruce/Workspaces/gem5/configs/ruby/Ruby.py(130): define_options
  configs/example/ruby_gpu_random_test.py(49): <module>
  src/python/m5/main.py(675): main
```

I couldn't reproduce this with any Linux/X86 system as my disposal and have to fully understand why this bug occurs. Though I found replacing these `exec` statements with `imprtlib.import_module` equivalents solved the problem.

I don't believe there are any advantages to using `exec` to import modules over utilizing `importlib`. It's probably better to use `importlib` as it's a more standardized way to do dynamic importing. so I'm suggesting this patch as both a fix and slight tidy-up of this code.