### PR TITLE
base: Add print when accessing an AssociativeCache entry

### DIFF
--- a/src/base/cache/associative_cache.hh
+++ b/src/base/cache/associative_cache.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -196,6 +196,13 @@ class AssociativeCache : public Named
     virtual void
     accessEntry(Entry *entry)
     {
+         if (debugFlag && debugFlag->tracing()) {
+            ::gem5::trace::getDebugLogger()->dprintf_flag(
+                curTick(), name(), debugFlag->name(),
+                "Accessing entry: %s\n", entry->print());
+        }
+
+
         replPolicy->touch(entry->replacementData);
     }
 


### PR DESCRIPTION
Adds a debug print message when an AssociativeCache entry is accessed. This is useful when investigating cache entry modification or verifying replacement policies are functioning correctly.
This builds on https://github.com/gem5/gem5/pull/1514

Change-Id: I73bae68c6ce2135f21988de83703a4985275d557
Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>