### PR TITLE
gpu-compute: Implement kernarg preload

### DIFF
--- a/src/gpu-compute/compute_unit.cc
+++ b/src/gpu-compute/compute_unit.cc
@@ -1159,9 +1159,10 @@ ComputeUnit::SQCPort::recvTimingResp(PacketPtr pkt)
         // then the request is an instruction fetch and can be handled in
         // the compute unit
         if (sender_state->isKernDispatch) {
-          computeUnit->shader->gpuCmdProc.completeTimingRead();
+            int dispType = sender_state->dispatchType;
+            computeUnit->shader->gpuCmdProc.completeTimingRead(dispType);
         } else {
-          computeUnit->handleSQCReturn(pkt);
+            computeUnit->handleSQCReturn(pkt);
         }
     } else {
         delete pkt->senderState;

--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -691,11 +691,19 @@ class ComputeUnit : public ClockedObject
 
         struct SenderState : public Packet::SenderState
         {
+            enum : int
+            {
+                DISPATCH_NONE,
+                DISPATCH_KERNEL_OBJECT,
+                DISPATCH_PRELOAD_ARG
+            };
+
             Wavefront *wavefront;
             Packet::SenderState *saved;
             // kernel id to be used in handling I-Cache invalidate response
             int kernId;
             bool isKernDispatch;
+            int dispatchType = DISPATCH_NONE;
             SenderState(Wavefront *_wavefront, Packet::SenderState
                     *sender_state=nullptr, int _kernId=-1)
                 : wavefront(_wavefront), saved(sender_state),

--- a/src/gpu-compute/gpu_command_processor.hh
+++ b/src/gpu-compute/gpu_command_processor.hh
@@ -87,11 +87,12 @@ class GPUCommandProcessor : public DmaVirtDevice
 
     struct KernelDispatchData
     {
-        AMDKernelCode *akc;
-        void *raw_pkt;
-        uint32_t queue_id;
-        Addr host_pkt_addr;
-        PacketPtr readPkt;
+        AMDKernelCode *akc = nullptr;
+        void *raw_pkt = nullptr;
+        uint32_t queue_id = 0;
+        Addr host_pkt_addr = 0;
+        PacketPtr readPkt = nullptr;
+        HSAQueueEntry *task = nullptr;
     };
 
     std::list<struct KernelDispatchData> kernelDispatchList;
@@ -102,9 +103,9 @@ class GPUCommandProcessor : public DmaVirtDevice
       Steal = 1
     };
 
-    void performTimingRead(PacketPtr pkt);
+    void performTimingRead(PacketPtr pkt, int dispType);
 
-    void completeTimingRead();
+    void completeTimingRead(int dispType);
 
     void submitAgentDispatchPkt(void *raw_pkt, uint32_t queue_id,
                            Addr host_pkt_addr);
@@ -319,6 +320,9 @@ class GPUCommandProcessor : public DmaVirtDevice
             dmaReadVirt(value_addr, sizeof(Addr), cb, &cb->dmaBuffer, 1e9);
         }
     }
+
+    void readPreload(AMDKernelCode *akc, HSAQueueEntry *task);
+    void initPreload(AMDKernelCode *akc, HSAQueueEntry *task);
 };
 
 } // namespace gem5

--- a/src/gpu-compute/kernel_code.hh
+++ b/src/gpu-compute/kernel_code.hh
@@ -60,12 +60,13 @@ enum ScalarRegInitFields : int
     DispatchId = 4,
     FlatScratchInit = 5,
     PrivateSegSize = 6,
-    WorkgroupIdX = 7,
-    WorkgroupIdY = 8,
-    WorkgroupIdZ = 9,
-    WorkgroupInfo = 10,
-    PrivSegWaveByteOffset = 11,
-    NumScalarInitFields = 12
+    KernargPreload = 7,
+    WorkgroupIdX = 8,
+    WorkgroupIdY = 9,
+    WorkgroupIdZ = 10,
+    WorkgroupInfo = 11,
+    PrivSegWaveByteOffset = 12,
+    NumScalarInitFields = 13
 };
 
 enum VectorRegInitFields : int
@@ -75,6 +76,12 @@ enum VectorRegInitFields : int
     WorkitemIdZ = 2,
     NumVectorInitFields = 3
 };
+
+/**
+ * The number of bytes after the dispatch packet which contain kernel
+ * arguments that should be preloaded into SGPRs before dispatch.
+ */
+constexpr int KernargPreloadPktSize = 256;
 
 // Kernel code object based on the table on LLVM's website:
 // https://llvm.org/docs/AMDGPUUsage.html#code-object-v3-kernel-descriptor

--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -346,6 +346,24 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
                         wfSlotId, wfDynId, physSgprIdx,
                         task->privMemPerItem());
                 break;
+              case KernargPreload:
+                DPRINTF(GPUInitAbi, "Preload %d user SGPRs starting at virtual"
+                        "SGPR %d\n", task->preloadLength(), regInitIdx);
+
+                for (int idx = 0; idx < task->preloadLength(); ++idx) {
+                    uint32_t finalValue = task->preloadArgs()[idx];
+                    physSgprIdx =
+                        computeUnit->registerManager->mapSgpr(this,
+                                                              regInitIdx);
+
+                    DPRINTF(GPUInitAbi, "CU%d: WF[%d][%d]: wave[%d] Setting "
+                            "s[%d] = %x\n", computeUnit->cu_id, simdId,
+                            wfSlotId, wfDynId, physSgprIdx, finalValue);
+
+                    computeUnit->srf[simdId]->write(physSgprIdx, finalValue);
+                    ++regInitIdx;
+                }
+                break;
               case WorkgroupIdX:
                 physSgprIdx =
                     computeUnit->registerManager->mapSgpr(this, regInitIdx);


### PR DESCRIPTION
Kernarg preloading is a way to pre-populate a wavefront's user SGPRs when the wave is created from device memory, avoiding some s_load_* instructions:

https://llvm.org/docs/AMDGPUUsage.html#preloaded-kernel-arguments

Implement this feature as it is used in newer versions of ROCm and is assumed by the compiler to be supported by gfx942.

Tested using hipblaslt-bench which uses the feature. Should fix any misbehaving application which printed "warn: Kernarg preload not implemented."