### PR TITLE
arch-riscv: Fix mip and sip

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -755,7 +755,7 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
 
           case MISCREG_IP:
             {
-                val = val & MI_MASK[getPrivilegeModeSet()];
+                val = val & MIP_MASK[getPrivilegeModeSet()];
                 auto ic = dynamic_cast<RiscvISA::Interrupts *>(
                     tc->getCpuPtr()->getInterruptController(tc->threadId()));
                 ic->setIP(val);
@@ -770,7 +770,7 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
             break;
           case MISCREG_SIP:
             {
-                RegVal mask = SI_MASK[getPrivilegeModeSet()];
+                RegVal mask = SIP_MASK[getPrivilegeModeSet()];
                 val = (val & mask) | (readMiscReg(MISCREG_IP) & ~mask);
                 setMiscReg(MISCREG_IP, val);
             }

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -1531,6 +1531,14 @@ const RegVal UTI_MASK = 1ULL << 4;
 const RegVal MSI_MASK = 1ULL << 3;
 const RegVal SSI_MASK = 1ULL << 1;
 const RegVal USI_MASK = 1ULL << 0;
+const RegVal MIP_MASK[enums::Num_PrivilegeModeSet] = {
+    [enums::M] = LOCAL_MASK,
+    [enums::MU] = LOCAL_MASK,
+    [enums::MNU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = LOCAL_MASK | SEI_MASK | STI_MASK | SSI_MASK,
+    [enums::MNSU] = LOCAL_MASK | SEI_MASK | UEI_MASK | STI_MASK | UTI_MASK |
+                    SSI_MASK | USI_MASK,
+};
 const RegVal MI_MASK[enums::Num_PrivilegeModeSet] = {
     [enums::M] = LOCAL_MASK | MEI_MASK| MTI_MASK | MSI_MASK,
     [enums::MU] = LOCAL_MASK | MEI_MASK| MTI_MASK | MSI_MASK,
@@ -1541,6 +1549,13 @@ const RegVal MI_MASK[enums::Num_PrivilegeModeSet] = {
     [enums::MNSU] = LOCAL_MASK | MEI_MASK | SEI_MASK | UEI_MASK |
                     MTI_MASK | STI_MASK | UTI_MASK |
                     MSI_MASK | SSI_MASK | USI_MASK,
+};
+const RegVal SIP_MASK[enums::Num_PrivilegeModeSet] = {
+    [enums::M] = 0ULL,
+    [enums::MU] = 0ULL,
+    [enums::MNU] = UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = SSI_MASK,
+    [enums::MNSU] = UEI_MASK | UTI_MASK | SSI_MASK | USI_MASK,
 };
 const RegVal SI_MASK[enums::Num_PrivilegeModeSet] = {
     [enums::M] = 0ULL,
@@ -1578,12 +1593,12 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV32][enums::M]},
             {CSR_SIE, SI_MASK[enums::M]},
-            {CSR_SIP, SI_MASK[enums::M]},
+            {CSR_SIP, SIP_MASK[enums::M]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV32][enums::M]},
             {CSR_MISA, MISA_MASKS[RV32]},
             {CSR_MIE, MI_MASK[enums::M]},
             {CSR_MSTATUSH, MSTATUSH_MASKS[enums::M]},
-            {CSR_MIP, MI_MASK[enums::M]},
+            {CSR_MIP, MIP_MASK[enums::M]},
         },
         [enums::MU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV32][enums::MU]},
@@ -1594,12 +1609,12 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV32][enums::MU]},
             {CSR_SIE, SI_MASK[enums::MU]},
-            {CSR_SIP, SI_MASK[enums::MU]},
+            {CSR_SIP, SIP_MASK[enums::MU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV32][enums::MU]},
             {CSR_MISA, MISA_MASKS[RV32]},
             {CSR_MIE, MI_MASK[enums::MU]},
             {CSR_MSTATUSH, MSTATUSH_MASKS[enums::MU]},
-            {CSR_MIP, MI_MASK[enums::MU]},
+            {CSR_MIP, MIP_MASK[enums::MU]},
         },
         [enums::MNU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV32][enums::MNU]},
@@ -1610,12 +1625,12 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV32][enums::MNU]},
             {CSR_SIE, SI_MASK[enums::MNU]},
-            {CSR_SIP, SI_MASK[enums::MNU]},
+            {CSR_SIP, SIP_MASK[enums::MNU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV32][enums::MNU]},
             {CSR_MISA, MISA_MASKS[RV32]},
             {CSR_MIE, MI_MASK[enums::MNU]},
             {CSR_MSTATUSH, MSTATUSH_MASKS[enums::MNU]},
-            {CSR_MIP, MI_MASK[enums::MNU]},
+            {CSR_MIP, MIP_MASK[enums::MNU]},
         },
         [enums::MSU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV32][enums::MSU]},
@@ -1626,12 +1641,12 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV32][enums::MSU]},
             {CSR_SIE, SI_MASK[enums::MSU]},
