### PR TITLE
arch-riscv: fix narrowing instructions with pin µop

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -434,19 +434,21 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
     mask_cond = True
     need_elem_idx = True
 
-    old_vd_idx = 2
     dest_reg_id = "vecRegClass[_machInst.vd + _microIdx / 2]"
     src1_is_vec = False
     if category in ["OPIVV"]:
-        src1_reg_id = "vecRegClass[_machInst.vs1 + _microIdx / 2]"
+        src1_reg_id = "vecRegClass[(_copyVs1 ? VecMemInternalReg0\
+                                             : _machInst.vs1) + _microIdx / 2]"
         src1_is_vec = True
     elif category in ["OPIVX"]:
         src1_reg_id = "intRegClass[_machInst.rs1]"
     elif category == "OPIVI":
-        old_vd_idx = 1
+        pass
     else:
         error("not supported category for VectorIntFormat: %s" % category)
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+
+    src2_reg_id = "vecRegClass[(_copyVs2 ? VecMemInternalReg0 : _machInst.vs2)\
+                               + _microIdx]"
     src2_sew_mul = 2
 
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
@@ -454,7 +456,6 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
     if category != "OPIVI":
         set_src_reg_idx += setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
     # code
     code = maskCondWrapper(code)
@@ -474,7 +475,6 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
-         'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare
         },
         flags)
@@ -484,7 +484,7 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
         VectorIntWideningMacroDeclare.subst(iop)
     decoder_output = \
         VectorIntWideningMicroConstructor.subst(microiop) + \
-        VectorIntWideningMacroConstructor.subst(iop)
+        VectorIntNarrowingMacroConstructor.subst(iop)
     exec_output = VectorIntNarrowingMicroExecute.subst(microiop)
     decode_block = VectorIntWideningDecodeBlock.subst(iop)
 }};
@@ -741,7 +741,7 @@ def format VectorFloatCvtFormat(code, category, *flags) {{
         VectorFloatCvtMicroDeclare.subst(microiop) + \
         VectorFloatCvtMacroDeclare.subst(iop)
     decoder_output = \
-        VectorFloatMicroConstructor.subst(microiop) + \
+        VectorIntWideningMicroConstructor.subst(microiop) + \
         VectorFloatMacroConstructor.subst(iop)
     exec_output = VectorFloatMicroExecute.subst(microiop)
     decode_block = VectorFloatDecodeBlock.subst(iop)
@@ -885,7 +885,7 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
         VectorFloatCvtMicroDeclare.subst(microiop) + \
         VectorFloatCvtMacroDeclare.subst(iop)
     decoder_output = \
-        VectorFloatMicroConstructor.subst(microiop) + \
+        VectorIntWideningMicroConstructor.subst(microiop) + \
         VectorIntWideningMacroConstructor.subst(iop)
     exec_output = VectorFloatWideningMicroExecute.subst(microiop)
     decode_block = VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
@@ -902,16 +902,15 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
         flags
     )
 
-    old_vd_idx = 1
     dest_reg_id = "vecRegClass[_machInst.vd + _microIdx / 2]"
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    src2_reg_id = "vecRegClass[(_copyVs2 ? VecMemInternalReg0 : _machInst.vs2)\
+                               + _microIdx]"
     src2_sew_mul = 2
 
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
 
     set_src_reg_idx = ""
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
     code = maskCondWrapper(code)
     code = eiDeclarePrefix(code, widening=True)
@@ -933,7 +932,6 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
-         'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare},
         flags)
 
@@ -941,8 +939,8 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
         VectorFloatCvtMicroDeclare.subst(microiop) + \
         VectorFloatCvtMacroDeclare.subst(iop)
     decoder_output = \
