### PR TITLE
arch-riscv: Use generic ISA resetThread for RISC-V workloads

### DIFF
--- a/src/arch/riscv/bare_metal/fs_workload.cc
+++ b/src/arch/riscv/bare_metal/fs_workload.cc
@@ -71,7 +71,7 @@ BareMetal::initState()
             "Could not load sections to memory.");
 
     for (auto *tc: system->threads) {
-        RiscvISA::Reset().invoke(tc);
+        tc->getIsaPtr()->resetThread();
         tc->activate();
     }
 }

--- a/src/arch/riscv/linux/fs_workload.cc
+++ b/src/arch/riscv/linux/fs_workload.cc
@@ -73,7 +73,7 @@ FsLinux::initState()
     }
 
     for (auto *tc: system->threads) {
-        RiscvISA::Reset().invoke(tc);
+        tc->getIsaPtr()->resetThread();
         tc->activate();
     }
 }
@@ -240,7 +240,7 @@ BootloaderKernelWorkload::initState()
     loadDtb();
 
     for (auto *tc: system->threads) {
-        RiscvISA::Reset().invoke(tc);
+        tc->getIsaPtr()->resetThread();
         tc->activate();
     }
 }


### PR DESCRIPTION
The RISC-V ISA resetThread is equivalent to `Reset().invoke(tc)`

https://github.com/gem5/gem5/blob/535993eb5415132e550dfa7ee831c8cfb300969e/src/arch/riscv/isa.cc#L1047-L1052

Change-Id: I7fc591b08a260baffd17f221a1cfeb698890e0b3