### PR TITLE
dev,arch-riscv: Fix Clint msip register read/write

### DIFF
--- a/src/dev/riscv/clint.hh
+++ b/src/dev/riscv/clint.hh
@@ -137,7 +137,6 @@ class Clint : public BasicPioDevice
 
     using Register32 = ClintRegisters::Register32;
 
-    uint32_t readMSIP(Register32& reg, const int thread_id);
     void writeMSIP(Register32& reg, const uint32_t& data, const int thread_id);
 
   // External API
@@ -156,6 +155,11 @@ class Clint : public BasicPioDevice
                    PortID idx=InvalidPortID) override;
     void serialize(CheckpointOut &cp) const override;
     void unserialize(CheckpointIn &cp) override;
+
+    /**
+     * Software Interrupt
+     */
+    void updateMSIP(const int thread_id);
 
   // CLINT reset
   public:


### PR DESCRIPTION
From SiFive U54MC datasheet

```
Each msip register is a 32-bit wide WARL register, where the upper 31 bits
are tied to 0. The least-significant bit is reflected in the MSIP bit of
the mip CSR. Other bits in the msip register are hardwired to zero.
```

The register needs to clear upper 31 bits rather than rely on an assertion check. For register reader part, we don't need to sync with mip.MSIP because the bit is read-only.

Change-Id: I9e52c039d4c689b757e85644a055ae341b9ba0bb