-        VectorFloatMicroConstructor.subst(microiop) + \
-        VectorIntWideningMacroConstructor.subst(iop)
+        VectorIntWideningMicroConstructor.subst(microiop) + \
+        VectorIntNarrowingMacroConstructor.subst(iop)
     exec_output = VectorFloatNarrowingMicroExecute.subst(microiop)
     decode_block = VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
 }};

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -408,7 +408,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
-                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+                   bool _copyVs1=false, bool _copyVs2=false);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -419,7 +420,8 @@ def template VectorIntWideningMicroConstructor {{
 
 template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+        bool _copyVs1, bool _copyVs2)
     : %(base_class)s("%(mnemonic)s", _machInst,
                      %(op_class)s, _microVl, _microIdx, _elen, _vlen)
 {
@@ -483,6 +485,70 @@ Fault
 
 }};
 
+def template VectorIntNarrowingMacroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
+{
+    %(set_reg_idx_arr)s;
+    %(constructor)s;
+    const int64_t vlmul = vtype_vlmul(_machInst.vtype8);
+    // when LMUL setted as m1, need to split to 2 micro insts
+    const uint32_t num_microops = 1 << std::max<int64_t>(0, vlmul + 1);
+
+    int32_t tmp_vl = this->vl;
+    const int32_t t_micro_vlmax = vtype_VLMAX(_machInst.vtype8, vlen, true);
+    const int32_t micro_vlmax = vlmul < 0 ? t_micro_vlmax : t_micro_vlmax / 2;
+    int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
+    StaticInstPtr microop;
+
+    if (micro_vl == 0) {
+        microop = new VectorNopMicroInst(_machInst);
+        this->microops.push_back(microop);
+    }
+
+    // copy on vs2 overlap, which can only happen once
+    bool copy_vs2 = (machInst.vd == machInst.vs2);
+    if (copy_vs2) {
+        microop = new VCpyVsMicroInst(machInst, 0, machInst.vs2, elen, vlen);
+        microop->setFlag(IsDelayedCommit);
+        this->microops.push_back(microop);
+    }
+
+    bool copy_vs1 = (machInst.vd == machInst.vs1);
+    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+        if (i%2 == 0 && tmp_vl > micro_vlmax) {
+            if (copy_vs1 && !copy_vs2) {
+                microop = new VCpyVsMicroInst(machInst, i/2, machInst.vs1,
+                                              elen, vlen);
+                microop->setFlag(IsDelayedCommit);
+                this->microops.push_back(microop);
+            }
+            microop = new VPinVdMicroInst(machInst, i/2, 2, elen, vlen);
+            microop->setFlag(IsDelayedCommit);
+            this->microops.push_back(microop);
+        }
+
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen, copy_vs1,
+                                                    copy_vs2);
+        microop->setDelayedCommit();
+        this->microops.push_back(microop);
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+
+        copy_vs2 = false;
+    }
+
+    this->microops.front()->setFirstMicroop();
+    this->microops.back()->setLastMicroop();
+}
+
+%(declare_varith_template)s;
+
+}};
+
 def template VectorIntNarrowingMicroExecute {{
 
 template <typename ElemType>
@@ -520,7 +586,6 @@ Fault
         (this->microIdx % 2 == 0) ? 0 : micro_vlmax;
 
     %(vm_decl_rd)s;
-    %(copy_old_vd)s;
     %(code)s;
     %(op_wb)s;
     return NoFault;
@@ -710,7 +775,8 @@ private:
     bool vm;
 public:
     %(class_name)s(ExtMachInst _machInst,
-        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+        bool _copyVs1=false, bool _copyVs2=false);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     std::string generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const override
@@ -814,7 +880,6 @@ Fault
         (this->microIdx % 2 == 0) ? 0 : micro_vlmax;
 
     %(vm_decl_rd)s;
-    %(copy_old_vd)s;
     %(code)s;
     %(op_wb)s;
     return NoFault;


### PR DESCRIPTION
This patch fixes vector narrowing instructions, which where losing data between µops to the same destination when a tail/mask agnostic policy was being applied (i.e. no copy of old destination is done and overwriting with 1s). The fix adds pinning to them so there's no loss of data.