### PR TITLE
mem: Fix IMP panics

### DIFF
--- a/src/mem/cache/prefetch/base.hh
+++ b/src/mem/cache/prefetch/base.hh
@@ -215,6 +215,15 @@ class Base : public ClockedObject
         }
 
         /**
+         * Check if the triggering request has data
+         * @return true if the request has data
+         */
+        bool requestHasData() const
+        {
+            return data != nullptr;
+        }
+
+        /**
          * Gets the associated data of the request triggering the event
          * @param Byte ordering of the stored data
          * @return the data

--- a/src/mem/cache/prefetch/indirect_memory.cc
+++ b/src/mem/cache/prefetch/indirect_memory.cc
@@ -103,6 +103,11 @@ IndirectMemory::calculatePrefetch(const PrefetchInfo &pfi,
                 pt_entry->address = addr;
                 pt_entry->secure = is_secure;
 
+                // If the miss does not have any data, we don't need to
+                // inspect response data
+                if (!pfi.requestHasData()) {
+                    return;
+                }
 
                 // if this is a read, read the data from the cache and assume
                 // it is an index (this is only possible if the data is already


### PR DESCRIPTION
The memory accesses induced by x86 IN instruction (an I/O instruction) was picked up by the prefetcher. I believe the memory accesses induced by an IN instruction are supposed to be uncacheable, but somehow it got past observeAccess.

This change checks if the request's response has data before letting the prefetcher inspect the packet.