### PR TITLE
python: remove duplicate exit handler for hypercall 5

### DIFF
--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -319,16 +319,6 @@ class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
         return True
 
 
-class ToTickExitHandler(ExitHandler, hypercall_num=5):
-    @overrides(ExitHandler)
-    def _process(self, simulator: "Simulator") -> None:
-        pass
-
-    @overrides(ExitHandler)
-    def _exit_simulation(self) -> bool:
-        return True
-
-
 class CheckpointExitHandler(ExitHandler, hypercall_num=7):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:


### PR DESCRIPTION
Previously, there were two exit event handlers, ToTickExitHandler and WorkEndExitHandler, registered to hypercall 5. This commit removes ToTickExitHandler, as it isn't being used.