### PR TITLE
dev,arch-riscv: Fix CLINT pio_size sanity check

### DIFF
--- a/src/dev/riscv/clint.cc
+++ b/src/dev/riscv/clint.cc
@@ -110,15 +110,19 @@ Clint::ClintRegisters::init()
 {
     using namespace std::placeholders;
 
+    // Sanity check
+    assert(clint->pioSize >= minBankSize);
+
     // Calculate reserved space size
     const size_t reserved0_size = mtimecmpStart - clint->nThread * 4;
     reserved.emplace_back("reserved0", reserved0_size);
     const size_t reserved1_size = mtimeStart
         - mtimecmpStart - clint->nThread * 8;
     reserved.emplace_back("reserved1", reserved1_size);
-
-    // Sanity check
-    assert((int) clint->pioSize <= maxBankSize);
+    const size_t reserved2_size = clint->pioSize - minBankSize;
+    if (reserved2_size > 0) {
+        reserved.emplace_back("reserved2", reserved2_size);
+    }
 
     // Initialize registers
     for (int i = 0; i < clint->nThread; i++) {
@@ -142,6 +146,9 @@ Clint::ClintRegisters::init()
     addRegister(reserved[1]);
     mtime.readonly();
     addRegister(mtime);
+    if (reserved2_size > 0) {
+        addRegister(reserved[2]);
+    }
 }
 
 uint32_t

--- a/src/dev/riscv/clint.hh
+++ b/src/dev/riscv/clint.hh
@@ -108,13 +108,14 @@ class Clint : public BasicPioDevice
      * 0x4000 - 0xBFF7: mtimecmp
      * ...:             reserved[1]
      * 0xBFF8:          mtime (read-only)
+     * ...:             reserved[2]
      */
     class ClintRegisters: public RegisterBankLE
     {
       public:
         const Addr mtimecmpStart = 0x4000;
         const Addr mtimeStart = 0xBFF8;
-        const Addr maxBankSize = 0xC000;
+        const Addr minBankSize = 0xC000;
 
         std::vector<Register32> msip;
         std::vector<Register64> mtimecmp;


### PR DESCRIPTION
The RISC-V spec doesn't specify the size of CLINT device. We should guarantee the CLINT size should not less than the back size instead of greater than it. The rest space after mtime register should be reserved.

Change-Id: Ic6849723e803d05e985a3286e6ea5ce3971511a3