### PR TITLE
misc: bump isort version to 6.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
           - id: destroyed-symlinks
           - id: requirements-txt-fixer
     - repo: https://github.com/PyCQA/isort
-      rev: 6.0.0
+      rev: 6.0.1
       hooks:
           - id: isort
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt


### PR DESCRIPTION
This commit bumps the isort version in .pre-commit-config.yaml to 6.0.1.