### PR TITLE
arch-riscv: Add support for vector stride segment load/store instructions

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -297,50 +297,60 @@ std::string VsWholeMacroInst::generateDisassembly(Addr pc,
     return ss.str();
 }
 
-std::string VlStrideMacroInst::generateDisassembly(Addr pc,
+std::string VlElementMacroInst::generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const
 {
     std::stringstream ss;
     ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", " <<
-        '(' << registerName(srcRegIdx(0)) << ')' <<
-        ", " << registerName(srcRegIdx(1));
-    if (!machInst.vm) ss << ", v0.t";
+        '(' << registerName(srcRegIdx(0)) << ')';
+    if (has_rs2) {
+        ss << ", " << registerName(srcRegIdx(1));
+    }
+    if (!machInst.vm)
+        ss << ", v0.t";
     return ss.str();
 }
 
-std::string VlStrideMicroInst::generateDisassembly(Addr pc,
+std::string VlElementMicroInst::generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const
 {
     std::stringstream ss;
     ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", " <<
-        '(' << registerName(srcRegIdx(0)) << ')' <<
-        ", "<< registerName(srcRegIdx(1));
+        '(' << registerName(srcRegIdx(0)) << ')';
+    if (has_rs2) {
+        ss << ", " << registerName(srcRegIdx(1));
+    }
     if (microIdx != 0 || machInst.vtype8.vma == 0 || machInst.vtype8.vta == 0)
-        ss << ", " << registerName(srcRegIdx(2));
+        ss << ", " << registerName(srcRegIdx(has_rs2 ? 2 : 1));
+    if (!machInst.vm)
+        ss << ", v0.t";
+    return ss.str();
+}
+
+std::string VsElementMacroInst::generateDisassembly(Addr pc,
+        const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    ss << mnemonic << ' ' << registerName(srcRegIdx(has_rs2 ? 2 : 1))
+        << ", " << '(' << registerName(srcRegIdx(0)) << ')';
+    if (has_rs2) {
+        ss << ", " << registerName(srcRegIdx(1));
+    }
     if (!machInst.vm) ss << ", v0.t";
     return ss.str();
 }
 
-std::string VsStrideMacroInst::generateDisassembly(Addr pc,
+std::string VsElementMicroInst::generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const
 {
     std::stringstream ss;
     ss << mnemonic << ' ' << registerName(srcRegIdx(2)) << ", " <<
-        '(' << registerName(srcRegIdx(0)) << ')' <<
-        ", " << registerName(srcRegIdx(1));
-    if (!machInst.vm) ss << ", v0.t";
-    return ss.str();
-}
-
-std::string VsStrideMicroInst::generateDisassembly(Addr pc,
-        const loader::SymbolTable *symtab) const
-{
-    std::stringstream ss;
-    ss << mnemonic << ' ' << registerName(srcRegIdx(2)) << ", " <<
-        '(' << registerName(srcRegIdx(0)) << ')' <<
-        ", "<< registerName(srcRegIdx(1));
+        '(' << registerName(srcRegIdx(0)) << ')';
+    if (has_rs2) {
+        ss << ", " << registerName(srcRegIdx(1));
+    }
     if (microIdx != 0 || machInst.vtype8.vma == 0 || machInst.vtype8.vta == 0)
-        ss << ", " << registerName(srcRegIdx(2));
+        ss << ", " << registerName(srcRegIdx(has_rs2 ? 2 : 1));
     if (!machInst.vm) ss << ", v0.t";
     return ss.str();
 }

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -58,6 +58,15 @@ getSew(uint32_t vsew)
 uint32_t
 getVlmax(VTYPE vtype, uint32_t vlen);
 
+inline uint32_t
+get_emul(uint32_t eew, uint32_t sew, float vflmul, bool is_mask_ldst)
+{
+    eew = is_mask_ldst ? 1 : eew;
+    float vemul = is_mask_ldst ? 1 : (float)eew / sew * vflmul;
+    uint32_t emul = vemul < 1 ? 1 : vemul;
+    return emul;
+}
+
 /**
  * Base class for Vector Config operations
  */
@@ -130,6 +139,10 @@ class VectorMacroInst : public RiscvMacroInst
     uint32_t vlen;
     int oldDstIdx = -1;
     int vmsrcIdx = -1;
+    const uint8_t vsew;
+    const int8_t vlmul;
+    const uint32_t sew;
+    const float vflmul;
 
     VectorMacroInst(const char* mnem, ExtMachInst _machInst,
                    OpClass __opClass, uint32_t _elen, uint32_t _vlen)
@@ -137,7 +150,11 @@ class VectorMacroInst : public RiscvMacroInst
         vl(_machInst.vl),
         vtype(_machInst.vtype8),
         elen(_elen),
-        vlen(_vlen)
+        vlen(_vlen),
+        vsew(_machInst.vtype8.vsew),
+        vlmul(vtype_vlmul(_machInst.vtype8)),
+        sew((8 << vsew)),
+        vflmul(vlmul < 0 ? (1.0 / (1 << (-vlmul))) : (1 << vlmul))
     {
         this->flags[IsVector] = true;
     }
@@ -153,6 +170,10 @@ protected:
     uint32_t vlen;
     int oldDstIdx = -1;
     int vmsrcIdx = -1;
+    const uint8_t vsew;
+    const int8_t vlmul;
+    const uint32_t sew;
+    const float vflmul;
 
     VectorMicroInst(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
       uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
@@ -161,7 +182,11 @@ protected:
         microIdx(_microIdx),
         vtype(_machInst.vtype8),
         elen(_elen),
-        vlen(_vlen)
+        vlen(_vlen),
+        vsew(_machInst.vtype8.vsew),
+        vlmul(vtype_vlmul(_machInst.vtype8)),
+        sew((8 << vsew)),
+        vflmul(vlmul < 0 ? (1.0 / (1 << (-vlmul))) : (1 << vlmul))
     {
         this->flags[IsVector] = true;
     }
@@ -169,15 +194,18 @@ protected:
 
 class VectorNopMicroInst : public RiscvMicroInst
 {
+protected:
+    const Fault fault;
 public:
-    VectorNopMicroInst(ExtMachInst _machInst)
+    VectorNopMicroInst(ExtMachInst _machInst, const Fault &fault = NoFault)
         : RiscvMicroInst("vnop", _machInst, No_OpClass)
+        , fault(fault)
     {}
 
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)
         const override
     {
-        return NoFault;
+        return fault;
     }
 
     std::string generateDisassembly(Addr pc, const loader::SymbolTable *symtab)
@@ -282,6 +310,8 @@ class VectorMemMicroInst : public VectorMicroInst
   protected:
     uint32_t offset; // Used to calculate EA.
     Request::Flags memAccessFlags;
+    const uint8_t veew;
+    const uint32_t eew;
 
     VectorMemMicroInst(const char* mnem, ExtMachInst _machInst,
                        OpClass __opClass, uint32_t _microVl,
@@ -291,15 +321,21 @@ class VectorMemMicroInst : public VectorMicroInst
                           _elen, _vlen)
         , offset(_offset)
         , memAccessFlags(0)
+        , veew(_machInst.width)
+        , eew(width_EEW(veew))
     {}
 };
 
 class VectorMemMacroInst : public VectorMacroInst
 {
   protected:
+    const uint8_t veew;
+    const uint32_t eew;
     VectorMemMacroInst(const char* mnem, ExtMachInst _machInst,
                         OpClass __opClass, uint32_t _elen, uint32_t _vlen)
         : VectorMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
+        , veew(_machInst.width)
+        , eew(width_EEW(veew))
     {}
 };
 
@@ -424,58 +460,70 @@ class VsWholeMicroInst : public VectorMicroInst
         Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
-class VlStrideMacroInst : public VectorMemMacroInst
+class VlElementMacroInst : public VectorMemMacroInst
 {
   protected:
-    VlStrideMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
+    const bool has_rs2;
+    VlElementMacroInst(const char* mnem, ExtMachInst _machInst,
+                  OpClass __opClass, bool _has_rs2, uint32_t _elen,
+                  uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen),
+          has_rs2(_has_rs2)
     {}
 
     std::string generateDisassembly(
             Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
-class VlStrideMicroInst : public VectorMemMicroInst
+class VlElementMicroInst : public VectorMemMicroInst
 {
   protected:
-  uint32_t regIdx;
-    VlStrideMicroInst(const char *mnem, ExtMachInst _machInst,
+    uint32_t regIdx;
+    const bool has_rs2;
+    VlElementMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint32_t _regIdx,
-                      uint32_t _microIdx, uint32_t _microVl, uint32_t _elen,
+                      uint32_t _microIdx, uint32_t _microVl,
+                      uint32_t _offset, bool _has_rs2, uint32_t _elen,
                       uint32_t _vlen)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
-                             _microIdx, 0, _elen, _vlen)
-        , regIdx(_regIdx)
+                            _microIdx, _offset, _elen, _vlen)
+        , regIdx(_regIdx),
+          has_rs2(_has_rs2)
     {}
 
     std::string generateDisassembly(
         Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
-class VsStrideMacroInst : public VectorMemMacroInst
+class VsElementMacroInst : public VectorMemMacroInst
 {
   protected:
-    VsStrideMacroInst(const char* mnem, ExtMachInst _machInst,
-                   OpClass __opClass, uint32_t _elen, uint32_t _vlen)
-        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
+    const bool has_rs2;
+    VsElementMacroInst(const char* mnem, ExtMachInst _machInst,
+                  OpClass __opClass, bool _has_rs2, uint32_t _elen,
+                  uint32_t _vlen)
+        : VectorMemMacroInst(mnem, _machInst, __opClass, _elen, _vlen),
+          has_rs2(_has_rs2)
     {}
 
     std::string generateDisassembly(
             Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
-class VsStrideMicroInst : public VectorMemMicroInst
+class VsElementMicroInst : public VectorMemMicroInst
 {
   protected:
     uint32_t regIdx;
-    VsStrideMicroInst(const char *mnem, ExtMachInst _machInst,
+    const bool has_rs2;
+    VsElementMicroInst(const char *mnem, ExtMachInst _machInst,
                       OpClass __opClass, uint32_t _regIdx,
-                      uint32_t _microIdx, uint32_t _microVl, uint32_t _elen,
+                      uint32_t _microIdx, uint32_t _microVl,
+                      uint32_t _offset, bool _has_rs2, uint32_t _elen,
                       uint32_t _vlen)
         : VectorMemMicroInst(mnem, _machInst, __opClass, _microVl,
-                             _microIdx, 0, _elen, _vlen)
-        , regIdx(_regIdx)
+                            _microIdx, _offset, _elen, _vlen)
+        , regIdx(_regIdx),
+          has_rs2(_has_rs2)
     {}
 
     std::string generateDisassembly(

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -748,9 +748,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_ub[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedLoadOp);
-                0x2: VlStrideOp::vlse8_v({{
-                    Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
-                }}, inst_flags=SimdStridedLoadOp);
+                0x2: decode NF {
+                    format VlStrideOp {
+                        0x0: vlse8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStridedLoadOp);
+                        0x1: vlsseg2e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x2: vlsseg3e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x3: vlsseg4e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x4: vlsseg5e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x5: vlsseg6e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x6: vlsseg7e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x7: vlsseg8e8_v({{
+                            Vd_ub[microIdx] = Mem_vc.as<uint8_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                    }
+                }
                 0x3: VlIndexOp::vloxei8_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
                 }}, {{
@@ -906,9 +931,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_uh[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedLoadOp);
-                0x2: VlStrideOp::vlse16_v({{
-                    Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
-                }}, inst_flags=SimdStridedLoadOp);
+                0x2: decode NF {
+                    format VlStrideOp {
+                        0x0: vlse16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStridedLoadOp);
+                        0x1: vlsseg2e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x2: vlsseg3e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x3: vlsseg4e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x4: vlsseg5e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x5: vlsseg6e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x6: vlsseg7e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x7: vlsseg8e16_v({{
+                            Vd_uh[microIdx] = Mem_vc.as<uint16_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                    }
+                }
                 0x3: VlIndexOp::vloxei16_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
                 }}, {{
@@ -1064,9 +1114,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_uw[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedLoadOp);
-                0x2: VlStrideOp::vlse32_v({{
-                    Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
-                }}, inst_flags=SimdStridedLoadOp);
+                0x2: decode NF {
+                    format VlStrideOp {
+                        0x0: vlse32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStridedLoadOp);
+                        0x1: vlsseg2e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x2: vlsseg3e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x3: vlsseg4e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x4: vlsseg5e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x5: vlsseg6e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x6: vlsseg7e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x7: vlsseg8e32_v({{
+                            Vd_uw[microIdx] = Mem_vc.as<uint32_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                    }
+                }
                 0x3: VlIndexOp::vloxei32_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
                 }}, {{
@@ -1222,9 +1297,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_ud[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedLoadOp);
-                0x2: VlStrideOp::vlse64_v({{
-                    Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
-                }}, inst_flags=SimdStridedLoadOp);
+                0x2: decode NF {
+                    format VlStrideOp {
+                        0x0: vlse64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStridedLoadOp);
+                        0x1: vlsseg2e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x2: vlsseg3e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x3: vlsseg4e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x4: vlsseg5e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x5: vlsseg6e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x6: vlsseg7e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                        0x7: vlsseg8e64_v({{
+                            Vd_ud[microIdx] = Mem_vc.as<uint64_t>()[0];
+                        }}, inst_flags=SimdStrideSegmentedLoadOp);
+                    }
+                }
                 0x3: VlIndexOp::vloxei64_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
                 }}, {{
@@ -1718,9 +1818,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_ub[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedStoreOp);
-                0x2: VsStrideOp::vsse8_v({{
-                    Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
-                }}, inst_flags=SimdStridedStoreOp);
+                0x2: decode NF {
+                    format VsStrideOp {
+                        0x0: vsse8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x1: vssseg2e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x2: vssseg3e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x3: vssseg4e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x4: vssseg5e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x5: vssseg6e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x6: vssseg7e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x7: vssseg8e8_v({{
+                            Mem_vc.as<uint8_t>()[0] = Vs3_ub[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                    }
+                }
                 0x3: VsIndexOp::vsoxei8_v({{
                     Mem_vc.as<vu>()[0] = Vs3_vu[vs3ElemIdx];
                 }}, {{
@@ -1763,9 +1888,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_uh[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedStoreOp);
-                0x2: VsStrideOp::vsse16_v({{
-                    Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
-                }}, inst_flags=SimdStridedStoreOp);
+                0x2: decode NF {
+                    format VsStrideOp{
+                        0x0:vsse16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x1:vssseg2e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x2:vssseg3e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x3:vssseg4e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x4:vssseg5e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x5:vssseg6e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x6:vssseg7e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x7:vssseg8e16_v({{
+                            Mem_vc.as<uint16_t>()[0] = Vs3_uh[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                    }
+                }
                 0x3: VsIndexOp::vsoxei16_v({{
                     Mem_vc.as<vu>()[0] = Vs3_vu[vs3ElemIdx];
                 }}, {{
@@ -1808,9 +1958,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_uw[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedStoreOp);
-                0x2: VsStrideOp::vsse32_v({{
-                    Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
-                }}, inst_flags=SimdStridedStoreOp);
+                0x2: decode NF {
+                    format VsStrideOp {
+                        0x0: vsse32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x1: vssseg2e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x2: vssseg3e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x3: vssseg4e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x4: vssseg5e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x5: vssseg6e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x6: vssseg7e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x7: vssseg8e32_v({{
+                            Mem_vc.as<uint32_t>()[0] = Vs3_uw[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                    }
+                }
                 0x3: VsIndexOp::vsoxei32_v({{
                     Mem_vc.as<vu>()[0] = Vs3_vu[vs3ElemIdx];
                 }}, {{
@@ -1853,9 +2028,34 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     EA = Rs1 + Vs2_ud[vs2ElemIdx];
                 }}, inst_flags=SimdIndexedStoreOp);
-                0x2: VsStrideOp::vsse64_v({{
-                    Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
-                }}, inst_flags=SimdStridedStoreOp);
+                0x2: decode NF {
+                    format VsStrideOp {
+                        0x0: vsse64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x1: vssseg2e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x2: vssseg3e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x3: vssseg4e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x4: vssseg5e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x5: vssseg6e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x6: vssseg7e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                        0x7: vssseg8e64_v({{
+                            Mem_vc.as<uint64_t>()[0] = Vs3_ud[microIdx];
+                        }}, inst_flags=SimdStridedStoreOp);
+                    }
+                }
                 0x3: VsIndexOp::vsoxei64_v({{
                     Mem_vc.as<vu>()[0] = Vs3_vu[vs3ElemIdx];
                 }}, {{

--- a/src/arch/riscv/isa/formats/vector_mem.isa
+++ b/src/arch/riscv/isa/formats/vector_mem.isa
@@ -67,6 +67,7 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags,
                    inst_flags, base_class, postacc_code='',
                    declare_template_base=VMemMacroDeclare,
                    decode_template=VMemBaseDecodeBlock, exec_template_base='',
+                   microop_template_base='',
                    # If it's a macroop, the corresponding microops will be
                    # generated.
                    is_macroop=True):
@@ -81,6 +82,8 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags,
         inst_flags)
 
     constructTemplate = eval(exec_template_base + 'Constructor')
+    if not microop_template_base:
+        microop_template_base = exec_template_base
 
     header_output   = declare_template_base.subst(iop)
     decoder_output  = constructTemplate.subst(iop)
@@ -89,13 +92,13 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags,
     if not is_macroop:
         return (header_output, decoder_output, decode_block, exec_output)
 
-    micro_class_name = exec_template_base + 'MicroInst'
+    micro_class_name = microop_template_base + 'MicroInst'
 
     fault_only_first = 'FaultOnlyFirst' in iop.op_class
 
     microiop = InstObjParams(name + '_micro',
         Name + 'Micro',
-        exec_template_base + 'MicroInst',
+        microop_template_base + 'MicroInst',
         {'ea_code': ea_code,
          'memacc_code': memacc_code,
          'postacc_code': postacc_code,
@@ -110,11 +113,11 @@ def VMemBase(name, Name, ea_code, memacc_code, mem_flags,
         s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
         microiop.constructor += s
 
-    microDeclTemplate = eval(exec_template_base + 'Micro' + 'Declare')
-    microConsTemplate = eval(exec_template_base + 'Micro' + 'Constructor')
-    microExecTemplate = eval(exec_template_base + 'Micro' + 'Execute')
-    microInitTemplate = eval(exec_template_base + 'Micro' + 'InitiateAcc')
-    microCompTemplate = eval(exec_template_base + 'Micro' + 'CompleteAcc')
+    microDeclTemplate = eval(microop_template_base + 'Micro' + 'Declare')
+    microConsTemplate = eval(microop_template_base + 'Micro' + 'Constructor')
+    microExecTemplate = eval(microop_template_base + 'Micro' + 'Execute')
+    microInitTemplate = eval(microop_template_base + 'Micro' + 'InitiateAcc')
+    microCompTemplate = eval(microop_template_base + 'Micro' + 'CompleteAcc')
     header_output = microDeclTemplate.subst(microiop) + header_output
     decoder_output = microConsTemplate.subst(microiop) + decoder_output
     micro_exec_output = (microExecTemplate.subst(microiop) +
@@ -203,27 +206,29 @@ def format VsWholeOp(
 def format VlStrideOp(
     memacc_code,
     ea_code={{
-        EA = Rs1 + Rs2 * (regIdx * vlenb / elem_size + microIdx);
+        EA = Rs1 + Rs2 * ei + offset;
     }},
     mem_flags=[],
     inst_flags=[]
 ) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
-                 'VlStrideMacroInst', exec_template_base='VlStride')
+                 'VlElementMacroInst', exec_template_base='VlStride',
+                 microop_template_base="VlElement")
 }};
 
 def format VsStrideOp(
     memacc_code,
     ea_code={{
-        EA = Rs1 + Rs2 * (regIdx * vlenb / elem_size + microIdx);
+        EA = Rs1 + Rs2 * ei + offset;
     }},
     mem_flags=[],
     inst_flags=[]
 ) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         VMemBase(name, Name, ea_code, memacc_code, mem_flags, inst_flags,
-                 'VsStrideMacroInst', exec_template_base='VsStride')
+                 'VsElementMacroInst', exec_template_base='VsStride',
+                 microop_template_base="VsElement")
 }};
 
 def format VlIndexOp(

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -793,11 +793,14 @@ def template VlStrideConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
                                uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, true, _elen,
+                     _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
 
+    const uint32_t nf = _machInst.nf + 1;
+    const uint32_t emul = get_emul(eew, sew, vflmul, false);
     const int32_t num_elems_per_vreg = vlen / width_EEW(_machInst.width);
     int32_t remaining_vl = this->vl;
     // Num of elems in one vreg
@@ -807,194 +810,48 @@ def template VlStrideConstructor {{
     if (micro_vl == 0) {
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
-    }
+    } else {
 
-    const uint8_t num_pinvd_microops = ceil((float) this->vl /
-                                                    num_elems_per_vreg);
-    for (uint32_t i = 0; i < num_pinvd_microops; i++) {
-        uint32_t vdNumElems = (vl >= num_elems_per_vreg*(i+1))
-                              ? num_elems_per_vreg : vl-num_elems_per_vreg*i;
-        microop = new VPinVdMicroInst(machInst, i, vdNumElems, elen, vlen);
-        microop->setFlag(IsDelayedCommit);
-        this->microops.push_back(microop);
-    }
+        for (int fn = 0; fn < nf; fn++) {
+            remaining_vl = this->vl;
+            micro_vl = std::min(remaining_vl, num_elems_per_vreg);
+            uint32_t segIdx = fn * emul;
+            uint32_t offset = fn * eew / 8;
+            for (int i = 0; micro_vl > 0; ++i) {
+                bool illegal = (machInst.vd + segIdx + i) >= 32;
+                if (illegal) {
+                    microop = new VectorNopMicroInst(_machInst,
+                        std::make_shared<IllegalInstFault>("vd is illegal",
+                        machInst));
+                    this->microops.push_back(microop);
+                    this->microops.front()->setFlag(IsFirstMicroop);
+                    this->microops.back()->setFlag(IsLastMicroop);
+                    this->flags[IsVector] = true;
+                    return;
+                }
 
-    for (int i = 0; micro_vl > 0; ++i) {
-        for (int j = 0; j < micro_vl; ++j) {
-            microop = new %(class_name)sMicro(machInst, i, j, micro_vl, elen,
-                                              vlen);
-            microop->setFlag(IsDelayedCommit);
-            microop->setFlag(IsLoad);
-            this->microops.push_back(microop);
+                microop = new VPinVdMicroInst(machInst, segIdx + i,
+                    micro_vl, elen, vlen);
+                microop->setFlag(IsDelayedCommit);
+                this->microops.push_back(microop);
+
+                for (int j = 0; j < micro_vl; ++j) {
+                    microop = new %(class_name)sMicro(machInst, i, segIdx, j,
+                                                      micro_vl, offset, true,
+                                                      elen, vlen);
+                    microop->setFlag(IsDelayedCommit);
+                    microop->setFlag(IsLoad);
+                    this->microops.push_back(microop);
+                }
+                remaining_vl -= num_elems_per_vreg;
+                micro_vl = std::min(remaining_vl, num_elems_per_vreg);
+            }
         }
-        remaining_vl -= num_elems_per_vreg;
-        micro_vl = std::min(remaining_vl, num_elems_per_vreg);
     }
 
     this->microops.front()->setFlag(IsFirstMicroop);
     this->microops.back()->setFlag(IsLastMicroop);
     this->flags[IsVector] = true;
-}
-
-}};
-
-def template VlStrideMicroDeclare {{
-
-class %(class_name)s : public %(base_class)s
-{
-private:
-    // rs1, rs2, vtmp0, vm
-    RegId srcRegIdxArr[4];
-    RegId destRegIdxArr[1];
-public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
-                   uint32_t _microVl, uint32_t _elen, uint32_t _vlen);
-
-    Fault execute(ExecContext *, trace::InstRecord *) const override;
-    Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
-    Fault completeAcc(PacketPtr, ExecContext *,
-                      trace::InstRecord *) const override;
-    using %(base_class)s::generateDisassembly;
-};
-
-}};
-
-def template VlStrideMicroConstructor {{
-
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _regIdx,
-                               uint32_t _microIdx, uint32_t _microVl,
-                               uint32_t _elen, uint32_t _vlen)
-  : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _regIdx, _microIdx,
-                   _microVl, _elen, _vlen)
-{
-    %(set_reg_idx_arr)s;
-    _numSrcRegs = 0;
-    _numDestRegs = 0;
-    setDestRegIdx(_numDestRegs++, vecRegClass[_machInst.vd + _regIdx]);
-    _numTypedDestRegs[VecRegClass]++;
-    setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs1]);
-    setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs2]);
-    // vtmp0 as dummy src reg to create dependency with pin vd micro
-    setSrcRegIdx(_numSrcRegs++, vecRegClass[VecMemInternalReg0]);
-    if (!_machInst.vm) {
-        setSrcRegIdx(_numSrcRegs++, vecRegClass[0]);
-    }
-    this->flags[IsLoad] = true;
-}
-
-}};
-
-def template VlStrideMicroExecute {{
-
-Fault
-%(class_name)s::execute(ExecContext *xc, trace::InstRecord *traceData) const
-{
-    Fault fault = NoFault;
-    Addr EA;
-
-    bool set_dirty = true;
-    bool check_vill = true;
-    fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (fault != NoFault) { return fault; }
-
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    constexpr uint8_t elem_size = sizeof(Vd[0]);
-    %(ea_code)s; // ea_code depends on elem_size
-
-    RiscvISA::vreg_t tmp_v0;
-    uint8_t *v0;
-    if (!machInst.vm) {
-        xc->getRegOperand(this, _numSrcRegs-1, &tmp_v0);
-        v0 = tmp_v0.as<uint8_t>();
-    }
-
-    uint32_t mem_size = elem_size;
-    const std::vector<bool> byte_enable(mem_size, true);
-
-    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
-    if (machInst.vm || elem_mask(v0, ei)) {
-        fault = xc->readMem(EA, Mem.as<uint8_t>(), mem_size,
-                                memAccessFlags, byte_enable);
-        if (fault != NoFault)
-            return fault;
-        %(memacc_code)s; /* Vd[this->microIdx] = Mem[0]; */
-    }
-
-    %(op_wb)s;
-    return fault;
-}
-
-}};
-
-def template VlStrideMicroInitiateAcc {{
-
-Fault
-%(class_name)s::initiateAcc(ExecContext* xc,
-                            trace::InstRecord* traceData) const
-{
-    Fault fault = NoFault;
-    Addr EA;
-
-    bool set_dirty = false;
-    bool check_vill = true;
-    fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (fault != NoFault) { return fault; }
-
-    %(op_src_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    constexpr uint8_t elem_size = sizeof(Vd[0]);
-    %(ea_code)s; // ea_code depends on elem_size
-
-    RiscvISA::vreg_t tmp_v0;
-    uint8_t *v0;
-    if (!machInst.vm) {
-        xc->getRegOperand(this, _numSrcRegs-1, &tmp_v0);
-        v0 = tmp_v0.as<uint8_t>();
-    }
-
-    uint32_t mem_size = elem_size;
-    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
-    bool need_load = machInst.vm || elem_mask(v0, ei);
-    const std::vector<bool> byte_enable(mem_size, need_load);
-    fault = initiateMemRead(xc, EA, mem_size, memAccessFlags, byte_enable);
-    return fault;
-}
-
-}};
-
-def template VlStrideMicroCompleteAcc {{
-
-Fault
-%(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
-                            trace::InstRecord *traceData) const
-{
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-
-    bool set_dirty = true;
-    bool check_vill = false;
-    Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (update_fault != NoFault) { return update_fault; }
-
-    RiscvISA::vreg_t tmp_v0;
-    uint8_t *v0;
-    if (!machInst.vm) {
-        xc->getRegOperand(this, _numSrcRegs-1, &tmp_v0);
-        v0 = tmp_v0.as<uint8_t>();
-    }
-
-    size_t ei = this->regIdx * vlenb / sizeof(Vd[0]) + this->microIdx;
-    if (machInst.vm || elem_mask(v0, ei)) {
-        memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), pkt->getSize());
-        %(memacc_code)s; /* Vd[this->microIdx] = Mem[0]; */
-    }
-
-    %(op_wb)s;
-    return NoFault;
 }
 
 }};
@@ -1003,11 +860,14 @@ def template VsStrideConstructor {{
 
 %(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
                                uint32_t _vlen)
-    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, true, _elen,
+                     _vlen)
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
 
+    const uint32_t nf = _machInst.nf + 1;
+    const uint32_t emul = get_emul(eew, sew, vflmul, false);
     const int32_t num_elems_per_vreg = vlen / width_EEW(_machInst.width);
     int32_t remaining_vl = this->vl;
     // Num of elems in one vreg
@@ -1017,157 +877,42 @@ def template VsStrideConstructor {{
     if (micro_vl == 0) {
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
-    }
-    for (int i = 0; micro_vl > 0; ++i) {
-        for (int j = 0; j < micro_vl; ++j) {
-            microop = new %(class_name)sMicro(machInst, i, j, micro_vl, elen,
-                                              vlen);
-            microop->setFlag(IsDelayedCommit);
-            microop->setFlag(IsStore);
-            this->microops.push_back(microop);
+    } else {
+        for (int fn = 0; fn < nf; fn++) {
+            remaining_vl = this->vl;
+            micro_vl = std::min(remaining_vl, num_elems_per_vreg);
+            uint32_t segIdx = fn * emul;
+            uint32_t offset = fn * eew / 8;
+            for (int i = 0; micro_vl > 0; ++i) {
+                bool illegal = (machInst.vs3 + segIdx + i) >= 32;
+                if (illegal) {
+                    microop = new VectorNopMicroInst(_machInst,
+                        std::make_shared<IllegalInstFault>("vs3 is illegal",
+                        machInst));
+                    this->microops.push_back(microop);
+                    this->microops.front()->setFlag(IsFirstMicroop);
+                    this->microops.back()->setFlag(IsLastMicroop);
+                    this->flags[IsVector] = true;
+                    return;
+                }
+
+                for (int j = 0; j < micro_vl; ++j) {
+                    microop = new %(class_name)sMicro(machInst, i, segIdx, j,
+                                                      micro_vl, offset, true,
+                                                      elen, _vlen);
+                    microop->setFlag(IsDelayedCommit);
+                    microop->setFlag(IsStore);
+                    this->microops.push_back(microop);
+                }
+                remaining_vl -= num_elems_per_vreg;
+                micro_vl = std::min(remaining_vl, num_elems_per_vreg);
+            }
         }
-        remaining_vl -= num_elems_per_vreg;
-        micro_vl = std::min(remaining_vl, num_elems_per_vreg);
     }
 
     this->microops.front()->setFlag(IsFirstMicroop);
     this->microops.back()->setFlag(IsLastMicroop);
     this->flags[IsVector] = true;
-}
-
-}};
-
-def template VsStrideMicroDeclare {{
-
-class %(class_name)s : public %(base_class)s
-{
-private:
-    // rs1, rs2, vs3, vm
-    RegId srcRegIdxArr[4];
-    RegId destRegIdxArr[0];
-public:
-    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _microIdx,
-                   uint32_t _microVl, uint32_t _elen, uint32_t _vlen);
-    Fault execute(ExecContext *, trace::InstRecord *) const override;
-    Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
-    Fault completeAcc(PacketPtr, ExecContext *,
-                      trace::InstRecord *) const override;
-    using %(base_class)s::generateDisassembly;
-};
-
-}};
-
-def template VsStrideMicroConstructor {{
-
-%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _regIdx,
-                               uint32_t _microIdx, uint32_t _microVl,
-                               uint32_t _elen, uint32_t _vlen)
-  : %(base_class)s("%(mnemonic)s""_micro", _machInst, %(op_class)s, _regIdx,
-                   _microIdx, _microVl, _elen, _vlen)
-{
-    %(set_reg_idx_arr)s;
-    _numSrcRegs = 0;
-    _numDestRegs = 0;
-    setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs1]);
-    setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs2]);
-    setSrcRegIdx(_numSrcRegs++, vecRegClass[_machInst.vs3 + _regIdx]);
-    if (!_machInst.vm) {
-        setSrcRegIdx(_numSrcRegs++, vecRegClass[0]);
-    }
-    this->flags[IsStore] = true;
-}
-
-}};
-
-def template VsStrideMicroExecute {{
-
-Fault
-%(class_name)s::execute(ExecContext *xc, trace::InstRecord *traceData) const
-{
-    Fault fault = NoFault;
-    Addr EA;
-
-    bool set_dirty = false;
-    bool check_vill = true;
-    fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (fault != NoFault) { return fault; }
-
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    constexpr uint8_t elem_size = sizeof(Vs3[0]);
-    %(ea_code)s;
-
-    RiscvISA::vreg_t tmp_v0;
-    uint8_t *v0;
-    if(!machInst.vm) {
-        xc->getRegOperand(this, _numSrcRegs - 1, &tmp_v0);
-        v0 = tmp_v0.as<uint8_t>();
-    }
-
-    uint32_t mem_size = elem_size;
-    const std::vector<bool> byte_enable(mem_size, true);
-
-    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
-    if (machInst.vm || elem_mask(v0, ei)) {
-        %(memacc_code)s;
-        fault = xc->writeMem(Mem.as<uint8_t>(), mem_size, EA,
-                             memAccessFlags, nullptr, byte_enable);
-    }
-    return fault;
-}
-
-}};
-
-def template VsStrideMicroInitiateAcc {{
-
-Fault
-%(class_name)s::initiateAcc(ExecContext* xc,
-                            trace::InstRecord* traceData) const
-{
-    Fault fault = NoFault;
-    Addr EA;
-
-    bool set_dirty = false;
-    bool check_vill = true;
-    fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (fault != NoFault) { return fault; }
-
-    RiscvISA::vreg_t tmp_v0;
-    uint8_t *v0;
-    if(!machInst.vm) {
-        xc->getRegOperand(this, _numSrcRegs - 1, &tmp_v0);
-        v0 = tmp_v0.as<uint8_t>();
-    }
-
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    constexpr uint8_t elem_size = sizeof(Vs3[0]);
-    %(ea_code)s;
-
-    uint32_t mem_size = elem_size;
-
-    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
-    bool need_store = machInst.vm || elem_mask(v0, ei);
-    if (need_store) {
-        const std::vector<bool> byte_enable(mem_size, need_store);
-        %(memacc_code)s;
-        fault = xc->writeMem(Mem.as<uint8_t>(), mem_size, EA,
-                            memAccessFlags, nullptr, byte_enable);
-    }
-    return fault;
-}
-
-}};
-
-def template VsStrideMicroCompleteAcc {{
-
-Fault
-%(class_name)s::completeAcc(PacketPtr pkt, ExecContext* xc,
-                            trace::InstRecord* traceData) const
-{
-    return NoFault;
 }
 
 }};
@@ -2076,6 +1821,314 @@ Fault
 }};
 
 def template VsSegMicroCompleteAcc {{
+
+Fault
+%(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
+                            trace::InstRecord *traceData) const
+{
+    return NoFault;
+}
+
+}};
+
+def template VlElementMicroDeclare {{
+
+class %(class_name)s : public %(base_class)s
+{
+private:
+    // rs1, rs2, dest, vm
+    RegId srcRegIdxArr[4];
+    RegId destRegIdxArr[1];
+public:
+    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _segIdx,
+                    uint32_t _microIdx, uint32_t _microVl, uint32_t _offset,
+                    bool _has_rs2, uint32_t _elen, uint32_t _vlen);
+
+    Fault execute(ExecContext *, trace::InstRecord *) const override;
+    Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
+    Fault completeAcc(PacketPtr, ExecContext *,
+                        trace::InstRecord *) const override;
+    using %(base_class)s::generateDisassembly;
+};
+
+}};
+
+def template VlElementMicroConstructor {{
+
+%(class_name)s::%(class_name)s(ExtMachInst _machInst, uint32_t _regIdx,
+                               uint32_t _segIdx, uint32_t _microIdx,
+                               uint32_t _microVl, uint32_t _offset,
+                               bool _has_rs2, uint32_t _elen, uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _regIdx,
+                     _microIdx, _microVl, _offset, _has_rs2, _elen, _vlen)
+{
+    %(set_reg_idx_arr)s;
+    _numSrcRegs = 0;
+    _numDestRegs = 0;
+    setDestRegIdx(_numDestRegs++,
+        vecRegClass[_machInst.vd + _segIdx +_regIdx]);
+    _numTypedDestRegs[VecRegClass]++;
+    setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs1]);
+    if (_has_rs2) {
+        setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs2]);
+    }
+    this->flags[IsLoad] = true;
+}
+
+}};
+
+def template VlElementMicroExecute {{
+
+Fault
+%(class_name)s::execute(ExecContext *xc, trace::InstRecord *traceData) const
+{
+    Fault fault = NoFault;
+    Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
+
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if ((machInst.nf + 1) * get_emul(eew, sew, vflmul, false) > 8)
+        return std::make_shared<IllegalInstFault>("nf * emul is illegal",
+        machInst);
+
+    status.vs = VPUStatus::DIRTY;
+    xc->setMiscReg(MISCREG_STATUS, status);
+
+    %(op_decl)s;
+    %(op_rd)s;
+    %(set_vlenb)s;
+    constexpr uint8_t elem_size = sizeof(Vd[0]);
+
+    VM_REQUIRED();
+
+    uint32_t mem_size = elem_size;
+    const std::vector<bool> byte_enable(mem_size, true);
+
+    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
+    %(ea_code)s; // ea_code depends on elem_size
+
+    if (machInst.vm || elem_mask(v0, ei)) {
+        fault = xc->readMem(EA, Mem.as<uint8_t>(), mem_size,
+                                memAccessFlags, byte_enable);
+        if (fault != NoFault)
+            return fault;
+        %(memacc_code)s; /* Vd[this->microIdx] = Mem[0]; */
+    }
+
+    %(op_wb)s;
+    return fault;
+}
+
+}};
+
+def template VlElementMicroInitiateAcc {{
+
+Fault
+%(class_name)s::initiateAcc(ExecContext* xc,
+                            trace::InstRecord* traceData) const
+{
+    Fault fault = NoFault;
+    Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if ((machInst.nf + 1) * get_emul(eew, sew, vflmul, false) > 8)
+        return std::make_shared<IllegalInstFault>("nf * emul is illegal",
+        machInst);
+
+    %(op_src_decl)s;
+    %(op_rd)s;
+    %(set_vlenb)s;
+    constexpr uint8_t elem_size = sizeof(Vd[0]);
+
+    VM_REQUIRED();
+
+    uint32_t mem_size = elem_size;
+    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
+    %(ea_code)s; // ea_code depends on elem_size
+
+    bool need_load = machInst.vm || elem_mask(v0, ei);
+    const std::vector<bool> byte_enable(mem_size, need_load);
+    fault = initiateMemRead(xc, EA, mem_size, memAccessFlags, byte_enable);
+    return fault;
+}
+
+}};
+
+def template VlElementMicroCompleteAcc {{
+
+Fault
+%(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,
+                            trace::InstRecord *traceData) const
+{
+    %(op_decl)s;
+    %(op_rd)s;
+    %(set_vlenb)s;
+
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    status.vs = VPUStatus::DIRTY;
+    xc->setMiscReg(MISCREG_STATUS, status);
+
+    VM_REQUIRED();
+
+    size_t ei = this->regIdx * vlenb / sizeof(Vd[0]) + this->microIdx;
+    if (machInst.vm || elem_mask(v0, ei)) {
+        memcpy(Mem.as<uint8_t>(), pkt->getPtr<uint8_t>(), pkt->getSize());
+        %(memacc_code)s; /* Vd[this->microIdx] = Mem[0]; */
+    }
+
+    %(op_wb)s;
+    return NoFault;
+}
+
+}};
+
+
+def template VsElementMicroDeclare {{
+
+class %(class_name)s : public %(base_class)s
+{
+private:
+    // rs1, rs2, vs3, vm
+    RegId srcRegIdxArr[4];
+    RegId destRegIdxArr[1];
+public:
+    %(class_name)s(ExtMachInst _machInst, uint32_t _regIdx, uint32_t _segIdx,
+                   uint32_t _microIdx, uint32_t _microVl, uint32_t _offset,
+                   bool _has_rs2, uint32_t _elen, uint32_t _vlen);
+    Fault execute(ExecContext *, trace::InstRecord *) const override;
+    Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
+    Fault completeAcc(PacketPtr, ExecContext *,
+                      trace::InstRecord *) const override;
+    using %(base_class)s::generateDisassembly;
+};
+
+}};
+
+def template VsElementMicroConstructor {{
+
+    %(class_name)s::%(class_name)s(ExtMachInst _machInst,uint32_t _regIdx,
+                                   uint32_t _segIdx, uint32_t _microIdx,
+                                   uint32_t _microVl, uint32_t _offset,
+                                   bool _has_rs2, uint32_t _elen,
+                                   uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s""_micro", _machInst, %(op_class)s,
+                     _regIdx, _microIdx, _microVl, _offset, _has_rs2, _elen,
+                     _vlen)
+{
+    %(set_reg_idx_arr)s;
+    _numSrcRegs = 0;
+    _numDestRegs = 0;
+    setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs1]);
+    if (_has_rs2) {
+        setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs2]);
+    }
+    setSrcRegIdx(_numSrcRegs++,
+        vecRegClass[_machInst.vs3 + _segIdx + _regIdx]);
+    SET_VM_SRC();
+    this->flags[IsStore] = true;
+}
+
+}};
+
+def template VsElementMicroExecute {{
+
+Fault
+%(class_name)s::execute(ExecContext *xc, trace::InstRecord *traceData) const
+{
+    Fault fault = NoFault;
+    Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if ((machInst.nf + 1) * get_emul(eew, sew, vflmul, false) > 8)
+        return std::make_shared<IllegalInstFault>("nf * emul is illegal",
+        machInst);
+
+    %(op_decl)s;
+    %(op_rd)s;
+    %(set_vlenb)s;
+    constexpr uint8_t elem_size = sizeof(Vs3[0]);
+
+    VM_REQUIRED();
+
+    uint32_t mem_size = elem_size;
+    const std::vector<bool> byte_enable(mem_size, true);
+
+    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
+    %(ea_code)s;
+
+    if (machInst.vm || elem_mask(v0, ei)) {
+        %(memacc_code)s;
+        fault = xc->writeMem(Mem.as<uint8_t>(), mem_size, EA,
+                             memAccessFlags, nullptr, byte_enable);
+    }
+    return fault;
+}
+
+}};
+
+def template VsElementMicroInitiateAcc {{
+
+Fault
+%(class_name)s::initiateAcc(ExecContext* xc,
+                            trace::InstRecord* traceData) const
+{
+    Fault fault = NoFault;
+    Addr EA;
+    MISA misa = xc->readMiscReg(MISCREG_ISA);
+    STATUS status = xc->readMiscReg(MISCREG_STATUS);
+    if (!misa.rvv || status.vs == VPUStatus::OFF) {
+        return std::make_shared<IllegalInstFault>(
+            "RVV is disabled or VPU is off", machInst);
+    }
+    if (machInst.vill)
+        return std::make_shared<IllegalInstFault>("VILL is set", machInst);
+    if ((machInst.nf + 1) * get_emul(eew, sew, vflmul, false) > 8)
+        return std::make_shared<IllegalInstFault>("nf * emul is illegal",
+        machInst);
+
+    VM_REQUIRED();
+
+    %(op_decl)s;
+    %(op_rd)s;
+    %(set_vlenb)s;
+    constexpr uint8_t elem_size = sizeof(Vs3[0]);
+
+    uint32_t mem_size = elem_size;
+
+    size_t ei = this->regIdx * vlenb / elem_size + this->microIdx;
+    %(ea_code)s;
+
+    bool need_store = machInst.vm || elem_mask(v0, ei);
+    if (need_store) {
+        const std::vector<bool> byte_enable(mem_size, need_store);
+        %(memacc_code)s;
+        fault = xc->writeMem(Mem.as<uint8_t>(), mem_size, EA,
+                            memAccessFlags, nullptr, byte_enable);
+    }
+    return fault;
+}
+
+}};
+
+def template VsElementMicroCompleteAcc {{
 
 Fault
 %(class_name)s::completeAcc(PacketPtr pkt, ExecContext *xc,

--- a/src/cpu/FuncUnit.py
+++ b/src/cpu/FuncUnit.py
@@ -114,6 +114,8 @@ class OpClass(Enum):
         "SimdUnitStrideSegmentedLoad",
         "SimdUnitStrideSegmentedStore",
         "SimdUnitStrideSegmentedFaultOnlyFirstLoad",
+        "SimdStrideSegmentedLoad",
+        "SimdStrideSegmentedStore",
         "SimdExt",
         "SimdFloatExt",
         "SimdConfig",

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -146,6 +146,7 @@ class ReadPort(FUDesc):
         OpDesc(opClass="SimdUnitStrideFaultOnlyFirstLoad"),
         OpDesc(opClass="SimdUnitStrideSegmentedFaultOnlyFirstLoad"),
         OpDesc(opClass="SimdWholeRegisterLoad"),
+        OpDesc(opClass="SimdStrideSegmentedLoad"),
     ]
     count = 0
 
@@ -159,6 +160,7 @@ class WritePort(FUDesc):
         OpDesc(opClass="SimdStridedStore"),
         OpDesc(opClass="SimdIndexedStore"),
         OpDesc(opClass="SimdWholeRegisterStore"),
+        OpDesc(opClass="SimdStrideSegmentedStore"),
     ]
     count = 0
 
@@ -181,6 +183,8 @@ class RdWrPort(FUDesc):
         OpDesc(opClass="SimdUnitStrideSegmentedFaultOnlyFirstLoad"),
         OpDesc(opClass="SimdWholeRegisterLoad"),
         OpDesc(opClass="SimdWholeRegisterStore"),
+        OpDesc(opClass="SimdStrideSegmentedLoad"),
+        OpDesc(opClass="SimdStrideSegmentedStore"),
     ]
     count = 4
 

--- a/src/cpu/op_class.hh
+++ b/src/cpu/op_class.hh
@@ -131,6 +131,10 @@ static const OpClass SimdUnitStrideSegmentedStoreOp
              = enums::SimdUnitStrideSegmentedStore;
 static const OpClass SimdUnitStrideSegmentedFaultOnlyFirstLoadOp
              = enums::SimdUnitStrideSegmentedFaultOnlyFirstLoad;
+static const OpClass SimdStrideSegmentedLoadOp
+             = enums::SimdStrideSegmentedLoad;
+static const OpClass SimdStrideSegmentedStoreOp
+             = enums::SimdStrideSegmentedStore;
 static const OpClass SimdExtOp = enums::SimdExt;
 static const OpClass SimdFloatExtOp = enums::SimdFloatExt;
 static const OpClass SimdConfigOp = enums::SimdConfig;


### PR DESCRIPTION
This PR added support for vector stride segment load/store instructions.

Change-Id: Ia3f1b0c9d5e7a8f2b4c6e9d0a1b2c3f4e5d6a7b8