### PR TITLE
scons: use --git-common-dir to detect hooks

### DIFF
--- a/site_scons/site_tools/git.py
+++ b/site_scons/site_tools/git.py
@@ -58,7 +58,7 @@ def install_style_hooks(env):
     try:
         gitdir = env.Dir(
             gem5_scons.util.readCommand(
-                ["git", "rev-parse", "--git-dir"]
+                ["git", "rev-parse", "--git-common-dir"]
             ).strip("\n")
         )
     except Exception as e:


### PR DESCRIPTION
To detect if pre-commit hooks are installed during compilation, the command `git rev-parse --git-dir` is used which return the path to the .git directory of current repository.

However, when using `git worktree` the above command returns for linked-worktree:

`<original repo>/.git/worktrees/<name of worktree>`

But hooks are shared between all worktree and situated in `<original repo>.git/hooks/` and so, scons will always ask to add pre-commit hooks on compilation even if they are already installed.

Using `--git-common-dir` instead of `--git-common` will return the path to `<original repo>/.git` which patch that bug.