### PR TITLE
tests: add tests for restoring from checkpoints using multisim

### DIFF
--- a/tests/gem5/multisim/configs/hello-restore-checkpoint.py
+++ b/tests/gem5/multisim/configs/hello-restore-checkpoint.py
@@ -42,17 +42,12 @@ from gem5.utils.requires import requires
 multisim.set_num_processes(5)
 
 for isa in [ISA.RISCV, ISA.ARM, ISA.X86]:
-    # In this setup we don't have a cache. `NoCache` can be used for such setups.
     cache_hierarchy = NoCache()
 
-    # We use a single channel DDR3_1600 memory system
     memory = SingleChannelDDR3_1600(size="32MiB")
 
-    # We use a simple Timing processor with one core.
     processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1)
 
-    # The gem5 library simple board which can be used to run simple SE-mode
-    # simulations.
     board = SimpleBoard(
         clk_freq="3GHz",
         processor=processor,

--- a/tests/gem5/multisim/configs/hello-restore-checkpoint.py
+++ b/tests/gem5/multisim/configs/hello-restore-checkpoint.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2022-2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import gem5.utils.multisim as multisim
+from gem5.components.boards.simple_board import SimpleBoard
+from gem5.components.cachehierarchies.classic.no_cache import NoCache
+from gem5.components.memory import SingleChannelDDR3_1600
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import (
+    CheckpointResource,
+    obtain_resource,
+)
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
+
+multisim.set_num_processes(5)
+
+for isa in [ISA.RISCV, ISA.ARM, ISA.X86]:
+    # In this setup we don't have a cache. `NoCache` can be used for such setups.
+    cache_hierarchy = NoCache()
+
+    # We use a single channel DDR3_1600 memory system
+    memory = SingleChannelDDR3_1600(size="32MiB")
+
+    # We use a simple Timing processor with one core.
+    processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1)
+
+    # The gem5 library simple board which can be used to run simple SE-mode
+    # simulations.
+    board = SimpleBoard(
+        clk_freq="3GHz",
+        processor=processor,
+        memory=memory,
+        cache_hierarchy=cache_hierarchy,
+    )
+
+    if isa == ISA.RISCV:
+        board.set_se_binary_workload(
+            obtain_resource("riscv-hello"),
+            checkpoint=CheckpointResource(
+                "./gem5/multisim/configs/riscv-hello-checkpoint/"
+            ),
+        )
+    elif isa == ISA.ARM:
+        board.set_se_binary_workload(
+            obtain_resource("arm-hello64-static"),
+            checkpoint=CheckpointResource(
+                "./gem5/multisim/configs/arm-hello-checkpoint/"
+            ),
+        )
+    else:
+        board.set_se_binary_workload(
+            obtain_resource("x86-hello64-static"),
+            checkpoint=CheckpointResource(
+                "./gem5/multisim/configs/x86-hello-checkpoint/"
+            ),
+        )
+
+    simulator = Simulator(
+        board=board, id=f"process-{isa.name}-checkpoint-restore"
+    )
+    multisim.add_simulator(simulator=simulator)

--- a/tests/gem5/multisim/configs/hello-restore-checkpoint.py
+++ b/tests/gem5/multisim/configs/hello-restore-checkpoint.py
@@ -63,22 +63,28 @@ for isa in [ISA.RISCV, ISA.ARM, ISA.X86]:
     if isa == ISA.RISCV:
         board.set_se_binary_workload(
             obtain_resource("riscv-hello"),
+            # When the correct resource is made, change the below to:
+            # checkpoint=obtain_resource("riscv-hello-1000000-tick-checkpoint")
             checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/riscv-hello-checkpoint/"
+                "./gem5/multisim/configs/process_RISCV-hello-checkpoint/"
             ),
         )
     elif isa == ISA.ARM:
         board.set_se_binary_workload(
             obtain_resource("arm-hello64-static"),
+            # When the correct resource is made, change the below to:
+            # checkpoint=obtain_resource("arm-hello64-static-1000000-tick-checkpoint")
             checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/arm-hello-checkpoint/"
+                "./gem5/multisim/configs/process_ARM-hello-checkpoint/"
             ),
         )
     else:
         board.set_se_binary_workload(
             obtain_resource("x86-hello64-static"),
+            # When the correct resource is made, change the below to:
+            # checkpoint=obtain_resource("x86-hello64-static-1000000-tick-checkpoint")
             checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/x86-hello-checkpoint/"
+                "./gem5/multisim/configs/process_X86-hello-checkpoint/"
             ),
         )
 

