### PR TITLE
Fix Stats::Vecotr::zero()

### DIFF
--- a/src/base/statistics.hh
+++ b/src/base/statistics.hh
@@ -1004,7 +1004,7 @@ class VectorBase : public DataWrapVec<Derived, VectorInfoProxy>
     zero() const
     {
         for (off_type i = 0; i < size(); ++i)
-            if (data(i)->zero())
+            if (!data(i)->zero())
                 return false;
         return true;
     }


### PR DESCRIPTION
Before:
nozero will print the stat if any value is zero

After:
nozero will print the stat if any value is not zero