### PR TITLE
arch-riscv: Add support for fault-only-first unit-stride segment load instructions

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -638,6 +638,8 @@ class VlSegMicroInst : public VectorMicroInst
   protected:
     Request::Flags memAccessFlags;
     uint8_t regIdx;
+    mutable bool trimVl;
+    mutable uint32_t faultIdx;
 
     VlSegMicroInst(const char *mnem, ExtMachInst _machInst,
                    OpClass __opClass, uint32_t _microVl,
@@ -646,6 +648,7 @@ class VlSegMicroInst : public VectorMicroInst
                    uint32_t _elen, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                           _microIdx, _elen, _vlen)
+        , trimVl(false), faultIdx(_microVl)
     {
       this->flags[IsLoad] = true;
     }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -642,43 +642,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e8_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                                 }
@@ -704,12 +711,72 @@ decode QUADRANT default Unknown::unknown() {
                     0x0b: VlmOp::vlm_v({{
                         Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                     }}, inst_flags=SimdUnitStrideMaskLoadOp);
-                    0x10: VleOp::vle8ff_v({{
-                        if ((machInst.vm || elem_mask(v0, ei)) &&
-                            i < this->microVl && i < this->faultIdx) {
-                            Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                    0x10: decode NF {
+                        0x00: VleOp::vle8ff_v({{
+                            if ((machInst.vm || elem_mask(v0, ei)) &&
+                                i < this->microVl && i < this->faultIdx) {
+                                Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                            }
+                        }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                        format VlSegOp {
+                            0x01: vlseg2e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x02: vlseg3e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x03: vlseg4e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x04: vlseg5e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x05: vlseg6e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x06: vlseg7e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x07: vlseg8e8ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
+                                    i < this->microVl) {
+                                    Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
                         }
-                    }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                    }
                 }
                 0x1: VlIndexOp::vluxei8_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -736,43 +803,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e16_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                                 }
@@ -795,12 +869,72 @@ decode QUADRANT default Unknown::unknown() {
                             }}, inst_flags=SimdWholeRegisterLoadOp);
                         }
                     }
-                    0x10: VleOp::vle16ff_v({{
-                        if ((machInst.vm || elem_mask(v0, ei)) &&
-                            i < this->microVl && i < this->faultIdx) {
-                            Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                    0x10: decode NF {
+                        0x00: VleOp::vle16ff_v({{
+                            if ((machInst.vm || elem_mask(v0, ei)) &&
+                                i < this->microVl && i < this->faultIdx) {
+                                Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                            }
+                        }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                        format VlSegOp {
+                            0x01: vlseg2e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x02: vlseg3e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x03: vlseg4e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x04: vlseg5e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x05: vlseg6e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x06: vlseg7e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x07: vlseg8e16ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
+                                    i < this->microVl) {
+                                    Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
                         }
-                    }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                    }
                 }
                 0x1: VlIndexOp::vluxei16_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -827,43 +961,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e32_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                                 }
@@ -886,12 +1027,72 @@ decode QUADRANT default Unknown::unknown() {
                             }}, inst_flags=SimdWholeRegisterLoadOp);
                         }
                     }
-                    0x10: VleOp::vle32ff_v({{
-                        if ((machInst.vm || elem_mask(v0, ei)) &&
-                            i < this->microVl && i < this->faultIdx) {
-                            Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                    0x10: decode NF {
+                        0x00: VleOp::vle32ff_v({{
+                            if ((machInst.vm || elem_mask(v0, ei)) &&
+                                i < this->microVl && i < this->faultIdx) {
+                                Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                            }
+                        }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                        format VlSegOp {
+                            0x01: vlseg2e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x02: vlseg3e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x03: vlseg4e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x04: vlseg5e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x05: vlseg6e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x06: vlseg7e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x07: vlseg8e32ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
+                                    i < this->microVl) {
+                                    Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
                         }
-                    }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                    }
                 }
                 0x1: VlIndexOp::vluxei32_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];
@@ -918,43 +1119,50 @@ decode QUADRANT default Unknown::unknown() {
                         }}, inst_flags=SimdUnitStrideLoadOp);
                         format VlSegOp {
                             0x01: vlseg2e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 2)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 2)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x02: vlseg3e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 3)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 3)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x03: vlseg4e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 4)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 4)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x04: vlseg5e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 5)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 5)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x05: vlseg6e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 6)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 6)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x06: vlseg7e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 7)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 7)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
                             }}, inst_flags=SimdUnitStrideSegmentedLoadOp);
                             0x07: vlseg8e64_v({{
-                                if ((machInst.vm || elem_mask_vseg(v0, ei + (field * micro_elems), 8)) &&
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                    ei + (field * micro_elems), 8)) &&
                                     i < this->microVl) {
                                     Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                                 }
@@ -977,12 +1185,72 @@ decode QUADRANT default Unknown::unknown() {
                             }}, inst_flags=SimdWholeRegisterLoadOp);
                         }
                     }
