### PR TITLE
arch-arm: Implement FEAT_FP16

### DIFF
--- a/src/arch/arm/ArmSystem.py
+++ b/src/arch/arm/ArmSystem.py
@@ -86,6 +86,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_F64MM",  # Optional in Armv8.2
         "FEAT_I8MM",  # Optional in Armv8.2
         "FEAT_DOTPROD",  # Optional in Armv8.2
+        "FEAT_FP16",
         # Armv8.3
         "FEAT_FCMA",
         "FEAT_JSCVT",
@@ -196,6 +197,7 @@ class ArmDefaultRelease(Armv8):
         "FEAT_F64MM",
         "FEAT_I8MM",
         "FEAT_DOTPROD",
+        "FEAT_FP16",
         # Armv8.3
         "FEAT_FCMA",
         "FEAT_JSCVT",
@@ -241,6 +243,7 @@ class Armv82(Armv81):
         "FEAT_F64MM",
         "FEAT_I8MM",
         "FEAT_DOTPROD",
+        "FEAT_FP16",
     ]
 
 

--- a/src/arch/arm/insts/fplib.cc
+++ b/src/arch/arm/insts/fplib.cc
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2012-2013, 2017-2018, 2020 ARM Limited
+* Copyright (c) 2012-2013, 2017-2018, 2020, 2025 Arm Limited
 * Copyright (c) 2020 Metempsy Technology Consulting
 * All rights reserved
 *
