### PR TITLE
scons: Improve codegen for build/../params/*.hh

### DIFF
--- a/build_tools/code_formatter.py
+++ b/build_tools/code_formatter.py
@@ -329,7 +329,8 @@ class code_formatter(metaclass=code_formatter_meta):
                 )
 
         d = code_formatter.pattern.sub(convert, format)
-        self._append(d)
+        if not kwargs.get("add_once") or d not in self._data:
+            self._append(d)
 
 
 __all__ = ["code_formatter"]

--- a/build_tools/sim_object_param_struct_hh.py
+++ b/build_tools/sim_object_param_struct_hh.py
@@ -168,7 +168,7 @@ code(
 # the normal Param mechanism; we slip them in here (needed
 # predecls now, actual declarations below)
 if sim_object == SimObject:
-    code("""#include <string>""")
+    code("""#include <string>""", add_once=True)
 
 cxx_class = CxxClass(
     sim_object._value_dict["cxx_class"],
@@ -186,12 +186,12 @@ for port in ports.values():
 code()
 
 if sim_object._base:
-    code('#include "params/${{sim_object._base.type}}.hh"')
+    code('#include "params/${{sim_object._base.type}}.hh"', add_once=True)
     code()
 
 for ptype in ptypes:
     if issubclass(ptype, Enum):
-        code('#include "enums/${{ptype.__name__}}.hh"')
+        code('#include "enums/${{ptype.__name__}}.hh"', add_once=True)
         code()
 
 code("namespace gem5")

--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -452,10 +452,10 @@ class MetaSimObject(type):
 
     # See ParamValue.cxx_predecls for description.
     def cxx_predecls(cls, code):
-        code('#include "params/$cls.hh"')
+        code('#include "params/$cls.hh"', add_once=True)
 
     def pybind_predecls(cls, code):
-        code('#include "${{cls.cxx_header}}"')
+        code('#include "${{cls.cxx_header}}"', add_once=True)
 
 
 # This *temporary* definition is required to support calls from the

--- a/src/python/m5/params.py
+++ b/src/python/m5/params.py
@@ -231,7 +231,7 @@ class ParamDesc:
         return self.ptype(value).pretty_print(value)
 
     def cxx_predecls(self, code):
-        code("#include <cstddef>")
+        code("#include <cstddef>", add_once=True)
         self.ptype.cxx_predecls(code)
 
     def pybind_predecls(self, code):
@@ -405,11 +405,11 @@ class VectorParamDesc(ParamDesc):
         return VectorParamValue(tmp_list)
 
     def cxx_predecls(self, code):
-        code("#include <vector>")
+        code("#include <vector>", add_once=True)
         self.ptype.cxx_predecls(code)
 
     def pybind_predecls(self, code):
-        code("#include <vector>")
+        code("#include <vector>", add_once=True)
         self.ptype.pybind_predecls(code)
 
     def cxx_decl(self, code):
@@ -463,7 +463,7 @@ class String(ParamValue, str):
 
     @classmethod
     def cxx_predecls(self, code):
-        code("#include <string>")
+        code("#include <string>", add_once=True)
 
     def __call__(self, value):
         self = value
@@ -565,7 +565,7 @@ class NumericParamValue(ParamValue):
     @classmethod
     def cxx_ini_predecls(cls, code):
         # Assume that base/str.hh will be included anyway
-        # code('#include "base/str.hh"')
+        # code('#include "base/str.hh"', add_once=True)
         pass
 
     # The default for parsing PODs from an .ini entry is to extract from an
@@ -637,7 +637,7 @@ class CheckedInt(NumericParamValue, metaclass=CheckedIntType):
     @classmethod
     def cxx_predecls(cls, code):
         # most derived types require this, so we just do it here once
-        code('#include "base/types.hh"')
+        code('#include "base/types.hh"', add_once=True)
 
     def getValue(self):
         return int(self.value)
@@ -746,7 +746,7 @@ class Cycles(CheckedInt):
     @classmethod
     def cxx_ini_predecls(cls, code):
         # Assume that base/str.hh will be included anyway
-        # code('#include "base/str.hh"')
+        # code('#include "base/str.hh"', add_once=True)
         pass
 
     @classmethod
@@ -782,7 +782,7 @@ class Float(ParamValue, float):
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code("#include <sstream>")
+        code("#include <sstream>", add_once=True)
 
     @classmethod
     def cxx_ini_parse(self, code, src, dest, ret):
@@ -887,11 +887,11 @@ class PcCountPair(ParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "cpu/probes/pc_count_pair.hh"')
+        code('#include "cpu/probes/pc_count_pair.hh"', add_once=True)
 
     @classmethod
     def pybind_predecls(cls, code):
-        code('#include "cpu/probes/pc_count_pair.hh"')
+        code('#include "cpu/probes/pc_count_pair.hh"', add_once=True)
 
 
 class AddrRange(ParamValue):
@@ -981,18 +981,18 @@ class AddrRange(ParamValue):
     @classmethod
     def cxx_predecls(cls, code):
         Addr.cxx_predecls(code)
-        code('#include "base/addr_range.hh"')
+        code('#include "base/addr_range.hh"', add_once=True)
 
     @classmethod
     def pybind_predecls(cls, code):
         Addr.pybind_predecls(code)
-        code('#include "base/addr_range.hh"')
+        code('#include "base/addr_range.hh"', add_once=True)
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code("#include <sstream>")
-        code("#include <vector>")
-        code('#include "base/types.hh"')
+        code("#include <sstream>", add_once=True)
+        code("#include <vector>", add_once=True)
+        code('#include "base/types.hh"', add_once=True)
 
     @classmethod
     def cxx_ini_parse(cls, code, src, dest, ret):
@@ -1082,7 +1082,7 @@ class Bool(ParamValue):
     @classmethod
     def cxx_ini_predecls(cls, code):
         # Assume that base/str.hh will be included anyway
-        # code('#include "base/str.hh"')
+        # code('#include "base/str.hh"', add_once=True)
         pass
 
     @classmethod
@@ -1095,7 +1095,7 @@ class HostSocket(ParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/socket.hh"')
+        code('#include "base/socket.hh"', add_once=True)
 
     def __init__(self, value):
         if isinstance(value, HostSocket):
@@ -1144,7 +1144,7 @@ class HostSocket(ParamValue):
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code('#include "base/socket.hh"')
+        code('#include "base/socket.hh"', add_once=True)
 
     @classmethod
     def cxx_ini_parse(cls, code, src, dest, ret):
@@ -1182,7 +1182,7 @@ class EthernetAddr(ParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/inet.hh"')
+        code('#include "base/inet.hh"', add_once=True)
 
     def __init__(self, value):
         if value == NextEthernetAddr:
@@ -1237,7 +1237,7 @@ class IpAddress(ParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/inet.hh"')
+        code('#include "base/inet.hh"', add_once=True)
 
     def __init__(self, value):
         if isinstance(value, IpAddress):
@@ -1291,7 +1291,7 @@ class IpNetmask(IpAddress):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/inet.hh"')
+        code('#include "base/inet.hh"', add_once=True)
 
     def __init__(self, *args, **kwargs):
         def handle_kwarg(self, kwargs, key, elseVal=None):
@@ -1367,7 +1367,7 @@ class IpWithPort(IpAddress):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/inet.hh"')
+        code('#include "base/inet.hh"', add_once=True)
 
     def __init__(self, *args, **kwargs):
         def handle_kwarg(self, kwargs, key, elseVal=None):
@@ -1488,7 +1488,7 @@ class Time(ParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code("#include <time.h>")
+        code("#include <time.h>", add_once=True)
 
     def __init__(self, value):
         self.value = parse_time(value)
@@ -1516,7 +1516,7 @@ class Time(ParamValue):
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code("#include <time.h>")
+        code("#include <time.h>", add_once=True)
 
     @classmethod
     def cxx_ini_parse(cls, code, src, dest, ret):
@@ -1611,7 +1611,7 @@ class Enum(ParamValue, metaclass=MetaEnum):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "enums/$0.hh"', cls.__name__)
+        code('#include "enums/$0.hh"', cls.__name__, add_once=True)
 
     @classmethod
     def cxx_ini_parse(cls, code, src, dest, ret):
@@ -1679,7 +1679,7 @@ class TickParamValue(NumericParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/types.hh"')
+        code('#include "base/types.hh"', add_once=True)
 
     def __call__(self, value):
         self.__init__(value)
@@ -1690,7 +1690,7 @@ class TickParamValue(NumericParamValue):
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code("#include <sstream>")
+        code("#include <sstream>", add_once=True)
 
     # Ticks are expressed in seconds in JSON files and in plain
     # Ticks in .ini files.  Switch based on a config flag
@@ -1887,12 +1887,12 @@ class Temperature(ParamValue):
 
     @classmethod
     def cxx_predecls(cls, code):
-        code('#include "base/temperature.hh"')
+        code('#include "base/temperature.hh"', add_once=True)
 
     @classmethod
     def cxx_ini_predecls(cls, code):
         # Assume that base/str.hh will be included anyway
-        # code('#include "base/str.hh"')
+        # code('#include "base/str.hh"', add_once=True)
         pass
 
     @classmethod
@@ -1937,7 +1937,7 @@ class NetworkBandwidth(float, ParamValue):
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code("#include <sstream>")
+        code("#include <sstream>", add_once=True)
 
     @classmethod
     def cxx_ini_parse(self, code, src, dest, ret):
@@ -1976,7 +1976,7 @@ class MemoryBandwidth(float, ParamValue):
 
     @classmethod
     def cxx_ini_predecls(cls, code):
-        code("#include <sstream>")
+        code("#include <sstream>", add_once=True)
 
     @classmethod
     def cxx_ini_parse(self, code, src, dest, ret):


### PR DESCRIPTION
Headers such as cstddef, string, vector etc were being #include-d once per SimObject configuration param if the param type depended on it. This lead to headers such as params/PciDevice.hh having 65 copies of '#include <cstddef>'.

Most system headers have include guards to stop them being included more than once, and modern GCC and Clang have special case code to avoid the cost of running the entire header through the C preprocessor to do this, but still, we may as well not create unnecessary work for our toolchain/language server/code analysis tools if we can easily avoid it.

Change-Id: Ib3313f515177c71ff2a77f7c7d6967f11585623e