### PR TITLE
arch: Add BaseISA::getIntegerLength interface

### DIFF
--- a/src/arch/arm/fastmodel/iris/isa.hh
+++ b/src/arch/arm/fastmodel/iris/isa.hh
@@ -82,6 +82,11 @@ class ISA : public BaseISA
     {
         panic("setMiscReg not implemented.");
     }
+
+    int64_t getIntegerLength() const override
+    {
+        panic("getIntegerLength not implemented.");
+    }
 };
 
 } // namespace Iris

--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -1803,5 +1803,11 @@ ISA::globalClearExclusive(ExecContext *xc)
     xc->setMiscReg(MISCREG_SEV_MAILBOX, true);
 }
 
+int64_t
+ISA::getIntegerLength() const
+{
+    return inAArch64(tc) ? 64 : 32;
+}
+
 } // namespace ArmISA
 } // namespace gem5

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -438,6 +438,8 @@ namespace ArmISA
         void globalClearExclusive(ExecContext *xc) override;
 
         int64_t getVectorLengthInBytes() const override { return sveVL * 16; }
+
+        int64_t getIntegerLength() const override;
     };
 
 } // namespace ArmISA

--- a/src/arch/arm/remote_gdb.cc
+++ b/src/arch/arm/remote_gdb.cc
@@ -373,7 +373,7 @@ RemoteGDB::getXferFeaturesRead(const std::string &annex, std::string &output)
 BaseGdbRegCache*
 RemoteGDB::gdbRegs()
 {
-    if (inAArch64(context()))
+    if (context()->getIsaPtr()->getIntegerLength() == 64)
         return &regCache64;
     else
         return &regCache32;

--- a/src/arch/generic/isa.hh
+++ b/src/arch/generic/isa.hh
@@ -146,6 +146,11 @@ class BaseISA : public SimObject
      * For other ISAs, this function returns -1.
      */
     virtual int64_t getVectorLengthInBytes() const { return -1; }
+
+    /**
+     * Get integer register length based on the current mode of the context.
+     */
+    virtual int64_t getIntegerLength() const = 0;
 };
 
 } // namespace gem5

--- a/src/arch/mips/isa.hh
+++ b/src/arch/mips/isa.hh
@@ -182,6 +182,8 @@ namespace MipsISA
         }
 
         void copyRegsFrom(ThreadContext *src) override;
+
+        int64_t getIntegerLength() const override { return 32; }
     };
 } // namespace MipsISA
 } // namespace gem5

--- a/src/arch/power/isa.cc
+++ b/src/arch/power/isa.cc
@@ -92,5 +92,12 @@ ISA::copyRegsFrom(ThreadContext *src)
     tc->pcState(src->pcState());
 }
 
+int64_t
+ISA::getIntegerLength() const
+{
+    Msr msr = tc->getReg(int_reg::Msr);
+    return msr.sf ? 64 : 32;
+}
+
 } // namespace PowerISA
 } // namespace gem5

--- a/src/arch/power/isa.hh
+++ b/src/arch/power/isa.hh
@@ -97,6 +97,8 @@ class ISA : public BaseISA
     using Params = PowerISAParams;
 
     ISA(const Params &p);
+
+    int64_t getIntegerLength() const override;
 };
 
 } // namespace PowerISA

--- a/src/arch/power/remote_gdb.cc
+++ b/src/arch/power/remote_gdb.cc
@@ -313,8 +313,8 @@ RemoteGDB::getXferFeaturesRead(const std::string &annex, std::string &output)
     };
 #undef GDB_XML
 
-    Msr msr = context()->getReg(int_reg::Msr);
-    auto& annexMap = msr.sf ? annexMap64 : annexMap32;
+    bool is_64bits = (context()->getIsaPtr()->getIntegerLength() == 64);
+    auto& annexMap = is_64bits ? annexMap64 : annexMap32;
     auto it = annexMap.find(annex);
     if (it == annexMap.end())
         return false;

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -1048,6 +1048,12 @@ ISA::resetThread()
     Reset().invoke(tc);
 }
 
