### PR TITLE
cpu: Fix postInterrupt wakeup

### DIFF
--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -244,7 +244,7 @@ BaseCPU::postInterrupt(ThreadID tid, int int_num, int index)
     // For RISC-V, the WFI sleep wake up is implementation defined.
     // The SiFive WFI wake up the hart only if mip & mie != 0
     if ((FullSystem && interrupts[tid]->isWakeUp()) ||
-        !system->futexMap.is_waiting(threadContexts[tid]))
+        (!FullSystem && !system->futexMap.is_waiting(threadContexts[tid])))
         wakeup(tid);
 }
 


### PR DESCRIPTION
The futexMap.is_waiting should only be checked in SE mode. After the #1641, the CPU will be waken by futexMap.is_waiting when isWakeUp is false in FullSystem.

Change-Id: I47f9f2d533428adb57f28b67fc0b075fb382c737