### PR TITLE
configs: Dump and reset m5 stats at kernel end in FS mode

### DIFF
--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -291,8 +291,12 @@ def runGpuFSSystem(args):
                 break
             kernels_completed += 1
             tasks_completed += 1
+            m5.stats.dump()
+            m5.stats.reset()
         elif "GPU Blit Kernel Completed" in exit_event.getCause():
             tasks_completed += 1
+            m5.stats.dump()
+            m5.stats.reset()
         elif "Skipping GPU Kernel" in exit_event.getCause():
             print(f"Skipping GPU kernel {kernels_completed}")
             kernels_completed += 1


### PR DESCRIPTION
This commit dumps and resets m5 stats whenever simulation receives kernel end exit events in GPU-FS mode. With this patch, the stats.txt file at the end of a GPU-FS simulation should contain a copy of each stat for every blit and normal kernel launched