### PR TITLE
python: Fix python 3.8 TypeError error in gem5stats

### DIFF
--- a/src/python/m5/stats/gem5stats.py
+++ b/src/python/m5/stats/gem5stats.py
@@ -339,7 +339,7 @@ def _process_simobject_stats(
     if isinstance(simobject, SimObject):
         return _process_simobject_object(simobject)
 
-    if isinstance(simobject, Union[List, SimObjectVector]):
+    if isinstance(simobject, (list, SimObjectVector)):
         stats_list = []
         for obj in simobject:
             stats_list.append(_process_simobject_stats(obj))


### PR DESCRIPTION
It looks like some python versions don't like instance or class checks with type generics. When dumping stats in JSON format they raise the following exception:

"TypeError: Subscripted generics cannot be used
with class and instance checks"

We amend the faulting code by not relying on subscripted generics. We don't lose any functionality by replacing

Union[List, SimObjectVector] with

isinstance(obj, (list, SimObjectVector))


Change-Id: I9590be0b2816020b6bdc4e40450768716f9e1f1a