--- a/tests/gem5/multisim/configs/hello-restore-checkpoint.py
+++ b/tests/gem5/multisim/configs/hello-restore-checkpoint.py
@@ -63,28 +63,20 @@ for isa in [ISA.RISCV, ISA.ARM, ISA.X86]:
     if isa == ISA.RISCV:
         board.set_se_binary_workload(
             obtain_resource("riscv-hello"),
-            # When the correct resource is made, change the below to:
-            # checkpoint=obtain_resource("riscv-hello-1000000-tick-checkpoint")
-            checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/process_RISCV-hello-checkpoint/"
-            ),
+            checkpoint=obtain_resource("riscv-hello-1000000-tick-checkpoint"),
         )
     elif isa == ISA.ARM:
         board.set_se_binary_workload(
             obtain_resource("arm-hello64-static"),
-            # When the correct resource is made, change the below to:
-            # checkpoint=obtain_resource("arm-hello64-static-1000000-tick-checkpoint")
-            checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/process_ARM-hello-checkpoint/"
+            checkpoint=obtain_resource(
+                "arm-hello64-static-1000000-tick-checkpoint"
             ),
         )
     else:
         board.set_se_binary_workload(
             obtain_resource("x86-hello64-static"),
-            # When the correct resource is made, change the below to:
-            # checkpoint=obtain_resource("x86-hello64-static-1000000-tick-checkpoint")
-            checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/process_X86-hello-checkpoint/"
+            checkpoint=obtain_resource(
+                "x86-hello64-static-1000000-tick-checkpoint"
             ),
         )
 

--- a/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
+++ b/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
@@ -41,24 +41,17 @@ from gem5.utils.requires import requires
 
 multisim.set_num_processes(5)
 
-# This check ensures the gem5 binary is compiled to the RISCV ISA target.
-# If not, an exception will be thrown.
 requires(isa_required=ISA.RISCV)
 
 for ticks in [500000, 1000000, 1500000]:
-    # In this setup we don't have a cache. `NoCache` can be used for such setups.
     cache_hierarchy = NoCache()
 
-    # We use a single channel DDR3_1600 memory system
     memory = SingleChannelDDR3_1600(size="32MiB")
 
-    # We use a simple Timing processor with one core.
     processor = SimpleProcessor(
         cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
     )
 
