### PR TITLE
mem-ruby: Update txnId in Send_CompI_Stale

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -3205,6 +3205,7 @@ action(Send_CompI_Stale, desc="") {
     out_msg.type := CHIResponseType:Comp_I;
     out_msg.responder := machineID;
     out_msg.Destination.add(tbe.requestor);
+    out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
     // We don't know if this is a stale writeback or a bug, so flag the
     // reponse so the requestor can make further checks


### PR DESCRIPTION
We forgot to update the txnId field in the Stale scenario

Change-Id: I2c6d10f88e7f6a7616aa8e6b058e45194f3f45c4