### PR TITLE
mem: fix multiprefetcher crash

### DIFF
--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -65,7 +65,7 @@ Base::PrefetchInfo::PrefetchInfo(PacketPtr pkt, Addr addr, bool miss)
     paddress(pkt->req->getPaddr()), cacheMiss(miss)
 {
     unsigned int req_size = pkt->req->getSize();
-    if ((!write && miss) || !pkt->hasData()) {
+    if (!write && miss) {
         data = nullptr;
     } else {
         data = new uint8_t[req_size];


### PR DESCRIPTION
Fixes issue 1487. This effectively reverts PR 871, which previously fixed a crash with riscv-ubuntu-run.py in the daily tests. Due to updates to the disk images, the fix in PR 871 is no longer necessary, so it shouldn't cause any problems to revert it to fix the multiprefetcher crash.

I tested this locally by running `riscv-ubuntu-run.py` and the long testlib tests.