### PR TITLE
python: assert if max processes not set for multisim

### DIFF
--- a/src/python/gem5/utils/multisim/multisim.py
+++ b/src/python/gem5/utils/multisim/multisim.py
@@ -205,6 +205,11 @@ def run(module_path: Path, processes: Optional[int] = None) -> None:
         "Simulators instantiated in main thread instead of child thread "
         "(after determining number of jobs)."
     )
+    assert max_num_processes is not None, (
+        "The maximum number of processes to use has not been set. Please "
+        "call `multisim.set_num_processes(num_processes)` in your "
+        "configuration script."
+    )
 
     active_processes = []
     remaining_ids = list(ids).copy()


### PR DESCRIPTION
This commit adds an assert for when multisim.set_num_processes() is not called in a config script. Previously, when the maximum number of processes was not set, the default behavior would be to use all of the threads available on the host system. A later change to multisim changed the default behavior, making it so that no simulations would be launched if the maximum wasn't set. This commit prevents this by making the user set a maximum number of processes.