### PR TITLE
systemc: Set response state in transport_dbg as well

### DIFF
--- a/src/systemc/tlm_bridge/tlm_to_gem5.cc
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.cc
@@ -435,6 +435,7 @@ TlmToGem5Bridge<BITWIDTH>::transport_dbg(tlm::tlm_generic_payload &trans)
         pkt->pushSenderState(new Gem5SystemC::TlmSenderState(trans));
 
         bmp.sendFunctional(pkt);
+        setPayloadResponse(trans, pkt);
 
         gem5::Packet::SenderState *senderState = pkt->popSenderState();
         sc_assert(


### PR DESCRIPTION
Response state is specified in other transport methods. This commit specifies the response state in transport_dbg as well so the initiator could validate the transaction result.