### PR TITLE
scons: Explicitly define call arg in `CheckLibWithHeader`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -798,10 +798,12 @@ for variant_path in variant_paths:
     with gem5_scons.Configure(env) as conf:
         # On Solaris you need to use libsocket for socket ops
         if not conf.CheckLibWithHeader(
-                [None, 'socket'], 'sys/socket.h', 'C++', 'accept(0,0,0);'):
+                [None, 'socket'], 'sys/socket.h', 'C++',
+                call='accept(0,0,0);'):
            error("Can't find library with socket calls (e.g. accept()).")
 
-        if not conf.CheckLibWithHeader('z', 'zlib.h', 'C++','zlibVersion();'):
+        if not conf.CheckLibWithHeader('z', 'zlib.h', 'C++',
+                                       call='zlibVersion();'):
             error('Did not find needed zlib compression library '
                   'and/or zlib.h header file.\n'
                   'Please install zlib and try again.')

--- a/src/base/SConsopts
+++ b/src/base/SConsopts
@@ -52,7 +52,7 @@ with gem5_scons.Configure(main) as conf:
 
     conf.env['CONF']['HAVE_POSIX_CLOCK'] = \
         conf.CheckLibWithHeader([None, 'rt'], 'time.h', 'C',
-                                'clock_nanosleep(0,0,NULL,NULL);')
+                                call='clock_nanosleep(0,0,NULL,NULL);')
     if not conf.env['CONF']['HAVE_POSIX_CLOCK']:
         warning("Can't find library for POSIX clocks.")
 

--- a/src/base/stats/SConsopts
+++ b/src/base/stats/SConsopts
@@ -43,9 +43,9 @@ with gem5_scons.Configure(main) as conf:
     # since some installations don't use pkg-config.
     conf.env['CONF']['HAVE_HDF5'] = \
             conf.CheckLibWithHeader('hdf5', 'hdf5.h', 'C',
-                                    'H5Fcreate("", 0, 0, 0);') and \
+                                    call='H5Fcreate("", 0, 0, 0);') and \
             conf.CheckLibWithHeader('hdf5_cpp', 'H5Cpp.h', 'C++',
-                                    'H5::H5File("", 0);')
+                                    call='H5::H5File("", 0);')
 
     if conf.env['CONF']['HAVE_HDF5']:
         conf.env.TagImplies('hdf5', 'gem5 lib')

--- a/src/cpu/kvm/SConsopts
+++ b/src/cpu/kvm/SConsopts
@@ -44,7 +44,7 @@ with gem5_scons.Configure(main) as conf:
         warning("Info: Compatible header file <linux/kvm.h> not found, "
                 "disabling KVM support.")
     elif not conf.CheckLibWithHeader([None, 'rt'], [ 'time.h', 'signal.h' ],
-            'C', 'timer_create(CLOCK_MONOTONIC, NULL, NULL);'):
+            'C', call='timer_create(CLOCK_MONOTONIC, NULL, NULL);'):
         warning("Cannot enable KVM, host doesn't support POSIX timers")
     else:
         # Generic support is available. We'll let the ISAs figure out if

--- a/src/mem/SConsopts
+++ b/src/mem/SConsopts
@@ -33,6 +33,6 @@ import gem5_scons
 with gem5_scons.Configure(main) as conf:
     have_shm_open = \
         conf.CheckLibWithHeader([None, 'rt'], 'sys/mman.h', 'C',
-                                'shm_open("/test", 0, 0);')
+                                call='shm_open("/test", 0, 0);')
     if not have_shm_open:
         warning("Can't find library for sys/mman.")

--- a/src/proto/SConsopts
+++ b/src/proto/SConsopts
@@ -62,7 +62,7 @@ with gem5_scons.Configure(main) as conf:
             (conf.env['HAVE_PKG_CONFIG'] and
             conf.CheckPkgConfig('protobuf', '--cflags', '--libs')) or
             conf.CheckLibWithHeader('protobuf', 'google/protobuf/message.h',
-                                    'C++', 'GOOGLE_PROTOBUF_VERIFY_VERSION;'))
+                                    'C++', call='GOOGLE_PROTOBUF_VERIFY_VERSION;'))
     )
 
 # If we have the compiler but not the library, print another warning.

--- a/src/sim/SConsopts
+++ b/src/sim/SConsopts
@@ -31,7 +31,7 @@ import gem5_scons
 
 with gem5_scons.Configure(main) as conf:
     if conf.CheckLibWithHeader([None, 'execinfo'], 'execinfo.h', 'C',
-            'backtrace_symbols_fd((void *)1, 0, 0);'):
+            call='backtrace_symbols_fd((void *)1, 0, 0);'):
         conf.env['BACKTRACE_IMPL'] = 'glibc'
     else:
         conf.env['BACKTRACE_IMPL'] = 'none'


### PR DESCRIPTION
This PR fixes gem5's build compatibility with SCons 4.9.0.

With the release of SCons 4.9.0, a new optional `extra_libs` argument was introduced in the `CheckLibWithHeader` function, modifying its signature from:

```python
def CheckLibWithHeader(context, libs, header, language,
                       call=None, autoadd=True, append=True, unique=False) -> bool:
```
to:
```python
def CheckLibWithHeader(context, libs, header, language,
                       extra_libs=None, call=None, autoadd=True,
                       append=True, unique=False) -> bool:
```

Since gem5 calls `CheckLibWithHeader` using positional arguments—for example:
```python
conf.CheckLibWithHeader('z', 'zlib.h', 'C++', 'zlibVersion();')
```
—in SCons 4.9.0, `'zlibVersion();'` is mistakenly assigned to `extra_libs` instead of `call`. This leads to SCons incorrectly trying to link with `lz -ll -li -lb -lV -le -lr -ls -li -lo -ln -l( -l) -l;` instead of calling `zlibversion();`, causing the build to fail.

To resolve this, this PR explicitly specifies the `call` argument:
```python
conf.CheckLibWithHeader('z', 'zlib.h', 'C++', call='zlibVersion();')
```
This ensures compatibility with both SCons 4.9.0 and older versions.