### PR TITLE
configs: Add BadAddr responder to the L2Cache XBar

### DIFF
--- a/configs/common/CacheConfig.py
+++ b/configs/common/CacheConfig.py
@@ -136,6 +136,8 @@ def config_cache(options, system):
         )
 
         system.tol2bus = L2XBar(clk_domain=system.cpu_clk_domain)
+        system.tol2bus.badaddr_responder = BadAddr()
+        system.tol2bus.default = system.tol2bus.badaddr_responder.pio
         system.l2.cpu_side = system.tol2bus.mem_side_ports
         system.l2.mem_side = system.membus.cpu_side_ports
 


### PR DESCRIPTION
I was running a a test binary that had a load after a conditional branch to address 0-immediate, i.e. 0xfff... which was working fine until I turned on an l2 cache. Then I was hitting`fatal("Unable to find destination for ...` which turns out to be because the L2XBar does not have a default destination.

Change-Id: I7ff624b0ef058789bd9b0ea31dbd46189769bce4