### PR TITLE
Add HiFive Unleashed/Unmatched DMA engine model

### DIFF
--- a/src/dev/riscv/HiFive.py
+++ b/src/dev/riscv/HiFive.py
@@ -35,18 +35,29 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from typing import (
+    Generator,
+    List,
+)
+
 from m5.objects.Clint import Clint
+from m5.objects.ClockedObject import ClockedObject
 from m5.objects.PciHost import GenericPciHost
 from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.Plic import Plic
 from m5.objects.PMAChecker import PMAChecker
 from m5.objects.RTC import RiscvRTC
+from m5.objects.Sf_PDMA import SfPDMA
 from m5.objects.Terminal import Terminal
 from m5.objects.Uart import RiscvUart8250
+from m5.objects.XBar import BaseXBar
 from m5.params import *
+from m5.params.port_params import PortRef
 from m5.proxy import *
 from m5.util.fdthelper import *
+
+from gem5.utils.override import overrides
 
 
 class GenericRiscvPciHost(GenericPciHost):
@@ -104,15 +115,31 @@ class HiFiveBase(Platform):
     # Set to 0 if using a pci interrupt for Uart instead
     uart_int_id = Param.Int(0, "PLIC Uart interrupt ID")
 
-    def _on_chip_devices(self):
+    def _on_chip_devices(self) -> List[ClockedObject]:
         """Returns a list of on-chip peripherals"""
         return []
 
-    def _off_chip_devices(self):
+    def _off_chip_devices(self) -> List[ClockedObject]:
         """Returns a list of off-chip peripherals"""
         return []
 
-    def _on_chip_ranges(self):
+    def _on_chip_ports_resp(self) -> List[PortRef]:
+        """Returns a list of on-chip peripherals response ports"""
+        return []
+
+    def _off_chip_ports_resp(self) -> List[PortRef]:
+        """Returns a list of off-chip peripherals response ports"""
+        return []
+
+    def _on_chip_ports_req(self) -> List[PortRef]:
+        """Returns a list of on-chip peripherals request/dma ports"""
+        return []
+
+    def _off_chip_ports_req(self) -> List[PortRef]:
+        """Returns a list of off-chip peripherals request/dma ports"""
+        return []
+
+    def _on_chip_ranges(self) -> List[AddrRange]:
         """Returns a list of on-chip peripherals
         address range
         """
@@ -121,7 +148,7 @@ class HiFiveBase(Platform):
             for dev in self._on_chip_devices()
         ]
 
-    def _off_chip_ranges(self):
+    def _off_chip_ranges(self) -> List[AddrRange]:
         """Returns a list of off-chip peripherals
         address range
         """
@@ -130,19 +157,19 @@ class HiFiveBase(Platform):
             for dev in self._off_chip_devices()
         ]
 
-    def attachOnChipIO(self, bus):
-        """Attach on-chip IO devices, needs modification
-        to support DMA
-        """
-        for device in self._on_chip_devices():
-            device.pio = bus.mem_side_ports
+    def attachOnChipIO(self, bus: BaseXBar, ruby: bool = False) -> None:
+        for port in self._on_chip_ports_resp():
+            port.connect(bus.mem_side_ports)
+        if not ruby:
+            for port in self._on_chip_ports_req():
+                port.connect(bus.cpu_side_ports)
 
-    def attachOffChipIO(self, bus):
-        """Attach off-chip IO devices, needs modification
-        to support DMA
-        """
-        for device in self._off_chip_devices():
-            device.pio = bus.mem_side_ports
+    def attachOffChipIO(self, bus: BaseXBar, ruby: bool = False) -> None:
+        for port in self._off_chip_ports_resp():
+            port.connect(bus.mem_side_ports)
+        if not ruby:
+            for port in self._off_chip_ports_req():
+                port.connect(bus.cpu_side_ports)
 
 
 class HiFive(HiFiveBase):
@@ -198,38 +225,83 @@ class HiFive(HiFiveBase):
     uart_int_id = 0xA
     terminal = Terminal()
 
-    def _on_chip_devices(self):
+    # DMA-controller
+    pdma = SfPDMA(
+        pio_addr=0x3000000,
+        done_irq=[i for i in range(23, 30, 2)],
+        error_irq=[i for i in range(24, 31, 2)],
+        _dma_coherent=True,
+    )
+
+    _off_chip_ports_extra = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        for i in range(self.pdma.chan_cnt):
+            self._off_chip_ports_extra.append(self.pdma.dma[i])
+
+    @overrides(HiFiveBase)
+    def _on_chip_devices(self) -> List[ClockedObject]:
         """Returns a list of on-chip peripherals"""
         return [self.clint, self.plic]
 
-    def _off_chip_devices(self):
+    @overrides(HiFiveBase)
+    def _off_chip_devices(self) -> List[ClockedObject]:
         """Returns a list of off-chip peripherals"""
-        devices = [self.uart]
+        devices = [self.uart, self.pdma]
         if hasattr(self, "disk"):
             devices.append(self.disk)
         if hasattr(self, "rng"):
             devices.append(self.rng)
         return devices
 
-    def attachPlic(self):
+    @overrides(HiFiveBase)
+    def _on_chip_ports_resp(self) -> List[PortRef]:
+        ports = []
+        for dev in self._on_chip_devices():
+            if hasattr(dev, "pio"):
+                ports.append(dev.pio)
+        return [i for i in ports if i.role == "GEM5 RESPONDER"]
+
+    @overrides(HiFiveBase)
+    def _off_chip_ports_resp(self) -> List[PortRef]:
+        ports = []
+        for dev in self._off_chip_devices():
+            if hasattr(dev, "pio"):
+                ports.append(dev.pio)
+        ports += self._off_chip_ports_extra
+        return [i for i in ports if i.role == "GEM5 RESPONDER"]
+
+    @overrides(HiFiveBase)
+    def _off_chip_ports_req(self) -> List[PortRef]:
+        ports = self._off_chip_ports_extra
+        return [i for i in ports if i.role == "GEM5 REQUESTOR"]
+
+    def attachPlic(self) -> None:
         """Count and set number of PLIC interrupt sources"""
         plic_srcs = [
             self.uart_int_id,
             self.pci_host.int_base + self.pci_host.int_count,
+            *self.pdma.done_irq,
+            *self.pdma.error_irq,
         ]
         for device in self._off_chip_devices():
             if hasattr(device, "interrupt_id"):
                 plic_srcs.append(device.interrupt_id)
         self.plic.n_src = max(plic_srcs) + 1
 
-    def setNumCores(self, num_cpu):
+    def setNumCores(self, num_cpu: int) -> None:
         """Sets the CLINT to number of threads and the PLIC hartID/pmode for
         each contexts. Assumes that the cores have a single hardware thread.
         """
         self.plic.hart_config = ",".join(["MS" for _ in range(num_cpu)])
         self.clint.num_threads = num_cpu
 