+int64_t
+ISA::getIntegerLength() const
+{
+    return (_rvType == RV64) ? 64 : 32;
+}
+
 Addr
 ISA::getFaultHandlerAddr(RegIndex idx, uint64_t cause, bool intr) const
 {

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -191,6 +191,8 @@ class ISA : public BaseISA
 
     int64_t getVectorLengthInBytes() const override { return vlen >> 3; }
 
+    int64_t getIntegerLength() const override;
+
     PrivilegeModeSet getPrivilegeModeSet() { return _privilegeModeSet; }
 
     bool resumeOnPending() { return _wfiResumeOnPending; }

--- a/src/arch/riscv/remote_gdb.cc
+++ b/src/arch/riscv/remote_gdb.cc
@@ -693,11 +693,11 @@ RemoteGDB::getXferFeaturesRead(const std::string &annex, std::string &output)
 BaseGdbRegCache *
 RemoteGDB::gdbRegs()
 {
-    BaseGdbRegCache* regs[enums::Num_RiscvType] = {
-        [RV32] = &regCache32,
-        [RV64] = &regCache64,
-    };
-    return regs[getRvType(context())];
+    if (context()->getIsaPtr()->getIntegerLength() == 64) {
+        return &regCache64;
+    } else {
+        return &regCache32;
+    }
 }
 
 } // namespace gem5

--- a/src/arch/sparc/isa.cc
+++ b/src/arch/sparc/isa.cc
@@ -968,5 +968,12 @@ ISA::unserialize(CheckpointIn &cp)
     }
 }
 
+int64_t
+ISA::getIntegerLength() const
+{
+    PSTATE pstate = readMiscRegNoEffect(MISCREG_PSTATE);
+    return pstate.am ? 32 : 64;
+}
+
 } // namespace SparcISA
 } // namespace gem5

--- a/src/arch/sparc/isa.hh
+++ b/src/arch/sparc/isa.hh
@@ -213,6 +213,8 @@ class ISA : public BaseISA
     void copyRegsFrom(ThreadContext *src) override;
 
     ISA(const Params &p);
+
+    int64_t getIntegerLength() const override;
 };
 
 } // namespace SparcISA

--- a/src/arch/sparc/remote_gdb.cc
+++ b/src/arch/sparc/remote_gdb.cc
@@ -249,8 +249,7 @@ RemoteGDB::SPARC64GdbRegCache::setRegs(ThreadContext *context) const
 BaseGdbRegCache*
 RemoteGDB::gdbRegs()
 {
-    PSTATE pstate = context()->readMiscReg(MISCREG_PSTATE);
-    if (pstate.am) {
+    if (context()->getIsaPtr()->getIntegerLength() == 32) {
         return &regCache32;
     } else {
         return &regCache64;

--- a/src/arch/x86/isa.cc
+++ b/src/arch/x86/isa.cc
@@ -534,5 +534,12 @@ ISA::getVendorString() const
     return vendorString;
 }
 
+int64_t
+ISA::getIntegerLength() const
+{
+    HandyM5Reg m5reg = readMiscRegNoEffect(misc_reg::M5Reg);
+    return (m5reg.submode == SixtyFourBitMode) ? 64 : 32;
+}
+
 } // namespace X86ISA
 } // namespace gem5

--- a/src/arch/x86/isa.hh
+++ b/src/arch/x86/isa.hh
@@ -93,6 +93,8 @@ class ISA : public BaseISA
 
     void setThreadContext(ThreadContext *_tc) override;
 
+    int64_t getIntegerLength() const override;
+
     std::string getVendorString() const;
 
     std::unique_ptr<X86CPUID> cpuid;

--- a/src/arch/x86/remote_gdb.cc
+++ b/src/arch/x86/remote_gdb.cc
@@ -113,8 +113,7 @@ RemoteGDB::gdbRegs()
     }
 
     // If that didn't work, decide based on the current mode of the context.
-    HandyM5Reg m5reg = context()->readMiscRegNoEffect(misc_reg::M5Reg);
-    if (m5reg.submode == SixtyFourBitMode)
+    if (context()->getIsaPtr()->getIntegerLength() == 64)
         return &regCache64;
     else
         return &regCache32;


### PR DESCRIPTION
Get integer register length based on the current mode of context. The Implementation is based on the checking arch bits methods of RemoteGDB::gdbRegs

Implemented the methods for each ISA:
ARM: Chech inAArch64
MIPS: Only 32 bits mode implemented
POWER: Check Msr.sf bit
RISC-V: Check ISA::_rvType
SPARC: Check PSTATE.am bit
X86: Check m5reg.submode