### PR TITLE
arch-arm: Fix off-by-one when initializing PMU counters

### DIFF
--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -178,7 +178,7 @@ PMU::regProbeListeners()
 
     // at this stage all probe configurations are done
     // counters can be configured
-    for (uint32_t index = 0; index < maximumCounterCount-1; index++) {
+    for (uint32_t index = 0; index < maximumCounterCount; index++) {
         counters.emplace_back(*this, index, use64bitCounters);
     }
 


### PR DESCRIPTION
When configured to have e.g. 6 counters we were only adding 5 which resulted in errors when trying to configure PMU[5]. It's possible the subtraction of 1 was there to handle the cycle counters, but that is now always a separate event.

Change-Id: Idbc3e98d8aea7307929143755a03c11f9f2ec9b4