-                    0x10: VleOp::vle64ff_v({{
-                        if ((machInst.vm || elem_mask(v0, ei)) &&
-                            i < this->microVl && i < this->faultIdx) {
-                            Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                    0x10: decode NF {
+                        0x00: VleOp::vle64ff_v({{
+                            if ((machInst.vm || elem_mask(v0, ei)) &&
+                                i < this->microVl && i < this->faultIdx) {
+                                Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                            }
+                        }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                        format VlSegOp {
+                            0x01: vlseg2e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 2)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x02: vlseg3e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 3)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x03: vlseg4e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 4)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x04: vlseg5e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 5)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x05: vlseg6e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 6)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x06: vlseg7e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 7)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
+                            0x07: vlseg8e64ff_v({{
+                                if ((machInst.vm || elem_mask_vseg(v0,
+                                ei + (field * micro_elems), 8)) &&
+                                    i < this->microVl) {
+                                    Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
+                                }
+                            }}, inst_flags=
+                            SimdUnitStrideSegmentedFaultOnlyFirstLoadOp);
                         }
-                    }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
+                    }
                 }
                 0x1: VlIndexOp::vluxei64_v({{
                     Vd_vu[vdElemIdx] = Mem_vc.as<vu>()[0];

--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1702,6 +1702,12 @@ def template VlSegConstructor {{
                 micro_vl = std::min(remaining_vl -= micro_vlmax, micro_vlmax);
             }
         }
+
+        if (microop->opClass() == SimdUnitStrideSegmentedFaultOnlyFirstLoadOp) {
+            microop = new VlFFTrimVlMicroOp(_machInst, this->vl, num_microops,
+                                            elen, vlen, microops);
+            this->microops.push_back(microop);
+        }
     }
 
     this->microops.front()->setFlag(IsFirstMicroop);
@@ -1807,6 +1813,8 @@ Fault
     Fault fault = xc->readMem(EA, Mem.as<uint8_t>(), mem_size, memAccessFlags,
                               byte_enable);
 
+    %(fault_code)s;
+
     if (fault != NoFault)
         return fault;
 
@@ -1856,6 +1864,9 @@ Fault
     const std::vector<bool> byte_enable(mem_size, true);
     Fault fault = initiateMemRead(xc, EA, mem_size, memAccessFlags,
                                   byte_enable);
+
+    %(fault_code)s;
+
     return fault;
 }
 

--- a/src/cpu/FuncUnit.py
+++ b/src/cpu/FuncUnit.py
@@ -113,6 +113,7 @@ class OpClass(Enum):
         "SimdUnitStrideFaultOnlyFirstLoad",
         "SimdUnitStrideSegmentedLoad",
         "SimdUnitStrideSegmentedStore",
+        "SimdUnitStrideSegmentedFaultOnlyFirstLoad",
         "SimdExt",
         "SimdFloatExt",
         "SimdConfig",

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -144,6 +144,7 @@ class ReadPort(FUDesc):
         OpDesc(opClass="SimdStridedLoad"),
         OpDesc(opClass="SimdIndexedLoad"),
         OpDesc(opClass="SimdUnitStrideFaultOnlyFirstLoad"),
+        OpDesc(opClass="SimdUnitStrideSegmentedFaultOnlyFirstLoad"),
         OpDesc(opClass="SimdWholeRegisterLoad"),
     ]
     count = 0
@@ -177,6 +178,7 @@ class RdWrPort(FUDesc):
         OpDesc(opClass="SimdIndexedLoad"),
         OpDesc(opClass="SimdIndexedStore"),
         OpDesc(opClass="SimdUnitStrideFaultOnlyFirstLoad"),
+        OpDesc(opClass="SimdUnitStrideSegmentedFaultOnlyFirstLoad"),
         OpDesc(opClass="SimdWholeRegisterLoad"),
         OpDesc(opClass="SimdWholeRegisterStore"),
     ]

--- a/src/cpu/op_class.hh
+++ b/src/cpu/op_class.hh
@@ -129,6 +129,8 @@ static const OpClass InstPrefetchOp = enums::InstPrefetch;
 static const OpClass SimdUnitStrideSegmentedLoadOp = enums::SimdUnitStrideSegmentedLoad;
 static const OpClass SimdUnitStrideSegmentedStoreOp
              = enums::SimdUnitStrideSegmentedStore;
+static const OpClass SimdUnitStrideSegmentedFaultOnlyFirstLoadOp
+             = enums::SimdUnitStrideSegmentedFaultOnlyFirstLoad;
 static const OpClass SimdExtOp = enums::SimdExt;
 static const OpClass SimdFloatExtOp = enums::SimdFloatExt;
 static const OpClass SimdConfigOp = enums::SimdConfig;


### PR DESCRIPTION
This PR added support for fault-only-first unit-stride segment load instructions.

Change-Id: I4a9b0c1d2e3f4567890abcdef0123456789abcd