### PR TITLE
mem-ruby: Implement CHI ReadNoSnp Request

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -515,6 +515,35 @@ action(Initiate_ReadShared_HitUpstream_NoOwner, desc="") {
   tbe.actions.push(Event:MaintainCoherence);
 }
 
+action(Initiate_ReadNoSnp, desc="") {
+  assert(is_HN);
+  tbe.dataToBeInvalid := true;
+  tbe.actions.push(Event:ReadMissPipe);
+
+  if (tbe.use_DMT) {
+    assert(is_invalid(cache_entry));
+    if (enable_DMT_early_dealloc) {
+      tbe.actions.push(Event:SendRespSepData);
+    }
+    tbe.actions.push(Event:WaitCompAck);
+    tbe.actions.pushNB(Event:SendReadNoSnpDMT);
+  } else {
+    tbe.actions.push(Event:SendReadNoSnp);
+    tbe.actions.push(Event:WaitCompAck);
+    tbe.actions.pushNB(Event:SendCompData);
+  }
+
+  tbe.updateDirOnCompAck := false;
+}
+
+action(Initiate_ReadNoSnp_Hit, desc="") {
+  assert(is_HN);
+  tbe.actions.push(Event:ReadHitPipe);
+  tbe.actions.push(Event:DataArrayRead);
+  tbe.actions.push(Event:WaitCompAck);
+  tbe.actions.pushNB(Event:SendCompData);
+  tbe.updateDirOnCompAck := false;
+}
 
 action(Initiate_ReadOnce_Miss, desc="") {
   // drop at the end if not doing a fill
@@ -2746,6 +2775,7 @@ action(Send_CompData, desc="") {
   assert(tbe.dataValid);
 
   bool is_rd_once := tbe.reqType == CHIRequestType:ReadOnce;
+  bool is_rd_no_snp := tbe.reqType == CHIRequestType:ReadNoSnp;
   bool is_rd_shared := (tbe.reqType == CHIRequestType:ReadShared) ||
                        (tbe.reqType == CHIRequestType:ReadNotSharedDirty);
   bool is_rd_nsd := tbe.reqType == CHIRequestType:ReadNotSharedDirty;
@@ -2765,7 +2795,7 @@ action(Send_CompData, desc="") {
   bool snd_dirty_on_rs := (is_rd_shared && !is_rd_nsd) &&
                           !tbe.dir_ownerExists;
 
-  if (is_rd_once) {
+  if (is_rd_once || is_rd_no_snp) {
     tbe.snd_msgType := CHIDataType:CompData_I;
   } else if (is_rd_unique || (is_rd_shared && snd_unique_on_rs)) {
     assert(tbe.dataUnique);

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1192,6 +1192,7 @@ bool isReadReqType(CHIRequestType type) {
       type == CHIRequestType:ReadShared ||
       type == CHIRequestType:ReadNotSharedDirty ||
       type == CHIRequestType:MakeReadUnique ||
+      type == CHIRequestType:ReadNoSnp ||
       type == CHIRequestType:ReadOnce) {
     return true;
   }
@@ -1248,6 +1249,8 @@ Event reqToEvent(CHIRequestType type, bool is_prefetch) {
     }
   } else if (type == CHIRequestType:CleanUnique) {
     return Event:CleanUnique;
+  } else if (type == CHIRequestType:ReadNoSnp) {
+    return Event:ReadNoSnp;
   } else if (type == CHIRequestType:ReadOnce) {
     return Event:ReadOnce;
   } else if (type == CHIRequestType:MakeReadUnique) {

--- a/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
@@ -223,6 +223,23 @@ transition({UD_RU,UC_RU,RU,RSD,RUSD}, {ReadShared,ReadNotSharedDirty}, BUSY_BLKD
   ProcessNextState;
 }
 
+// ReadNoSnp
+transition(I, ReadNoSnp, BUSY_BLKD) {
+  Initiate_Request;
+  Initiate_ReadNoSnp;
+  Profile_Miss;
+  Pop_ReqRdyQueue;
+  ProcessNextState;
+}
+
+transition({UD,SD,UC,SC}, ReadNoSnp, BUSY_BLKD) {
+  Initiate_Request;
+  Initiate_ReadNoSnp_Hit;
+  Profile_Hit;
+  Pop_ReqRdyQueue;
+  ProcessNextState;
+}
+
 // ReadOnce
 
 transition(I, ReadOnce, BUSY_BLKD) {
@@ -948,6 +965,7 @@ transition({I,SC,UC,SD,UD,RU,RSC,RSD,RUSD,SC_RSC,UC_RSC,SD_RSC,UD_RSC,UC_RU,UD_R
 
 transition({BUSY_BLKD,BUSY_INTR},
             {ReadShared, ReadNotSharedDirty, ReadUnique, ReadUnique_PoC,
+            ReadNoSnp,
             ReadOnce, CleanUnique, CleanUnique_Stale,
             Load, Store, AtomicLoad, AtomicStore, Prefetch,
             MakeReadUnique,

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -311,6 +311,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     ReadNotSharedDirty,          desc="", in_trans="yes";
     ReadUnique,                  desc="", in_trans="yes";
     ReadUnique_PoC,              desc="", in_trans="yes";
+    ReadNoSnp,                   desc="", in_trans="yes";
     ReadOnce,                    desc="", in_trans="yes";
     CleanUnique,                 desc="", in_trans="yes";
     MakeReadUnique,              desc="", in_trans="yes";


### PR DESCRIPTION
This is an uncacheable request. Prior to this patch the SNF was the only node capable of handling a ReadNoSnp. With this path we extend the HN to handle an incoming ReadNoSnp request.  Differently from ReadOnce it does not send any snooping message to retrieve a coherent snapshot of the data


Change-Id: I61c30e06da432e604840251a7e5c30ef4f7d7d1d
Reviewed-by: Tiago Muck <tiago.muck@arm.com>