### PR TITLE
Improvements to exit events

### DIFF
--- a/configs/example/gem5_library/exit_handling/user-exit-handler.py
+++ b/configs/example/gem5_library/exit_handling/user-exit-handler.py
@@ -129,9 +129,5 @@ class MyExitHandler(ScheduledExitEventHandler):
 # Create the Simulator and set the the exit event handler for type ID 4.
 simulator = Simulator(board=board)
 
-# The scheduler for the to-tick exit events returns type ID of one.
-# Here we override it for the behavior we desire.
-simulator.update_exit_handler_id_map({6: MyExitHandler})
-
 # Run the simulation.
 simulator.run()

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -31,9 +31,13 @@ from abc import (
 from pathlib import Path
 from typing import (
     Any,
+    Callable,
     Dict,
+    Generator,
+    List,
     Optional,
     Type,
+    Union,
 )
 
 import m5
@@ -42,6 +46,17 @@ from m5.util import warn
 
 from gem5.simulate.exit_event import ExitEvent
 from gem5.utils.override import overrides
+
+from .exit_event_generators import (
+    dump_stats_generator,
+    exit_generator,
+    reset_stats_generator,
+    save_checkpoint_generator,
+    skip_generator,
+    spatter_exit_generator,
+    switch_generator,
+    warn_default_decorator,
+)
 
 
 class ExitHandlerMeta(ABCMeta):
@@ -345,3 +360,301 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
     @overrides(ExitHandler)
     def _exit_simulation(self) -> bool:
         return False
+
+
+class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
+    """A handler designed to be the default for the classic exit event.
+
+    ``on_exit_event`` usage notes
+    ---------------------------
+
+    With Generators
+    ===============
+
+    The ``on_exit_event`` parameter specifies a Python generator for each
+    exit event. `next(<generator>)` is run each time an exit event. The
+    generator may yield a boolean. If this value of this boolean is ``True``
+    the Simulator run loop will exit, otherwise
+    the Simulator run loop will continue execution. If the generator has
+    finished (i.e. a ``StopIteration`` exception is thrown when
+    ``next(<generator>)`` is executed), then the default behavior for that
+    exit event is run.
+
+    As an example, a user may specify their own exit event setup like so:
+
+    .. code-block::
+
+        def unique_exit_event():
+            processor.switch()
+            yield False
+            m5.stats.dump()
+            yield False
+            yield True
+
+        simulator = Simulator(
+            board=board
+            on_exit_event = {
+                ExitEvent.Exit : unique_exit_event(),
+            },
+        )
+
+
+    This will execute ``processor.switch()`` the first time an exit event is
+    encountered, will dump gem5 statistics the second time an exit event is
+    encountered, and will terminate the Simulator run loop the third time.
+
+    With a list of functions
+    ========================
+
+    Alternatively, instead of passing a generator per exit event, a list of
+    functions may be passed. Each function must take no mandatory arguments
+    and return True if the simulator is to exit after being called.
+
+    An example:
+
+    .. code-block::
+
+        def stop_simulation() -> bool:
+            return True
+
+        def switch_cpus() -> bool:
+            processor.switch()
+            return False
+
+        def print_hello() -> None:
+            # Here we don't explicitly return a boolean, but the simulator
+            # treats a None return as False. Ergo the Simulation loop is not
+            # terminated.
+            print("Hello")
+
+
+        simulator = Simulator(
+            board=board,
+            on_exit_event = {
+                ExitEvent.Exit : [
+                    print_hello,
+                    switch_cpus,
+                    print_hello,
+                    stop_simulation
+                ],
+            },
+        )
+
+
+    Upon each ``EXIT`` type exit event the list will function as a queue,
+    with the top function of the list popped and executed. Therefore, in
+    this example, the first ``EXIT`` type exit event will cause ``print_hello``
+    to be executed, and the second ``EXIT`` type exit event will cause the
+    ``switch_cpus`` function to run. The third will execute ``print_hello``
+    again before finally, on the forth exit event will call
+    ``stop_simulation`` which will stop the simulation as it returns ``False``.
+
+    With a function
+    ===============
+    A single function can be passed. In this case every exit event of that
+    type will execute that function every time. The function should not
+    accept any mandatory parameters and return a boolean specifying if the
+    simulation loop should end after it is executed.
+    An example:
+
+    .. code-block::
+
+        def print_hello() -> bool:
+            print("Hello")
+            return False
+        simulator = Simulator(
+            board=board,
+            on_exit_event = {
+                ExitEvent.Exit : print_hello
+            },
+        )
+
+    The above will print "Hello" on every ``Exit`` type Exit Event. As the
+    function returns False, the simulation loop will not end on these
+    events.
+
+
+    Exit Event defaults
+    ===================
+
+    Each exit event has a default behavior if none is specified by the
+    user. These are as follows:
+
+        * ExitEvent.EXIT:  exit simulation
+        * ExitEvent.CHECKPOINT: take a checkpoint
+        * ExitEvent.FAIL : exit simulation
+        * ExitEvent.SWITCHCPU: call ``switch`` on the processor
+        * ExitEvent.WORKBEGIN: reset stats
+        * ExitEvent.WORKEND: dump stats
+        * ExitEvent.USER_INTERRUPT: exit simulation
+        * ExitEvent.MAX_TICK: exit simulation
+        * ExitEvent.SCHEDULED_TICK: exit simulation
+        * ExitEvent.SIMPOINT_BEGIN: reset stats
+        * ExitEvent.MAX_INSTS: exit simulation
+
+    These generators can be found in the ``exit_event_generator.py`` module.
+    """
+
+    def __init__(self, payload: Dict[str, str]) -> None:
+        super().__init__(payload)
+        self._exit_on_completion = None
+
+    @classmethod
+    def set_exit_event_map(
+        cls,
+        on_exit_event: Optional[
+            Dict[
+                ExitEvent,
+                Union[
+                    Generator[Optional[bool], None, None],
+                    List[Callable],
+                    Callable,
+                ],
+            ]
+        ],
+        expected_execution_order: Optional[List[ExitEvent]],
+        board: Optional["Board"],
+    ) -> None:
+        # We specify a dictionary here outlining the default behavior for each
+        # exit event. Each exit event is mapped to a generator.
+        cls._default_on_exit_dict = {
+            ExitEvent.EXIT: exit_generator(),
+            ExitEvent.CHECKPOINT: warn_default_decorator(
+                save_checkpoint_generator,
+                "checkpoint",
+                "creating a checkpoint and continuing",
+            )(),
+            ExitEvent.FAIL: exit_generator(),
+            ExitEvent.SPATTER_EXIT: warn_default_decorator(
+                spatter_exit_generator,
+                "spatter exit",
+                "dumping and resetting stats after each sync point. "
+                "Note that there will be num_cores*sync_points spatter_exits.",
+            )(spatter_gen=board.get_processor()),
+            ExitEvent.SWITCHCPU: warn_default_decorator(
+                switch_generator,
+                "switch CPU",
+                "switching the CPU type of the processor and continuing",
+            )(processor=board.get_processor()),
+            ExitEvent.WORKBEGIN: warn_default_decorator(
+                reset_stats_generator,
+                "work begin",
+                "resetting the stats and continuing",
+            )(),
+            ExitEvent.WORKEND: warn_default_decorator(
+                dump_stats_generator,
+                "work end",
+                "dumping the stats and continuing",
+            )(),
+            ExitEvent.USER_INTERRUPT: exit_generator(),
+            ExitEvent.MAX_TICK: exit_generator(),
+            ExitEvent.SCHEDULED_TICK: exit_generator(),
+            ExitEvent.SIMPOINT_BEGIN: warn_default_decorator(
+                skip_generator,
+                "simpoint begin",
+                "resetting the stats and continuing",
+            )(),
+            ExitEvent.MAX_INSTS: warn_default_decorator(
+                exit_generator,
+                "max instructions",
+                "exiting the simulation",
+            )(),
+            ExitEvent.KERNEL_PANIC: exit_generator(),
+            ExitEvent.KERNEL_OOPS: exit_generator(),
+        }
+
+        if on_exit_event:
+            cls._on_exit_event = {}
+            for key, value in on_exit_event.items():
+                if isinstance(value, Generator):
+                    cls._on_exit_event[key] = value
+                elif isinstance(value, List):
+                    # In instances where we have a list of functions, we
+                    # convert this to a generator.
+                    cls._on_exit_event[key] = (func() for func in value)
+                elif isinstance(value, Callable):
+                    # In instances where the user passes a lone function, the
+                    # function is called on every exit event of that type. Here
+                    # we convert the function into an infinite generator.
+
+                    # We check if the function is a generator. If it is we
+                    # throw a warning as this is likely a mistake.
+                    import inspect
+
+                    if inspect.isgeneratorfunction(value):
+                        warn(
+                            f"Function passed for '{key.value}' exit event "
+                            "is not a generator but a function that returns "
+                            "a generator. Did you mean to do this? (e.g., "
+                            "did you mean `ExitEvent.EVENT : gen()` instead "
+                            "of `ExitEvent.EVENT : gen`)"
+                        )
+
+                    def function_generator(func: Callable):
+                        while True:
+                            yield func()
+
+                    cls._on_exit_event[key] = function_generator(func=value)
+                else:
+                    raise Exception(
+                        f"`on_exit_event` for '{key.value}' event is "
+                        "not a Generator or List[Callable]."
+                    )
+        else:
+            cls._on_exit_event = cls._default_on_exit_dict
+
+        cls._expected_execution_order = expected_execution_order
+
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        #  # Translate the exit event cause to the exit event enum.
+        exit_enum = ExitEvent.translate_exit_status(
+            simulator.get_last_exit_event_cause()
+        )
+
+        # Check to see the run is corresponding to the expected execution
+        # order (assuming this check is demanded by the user).
+        if self._expected_execution_order:
+            expected_enum = self._expected_execution_order[
+                simulator._exit_event_count
+            ]
+            if exit_enum.value != expected_enum.value:
+                raise Exception(
+                    f"Expected a '{expected_enum.value}' exit event but a "
+                    f"'{exit_enum.value}' exit event was encountered."
+                )
+
+        # Record the current tick and exit event enum.
+        simulator._tick_stopwatch.append(
+            (exit_enum, simulator.get_current_tick())
+        )
+
+        try:
+            # If the user has specified their own generator for this exit
+            # event, use it.
+            self._exit_on_completion = next(self._on_exit_event[exit_enum])
+        except StopIteration:
+            # If the user's generator has ended, throw a warning and use
+            # the default generator for this exit event.
+            warn(
+                "User-specified generator/function list for the exit "
+                f"event'{exit_enum.value}' has ended. Using the default "
+                "generator."
+            )
+            self._exit_on_completion = next(
+                self._default_on_exit_dict[exit_enum]
+            )
+
+        except KeyError:
+            # If the user has not specified their own generator for this
+            # exit event, use the default.
+            self._exit_on_completion = next(
+                self._default_on_exit_dict[exit_enum]
+            )
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        assert (
+            self._exit_on_completion is not None
+        ), "Exit on completion boolean var is not set."
+        return self._exit_on_completion


### PR DESCRIPTION
Depends on #1982 

This updates how the new hypercall exit events are declared and also moves the code for the classic exit events out of the simulator to reduce the complexity in that object.

Example of how to use the new API:

```python
from gem5.prebuilt.demo.x86_demo_board import X86DemoBoard
from gem5.resources.resource import obtain_resource
from gem5.simulate.exit_handler import (
    ExitHandler,
    register_exit_handler,
    ScheduledExitEventHandler,
)
from gem5.simulate.simulator import Simulator

from m5.simulate import scheduleTickExitAbsolute

# You can test this file by using the transmitter program in
# util/hypercall_external_signal. To test you may need to disable
# the `scheduleTickExitAbsolute` call below.
#
# ```
# ./transmitter.py <PID of gem5> 100 '{"hello":2}'
# ./transmitter.py <PID of gem5> 101 '{"hello":5}'
# ./transmitter.py <PID of gem5> 1101 '{"hello":12}'
# ```

# This is an example of how to create a new exit handler for a bespoke
# hypercall
class MyExitHandler(ExitHandler, hypercall_num=100):
    num_hypercalls: int = 0

    def __init__(self, payload):
        super().__init__(payload)
        self.should_exit = False

    # Override the _process method to define what happens when the exit
    def _process(self, simulator) -> None:
        # Note: You have to use a class variable if you want your handler
        # to have state since each hypercall will create a new instance
        MyExitHandler.num_hypercalls += 1

        print("Got this hypercall")
        print(f"got {self.num_hypercalls} hypercalls")

        # The payload is available for use in the instance. This is different
        # for each instance of the exit.
        print(f"payload is {self._payload}")

        # The simulator is also available for use in the instance.
        print(f"the current tick is {simulator.get_current_tick()}")

        # You can use dynamic information to set the exit condition for this
        # instance.
        if simulator.get_current_tick() > 1000000000:
            self.should_exit = True
        else:
            self.should_exit = False

    def _exit_simulation(self):
        return self.should_exit


# ------------------------------------------------------------------------


# Here is an alternative way to specify the hypercall behavior.
# You can create a function that takes the simulator and payload as
# arguments and returns a boolean indicating whether to exit the
# simulation. This function can be used for many different hypercalls.
def do_a_thing(simulator, payload):
    print("Doing a thing")
    print(f"payload is {payload}")
    print(f"the current tick is {simulator.get_current_tick()}")
    return False


# here is how you register a function to handler a hyperall.
# The last parameter is a human understandable string for the hypercall
register_exit_handler(101, do_a_thing, "my handler for 101")
register_exit_handler(1101, do_a_thing, "my handler for 1101")

# ------------------------------------------------------------------------


# Here is an example of overriding an exit handler that already exists
# Note that you don't need to know the hypercall number. It is inferred
# from the parent class. The new handler will replace the old one.
class MySchedHandler(ScheduledExitEventHandler):
    def _process(self, simulator):
        super()._process(simulator)
        print("Got this scheduled event")
        print(f"the current tick is {simulator.get_current_tick()}")
        print(f"justification is {self.justification()}")

    def _exit_simulation(self):
        return False


board = X86DemoBoard()
workload = obtain_resource("x86-ubuntu-24.04-boot-with-systemd")
board.set_workload(workload)

simulator = Simulator(board=board)

scheduleTickExitAbsolute(10000000, "hello!")

simulator.run()
```