@@ -4968,7 +4968,7 @@ fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding,
 {
     int flags = 0;
     uint16_t res = fp16_cvtf(op, fbits, u,
-                             (int)rounding | ((uint32_t)fpscr >> 22 & 12),
+                             (int)rounding | (modeConv(fpscr) & 0xFC),
                              &flags);
     set_fpscr0(fpscr, flags);
     return res;
@@ -4980,7 +4980,7 @@ fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding, FPSCR &fpscr
 {
     int flags = 0;
     uint32_t res = fp32_cvtf(op, fbits, u,
-                             (int)rounding | ((uint32_t)fpscr >> 22 & 12),
+                             (int)rounding | (modeConv(fpscr) & 0xFC),
                              &flags);
     set_fpscr0(fpscr, flags);
     return res;
@@ -4992,7 +4992,7 @@ fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding, FPSCR &fpscr
 {
     int flags = 0;
     uint64_t res = fp64_cvtf(op, fbits, u,
-                             (int)rounding | ((uint32_t)fpscr >> 22 & 12),
+                             (int)rounding | (modeConv(fpscr) & 0xFC),
                              &flags);
     set_fpscr0(fpscr, flags);
     return res;

--- a/src/arch/arm/insts/fplib.cc
+++ b/src/arch/arm/insts/fplib.cc
@@ -1400,6 +1400,67 @@ fp64_add(uint64_t a, uint64_t b, int neg, int mode, int *flags)
 }
 
 static uint16_t
+fp16_halved_add(uint16_t a, uint16_t b, int neg, int mode, int *flags)
+{
+    int a_sgn, a_exp, b_sgn, b_exp, x_sgn, x_exp;
+    uint16_t a_mnt, b_mnt, x, x_mnt;
+
+    fp16_unpack(&a_sgn, &a_exp, &a_mnt, a, mode, flags);
+    fp16_unpack(&b_sgn, &b_exp, &b_mnt, b, mode, flags);
+
+    if ((x = fp16_process_NaNs(a, b, mode, flags))) {
+        return x;
+    }
+
+    b_sgn ^= neg;
+
+    // Handle infinities and zeroes:
+    if (a_exp == FP16_EXP_INF && b_exp == FP16_EXP_INF && a_sgn != b_sgn) {
+        *flags |= FPLIB_IOC;
+        return fp16_defaultNaN();
+    } else if (a_exp == FP16_EXP_INF) {
+        return fp16_infinity(a_sgn);
+    } else if (b_exp == FP16_EXP_INF) {
+        return fp16_infinity(b_sgn);
+    } else if (!a_mnt && !b_mnt && a_sgn == b_sgn) {
+        return fp16_zero(a_sgn);
+    }
+
+    a_mnt <<= 3;
+    b_mnt <<= 3;
+    if (a_exp >= b_exp) {
+        b_mnt = (lsr16(b_mnt, a_exp - b_exp) |
+                 !!(b_mnt & (lsl16(1, a_exp - b_exp) - 1)));
+        b_exp = a_exp;
+    } else {
+        a_mnt = (lsr16(a_mnt, b_exp - a_exp) |
+                 !!(a_mnt & (lsl16(1, b_exp - a_exp) - 1)));
+        a_exp = b_exp;
+    }
+    x_sgn = a_sgn;
+    x_exp = a_exp;
+    if (a_sgn == b_sgn) {
+        x_mnt = a_mnt + b_mnt;
+    } else if (a_mnt >= b_mnt) {
+        x_mnt = a_mnt - b_mnt;
+    } else {
+        x_sgn ^= 1;
+        x_mnt = b_mnt - a_mnt;
+    }
+
+    if (!x_mnt) {
+        // Sign of exact zero result depends on rounding mode
+        return fp16_zero((mode & 3) == 2);
+    }
+
+    x_exp -= 1; // halved
+    x_mnt = fp16_normalise(x_mnt, &x_exp);
+
+    return fp16_round(x_sgn, x_exp + FP16_EXP_BITS - 3, x_mnt << 1,
+                      mode, flags);
+}
+
+static uint16_t
 fp16_mul(uint16_t a, uint16_t b, int mode, int *flags)
 {
     int a_sgn, a_exp, b_sgn, b_exp, x_sgn, x_exp;
@@ -5038,6 +5099,64 @@ uint64_t
 fplibDefaultNaN()
 {
     return fp64_defaultNaN();
+}
+
+
+template <>
+uint16_t
+fplib32RSqrtStep(uint16_t op1, uint16_t op2, FPSCR &fpscr)
+{
+    int mode = modeConv(fpscr);
+    int flags = 0;
+    int sgn1, exp1, sgn2, exp2;
+    uint16_t mnt1, mnt2, result;
+
+    fp16_unpack(&sgn1, &exp1, &mnt1, op1, mode, &flags);
+    fp16_unpack(&sgn2, &exp2, &mnt2, op2, mode, &flags);
+
+    result = fp16_process_NaNs(op1, op2, mode, &flags);
+    if (!result) {
+        if ((exp1 == FP16_EXP_INF && !mnt2) ||
+            (exp2 == FP16_EXP_INF && !mnt1)) {
+            result = fp16_FPOnePointFive(0);
+        } else {
+            uint16_t product = fp16_mul(op1, op2, mode, &flags);
+            result = fp16_halved_add(fp16_FPThree(0), product, 1, mode,
+                                     &flags);
+        }
+    }
+
+    set_fpscr0(fpscr, flags);
+
+    return result;
+}
+
+template <>
+uint16_t
+fplib32RecipStep(uint16_t op1, uint16_t op2, FPSCR &fpscr)
+{
+    int mode = modeConv(fpscr);
+    int flags = 0;
+    int sgn1, exp1, sgn2, exp2;
+    uint16_t mnt1, mnt2, result;
+
+    fp16_unpack(&sgn1, &exp1, &mnt1, op1, mode, &flags);
+    fp16_unpack(&sgn2, &exp2, &mnt2, op2, mode, &flags);
+
+    result = fp16_process_NaNs(op1, op2, mode, &flags);
+    if (!result) {
+        if ((exp1 == FP16_EXP_INF && !mnt2) ||
+            (exp2 == FP16_EXP_INF && !mnt1)) {
+            result = fp16_FPTwo(0);
+        } else {
+            uint16_t product = fp16_mul(op1, op2, mode, &flags);
+            result = fp16_add(fp16_FPTwo(0), product, 1, mode, &flags);
+        }
+    }
+
+    set_fpscr0(fpscr, flags);
+
+    return result;
 }
 
 } // namespace ArmISA

--- a/src/arch/arm/insts/fplib.hh
+++ b/src/arch/arm/insts/fplib.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013, 2017-2018 ARM Limited
+ * Copyright (c) 2012-2013, 2017-2018, 2024-2025 ARM Limited
  * Copyright (c) 2020 Metempsy Technology Consulting
  * All rights reserved
  *
@@ -178,6 +178,11 @@ template <class T>
 T fplibDefaultNaN();
 /** Floating-point  JS convert to a signed integer, with rounding to zero. */
 uint32_t fplibFPToFixedJS(uint64_t op, FPSCR &fpscr, bool Is64, uint8_t &nz);
+
+template <class T>
+T fplib32RSqrtStep(T op1, T op2, FPSCR &fpscr);
+template <class T>
+T fplib32RecipStep(T op1, T op2, FPSCR &fpscr);
 
 /* Function specializations... */
 template <>
@@ -417,6 +422,11 @@ template <>
 uint32_t fplibDefaultNaN();
 template <>
 uint64_t fplibDefaultNaN();
+
+template <>
+uint16_t fplib32RSqrtStep(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+template <>
+uint16_t fplib32RecipStep(uint16_t op1, uint16_t op2, FPSCR &fpscr);
 
 } // namespace ArmISA
 } // namespace gem5

--- a/src/arch/arm/isa/decoder/thumb.isa
+++ b/src/arch/arm/isa/decoder/thumb.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2010-2012 ARM Limited
+// Copyright (c) 2010-2012, 2024, 2025 ARM Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -142,12 +142,13 @@ decode BIGTHUMB {
             default: decode HTOPCODE_9_8 {
                 0x2: decode LTOPCODE_4 {
                     0x0: decode LTCOPROC {
-                        0x8: Thumb32NeonSIMD::thumb32NeonSIMD();
+                        0x8, 0xc, 0xd: Thumb32NeonSIMD::thumb32NeonSIMD();
                         0xa, 0xb: VfpData::vfpData();
                         default: WarnUnimpl::cdp(); // cdp2
                     }
                     0x1: decode LTCOPROC {
                         0x1: Gem5Op::gem5op();
+                        0x8, 0xc, 0xd: Thumb32NeonSIMD::Thumb32NeonSIMD();
                         0xa, 0xb: ShortFpTransfer::shortFpTransfer();
                         0xe: McrMrc14::mcrMrc14();
                         0xf: McrMrc15::mcrMrc15();

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024 Arm Limited
+// Copyright (c) 2011-2025 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -2708,6 +2708,10 @@ namespace Aarch64
                 return new FcvtWUIntFpD(machInst, rd, rn);
               case 3: // UCVTF Dd = convertFromInt(Xn)
                 return new FcvtXUIntFpD(machInst, rd, rn);
+              case 6: // UCVTF Hd = convertFromInt(Wn)
+                return new FcvtWUIntFpH(machInst, rd, rn);
+              case 7: // UCVTF Hd = convertFromInt(Xn)
+                return new FcvtXUIntFpH(machInst, rd, rn);
               default:
                 return new Unknown64(machInst);
             }
@@ -2931,12 +2935,11 @@ namespace Aarch64
         if (bits(machInst, 31) ||
                 bits(machInst, 29) ||
                 bits(machInst, 15, 14) ||
-                bits(machInst, 23) ||
                 bits(machInst, 2, 0)) {
             return new Unknown64(machInst);
         }
         uint8_t switchVal = (bits(machInst, 4, 3) << 0) |
-                            (bits(machInst, 22) << 2);
+                            (bits(machInst, 23, 22) << 2);
         RegIndex rn = (RegIndex)(uint32_t)bits(machInst, 9, 5);
         RegIndex rm = (RegIndex)(uint32_t)bits(machInst, 20, 16);
 
@@ -2966,6 +2969,18 @@ namespace Aarch64
           case 0x7:
             // FCMPE flags = compareSignaling(Dn,0.0)
             return new FCmpEImmD(machInst, rn, 0);
+          case 0xc:
+            // FCMP flags = compareQuiet(Hn,Hm)
+            return new FCmpRegH(machInst, rn, rm);
+          case 0xd:
+            // FCMP flags = compareQuiet(Hn,0.0)
+            return new FCmpImmH(machInst, rn, 0);
+          case 0xe:
+            // FCMPE flags = compareSignaling(Hn,Hm)
+            return new FCmpERegH(machInst, rn, rm);
+          case 0xf:
+            // FCMPE flags = compareSignaling(Hn,0.0)
+            return new FCmpEImmH(machInst, rn, 0);
           default:
             return new Unknown64(machInst);
         }
@@ -3159,6 +3174,24 @@ output decoder {{
         '0','0','X','X', // op2
         'X','X','X','0','X','X','X','X','1'>(); // op3
 
+    inline constexpr auto isAdvSIMDSc3SameFp16 = bitPatternMatcher<
+        MachInst,
+        31, 10,
+        '0','1','X','1', // op0
+        '1','1','1',
+        '0','X', // op1
+        '1','0','X','X', // op2
+        'X','X','X','0','0','X','X','X','1'>(); // op3
+
+    inline constexpr auto isAdvSIMDSc2RegMiscFp16 = bitPatternMatcher<
+        MachInst,
+        31, 10,
+        '0','1','X','1', // op0
+        '1','1','1',
+        '0','X', // op1
+        '1','1','1','1', // op2
+        '0','0','X','X','X','X','X','1','0'>(); // op3
+
     inline constexpr auto isAdvSIMDSc3SameExtra = bitPatternMatcher<
         MachInst,
         31, 10,
@@ -3257,6 +3290,24 @@ output decoder {{
         '0','0', // op1
         '0','0','X','X', // op2
         'X','X','X','0','X','X','X','X','1'>(); // op3
+
+    inline constexpr auto isAdvSIMD3SameFp16 = bitPatternMatcher<
+        MachInst,
+        31, 10,
+        '0','X','X','0', // op0
+        '1','1','1',
+        '0','X', // op1
+        '1','0','X','X', // op2
+        'X','X','X','0','0','X','X','X','1'>(); // op3
+
+    inline constexpr auto isAdvSIMD2RegMiscFp16 = bitPatternMatcher<
+        MachInst,
+        31, 10,
+        '0','X','X','0', // op0
+        '1','1','1',
+        '0','X', // op1
+        '1','1','1','1', // op2
+        '0','0','X','X','X','X','X','1','0'>(); // op3
 
     inline constexpr auto isAdvSIMD3RegExt = bitPatternMatcher<
         MachInst,
@@ -3424,6 +3475,8 @@ namespace Aarch64
         if (isCrypto3SHA(machInst)) return decodeCryptoThreeRegSHA(machInst);
         if (isCrypto2SHA(machInst)) return decodeCryptoTwoRegSHA(machInst);
         if (isAdvSIMDScCopy(machInst)) return decodeNeonScCopy(machInst);
+        if (isAdvSIMDSc3SameFp16(machInst)) return decodeNeonSc3SameFp16(machInst);
+        if (isAdvSIMDSc2RegMiscFp16(machInst)) return decodeNeonSc2RegMiscFp16(machInst);
         if (isAdvSIMDSc3SameExtra(machInst)) return decodeNeonSc3SameExtra(machInst);
         if (isAdvSIMDSc2RegMisc(machInst)) return decodeNeonSc2RegMisc(machInst);
         if (isAdvSIMDSc2Pwise(machInst)) return decodeNeonScPwise(machInst);
@@ -3435,6 +3488,8 @@ namespace Aarch64
         if (isAdvSIMDPermute(machInst)) return decodeNeonZipUzpTrn(machInst);
         if (isAdvSIMDExtract(machInst)) return decodeNeonExt(machInst);
         if (isAdvSIMDCopy(machInst)) return decodeNeonCopy(machInst);
+        if (isAdvSIMD3SameFp16(machInst)) return decodeNeon3SameFp16(machInst);
+        if (isAdvSIMD2RegMiscFp16(machInst)) return decodeNeon2RegMiscFp16(machInst);
         if (isAdvSIMD3RegExt(machInst)) return decodeNeon3RegExtension<DecoderFeatures>(machInst);
         if (isAdvSIMD2RegMisc(machInst)) return decodeNeon2RegMisc(machInst);
         if (isAdvSIMDAcrossLanes(machInst)) return decodeNeonAcrossLanes(machInst);

--- a/src/arch/arm/isa/formats/fp.isa
+++ b/src/arch/arm/isa/formats/fp.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2010-2011, 2016-2019, 2024 ARM Limited
+// Copyright (c) 2010-2011, 2016-2019, 2024-2025 ARM Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -340,6 +340,22 @@ let {{
     StaticInstPtr
     decodeAdvancedSIMD(ExtMachInst machInst)
     {
+        // VINS and VMOVX for FP16
+        if (bits(machInst, 31, 23) == 0x1FD && bits(machInst, 21, 16) == 0x30
+            && bits(machInst, 11, 8) == 0xa && bits(machInst, 6) == 1) {
+
+            RegIndex vd = decodeFpVd(machInst, 0x1, false);
+            RegIndex vm = decodeFpVm(machInst, 0x1, false);
+
+            if (bits(machInst, 7) == 0) {
+                // VMOVX
+                return new NVmovx<uint16_t>(machInst, vd, vm, 0);
+            } else {
+                // VINS
+                return new NVins<uint16_t>(machInst, vd, vm, 0);
+            }
+        }
+
         uint8_t op_code = (bits(machInst, 25) << 1)
                           | bits(machInst, 21);
 
@@ -676,18 +692,37 @@ let {{
                     return decodeNeonSThreeSReg<VqrdmlshD, VqrdmlshQ>(
                             q, size, machInst, vd, vn, vm);
                 } else {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new NVfmaQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new NVfmaDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new NVfmaQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new NVfmaDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new NVfmsQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new NVfmsDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new NVfmsQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new NVfmsDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 }
             } else {
@@ -723,103 +758,216 @@ let {{
           case 0xd:
             if (o1) {
                 if (u) {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new NVmulQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new NVmulDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new NVmulQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new NVmulDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
                         return new Unknown(machInst);
                     }
                 } else {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new NVmlaQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new NVmlaDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new NVmlaQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new NVmlaDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new NVmlsQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new NVmlsDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new NVmlsQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new NVmlsDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 }
             } else {
                 if (u) {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VpaddQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VpaddDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VpaddQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VpaddDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VabdQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VabdDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VabdQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VabdDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VaddQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VaddDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VaddQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VaddDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VsubQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VsubDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VsubQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VsubDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 }
             }
           case 0xe:
             if (o1) {
                 if (u) {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VacgeQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VacgeDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VacgeQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VacgeDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VacgtQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VacgtDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VacgtQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VacgtDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     return new Unknown(machInst);
                 }
             } else {
                 if (u) {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VcgeQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VcgeDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VcgeQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VcgeDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VcgtQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VcgtDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VcgtQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VcgtDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VceqQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VceqDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VceqQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VceqDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
                         return new Unknown(machInst);
                     }
                 }
@@ -827,7 +975,8 @@ let {{
           case 0xf:
             if (o1) {
                 if (u) {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VmaxnmQFp<uint32_t>(
                                 machInst, vd, vn, vm);
@@ -835,7 +984,15 @@ let {{
                             return new VmaxnmDFp<uint32_t>(
                                 machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VmaxnmQFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VmaxnmDFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VminnmQFp<uint32_t>(
                                 machInst, vd, vn, vm);
@@ -843,25 +1000,55 @@ let {{
                             return new VminnmDFp<uint32_t>(
                                 machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VminnmQFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VminnmDFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VrecpsQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VrecpsDFp<float>(machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VrecpsQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VrecpsDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VrsqrtsQFp<float>(machInst, vd, vn, vm);
                         } else {
                             return new VrsqrtsDFp<float>(machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VrsqrtsQFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VrsqrtsDFpH<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 }
             } else {
                 if (u) {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VpmaxQFp<uint32_t>(
                                 machInst, vd, vn, vm);
@@ -869,7 +1056,15 @@ let {{
                             return new VpmaxDFp<uint32_t>(
                                 machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VpmaxQFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VpmaxDFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VpminQFp<uint32_t>(
                                 machInst, vd, vn, vm);
@@ -877,9 +1072,20 @@ let {{
                             return new VpminDFp<uint32_t>(
                                 machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VpminQFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VpminDFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
-                    if (bits(size, 1) == 0) {
+                    switch (size) {
+                      case 0:
                         if (q) {
                             return new VmaxQFp<uint32_t>(
                                 machInst, vd, vn, vm);
@@ -887,7 +1093,15 @@ let {{
                             return new VmaxDFp<uint32_t>(
                                 machInst, vd, vn, vm);
                         }
-                    } else {
+                      case 1:
+                        if (q) {
+                            return new VmaxQFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VmaxDFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      case 2:
                         if (q) {
                             return new VminQFp<uint32_t>(
                                 machInst, vd, vn, vm);
@@ -895,6 +1109,16 @@ let {{
                             return new VminDFp<uint32_t>(
                                 machInst, vd, vn, vm);
                         }
+                      case 3:
+                        if (q) {
+                            return new VminQFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        } else {
+                            return new VminDFp<uint16_t>(
+                                machInst, vd, vn, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 }
             }
@@ -1111,6 +1335,54 @@ let {{
                 return decodeNeonUSTwoShiftSReg<NVmovl, NVshll>(
                         lShiftAmt, u, size, machInst, vd, vm, lShiftAmt);
             }
+          case 0xc:
+            if (l) {
+                return new Unknown(machInst);
+            } else {
+                if (bits(imm6, 5) == 0)
+                    return new Unknown(machInst);
+                if (u) {
+                    if (q) {
+                        return new NVcvtu2fpHQ<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    } else {
+                        return new NVcvtu2fpHD<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    }
+                } else {
+                    if (q) {
+                        return new NVcvts2fpHQ<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    } else {
+                        return new NVcvts2fpHD<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    }
+                }
+            }
+          case 0xd:
+            if (l) {
+                return new Unknown(machInst);
+            } else {
+                if (bits(imm6, 5) == 0)
+                    return new Unknown(machInst);
+                if (u) {
+                    if (q) {
+                        return new NVcvt2ufxHQ<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    } else {
+                        return new NVcvt2ufxHD<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    }
+                } else {
+                    if (q) {
+                        return new NVcvt2sfxHQ<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    } else {
+                        return new NVcvt2sfxHD<uint16_t>(
+                                machInst, vd, vm, 64 - imm6);
+                    }
+                }
+            }
           case 0xe:
             if (l) {
                 return new Unknown(machInst);
@@ -1294,10 +1566,27 @@ let {{
                 }
             }
           case 0x1:
-            if (u)
-                return new VmlasQFp<float>(machInst, vd, vn, vm, index);
-            else
-                return new VmlasDFp<float>(machInst, vd, vn, vm, index);
+            if (u) {
+                switch (size) {
+                  case 1:
+                    return new VmlasQFpH<uint16_t>(
+                        machInst, vd, vn, vm, index);
+                  case 2:
+                    return new VmlasQFp<float>(machInst, vd, vn, vm, index);
+                  default:
+                    return new Unknown(machInst);
+                }
+            } else {
+                switch (size) {
+                  case 1:
+                    return new VmlasDFpH<uint16_t>(
+                        machInst, vd, vn, vm, index);
+                  case 2:
+                    return new VmlasDFp<float>(machInst, vd, vn, vm, index);
+                  default:
+                    return new Unknown(machInst);
+                }
+            }
           case 0x4:
             if (u) {
                 switch (size) {
@@ -1319,10 +1608,27 @@ let {{
                 }
             }
           case 0x5:
-            if (u)
-                return new VmlssQFp<float>(machInst, vd, vn, vm, index);
-            else
-                return new VmlssDFp<float>(machInst, vd, vn, vm, index);
+            if (u) {
+                switch (size) {
+                  case 1:
+                    return new VmlssQFpH<uint16_t>(
+                        machInst, vd, vn, vm, index);
+                  case 2:
+                    return new VmlssQFp<float>(machInst, vd, vn, vm, index);
+                  default:
+                    return new Unknown(machInst);
+                }
+            } else {
+                switch (size) {
+                  case 1:
+                    return new VmlssDFpH<uint16_t>(
+                        machInst, vd, vn, vm, index);
+                  case 2:
+                    return new VmlssDFp<float>(machInst, vd, vn, vm, index);
+                  default:
+                    return new Unknown(machInst);
+                }
+            }
           case 0x2:
             if (u) {
                 switch (size) {
@@ -1410,10 +1716,27 @@ let {{
                 }
             }
           case 0x9:
-            if (u)
-                return new VmulsQFp<float>(machInst, vd, vn, vm, index);
-            else
-                return new VmulsDFp<float>(machInst, vd, vn, vm, index);
+            if (u) {
+                switch (size) {
+                  case 1:
+                    return new VmulsQFpH<uint16_t>(
+                        machInst, vd, vn, vm, index);
+                  case 2:
+                    return new VmulsQFp<float>(machInst, vd, vn, vm, index);
+                  default:
+                    return new Unknown(machInst);
+                }
+            } else {
+                switch (size) {
+                  case 1:
+                    return new VmulsDFpH<uint16_t>(
+                        machInst, vd, vn, vm, index);
+                  case 2:
+                    return new VmulsDFp<float>(machInst, vd, vn, vm, index);
+                  default:
+                    return new Unknown(machInst);
+                }
+            }
           case 0xa:
             if (u) {
                 switch (size) {
@@ -1677,10 +2000,21 @@ let {{
             switch (bits(b, 3, 1)) {
               case 0x0:
                 if (bits(b, 4)) {
-                    if (q) {
-                        return new NVcgtQFp<float>(machInst, vd, vm);
-                    } else {
-                        return new NVcgtDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q) {
+                            return new NVcgtQFpH<uint16_t>(machInst, vd, vm);
+                        } else {
+                            return new NVcgtDFpH<uint16_t>(machInst, vd, vm);
+                        }
+                      case 2:
+                        if (q) {
+                            return new NVcgtQFp<float>(machInst, vd, vm);
+                        } else {
+                            return new NVcgtDFp<float>(machInst, vd, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     return decodeNeonSTwoMiscReg<NVcgtD, NVcgtQ>(
@@ -1688,10 +2022,21 @@ let {{
                 }
               case 0x1:
                 if (bits(b, 4)) {
-                    if (q) {
-                        return new NVcgeQFp<float>(machInst, vd, vm);
-                    } else {
-                        return new NVcgeDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q) {
+                            return new NVcgeQFpH<uint16_t>(machInst, vd, vm);
+                        } else {
+                            return new NVcgeDFpH<uint16_t>(machInst, vd, vm);
+                        }
+                      case 2:
+                        if (q) {
+                            return new NVcgeQFp<float>(machInst, vd, vm);
+                        } else {
+                            return new NVcgeDFp<float>(machInst, vd, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     return decodeNeonSTwoMiscReg<NVcgeD, NVcgeQ>(
@@ -1699,10 +2044,21 @@ let {{
                 }
               case 0x2:
                 if (bits(b, 4)) {
-                    if (q) {
-                        return new NVceqQFp<float>(machInst, vd, vm);
-                    } else {
-                        return new NVceqDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q) {
+                            return new NVceqQFpH<uint16_t>(machInst, vd, vm);
+                        } else {
+                            return new NVceqDFpH<uint16_t>(machInst, vd, vm);
+                        }
+                      case 2:
+                        if (q) {
+                            return new NVceqQFp<float>(machInst, vd, vm);
+                        } else {
+                            return new NVceqDFp<float>(machInst, vd, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     return decodeNeonSTwoMiscReg<NVceqD, NVceqQ>(
@@ -1710,10 +2066,21 @@ let {{
                 }
               case 0x3:
                 if (bits(b, 4)) {
-                    if (q) {
-                        return new NVcleQFp<float>(machInst, vd, vm);
-                    } else {
-                        return new NVcleDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q) {
+                            return new NVcleQFpH<uint16_t>(machInst, vd, vm);
+                        } else {
+                            return new NVcleDFpH<uint16_t>(machInst, vd, vm);
+                        }
+                      case 2:
+                        if (q) {
+                            return new NVcleQFp<float>(machInst, vd, vm);
+                        } else {
+                            return new NVcleDFp<float>(machInst, vd, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     return decodeNeonSTwoMiscReg<NVcleD, NVcleQ>(
@@ -1721,10 +2088,21 @@ let {{
                 }
               case 0x4:
                 if (bits(b, 4)) {
-                    if (q) {
-                        return new NVcltQFp<float>(machInst, vd, vm);
-                    } else {
-                        return new NVcltDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q) {
+                            return new NVcltQFpH<uint16_t>(machInst, vd, vm);
+                        } else {
+                            return new NVcltDFpH<uint16_t>(machInst, vd, vm);
+                        }
+                      case 2:
+                        if (q) {
+                            return new NVcltQFp<float>(machInst, vd, vm);
+                        } else {
+                            return new NVcltDFp<float>(machInst, vd, vm);
+                        }
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     return decodeNeonSTwoMiscReg<NVcltD, NVcltQ>(
@@ -1738,26 +2116,46 @@ let {{
                 }
               case 0x6:
                 if (bits(machInst, 10)) {
-                    if (q)
-                        return new NVabsQFp<float>(machInst, vd, vm);
-                    else
-                        return new NVabsDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q)
+                            return new NVabsQFpH<uint16_t>(machInst, vd, vm);
+                        else
+                            return new NVabsDFpH<uint16_t>(machInst, vd, vm);
+                      case 2:
+                        if (q)
+                            return new NVabsQFp<float>(machInst, vd, vm);
+                        else
+                            return new NVabsDFp<float>(machInst, vd, vm);
+                      default:
+                        return new Unknown(machInst);
+                    }
                 } else {
                     return decodeNeonSTwoMiscReg<NVabsD, NVabsQ>(
                             q, size, machInst, vd, vm);
                 }
               case 0x7:
                 if (bits(machInst, 10)) {
-                    if (q)
-                        return new NVnegQFp<float>(machInst, vd, vm);
-                    else
-                        return new NVnegDFp<float>(machInst, vd, vm);
+                    switch (size) {
+                      case 1:
+                        if (q)
+                            return new NVnegQFpH<uint16_t>(machInst, vd, vm);
+                        else
+                            return new NVnegDFpH<uint16_t>(machInst, vd, vm);
+                      case 2:
+                        if (q)
+                            return new NVnegQFp<float>(machInst, vd, vm);
+                        else
+                            return new NVnegDFp<float>(machInst, vd, vm);
+                      default:
+                        return new Unknown(machInst);
+                    }
                 } else {
                     return decodeNeonSTwoMiscReg<NVnegD, NVnegQ>(
                             q, size, machInst, vd, vm);
                 }
               default:
-                return new Unknown64(machInst);
+                return new Unknown(machInst);
             }
           case 0x2:
             switch (bits(b, 4, 1)) {
@@ -1819,7 +2217,7 @@ let {{
                         return new NVrintnspD<uint32_t>(machInst, vd, vm);
                     }
                   default:
-                    return new Unknown64(machInst);
+                    return new Unknown(machInst);
                 }
               case 0x9:
                 switch (size) {
@@ -1836,7 +2234,7 @@ let {{
                         return new NVrintxspD<uint32_t>(machInst, vd, vm);
                     }
                   default:
-                    return new Unknown64(machInst);
+                    return new Unknown(machInst);
                 }
               case 0xa:
                 switch (size) {
@@ -1853,7 +2251,7 @@ let {{
                         return new NVrintaspD<uint32_t>(machInst, vd, vm);
                     }
                   default:
-                    return new Unknown64(machInst);
+                    return new Unknown(machInst);
                 }
               case 0xb:
                 switch (size) {
@@ -1870,7 +2268,7 @@ let {{
                         return new NVrintzspD<uint32_t>(machInst, vd, vm);
                     }
                   default:
-                    return new Unknown64(machInst);
+                    return new Unknown(machInst);
                 }
               case 0xd:
                 switch (size) {
@@ -1887,7 +2285,7 @@ let {{
                         return new NVrintmspD<uint32_t>(machInst, vd, vm);
                     }
                   default:
-                    return new Unknown64(machInst);
+                    return new Unknown(machInst);
                 }
               case 0xf:
                 switch (size) {
@@ -1904,7 +2302,7 @@ let {{
                         return new NVrintpspD<uint32_t>(machInst, vd, vm);
                     }
                   default:
-                    return new Unknown64(machInst);
+                    return new Unknown(machInst);
                 }
               case 0xc:
               case 0xe:
@@ -1924,9 +2322,47 @@ let {{
             }
           case 0x3:
             if (bits(b, 4, 3) == 0x3) {
-                if ((q && (vd % 2 || vm % 2)) || size != 2) {
+                if ((q && (vd % 2 || vm % 2)) || (size != 2 && size != 1)) {
                     return new Unknown(machInst);
-                } else {
+                } else if (size == 1) {
+                    if (bits(b, 2)) {
+                        if (bits(b, 1)) {
+                            if (q) {
+                                return new NVcvt2ufxHQ<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            } else {
+                                return new NVcvt2ufxHD<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            }
+                        } else {
+                            if (q) {
+                                return new NVcvt2sfxHQ<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            } else {
+                                return new NVcvt2sfxHD<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            }
+                        }
+                    } else {
+                        if (bits(b, 1)) {
+                            if (q) {
+                                return new NVcvtu2fpHQ<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            } else {
+                                return new NVcvtu2fpHD<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            }
+                        } else {
+                            if (q) {
+                                return new NVcvts2fpHQ<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            } else {
+                                return new NVcvts2fpHD<uint16_t>(
+                                        machInst, vd, vm, 0);
+                            }
+                        }
+                    }
+                } else if (size == 2) {
                     if (bits(b, 2)) {
                         if (bits(b, 1)) {
                             if (q) {
@@ -1968,9 +2404,23 @@ let {{
             } else if ((b & 0x1a) == 0x10) {
                 if (bits(b, 2)) {
                     if (q) {
-                        return new NVrecpeQFp<float>(machInst, vd, vm);
+                        switch (size) {
+                          case 1:
+                            return new NVrecpeQFpH<uint16_t>(machInst, vd, vm);
+                          case 2:
+                            return new NVrecpeQFp<float>(machInst, vd, vm);
+                          default:
+                            return new Unknown(machInst);
+                        }
                     } else {
-                        return new NVrecpeDFp<float>(machInst, vd, vm);
+                        switch (size) {
+                          case 1:
+                            return new NVrecpeDFpH<uint16_t>(machInst, vd, vm);
+                          case 2:
+                            return new NVrecpeDFp<float>(machInst, vd, vm);
+                          default:
+                            return new Unknown(machInst);
+                        }
                     }
                 } else {
                     if (q) {
@@ -1982,9 +2432,19 @@ let {{
             } else if ((b & 0x1a) == 0x12) {
                 if (bits(b, 2)) {
                     if (q) {
-                        return new NVrsqrteQFp<float>(machInst, vd, vm);
+                        if (size == 1) {
+                            return new NVrsqrteQFpH<uint16_t>(
+                                machInst, vd, vm);
+                        } else {
+                            return new NVrsqrteQFp<float>(machInst, vd, vm);
+                        }
                     } else {
-                        return new NVrsqrteDFp<float>(machInst, vd, vm);
+                        if (size == 1) {
+                            return new NVrsqrteDFpH<uint16_t>(
+                                machInst, vd, vm);
+                        } else {
+                            return new NVrsqrteDFp<float>(machInst, vd, vm);
+                        }
                     }
                 } else {
                     if (q) {
@@ -2507,38 +2967,56 @@ let {{
                     {
                 const uint32_t o1 = bits(machInst, 18);
                 if (o1 == 0) {
-                    if (size == 3) {
+                    switch (size) {
+                      case 1:
                         switch(rm) {
-                            case 0x0:
-                            return decodeVfpRegRegOp<VRIntAD>(machInst, vd, vm,
-                                                                true);
-                            case 0x1:
-                            return decodeVfpRegRegOp<VRIntND>(machInst, vd, vm,
-                                                                true);
-                            case 0x2:
-                            return decodeVfpRegRegOp<VRIntPD>(machInst, vd, vm,
-                                                                true);
-                            case 0x3:
-                            return decodeVfpRegRegOp<VRIntMD>(machInst, vd, vm,
-                                                                true);
-                            default: return new Unknown(machInst);
+                          case 0x0:
+                            return decodeVfpRegRegOp<VRIntAH>(machInst, vd, vm,
+                                                                false);
+                          case 0x1:
+                            return decodeVfpRegRegOp<VRIntNH>(machInst, vd, vm,
+                                                                false);
+                          case 0x2:
+                            return decodeVfpRegRegOp<VRIntPH>(machInst, vd, vm,
+                                                                false);
+                          case 0x3:
+                            return decodeVfpRegRegOp<VRIntMH>(machInst, vd, vm,
+                                                                false);
+                          default: return new Unknown(machInst);
                         }
-                    } else {
+                      case 2:
                         switch(rm) {
-                            case 0x0:
+                          case 0x0:
                             return decodeVfpRegRegOp<VRIntAS>(machInst, vd, vm,
                                                                 false);
-                            case 0x1:
+                          case 0x1:
                             return decodeVfpRegRegOp<VRIntNS>(machInst, vd, vm,
                                                                 false);
-                            case 0x2:
+                          case 0x2:
                             return decodeVfpRegRegOp<VRIntPS>(machInst, vd, vm,
                                                                 false);
-                            case 0x3:
+                          case 0x3:
                             return decodeVfpRegRegOp<VRIntMS>(machInst, vd, vm,
                                                                 false);
-                            default: return new Unknown(machInst);
+                          default: return new Unknown(machInst);
                         }
+                      case 3:
+                        switch(rm) {
+                          case 0x0:
+                            return decodeVfpRegRegOp<VRIntAD>(machInst, vd, vm,
+                                                                true);
+                          case 0x1:
+                            return decodeVfpRegRegOp<VRIntND>(machInst, vd, vm,
+                                                                true);
+                          case 0x2:
+                            return decodeVfpRegRegOp<VRIntPD>(machInst, vd, vm,
+                                                                true);
+                          case 0x3:
+                            return decodeVfpRegRegOp<VRIntMD>(machInst, vd, vm,
+                                                                true);
+                          default: return new Unknown(machInst);
+                        }
+                      default: return new Unknown(machInst);
                     }
                 } else {
                     const bool op = bits(machInst, 7);
@@ -2844,10 +3322,27 @@ let {{
     StaticInstPtr
     decodeVfpData(ExtMachInst machInst)
     {
+        // VINS and VMOVX for FP16
+        if (bits(machInst, 31, 23) == 0x1FD && bits(machInst, 21, 16) == 0x30
+            && bits(machInst, 11, 8) == 0xa && bits(machInst, 6) == 1) {
+
+            RegIndex vd = decodeFpVd(machInst, 0x1, false);
+            RegIndex vm = decodeFpVm(machInst, 0x1, false);
+
+            if (bits(machInst, 7) == 0) {
+                // VMOVX
+                return new NVmovx<uint16_t>(machInst, vd, vm, 0);
+            } else {
+                // VINS
+                return new NVins<uint16_t>(machInst, vd, vm, 0);
+            }
+        }
+
         const uint32_t opc1 = bits(machInst, 23, 20);
         const uint32_t opc2 = bits(machInst, 19, 16);
         const uint32_t opc3 = bits(machInst, 7, 6);
         //const uint32_t opc4 = bits(machInst, 3, 0);
+        const uint32_t size = bits(machInst, 9, 8);
         const bool single = (bits(machInst, 8) == 0);
         // Used to select between vcmp and vcmpe.
         const bool e = (bits(machInst, 7) == 1);
@@ -3033,22 +3528,34 @@ let {{
                                 machInst, vd, vm, true);
                     }
                 } else {
-                    if (single) {
+                    switch (size) {
+                      case 1:
+                        return decodeVfpRegRegOp<VabsH>(
+                                machInst, vd, vm, false);
+                      case 2:
                         return decodeVfpRegRegOp<VabsS>(
                                 machInst, vd, vm, false);
-                    } else {
+                      case 3:
                         return decodeVfpRegRegOp<VabsD>(
                                 machInst, vd, vm, true);
+                      default:
+                        return new Unknown(machInst);
                     }
                 }
               case 0x1:
                 if (opc3 == 1) {
-                    if (single) {
+                    switch (size) {
+                      case 1:
+                        return decodeVfpRegRegOp<VnegH>(
+                                machInst, vd, vm, false);
+                      case 2:
                         return decodeVfpRegRegOp<VnegS>(
                                 machInst, vd, vm, false);
-                    } else {
+                      case 3:
                         return decodeVfpRegRegOp<VnegD>(
                                 machInst, vd, vm, true);
+                      default:
+                        return new Unknown(machInst);
                     }
                 } else {
                     if (single) {

--- a/src/arch/arm/isa/formats/fp.isa
+++ b/src/arch/arm/isa/formats/fp.isa
@@ -356,77 +356,221 @@ let {{
             }
         }
 
-        uint8_t op_code = (bits(machInst, 25) << 1)
-                          | bits(machInst, 21);
-
+        uint8_t bit_31_24 = bits(machInst, 31, 24);
+        uint8_t bit_11_8 = bits(machInst, 11, 8);
+        uint8_t op1_op2 = (bits(machInst, 23) << 2)
+                          | bits(machInst, 21, 20);
+        bool q = bits(machInst, 6);
+        bool u = bits(machInst, 4);
         RegIndex vd = (RegIndex)(2 * (bits(machInst, 15, 12) |
-                               (bits(machInst, 22) << 4)));
+                              (bits(machInst, 22) << 4)));
         RegIndex vn = (RegIndex)(2 * (bits(machInst, 19, 16) |
-                               (bits(machInst, 7) << 4)));
+                              (bits(machInst, 7) << 4)));
         RegIndex vm = (RegIndex)(2 * (bits(machInst, 3, 0) |
-                               (bits(machInst, 5) << 4)));
-        bool q = bits (machInst, 6);
-        switch (op_code) {
-          case 0x0:
-          {
-            // VCADD
-            bool s = bits (machInst, 20);
-            if (s) {
-               if (q)
-                   return new VcaddQ<uint32_t>(machInst, vd, vn, vm);
-               else
-                   return new VcaddD<uint32_t>(machInst, vd, vn, vm);
-            } else {
-               if (q)
-                   return new VcaddQ<uint16_t>(machInst, vd, vn, vm);
-               else
-                   return new VcaddD<uint16_t>(machInst, vd, vn, vm);
+                              (bits(machInst, 5) << 4)));
+
+        if (bit_31_24 == 0xFC && bit_11_8 == 0x8) {
+            switch (op1_op2) {
+              case 2: case 3: case 6: case 7:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    // VCMLA
+                    bool s = bits (machInst, 20);
+                    if (s) {
+                      if (q)
+                          return new VcmlaQ<uint32_t>(machInst, vd, vn, vm);
+                      else
+                          return new VcmlaD<uint32_t>(machInst, vd, vn, vm);
+                    } else {
+                      if (q)
+                          return new VcmlaQ<uint16_t>(machInst, vd, vn, vm);
+                      else
+                          return new VcmlaD<uint16_t>(machInst, vd, vn, vm);
+                    }
+                }
+              case 4: case 5:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    bool s = bits (machInst, 20);
+                    if (s) {
+                        if (q)
+                            return new VcaddQ<uint32_t>(machInst, vd, vn, vm);
+                        else
+                            return new VcaddD<uint32_t>(machInst, vd, vn, vm);
+                    } else {
+                        if (q)
+                            return new VcaddQ<uint16_t>(machInst, vd, vn, vm);
+                        else
+                            return new VcaddD<uint16_t>(machInst, vd, vn, vm);
+                    }
+                }
+              default:
+                return new Unknown64(machInst);
             }
-          }
-          case 0x1:
-          {
-            // VCMLA
-            bool s = bits (machInst, 20);
-            if (s) {
-               if (q)
-                   return new VcmlaQ<uint32_t>(machInst, vd, vn, vm);
-               else
-                   return new VcmlaD<uint32_t>(machInst, vd, vn, vm);
-            } else {
-               if (q)
-                   return new VcmlaQ<uint16_t>(machInst, vd, vn, vm);
-               else
-                   return new VcmlaD<uint16_t>(machInst, vd, vn, vm);
+        } else if (bit_31_24 == 0xFC && bit_11_8 == 0xc) {
+            switch (op1_op2) {
+              case 2:
+                if (u) {
+                    if (q)
+                        return new VummlaQ<uint32_t>(machInst, vd, vn, vm);
+                    else
+                        return new Unknown64(machInst);
+                } else {
+                    if (q)
+                        return new VsmmlaQ<int32_t>(machInst, vd, vn, vm);
+                    else
+                        return new Unknown64(machInst);
+                }
+              case 6:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    if (q)
+                        return new VusmmlaQ<int32_t>(machInst, vd, vn, vm);
+                    else
+                        return new Unknown64(machInst);
+                }
+              default:
+                return new Unknown64(machInst);
             }
-          }
-          case 0x2:
-          case 0x3:
-          {
-            // VCMLA by element
-            bool s = bits (machInst, 23);
-            if (s) {
-               uint8_t index_fp = 0;
-               if (q)
-                   return new VcmlaElemQ<uint32_t>(machInst, vd, vn, vm,
-                                                   index_fp);
-               else
-                   return new VcmlaElemD<uint32_t>(machInst, vd, vn, vm,
-                                                   index_fp);
-            } else {
-               vm = (RegIndex)(uint8_t)(2* bits(machInst, 3, 0));
-               uint8_t index_fp = bits(machInst, 5);
-               if (q)
-                   return new VcmlaElemQ<uint16_t>(machInst, vd, vn, vm,
-                                                   index_fp);
-               else
-                   return new VcmlaElemD<uint16_t>(machInst, vd, vn, vm,
-                                                   index_fp);
+        } else if (bit_31_24 == 0xFC && bit_11_8 == 0xd) {
+            switch (op1_op2) {
+              case 2:
+                if (u) {
+                    if (q)
+                        return new VudotQ<uint32_t>(machInst, vd, vn, vm);
+                    else
+                        return new VudotD<uint32_t>(machInst, vd, vn, vm);
+                } else {
+                    if (q)
+                        return new VsdotQ<int32_t>(machInst, vd, vn, vm);
+                    else
+                        return new VsdotD<int32_t>(machInst, vd, vn, vm);
+                }
+              case 6:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    if (q)
+                        return new VusdotQ<int32_t>(machInst, vd, vn, vm);
+                    else
+                        return new VusdotD<int32_t>(machInst, vd, vn, vm);
+                }
+              default:
+                return new Unknown64(machInst);
             }
-          }
-          default:
+        } else if (bit_31_24 == 0xFD && bit_11_8 == 0x8) {
+            switch (op1_op2) {
+              case 2: case 3: case 6: case 7:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    // VCMLA
+                    bool s = bits (machInst, 20);
+                    if (s) {
+                      if (q)
+                          return new VcmlaQ<uint32_t>(machInst, vd, vn, vm);
+                      else
+                          return new VcmlaD<uint32_t>(machInst, vd, vn, vm);
+                    } else {
+                      if (q)
+                          return new VcmlaQ<uint16_t>(machInst, vd, vn, vm);
+                      else
+                          return new VcmlaD<uint16_t>(machInst, vd, vn, vm);
+                    }
+                }
+              case 4: case 5:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    bool s = bits (machInst, 20);
+                    if (s) {
+                        if (q)
+                            return new VcaddQ<uint32_t>(machInst, vd, vn, vm);
+                        else
+                            return new VcaddD<uint32_t>(machInst, vd, vn, vm);
+                    } else {
+                        if (q)
+                            return new VcaddQ<uint16_t>(machInst, vd, vn, vm);
+                        else
+                            return new VcaddD<uint16_t>(machInst, vd, vn, vm);
+                    }
+                }
+              default:
+                return new Unknown64(machInst);
+            }
+        } else if (bit_31_24 == 0xFE && bit_11_8 == 0x8) {
+            vm = (RegIndex)(2 * bits(machInst, 2, 0));
+
+            if (u) {
+                return new Unknown64(machInst);
+            } else {
+                // VCMLA by element
+                bool s = bits (machInst, 23);
+                if (s) {
+                    uint8_t index_fp = 0;
+                    if (q)
+                        return new VcmlaElemQ<uint32_t>(machInst, vd, vn, vm,
+                                                        index_fp);
+                    else
+                        return new VcmlaElemD<uint32_t>(machInst, vd, vn, vm,
+                                                        index_fp);
+                } else {
+                    vm = (RegIndex)(uint8_t)(2* bits(machInst, 3, 0));
+                    uint8_t index_fp = bits(machInst, 5);
+                    if (q)
+                        return new VcmlaElemQ<uint16_t>(machInst, vd, vn, vm,
+                                                        index_fp);
+                    else
+                        return new VcmlaElemD<uint16_t>(machInst, vd, vn, vm,
+                                                        index_fp);
+                }
+            }
+        } else if (bit_31_24 == 0xFE && bit_11_8 == 0xd) {
+            vm = (RegIndex)(2 * bits(machInst, 3, 0));
+            uint8_t index = bits(machInst, 5);
+
+            switch (op1_op2) {
+              case 2:
+                if (u) {
+                    if (q)
+                        return new VudotElemQ<uint32_t>(
+                            machInst, vd, vn, vm, index);
+                    else
+                        return new VudotElemD<uint32_t>(
+                            machInst, vd, vn, vm, index);
+                } else {
+                    if (q)
+                        return new VsdotElemQ<int32_t>(
+                            machInst, vd, vn, vm, index);
+                    else
+                        return new VsdotElemD<int32_t>(
+                            machInst, vd, vn, vm, index);
+                }
+              case 4:
+                if (u) {
+                    if (q)
+                        return new VsudotElemQ<int32_t>(
+                            machInst, vd, vn, vm, index);
+                    else
+                        return new VsudotElemD<int32_t>(
+                            machInst, vd, vn, vm, index);
+                } else {
+                    if (q)
+                        return new VusdotElemQ<int32_t>(
+                            machInst, vd, vn, vm, index);
+                    else
+                        return new VusdotElemD<int32_t>(
+                            machInst, vd, vn, vm, index);
+                }
+              default:
+                return new Unknown64(machInst);
+            }
+        } else {
             return new Unknown64(machInst);
         }
-
     }
     '''
 

--- a/src/arch/arm/isa/formats/neon64.isa
+++ b/src/arch/arm/isa/formats/neon64.isa
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2013, 2020 ARM Limited
+// Copyright (c) 2012-2013, 2020, 2025 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -39,6 +39,8 @@ namespace Aarch64
     // AdvSIMD three same
     template <typename DecoderFeatures>
     StaticInstPtr decodeNeon3Same(ExtMachInst machInst);
+    // AdvSIMD three same FP16
+    StaticInstPtr decodeNeon3SameFp16(ExtMachInst machInst);
     // AdvSIMD three register extension
     template <typename DecoderFeatures>
     StaticInstPtr decodeNeon3RegExtension(ExtMachInst machInst);
@@ -46,6 +48,8 @@ namespace Aarch64
     inline StaticInstPtr decodeNeon3Diff(ExtMachInst machInst);
     // AdvSIMD two-reg misc
     inline StaticInstPtr decodeNeon2RegMisc(ExtMachInst machInst);
+    // AdvSIMD two-reg misc FP16
+    inline StaticInstPtr decodeNeon2RegMiscFp16(ExtMachInst machInst);
     // AdvSIMD across lanes
     inline StaticInstPtr decodeNeonAcrossLanes(ExtMachInst machInst);
     // AdvSIMD copy
@@ -66,12 +70,16 @@ namespace Aarch64
 
     // AdvSIMD scalar three same
     inline StaticInstPtr decodeNeonSc3Same(ExtMachInst machInst);
+    // AdvSIMD scalar three same FP16
+    inline StaticInstPtr decodeNeonSc3SameFp16(ExtMachInst machInst);
     // AdvSIMD scalar three same extra
     inline StaticInstPtr decodeNeonSc3SameExtra(ExtMachInst machInst);
     // AdvSIMD scalar three different
     inline StaticInstPtr decodeNeonSc3Diff(ExtMachInst machInst);
     // AdvSIMD scalar two-reg misc
     inline StaticInstPtr decodeNeonSc2RegMisc(ExtMachInst machInst);
+    // AdvSIMD scalar two-reg misc FP16
+    inline StaticInstPtr decodeNeonSc2RegMiscFp16(ExtMachInst machInst);
     // AdvSIMD scalar pairwise
     inline StaticInstPtr decodeNeonScPwise(ExtMachInst machInst);
     // AdvSIMD scalar copy
@@ -89,6 +97,145 @@ namespace Aarch64
 output decoder {{
 namespace Aarch64
 {
+    StaticInstPtr
+    decodeNeon3SameFp16(ExtMachInst machInst)
+    {
+        uint8_t u_a_opcode = bits(machInst, 29) << 4 | // u
+                             bits(machInst, 23) << 3 | // a
+                             bits(machInst, 13, 11);   // opcode
+
+        RegIndex vd = (RegIndex) (uint8_t) bits(machInst, 4, 0);
+        RegIndex vn = (RegIndex) (uint8_t) bits(machInst, 9, 5);
+        RegIndex vm = (RegIndex) (uint8_t) bits(machInst, 20, 16);
+
+        uint8_t q = bits(machInst, 30);
+
+        switch (u_a_opcode) {
+          case 0b00000:
+            if (q)
+                return new FmaxnmQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmaxnmDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00001:
+            if (q)
+                return new FmlaQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmlaDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00010:
+            if (q)
+                return new FaddQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FaddDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00011:
+            if (q)
+                return new FmulxQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmulxDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00100:
+            if (q)
+                return new FcmeqQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FcmeqDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00110:
+            if (q)
+                return new FmaxQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmaxDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00111:
+            if (q)
+                return new FrecpsQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FrecpsDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b01000:
+            if (q)
+                return new FminnmQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FminnmDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b01001:
+            if (q)
+                return new FmlsQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmlsDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b01010:
+            if (q)
+                return new FsubQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FsubDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b01110:
+            if (q)
+                return new FminQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FminDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b01111:
+            if (q)
+                return new FrsqrtsQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FrsqrtsDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10000:
+            if (q)
+                return new FmaxnmpQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmaxnmpDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10010:
+            if (q)
+                return new FaddpQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FaddpDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10011:
+            if (q)
+                return new FmulQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmulDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10100:
+            if (q)
+                return new FcmgeQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FcmgeDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10101:
+            if (q)
+                return new FacgeQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FacgeDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10110:
+            if (q)
+                return new FmaxpQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FmaxpDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10111:
+            if (q)
+                return new FdivQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FdivDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11000:
+            if (q)
+                return new FminnmpQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FminnmpDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11010:
+            if (q)
+                return new FabdQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FabdDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11100:
+            if (q)
+                return new FcmgtQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FcmgtDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11101:
+            if (q)
+                return new FacgtQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FacgtDX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11110:
+            if (q)
+                return new FminpQX<uint16_t>(machInst, vd, vn, vm);
+            else
+                return new FminpDX<uint16_t>(machInst, vd, vn, vm);
+          default:
+            return new Unknown64(machInst);
+        }
+    }
+
     template <typename DecoderFeatures>
     StaticInstPtr
     decodeNeon3Same(ExtMachInst machInst)
@@ -1157,6 +1304,36 @@ namespace Aarch64
                 return new Unknown64(machInst);
             return decodeNeonSAcrossLanesReg<SmaxvDX, SmaxvQX>(
                 q, size, machInst, vd, vn);
+          case 0x0c:
+            switch (size) {
+              case 0b00:
+                if (q)
+                    return new FmaxnmvQX<uint16_t>(machInst, vd, vn);
+                else
+                    return new FmaxnmvDX<uint16_t>(machInst, vd, vn);
+              case 0b10:
+                if (q)
+                    return new FminnmvQX<uint16_t>(machInst, vd, vn);
+                else
+                    return new FminnmvDX<uint16_t>(machInst, vd, vn);
+              default:
+                return new Unknown64(machInst);
+            }
+          case 0x0f:
+            switch (size) {
+              case 0b00:
+                if (q)
+                    return new FmaxvQX<uint16_t>(machInst, vd, vn);
+                else
+                    return new FmaxvDX<uint16_t>(machInst, vd, vn);
+              case 0b10:
+                if (q)
+                    return new FminvQX<uint16_t>(machInst, vd, vn);
+                else
+                    return new FminvDX<uint16_t>(machInst, vd, vn);
+              default:
+                return new Unknown64(machInst);
+            }
           case 0x1a:
             if (size_q == 0x4 || size == 0x3)
                 return new Unknown64(machInst);
@@ -1392,8 +1569,9 @@ namespace Aarch64
         RegIndex vm_bf = (RegIndex) (uint8_t) bits(machInst, 19, 16);
 
         uint8_t index = 0;
+        RegIndex vm = 0;
         uint8_t index_fp = 0;
-        uint8_t vmh = 0;
+        RegIndex vm_fp = 0;
         uint8_t sz = size & 0x1;
         uint8_t sz_q = (sz << 1) | bits(machInst, 30);
         uint8_t sz_L = (sz << 1) | L;
@@ -1401,21 +1579,29 @@ namespace Aarch64
         // Index and 2nd register operand for integer instructions
         if (size == 0x1) {
             index = (H << 2) | (L << 1) | M;
-            // vmh = 0;
+            vm = vm_bf;
         } else if (size == 0x2) {
             index = (H << 1) | L;
-            vmh = M;
+            vm = (M << 4 | vm_bf);
         }
-        RegIndex vm = (RegIndex) (uint8_t) (vmh << 4 | vm_bf);
 
         // Index and 2nd register operand for FP instructions
-        vmh = M;
-        if ((size & 0x1) == 0) {
+        switch (size) {
+          case 0b00:
+            index_fp = (H << 2) | (L << 1) | M;
+            vm_fp = vm_bf;
+            break;
+          case 0b10:
             index_fp = (H << 1) | L;
-        } else if (L == 0) {
+            vm_fp = (M << 4 | vm_bf);
+            break;
+          case 0b11:
             index_fp = H;
+            vm_fp = (M << 4 | vm_bf);
+            break;
+          default:
+            break;
         }
-        RegIndex vm_fp = (RegIndex) (uint8_t) (vmh << 4 | vm_bf);
 
         // Index and 2nd register operand for FEAT_DOTPROD and
         // FEAT_I8MM instructions
@@ -1430,10 +1616,10 @@ namespace Aarch64
                 return decodeNeonUThreeImmHAndWReg<MlaElemDX, MlaElemQX>(
                     q, size, machInst, vd, vn, vm, index);
           case 0x1:
-            if (!u && size >= 2 && sz_q != 0x2 && sz_L != 0x3)
+            if (!u && sz_q != 0x2 && sz_L != 0x3) {
                 return decodeNeonUThreeImmFpReg<FmlaElemDX, FmlaElemQX>(
-                    q, sz, machInst, vd, vn, vm_fp, index_fp);
-            else if (u && (size == 1 || size == 2)){
+                    q, size, machInst, vd, vn, vm_fp, index_fp);
+            } else if (u && (size == 1 || size == 2)) {
                 // FCMLA by element
                 if (size == 0x2) {
                     index_fp = H;
@@ -1497,10 +1683,10 @@ namespace Aarch64
             else
                 return new Unknown64(machInst);
           case 0x5:
-            if (!u && size >= 0x2 && sz_L != 0x3 && sz_q != 0x2)
+            if (!u && sz_L != 0x3 && sz_q != 0x2) {
                 return decodeNeonUThreeImmFpReg<FmlsElemDX, FmlsElemQX>(
-                    q, sz, machInst, vd, vn, vm_fp, index_fp);
-            else if (u && (size == 1 || size == 2)){
+                    q, size, machInst, vd, vn, vm_fp, index_fp);
+            } else if (u && (size == 1 || size == 2)) {
                 // FCMLA by element
                 if (size == 0x2) {
                     index_fp = H;
@@ -1563,13 +1749,13 @@ namespace Aarch64
                 return decodeNeonUThreeImmHAndWReg<MulElemDX, MulElemQX>(
                     q, size, machInst, vd, vn, vm, index);
           case 0x9:
-            if (size >= 2 && sz_q != 0x2 && sz_L != 0x3) {
+            if (sz_q != 0x2 && sz_L != 0x3) {
                 if (u)
                     return decodeNeonUThreeImmFpReg<FmulxElemDX, FmulxElemQX>(
-                        q, sz, machInst, vd, vn, vm_fp, index_fp);
+                        q, size, machInst, vd, vn, vm_fp, index_fp);
                 else
                     return decodeNeonUThreeImmFpReg<FmulElemDX, FmulElemQX>(
-                        q, sz, machInst, vd, vn, vm_fp, index_fp);
+                        q, size, machInst, vd, vn, vm_fp, index_fp);
             } else {
                 return new Unknown64(machInst);
             }
@@ -1672,7 +1858,28 @@ namespace Aarch64
 
         RegIndex vd = (RegIndex) (uint8_t) bits(machInst, 4, 0);
 
-        if (o2 == 0x1 || (op == 0x1 && cmode == 0xf && !q))
+        if (o2 == 0x1) {
+            if (op == 0b0 && cmode == 0b1111) {
+                uint8_t imm8 = abcdefgh;
+                uint16_t imm16 = bits(imm8, 7) << 15 | !bits(imm8, 6) << 14 |
+                                 bits(imm8, 6) << 13 | bits(imm8, 6) << 12 |
+                                 bits(imm8, 5, 0) << 6;
+
+                uint64_t imm = 0;
+                for (int index = 0; index < (64 << q); index+=16) {
+                    imm |= (imm16 << index);
+                }
+                if (q) {
+                    return new FmovQX<uint16_t>(machInst, vd, imm);
+                } else {
+                    return new FmovDX<uint16_t>(machInst, vd, imm);
+                }
+            } else {
+                return new Unknown64(machInst);
+            }
+        }
+
+        if (op == 0x1 && cmode == 0xf && !q)
             return new Unknown64(machInst);
 
         bool immValid = true;
@@ -1923,38 +2130,50 @@ namespace Aarch64
                 return decodeNeonSTwoShiftSReg<SshllX, Sshll2X>(
                     q, size, machInst, vd, vn, shiftAmt);
           case 0x1c:
-            if (immh < 0x4 || immh3_q == 0x2)
+            if (immh < 0x2 || immh3_q == 0x2)
                 return new Unknown64(machInst);
             shiftAmt = (8 << (size + 1)) - ((immh << 3) | immb);
             if (u) {
                 return decodeNeonUTwoShiftFpReg<UcvtfFixedDX, UcvtfFixedQX>(
-                    q, size & 0x1, machInst, vd, vn, shiftAmt);
+                    q, size, machInst, vd, vn, shiftAmt);
             } else {
                 if (q) {
-                    if (size & 0x1)
-                        return new ScvtfFixedDQX<uint64_t>(machInst, vd, vn,
-                                                           shiftAmt);
-                    else
-                        return new ScvtfFixedSQX<uint32_t>(machInst, vd, vn,
-                                                           shiftAmt);
+                    switch (size) {
+                      case 0b11:
+                        return new ScvtfFixedDQX<uint64_t>(
+                            machInst, vd, vn, shiftAmt);
+                      case 0b10:
+                        return new ScvtfFixedSQX<uint32_t>(
+                            machInst, vd, vn, shiftAmt);
+                      case 0b01:
+                        return new ScvtfFixedSQX<uint16_t>(
+                            machInst, vd, vn, shiftAmt);
+                      default:
+                        return new Unknown64(machInst);
+                    }
                 } else {
-                    if (size & 0x1)
-                        return new Unknown(machInst);
-                    else
-                        return new ScvtfFixedDX<uint32_t>(machInst, vd, vn,
-                                                          shiftAmt);
+                    switch (size) {
+                      case 0b10:
+                        return new ScvtfFixedDX<uint32_t>(
+                            machInst, vd, vn, shiftAmt);
+                      case 0b01:
+                        return new ScvtfFixedDX<uint16_t>(
+                            machInst, vd, vn, shiftAmt);
+                      default:
+                        return new Unknown64(machInst);
+                    }
                 }
             }
           case 0x1f:
-            if (immh < 0x4 || immh3_q == 0x2)
+            if (immh < 0x2 || immh3_q == 0x2)
                 return new Unknown64(machInst);
             shiftAmt = (8 << (size + 1)) - ((immh << 3) | immb);
             if (u)
                 return decodeNeonUTwoShiftFpReg<FcvtzuFixedDX, FcvtzuFixedQX>(
-                    q, size & 0x1, machInst, vd, vn, shiftAmt);
+                    q, size, machInst, vd, vn, shiftAmt);
             else
                 return decodeNeonUTwoShiftFpReg<FcvtzsFixedDX, FcvtzsFixedQX>(
-                    q, size & 0x1, machInst, vd, vn, shiftAmt);
+                    q, size, machInst, vd, vn, shiftAmt);
           default:
             return new Unknown64(machInst);
         }
@@ -2247,6 +2466,41 @@ namespace Aarch64
     }
 
     StaticInstPtr
+    decodeNeonSc3SameFp16(ExtMachInst machInst)
+    {
+        uint8_t u_a_opcode = bits(machInst, 29) << 4 | // u
+                             bits(machInst, 23) << 3 | // a
+                             bits(machInst, 13, 11);   // opcode
+
+        RegIndex vd = (RegIndex) (uint8_t) bits(machInst, 4, 0);
+        RegIndex vn = (RegIndex) (uint8_t) bits(machInst, 9, 5);
+        RegIndex vm = (RegIndex) (uint8_t) bits(machInst, 20, 16);
+
+        switch (u_a_opcode) {
+          case 0b00011:
+            return new FmulxScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00100:
+            return new FcmeqScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b00111:
+            return new FrecpsScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b01111:
+            return new FrsqrtsScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10100:
+            return new FcmgeScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b10101:
+            return new FacgeScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11010:
+            return new FabdScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11100:
+            return new FcmgtScX<uint16_t>(machInst, vd, vn, vm);
+          case 0b11101:
+            return new FacgtScX<uint16_t>(machInst, vd, vn, vm);
+          default:
+            return new Unknown64(machInst);
+        }
+    }
+
+    StaticInstPtr
     decodeNeonSc3Diff(ExtMachInst machInst)
     {
         if (bits(machInst, 29))
@@ -2476,6 +2730,225 @@ namespace Aarch64
     }
 
     StaticInstPtr
+    decodeNeonSc2RegMiscFp16(ExtMachInst machInst)
+    {
+        uint8_t u_a_opcode = bits(machInst, 29) << 6 | // u
+                             bits(machInst, 23) << 5 | // a
+                             bits(machInst, 16, 12);   // opcode
+
+        RegIndex vd = (RegIndex) (uint8_t) bits(machInst, 4, 0);
+        RegIndex vn = (RegIndex) (uint8_t) bits(machInst, 9, 5);
+
+        switch (u_a_opcode) {
+          case 0b0011010:
+            return new FcvtnsScX<uint16_t>(machInst, vd, vn);
+          case 0b0011011:
+            return new FcvtmsScX<uint16_t>(machInst, vd, vn);
+          case 0b0011100:
+            return new FcvtasScX<uint16_t>(machInst, vd, vn);
+          case 0b0011101:
+            return new ScvtfIntScHX<uint16_t>(machInst, vd, vn);
+          case 0b0101100:
+            return new FcmgtZeroScX<uint16_t>(machInst, vd, vn);
+          case 0b0101101:
+            return new FcmeqZeroScX<uint16_t>(machInst, vd, vn);
+          case 0b0101110:
+            return new FcmltZeroScX<uint16_t>(machInst, vd, vn);
+          case 0b0111010:
+            return new FcvtpsScX<uint16_t>(machInst, vd, vn);
+          case 0b0111011:
+            return new FcvtzsIntScX<uint16_t>(machInst, vd, vn);
+          case 0b0111101:
+            return new FrecpeScX<uint16_t>(machInst, vd, vn);
+          case 0b0111111:
+            return new FrecpxX<uint16_t>(machInst, vd, vn);
+          case 0b1011010:
+            return new FcvtnuScX<uint16_t>(machInst, vd, vn);
+          case 0b1011011:
+            return new FcvtmuScX<uint16_t>(machInst, vd, vn);
+          case 0b1011100:
+            return new FcvtauScX<uint16_t>(machInst, vd, vn);
+          case 0b1011101:
+            return new UcvtfIntScX<uint16_t>(machInst, vd, vn);
+          case 0b1101100:
+            return new FcmgeZeroScX<uint16_t>(machInst, vd, vn);
+          case 0b1101101:
+            return new FcmleZeroScX<uint16_t>(machInst, vd, vn);
+          case 0b1111010:
+            return new FcvtpuScX<uint16_t>(machInst, vd, vn);
+          case 0b1111011:
+            return new FcvtzuIntScX<uint16_t>(machInst, vd, vn);
+          case 0b1111101:
+            return new FrsqrteScX<uint16_t>(machInst, vd, vn);
+          default:
+            return new Unknown64(machInst);
+        }
+    }
+
+    StaticInstPtr
+    decodeNeon2RegMiscFp16(ExtMachInst machInst)
+    {
+        uint8_t u_a_opcode = bits(machInst, 29) << 6 | // u
+                             bits(machInst, 23) << 5 | // a
+                             bits(machInst, 16, 12);   // opcode
+
+        uint8_t q = bits(machInst, 30);
+
+        RegIndex vd = (RegIndex) (uint8_t) bits(machInst, 4, 0);
+        RegIndex vn = (RegIndex) (uint8_t) bits(machInst, 9, 5);
+
+        switch (u_a_opcode) {
+          case 0b0011000:
+            if (q)
+                return new FrintnQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintnDX<uint16_t>(machInst, vd, vn);
+          case 0b0011001:
+            if (q)
+                return new FrintmQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintmDX<uint16_t>(machInst, vd, vn);
+          case 0b0011010:
+            if (q)
+                return new FcvtnsQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtnsDX<uint16_t>(machInst, vd, vn);
+          case 0b0011011:
+            if (q)
+                return new FcvtmsQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtmsDX<uint16_t>(machInst, vd, vn);
+          case 0b0011100:
+            if (q)
+                return new FcvtasQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtasDX<uint16_t>(machInst, vd, vn);
+          case 0b0011101:
+            if (q)
+                return new ScvtfIntSQX<uint16_t>(machInst, vd, vn);
+            else
+                return new ScvtfIntDX<uint16_t>(machInst, vd, vn);
+          case 0b0101100:
+            if (q)
+                return new FcmgtZeroQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcmgtZeroDX<uint16_t>(machInst, vd, vn);
+          case 0b0101101:
+            if (q)
+                return new FcmeqZeroQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcmeqZeroDX<uint16_t>(machInst, vd, vn);
+          case 0b0101110:
+            if (q)
+                return new FcmltZeroQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcmltZeroDX<uint16_t>(machInst, vd, vn);
+          case 0b0101111:
+            if (q)
+                return new FabsQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FabsDX<uint16_t>(machInst, vd, vn);
+          case 0b0111000:
+            if (q)
+                return new FrintpQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintpDX<uint16_t>(machInst, vd, vn);
+          case 0b0111001:
+            if (q)
+                return new FrintzQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintzDX<uint16_t>(machInst, vd, vn);
+          case 0b0111010:
+            if (q)
+                return new FcvtpsQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtpsDX<uint16_t>(machInst, vd, vn);
+          case 0b0111011:
+            if (q)
+                return new FcvtzsIntQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtzsIntDX<uint16_t>(machInst, vd, vn);
+          case 0b0111101:
+            if (q)
+                return new FrecpeQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrecpeDX<uint16_t>(machInst, vd, vn);
+          case 0b1011000:
+            if (q)
+                return new FrintaQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintaDX<uint16_t>(machInst, vd, vn);
+          case 0b1011001:
+            if (q)
+                return new FrintxQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintxDX<uint16_t>(machInst, vd, vn);
+          case 0b1011010:
+            if (q)
+                return new FcvtnuQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtnuDX<uint16_t>(machInst, vd, vn);
+          case 0b1011011:
+            if (q)
+                return new FcvtmuQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtmuDX<uint16_t>(machInst, vd, vn);
+          case 0b1011100:
+            if (q)
+                return new FcvtauQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtauDX<uint16_t>(machInst, vd, vn);
+          case 0b1011101:
+            if (q)
+                return new UcvtfIntQX<uint16_t>(machInst, vd, vn);
+            else
+                return new UcvtfIntDX<uint16_t>(machInst, vd, vn);
+          case 0b1101100:
+            if (q)
+                return new FcmgeZeroQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcmgeZeroDX<uint16_t>(machInst, vd, vn);
+          case 0b1101101:
+            if (q)
+                return new FcmleZeroQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcmleZeroDX<uint16_t>(machInst, vd, vn);
+          case 0b1101111:
+            if (q)
+                return new FnegQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FnegDX<uint16_t>(machInst, vd, vn);
+          case 0b1111001:
+            if (q)
+                return new FrintiQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrintiDX<uint16_t>(machInst, vd, vn);
+          case 0b1111010:
+            if (q)
+                return new FcvtpuQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtpuDX<uint16_t>(machInst, vd, vn);
+          case 0b1111011:
+            if (q)
+                return new FcvtzuIntQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FcvtzuIntDX<uint16_t>(machInst, vd, vn);
+          case 0b1111101:
+            if (q)
+                return new FrsqrteQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FrsqrteDX<uint16_t>(machInst, vd, vn);
+          case 0b1111111:
+            if (q)
+                return new FsqrtQX<uint16_t>(machInst, vd, vn);
+            else
+                return new FsqrtDX<uint16_t>(machInst, vd, vn);
+          default:
+            return new Unknown64(machInst);
+        }
+    }
+
+    StaticInstPtr
     decodeNeonScPwise(ExtMachInst machInst)
     {
         uint8_t u = bits(machInst, 29);
@@ -2485,8 +2958,8 @@ namespace Aarch64
         RegIndex vd = (RegIndex) (uint8_t) bits(machInst, 4, 0);
         RegIndex vn = (RegIndex) (uint8_t) bits(machInst, 9, 5);
 
-        if (!u) {
-            if (opcode == 0x1b && size == 0x3)
+        if (!u && opcode == 0x1b) {
+            if (size == 0x3)
                 return new AddpScQX<uint64_t>(machInst, vd, vn);
             else
                 return new Unknown64(machInst);
@@ -2496,24 +2969,24 @@ namespace Aarch64
         switch (switchVal) {
           case 0x0c:
           case 0x2c:
-            return decodeNeonUTwoMiscPwiseScFpReg<FmaxnmpScDX, FmaxnmpScQX>(
-                    size & 0x1, machInst, vd, vn);
+            return decodeNeonUTwoMiscPwiseScFpReg<FmaxnmpScSX, FmaxnmpScDX, FmaxnmpScQX>(
+                    u, size & 0x1, machInst, vd, vn);
           case 0x0d:
           case 0x2d:
-            return decodeNeonUTwoMiscPwiseScFpReg<FaddpScDX, FaddpScQX>(
-                    size & 0x1, machInst, vd, vn);
+            return decodeNeonUTwoMiscPwiseScFpReg<FaddpScSX, FaddpScDX, FaddpScQX>(
+                    u, size & 0x1, machInst, vd, vn);
           case 0x0f:
           case 0x2f:
-            return decodeNeonUTwoMiscPwiseScFpReg<FmaxpScDX, FmaxpScQX>(
-                    size & 0x1, machInst, vd, vn);
+            return decodeNeonUTwoMiscPwiseScFpReg<FmaxpScSX, FmaxpScDX, FmaxpScQX>(
+                    u, size & 0x1, machInst, vd, vn);
           case 0x4c:
           case 0x6c:
-            return decodeNeonUTwoMiscPwiseScFpReg<FminnmpScDX, FminnmpScQX>(
-                    size & 0x1, machInst, vd, vn);
+            return decodeNeonUTwoMiscPwiseScFpReg<FminnmpScSX, FminnmpScDX, FminnmpScQX>(
+                    u, size & 0x1, machInst, vd, vn);
           case 0x4f:
           case 0x6f:
-            return decodeNeonUTwoMiscPwiseScFpReg<FminpScDX, FminpScQX>(
-                    size & 0x1, machInst, vd, vn);
+            return decodeNeonUTwoMiscPwiseScFpReg<FminpScSX, FminpScDX, FminpScQX>(
+                    u, size & 0x1, machInst, vd, vn);
           default:
             return new Unknown64(machInst);
         }
@@ -2555,41 +3028,50 @@ namespace Aarch64
         RegIndex vm_bf = (RegIndex) (uint8_t) bits(machInst, 19, 16);
 
         uint8_t index = 0;
+        RegIndex vm = 0;
         uint8_t index_fp = 0;
-        uint8_t vmh = 0;
+        RegIndex vm_fp = 0;
         uint8_t sz_L = bits(machInst, 22, 21);
 
         // Index and 2nd register operand for integer instructions
         if (size == 0x1) {
             index = (H << 2) | (L << 1) | M;
-            // vmh = 0;
+            vm = vm_bf;
         } else if (size == 0x2) {
             index = (H << 1) | L;
-            vmh = M;
+            vm = (M << 4 | vm_bf);
         } else if (size == 0x3) {
             index = H;
-            vmh = M;
+            vm = (M << 4 | vm_bf);
         }
-        RegIndex vm = (RegIndex) (uint8_t) (vmh << 4 | vm_bf);
 
         // Index and 2nd register operand for FP instructions
-        vmh = M;
-        if ((size & 0x1) == 0) {
+        switch (size) {
+          case 0b00:
+            index_fp = (H << 2) | (L << 1) | M;
+            vm_fp = vm_bf;
+            break;
+          case 0b10:
             index_fp = (H << 1) | L;
-        } else if (L == 0) {
+            vm_fp = (M << 4 | vm_bf);
+            break;
+          case 0b11:
             index_fp = H;
+            vm_fp = (M << 4 | vm_bf);
+            break;
+          default:
+            break;
         }
-        RegIndex vm_fp = (RegIndex) (uint8_t) (vmh << 4 | vm_bf);
 
         uint8_t u_opcode = opcode | u << 4;
 
         switch (u_opcode) {
           case 0x1:
-            if (size < 2 || sz_L == 0x3)
+            if (sz_L == 0x3)
                 return new Unknown64(machInst);
             else
                 return decodeNeonUThreeImmScFpReg<FmlaElemScX>(
-                    size & 0x1, machInst, vd, vn, vm_fp, index_fp);
+                    size, machInst, vd, vn, vm_fp, index_fp);
           case 0x3:
             if (size == 0x0 || size == 0x3)
                 return new Unknown64(machInst);
@@ -2597,11 +3079,11 @@ namespace Aarch64
                 return decodeNeonSThreeImmHAndWReg<SqdmlalElemScX>(
                     size, machInst, vd, vn, vm, index);
           case 0x5:
-            if (size < 2 || sz_L == 0x3)
+            if (sz_L == 0x3)
                 return new Unknown64(machInst);
             else
                 return decodeNeonUThreeImmScFpReg<FmlsElemScX>(
-                    size & 0x1, machInst, vd, vn, vm_fp, index_fp);
+                    size, machInst, vd, vn, vm_fp, index_fp);
           case 0x7:
             if (size == 0x0 || size == 0x3)
                 return new Unknown64(machInst);
@@ -2609,10 +3091,10 @@ namespace Aarch64
                 return decodeNeonSThreeImmHAndWReg<SqdmlslElemScX>(
                     size, machInst, vd, vn, vm, index);
           case 0x9:
-            if (size < 2 || sz_L == 0x3)
+            if (sz_L == 0x3)
                 return new Unknown64(machInst);
             return decodeNeonUThreeImmScFpReg<FmulElemScX>(
-                    size & 0x1, machInst, vd, vn, vm_fp, index_fp);
+                    size, machInst, vd, vn, vm_fp, index_fp);
           case 0xb:
             if (size == 0x0 || size == 0x3)
                 return new Unknown64(machInst);
@@ -2629,11 +3111,11 @@ namespace Aarch64
             return decodeNeonSThreeImmHAndWReg<SqrdmulhElemScX>(
                     size, machInst, vd, vn, vm, index);
           case 0x19:
-            if (size < 2 || sz_L == 0x3)
+            if (sz_L == 0x3)
                 return new Unknown64(machInst);
-            return decodeNeonUThreeImmScFpReg<FmulxElemScX>(
-                    size & 0x1, machInst, vd, vn, vm_fp, index_fp);
-
+            else
+                return decodeNeonUThreeImmScFpReg<FmulxElemScX>(
+                        size, machInst, vd, vn, vm_fp, index_fp);
           case 0x1d:
             return decodeNeonSThreeImmHAndWReg<SqrdmlahElemScX>(
                     size, machInst, vd, vn, vm, index);
@@ -2762,12 +3244,12 @@ namespace Aarch64
                 return decodeNeonSTwoShiftUSReg<SqrshrnScX>(
                     size, machInst, vd, vn, shiftAmt);
           case 0x1c:
-            if (immh < 0x4)
+            if (immh < 0x2)
                 return new Unknown64(machInst);
             shiftAmt = (8 << (size + 1)) - ((immh << 3) | immb);
             if (u) {
                 return decodeNeonUTwoShiftUFpReg<UcvtfFixedScX>(
-                    size & 0x1, machInst, vd, vn, shiftAmt);
+                    size, machInst, vd, vn, shiftAmt);
             } else {
                 if (size & 0x1)
                     return new ScvtfFixedScDX<uint64_t>(machInst, vd, vn,
@@ -2777,15 +3259,15 @@ namespace Aarch64
                                                         shiftAmt);
             }
           case 0x1f:
-            if (immh < 0x4)
+            if (immh < 0x2)
                 return new Unknown64(machInst);
             shiftAmt = (8 << (size + 1)) - ((immh << 3) | immb);
             if (u)
                 return decodeNeonUTwoShiftUFpReg<FcvtzuFixedScX>(
-                    size & 0x1, machInst, vd, vn, shiftAmt);
+                    size, machInst, vd, vn, shiftAmt);
             else
                 return decodeNeonUTwoShiftUFpReg<FcvtzsFixedScX>(
-                    size & 0x1, machInst, vd, vn, shiftAmt);
+                    size, machInst, vd, vn, shiftAmt);
           default:
             return new Unknown64(machInst);
         }

--- a/src/arch/arm/isa/formats/neon64.isa
+++ b/src/arch/arm/isa/formats/neon64.isa
@@ -3251,12 +3251,19 @@ namespace Aarch64
                 return decodeNeonUTwoShiftUFpReg<UcvtfFixedScX>(
                     size, machInst, vd, vn, shiftAmt);
             } else {
-                if (size & 0x1)
+                switch (size) {
+                  case 0b11:
                     return new ScvtfFixedScDX<uint64_t>(machInst, vd, vn,
                                                         shiftAmt);
-                else
+                  case 0b10:
                     return new ScvtfFixedScSX<uint32_t>(machInst, vd, vn,
                                                         shiftAmt);
+                  case 0b01:
+                    return new ScvtfFixedScSX<uint16_t>(machInst, vd, vn,
+                                                        shiftAmt);
+                  default:
+                    return new Unknown64(machInst);
+                }
             }
           case 0x1f:
             if (immh < 0x2)

--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2010-2013,2016,2018-2019 ARM Limited
+// Copyright (c) 2010-2013,2016,2018-2019,2024-2025 ARM Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -467,6 +467,20 @@ let {{
     decoder_output = ""
     exec_output = ""
 
+    halfCode = vfpEnabledCheckCode + '''
+        [[maybe_unused]] FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        uint16_t half_src1 = FpOp1_uw & 0xFFFF;
+        uint16_t half_src2 = (FpOp1_uw >> 16) & 0xFFFF;
+        static_assert(std::is_same_v<decltype(%(op1)s), uint16_t>,
+                      "operation triggers invalid implicit conversion");
+        static_assert(std::is_same_v<decltype(%(op2)s), uint16_t>,
+                      "operation triggers invalid implicit conversion");
+        uint16_t half_dest1 = %(op1)s;
+        uint16_t half_dest2 = %(op2)s;
+        FpDestP0 = (uint32_t)half_dest1 | ((uint32_t)half_dest2 << 16);
+        FpscrExc = fpscr;
+    '''
+
     singleSimpleCode = vfpEnabledCheckCode + '''
         [[maybe_unused]] FPSCR fpscr = (FPSCR) FpscrExc;
         static_assert(std::is_same_v<decltype(%(op)s), uint32_t>,
@@ -677,11 +691,16 @@ let {{
     buildUnaryFpOp("vsqrt", "Vsqrt", "FpRegRegOp", "SimdFloatSqrtOp", "sqrtf",
                    "sqrt")
 
-    def buildSimpleUnaryFpOp(name, Name, base, opClass, singleOp, doubleOp):
+    def buildSimpleUnaryFpOp(name, Name, base, opClass,
+                             halfOp1, halfOp2, singleOp, doubleOp):
         if doubleOp is None:
             doubleOp = singleOp
         global header_output, decoder_output, exec_output
 
+        hIop = ArmInstObjParams(name + ".f16", Name + "H", base,
+                { "code": halfCode % { "op1": halfOp1, "op2": halfOp2 },
+                  "predicate_test": predicateTest,
+                  "op_class": opClass }, [])
         sIop = ArmInstObjParams(name + ".f32", Name + "S", base,
                 { "code": singleSimpleCode % { "op": singleOp },
                   "predicate_test": predicateTest,
@@ -694,28 +713,38 @@ let {{
         declareTempl = eval(base + "Declare");
         constructorTempl = eval(base + "Constructor");
 
-        for iop in sIop, dIop:
+        for iop in hIop, sIop, dIop:
             header_output += declareTempl.subst(iop)
             decoder_output += constructorTempl.subst(iop)
             exec_output += PredOpExecute.subst(iop)
 
     buildSimpleUnaryFpOp("vneg", "Vneg", "FpRegRegOp", "SimdFloatMiscOp",
+                         "fplibNeg(half_src1)", "fplibNeg(half_src2)",
                          "fplibNeg(FpOp1_uw)", "fplibNeg(cOp1)")
     buildSimpleUnaryFpOp("vabs", "Vabs", "FpRegRegOp", "SimdFloatMiscOp",
+                         "fplibAbs(half_src1)", "fplibAbs(half_src2)",
                          "fplibAbs(FpOp1_uw)", "fplibAbs(cOp1)")
     buildSimpleUnaryFpOp("vrintp", "VRIntP", "FpRegRegOp", "SimdFloatMiscOp",
+        "fplibRoundInt<uint16_t>(half_src1, FPRounding_POSINF, false, fpscr)",
+        "fplibRoundInt<uint16_t>(half_src2, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_POSINF, false, fpscr)"
         )
     buildSimpleUnaryFpOp("vrintm", "VRIntM", "FpRegRegOp", "SimdFloatMiscOp",
+        "fplibRoundInt<uint16_t>(half_src1, FPRounding_NEGINF, false, fpscr)",
+        "fplibRoundInt<uint16_t>(half_src2, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_NEGINF, false, fpscr)"
         )
     buildSimpleUnaryFpOp("vrinta", "VRIntA", "FpRegRegOp", "SimdFloatMiscOp",
+        "fplibRoundInt<uint16_t>(half_src1, FPRounding_TIEAWAY, false, fpscr)",
+        "fplibRoundInt<uint16_t>(half_src2, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_TIEAWAY, false, fpscr)"
         )
     buildSimpleUnaryFpOp("vrintn", "VRIntN", "FpRegRegOp", "SimdFloatMiscOp",
+        "fplibRoundInt<uint16_t>(half_src1, FPRounding_TIEEVEN, false, fpscr)",
+        "fplibRoundInt<uint16_t>(half_src2, FPRounding_TIEEVEN, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_TIEEVEN, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_TIEEVEN, false, fpscr)"
         )

--- a/src/arch/arm/isa/insts/fp64.isa
+++ b/src/arch/arm/isa/insts/fp64.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2012-2013, 2016-2018 ARM Limited
+// Copyright (c) 2012-2013, 2016-2018, 2025 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -518,11 +518,32 @@ let {{
     decoder_output = ""
     exec_output = ""
 
+    def bitsToSuffix(bits):
+        if bits == 64:
+            return 'D'
+        elif bits == 32:
+            return 'S'
+        elif bits == 16:
+            return 'H'
+        else:
+            raise Exception("Invalid bits")
+
+    def bitsToStorage(bits):
+        if bits == 64:
+            return 'uint64_t'
+        elif bits == 32:
+            return 'uint32_t'
+        elif bits == 16:
+            return 'uint16_t'
+        else:
+            raise Exception("Invalid bits")
+
+
     # Creates the integer to floating point instructions, including variants for
     # signed/unsigned, float/double, etc
     for regL, regOpL, width in [["W", "w", 32],
                                 ["X", "d", 64]]:
-        for isDouble in True, False:
+        for bits in (16, 32, 64):
             for us, usCode in [["U", "uint%d_t cSrc = %sOp1_u%s;" %(width, regL, regOpL)],
                                ["S", "int%d_t  cSrc = %sOp1_u%s;" %(width, regL, regOpL)]]:
                 fcvtIntFpDCode = vfp64EnabledCheckCode + '''
@@ -530,7 +551,7 @@ let {{
                     %s
                 ''' %(usCode)
 
-                if isDouble:
+                if bits == 64:
                     fcvtIntFpDCode += '''
                         uint64_t cDest = fplibFixedToFP<uint64_t>(cSrc, 0,
                             %s, FPCRRounding(fpscr), fpscr);
@@ -539,18 +560,18 @@ let {{
                     ''' % ("true" if us == "U" else "false")
                 else:
                     fcvtIntFpDCode += '''
-                        uint32_t cDest = fplibFixedToFP<uint32_t>(cSrc, 0,
+                        uint32_t cDest = fplibFixedToFP<%s>(cSrc, 0,
                             %s, FPCRRounding(fpscr), fpscr);
                         AA64FpDestP0_uw = cDest;
                         AA64FpDestP1_uw = 0;
-                    ''' % ("true" if us == "U" else "false")
+                    ''' % (bitsToStorage(bits), "true" if us == "U" else "false")
                 fcvtIntFpDCode += '''
                     AA64FpDestP2_uw = 0;
                     AA64FpDestP3_uw = 0;
                     FpscrExc = fpscr;
                 '''
 
-                instName = "Fcvt%s%sIntFp%s" %(regL, us, "D" if isDouble else "S")
+                instName = "Fcvt%s%sIntFp%s" %(regL, us, bitsToSuffix(bits))
                 mnem     = "%scvtf" %(us.lower())
                 fcvtIntFpDIop = ArmInstObjParams(mnem, instName, "FpRegRegOp",
                                                  { "code": fcvtIntFpDCode,
@@ -703,38 +724,41 @@ let {{
         decoder_output += AA64FpRegRegOpConstructor.subst(fcvtFpFpHIop);
         exec_output    += BasicExecute.subst(fcvtFpFpHIop);
 
+
     # Build the various versions of the floating point compare instructions
-    def buildFCmpOp(isQuiet, isDouble, isImm):
+    def buildFCmpOp(isQuiet, bits, isImm):
         global header_output, decoder_output, exec_output
+
+        storage = bitsToStorage(bits)
+        suffix = bitsToSuffix(bits)
 
         fcmpCode = vfp64EnabledCheckCode + '''
             FPSCR fpscr = (FPSCR) FpscrExc;
             %s cOp1 = %s;
-        ''' % ("uint64_t" if isDouble else "uint32_t",
+        ''' % (storage,
                "AA64FpDestP0_uw | (uint64_t)AA64FpDestP1_uw << 32"
-               if isDouble else "AA64FpDestP0_uw")
+               if bits > 32 else "AA64FpDestP0_uw")
         if isImm:
             fcmpCode += '''
                 %s cOp2 = imm;
-            ''' % ("uint64_t" if isDouble else "uint32_t")
+            ''' % (storage)
         else:
             fcmpCode += '''
                 %s cOp2  = %s;
-            ''' % ("uint64_t" if isDouble else "uint32_t",
+            ''' % (storage,
                    "AA64FpOp1P0_uw | (uint64_t)AA64FpOp1P1_uw << 32"
-                   if isDouble else "AA64FpOp1P0_uw")
+                   if bits > 32 else "AA64FpOp1P0_uw")
         fcmpCode += '''
-            int cc = fplibCompare<uint%s_t>(cOp1, cOp2, %s, fpscr);
+            int cc = fplibCompare<%s>(cOp1, cOp2, %s, fpscr);
             CondCodesNZ = cc >> 2 & 3;
             CondCodesC = cc >> 1 & 1;
             CondCodesV = cc & 1;
             FpCondCodes = fpscr & FpCondCodesMask;
             FpscrExc    = fpscr;
-        ''' % ("64" if isDouble else "32", "false" if isQuiet else "true")
+        ''' % (storage, "false" if isQuiet else "true")
 
         typeName = "Imm" if isImm else "Reg"
-        instName = "FCmp%s%s%s" %(""  if isQuiet  else "E", typeName,
-                                  "D" if isDouble else "S")
+        instName = "FCmp%s%s%s" %("" if isQuiet  else "E", typeName, suffix)
         fcmpIop = ArmInstObjParams("fcmp%s" % ("" if isQuiet else "e"),
                                    instName, "FpReg%sOp" % typeName,
                                    { "code": fcmpCode,
@@ -747,9 +771,9 @@ let {{
         exec_output    += BasicExecute.subst(fcmpIop);
 
     for isQuiet in True, False:
-        for isDouble in True, False:
+        for bits in (16, 32, 64):
             for isImm in True, False:
-                buildFCmpOp(isQuiet, isDouble, isImm)
+                buildFCmpOp(isQuiet, bits, isImm)
 
     # Build the various versions of the conditional floating point compare
     # instructions

--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2010-2011, 2015, 2019, 2024 ARM Limited
+// Copyright (c) 2010-2011, 2015, 2019, 2024-2025 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -348,14 +348,20 @@ output header {{
 
     template <template <typename T> class Base>
     StaticInstPtr
-    decodeNeonUThreeImmScFpReg(bool size, ExtMachInst machInst,
+    decodeNeonUThreeImmScFpReg(uint8_t size, ExtMachInst machInst,
                                RegIndex dest, RegIndex op1,
                                RegIndex op2, uint64_t imm)
     {
-        if (size)
+        switch (size) {
+          case 0b11:
             return new Base<uint64_t>(machInst, dest, op1, op2, imm);
-        else
+          case 0b10:
             return new Base<uint32_t>(machInst, dest, op1, op2, imm);
+          case 0b00:
+            return new Base<uint16_t>(machInst, dest, op1, op2, imm);
+          default:
+            return new Unknown(machInst);
+        }
     }
 
     template <template <typename T> class BaseD,
@@ -422,15 +428,25 @@ output header {{
                              RegIndex op2, uint64_t imm)
     {
         if (q) {
-            if (size)
+            switch (size) {
+              case 0b11:
                 return new BaseQ<uint64_t>(machInst, dest, op1, op2, imm);
-            else
+              case 0b10:
                 return new BaseQ<uint32_t>(machInst, dest, op1, op2, imm);
-        } else {
-            if (size)
+              case 0b00:
+                return new BaseQ<uint16_t>(machInst, dest, op1, op2, imm);
+              default:
                 return new Unknown(machInst);
-            else
+            }
+        } else {
+            switch (size) {
+              case 0b10:
                 return new BaseD<uint32_t>(machInst, dest, op1, op2, imm);
+              case 0b00:
+                return new BaseD<uint16_t>(machInst, dest, op1, op2, imm);
+              default:
+                return new Unknown(machInst);
+            }
         }
     }
 
@@ -682,10 +698,16 @@ output header {{
     decodeNeonUTwoShiftUFpReg(unsigned size, ExtMachInst machInst,
                               RegIndex dest, RegIndex op1, uint64_t imm)
     {
-        if (size)
+        switch (size) {
+          case 0b11:
             return new Base<uint64_t>(machInst, dest, op1, imm);
-        else
+          case 0b10:
             return new Base<uint32_t>(machInst, dest, op1, imm);
+          case 0b01:
+            return new Base<uint16_t>(machInst, dest, op1, imm);
+          default:
+            return new Unknown(machInst);
+        }
     }
 
     template <template <typename T> class BaseD,
@@ -695,15 +717,25 @@ output header {{
                              RegIndex dest, RegIndex op1, uint64_t imm)
     {
         if (q) {
-            if (size)
+            switch (size) {
+              case 0b11:
                 return new BaseQ<uint64_t>(machInst, dest, op1, imm);
-            else
+              case 0b10:
                 return new BaseQ<uint32_t>(machInst, dest, op1, imm);
-        } else {
-            if (size)
+              case 0b01:
+                return new BaseQ<uint16_t>(machInst, dest, op1, imm);
+              default:
                 return new Unknown(machInst);
-            else
+            }
+        } else {
+            switch (size) {
+              case 0b10:
                 return new BaseD<uint32_t>(machInst, dest, op1, imm);
+              case 0b01:
+                return new BaseD<uint16_t>(machInst, dest, op1, imm);
+              default:
+                return new Unknown(machInst);
+            }
         }
     }
 
@@ -900,16 +932,25 @@ output header {{
         }
     }
 
-    template <template <typename T> class BaseD,
+    template <template <typename T> class BaseS,
+              template <typename T> class BaseD,
               template <typename T> class BaseQ>
     StaticInstPtr
-    decodeNeonUTwoMiscPwiseScFpReg(unsigned size, ExtMachInst machInst,
+    decodeNeonUTwoMiscPwiseScFpReg(unsigned u, unsigned size,
+                                   ExtMachInst machInst,
                                    RegIndex dest, RegIndex op1)
     {
-        if (size)
-            return new BaseQ<uint64_t>(machInst, dest, op1);
-        else
-            return new BaseD<uint32_t>(machInst, dest, op1);
+        if (u) {
+            if (size)
+                return new BaseQ<uint64_t>(machInst, dest, op1);
+            else
+                return new BaseD<uint32_t>(machInst, dest, op1);
+        } else {
+            if (size)
+                return new Unknown64(machInst);
+            else
+                return new BaseS<uint16_t>(machInst, dest, op1);
+        }
     }
 
     template <template <typename T> class Base>

--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -1594,7 +1594,7 @@ let {{
             exec_output += NeonExecDeclare.subst(substDict)
 
     def twoRegShiftInst(name, Name, opClass, types, rCount, op,
-            readDest=False, toInt=False, fromInt=False):
+            readDest=False, toInt=False, fromInt=False, readSrcElem=True):
         global header_output, exec_output
         eWalkCode = simdEnabledCheckCode + '''
         RegVect srcRegs1, destRegs;
@@ -1628,7 +1628,7 @@ let {{
             %(op)s
             %(writeDest)s
         }
-        ''' % { "readOp" : readOpCode,
+        ''' % { "readOp" : readOpCode if readSrcElem else "",
                 "declDest" : declDest,
                 "readDest" : readDestCode,
                 "op" : op,
@@ -2924,7 +2924,7 @@ let {{
             name,
             Name,
             "SimdFloatCmpOp",
-            ("uint32_t",),
+            ("uint16_t", "uint32_t",),
             rCount,
             vMinMaxFpCode % op,
             pairwise=pairwise,
@@ -2945,6 +2945,21 @@ let {{
     threeEqualRegInstFp("vpadd", "VpaddQFp", "SimdFloatAddOp", ("float",),
                         4, vaddfpCode, pairwise=True)
 
+    vaddfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibAdd(srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vadd", "VaddDFpH", "SimdFloatAddOp", ("uint16_t",),
+            2, vaddfpHCode)
+    threeEqualRegInst("vadd", "VaddQFpH", "SimdFloatAddOp", ("uint16_t",),
+            4, vaddfpHCode)
+
+    threeEqualRegInst("vpadd", "VpaddDFpH", "SimdFloatAddOp", ("uint16_t",),
+                        2, vaddfpHCode, pairwise=True)
+    threeEqualRegInst("vpadd", "VpaddQFpH", "SimdFloatAddOp", ("uint16_t",),
+                        4, vaddfpHCode, pairwise=True)
+
     vsubfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = binaryOp(fpscr, srcReg1, srcReg2, fpSubS,
@@ -2954,6 +2969,16 @@ let {{
     threeEqualRegInstFp("vsub", "VsubDFp", "SimdFloatAddOp", ("float",), 2, vsubfpCode)
     threeEqualRegInstFp("vsub", "VsubQFp", "SimdFloatAddOp", ("float",), 4, vsubfpCode)
 
+    vsubfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibSub(srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vsub", "VsubDFpH", "SimdFloatAddOp", ("uint16_t",),
+            2, vsubfpHCode)
+    threeEqualRegInst("vsub", "VsubQFpH", "SimdFloatAddOp", ("uint16_t",),
+            4, vsubfpHCode)
+
     vmulfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = binaryOp(fpscr, srcReg1, srcReg2, fpMulS,
@@ -2962,6 +2987,16 @@ let {{
     '''
     threeEqualRegInstFp("vmul", "NVmulDFp", "SimdFloatMultOp", ("float",), 2, vmulfpCode)
     threeEqualRegInstFp("vmul", "NVmulQFp", "SimdFloatMultOp", ("float",), 4, vmulfpCode)
+
+    vmulfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibMul(srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vmul", "NVmulDFpH", "SimdFloatMultOp", ("uint16_t",),
+            2, vmulfpHCode)
+    threeEqualRegInst("vmul", "NVmulQFpH", "SimdFloatMultOp", ("uint16_t",),
+            4, vmulfpHCode)
 
     vmlafpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -2974,6 +3009,17 @@ let {{
     threeEqualRegInstFp("vmla", "NVmlaDFp", "SimdFloatMultAccOp", ("float",), 2, vmlafpCode, True)
     threeEqualRegInstFp("vmla", "NVmlaQFp", "SimdFloatMultAccOp", ("float",), 4, vmlafpCode, True)
 
+    vmlafpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibAdd(
+            destElem, fplibMul(srcElem1, srcElem2, fpscr), fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vmla", "NVmlaDFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      2, vmlafpHCode, True)
+    threeEqualRegInst("vmla", "NVmlaQFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      4, vmlafpHCode, True)
+
     vfmafpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = ternaryOp(fpscr, srcReg1, srcReg2, destReg, fpMulAdd<float>,
@@ -2983,6 +3029,16 @@ let {{
     threeEqualRegInstFp("vfma", "NVfmaDFp", "SimdFloatMultAccOp", ("float",), 2, vfmafpCode, True)
     threeEqualRegInstFp("vfma", "NVfmaQFp", "SimdFloatMultAccOp", ("float",), 4, vfmafpCode, True)
 
+    vfmafpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibMulAdd(destElem, srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vfma", "NVfmaDFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      2, vfmafpHCode, True)
+    threeEqualRegInst("vfma", "NVfmaQFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      4, vfmafpHCode, True)
+
     vfmsfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = ternaryOp(fpscr, -srcReg1, srcReg2, destReg, fpMulAdd<float>,
@@ -2991,6 +3047,16 @@ let {{
     '''
     threeEqualRegInstFp("vfms", "NVfmsDFp", "SimdFloatMultAccOp", ("float",), 2, vfmsfpCode, True)
     threeEqualRegInstFp("vfms", "NVfmsQFp", "SimdFloatMultAccOp", ("float",), 4, vfmsfpCode, True)
+
+    vfmsfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibMulAdd(destElem, fplibNeg(srcElem1), srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vfms", "NVfmsDFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      2, vfmsfpHCode, True)
+    threeEqualRegInst("vfms", "NVfmsQFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      4, vfmsfpHCode, True)
 
     vmlsfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -3002,6 +3068,17 @@ let {{
     '''
     threeEqualRegInstFp("vmls", "NVmlsDFp", "SimdFloatMultAccOp", ("float",), 2, vmlsfpCode, True)
     threeEqualRegInstFp("vmls", "NVmlsQFp", "SimdFloatMultAccOp", ("float",), 4, vmlsfpCode, True)
+
+    vmlsfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibAdd(
+            destElem, fplibNeg(fplibMul(srcElem1, srcElem2, fpscr)), fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vmls", "NVmlsDFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      2, vmlsfpHCode, True)
+    threeEqualRegInst("vmls", "NVmlsQFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                      4, vmlsfpHCode, True)
 
     vcgtfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -3017,6 +3094,17 @@ let {{
     threeEqualRegInstFp("vcgt", "VcgtQFp", "SimdFloatCmpOp", ("float",),
             4, vcgtfpCode, toInt = True)
 
+    vcgtfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGT(srcElem1, srcElem2, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vcgt", "VcgtDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vcgtfpHCode)
+    threeEqualRegInst("vcgt", "VcgtQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vcgtfpHCode)
+
     vcgefpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, srcReg2, vcgeFunc,
@@ -3030,6 +3118,17 @@ let {{
             2, vcgefpCode, toInt = True)
     threeEqualRegInstFp("vcge", "VcgeQFp", "SimdFloatCmpOp", ("float",),
             4, vcgefpCode, toInt = True)
+
+    vcgefpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGE(srcElem1, srcElem2, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vcge", "VcgeDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vcgefpHCode)
+    threeEqualRegInst("vcge", "VcgeQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vcgefpHCode)
 
     vacgtfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -3045,6 +3144,18 @@ let {{
     threeEqualRegInstFp("vacgt", "VacgtQFp", "SimdFloatCmpOp", ("float",),
             4, vacgtfpCode, toInt = True)
 
+    vacgtfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGT(
+            fplibAbs(srcElem1), fplibAbs(srcElem2), fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vacgt", "VacgtDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vacgtfpHCode)
+    threeEqualRegInst("vacgt", "VacgtQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vacgtfpHCode)
+
     vacgefpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, srcReg2, vacgeFunc,
@@ -3058,6 +3169,18 @@ let {{
             2, vacgefpCode, toInt = True)
     threeEqualRegInstFp("vacge", "VacgeQFp", "SimdFloatCmpOp", ("float",),
             4, vacgefpCode, toInt = True)
+
+    vacgefpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGE(
+            fplibAbs(srcElem1), fplibAbs(srcElem2), fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vacge", "VacgeDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vacgefpHCode)
+    threeEqualRegInst("vacge", "VacgeQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vacgefpHCode)
 
     vceqfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -3073,6 +3196,17 @@ let {{
     threeEqualRegInstFp("vceq", "VceqQFp", "SimdFloatCmpOp", ("float",),
             4, vceqfpCode, toInt = True)
 
+    vceqfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareEQ(srcElem1, srcElem2, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vceq", "VceqDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vceqfpHCode)
+    threeEqualRegInst("vceq", "VceqQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vceqfpHCode)
+
     vrecpsCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = binaryOp(fpscr, srcReg1, srcReg2, fpRecpsS,
@@ -3082,6 +3216,16 @@ let {{
     threeEqualRegInstFp("vrecps", "VrecpsDFp", "SimdFloatMultAccOp", ("float",), 2, vrecpsCode)
     threeEqualRegInstFp("vrecps", "VrecpsQFp", "SimdFloatMultAccOp", ("float",), 4, vrecpsCode)
 
+    vrecpsFpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplib32RecipStep(srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vrecps", "VrecpsDFpH", "SimdFloatMultAccOp",
+                      ("uint16_t",), 2, vrecpsFpHCode)
+    threeEqualRegInst("vrecps", "VrecpsQFpH", "SimdFloatMultAccOp",
+                      ("uint16_t",), 4, vrecpsFpHCode)
+
     vrsqrtsCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = binaryOp(fpscr, srcReg1, srcReg2, fpRSqrtsS,
@@ -3090,6 +3234,16 @@ let {{
     '''
     threeEqualRegInstFp("vrsqrts", "VrsqrtsDFp", "SimdFloatMiscOp", ("float",), 2, vrsqrtsCode)
     threeEqualRegInstFp("vrsqrts", "VrsqrtsQFp", "SimdFloatMiscOp", ("float",), 4, vrsqrtsCode)
+
+    vrsqrtsFpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplib32RSqrtStep(srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vrsqrts", "VrsqrtsDFpH", "SimdFloatMiscOp",
+                      ("uint16_t",), 2, vrsqrtsFpHCode)
+    threeEqualRegInst("vrsqrts", "VrsqrtsQFpH", "SimdFloatMiscOp",
+                      ("uint16_t",), 4, vrsqrtsFpHCode)
 
     vabdfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -3101,22 +3255,50 @@ let {{
     threeEqualRegInstFp("vabd", "VabdDFp", "SimdFloatAddOp", ("float",), 2, vabdfpCode)
     threeEqualRegInstFp("vabd", "VabdQFp", "SimdFloatAddOp", ("float",), 4, vabdfpCode)
 
-    twoEqualRegInst("vmla", "VmlasD", "SimdMultAccOp", unsignedTypes, 2, vmlaCode, True)
-    twoEqualRegInst("vmla", "VmlasQ", "SimdMultAccOp", unsignedTypes, 4, vmlaCode, True)
-    twoEqualRegInstFp("vmla", "VmlasDFp", "SimdFloatMultAccOp", ("float",), 2, vmlafpCode, True)
-    twoEqualRegInstFp("vmla", "VmlasQFp", "SimdFloatMultAccOp", ("float",), 4, vmlafpCode, True)
-    twoRegLongInst("vmlal", "Vmlals", "SimdMultAccOp", smallTypes, vmlalCode, True)
+    vabdfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibAbs<Element>(fplibSub(srcElem1, srcElem2, fpscr));
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vabd", "VabdDFpH", "SimdFloatAddOp", ("uint16_t",), 2,
+                      vabdfpHCode)
+    threeEqualRegInst("vabd", "VabdQFpH", "SimdFloatAddOp", ("uint16_t",), 4,
+                      vabdfpHCode)
+
+    twoEqualRegInst("vmla", "VmlasD", "SimdMultAccOp", unsignedTypes, 2,
+                    vmlaCode, True)
+    twoEqualRegInst("vmla", "VmlasQ", "SimdMultAccOp", unsignedTypes, 4,
+                    vmlaCode, True)
+    twoEqualRegInstFp("vmla", "VmlasDFp", "SimdFloatMultAccOp", ("float",), 2,
+                      vmlafpCode, True)
+    twoEqualRegInstFp("vmla", "VmlasQFp", "SimdFloatMultAccOp", ("float",), 4,
+                      vmlafpCode, True)
+    twoEqualRegInst("vmla", "VmlasDFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                    2, vmlafpHCode, True)
+    twoEqualRegInst("vmla", "VmlasQFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                    4, vmlafpHCode, True)
+    twoRegLongInst("vmlal", "Vmlals", "SimdMultAccOp", smallTypes, vmlalCode,
+                   True)
 
     twoEqualRegInst("vmls", "VmlssD", "SimdMultAccOp", allTypes, 2, vmlsCode, True)
     twoEqualRegInst("vmls", "VmlssQ", "SimdMultAccOp", allTypes, 4, vmlsCode, True)
     twoEqualRegInstFp("vmls", "VmlssDFp", "SimdFloatMultAccOp", ("float",), 2, vmlsfpCode, True)
     twoEqualRegInstFp("vmls", "VmlssQFp", "SimdFloatMultAccOp", ("float",), 4, vmlsfpCode, True)
-    twoRegLongInst("vmlsl", "Vmlsls", "SimdMultAccOp", smallTypes, vmlslCode, True)
+    twoEqualRegInst("vmls", "VmlssDFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                    2, vmlsfpHCode, True)
+    twoEqualRegInst("vmls", "VmlssQFpH", "SimdFloatMultAccOp", ("uint16_t",),
+                    4, vmlsfpHCode, True)
+    twoRegLongInst("vmlsl", "Vmlsls", "SimdMultAccOp", smallTypes, vmlslCode,
+                   True)
 
     twoEqualRegInst("vmul", "VmulsD", "SimdMultOp", allTypes, 2, vmulCode)
     twoEqualRegInst("vmul", "VmulsQ", "SimdMultOp", allTypes, 4, vmulCode)
     twoEqualRegInstFp("vmul", "VmulsDFp", "SimdFloatMultOp", ("float",), 2, vmulfpCode)
     twoEqualRegInstFp("vmul", "VmulsQFp", "SimdFloatMultOp", ("float",), 4, vmulfpCode)
+    twoEqualRegInst("vmul", "VmulsDFpH", "SimdFloatMultOp", ("uint16_t",),
+                    2, vmulfpHCode)
+    twoEqualRegInst("vmul", "VmulsQFpH", "SimdFloatMultOp", ("uint16_t",),
+                    4, vmulfpHCode)
     twoRegLongInst("vmull", "Vmulls", "SimdMultOp", smallTypes, vmullCode)
 
     twoRegLongInst("vqdmull", "Vqdmulls", "SimdMultOp", smallTypes, vqdmullCode)
@@ -3548,6 +3730,17 @@ let {{
     twoRegShiftInst("vcvt", "NVcvt2ufxQ", "SimdCvtOp", ("float",),
             4, vcvt2ufxCode, toInt = True)
 
+    vcvt2ufxHCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibFPToFixed<uint16_t, uint16_t>(
+            srcElem1, imm, true, FPRounding_ZERO, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegShiftInst("vcvt", "NVcvt2ufxHD", "SimdCvtOp", ("uint16_t",),
+            2, vcvt2ufxHCode)
+    twoRegShiftInst("vcvt", "NVcvt2ufxHQ", "SimdCvtOp", ("uint16_t",),
+            4, vcvt2ufxHCode)
+
     vcvt2sfxCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         if (flushToZero(srcElem1))
@@ -3564,6 +3757,17 @@ let {{
     twoRegShiftInst("vcvt", "NVcvt2sfxQ", "SimdCvtOp", ("float",),
             4, vcvt2sfxCode, toInt = True)
 
+    vcvt2sfxHCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibFPToFixed<uint16_t, uint16_t>(
+            srcElem1, imm, false, FPRounding_ZERO, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegShiftInst("vcvt", "NVcvt2sfxHD", "SimdCvtOp", ("uint16_t",),
+            2, vcvt2sfxHCode)
+    twoRegShiftInst("vcvt", "NVcvt2sfxHQ", "SimdCvtOp", ("uint16_t",),
+            4, vcvt2sfxHCode)
+
     vcvtu2fpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         VfpSavedState state = prepFpState(VfpRoundNearest);
@@ -3578,6 +3782,17 @@ let {{
     twoRegShiftInst("vcvt", "NVcvtu2fpQ", "SimdCvtOp", ("float",),
             4, vcvtu2fpCode, fromInt = True)
 
+    vcvtu2fpHCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibFixedToFP<uint16_t>(
+            srcElem1, imm, true, FPRounding_TIEEVEN, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegShiftInst("vcvt", "NVcvtu2fpHD", "SimdCvtOp", ("uint16_t",),
+            2, vcvtu2fpHCode)
+    twoRegShiftInst("vcvt", "NVcvtu2fpHQ", "SimdCvtOp", ("uint16_t",),
+            4, vcvtu2fpHCode)
+
     vcvts2fpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         VfpSavedState state = prepFpState(VfpRoundNearest);
@@ -3591,6 +3806,17 @@ let {{
             2, vcvts2fpCode, fromInt = True)
     twoRegShiftInst("vcvt", "NVcvts2fpQ", "SimdCvtOp", ("float",),
             4, vcvts2fpCode, fromInt = True)
+
+    vcvts2fpHCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibFixedToFP<uint16_t>(
+            sext<16>(srcElem1), imm, false, FPRounding_TIEEVEN, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegShiftInst("vcvt", "NVcvts2fpHD", "SimdCvtOp", ("uint16_t",),
+            2, vcvts2fpHCode)
+    twoRegShiftInst("vcvt", "NVcvts2fpHQ", "SimdCvtOp", ("uint16_t",),
+            4, vcvts2fpHCode)
 
     vcvts2hCode = '''
         destElem = 0;
@@ -3623,61 +3849,55 @@ let {{
     twoRegLongMiscInst("vcvt", "NVcvth2s", "SimdCvtOp", ("uint16_t",), vcvth2sCode)
 
     vcvthp2hCode = '''
-        FPSCR fpscr = (FPSCR) FpscrExc;
-        VfpSavedState state = prepFpState(fpscr.rMode);
-        __asm__ __volatile__("" : "=m" (srcElem1) : "m" (srcElem1));
-        float mid = vcvtFpHFpS(fpscr, fpscr.dn, fpscr.ahp, srcElem1);
-        if (flushToZero(mid))
-            fpscr.idc = 1;
-        destElem = vfpFpToFixed<float>(mid, %s, 16, 0, true, %s);
-        __asm__ __volatile__("" :: "m" (destElem));
-        finishVfp(fpscr, state, true);
-        FpscrExc = fpscr;
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibFPToFixed<uint16_t, uint16_t>(
+            srcElem1, 0, %s, %s, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
     '''
 
-    vcvtahp2uhCode = vcvthp2hCode % ("false", "VfpRoundAway")
+    vcvtahp2uhCode = vcvthp2hCode % ("true", "FPRounding_TIEAWAY")
     twoRegMiscInst("vcvta.u16.f16", "NVcvt2uhAD", "SimdCvtOp",
                    ("uint16_t",), 2, vcvtahp2uhCode)
     twoRegMiscInst("vcvta.u16.f16", "NVcvt2uhAQ", "SimdCvtOp",
                    ("uint16_t",), 4, vcvtahp2uhCode)
 
-    vcvtnhp2uhCode = vcvthp2hCode % ("false", "VfpRoundNearest")
+    vcvtnhp2uhCode = vcvthp2hCode % ("true", "FPRounding_TIEEVEN")
     twoRegMiscInst("vcvtn.u16.f16", "NVcvt2uhND", "SimdCvtOp",
                    ("uint16_t",), 2, vcvtnhp2uhCode)
     twoRegMiscInst("vcvtn.u16.f16", "NVcvt2uhNQ", "SimdCvtOp",
                    ("uint16_t",), 4, vcvtnhp2uhCode)
 
-    vcvtphp2uhCode = vcvthp2hCode % ("false", "VfpRoundUpward")
+    vcvtphp2uhCode = vcvthp2hCode % ("true", "FPRounding_POSINF")
     twoRegMiscInst("vcvtp.u16.f16", "NVcvt2uhPD", "SimdCvtOp",
                    ("uint16_t",), 2, vcvtphp2uhCode)
     twoRegMiscInst("vcvtp.u16.f16", "NVcvt2uhPQ", "SimdCvtOp",
                    ("uint16_t",), 4, vcvtphp2uhCode)
 
-    vcvtmhp2uhCode = vcvthp2hCode % ("false", "VfpRoundDown")
+    vcvtmhp2uhCode = vcvthp2hCode % ("true", "FPRounding_NEGINF")
     twoRegMiscInst("vcvtm.u16.f16", "NVcvt2uhMD", "SimdCvtOp",
                    ("uint16_t",), 2, vcvtmhp2uhCode)
     twoRegMiscInst("vcvtm.u16.f16", "NVcvt2uhMQ", "SimdCvtOp",
                    ("uint16_t",), 4, vcvtmhp2uhCode)
 
-    vcvtahp2shCode = vcvthp2hCode % ("true", "VfpRoundAway")
+    vcvtahp2shCode = vcvthp2hCode % ("false", "FPRounding_TIEAWAY")
     twoRegMiscInst("vcvta.s16.f16", "NVcvt2shAD", "SimdCvtOp",
                    ("int16_t",), 2, vcvtahp2shCode)
     twoRegMiscInst("vcvta.s16.f16", "NVcvt2shAQ", "SimdCvtOp",
                    ("int16_t",), 4, vcvtahp2shCode)
 
-    vcvtnhp2shCode = vcvthp2hCode % ("true", "VfpRoundNearest")
+    vcvtnhp2shCode = vcvthp2hCode % ("false", "FPRounding_TIEEVEN")
     twoRegMiscInst("vcvtn.s16.f16", "NVcvt2shND", "SimdCvtOp",
                    ("int16_t",), 2, vcvtnhp2shCode)
     twoRegMiscInst("vcvtn.s16.f16", "NVcvt2shNQ", "SimdCvtOp",
                    ("int16_t",), 4, vcvtnhp2shCode)
 
-    vcvtphp2shCode = vcvthp2hCode % ("true", "VfpRoundUpward")
+    vcvtphp2shCode = vcvthp2hCode % ("false", "FPRounding_POSINF")
     twoRegMiscInst("vcvtp.s16.f16", "NVcvt2shPD", "SimdCvtOp",
                    ("int16_t",), 2, vcvtphp2shCode)
     twoRegMiscInst("vcvtp.s16.f16", "NVcvt2shPQ", "SimdCvtOp",
                    ("int16_t",), 4, vcvtphp2shCode)
 
-    vcvtmhp2shCode = vcvthp2hCode % ("true", "VfpRoundDown")
+    vcvtmhp2shCode = vcvthp2hCode % ("false", "FPRounding_NEGINF")
     twoRegMiscInst("vcvtm.s16.f16", "NVcvt2shMD", "SimdCvtOp",
                    ("int16_t",), 2, vcvtmhp2shCode)
     twoRegMiscInst("vcvtm.s16.f16", "NVcvt2shMQ", "SimdCvtOp",
@@ -3745,46 +3965,36 @@ let {{
                    ("int32_t",), 4, vcvtmsp2ssCode)
 
     vrinthpCode = '''
-        FPSCR fpscr = (FPSCR) FpscrExc;
-        VfpSavedState state = prepFpState(fpscr.rMode);
-        __asm__ __volatile__("" : "=m" (srcElem1) : "m" (srcElem1));
-        float mid = vcvtFpHFpS(fpscr, fpscr.dn, fpscr.ahp, srcElem1);
-        if (flushToZero(mid))
-            fpscr.idc = 1;
-        float mid2 = vfpFpRint<float>(mid, %s, fpscr.dn, true, %s);
-        destElem = vcvtFpSFpH(fpscr, fpscr.fz, fpscr.dn, %s, fpscr.ahp, mid2);
-        __asm__ __volatile__("" :: "m" (destElem));
-        finishVfp(fpscr, state, true);
-        FpscrExc = fpscr;
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibRoundInt<uint16_t>(srcElem1, %s, %s, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
     '''
-    vrintnhpCode = vrinthpCode % ("false",
-                                  "VfpRoundNearest", "VfpRoundNearest")
+    vrintnhpCode = vrinthpCode % ("FPRounding_TIEEVEN", "false")
     twoRegMiscInst("vrintn.f16", "NVrintnhpD", "SimdCvtOp",
                    ("uint16_t",), 2, vrintnhpCode)
     twoRegMiscInst("vrintn.f16", "NVrintnhpQ", "SimdCvtOp",
                    ("uint16_t",), 4, vrintnhpCode)
-    vrintxhpCode = vrinthpCode % ("true",
-                                  "VfpRoundNearest", "VfpRoundNearest")
+    vrintxhpCode = vrinthpCode % ("FPRounding_TIEEVEN", "true")
     twoRegMiscInst("vrintx.f16", "NVrintxhpD", "SimdCvtOp",
                    ("uint16_t",), 2, vrintxhpCode)
     twoRegMiscInst("vrintx.f16", "NVrintxhpQ", "SimdCvtOp",
                    ("uint16_t",), 4, vrintxhpCode)
-    vrintahpCode = vrinthpCode % ("false", "VfpRoundAway", "VfpRoundAway")
+    vrintahpCode = vrinthpCode % ("FPRounding_TIEAWAY", "false")
     twoRegMiscInst("vrinta.f16", "NVrintahpD", "SimdCvtOp",
                    ("uint16_t",), 2, vrintahpCode)
     twoRegMiscInst("vrinta.f16", "NVrintahpQ", "SimdCvtOp",
                    ("uint16_t",), 4, vrintahpCode)
-    vrintzhpCode = vrinthpCode % ("false", "VfpRoundZero", "VfpRoundZero")
+    vrintzhpCode = vrinthpCode % ("FPRounding_ZERO", "false")
     twoRegMiscInst("vrintz.f16", "NVrintzhpD", "SimdCvtOp",
                    ("uint16_t",), 2, vrintzhpCode)
     twoRegMiscInst("vrintz.f16", "NVrintzhpQ", "SimdCvtOp",
                    ("uint16_t",), 4, vrintzhpCode)
-    vrintmhpCode = vrinthpCode % ("false", "VfpRoundDown", "VfpRoundDown")
+    vrintmhpCode = vrinthpCode % ("FPRounding_NEGINF", "false")
     twoRegMiscInst("vrintm.f16", "NVrintmhpD", "SimdCvtOp",
                    ("uint16_t",), 2, vrintmhpCode)
     twoRegMiscInst("vrintm.f16", "NVrintmhpQ", "SimdCvtOp",
                    ("uint16_t",), 4, vrintmhpCode)
-    vrintphpCode = vrinthpCode % ("false", "VfpRoundUpward", "VfpRoundUpward")
+    vrintphpCode = vrinthpCode % ("FPRounding_POSINF", "false")
     twoRegMiscInst("vrintp.f16", "NVrintphpD", "SimdCvtOp",
                    ("uint16_t",), 2, vrintphpCode)
     twoRegMiscInst("vrintp.f16", "NVrintphpQ", "SimdCvtOp",
@@ -3856,6 +4066,16 @@ let {{
     twoRegMiscInstFp("vrsqrte", "NVrsqrteDFp", "SimdFloatSqrtOp", ("float",), 2, vrsqrtefpCode)
     twoRegMiscInstFp("vrsqrte", "NVrsqrteQFp", "SimdFloatSqrtOp", ("float",), 4, vrsqrtefpCode)
 
+    vrsqrtefpHCode = '''
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        destElem = fprSqrtEstimateFpH(fpscr, srcElem1);
+        FpscrExc = fpscr;
+    '''
+    twoRegMiscInst("vrsqrte", "NVrsqrteDFpH", "SimdFloatSqrtOp", ("uint16_t",),
+                   2, vrsqrtefpHCode)
+    twoRegMiscInst("vrsqrte", "NVrsqrteQFpH", "SimdFloatSqrtOp", ("uint16_t",),
+                   4, vrsqrtefpHCode)
+
     vrecpeCode = '''
         destElem = unsignedRecipEstimate(srcElem1);
     '''
@@ -3871,6 +4091,16 @@ let {{
     '''
     twoRegMiscInstFp("vrecpe", "NVrecpeDFp", "SimdFloatMultAccOp", ("float",), 2, vrecpefpCode)
     twoRegMiscInstFp("vrecpe", "NVrecpeQFp", "SimdFloatMultAccOp", ("float",), 4, vrecpefpCode)
+
+    vrecpefpHCode = '''
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        destElem = fpRecipEstimateFpH(fpscr, srcElem1);
+        FpscrExc = fpscr;
+    '''
+    twoRegMiscInst("vrecpe", "NVrecpeDFpH", "SimdMultAccOp", ("uint16_t",), 2,
+                   vrecpefpHCode)
+    twoRegMiscInst("vrecpe", "NVrecpeQFpH", "SimdMultAccOp", ("uint16_t",), 4,
+                   vrecpefpHCode)
 
     vrev16Code = '''
         destElem = srcElem1;
@@ -4001,6 +4231,7 @@ let {{
 
     twoRegMiscInst("vabs", "NVabsD", "SimdAluOp", signedTypes, 2, vabsCode)
     twoRegMiscInst("vabs", "NVabsQ", "SimdAluOp", signedTypes, 4, vabsCode)
+
     vabsfpCode = '''
         union
         {
@@ -4014,20 +4245,38 @@ let {{
     twoRegMiscInstFp("vabs", "NVabsDFp", "SimdFloatAluOp", ("float",), 2, vabsfpCode)
     twoRegMiscInstFp("vabs", "NVabsQFp", "SimdFloatAluOp", ("float",), 4, vabsfpCode)
 
+    vabsfpHCode = '''
+        destElem = srcElem1 & mask(sizeof(uint16_t) * 8 - 1);
+    '''
+    twoRegMiscInst("vabs", "NVabsDFpH", "SimdFloatAluOp", ("uint16_t",),
+            2, vabsfpHCode)
+    twoRegMiscInst("vabs", "NVabsQFpH", "SimdFloatAluOp", ("uint16_t",),
+            4, vabsfpHCode)
+
     vnegCode = '''
         destElem = -srcElem1;
     '''
     twoRegMiscInst("vneg", "NVnegD", "SimdAluOp", signedTypes, 2, vnegCode)
     twoRegMiscInst("vneg", "NVnegQ", "SimdAluOp", signedTypes, 4, vnegCode)
+
     vnegfpCode = '''
         destReg = -srcReg1;
     '''
     twoRegMiscInstFp("vneg", "NVnegDFp", "SimdFloatAluOp", ("float",), 2, vnegfpCode)
     twoRegMiscInstFp("vneg", "NVnegQFp", "SimdFloatAluOp", ("float",), 4, vnegfpCode)
 
+    vnegfpHCode = '''
+        destElem = fplibNeg(srcElem1);
+    '''
+    twoRegMiscInst("vneg", "NVnegDFpH", "SimdFloatAluOp", ("uint16_t",),
+            2, vnegfpHCode)
+    twoRegMiscInst("vneg", "NVnegQFpH", "SimdFloatAluOp", ("uint16_t",),
+            4, vnegfpHCode)
+
     vcgtCode = 'destElem = (srcElem1 > 0) ? mask(sizeof(Element) * 8) : 0;'
     twoRegMiscInst("vcgt", "NVcgtD", "SimdCmpOp", signedTypes, 2, vcgtCode)
     twoRegMiscInst("vcgt", "NVcgtQ", "SimdCmpOp", signedTypes, 4, vcgtCode)
+
     vcgtfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, (float)0.0, vcgtFunc,
@@ -4042,9 +4291,21 @@ let {{
     twoRegMiscInstFp("vcgt", "NVcgtQFp", "SimdFloatCmpOp", ("float",),
             4, vcgtfpCode, toInt = True)
 
+    vcgtfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGT(srcElem1, (Element)0, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegMiscInst("vcgt", "NVcgtDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vcgtfpHCode)
+    twoRegMiscInst("vcgt", "NVcgtQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vcgtfpHCode)
+
     vcgeCode = 'destElem = (srcElem1 >= 0) ? mask(sizeof(Element) * 8) : 0;'
     twoRegMiscInst("vcge", "NVcgeD", "SimdCmpOp", signedTypes, 2, vcgeCode)
     twoRegMiscInst("vcge", "NVcgeQ", "SimdCmpOp", signedTypes, 4, vcgeCode)
+
     vcgefpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, (float)0.0, vcgeFunc,
@@ -4059,9 +4320,21 @@ let {{
     twoRegMiscInstFp("vcge", "NVcgeQFp", "SimdFloatCmpOp", ("float",),
             4, vcgefpCode, toInt = True)
 
+    vcgefpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGE(srcElem1, (Element)0, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegMiscInst("vcge", "NVcgeDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vcgefpHCode)
+    twoRegMiscInst("vcge", "NVcgeQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vcgefpHCode)
+
     vceqCode = 'destElem = (srcElem1 == 0) ? mask(sizeof(Element) * 8) : 0;'
     twoRegMiscInst("vceq", "NVceqD", "SimdCmpOp", signedTypes, 2, vceqCode)
     twoRegMiscInst("vceq", "NVceqQ", "SimdCmpOp", signedTypes, 4, vceqCode)
+
     vceqfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, (float)0.0, vceqFunc,
@@ -4076,9 +4349,21 @@ let {{
     twoRegMiscInstFp("vceq", "NVceqQFp", "SimdFloatCmpOp", ("float",),
             4, vceqfpCode, toInt = True)
 
+    vceqfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareEQ(srcElem1, (Element)0, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegMiscInst("vceq", "NVceqDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vceqfpHCode)
+    twoRegMiscInst("vceq", "NVceqQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vceqfpHCode)
+
     vcleCode = 'destElem = (srcElem1 <= 0) ? mask(sizeof(Element) * 8) : 0;'
     twoRegMiscInst("vcle", "NVcleD", "SimdCmpOp", signedTypes, 2, vcleCode)
     twoRegMiscInst("vcle", "NVcleQ", "SimdCmpOp", signedTypes, 4, vcleCode)
+
     vclefpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, (float)0.0, vcleFunc,
@@ -4093,9 +4378,21 @@ let {{
     twoRegMiscInstFp("vcle", "NVcleQFp", "SimdFloatCmpOp", ("float",),
             4, vclefpCode, toInt = True)
 
+    vclefpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGE((Element)0, srcElem1, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegMiscInst("vcle", "NVcleDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vclefpHCode)
+    twoRegMiscInst("vcle", "NVcleQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vclefpHCode)
+
     vcltCode = 'destElem = (srcElem1 < 0) ? mask(sizeof(Element) * 8) : 0;'
     twoRegMiscInst("vclt", "NVcltD", "SimdCmpOp", signedTypes, 2, vcltCode)
     twoRegMiscInst("vclt", "NVcltQ", "SimdCmpOp", signedTypes, 4, vcltCode)
+
     vcltfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         float res = binaryOp(fpscr, srcReg1, (float)0.0, vcltFunc,
@@ -4109,6 +4406,17 @@ let {{
             2, vcltfpCode, toInt = True)
     twoRegMiscInstFp("vclt", "NVcltQFp", "SimdFloatCmpOp", ("float",),
             4, vcltfpCode, toInt = True)
+
+    vcltfpHCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        bool test_passed = fplibCompareGT((Element)0, srcElem1, fpscr);
+        destElem = test_passed ? 0xFFFF : 0x0000;
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegMiscInst("vclt", "NVcltDFpH", "SimdFloatCmpOp", ("uint16_t",),
+            2, vcltfpHCode)
+    twoRegMiscInst("vclt", "NVcltQFpH", "SimdFloatCmpOp", ("uint16_t",),
+            4, vcltfpHCode)
 
     vswpCode = '''
         uint32_t mid;
@@ -4170,6 +4478,26 @@ let {{
     vdupCode = 'destElem = srcElem1;'
     twoRegMiscScInst("vdup", "NVdupD", "SimdAluOp", smallUnsignedTypes, 2, vdupCode)
     twoRegMiscScInst("vdup", "NVdupQ", "SimdAluOp", smallUnsignedTypes, 4, vdupCode)
+
+    vmovxCode = '''
+        if (i == 0) {
+            destElem = letoh(srcRegs1.elements[1]);
+        } else {
+            destElem = (Element)0;
+        }
+    '''
+    twoRegShiftInst("vmovx", "NVmovx", "SimdMiscOp", ("uint16_t",), 1,
+                    vmovxCode, readSrcElem=False)
+
+    vinsCode = '''
+        if (i == 1) {
+            destElem = letoh(srcRegs1.elements[0]);
+        } else {
+            destElem = letoh(destRegs.elements[i]);
+        }
+    '''
+    twoRegShiftInst("vins", "NVins", "SimdMiscOp", ("uint16_t",), 1,
+                    vinsCode, readDest=True, readSrcElem=False)
 
     def vdupGprInst(name, Name, opClass, types, rCount):
         global header_output, exec_output

--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -3323,6 +3323,80 @@ let {{
             "SimdMultOp", smallSignedTypes, 4, vqrdmlshCode, readDest=True,
             extra=rdm_check)
 
+    vdotCode = '''
+        int way = sizeof(Element) / sizeof(%(src1_type)s);
+
+        Element res = destElem;
+        for (int w = 0; w < way; w ++) {
+            Element src1_elem = (%(src1_type)s)
+                (srcElem1 >> (8 * sizeof(%(src1_type)s) * w));
+            Element src2_elem = (%(src2_type)s)
+                (srcElem2 >> (8 * sizeof(%(src2_type)s) * w));
+            res = res + src1_elem * src2_elem;
+        }
+        destElem = res;
+    '''
+    twoEqualRegInst("vudot", "VudotElemD", "SimdMultOp", ("uint32_t",), 2,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "uint8_t"}, True)
+    twoEqualRegInst("vudot", "VudotElemQ", "SimdMultOp", ("uint32_t",), 4,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "uint8_t"}, True)
+    twoEqualRegInst("vsdot", "VsdotElemD", "SimdMultOp", ("int32_t",), 2,
+        vdotCode % {"src1_type": "int8_t", "src2_type": "int8_t"}, True)
+    twoEqualRegInst("vsdot", "VsdotElemQ", "SimdMultOp", ("int32_t",), 4,
+        vdotCode % {"src1_type": "int8_t", "src2_type": "int8_t"}, True)
+
+    threeEqualRegInst("vudot", "VudotD", "SimdMultOp", ("uint32_t",), 2,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "uint8_t"}, True)
+    threeEqualRegInst("vudot", "VudotQ", "SimdMultOp", ("uint32_t",), 4,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "uint8_t"}, True)
+    threeEqualRegInst("vsdot", "VsdotD", "SimdMultOp", ("int32_t",), 2,
+        vdotCode % {"src1_type": "int8_t", "src2_type": "int8_t"}, True)
+    threeEqualRegInst("vsdot", "VsdotQ", "SimdMultOp", ("int32_t",), 4,
+        vdotCode % {"src1_type": "int8_t", "src2_type": "int8_t"}, True)
+
+    twoEqualRegInst("vusdot", "VusdotElemD", "SimdMultOp", ("int32_t",), 2,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "int8_t"}, True)
+    twoEqualRegInst("vusdot", "VusdotElemQ", "SimdMultOp", ("int32_t",), 4,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "int8_t"}, True)
+    twoEqualRegInst("vsudot", "VsudotElemD", "SimdMultOp", ("int32_t",), 2,
+        vdotCode % {"src1_type": "int8_t", "src2_type": "uint8_t"}, True)
+    twoEqualRegInst("vsudot", "VsudotElemQ", "SimdMultOp", ("int32_t",), 4,
+        vdotCode % {"src1_type": "int8_t", "src2_type": "uint8_t"}, True)
+
+    threeEqualRegInst("vusdot", "VusdotD", "SimdMultOp", ("int32_t",), 2,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "int8_t"}, True)
+    threeEqualRegInst("vusdot", "VusdotQ", "SimdMultOp", ("int32_t",), 4,
+        vdotCode % {"src1_type": "uint8_t", "src2_type": "int8_t"}, True)
+
+    vmmla8bCode = '''
+        for (int i = 0; i < 2; i ++) {
+            for (int j = 0; j < 2; j ++) {
+                Element sum = letoh(destReg.elements[2 * i + j]);
+                for (int e = 0; e < 2; e ++) {
+                    Element srcElem1 = letoh(srcReg1.elements[2 * i + e]);
+                    Element srcElem2 = letoh(srcReg2.elements[2 * j + e]);
+                    for (int w = 0; w < 4; w ++) {
+                        Element src1_elem = (%(src1_type)s)
+                            (srcElem1 >> (8 * sizeof(%(src1_type)s) * w));
+                        Element src2_elem = (%(src2_type)s)
+                            (srcElem2 >> (8 * sizeof(%(src2_type)s) * w));
+                        sum = sum + src1_elem * src2_elem;
+                    }
+                }
+                destReg.elements[2 * i + j] = htole(sum);
+            }
+        }
+    '''
+    threeEqualRegInst("vummla", "VummlaQ", "SimdMultOp", ("uint32_t",), 4,
+        vmmla8bCode % {"src1_type": "uint8_t", "src2_type": "uint8_t"},
+        readDest=True, complex=True)
+    threeEqualRegInst("vsmmla", "VsmmlaQ", "SimdMultOp", ("int32_t",), 4,
+        vmmla8bCode % {"src1_type": "int8_t", "src2_type": "int8_t"},
+        readDest=True, complex=True)
+    threeEqualRegInst("vusmmla", "VusmmlaQ", "SimdMultOp", ("int32_t",), 4,
+        vmmla8bCode % {"src1_type": "uint8_t", "src2_type": "int8_t"},
+        readDest=True, complex=True)
+
     vshrCode = '''
         if (imm >= sizeof(srcElem1) * 8) {
             if (ltz(srcElem1))

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 
-// Copyright (c) 2012-2013, 2015-2018, 2020, 2024 ARM Limited
+// Copyright (c) 2012-2013, 2015-2018, 2020, 2024-2025 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -43,7 +43,7 @@ let {{
 
     # FP types (FP operations always work with unsigned representations)
     floatTypes = ("uint16_t", "uint32_t", "uint64_t")
-    smallFloatTypes = ("uint32_t",)
+    smallFloatTypes = ("uint16_t","uint32_t")
 
     zeroSveVecRegUpperPartCode = '''
         ArmISA::ISA::zeroSveVecRegUpperPart(%s,
@@ -555,7 +555,13 @@ let {{
         %(op)s
         destReg.elements[0] = htole(destElem);
         ''' % { "op" : op }
-        destCnt = rCount // 2
+
+        if rCount == 1:
+            # This is the FP16 case
+            destCnt = rCount
+        else:
+            destCnt = rCount // 2
+
         for reg in range(destCnt):
             eWalkCode += '''
         AA64FpDestP%(reg)d_uw = letoh(destReg.regs[%(reg)d]);
@@ -1435,6 +1441,8 @@ let {{
     threeEqualRegInstX("fadd", "FaddQX", "SimdFloatAddOp", floatTypes, 4,
                        faddCode)
     # FADDP (scalar)
+    twoRegPairwiseScInstX("faddp", "FaddpScSX", "SimdFloatAddOp",
+                          ("uint16_t",), 1, faddCode)
     twoRegPairwiseScInstX("faddp", "FaddpScDX", "SimdFloatAddOp",
                           ("uint32_t",), 2, faddCode)
     twoRegPairwiseScInstX("faddp", "FaddpScQX", "SimdFloatAddOp",
@@ -1653,6 +1661,8 @@ let {{
     threeEqualRegInstX("fmaxnm", "FmaxnmQX", "SimdFloatCmpOp", floatTypes, 4,
                        fmaxnmCode)
     # FMAXNMP (scalar)
+    twoRegPairwiseScInstX("fmaxnmp", "FmaxnmpScSX", "SimdFloatCmpOp",
+                          ("uint16_t",), 1, fmaxnmCode)
     twoRegPairwiseScInstX("fmaxnmp", "FmaxnmpScDX", "SimdFloatCmpOp",
                           ("uint32_t",), 2, fmaxnmCode)
     twoRegPairwiseScInstX("fmaxnmp", "FmaxnmpScQX", "SimdFloatCmpOp",
@@ -1666,9 +1676,15 @@ let {{
     # Note: SimdFloatCmpOp can be a bit optimistic here
     fpAcrossOp = fpOp % "fplib%s<Element>(destElem, srcElem1, fpscr)"
     fmaxnmAcrossCode = fpAcrossOp % "MaxNum"
-    twoRegAcrossInstX("fmaxnmv", "FmaxnmvQX", "SimdFloatCmpOp", ("uint32_t",),
-                      4, fmaxnmAcrossCode, False, False, True)
+    twoRegAcrossInstX("fmaxnmv", "FmaxnmvDX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 2, fmaxnmAcrossCode,
+                      False, False, True)
+    twoRegAcrossInstX("fmaxnmv", "FmaxnmvQX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 4, fmaxnmAcrossCode,
+                      False, False, True)
     # FMAXP (scalar)
+    twoRegPairwiseScInstX("fmaxp", "FmaxpScSX", "SimdFloatCmpOp",
+                          ("uint16_t",), 1, fmaxCode)
     twoRegPairwiseScInstX("fmaxp", "FmaxpScDX", "SimdFloatCmpOp",
                           ("uint32_t",), 2, fmaxCode)
     twoRegPairwiseScInstX("fmaxp", "FmaxpScQX", "SimdFloatCmpOp",
@@ -1681,7 +1697,11 @@ let {{
     # FMAXV
     # Note: SimdFloatCmpOp can be a bit optimistic here
     fmaxAcrossCode = fpAcrossOp % "Max"
-    twoRegAcrossInstX("fmaxv", "FmaxvQX", "SimdFloatCmpOp", ("uint32_t",), 4,
+    twoRegAcrossInstX("fmaxv", "FmaxvDX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 2,
+                      fmaxAcrossCode, False, False, True)
+    twoRegAcrossInstX("fmaxv", "FmaxvQX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 4,
                       fmaxAcrossCode, False, False, True)
     # FMIN
     fminCode = fpBinOp % "Min"
@@ -1696,6 +1716,8 @@ let {{
     threeEqualRegInstX("fminnm", "FminnmQX", "SimdFloatCmpOp", floatTypes, 4,
                        fminnmCode)
     # FMINNMP (scalar)
+    twoRegPairwiseScInstX("fminnmp", "FminnmpScSX", "SimdFloatCmpOp",
+                          ("uint16_t",), 1, fminnmCode)
     twoRegPairwiseScInstX("fminnmp", "FminnmpScDX", "SimdFloatCmpOp",
                           ("uint32_t",), 2, fminnmCode)
     twoRegPairwiseScInstX("fminnmp", "FminnmpScQX", "SimdFloatCmpOp",
@@ -1708,9 +1730,15 @@ let {{
     # FMINNMV
     # Note: SimdFloatCmpOp can be a bit optimistic here
     fminnmAcrossCode = fpAcrossOp % "MinNum"
-    twoRegAcrossInstX("fminnmv", "FminnmvQX", "SimdFloatCmpOp", ("uint32_t",),
-                      4, fminnmAcrossCode, False, False, True)
+    twoRegAcrossInstX("fminnmv", "FminnmvDX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 2, fminnmAcrossCode,
+                      False, False, True)
+    twoRegAcrossInstX("fminnmv", "FminnmvQX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 4, fminnmAcrossCode,
+                      False, False, True)
     # FMINP (scalar)
+    twoRegPairwiseScInstX("fminp", "FminpScSX", "SimdFloatCmpOp",
+                          ("uint16_t",), 1, fminCode)
     twoRegPairwiseScInstX("fminp", "FminpScDX", "SimdFloatCmpOp",
                           ("uint32_t",), 2, fminCode)
     twoRegPairwiseScInstX("fminp", "FminpScQX", "SimdFloatCmpOp",
@@ -1723,7 +1751,11 @@ let {{
     # FMINV
     # Note: SimdFloatCmpOp can be a bit optimistic here
     fminAcrossCode = fpAcrossOp % "Min"
-    twoRegAcrossInstX("fminv", "FminvQX", "SimdFloatCmpOp", ("uint32_t",), 4,
+    twoRegAcrossInstX("fminv", "FminvDX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 2,
+                      fminAcrossCode, False, False, True)
+    twoRegAcrossInstX("fminv", "FminvQX", "SimdFloatCmpOp",
+                      ("uint16_t", "uint32_t"), 4,
                       fminAcrossCode, False, False, True)
     # FMLA (by element)
     fmlaCode = fpOp % ("fplibMulAdd<Element>("
@@ -2155,7 +2187,9 @@ let {{
                      scvtfIntCode % 32)
     twoEqualRegInstX("scvtf", "ScvtfIntDQX", "SimdCvtOp", ("uint64_t",), 4,
                      scvtfIntCode % 64)
-    twoEqualRegInstX("scvtf", "ScvtfIntScSX", "SimdCvtOp", smallFloatTypes, 4,
+    twoEqualRegInstX("scvtf", "ScvtfIntScHX", "SimdCvtOp", ("uint16_t",), 4,
+                     scvtfIntCode % 16, scalar=True)
+    twoEqualRegInstX("scvtf", "ScvtfIntScSX", "SimdCvtOp", ("uint32_t",), 4,
                      scvtfIntCode % 32, scalar=True)
     twoEqualRegInstX("scvtf", "ScvtfIntScDX", "SimdCvtOp", ("uint64_t",), 4,
                      scvtfIntCode % 64, scalar=True)

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -2166,33 +2166,35 @@ let {{
     threeRegWideInstX("saddw2", "Saddw2X", "SimdAddAccOp", smallSignedTypes,
                       addlwCode, hi=True)
     # SCVTF (fixed-point)
-    scvtfFixedCode = fpOp % ("fplibFixedToFP<Element>((int%d_t) srcElem1, imm,"
+    scvtfFixedCode = fpOp % ("fplibFixedToFP<Element>("
+                             "sext<sizeof(Element) * 8>(srcElem1), imm,"
                              " false, FPCRRounding(fpscr), fpscr)")
     twoEqualRegInstX("scvtf", "ScvtfFixedDX", "SimdCvtOp", smallFloatTypes, 2,
-                     scvtfFixedCode % 32, hasImm=True)
+                     scvtfFixedCode, hasImm=True)
     twoEqualRegInstX("scvtf", "ScvtfFixedSQX", "SimdCvtOp", smallFloatTypes, 4,
-                     scvtfFixedCode % 32, hasImm=True)
+                     scvtfFixedCode, hasImm=True)
     twoEqualRegInstX("scvtf", "ScvtfFixedDQX", "SimdCvtOp", ("uint64_t",), 4,
-                     scvtfFixedCode % 64, hasImm=True)
+                     scvtfFixedCode, hasImm=True)
     twoEqualRegInstX("scvtf", "ScvtfFixedScSX", "SimdCvtOp", smallFloatTypes,
-                     4, scvtfFixedCode % 32, hasImm=True, scalar=True)
+                     4, scvtfFixedCode, hasImm=True, scalar=True)
     twoEqualRegInstX("scvtf", "ScvtfFixedScDX", "SimdCvtOp", ("uint64_t",), 4,
-                     scvtfFixedCode % 64, hasImm=True, scalar=True)
+                     scvtfFixedCode, hasImm=True, scalar=True)
     # SCVTF (integer)
-    scvtfIntCode = fpOp % ("fplibFixedToFP<Element>((int%d_t) srcElem1, 0,"
+    scvtfIntCode = fpOp % ("fplibFixedToFP<Element>("
+                           "sext<sizeof(Element) * 8>(srcElem1), 0,"
                            " false, FPCRRounding(fpscr), fpscr)")
     twoEqualRegInstX("scvtf", "ScvtfIntDX", "SimdCvtOp", smallFloatTypes, 2,
-                     scvtfIntCode % 32)
+                     scvtfIntCode)
     twoEqualRegInstX("scvtf", "ScvtfIntSQX", "SimdCvtOp", smallFloatTypes, 4,
-                     scvtfIntCode % 32)
+                     scvtfIntCode)
     twoEqualRegInstX("scvtf", "ScvtfIntDQX", "SimdCvtOp", ("uint64_t",), 4,
-                     scvtfIntCode % 64)
+                     scvtfIntCode)
     twoEqualRegInstX("scvtf", "ScvtfIntScHX", "SimdCvtOp", ("uint16_t",), 4,
-                     scvtfIntCode % 16, scalar=True)
+                     scvtfIntCode, scalar=True)
     twoEqualRegInstX("scvtf", "ScvtfIntScSX", "SimdCvtOp", ("uint32_t",), 4,
-                     scvtfIntCode % 32, scalar=True)
+                     scvtfIntCode, scalar=True)
     twoEqualRegInstX("scvtf", "ScvtfIntScDX", "SimdCvtOp", ("uint64_t",), 4,
-                     scvtfIntCode % 64, scalar=True)
+                     scvtfIntCode, scalar=True)
     # SHADD
     haddCode = '''
             Element carryBit =

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2015-2024 Arm Limited
+ * Copyright (c) 2010-2013, 2015-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -4899,6 +4899,8 @@ ISA::initializeMiscRegMetadata()
           pfr0_el1.el2 = release->has(ArmExtension::VIRTUALIZATION)
                                   ? 0x2 : 0x0;
           pfr0_el1.el3 = release->has(ArmExtension::SECURITY) ? 0x2 : 0x0;
+          pfr0_el1.fp = release->has(ArmExtension::FEAT_FP16) ? 0x1 : 0x0;
+          pfr0_el1.advsimd = release->has(ArmExtension::FEAT_FP16) ? 0x1 : 0x0;
           pfr0_el1.sve = release->has(ArmExtension::FEAT_SVE) ? 0x1 : 0x0;
           pfr0_el1.sel2 = release->has(ArmExtension::FEAT_SEL2) ? 0x1 : 0x0;
           // See MPAM frac in MISCREG_ID_AA64PFR1_EL1. Currently supporting


### PR DESCRIPTION
According to the Arm architecture reference manual, FEAT_FP16 is
optional in Armv8.2 implementations, though it is mandatory
if FEAT_SVE is implemented