### PR TITLE
Add a bi-directional communication orchestrator to gem5's stdlib

### DIFF
--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -112,6 +112,7 @@ class AbstractBoard:
         # determined by which kind of workload is set.
         self._is_fs = None
         self._is_workload_set = False
+        self._workload: WorkloadResource = None
 
         # This variable is used to record the checkpoint directory which is
         # set when declaring the board's workload and then used by the
@@ -235,6 +236,7 @@ class AbstractBoard:
 
         :param workload: The workload to be set to this board.
         """
+        self._workload = workload
 
         try:
             func = getattr(self, workload.get_function_str())
@@ -255,6 +257,9 @@ class AbstractBoard:
                 )
 
         func(**workload.get_parameters())
+
+    def get_workload(self) -> Optional[WorkloadResource]:
+        return self._workload
 
     @abstractmethod
     def _setup_board(self) -> None:

--- a/src/python/gem5/components/processors/abstract_core.py
+++ b/src/python/gem5/components/processors/abstract_core.py
@@ -175,3 +175,11 @@ class AbstractCore(SubSystem):
         self, target_pair: List[PcCountPair], manager: PcCountTrackerManager
     ) -> None:
         raise NotImplementedError
+
+    @abstractmethod
+    def get_total_instructions(self) -> int:
+        """Return the number of instructions executed by this core.
+
+        Note: This total is the sum since the last call to reset stats
+        """
+        raise NotImplementedError

--- a/src/python/gem5/components/processors/abstract_processor.py
+++ b/src/python/gem5/components/processors/abstract_processor.py
@@ -79,6 +79,13 @@ class AbstractProcessor(SubSystem):
     def get_isa(self) -> ISA:
         return self._isa
 
+    def get_total_instructions(self) -> int:
+        """Return the number of instructions executed by all cores.
+
+        Note: This total is the sum since the last call to reset stats
+        """
+        return sum(core.get_total_instructions() for core in self.get_cores())
+
     @abstractmethod
     def incorporate_processor(self, board: AbstractBoard) -> None:
         raise NotImplementedError

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -187,3 +187,7 @@ class BaseCPUCore(AbstractCore):
         pair_tracker.core = self.core
         pair_tracker.ptmanager = manager
         self.core.probeListener = pair_tracker
+
+    @overrides(AbstractCore)
+    def get_total_instructions(self) -> int:
+        return self.core.totalInsts()

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -24,6 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
+import socket
 from abc import (
     ABCMeta,
     abstractmethod,
@@ -356,6 +358,47 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         m5.stats.dump()
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return False
+
+
+class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
+
+    def _get_status(self, simulator: "Simulator") -> Dict[str, str]:
+        return {
+            "workload": simulator.get_workload().get_id(),
+            "tick": simulator.get_current_tick(),
+            "sim_id": simulator.get_id(),
+            "instruction_count": simulator.get_instruction_count(),
+        }
+
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        try:
+            socket_path = self._payload.get("response_socket")
+            function = self._payload.get("function", "status")
+
+            if socket_path:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(socket_path)
+
+                if function == "status":
+                    response = json.dumps(self._get_status(simulator))
+                elif function == "get_stats":
+                    stats = simulator.get_stats()
+                    response = json.dumps(stats)
+                else:
+                    response = json.dumps(
+                        {"error": f"Unknown function: {function}"}
+                    )
+
+                sock.send(response.encode())
+                sock.close()
+
+        except Exception as e:
+            print(f"Error in OrchestratorExitHandler: {e}")
 
     @overrides(ExitHandler)
     def _exit_simulation(self) -> bool:

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -46,6 +46,7 @@ from m5.util import warn
 
 from gem5.components.boards.abstract_board import AbstractBoard
 
+from ..resources.resource import WorkloadResource
 from .exit_event import ExitEvent
 from .exit_handler import (
     ClassicGeneratorExitHandler,
@@ -306,6 +307,12 @@ class Simulator:
         """
         for core in self._board.get_processor().get_cores():
             core._set_inst_stop_any_thread(inst, self._instantiated)