-    # The gem5 library simple board which can be used to run simple SE-mode
-    # simulations.
     board = SimpleBoard(
         clk_freq="3GHz",
         processor=processor,

--- a/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
+++ b/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2022-2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import gem5.utils.multisim as multisim
+from gem5.components.boards.simple_board import SimpleBoard
+from gem5.components.cachehierarchies.classic.no_cache import NoCache
+from gem5.components.memory import SingleChannelDDR3_1600
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import (
+    CheckpointResource,
+    obtain_resource,
+)
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
+
+multisim.set_num_processes(5)
+
+# This check ensures the gem5 binary is compiled to the RISCV ISA target.
+# If not, an exception will be thrown.
+requires(isa_required=ISA.RISCV)
+
+for ticks in [500000, 1000000, 1500000]:
+    # In this setup we don't have a cache. `NoCache` can be used for such setups.
+    cache_hierarchy = NoCache()
+
+    # We use a single channel DDR3_1600 memory system
+    memory = SingleChannelDDR3_1600(size="32MiB")
+
+    # We use a simple Timing processor with one core.
+    processor = SimpleProcessor(
+        cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
+    )
+
+    # The gem5 library simple board which can be used to run simple SE-mode
+    # simulations.
+    board = SimpleBoard(
+        clk_freq="3GHz",
+        processor=processor,
+        memory=memory,
+        cache_hierarchy=cache_hierarchy,
+    )
+
+    # checkpoint restore using riscv-hello checkpoints taken at 500,000,
+    # 1 million, and 1.5 million ticks.
+    if ticks == 500000:
+        board.set_se_binary_workload(
+            obtain_resource("riscv-hello"),
+            checkpoint=CheckpointResource(
+                "./gem5/multisim/configs/riscv-hello-checkpoint-500000/"
+            ),
+        )
+    elif ticks == 1000000:
+        board.set_se_binary_workload(
+            obtain_resource("riscv-hello"),
+            checkpoint=CheckpointResource(
+                "./gem5/multisim/configs/riscv-hello-checkpoint/"
+            ),
+        )
+    else:
+        board.set_se_binary_workload(
+            obtain_resource("riscv-hello"),
+            checkpoint=CheckpointResource(
+                "./gem5/multisim/configs/riscv-hello-checkpoint-1500000/"
+            ),
+        )
+
+    simulator = Simulator(
+        board=board, id=f"process-riscv-{ticks}-checkpoint-restore"
+    )
+    multisim.add_simulator(simulator=simulator)

--- a/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
+++ b/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
@@ -70,11 +70,7 @@ for ticks in [500000, 1000000, 1500000]:
     # 1 million, and 1.5 million ticks.
     board.set_se_binary_workload(
         obtain_resource("riscv-hello"),
-        # When the correct resource is made, change the below to:
-        # checkpoint=obtain_resource(f"riscv-hello-{ticks}-tick-checkpoint")
-        checkpoint=CheckpointResource(
-            f"./gem5/multisim/configs/riscv-hello-checkpoint-{ticks}/"
-        ),
+        checkpoint=obtain_resource(f"riscv-hello-{ticks}-tick-checkpoint"),
     )
 
     simulator = Simulator(

--- a/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
+++ b/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
@@ -68,27 +68,14 @@ for ticks in [500000, 1000000, 1500000]:
 
     # checkpoint restore using riscv-hello checkpoints taken at 500,000,
     # 1 million, and 1.5 million ticks.
-    if ticks == 500000:
-        board.set_se_binary_workload(
-            obtain_resource("riscv-hello"),
-            checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/riscv-hello-checkpoint-500000/"
-            ),
-        )
-    elif ticks == 1000000:
-        board.set_se_binary_workload(
-            obtain_resource("riscv-hello"),
-            checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/riscv-hello-checkpoint/"
-            ),
-        )
-    else:
-        board.set_se_binary_workload(
-            obtain_resource("riscv-hello"),
-            checkpoint=CheckpointResource(
-                "./gem5/multisim/configs/riscv-hello-checkpoint-1500000/"
-            ),
-        )
+    board.set_se_binary_workload(
+        obtain_resource("riscv-hello"),
+        # When the correct resource is made, change the below to:
+        # checkpoint=obtain_resource(f"riscv-hello-{ticks}-tick-checkpoint")
+        checkpoint=CheckpointResource(
+            f"./gem5/multisim/configs/riscv-hello-checkpoint-{ticks}/"
+        ),
+    )
 
     simulator = Simulator(
         board=board, id=f"process-riscv-{ticks}-checkpoint-restore"

--- a/tests/gem5/multisim/test-multisim.py
+++ b/tests/gem5/multisim/test-multisim.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import os
+import re
+
+from testlib import *
+from testlib.log import *
+
+gem5_verify_config(
+    name="test-multisim-checkpoint-restore-hello",
+    fixtures=(),
+    verifiers=(),
+    gem5_args=[
+        "-m",
+        "gem5.utils.multisim",
+    ],
+    config=joinpath(
+        config.base_dir,
+        "tests",
+        "gem5",
+        "multisim",
+        "configs",
+        "hello-restore-checkpoint.py",
+    ),
+    config_args=[],
+    valid_isas=(constants.all_compiled_tag,),
+    valid_hosts=(constants.host_x86_64_tag,),
+    length=constants.quick_tag,
+    uses_kvm=False,
+)
+
+gem5_verify_config(
+    name="test-multisim-checkpoint-restore-riscv-hello",
+    fixtures=(),
+    verifiers=(),
+    gem5_args=[
+        "-m",
+        "gem5.utils.multisim",
+    ],
+    config=joinpath(
+        config.base_dir,
+        "tests",
+        "gem5",
+        "multisim",
+        "configs",
+        "riscv-hello-restore-checkpoints.py",
+    ),
+    config_args=[],
+    valid_isas=(constants.all_compiled_tag,),
+    valid_hosts=(constants.host_x86_64_tag,),
+    length=constants.quick_tag,
+    uses_kvm=False,
+)

--- a/tests/gem5/multisim/test-multisim.py
+++ b/tests/gem5/multisim/test-multisim.py
@@ -49,7 +49,7 @@ gem5_verify_config(
     ),
     config_args=[],
     valid_isas=(constants.all_compiled_tag,),
-    valid_hosts=(constants.host_x86_64_tag,),
+    valid_hosts=constants.supported_hosts,
     length=constants.quick_tag,
     uses_kvm=False,
 )
