### PR TITLE
misc: bump Jinja2 version to 3.1.6

### DIFF
--- a/util/gem5-resources-manager/requirements.txt
+++ b/util/gem5-resources-manager/requirements.txt
@@ -12,7 +12,7 @@ Flask==2.3.2
 idna==3.7
 importlib-metadata==6.6.0
 itsdangerous==2.1.2
-Jinja2==3.1.5
+Jinja2==3.1.6
 jsonschema==4.17.3
 Markdown==3.4.3
 MarkupSafe==2.1.3


### PR DESCRIPTION
This PR bumps the Jinja2 version to 3.1.6 in util/gem5-resources-manage/requirements.txt