### PR TITLE
gpu-compute: GPU protocol tester bug

### DIFF
--- a/src/cpu/testers/gpu_ruby_test/tester_thread.cc
+++ b/src/cpu/testers/gpu_ruby_test/tester_thread.cc
@@ -491,7 +491,7 @@ TesterThread::printAllOutstandingReqs(std::stringstream& ss) const
 std::string
 TesterThread::printAddress(Addr addr) const
 {
-    return ruby::printAddress(addr, cacheLineSize * 8);
+    return ruby::printAddress(addr, floorLog2(cacheLineSize));
 }
 
 } // namespace gem5


### PR DESCRIPTION
Recent commits that added multiple RubySystems to gem5 caused a bug in the GPU protocol tester where the parameter needs to use floorLog2 of the cache line size to properly set the number of bits in a cache line for the tester.