### PR TITLE
ext,stdlib: Update integration of DRAMSys

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -250,7 +250,7 @@ jobs:
             - uses: actions/checkout@v4
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
-              run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.0 --depth 1 DRAMSys
+              run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.1 --depth 1 DRAMSys
 
               # gem5 is built separately because it depends on the DRAMSys library
             - name: Build gem5

--- a/configs/example/gem5_library/dramsys/arm-hello-dramsys.py
+++ b/configs/example/gem5_library/dramsys/arm-hello-dramsys.py
@@ -53,7 +53,7 @@ requires(isa_required=ISA.ARM)
 cache_hierarchy = PrivateL1CacheHierarchy(l1d_size="32KiB", l1i_size="32KiB")
 
 # We use a single channel DDR3_1600 memory system
-memory = DRAMSysDDR3_1600(recordable=True)
+memory = DRAMSysDDR3_1600()
 
 # We use a simple Timing processor with one core.
 processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1)

--- a/configs/example/gem5_library/dramsys/dramsys-traffic.py
+++ b/configs/example/gem5_library/dramsys/dramsys-traffic.py
@@ -39,7 +39,6 @@ from gem5.simulate.simulator import Simulator
 
 memory = DRAMSysMem(
     configuration="ext/dramsys/DRAMSys/configs/ddr4-example.json",
-    recordable=True,
     size="4GiB",
 )
 

--- a/ext/dramsys/CMakeLists.txt
+++ b/ext/dramsys/CMakeLists.txt
@@ -27,12 +27,8 @@
 cmake_minimum_required(VERSION 3.22.0)
 project(DRAMSys)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
 set(BUILD_SHARED_LIBS OFF)
-
-add_library(systemc INTERFACE)
-
-target_include_directories(systemc INTERFACE "${SCONS_SOURCE_DIR}/src/systemc/ext/systemc_home/include")
-
-add_library(SystemC::systemc ALIAS systemc)
 
 add_subdirectory(DRAMSys)

--- a/ext/dramsys/README
+++ b/ext/dramsys/README
@@ -1,16 +1,16 @@
 Follow these steps to build DRAMSys as part of gem5
 
 1. Go to ext/dramsys (this directory)
-2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys --branch v5.0 --depth 1 DRAMSys'
+2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys --branch v5.1 --depth 1 DRAMSys'
 
-The latest verified working version is v5.0, but later versions might work too.
+The latest verified working version is v5.1, but later versions might work too.
 gem5 will automatically pick up DRAMSys as an external module when it is rebuilt.
 
 If you wish to run a simulation using the gem5 processor cores, make sure to enable the storage mode in DRAMSys.
 This is done by setting the value of the "StoreMode" key to "Store" in the base configuration file.
-Those configuration file can be found in 'DRAMSys/library/resources/configs/simulator'.
+Those configuration file can be found in 'DRAMSys/configs/simconfig'.
 
-Currently, DRAMSys is only supported in conjunction with a cache. Running DRAMSys in Release mode without caches will silently fail!
+Currently, DRAMSys is only supported in conjunction with a cache. Running DRAMSys in Release mode without a cache will silently fail!
 
 Note: DRAMSys requires cmake version >= 3.24. This is not available via apt on Ubuntu 20.04 or 22.04. 
 See `util/dockerfiles/ubuntu-20.04_all-dependencies/Dockerfile` for an example of how to install cmake 3.24.

--- a/ext/dramsys/SConscript
+++ b/ext/dramsys/SConscript
@@ -73,10 +73,10 @@ subprocess.run(
     check=True
 )
 
-env.Append(LIBS="DRAMSys_libdramsys")
+env.Append(LIBS="liblibdramsys")
 env.Append(LIBPATH=Dir("./DRAMSys/src/libdramsys").abspath)
 
-env.Append(LIBS="DRAMSys_Configuration")
+env.Append(LIBS="libconfiguration")
 env.Append(LIBPATH=Dir("./DRAMSys/src/configuration").abspath)
 
 env.Append(LIBS="sqlite3")

