### PR TITLE
arch-arm: Fix ARM KVM build problems

### DIFF
--- a/src/arch/arm/kvm/SConscript
+++ b/src/arch/arm/kvm/SConscript
@@ -58,16 +58,17 @@ SimObject(
 )
 Source('base_cpu.cc', tags=['arm kvm'])
 
-SimObject(
-    'ArmKvmCPU.py',
-    sim_objects=['ArmKvmCPU'],
-    tags=['armv71 kvm']
-)
-Source('arm_cpu.cc', tags=['armv71 kvm'])
-
-SimObject(
-    'ArmV8KvmCPU.py',
-    sim_objects=['ArmV8KvmCPU'],
-    tags=['aarch64 kvm']
-)
-Source('armv8_cpu.cc', tags=['aarch64 kvm'])
+if host_isa == 'aarch64':
+    SimObject(
+        'ArmV8KvmCPU.py',
+        sim_objects=['ArmV8KvmCPU'],
+        tags=['aarch64 kvm']
+    )
+    Source('armv8_cpu.cc', tags=['aarch64 kvm'])
+else:
+    SimObject(
+        'ArmKvmCPU.py',
+        sim_objects=['ArmKvmCPU'],
+        tags=['armv71 kvm']
+    )
+    Source('arm_cpu.cc', tags=['armv71 kvm'])

--- a/src/arch/arm/kvm/arm_cpu.hh
+++ b/src/arch/arm/kvm/arm_cpu.hh
@@ -101,7 +101,7 @@ class ArmKvmCPU : public BaseKvmCPU
     void
     stutterPC(PCStateBase &pc) const
     {
-        pc.as<ArmISA::PCState>().setNPC(pc->instAddr());
+        pc.as<ArmISA::PCState>().setNPC(pc.instAddr());
     }
 
     /**

--- a/src/arch/arm/kvm/arm_cpu.hh
+++ b/src/arch/arm/kvm/arm_cpu.hh
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include "arch/arm/pcstate.hh"
+#include "arch/arm/regs/misc.hh"
 #include "cpu/kvm/base.hh"
 #include "params/ArmKvmCPU.hh"
 

--- a/src/arch/arm/kvm/arm_cpu.hh
+++ b/src/arch/arm/kvm/arm_cpu.hh
@@ -69,7 +69,7 @@ class ArmKvmCPU : public BaseKvmCPU
 
     void startup();
 
-    void dump();
+    void dump() const override;
 
   protected:
     struct KvmIntRegInfo


### PR DESCRIPTION
Currently, there are two types of arm KVM CPUs,
- `arm_cpu.hh` and `arm_cpu.cc` and `ArmKvmCPU.py` targeting using KVM on arm v7.1 architectures.
- `armv8_cpu.hh` and `armv8_cpu.cc` and `ArmV8KvmCPU.py` targeting using KVM on arm v8 architectures.

Recently, PR #1785 added gem5_lib to all SimObjects, so all source files are compiled by default if Source() or SimObject() are called. The current logic in `arch/arm/kvm/SConscript` leads to both KVM CPUs targeting two different host architectures (armv7 and armv8) being built.
    
This change fixes the above problem by choosing the KVM CPU based on the host's architecture string.

This change also fixes the following compilation error in `kvm/arm_cpu.hh` and `kvm/arm_cpu.cc`,

I think the KVM build problems surface another problem: the syntactic errors in armv7 KVM CPU suggests that this CPU type is not widely used and being bit rot. Unless we have a way to test it, I think we should consider removing the armv7 KVM CPU, or renaming `kvm/arm_cpu*` to `kvm/armv7_cpu`.