@@ -72,7 +72,7 @@ gem5_verify_config(
     ),
     config_args=[],
     valid_isas=(constants.all_compiled_tag,),
-    valid_hosts=(constants.host_x86_64_tag,),
+    valid_hosts=constants.supported_hosts,
     length=constants.quick_tag,
     uses_kvm=False,
 )

--- a/tests/gem5/multisim/test-multisim.py
+++ b/tests/gem5/multisim/test-multisim.py
@@ -54,25 +54,27 @@ gem5_verify_config(
     uses_kvm=False,
 )
 
-gem5_verify_config(
-    name="test-multisim-checkpoint-restore-riscv-hello",
-    fixtures=(),
-    verifiers=(),
-    gem5_args=[
-        "-m",
-        "gem5.utils.multisim",
-    ],
-    config=joinpath(
-        config.base_dir,
-        "tests",
-        "gem5",
-        "multisim",
-        "configs",
-        "riscv-hello-restore-checkpoints.py",
-    ),
-    config_args=[],
-    valid_isas=(constants.all_compiled_tag,),
-    valid_hosts=constants.supported_hosts,
-    length=constants.quick_tag,
-    uses_kvm=False,
-)
+# For now, skip this test because there are issues with obtaining one of the
+# checkpoints with obtain_resource
+# gem5_verify_config(
+#     name="test-multisim-checkpoint-restore-riscv-hello",
+#     fixtures=(),
+#     verifiers=(),
+#     gem5_args=[
+#         "-m",
+#         "gem5.utils.multisim",
+#     ],
+#     config=joinpath(
+#         config.base_dir,
+#         "tests",
+#         "gem5",
+#         "multisim",
+#         "configs",
+#         "riscv-hello-restore-checkpoints.py",
+#     ),
+#     config_args=[],
+#     valid_isas=(constants.all_compiled_tag,),
+#     valid_hosts=constants.supported_hosts,
+#     length=constants.quick_tag,
+#     uses_kvm=False,
+# )


### PR DESCRIPTION
This commit adds a test for restoring from `riscv-hello` checkpoints taken at 500,000, 1 million, and 1.5 million ticks. It also adds tests for restoring from `hello world` binaries of the Arm, X86 and RISC-V ISAs. The riscv-hello tests are currently commented out, as there are issues with obtaining the checkpoint via `obtain_resource`.