### PR TITLE
arch-riscv: Follow up mip and sip fixes

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -755,9 +755,10 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
 
           case MISCREG_IP:
             {
-                val = val & MIP_MASK[getPrivilegeModeSet()];
+                RegVal mask = MIP_MASK[getPrivilegeModeSet()];
                 auto ic = dynamic_cast<RiscvISA::Interrupts *>(
                     tc->getCpuPtr()->getInterruptController(tc->threadId()));
+                val = (val & mask) | (ic->readIP() & ~mask);
                 ic->setIP(val);
             }
             break;


### PR DESCRIPTION
When we write xip CSR in software, it will clear all of unmask mip bits, including MSIP, MTIP and MEIP. We should read original unmask mip bits when setting xip.

Change-Id: I3e0fa867b51e5fe8bb326cb2485c685a4ac4c87c