### PR TITLE
mem-ruby: Move GPU L1 cache MSHR to the coalescer

### DIFF
--- a/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-SQC.sm
@@ -48,9 +48,6 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
 {
   state_declaration(State, desc="SQC Cache States", default="SQC_State_I") {
     I, AccessPermission:Invalid, desc="Invalid";
-    // Note: currently IV in the TCP is only for pending loads to a given cache
-    // line.  Since the SQC is read only, there are no stores.
-    IV, AccessPermission:Invalid, desc="Going from I to V, waiting on TCC data";
     V, AccessPermission:Read_Only, desc="Valid";
   }
 
@@ -103,7 +100,6 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
   void unset_tbe();
   void wakeUpAllBuffers();
   void wakeUpBuffers(Addr a);
-  void wakeUpAllBuffers(Addr a);
   Cycles curCycle();
 
   // Internal functions
@@ -286,31 +282,12 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
     }
   }
 
-  action(t_allocateTBE, "t", desc="allocate TBE Entry") {
-    check_allocate(TBEs);
-    TBEs.allocate(address);
-    set_tbe(TBEs.lookup(address));
-  }
-
-  action(d_deallocateTBE, "d", desc="Deallocate TBE") {
-    TBEs.deallocate(address);
-    unset_tbe();
-  }
-
-  action(st_stallAndWaitRequest, "st", desc="Stall and wait on the address") {
-    stall_and_wait(mandatoryQueue_in, address);
-  }
-
   action(p_popMandatoryQueue, "pm", desc="Pop Mandatory Queue") {
     mandatoryQueue_in.dequeue(clockEdge());
   }
 
   action(pr_popResponseQueue, "pr", desc="Pop Response Queue") {
     responseToSQC_in.dequeue(clockEdge());
-  }
-
-  action(wada_wakeUpAllDependentsAddr, "wada", desc="Wake up any requests waiting for this address") {
-    wakeUpAllBuffers(address);
   }
 
   action(l_loadDoneHit, "ldh", desc="local load done (hits in SQC)") {
@@ -352,59 +329,29 @@ machine(MachineType:SQC, "GPU SQC (L1 I Cache)")
 
   // Transitions
 
-  // if another request arrives for the same cache line that has a pending
-  // load, put it on the wakeup buffer.  This reduced resource contention since
-  // they won't try again every cycle and will instead only try again once woken
-  // up
-  transition(IV, {Fetch}) {
-      st_stallAndWaitRequest;
-  }
-
   // transitions from base
-  transition({I, IV, V}, Repl, I) {TagArrayRead, TagArrayWrite} {
+  transition({I, V}, Repl, I) {TagArrayRead, TagArrayWrite} {
     // since we're evicting something, don't bother classifying as hit/miss
     ic_invCache;
   }
 
-  transition({I, IV, V}, Evict, I) {TagArrayRead, TagArrayWrite} {
+  transition({I, V}, Evict, I) {TagArrayRead, TagArrayWrite} {
     // since we're evicting something, don't bother classifying as hit/miss
     ic_invCache;
     inv_invDone;
     p_popMandatoryQueue;
   }
 
-  // if we got a response for a load where the line is in I, then
-  // another request must have come in that replaced the line in question in
-  // the cache.  Thus, complete this request without allocating the line, but
-  // still deallocate TBE and wakeup any dependent addresses.
-  transition(I, Data) {TagArrayRead, TagArrayWrite, DataArrayRead} {
-    // don't profile this as a hit/miss since it's a reponse from L2,
-    // so we already counted it
-    l_loadDoneMiss;
-    wada_wakeUpAllDependentsAddr;
-    d_deallocateTBE;
-    pr_popResponseQueue;
-  }
-
-  // if line is currently in IV, then Data is returning the data for a
-  // pending load, so transition to V, deallocate TBE, and wakeup any dependent
-  // requests so they will be replayed now that this request has returned.
-  transition(IV, Data, V) {TagArrayRead, TagArrayWrite, DataArrayRead} {
+  transition(I, Data, V) {TagArrayRead, TagArrayWrite, DataArrayRead} {
     a_allocate;
     // don't profile this as a hit/miss since it's a reponse from L2,
     // so we already counted it
     w_writeCache;
     l_loadDoneMiss;
-    wada_wakeUpAllDependentsAddr;
-    d_deallocateTBE;
     pr_popResponseQueue;
   }
 
-  // if we have a load that misses, allocate TBE entry and transition to IV
-  // to prevent subsequent requests to same cache line from also going to TCC
-  // while this request is pending
-  transition(I, Fetch, IV) {TagArrayRead, TagArrayWrite} {
-    t_allocateTBE;
+  transition(I, Fetch) {TagArrayRead, TagArrayWrite} {
     nS_issueRdBlkS;
     uu_profileDataMiss; // since line wasn't in SQC, we missed
     p_popMandatoryQueue;

--- a/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
+++ b/src/mem/ruby/protocol/GPU_VIPER-TCP.sm
@@ -54,10 +54,6 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
 {
   state_declaration(State, desc="TCP Cache States", default="TCP_State_I") {
     I, AccessPermission:Invalid,   desc="Invalid";
-    // Note: currently IV in the TCP is only for pending loads to a given cache
-    // line. Since the TCP is write through, stores should be allowed to pass
-    // through without requiring them to wait.
-    IV, AccessPermission:Invalid,  desc="Going from I to V, waiting on TCC data";
     V, AccessPermission:Read_Only, desc="Valid";
     A, AccessPermission:Invalid,   desc="Waiting on Atomic";
 
@@ -742,18 +738,14 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
   // they can cause a resource stall deadlock!
 
   // if another request arrives for the same cache line that has a pending
-  // atomic or load, put it on the wakeup buffer instead of z_stall'ing it.  By
+  // atomic, put it on the wakeup buffer instead of z_stall'ing it.  By
   // doing so we reduce resource contention since they won't try again every cycle
   // and will instead only try again once woken up
-  transition({A, IV}, {Load, LoadBypassEvict, Atomic, Store, StoreThrough, Flush}) {
+  transition(A, {Load, LoadBypassEvict, Atomic, Store, StoreThrough, Flush}) {
       st_stallAndWaitRequest;
   }
 
-  // if we have a load that misses, allocate TBE entry and transition to IV
-  // to prevent subsequent requests to same cache line from also going to TCC
-  // while this request is pending
-  transition(I, Load, IV) {TagArrayRead} {
-    t_allocateTBE;
+  transition(I, Load) {TagArrayRead} {
     n_issueRdBlk;
     uu_profileDataMiss;
     p_popMandatoryQueue;
@@ -808,38 +800,16 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
     p_popMandatoryQueue;
   }
 
-  // if we got a response for a load where the line is in I, then
-  // another request must have come in that replaced the line in question in
-  // the cache.  Thus, complete this request without allocating the line, but
-  // still deallocate TBE and wakeup any dependent addresses.
-  // (Note: this assumes TCC_AckWB is what stores use)
-  transition(I, TCC_Ack) {TagArrayRead, TagArrayWrite} {
-    wada_wakeUpAllDependentsAddr;
-    // NOTE: Because we invalidated the cache line, the assert in l_loadDoneMiss
-    // will fail -- unlike atomics that automatically go to I when the line returns
-    // loads do not automatically go to I.  Resolve this by passing data from
-    // message.
-    ldmi_loadDoneMissInv;
-    d_deallocateTBE;
-    pr_popResponseQueue;
-  }
-
-  // if line is currently in IV, then TCC_Ack is returning the data for a
-  // pending load, so transition to V, deallocate TBE, and wakeup any dependent
-  // requests so they will be replayed now that this request has returned.
-  transition(IV, TCC_Ack, V) {TagArrayRead, TagArrayWrite, DataArrayRead, DataArrayWrite} {
+  transition(I, TCC_Ack, V) {TagArrayRead, TagArrayWrite, DataArrayRead, DataArrayWrite} {
     a_allocate;
     w_writeCache;
-    wada_wakeUpAllDependentsAddr;
     l_loadDoneMiss;
-    d_deallocateTBE;
     pr_popResponseQueue;
   }
 
-  // if a bypass request arrives back at the TCP, regardless of whether the line
-  // is in I (from the bypass request) or IV (from a subsequent non-bypassing
-  // load), retain the current state and complete the bypassing request.
-  transition({I, IV}, Bypass) {
+  // if a bypass request arrives back at the TCP,
+  // retain the current state and complete the bypassing request.
+  transition(I, Bypass) {
     rb_bypassDone;
     pr_popResponseQueue;
   }
@@ -871,12 +841,6 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
   }
 
   transition({A}, Repl) {TagArrayRead, TagArrayWrite} {
-    ic_invCache;
-  }
-
-  // if a line with a pending load gets evicted, transition the line to I and
-  // invalidate it.
-  transition(IV, Repl, I) {TagArrayRead, TagArrayWrite} {
     ic_invCache;
   }
 
@@ -913,11 +877,8 @@ machine(MachineType:TCP, "GPU TCP (L1 Data Cache)")
     pr_popResponseQueue;
   }
 
-  // if a line is in IV and a TCC_AckWB comes back, we must have had a WT
-  // store followed by a load. Thus, complete the store without affecting
-  // TBE or line state.
   // TCC_AckWB only snoops TBE
-  transition({V, I, IV}, TCC_AckWB) {
+  transition({V, I}, TCC_AckWB) {
     wd_wtDone;
     pr_popResponseQueue;
   }

--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -530,16 +530,34 @@ GPUCoalescer::readCallback(Addr address,
     fatal_if(crequest->getRubyType() != RubyRequestType_LD,
              "readCallback received non-read type response\n");
 
+    // Iterate over the coalesced requests to respond to as many loads as
+    // possible until another request type is seen. Models MSHR for
+    // Coalescer. Do not respond to pending loads that have SLC/GLC flags
+    // set; issue them instead
+    while (crequest->getRubyType() == RubyRequestType_LD) {
     hitCallback(crequest, mach, data, true, crequest->getIssueTime(),
                 forwardRequestTime, firstResponseTime, isRegion, externalHit);
 
-    delete crequest;
-    coalescedTable.at(address).pop_front();
+        delete crequest;
+        coalescedTable.at(address).pop_front();
+        if (coalescedTable.at(address).empty()) {
+            break;
+        }
+
+        crequest = coalescedTable.at(address).front();
+
+        PacketPtr pkt = crequest->getFirstPkt();
+        bool is_request_local = !pkt->isGLCSet() && !pkt->isSLCSet();
+        if (!is_request_local) {
+            break;
+        }
+    }
+
     if (coalescedTable.at(address).empty()) {
-      coalescedTable.erase(address);
+        coalescedTable.erase(address);
     } else {
-      auto nextRequest = coalescedTable.at(address).front();
-      issueRequest(nextRequest);
+        auto nextRequest = coalescedTable.at(address).front();
+        issueRequest(nextRequest);
     }
 }
 

--- a/src/mem/ruby/system/GPUCoalescer.cc
+++ b/src/mem/ruby/system/GPUCoalescer.cc
@@ -211,6 +211,7 @@ GPUCoalescer::GPUCoalescer(const Params &p)
                  false, Event::Progress_Event_Pri),
       uncoalescedTable(this),
       deadlockCheckEvent([this]{ wakeup(); }, "GPUCoalescer deadlock check"),
+      stats(this),
       gmTokenPort(name() + ".gmTokenPort")
 {
     m_store_waiting_on_load_cycles = 0;
@@ -439,7 +440,7 @@ GPUCoalescer::writeCallback(Addr address,
     auto crequest = coalescedTable.at(address).front();
 
     hitCallback(crequest, mach, data, true, crequest->getIssueTime(),
-                forwardRequestTime, firstResponseTime, isRegion, false);
+                forwardRequestTime, firstResponseTime, isRegion, false, false);
 
     // remove this crequest in coalescedTable
     delete crequest;
@@ -530,13 +531,15 @@ GPUCoalescer::readCallback(Addr address,
     fatal_if(crequest->getRubyType() != RubyRequestType_LD,
              "readCallback received non-read type response\n");
 
+    bool mshr_hit_under_miss = false;
     // Iterate over the coalesced requests to respond to as many loads as
     // possible until another request type is seen. Models MSHR for
     // Coalescer. Do not respond to pending loads that have SLC/GLC flags
     // set; issue them instead
     while (crequest->getRubyType() == RubyRequestType_LD) {
-    hitCallback(crequest, mach, data, true, crequest->getIssueTime(),
-                forwardRequestTime, firstResponseTime, isRegion, externalHit);
+    hitCallback(crequest, mach, data, true,
+            crequest->getIssueTime(), forwardRequestTime, firstResponseTime,
+            isRegion, externalHit, mshr_hit_under_miss);
 
         delete crequest;
         coalescedTable.at(address).pop_front();
@@ -551,6 +554,8 @@ GPUCoalescer::readCallback(Addr address,
         if (!is_request_local) {
             break;
         }
+
+        mshr_hit_under_miss = true;
     }
 
     if (coalescedTable.at(address).empty()) {
@@ -570,7 +575,8 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                        Cycles forwardRequestTime,
                        Cycles firstResponseTime,
                        bool isRegion,
-                       bool externalHit = false)
+                       bool externalHit = false,
+                       bool mshrHitUnderMiss = false)
 {
     PacketPtr pkt = crequest->getFirstPkt();
     Addr request_address = pkt->getAddr();
@@ -585,11 +591,12 @@ GPUCoalescer::hitCallback(CoalescedRequest* crequest,
                         externalHit ? "hit" : "miss",
                         printAddress(request_address));
 
-    recordMissLatency(crequest, mach,
+    recordStats(crequest, mach,
                       initialRequestTime,
                       forwardRequestTime,
                       firstResponseTime,
-                      success, isRegion);
+                      isRegion,
+                      mshrHitUnderMiss);
     // update the data
     //
     // MUST ADD DOING THIS FOR EACH REQUEST IN COALESCER
@@ -1043,12 +1050,52 @@ GPUCoalescer::completeHitCallback(std::vector<PacketPtr> & mylist)
 }
 
 void
-GPUCoalescer::recordMissLatency(CoalescedRequest* crequest,
+GPUCoalescer::recordStats(CoalescedRequest* crequest,
                                 MachineType mach,
                                 Cycles initialRequestTime,
                                 Cycles forwardRequestTime,
                                 Cycles firstResponseTime,
-                                bool success, bool isRegion)
+                                bool isRegion, bool mshrHitUnderMiss)
+{
+    RubyRequestType type = crequest->getRubyType();
+
+    if (mshrHitUnderMiss) {
+        // Add the number of mshr hits under misses to the
+        // TCP demand hits stat.
+        // We don't need to profile misses since they will be
+        // profiled at the TCP. Only the MSHR hits under misses
+        // needs to be profiled here
+        PacketPtr pkt = crequest->getFirstPkt();
+        if (!pkt->isGLCSet() &&
+                !pkt->isSLCSet()) {
+            m_dataCache_ptr->profileDemandHit();
+        }
+
+        // Since the request hit in the mshr, update mshr stats
+        if (type == RubyRequestType_LD) {
+            stats.m_mshr_ld_hits_under_miss++;
+        }
+    } else  {
+        if (type == RubyRequestType_LD) {
+            stats.m_mshr_ld_misses++;
+        } else {
+            stats.m_mshr_st_misses++;
+        }
+    }
+}
+
+GPUCoalescer::GPUCoalescerStats::GPUCoalescerStats(statistics::Group *parent)
+    : statistics::Group(parent),
+    ADD_STAT(m_mshr_ld_hits_under_miss,
+            "Number of load requests that hit in the coalescer MSHR"),
+    ADD_STAT(m_mshr_ld_misses,
+            "Number of load requests that miss in the coalescer MSHR"),
+    ADD_STAT(m_mshr_st_misses,
+            "Number of store requests that miss in the coalescer MSHR"),
+    ADD_STAT(m_mshr_accesses,
+            "Number of mshr accesses",
+            m_mshr_ld_hits_under_miss + m_mshr_ld_misses
+            + m_mshr_st_misses)
 {
 }
 

--- a/src/mem/ruby/system/GPUCoalescer.hh
+++ b/src/mem/ruby/system/GPUCoalescer.hh
@@ -398,13 +398,17 @@ class GPUCoalescer : public RubyPort
                      Cycles forwardRequestTime,
                      Cycles firstResponseTime,
                      bool isRegion,
-                     bool externalHit);
-    void recordMissLatency(CoalescedRequest* crequest,
+                     bool externalHit,
+                     bool mshrHitUnderMiss);
+
+    void recordStats(CoalescedRequest* crequest,
                            MachineType mach,
                            Cycles initialRequestTime,
                            Cycles forwardRequestTime,
                            Cycles firstResponseTime,
-                           bool success, bool isRegion);
+                           bool isRegion,
+                           bool mshrHitUnderMiss);
+
     void completeHitCallback(std::vector<PacketPtr> & mylist);
 
     virtual RubyRequestType getRequestType(PacketPtr pkt);
@@ -467,6 +471,18 @@ class GPUCoalescer : public RubyPort
 
     EventFunctionWrapper deadlockCheckEvent;
     bool assumingRfOCoherence;
+
+    struct GPUCoalescerStats : public statistics::Group
+    {
+        GPUCoalescerStats(statistics::Group *parent);
+        statistics::Scalar m_mshr_ld_hits_under_miss;
+        statistics::Scalar m_mshr_ld_misses;
+
+        statistics::Scalar m_mshr_st_misses;
+
+        statistics::Formula m_mshr_accesses;
+    } stats;
+
 
 // TODO - Need to update the following stats once the VIPER protocol
 //        is re-integrated.


### PR DESCRIPTION
This commit undoes PR https://github.com/gem5/gem5/pull/540 which added MSHRs to the L1 SQC/TCP to handle requests to the same line. The commit moves the MSHR instead to the coalescer where the coalescedTable maintains a list of all requests that go to the same line. These pending requests are completed as soon as the first request that went to cache returns. If any of these pending requests have GLC/SLC flags set, then the request is not marked complete. It is instead sent to cache. The commit also adds stats to track coalescer mshr misses and hits under misses