### PR TITLE
arch-riscv: Fix mnepc lower bits

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -515,6 +515,7 @@ ISA::readMiscReg(RegIndex idx)
         }
       case MISCREG_SEPC:
       case MISCREG_MEPC:
+      case MISCREG_MNEPC:
         {
             MISA misa = readMiscRegNoEffect(MISCREG_ISA);
             auto val = readMiscRegNoEffect(idx);


### PR DESCRIPTION
From spec:
The low bit of mnepc (mnepc[0]) is always zero. On implementations that support only IALIGN=32, the two low bits (mnepc[1:0]) are always zero.

[1] https://github.com/riscv/riscv-isa-manual/blob/main/src/rnmi.adoc#rnmi-csrs

Change-Id: I5be1851e9de572e780e76ccefe3e7dc5a51a7e5f