-    def generateDeviceTree(self, state):
+    @overrides(SimObject)
+    def generateDeviceTree(
+        self, state: FdtState
+    ) -> Generator[FdtNode, None, None]:
         cpus_node = FdtNode("cpus")
         cpus_node.append(FdtPropertyWords("timebase-frequency", [10000000]))
         yield cpus_node
@@ -249,7 +321,8 @@ class HiFive(HiFiveBase):
     # For generating devicetree
     _cpu_count = 0
 
-    def annotateCpuDeviceNode(self, cpu, state):
+    @overrides(Platform)
+    def annotateCpuDeviceNode(self, cpu: FdtNode, state: FdtState) -> None:
         cpu.append(FdtPropertyStrings("mmu-type", "riscv,sv48"))
         cpu.append(FdtPropertyStrings("status", "okay"))
         cpu.append(FdtPropertyStrings("riscv,isa", "rv64imafdc"))

--- a/src/dev/riscv/SConscript
+++ b/src/dev/riscv/SConscript
@@ -50,10 +50,12 @@ SimObject(
 SimObject('RTC.py', sim_objects=['RiscvRTC'], tags=['riscv isa'])
 SimObject('RiscvVirtIOMMIO.py', sim_objects=['RiscvMmioVirtIO'],
     tags=['riscv isa'])
+SimObject('Sf_PDMA.py', sim_objects=['SfPDMA'], tags=['riscv isa'])
 
 DebugFlag('Clint', tags=['riscv isa'])
 DebugFlag('Plic', tags=['riscv isa'])
 DebugFlag('VirtIOMMIO', tags=['riscv isa'])
+DebugFlag('SfPDMA', tags=['riscv isa'])
 
 Source('pci_host.cc', tags=['riscv isa'])
 
@@ -64,3 +66,4 @@ Source('plic_device.cc', tags=['riscv isa'])
 Source('plic.cc', tags=['riscv isa'])
 Source('rtc.cc', tags=['riscv isa'])
 Source('vio_mmio.cc', tags=['riscv isa'])
+Source('sf_pdma.cc', tags=['riscv isa'])

--- a/src/dev/riscv/Sf_PDMA.py
+++ b/src/dev/riscv/Sf_PDMA.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 Nikita Proshkin
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects.Device import PioDevice
+from m5.params import *
+from m5.proxy import *
+
+
+class SfPDMA(PioDevice):
+    type = "SfPDMA"
+    cxx_header = "dev/riscv/sf_pdma.hh"
+    cxx_class = "gem5::SfPDMA"
+
+    dma = VectorRequestPort("DMA ports")
+
+    pio_addr = Param.Addr("Device base address")
+    pio_size = Param.Addr("Size of address range")
+    chan_cnt = Param.UInt8(4, "Number of DMA channels that exist on device")
+    platform = Param.Platform(Parent.any, "Platform")
+
+    sid = Param.UInt8(0, "StreamID for iommu")
+
+    done_irq = VectorParam.Int("Done IRQ for channels")
+    error_irq = VectorParam.Int("Error IRQ for channels")
+
+    pkts_each_dir = Param.UInt8(
+        5,
+        "Max number of in-flight packets in each direction "
+        "(e.g. 1 means there might be 2 dma packets from "
+        "SfPDMA in memory system - one for read and one for write)",
+    )
+
+    chan_reg_rd_wr_delay = Param.Cycles(
+        1, "Latency to access MMIO channels registers"
+    )
+    lat_before_begin = Param.Cycles(
+        1, "Latency after a DMA command is seen before it's processed"
+    )
+    lat_before_completion = Param.Cycles(
+        1,
+        "Latency between DMA completion and displaying it with registers and irq",
+    )
+    dma_ports_width = Param.Unsigned(
+        64, "Width in bytes of the channels dma ports"
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.pio_size = 0x1000 * int(self.chan_cnt)

--- a/src/dev/riscv/Sf_PDMA.py
+++ b/src/dev/riscv/Sf_PDMA.py
@@ -27,6 +27,7 @@
 from m5.objects.Device import PioDevice
 from m5.params import *
 from m5.proxy import *
+from m5.util.fdthelper import *
 
 
 class SfPDMA(PioDevice):
@@ -70,3 +71,50 @@ class SfPDMA(PioDevice):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.pio_size = 0x1000 * int(self.chan_cnt)
+
+    # fdt generation
+    _dma_coherent = True
+    _iommu = None
+
+    def generateDeviceTree(self, state):
+        node = FdtNode(f"dma@{int(self.pio_addr):x}")
+        node.appendCompatible(["microchip,mpfs-pdma", "sifive,pdma0"])
+        node.append(
+            FdtPropertyWords(
+                "reg",
+                state.addrCells(self.pio_addr)
+                + state.sizeCells(0x1000 * int(self.chan_cnt)),
+            )
+        )
+        node.append(FdtPropertyWords("#dma-cells", [1]))
+        node.append(FdtPropertyWords("dma-channels", [self.chan_cnt]))
+
+        platform = self.platform.unproxy(self)
+        plic = platform.plic
+
+        if plic is not None:
+            node.append(
+                FdtPropertyWords("interrupt-parent", state.phandle(plic))
+            )
+
+            # driver awaits interrupts list in form [done_irq0, err_irq0, ...]
+            driver_irq = []
+            for done, err in zip(self.done_irq, self.error_irq):
+                driver_irq.append(done)
+                driver_irq.append(err)
+
+            node.append(FdtPropertyWords("interrupts", driver_irq))
+        else:
+            print("SfPDMA: Failed to find plic")
+
+        if self._dma_coherent:
+            node.append(FdtProperty("dma-coherent"))
+
+        if self._iommu is not None:
+            node.append(
+                FdtPropertyWords(
+                    "iommus", [state.phandle(self._iommu), self.sid]
+                )
+            )
+
+        yield node

--- a/src/dev/riscv/sf_pdma.cc
+++ b/src/dev/riscv/sf_pdma.cc
@@ -1,0 +1,694 @@
+/*
+ * Copyright (c) 2025 Nikita Proshkin
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dev/riscv/sf_pdma.hh"
+
+#include "base/bitfield.hh"
+#include "debug/Checkpoint.hh"
+#include "debug/Drain.hh"
+#include "debug/SfPDMA.hh"
+
+namespace gem5
+{
+
+PDMAChannel::PDMAReqPort::PDMAReqPort(const std::string &name,
+        PDMAChannel &chan) : RequestPort(name), chan(chan)
+{}
+
+bool
+PDMAChannel::PDMAReqPort::recvTimingResp(PacketPtr pkt)
+{
+    DPRINTF(SfPDMA, "Got response addr: 0x%x cmd: %s\n", pkt->getAddr(),
+            pkt->cmdString());
+    PDMAPkt *payload = safe_cast<PDMAPkt *>(pkt->popSenderState());
+
+    if (pkt->isError())
+        chan.processRespError(payload);
+    else
+        chan.processRespSuccess(payload);
+    delete pkt;
+    return true;
+}
+
+void
+PDMAChannel::PDMAReqPort::recvReqRetry()
+{
+    DPRINTF(SfPDMA, "Got request retry\n");
+
+    chan.waitingRetry = false;
+    if (!chan.sendPktsEvent.scheduled() && chan.ctrl.run) {
+        chan.processTiming();
+    }
+}
+
+PDMAChannel::PDMAChannel(SfPDMA *pdma, const SfPDMAParams &p, int cid) :
+    pdma(pdma), system(p.system), chanId(cid),
+    dma(csprintf("%s.dma", name()), *this),
+    requestorId(p.system->getRequestorId(pdma)), streamId(p.sid),
+    doneIrq(p.done_irq[cid]), errIrq(p.error_irq[cid]), platform(p.platform),
+    pktsN(p.pkts_each_dir * 2), dmaWidth(p.dma_ports_width),
+    dataFifo(FIFO_SIZE), sendPktsEvent(*this), sendComplEvent(*this),
+    stats(*this)
+{
+    delays.chanRegRdWrDelay = p.chan_reg_rd_wr_delay;
+    delays.latBeforeBegin = p.lat_before_begin;
+    delays.latBeforeCompletion = p.lat_before_completion;
+
+    // We can transfer a maximum of Cache Line Size bytes in one packet not
+    // to trigger cache asserts.
+    size_t buf_size = system->cacheLineSize();
+
+    for (int i = 0; i < pktsN; i++)
+        idlePkts.push(std::make_unique<PDMAPkt>(buf_size));
+}
+
+Port &
+PDMAChannel::getPort()
+{
+    return dma;
+}
+
+std::string
+PDMAChannel::name() const
+{
+    assert(pdma);
+    return csprintf("%s-chan%d", pdma->name(), chanId);
+}
+
+Tick
+PDMAChannel::read(PacketPtr pkt, Addr addr, int size)
+{
+    DPRINTF(SfPDMA, "Read register 0x%x size: %d\n", addr, size);
+
+    pkt->makeResponse();
+
+    if (addr == PDMA_CTRL_OFFSET && size == 4) {
+        pkt->setLE<uint32_t>(ctrl);
+        return delays.chanRegRdWrDelay * pdma->clockPeriod();
+    }
+
+    PDMARegs *regs;
+    // 'Next' regs have offsets 0x0**, 'Exec' regs - 0x1**
+    switch (addr & 0xf00) {
+    case 0x0:
+        regs = &next;
+        break;
+    case 0x100:
+        regs = &exec;
+        break;
+    default:
+        return 0;
+    }
+
+    addr &= 0xff;
+    switch (addr) {
+    case PDMA_CONF_OFFSET:
+        if (size == 4)
+            pkt->setLE<uint32_t>(regs->config);
+        break;
+    case PDMA_SIZE_OFFSET:
+    case PDMA_DEST_OFFSET:
+    case PDMA_SRC_OFFSET:
+        if (size == 8) {
+            pkt->setLE<uint64_t>(
+                    *reinterpret_cast<uint64_t *>(regs->data + addr));
+        }
+        break;
+    default:
+        break;
+    }
+
+    return delays.chanRegRdWrDelay * pdma->clockPeriod();
+}
+
+Tick
+PDMAChannel::write(PacketPtr pkt, Addr addr, int size)
+{
+    DPRINTF(SfPDMA, "Write register 0x%x size: %d data: 0x%x cmd: %s\n", addr,
+            size, size == 4 ? pkt->getLE<uint32_t>() : pkt->getLE<uint64_t>(),
+            pkt->cmdString().c_str());
+
+    pkt->makeResponse();
+
+    switch (addr) {
+    case PDMA_CTRL_OFFSET: {
+        if (size != 4)
+            return 0;
+        PDMACtrl data = pkt->getLE<uint32_t>();
+        ctrl.done_ie = data.done_ie;
+        ctrl.error_ie = data.error_ie;
+
+        if (ctrl.run != data.run) {
+            // Start transfer
+            if (data.run) {
+                run(false);
+            }
+            // Stop transfer.
+            // Transfer processing routines will do all the necessary work,
+            // do not touch state here.
+            else {
+                shutdownDescr = true;
+            }
+        }
+
+        // Setting 'claim' bit clears all 'Next' registers.
+        // 'claim' can only be cleared when run is low.
+        if (ctrl.claim != data.claim) {
+            if (data.claim) {
+                ctrl.claim = 1;
+                memset(next.data, 0, sizeof(next));
+            } else if (!ctrl.run) {
+                ctrl.claim = 0;
+            }
+        }
+
+        if (!data.done) {
+            ctrl.done = 0;
+            platform->clearPciInt(doneIrq);
+        }
+
+        if (!data.error) {
+            ctrl.error = 0;
+            platform->clearPciInt(errIrq);
+            busErr = false;
+        }
+    } break;
+    case PDMA_CONF_OFFSET: {
+        if (size != 4)
+            return 0;
+        PDMAConf data = pkt->getLE<uint32_t>();
+        int log_max_size = findMsbSet(system->cacheLineSize());
+        if (data.wsize > log_max_size)
+            warn("pdma: wsize is limited to %d, got: %d\n", log_max_size,
+                    data.wsize);
+        data.wsize = std::min(static_cast<int>(data.wsize), log_max_size);
+        if (data.rsize > log_max_size)
+            warn("pdma: rsize is limited to %d, got: %d\n", log_max_size,
+                    data.rsize);
+        data.rsize = std::min(static_cast<int>(data.rsize), log_max_size);
+
+        next.config = data;
+    } break;
+    case PDMA_SIZE_OFFSET:
+        if (size == 8)
+            next.size = pkt->getLE<uint64_t>();
+        break;
+    case PDMA_DEST_OFFSET:
+        if (size == 8)
+            next.dest = pkt->getLE<uint64_t>();
+        break;
+    case PDMA_SRC_OFFSET:
+        if (size == 8)
+            next.src = pkt->getLE<uint64_t>();
+        break;
+    default:
+        break;
+    }
+
+    return delays.chanRegRdWrDelay * pdma->clockPeriod();
+}
+
+DrainState
+PDMAChannel::drain()
+{
+    if (readyForDrain()) {
+        DPRINTF(Drain, "drained\n");
+        return DrainState::Drained;
+    } else {
+        DPRINTF(Drain, "not drained. Waiting for in flight pkts\n");
+        return DrainState::Draining;
+    }
+}
+
+void
+PDMAChannel::drainResume()
+{
+    if (ctrl.run && !sendPktsEvent.scheduled() &&
+            !sendComplEvent.scheduled()) {
+        if (system->isAtomicMode())
+            sendAtomicPkts();
+        else
+            processTiming();
+    }
+}
+
+bool
+PDMAChannel::readyForDrain()
+{
+    return inFlightR == 0 && inFlightW == 0 && pendingPkts.empty() &&
+           !nextTimingPkt;
+}
+
+void
+PDMAChannel::serialize(CheckpointOut &cp) const
+{
+    DPRINTF(Checkpoint, "Serializing Sf-PDMA\n");
+    SERIALIZE_SCALAR(ctrl.__storage);
+    SERIALIZE_SCALAR(shutdownDescr);
+    SERIALIZE_SCALAR(busErr);
+    SERIALIZE_ARRAY(next.data, sizeof(next.data) / sizeof(next.data[0]));
+    SERIALIZE_ARRAY(exec.data, sizeof(exec.data) / sizeof(exec.data[0]));
+    arrayParamOut(cp, "dataFifo", dataFifo);
+}
+
+void
+PDMAChannel::unserialize(CheckpointIn &cp)
+{
+    DPRINTF(Checkpoint, "Unserializing Sf-PDMA\n");
+    UNSERIALIZE_SCALAR(ctrl.__storage);
+    UNSERIALIZE_SCALAR(shutdownDescr);
+    UNSERIALIZE_SCALAR(busErr);
+    UNSERIALIZE_ARRAY(next.data, sizeof(next.data) / sizeof(next.data[0]));
+    UNSERIALIZE_ARRAY(exec.data, sizeof(exec.data) / sizeof(exec.data[0]));
+    arrayParamIn(cp, "dataFifo", dataFifo);
+}
+
+void
+PDMAChannel::run(bool repeated)
+{
+    // - Copy transfer params set by driver from 'Next' regs to
+    //  'Exec' set;
+    // - Reset channel state according to new transfer params;
+    // - In RO 'Exec' regs channel keeps in-progress transfer state
+    //   (for example, the driver can read from them how much more
+    //   data is left to transfer).
+
+    if (!repeated) {
+        ctrl.run = 1;
+        ctrl.done = 0;
+        ctrl.error = 0;
+        platform->clearPciInt(doneIrq);
+        shutdownDescr = false;
+        busErr = false;
+        platform->clearPciInt(errIrq);
+    }
+
+    exec = next;
+
+    PDMAConf conf = static_cast<PDMAConf>(exec.config);
+
+    // User can set max number of in-flight packets in each
+    // direction through Params. Channel constructor set this
+    // value multiplied by 2 to the pktsN.
+    // So, the default value for inFlightMax (meaning packets
+    // in each direction) is pktsN / 2. This is the case when
+    // out-of-order responses to read requests are possible.
+    // Also, transfer config has 'order' bit using which driver
+    // can allow to exist only one packet in each direction
+    // in-flight at a time.
+    inFlightMax = conf.order ? 1 : pktsN / 2;
+    rChunks.reset(new ChunkGenerator(exec.src, exec.size, 1 << conf.rsize));
+    wrChunks.reset(new ChunkGenerator(exec.dest, exec.size, 1 << conf.wsize));
+    startTime = curTick();
+    pendingId = 0;
+    idsForReads = 0;
+    dataFifo.flush();
+    nextTimingPkt = nullptr;
+    pdma->schedule(sendPktsEvent, pdma->clockEdge(delays.latBeforeBegin));
+}
+
+void
+PDMAChannel::processCompletion()
+{
+    ctrl.done = (exec.size == 0);
+    ctrl.error = busErr;
+    stats.workTime += curTick() - startTime;
+
+    bool repeat = static_cast<PDMAConf>(exec.config).repeat;
+
+    if (ctrl.done && !shutdownDescr && repeat) {
+        run(true);
+    } else {
+        ctrl.claim = 0;
+        ctrl.run = 0;
+    }
+
+    if (ctrl.done && ctrl.done_ie) {
+        DPRINTF(SfPDMA, "raising done irq\n");
+        platform->postPciInt(doneIrq);
+    }
+
+    if (ctrl.error && ctrl.error_ie) {
+        DPRINTF(SfPDMA, "raising err irq\n");
+        platform->postPciInt(errIrq);
+    }
+}
+
+PacketPtr
+PDMAChannel::buildPkt(PDMAPkt *pkt, MemCmd::Command cmd)
+{
+    RequestPtr req;
+    PacketPtr pkt_to_send;
+
+    if (cmd == MemCmd::WriteReq) {
+        if ((dataFifo.size() < wrChunks->size()) || wrChunks->done())
+            return nullptr;
+        pkt->cmd = MemCmd::WriteReq;
+        pkt->pktSize = wrChunks->size();
+        dataFifo.read(pkt->buf.get(), wrChunks->size());
+
+        req = std::make_shared<Request>(
+                wrChunks->addr(), wrChunks->size(), 0, requestorId);
+
+        wrChunks->next();
+    } else if (cmd == MemCmd::ReadReq) {
+        if (rChunks->done())
+            return nullptr;
+        pkt->cmd = MemCmd::ReadReq;
+        pkt->pktSize = rChunks->size();
+        pkt->id = idsForReads;
+        idsForReads++;
+
+        req = std::make_shared<Request>(
+                rChunks->addr(), rChunks->size(), 0, requestorId);
+
+        rChunks->next();
+    } else
+        panic("Invalid pkt command");
+
+    pkt_to_send = new Packet(req, pkt->cmd);
+    pkt_to_send->dataStatic(pkt->buf.get());
+    pkt_to_send->pushSenderState(pkt);
+    pkt_to_send->req->taskId(context_switch_task_id::DMA);
+    pkt_to_send->req->setStreamId(streamId);
+    return pkt_to_send;
+}
+
+void
+PDMAChannel::sendPkts()
+{
+    if (system->isTimingMode()) {
+        processTiming();
+    } else if (system->isAtomicMode()) {
+        sendAtomicPkts();
+    } else
+        panic("Not in timing or atomic mode!");
+}
+
+void
+PDMAChannel::sendAtomicPkts()
+{
+    if (drainState() == DrainState::Draining)
+        return;
+
+    Tick total_delay = 0;
+    Tick delay;
+
+    std::unique_ptr<Packet> pkt_to_send;
+    PDMAPkt *pkt = idlePkts.front().get();
+
+    while (!wrChunks->done() && !shutdownDescr) {
+        if ((dataFifo.size() + rChunks->size()) < dataFifo.capacity()) {
+            pkt_to_send.reset(buildPkt(pkt, MemCmd::ReadReq));
+            if (pkt_to_send) {
+                DPRINTF(SfPDMA, "Starting read [a] src: 0x%x size: %d\n",
+                        pkt_to_send->getAddr(), pkt_to_send->getSize());
+                // '+1' to simulate transmission delay for packet with no data
+                delay = dma.sendAtomic(pkt_to_send.get()) + 1;
+                stats.turnaroundRdPkts.sample(delay);
+                total_delay += delay;
+                if (!pkt_to_send->isError()) {
+                    dataFifo.write(pkt->buf.get(), pkt->pktSize);
+                } else {
+                    DPRINTF(SfPDMA, "Abort\n");
+                    shutdownDescr = true;
+                    busErr = true;
+                    break;
+                }
+            }
+        }
+        // Move new Packet to the unique_ptr.
+        // Previous Packet assembled by buildPkt() was already used by
+        // sendAtomic(), so we can free its memory.
+        pkt_to_send.reset(buildPkt(pkt, MemCmd::WriteReq));
+        if (pkt_to_send) {
+            DPRINTF(SfPDMA, "Starting write [a] dst: 0x%x size: %d\n",
+                    pkt_to_send->getAddr(), pkt_to_send->getSize());
+            delay = dma.sendAtomic(pkt_to_send.get()) +
+                    (pkt_to_send->getSize() + (dmaWidth - 1)) / dmaWidth;
+            stats.turnaroundWrPkts.sample(delay);
+            total_delay += delay;
+            if (!pkt_to_send->isError()) {
+                stats.bytesTransmitted += pkt->pktSize;
+                exec.src += pkt->pktSize;
+                exec.dest += pkt->pktSize;
+                exec.size -= pkt->pktSize;
+            } else {
+                DPRINTF(SfPDMA, "Abort\n");
+                shutdownDescr = true;
+                busErr = true;
+                break;
+            }
+        }
+    }
+
+    pdma->schedule(sendComplEvent,
+            pdma->clockEdge(delays.latBeforeCompletion) + total_delay);
+}
+
+void
+PDMAChannel::processTiming()
+{
+    if (!sendPktsEvent.scheduled())
+        sendTimingPkts();
+    if ((drainState() == DrainState::Draining) && readyForDrain()) {
+        DPRINTF(Drain, "Drained. Signaling to DrainManager\n");
+        signalDrainDone();
+    } else if (!shutdownDescr) {
+        if (exec.size == 0)
+            pdma->schedule(sendComplEvent,
+                    pdma->clockEdge(delays.latBeforeCompletion));
+    } else if (inFlightR == 0 && inFlightW == 0)
+        pdma->schedule(
+                sendComplEvent, pdma->clockEdge(delays.latBeforeCompletion));
+}
+
+void
+PDMAChannel::sendTimingPkts()
+{
+    fillFifo();
+
+    if (waitingRetry)
+        return;
+
+    // Nothing to resend and no available buffers to build a new Packet
+    if (!nextTimingPkt && idlePkts.empty())
+        return;
+
+    if (!nextTimingPkt && inFlightW < inFlightMax && !shutdownDescr) {
+        nextTimingPkt = buildPkt(idlePkts.front().get(), MemCmd::WriteReq);
+    }
+
+    if (!nextTimingPkt && inFlightR < inFlightMax && !shutdownDescr &&
+            drainState() != DrainState::Draining) {
+        nextTimingPkt = buildPkt(idlePkts.front().get(), MemCmd::ReadReq);
+    }
+
+    if (nextTimingPkt) {
+        idlePkts.front()->pktSendTime = curTick();
+
+        if (dma.sendTimingReq(nextTimingPkt)) {
+            uint64_t nbeats;
+
+            if (nextTimingPkt->isWrite()) {
+                inFlightW++;
+                nbeats =
+                        (nextTimingPkt->getSize() + (dmaWidth - 1)) / dmaWidth;
+                DPRINTF(SfPDMA, "Starting write [t] dst: 0x%x size: %d\n",
+                        nextTimingPkt->getAddr(), nextTimingPkt->getSize());
+            } else {
+                inFlightR++;
+                // to simulate transmission delay for packet with no data
+                nbeats = 1;
+                DPRINTF(SfPDMA, "Starting read [t] src: 0x%x size: %d\n",
+                        nextTimingPkt->getAddr(), nextTimingPkt->getSize());
+            }
+            idlePkts.front().release();
+            idlePkts.pop();
+            nextTimingPkt = nullptr;
+            pdma->schedule(sendPktsEvent, pdma->clockEdge(Cycles(nbeats)));
+        } else
+            waitingRetry = true;
+    }
+
+    fillFifo();
+}
+
+void
+PDMAChannel::fillFifo()
+{
+    while (!pendingPkts.empty() && pendingPkts.top()->id == pendingId &&
+            ((dataFifo.size() + pendingPkts.top()->pktSize) <
+                    dataFifo.capacity())) {
+        dataFifo.write(
+                pendingPkts.top()->buf.get(), pendingPkts.top()->pktSize);
+        idlePkts.push(std::unique_ptr<PDMAPkt>(pendingPkts.top()));
+        pendingPkts.pop();
+        pendingId++;
+    }
+}
+
+void
+PDMAChannel::processRespSuccess(PDMAPkt *pkt)
+{
+    if (pkt->cmd == MemCmd::ReadReq) {
+        inFlightR--;
+        stats.turnaroundRdPkts.sample(curTick() - pkt->pktSendTime);
+        if (!shutdownDescr)
+            pendingPkts.push(pkt);
+        else
+            idlePkts.push(std::unique_ptr<PDMAPkt>(pkt));
+    } else {
+        inFlightW--;
+        stats.turnaroundWrPkts.sample(curTick() - pkt->pktSendTime);
+
+        exec.src += pkt->pktSize;
+        exec.dest += pkt->pktSize;
+        exec.size -= pkt->pktSize;
+        stats.bytesTransmitted += pkt->pktSize;
+        idlePkts.push(std::unique_ptr<PDMAPkt>(pkt));
+    }
+    processTiming();
+}
+
+void
+PDMAChannel::processRespError(PDMAPkt *pkt)
+{
+    DPRINTF(SfPDMA, "Abort\n");
+
+    shutdownDescr = true;
+    busErr = true;
+    while (!pendingPkts.empty()) {
+        idlePkts.push(std::unique_ptr<PDMAPkt>(pendingPkts.top()));
+        pendingPkts.pop();
+    }
+
+    if (pkt->cmd == MemCmd::WriteReq)
+        inFlightW--;
+    else
+        inFlightR--;
+    idlePkts.push(std::unique_ptr<PDMAPkt>(pkt));
+    processTiming();
+}
+
+PDMAChannel::PDMAStats::PDMAStats(PDMAChannel &chan) :
+    statistics::Group(chan.pdma, csprintf("chan%d", chan.chanId).c_str()),
+    ADD_STAT(turnaroundRdPkts, statistics::units::Tick::get(),
+            "Turnaround delay for dma rd pkts"),
+    ADD_STAT(turnaroundWrPkts, statistics::units::Tick::get(),
+            "Turnaround delay for dma wr pkts"),
+    ADD_STAT(bytesTransmitted, statistics::units::Byte::get(),
+            "Number of bytes copied by channel"),
+    ADD_STAT(workTime, statistics::units::Tick::get(),
+            "Sum of intervals between receiving dma command and raising irq"),
+    ADD_STAT(averageSpeed,
+            statistics::units::Rate<statistics::units::Byte,
+                    statistics::units::Second>::get(),
+            "Channel average transmission speed")
+{
+    using namespace statistics;
+
+    turnaroundRdPkts.init(4).flags(nozero | nonan);
+    turnaroundWrPkts.init(4).flags(nozero | nonan);
+    bytesTransmitted.flags(nozero | nonan);
+    workTime.flags(nozero | nonan);
+    averageSpeed.precision(0).prereq(bytesTransmitted).flags(nozero | nonan);
+    averageSpeed = bytesTransmitted / (workTime / simFreq);
+}
+
+SfPDMA::SfPDMA(const SfPDMAParams &p) :
+    PioDevice(p), pioAddr(p.pio_addr), chanCnt(p.chan_cnt)
+{
+    if (p.done_irq.size() != chanCnt || p.error_irq.size() != chanCnt)
+        fatal("pdma: need to provide all irqs\n");
+
+    for (int i = 0; i < p.chan_cnt; i++)
+        chans.push_back(std::make_unique<PDMAChannel>(this, p, i));
+}
+
+PDMAChannel *
+SfPDMA::chanByAddr(Addr addr)
+{
+    addr -= pioAddr;
+    uint8_t chan = bits(addr, 15, 12);
+    fatal_if(chan >= chanCnt, "pdma: access to nonexistent channel\n");
+    return chans[chan].get();
+}
+
+Tick
+SfPDMA::read(PacketPtr pkt)
+{
+    Addr addr = pkt->getAddr() & 0xfff;
+    int size = pkt->getSize();
+    return chanByAddr(pkt->getAddr())->read(pkt, addr, size);
+}
+
+Tick
+SfPDMA::write(PacketPtr pkt)
+{
+    Addr addr = pkt->getAddr() & 0xfff;
+    int size = pkt->getSize();
+    return chanByAddr(pkt->getAddr())->write(pkt, addr, size);
+}
+
+AddrRangeList
+SfPDMA::getAddrRanges() const
+{
+    return AddrRangeList({RangeSize(pioAddr, 0x1000 * chanCnt)});
+}
+
+Port &
+SfPDMA::getPort(const std::string &if_name, PortID idx)
+{
+    if (if_name != "dma") {
+        // pass it along to our super class
+        return PioDevice::getPort(if_name, idx);
+    } else {
+        fatal_if(idx >= chanCnt, "pdma::getPort: unknown index %d\n", idx);
+
+        return chans[idx]->getPort();
+    }
+}
+
+void
+SfPDMA::serialize(CheckpointOut &cp) const
+{
+    PioDevice::serialize(cp);
+    for (int i = 0; i < chanCnt; i++)
+        chans[i]->serializeSection(cp, csprintf("channel%d", i));
+}
+
+void
+SfPDMA::unserialize(CheckpointIn &cp)
+{
+    PioDevice::unserialize(cp);
+    for (int i = 0; i < chanCnt; i++)
+        chans[i]->unserializeSection(cp, csprintf("channel%d", i));
+}
+
+} // namespace gem5

--- a/src/dev/riscv/sf_pdma.hh
+++ b/src/dev/riscv/sf_pdma.hh
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025 Nikita Proshkin
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SF_PDMA_HH_
+#define _SF_PDMA_HH_
+
+#include <queue>
+
+#include "base/chunk_generator.hh"
+#include "base/circlebuf.hh"
+#include "dev/io_device.hh"
+#include "dev/platform.hh"
+#include "mem/packet.hh"
+#include "mem/packet_access.hh"
+#include "params/SfPDMA.hh"
+#include "sf_pdma_defs.hh"
+#include "sim/stats.hh"
+#include "sim/system.hh"
+
+/**
+ * @file
+ * Model of the SiFive FU540 Platform DMA engine.
+ * Memcpy DMA engine with variable number of channels.
+ *
+ * Interface corresponds with the one described in Chapter 12 of
+ * https://static.dev.sifive.com/FU540-C000-v1.0.pdf
+ *
+ * - Compatible with sf-pdma Linux driver;
+ * - Supports out-of-order transactions mode.
+ */
+
+namespace gem5
+{
+
+class SfPDMA;
+
+struct PDMATiming
+{
+    Cycles chanRegRdWrDelay;
+    Cycles latBeforeBegin;
+    Cycles latBeforeCompletion;
+};
+
+class PDMAChannel : public Drainable, public Serializable
+{
+  private:
+    class PDMAPkt : public Packet::SenderState
+    {
+      public:
+        std::unique_ptr<uint8_t[]> buf;
+        const size_t bufSize;
+
+        MemCmd::Command cmd;
+        size_t pktSize;
+        Tick pktSendTime;
+        uint64_t id;
+
+        PDMAPkt(size_t bufSize) : buf(new uint8_t[bufSize]), bufSize(bufSize)
+        {}
+
+        struct Comparator
+        {
+            bool
+            operator()(PDMAPkt *a, PDMAPkt *b) const
+            {
+                return a->id > b->id;
+            }
+        };
+    };
+
+    class PDMAReqPort : public RequestPort
+    {
+      protected:
+        PDMAChannel &chan;
+
+        bool recvTimingResp(PacketPtr pkt) override;
+        void recvReqRetry() override;
+
+      public:
+        PDMAReqPort(const std::string &name, PDMAChannel &chan);
+        virtual ~PDMAReqPort() {}
+    };
+
+    const size_t FIFO_SIZE = 256;
+
+    // State
+    PDMACtrl ctrl = 0;
+    PDMARegs next = {0};
+    PDMARegs exec = {0};
+
+    /**
+     * Driver requires pdma to stop transfer or dma request resulted with an
+     * error (was stoped by iommu, for example)
+     */
+    bool shutdownDescr = false;
+
+    bool busErr = false;
+    //
+
+    SfPDMA *pdma;
+    const System *system;
+    int chanId;
+    PDMAReqPort dma;
+    const RequestorID requestorId;
+    const uint32_t streamId;
+
+    int doneIrq;
+    int errIrq;
+    Platform *platform;
+
+    size_t pktsN;
+
+    PDMATiming delays;
+    const uint32_t dmaWidth;
+
+    // Descriptor processing
+
+    /**
+     * Pool (of size pktsN) of buffers used to generate pkts
+     */
+    std::queue<std::unique_ptr<PDMAPkt>> idlePkts;
+
+    /**
+     * Need to sort possible out-of-order Read responses when issuing several
+     * parallel in-flight requests
+     */
+    std::priority_queue<PDMAPkt *, std::vector<PDMAPkt *>, PDMAPkt::Comparator>
+            pendingPkts;
+
+    size_t inFlightW = 0;
+    size_t inFlightR = 0;
+    size_t inFlightMax;
+
+    /**
+     * Use ChunkGenerators to handle unaligned src/dest addresses and to avoid
+     * triggering cache system asserts about requests not fitting into cache
+     * block
+     */
+    std::unique_ptr<ChunkGenerator> rChunks;
+    std::unique_ptr<ChunkGenerator> wrChunks;
+
+    Fifo<uint8_t> dataFifo;
+
+    uint64_t idsForReads = 0;
+    uint64_t pendingId = 0;
+
+    PacketPtr nextTimingPkt = nullptr;
+    bool waitingRetry = false;
+
+    Tick startTime;
+
+    /**
+     * This function should be called when driver sets the 'run' bit.
+     * Reset channel state according to new transfer params and start
+     * descriptor processing.
+     *
+     * @param repeated Transfer was repeated because 'repeat' bit was set in
+     *                 the config
+     */
+    void run(bool repeated);
+
+    /**
+     * Generate ReadReq/WriteReq pkts to read/write data to dataFifo.
+     * Check that wrChunks or rChunks are not done and that there is enough
+     * ready data in dataFifo for write request packet.
+     * Return nulltpr when cannot assemble the packet.
+     * For read packets don't check if there is any free space in fifo.
+     * Pkt must be consumed by port or we will lose data.
+     */
+    PacketPtr buildPkt(PDMAPkt *pkt, MemCmd::Command cmd);
+
+    /**
+     * Entry point to start descriptor processing.
+     */
+    void sendPkts();
+
+    bool readyForDrain();
+
+    /**
+     * Update Control register and trigger irqs when descriptor is processed.
+     */
+    void processCompletion();
+
+    void sendAtomicPkts();
+
+    // Timing mode
+    void processTiming();
+    void sendTimingPkts();
+
+    /**
+     * Pick up pkts from the priority_queue in the right order based on ids and
+     * feed their data to fifo. Later write requests will consume it.
+     */
+    void fillFifo();
+
+    /**
+     * Functions to call from the recvTimingResp of the dma port.
+     */
+    void processRespSuccess(PDMAPkt *pkt);
+    void processRespError(PDMAPkt *pkt);
+
+    MemberEventWrapper<&PDMAChannel::sendPkts> sendPktsEvent;
+    MemberEventWrapper<&PDMAChannel::processCompletion> sendComplEvent;
+
+  protected:
+    struct PDMAStats : public statistics::Group
+    {
+        PDMAStats(PDMAChannel &chan);
+
+        statistics::Histogram turnaroundRdPkts;
+        statistics::Histogram turnaroundWrPkts;
+        statistics::Scalar bytesTransmitted;
+        statistics::Scalar workTime;
+        statistics::Formula averageSpeed;
+    } stats;
+
+  public:
+    PDMAChannel(SfPDMA *pdma, const SfPDMAParams &p, int cid);
+    virtual ~PDMAChannel() {}
+
+    Port &getPort();
+    std::string name() const;
+
+    // Offset inside channel mem map
+    Tick read(PacketPtr pkt, Addr addr, int size);
+    Tick write(PacketPtr pkt, Addr addr, int size);
+
+    DrainState drain() override;
+    void drainResume() override;
+
+    void serialize(CheckpointOut &cp) const override;
+    void unserialize(CheckpointIn &cp) override;
+};
+
+class SfPDMA : public PioDevice
+{
+  private:
+    const Addr pioAddr;
+    const uint8_t chanCnt;
+    std::vector<std::unique_ptr<PDMAChannel>> chans;
+
+    PDMAChannel *chanByAddr(Addr addr);
+
+  public:
+    SfPDMA(const SfPDMAParams &p);
+    virtual ~SfPDMA() {}
+
+    Tick read(PacketPtr pkt) override;
+    Tick write(PacketPtr pkt) override;
+    AddrRangeList getAddrRanges() const override;
+
+    Port &getPort(
+            const std::string &if_name, PortID idx = InvalidPortID) override;
+
+    void serialize(CheckpointOut &cp) const override;
+    void unserialize(CheckpointIn &cp) override;
+};
+
+} // namespace gem5
+
+#endif

--- a/src/dev/riscv/sf_pdma_defs.hh
+++ b/src/dev/riscv/sf_pdma_defs.hh
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 Nikita Proshkin
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SF_PDMA_DEFS_HH_
+#define _SF_PDMA_DEFS_HH_
+
+#include <stdint.h>
+
+#include "base/bitunion.hh"
+
+// Channel Memory Map
+// Each channel mapping starts from the new page (4 KiB).
+//
+// Offset   | Size  | Name              | Description
+// 0x0      | 4     | Control           | Channel Control Register
+// 0x004    | 4     | NextConfig        | Next transfer type
+// 0x008    | 8     | NextBytes         | Number of bytes to move
+// 0x010    | 8     | NextDestination   | Destination start address
+// 0x018    | 8     | NextSource        | Source start address
+// 0x104    | 4     | ExecConfig        | Active transfer type
+// 0x108    | 8     | ExecBytes         | Number of bytes remaining
+// 0x110    | 8     | ExecDestination   | Destination current address
+// 0x118    | 8     | ExecSource        | Source current address
+//
+// 'Next' registers are RW and used by the driver to configure next transfer.
+// 'Exec' registers are RO and associated with the transfer in progress.
+// When driver sets 'run' bit in Control register, PDMA copies 'Next' registers
+// to the 'Exec' set and starts the transfer.
+
+// Control Register
+BitUnion32(PDMACtrl)
+    // Indicates that the channel is in use. Setting this clears all of the
+    // channel’s Next registers. This bit can only be cleared when run is low.
+    Bitfield<0> claim;
+    // Setting this bit starts a DMA transfer by copying the Next registers
+    // into their Exec counterparts.
+    Bitfield<1> run;
+    // Enable transfer done interrupts.
+    Bitfield<14> done_ie;
+    // Enable bus error interrupts.
+    Bitfield<15> error_ie;
+    // Indicates that a transfer has completed since the channel was claimed.
+    Bitfield<30> done;
+    // Indicates that a transfer error has occurred since the channel was
+    // claimed.
+    Bitfield<31> error;
+EndBitUnion(PDMACtrl)
+
+// Next/ExecConfig Register
+BitUnion32(PDMAConf)
+    // If set, the Exec registers are reloaded from the Next registers once a
+    // transfer is complete. The repeat bit must be cleared by software for the
+    // sequence to stop.
+    Bitfield<2> repeat;
+    // Enforces strict ordering by only allowing one of each transfer type
+    // in-flight at a time.
+    Bitfield<3> order;
+    // The wsize and rsize fields are used to determine the size and alignment
+    // of individual PDMA transactions, as a single PDMA transfer might require
+    // multiple transactions. They contain Base 2 Logarithm of PDMA transaction
+    // sizes.
+    Bitfield<27, 24> wsize;
+    Bitfield<31, 28> rsize;
+EndBitUnion(PDMAConf)
+
+// Set of 'Next' or 'Exec' registers
+union PDMARegs
+{
+    uint8_t data[32];
+
+    struct
+    {
+        // Keep 0x004 offset requirement
+        uint32_t reserved;
+        // Transfer config (PDMAConf)
+        uint32_t config;
+        // Transfer size
+        uint64_t size;
+        // Transfer destination address
+        uint64_t dest;
+        // Transfer source address
+        uint64_t src;
+    };
+};
+
+#define PDMA_CTRL_OFFSET    0x0
+#define PDMA_CONF_OFFSET    0x4
+#define PDMA_SIZE_OFFSET    0x8
+#define PDMA_DEST_OFFSET    0x10
+#define PDMA_SRC_OFFSET     0x18
+
+#endif

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -57,6 +57,7 @@ from m5.params import (
     AddrRange,
     Port,
 )
+from m5.util.attrdict import attrdict
 from m5.util.fdthelper import (
     Fdt,
     FdtNode,
@@ -137,7 +138,7 @@ class RiscvBoard(
             self.iobus.default = self.iobus.badaddr_responder.pio
 
             # The virtio disk
-            self.disk = RiscvMmioVirtIO(
+            self.platform.disk = RiscvMmioVirtIO(
                 vio=VirtIOBlock(),
                 interrupt_id=0x8,
                 pio_size=4096,
@@ -145,17 +146,12 @@ class RiscvBoard(
             )
 
             # The virtio rng
-            self.rng = RiscvMmioVirtIO(
+            self.platform.rng = RiscvMmioVirtIO(
                 vio=VirtIORng(),
                 interrupt_id=0x8,
                 pio_size=4096,
                 pio_addr=0x10007000,
             )
-
-            # Note: This overrides the platform's code because the platform
-            # isn't general enough.
-            self._on_chip_devices = [self.platform.clint, self.platform.plic]
-            self._off_chip_devices = [self.platform.uart, self.disk, self.rng]
 
         else:
             # SE mode board setup
@@ -185,15 +181,22 @@ class RiscvBoard(
         self.ethernet.pio = self.platform.pci_bus.mem_side_ports
         self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
 
+        self.platform.attachOffChipIO(
+            self.iobus, self.get_cache_hierarchy().is_ruby()
+        )
+
         if self.get_cache_hierarchy().is_ruby():
-            for device in self._off_chip_devices + self._on_chip_devices:
-                device.pio = self.iobus.mem_side_ports
+            self.platform.attachOnChipIO(self.iobus, True)
 
         else:
-            for device in self._off_chip_devices:
-                device.pio = self.iobus.mem_side_ports
-            for device in self._on_chip_devices:
-                device.pio = self.get_cache_hierarchy().get_mem_side_port()
+            membus = attrdict()
+            membus["mem_side_ports"] = (
+                self.get_cache_hierarchy().get_mem_side_port()
+            )
+            membus["cpu_side_ports"] = (
+                self.get_cache_hierarchy().get_cpu_side_port()
+            )
+            self.platform.attachOnChipIO(membus, False)
 
             self.bridge = Bridge(delay="10ns")
             self.bridge.mem_side_port = self.iobus.cpu_side_ports
@@ -202,7 +205,7 @@ class RiscvBoard(
             )
             self.bridge.ranges = [
                 AddrRange(dev.pio_addr, size=dev.pio_size)
-                for dev in self._off_chip_devices
+                for dev in self.platform._off_chip_devices()
             ]
 
             # PCI
@@ -215,7 +218,8 @@ class RiscvBoard(
 
         uncacheable_range = [
             AddrRange(dev.pio_addr, size=dev.pio_size)
-            for dev in self._on_chip_devices + self._off_chip_devices
+            for dev in self.platform._on_chip_devices()
+            + self.platform._off_chip_devices()
         ]
 
         # PCI
@@ -231,13 +235,18 @@ class RiscvBoard(
 
     @overrides(AbstractBoard)
     def has_dma_ports(self) -> bool:
-        return False
+        return self.is_fullsystem()
 
     @overrides(AbstractBoard)
     def get_dma_ports(self) -> List[Port]:
-        raise Exception(
-            "Cannot execute `get_dma_ports()`: Board does not have DMA ports "
-            "to return. Use `has_dma_ports()` to check this."
+        if not self.has_dma_ports():
+            raise Exception(
+                "Cannot execute `get_dma_ports()`: Board does not have DMA ports "
+                "to return. Use `has_dma_ports()` to check this."
+            )
+        return (
+            self.platform._on_chip_ports_req()
+            + self.platform._off_chip_ports_req()
         )
 
     @overrides(AbstractBoard)
@@ -522,7 +531,7 @@ class RiscvBoard(
         soc_node.append(uart_node)
 
         # VirtIO MMIO disk node
-        disk = self.disk
+        disk = self.platform.disk
         disk_node = disk.generateBasicPioDeviceNode(
             soc_state, "virtio_mmio", disk.pio_addr, disk.pio_size
         )
@@ -534,7 +543,7 @@ class RiscvBoard(
         soc_node.append(disk_node)
 
         # VirtIO MMIO rng node
-        rng = self.rng
+        rng = self.platform.rng
         rng_node = rng.generateBasicPioDeviceNode(
             soc_state, "virtio_mmio", rng.pio_addr, rng.pio_size
         )
@@ -544,6 +553,10 @@ class RiscvBoard(
         )
         rng_node.appendCompatible(["virtio,mmio"])
         soc_node.append(rng_node)
+
+        # DMA controller
+        dma_node = self.platform.pdma.generateDeviceTree(soc_state)
+        soc_node.append(dma_node)
 
         root.append(soc_node)
 
@@ -595,7 +608,7 @@ class RiscvBoard(
             child=RawDiskImage(read_only=True), read_only=False
         )
         image.child.image_file = disk_image.get_local_path()
-        self.disk.vio.image = image
+        self.platform.disk.vio.image = image
 
         # Note: The below is a bit of a hack. We need to wait to generate the
         # device tree until after the disk is set up. Now that the disk and

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -160,6 +160,7 @@ class RISCVMatchedBoard(
             )
             self.platform.attachPlic()
             self.platform.clint.num_threads = self.processor.get_num_cores()
+            self.platform.clear_child("pdma")
 
             # Add the RTC
             self.platform.rtc = RiscvRTC(


### PR DESCRIPTION
Add model of the SiFive Platform DMA Engine (PDMA). This DMA engine is a part of FU540 and FU740 SoCs (used by HiFive Unleashed and Unmatched boards). This is a basic DMA memcpy controller which can be used to transfer data between devices and main memory or copy data between two locations in memory.

PDMA is decribed in SiFive FU540 Manual, Chapter 12:
https://static.dev.sifive.com/FU540-C000-v1.0.pdf

PDMA gem5 model is compatible with sf-pdma Linux driver and can be used as a generator of the DMA-requests.

Also a small demo with Linux dmatest module is available: https://drive.google.com/drive/folders/10m4tfQVQPKWBl1Gt_kMV2JktqFn2Uwsm?usp=sharing
You can use it to see how the new model works.

**_Pay attention:_**
For convenience and usage demonstration (and also because physical FU540 has a PDMA on-board) new model was added to the existent gem5 HiFive platform. But this platform did not support devices with DMA ports that required additional changes to it and also led to changes to the boards that use this platform (`RiscvBoard` and `RISCVMatchedBoard`). The tests are passing and it looks like the existing scripts using these boards are working, but I'm not an expert in the gem5 stdlib at all, so please double check these changes.