+
+    def get_workload(self) -> WorkloadResource:
+        """
+        Returns the workload of the board.
+        """
+        return self._board.get_workload()
 
     def get_stats(self) -> Dict:
         """

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -308,6 +308,14 @@ class Simulator:
         for core in self._board.get_processor().get_cores():
             core._set_inst_stop_any_thread(inst, self._instantiated)
 
+    def get_instruction_count(self) -> int:
+        """
+        Returns the number of instructions executed by all cores.
+
+        Note: This total is the sum since the last call to reset stats.
+        """
+        return self._board.get_processor().get_total_instructions()
+
     def get_workload(self) -> WorkloadResource:
         """
         Returns the workload of the board.

--- a/util/hypercall_external_signal/orchestrator-request.py
+++ b/util/hypercall_external_signal/orchestrator-request.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# Copyright (c) Jason Lowe-Power
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+A utility script for sending hypercalls to gem5 and receiving responses
+via Unix sockets.
+
+This script provides a command-line interface for communicating with a running
+gem5 simulation. It supports sending various commands and receiving
+JSON-formatted responses.
+
+Supported functions:
+    * status: Get current simulation status (workload, ticks, etc.)
+    * get_stats: Retrieve simulation statistics
+
+Usage::
+
+    orchestrator-request.py [--pid PID] <function>
+
+Arguments:
+    * --pid: Process ID of gem5 (optional, auto-detected if not specified)
+    * function: Command to execute (status|get_stats)
+
+Dependencies:
+    * transmitter.py: For sending hypercalls to gem5
+
+Examples::
+
+    # Auto-detect gem5 process and get status
+    $ python orchestrator-request.py status
+
+    # Get stats from specific gem5 process
+    $ python orchestrator-request.py --pid 1234 get_stats
+
+Response Format:
+    Example status response::
+
+        {
+            "workload": "x86-ubuntu-22.04",
+            "tick": 1234567,
+            "sim_id": "abc123",
+            "instruction_count": 9876
+        }
+
+Error Handling:
+    * Raises ValueError if no gem5 process found or multiple processes found
+    * Raises TimeoutError if gem5 doesn't respond within timeout period
+    * Handles SIGINT (Ctrl+C) gracefully with proper cleanup
+
+Note:
+    Requires a running gem5 simulation with hypercall support enabled
+    (gem5-v25.0 or later).
+"""
+
+import argparse
+import json
+import logging
+import os
+import select
+import signal
+import socket
+import sys
+
+from transmitter import send_signal
+
+logger = logging.getLogger(__name__)
+socket_path = None
+sock = None
+
+
+def find_gem5_pid() -> int:
+    """
+    Find the PID of a running gem5 process.
+
+    Searches through /proc for a process containing 'gem5' in its name.
+
+    :return: Process ID of the gem5 process
+    :raises ValueError: If no gem5 process found or if multiple gem5 processes
+                        are found
+    """
+    gem5_pids = []
+
+    # List all processes in /proc
+    for pid in os.listdir("/proc"):
+        if not pid.isdigit():
+            continue
+
+        try:
+            # Read process name from /proc/[pid]/comm
+            with open(f"/proc/{pid}/comm") as f:
+                comm = f.read().strip()
+                if "gem5" in comm:
+                    gem5_pids.append(int(pid))
+        except (OSError, PermissionError):
+            # Skip processes we can't read
+            continue
+
+    if not gem5_pids:
+        raise ValueError("No gem5 process found")
+    if len(gem5_pids) > 1:
+        raise ValueError(f"Multiple gem5 processes found: {gem5_pids}")
+    return gem5_pids[0]
+
+
+def cleanup(signum=None, frame=None) -> None:
+    """
+    Clean up socket resources and handle process termination.
+
+    Closes open sockets and removes socket files. When called as a signal
+    handler, also exits the process.
+
+    :param signum: Signal number that triggered handler (if called as handler)
+    :param frame: Current stack frame (if called as handler)
+    """
+    global sock, socket_path
+    if sock:
+        sock.close()
+    if socket_path and os.path.exists(socket_path):
+        os.unlink(socket_path)
+    if signum is not None:  # Only exit if signal handler
+        sys.exit(0)
+
+
+def receive_full_message(conn: socket.socket, timeout: float = 30.0) -> str:
+    """
+    Receive a complete message from a socket connection.
+
+    Reads data in chunks until connection is closed or timeout occurs.
+    Handles messages larger than the standard buffer size.
+
+    :param conn: Connected socket to read from
+    :param timeout: Maximum time to wait for data in seconds
+    :return: Complete decoded message
+    :raises TimeoutError: If no data received within timeout period
+    """
+    chunks = []
+    while True:
+        ready, _, _ = select.select([conn], [], [], timeout)
+        if not ready:
+            raise TimeoutError("Timeout waiting for complete response")
+
+        chunk = conn.recv(4096)
+        if not chunk:  # Connection closed by remote
+            break
+        chunks.append(chunk)
+
+    return b"".join(chunks).decode()
+
+
+def send_and_receive_hypercall(pid: int, function: str) -> str:
+    """
+    Send a hypercall to gem5 and wait for response.
+
+    Creates Unix socket, sends hypercall via transmitter, and waits for
+    response.
+
+    :param pid: Process ID of gem5 instance
+    :type pid: int
+    :param function: Hypercall function to execute ('status'|'get_stats')
+    :type function: str
+    :return: JSON response from gem5
+    :rtype: str
+    :raises TimeoutError: If gem5 doesn't respond within timeout
+    :raises ValueError: If payload or response format is invalid
+    """
+    global sock, socket_path
+
+    socket_path = f"/tmp/hypercall_{os.getpid()}.sock"
+
+    try:
+        os.unlink(socket_path)
+    except OSError:
+        pass
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(socket_path)
+    sock.listen(1)
+
+    try:
+        payload = json.dumps(
+            {"function": function, "response_socket": socket_path}
+        )
+        send_signal(pid, 1000, payload)
+
+        ready, _, _ = select.select([sock], [], [], 30.0)
+        if not ready:
+            raise TimeoutError("Timeout waiting for gem5 response")
+
+        conn, addr = sock.accept()
+        try:
+            return receive_full_message(conn)
+        finally:
+            conn.close()
+    finally:
+        cleanup()
+
+
+def write_response_to_file(response: str, filename: str) -> None:
+    """
+    Write response to specified file.
+
+    :param response: JSON response string
+    :param filename: Path to output file
+    """
+    with open(filename, "w") as f:
+        f.write(response)
+
+
+def main():
+    signal.signal(signal.SIGINT, cleanup)
+
+    parser = argparse.ArgumentParser(description="Send hypercalls to gem5")
+    parser.add_argument(
+        "--pid",
+        type=int,
+        help="Process ID to send hypercall to "
+        "(auto-detected if not specified)",
+    )
+    parser.add_argument(
+        "function", choices=["status", "get_stats"], help="Function to execute"
+    )
+    parser.add_argument(
+        "--output", type=str, help="Write response to specified file"
+    )
+    args = parser.parse_args()
+
+    try:
+        pid = args.pid if args.pid is not None else find_gem5_pid()
+        response = send_and_receive_hypercall(pid, args.function)
+        if args.output:
+            write_response_to_file(response, args.output)
+        else:
+            print(f"Response: {response}")
+    except (ValueError, TimeoutError) as e:
+        logger.error(f"Error: {str(e)}")
+        sys.exit(1)
+    except OSError as e:
+        logger.error(f"File error: {str(e)}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        cleanup()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Note: This depends on #1982 (#1982 is included in this PR, but should be removed after it is merged.)

The gem5 orchestrator is a starting point and example of how the new
external process handler interface can be used. The orchestrator is a
bi-directional communication framework so that an external process can
both send commands to a running gem5 instance and receive responses.

The orchestrator sends commands using the externalProcessHandler in
gem5. The commands are simple json packages using the hypercall number
1000 (now reserved for this purpose). In this json message the
orchestrator can send a string function to run and a socket path to
communicate back (note that this only supports unix socket communication
right now, so likely no Windows support. This has not been tested on
MacOS.)

Two functions are initially supported:
- status: Returns the number of instructions and ticks executed so far
  and the workload that is running.
- get_stats: Returns a json object with all of the current statistic
  values.

This patch also includes a simple script that leverages the transmitter
script to run these two functions.

Note: The orchestrator will only support connecting to gem5 when its
running using the standard library. fs/se.py or other fully custom
scripts will not be supported.


Example output

![image](https://github.com/user-attachments/assets/31d3dbfc-352b-45e3-b2d0-c71bad36d218)
