### PR TITLE
arch-riscv: fix vector reduction instructions when LMUL>1

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3100,7 +3100,7 @@ decode QUADRANT default Unknown::unknown() {
                     Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fadd<et>(ftype<et>(src1), ftype<et>(src2));
                     }, Vs1_vu, Vs2_vu);
-                }}, OPFVV, SimdFloatReduceAddOp);
+                }}, OPFVV, SimdFloatReduceAddOp, IsSerializeAfter);
                 0x04: VectorFloatFormat::vfmin_vv({{
                     auto fd = fmin<et>(ftype<et>(Vs2_vu[i]),
                                        ftype<et>(Vs1_vu[i]));
@@ -3368,7 +3368,7 @@ decode QUADRANT default Unknown::unknown() {
                                     f_to_wf<et>(ftype<et>(src2))
                                 );
                             }, Vs1_vwu, Vs2_vu);
-                    }}, OPFVV, SimdFloatReduceAddOp);
+                    }}, OPFVV, SimdFloatReduceAddOp, IsSerializeAfter);
                 }
                 format VectorFloatWideningFormat {
                     0x30: vfwadd_vv({{

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1205,12 +1205,14 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs1]"
+    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs2)\
+                               + _microIdx]"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
@@ -1228,7 +1230,6 @@ def format VectorReduceIntFormat(code, category, *flags) {{
          'set_vlenb' : set_vlenb,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
-         'copy_old_vd': copyOldVd(2),
          'declare_varith_template': declareVArithTemplate(Name + "Micro")},
         flags)
 
@@ -1253,12 +1254,14 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs1]"
+    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs2)\
+                               + _microIdx]"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
@@ -1280,7 +1283,6 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
-         'copy_old_vd': copyOldVd(2),
          'declare_varith_template': varith_micro_declare},
         flags)
 
@@ -1306,12 +1308,14 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs1]"
+    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs2)\
+                               + _microIdx]"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
@@ -1333,7 +1337,6 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
-         'copy_old_vd': copyOldVd(2),
          'declare_varith_template': varith_micro_declare},
         flags)
 
@@ -1418,12 +1421,14 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs1]"
+    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
+                               ? VecMemInternalReg0 : _machInst.vs2)\
+                               + _microIdx]"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
@@ -1437,7 +1442,6 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
-         'copy_old_vd': copyOldVd(2),
          'declare_varith_template': varith_micro_declare},
         flags)
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1713,13 +1713,40 @@ template<typename ElemType>
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
     }
+
+    if (machInst.vd == machInst.vs1) {
+        microop = new VCpyVsMicroInst(machInst, 0, machInst.vs1, elen, vlen);
+        microop->setFlag(IsDelayedCommit);
+        this->microops.push_back(microop);
+    }
+
+    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+        if (machInst.vd == (machInst.vs2 + i) && machInst.vd != machInst.vs1) {
+            microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen,
+                                          vlen);
+            microop->setFlag(IsDelayedCommit);
+            this->microops.push_back(microop);
+        }
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+    }
+
+    microop = new VPinVdMicroInst(machInst, 0, num_microops, elen, vlen);
+    microop->setFlag(IsDelayedCommit);
+    this->microops.push_back(microop);
+
+    tmp_vl = this->vl;
+    micro_vl = std::min(tmp_vl, micro_vlmax);
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
         microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
                                                     _elen, _vlen);
+        if (flags[IsSerializeAfter] && i < num_microops-1) { // ordered
+            microop->setFlag(StaticInst::IsSerializeAfter);
+        }
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
+
     this->microops.front()->setFirstMicroop();
     this->microops.back()->setLastMicroop();
 }
@@ -1734,8 +1761,8 @@ template<typename ElemType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    // vs2, vs1, vd, vm
-    RegId srcRegIdxArr[4];
+    // vs2, vs1, vm
+    RegId srcRegIdxArr[3];
     RegId destRegIdxArr[1];
     bool vm;
 public:
@@ -1795,11 +1822,10 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
-    %(copy_old_vd)s;
 
     auto reduce_loop =
         [&, this](const auto& f, const auto* _, const auto* vs2) {
-            ElemType microop_result = Vs1[0];
+            ElemType microop_result = (microIdx == 0) ? Vs1[0]:Vd[0];
             for (uint32_t i = 0; i < this->microVl; i++) {
                 uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
                     this->microIdx;
@@ -1845,11 +1871,10 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
-    %(copy_old_vd)s;
 
     auto reduce_loop =
         [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vu tmp_val = Vs1[0];
+            vu tmp_val = (microIdx == 0) ? Vs1[0]:Vd[0];
             for (uint32_t i = 0; i < this->microVl; i++) {
                 uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
                     this->microIdx;
@@ -1896,11 +1921,10 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
-    %(copy_old_vd)s;
 
     auto reduce_loop =
         [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vwu tmp_val = Vs1[0];
+            vu tmp_val = (microIdx == 0) ? Vs1[0]:Vd[0];
             for (uint32_t i = 0; i < this->microVl; i++) {
                 uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
                     this->microIdx;
@@ -2255,11 +2279,10 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
-    %(copy_old_vd)s;
 
     auto reduce_loop =
         [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vwu tmp_val = Vs1[0];
+            vwu tmp_val = (microIdx == 0) ? Vs1[0]:Vd[0];
             for (uint32_t i = 0; i < this->microVl; i++) {
                 uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
                     this->microIdx;


### PR DESCRIPTION
This patch aims to fix incorrect vector reduction instructions when LMUL>1, which previously were not accumulating results between micro instructions correctly. The patch also adds register pinning to reduce the demand of physical registers. 

Finally, since pinning removes any kind of data dependency between micro instructions,  the `IsSerializeAfter` flag was added to `vf{w}redosum.vs` to enforce that the sum is done in element order as per spec.

Should fix issue #1856.