### PR TITLE
arch-arm: arm misc reg for gic pfr0_el1.gic

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -128,10 +128,15 @@ ISA::ISA(const Params &p) : BaseISA(p, "arm"), system(NULL),
     }
 
     selfDebug = new SelfDebug();
-    initializeMiscRegMetadata();
-    preUnflattenMiscReg();
 
     clear();
+}
+
+void
+ISA::initState()
+{
+    initializeMiscRegMetadata();
+    preUnflattenMiscReg();
 }
 
 void

--- a/src/arch/arm/isa.hh
+++ b/src/arch/arm/isa.hh
@@ -201,6 +201,8 @@ namespace ArmISA
         RegVal readMiscRegReset(RegIndex) const;
         void setMiscRegReset(RegIndex, RegVal val);
 
+        void initState() override;
+
         int
         flattenMiscIndex(int reg) const
         {


### PR DESCRIPTION
the value of pfr0_el1.gic is set before the gic pointer is initialized, so the vaule will always be false.
the solution is to set pfr0_el1.gic in ISA::initState() which is called after the  gic pointer's initialization (in BaseGic::init())

more details please refer to : https://github.com/gem5/gem5/issues/1941