-            {CSR_SIP, SI_MASK[enums::MSU]},
+            {CSR_SIP, SIP_MASK[enums::MSU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV32][enums::MSU]},
             {CSR_MISA, MISA_MASKS[RV32]},
             {CSR_MIE, MI_MASK[enums::MSU]},
             {CSR_MSTATUSH, MSTATUSH_MASKS[enums::MSU]},
-            {CSR_MIP, MI_MASK[enums::MSU]},
+            {CSR_MIP, MIP_MASK[enums::MSU]},
         },
         [enums::MNSU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV32][enums::MNSU]},
@@ -1642,12 +1657,12 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV32][enums::MNSU]},
             {CSR_SIE, SI_MASK[enums::MNSU]},
-            {CSR_SIP, SI_MASK[enums::MNSU]},
+            {CSR_SIP, SIP_MASK[enums::MNSU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV32][enums::MNSU]},
             {CSR_MISA, MISA_MASKS[RV32]},
             {CSR_MIE, MI_MASK[enums::MNSU]},
             {CSR_MSTATUSH, MSTATUSH_MASKS[enums::MNSU]},
-            {CSR_MIP, MI_MASK[enums::MNSU]},
+            {CSR_MIP, MIP_MASK[enums::MNSU]},
         },
     },
     [RV64] = {
@@ -1660,11 +1675,11 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV64][enums::M]},
             {CSR_SIE, SI_MASK[enums::M]},
-            {CSR_SIP, SI_MASK[enums::M]},
+            {CSR_SIP, SIP_MASK[enums::M]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV64][enums::M]},
             {CSR_MISA, MISA_MASKS[RV64]},
             {CSR_MIE, MI_MASK[enums::M]},
-            {CSR_MIP, MI_MASK[enums::M]},
+            {CSR_MIP, MIP_MASK[enums::M]},
         },
         [enums::MU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV64][enums::MU]},
@@ -1675,11 +1690,11 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV64][enums::MU]},
             {CSR_SIE, SI_MASK[enums::MU]},
-            {CSR_SIP, SI_MASK[enums::MU]},
+            {CSR_SIP, SIP_MASK[enums::MU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV64][enums::MU]},
             {CSR_MISA, MISA_MASKS[RV64]},
             {CSR_MIE, MI_MASK[enums::MU]},
-            {CSR_MIP, MI_MASK[enums::MU]},
+            {CSR_MIP, MIP_MASK[enums::MU]},
         },
         [enums::MNU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV64][enums::MNU]},
@@ -1690,11 +1705,11 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV64][enums::MNU]},
             {CSR_SIE, SI_MASK[enums::MNU]},
-            {CSR_SIP, SI_MASK[enums::MNU]},
+            {CSR_SIP, SIP_MASK[enums::MNU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV64][enums::MNU]},
             {CSR_MISA, MISA_MASKS[RV64]},
             {CSR_MIE, MI_MASK[enums::MNU]},
-            {CSR_MIP, MI_MASK[enums::MNU]},
+            {CSR_MIP, MIP_MASK[enums::MNU]},
         },
         [enums::MSU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV64][enums::MSU]},
@@ -1705,11 +1720,11 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV64][enums::MSU]},
             {CSR_SIE, SI_MASK[enums::MSU]},
-            {CSR_SIP, SI_MASK[enums::MSU]},
+            {CSR_SIP, SIP_MASK[enums::MSU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV64][enums::MSU]},
             {CSR_MISA, MISA_MASKS[RV64]},
             {CSR_MIE, MI_MASK[enums::MSU]},
-            {CSR_MIP, MI_MASK[enums::MSU]},
+            {CSR_MIP, MIP_MASK[enums::MSU]},
         },
         [enums::MNSU] = {
             {CSR_USTATUS, USTATUS_MASKS[RV64][enums::MNSU]},
@@ -1720,11 +1735,11 @@ CSRMasks[enums::Num_RiscvType][enums::Num_PrivilegeModeSet] = {
             {CSR_FCSR, FFLAGS_MASK | (FRM_MASK << FRM_OFFSET)},
             {CSR_SSTATUS, SSTATUS_MASKS[RV64][enums::MNSU]},
             {CSR_SIE, SI_MASK[enums::MNSU]},
-            {CSR_SIP, SI_MASK[enums::MNSU]},
+            {CSR_SIP, SIP_MASK[enums::MNSU]},
             {CSR_MSTATUS, MSTATUS_MASKS[RV64][enums::MNSU]},
             {CSR_MISA, MISA_MASKS[RV64]},
             {CSR_MIE, MI_MASK[enums::MNSU]},
-            {CSR_MIP, MI_MASK[enums::MNSU]},
+            {CSR_MIP, MIP_MASK[enums::MNSU]},
         },
     },
 };


### PR DESCRIPTION
According to RISC-V spec:
mip.MSIP, mip.MTIP and mip.MEIP are read-only
sip.STIP and sip.SEIP are read-only

[1] https://github.com/riscv/riscv-isa-manual/blob/main/src/machine.adoc#machine-interrupt-mip-and-mie-registers
[2] https://github.com/riscv/riscv-isa-manual/blob/main/src/supervisor.adoc#supervisor-interrupt-sip-and-sie-registers

Change-Id: I71846a5f24de3c10ee1161cb4045b0aecc521f7a