--- a/ext/dramsys/cmake/FindSystemCLanguage.cmake
+++ b/ext/dramsys/cmake/FindSystemCLanguage.cmake
@@ -1,0 +1,9 @@
+if (NOT SystemCLanguage_FOUND)
+    add_library(systemc INTERFACE)
+
+    target_include_directories(systemc INTERFACE "${SCONS_SOURCE_DIR}/src/systemc/ext/systemc_home/include")
+
+    add_library(SystemC::systemc ALIAS systemc)
+    
+    set(SystemCLanguage_FOUND TRUE)
+endif()

--- a/src/mem/DRAMSys.py
+++ b/src/mem/DRAMSys.py
@@ -40,7 +40,6 @@ class DRAMSys(AbstractMemory):
 
     configuration = Param.String("Path to the DRAMSys configuration")
     resource_directory = Param.String("Path to the DRAMSys resource directory")
-    recordable = Param.Bool(True, "Whether DRAMSys should record a trace file")
 
 
 add_citation(

--- a/src/mem/dramsys.cc
+++ b/src/mem/dramsys.cc
@@ -40,7 +40,7 @@ DRAMSys::DRAMSys(Params const& params) :
     config(::DRAMSys::Config::from_path(params.configuration,
                                         params.resource_directory)),
     dramSysWrapper(
-        params.name.c_str(), config, params.recordable, params.range)
+        params.name.c_str(), config, params.range)
 {
     dramSysWrapper.dramsys->registerIdleCallback(
         [this]
@@ -85,7 +85,6 @@ void DRAMSys::serialize(CheckpointOut& cp) const
             if (serializableObject != nullptr)
             {
                 std::string dumpFileName(object->name());
-                dumpFileName += ".pmem";
                 std::ofstream stream(checkpointPath / dumpFileName,
                                      std::ios::binary);
                 serializableObject->serialize(stream);
@@ -118,7 +117,6 @@ void DRAMSys::unserialize(CheckpointIn& cp)
             if (deserializableObject != nullptr)
             {
                 std::string dumpFileName(object->name());
-                dumpFileName += ".pmem";
                 std::ifstream stream(checkpointPath / dumpFileName,
                                      std::ios::binary);
                 deserializableObject->deserialize(stream);

--- a/src/mem/dramsys_wrapper.cc
+++ b/src/mem/dramsys_wrapper.cc
@@ -37,10 +37,9 @@ namespace memory
 DRAMSysWrapper::DRAMSysWrapper(
     sc_core::sc_module_name name,
     ::DRAMSys::Config::Configuration const &config,
-    bool recordable,
     AddrRange range) :
     sc_core::sc_module(name),
-    dramsys(instantiateDRAMSys(recordable, config)),
+    dramsys(std::make_shared<::DRAMSys::DRAMSys>("DRAMSys", config)),
     range(range)
 {
     tSocket.register_nb_transport_fw(this, &DRAMSysWrapper::nb_transport_fw);
@@ -59,16 +58,6 @@ DRAMSysWrapper::DRAMSysWrapper(
             // Workaround for BUG GEM5-1233
             sc_gem5::Kernel::stop();
         });
-}
-
-std::shared_ptr<::DRAMSys::DRAMSys>
-DRAMSysWrapper::instantiateDRAMSys(
-    bool recordable,
-    ::DRAMSys::Config::Configuration const &config)
-{
-    return recordable
-        ? std::make_shared<::DRAMSys::DRAMSysRecordable>("DRAMSys", config)
-        : std::make_shared<::DRAMSys::DRAMSys>("DRAMSys", config);
 }
 
 void DRAMSysWrapper::b_transport(

--- a/src/mem/dramsys_wrapper.hh
+++ b/src/mem/dramsys_wrapper.hh
@@ -33,7 +33,7 @@
 #include <memory>
 
 #include "DRAMSys/config/DRAMSysConfiguration.h"
-#include "DRAMSys/simulation/DRAMSysRecordable.h"
+#include "DRAMSys/simulation/DRAMSys.h"
 #include "mem/abstract_mem.hh"
 #include "params/DRAMSys.hh"
 #include "sim/core.hh"
@@ -59,14 +59,9 @@ class DRAMSysWrapper : public sc_core::sc_module
     SC_HAS_PROCESS(DRAMSysWrapper);
     DRAMSysWrapper(sc_core::sc_module_name name,
                    ::DRAMSys::Config::Configuration const &config,
-                   bool recordable,
                    AddrRange range);
 
   private:
-    static std::shared_ptr<::DRAMSys::DRAMSys>
-    instantiateDRAMSys(bool recordable,
-        ::DRAMSys::Config::Configuration const &config);
-
     tlm::tlm_sync_enum nb_transport_fw(tlm::tlm_generic_payload &payload,
                                        tlm::tlm_phase &phase,
                                        sc_core::sc_time &fwDelay);

--- a/src/python/gem5/components/memory/dramsys.py
+++ b/src/python/gem5/components/memory/dramsys.py
@@ -65,13 +65,11 @@ class DRAMSysMem(AbstractMemorySystem):
         self,
         configuration: str,
         size: str,
-        recordable: bool,
         resource_directory: Optional[str] = None,
     ) -> None:
         """
         :param configuration: Path to the base configuration JSON for DRAMSys.
         :param size: Memory size of DRAMSys. Must match the size specified in JSON configuration.
-        :param recordable: Whether the database recording feature of DRAMSys is enabled.
         :param resource_directory: Path to the base resource directory for DRAMSys.
         """
         super().__init__()
@@ -85,7 +83,6 @@ class DRAMSysMem(AbstractMemorySystem):
         self.dramsys = DRAMSys(
             configuration=configuration,
             resource_directory=resource_directory_path.as_posix(),
-            recordable=recordable,
         )
 
         self._size = toMemorySize(size)
@@ -125,16 +122,12 @@ class DRAMSysDDR4_1866(DRAMSysMem):
     An example DDR4 1866 DRAMSys configuration.
     """
 
-    def __init__(self, recordable: bool):
-        """
-        :param recordable: Whether the database recording feature of DRAMSys is enabled.
-        """
+    def __init__(self):
         super().__init__(
             configuration=(
                 DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr4-example.json"
             ).as_posix(),
             size="4GiB",
-            recordable=recordable,
         )
 
 
@@ -143,16 +136,12 @@ class DRAMSysDDR3_1600(DRAMSysMem):
     An example DDR3 1600 DRAMSys configuration.
     """
 
-    def __init__(self, recordable: bool):
-        """
-        :param recordable: Whether the database recording feature of DRAMSys is enabled.
-        """
+    def __init__(self):
         super().__init__(
             configuration=(
                 DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr3-gem5-se.json"
             ).as_posix(),
             size="1GiB",
-            recordable=recordable,
         )
 
 
@@ -161,16 +150,12 @@ class DRAMSysLPDDR4_3200(DRAMSysMem):
     An example LPDDR4 3200 DRAMSys configuration.
     """
 
-    def __init__(self, recordable: bool):
-        """
-        :param recordable: Whether the database recording feature of DRAMSys is enabled.
-        """
+    def __init__(self):
         super().__init__(
             configuration=(
                 DEFAULT_DRAMSYS_DIRECTORY / "configs/lpddr4-example.json"
             ).as_posix(),
             size="1GiB",
-            recordable=recordable,
         )
 
 
@@ -179,14 +164,10 @@ class DRAMSysHBM2(DRAMSysMem):
     An example HBM2 DRAMSys configuration.
     """
 
-    def __init__(self, recordable: bool):
-        """
-        :param recordable: Whether the database recording feature of DRAMSys is enabled.
-        """
+    def __init__(self):
         super().__init__(
             configuration=(
                 DEFAULT_DRAMSYS_DIRECTORY / "configs/hbm2-example.json"
             ).as_posix(),
             size="1GiB",
-            recordable=recordable,
         )


### PR DESCRIPTION
The latest version of DRAMSys required several API changes which were applied in this commit.

Also, the README for the usage of DRAMSys has been updated.

The updated version fixes a bug in DRAMSys that caused some full-system simulations to loop endlessly.

GitHub Issue: https://github.com/gem5/gem5/issues/1452