### PR TITLE
stdlib: Add warning message for multisim processor switching

### DIFF
--- a/src/python/gem5/components/processors/switchable_processor.py
+++ b/src/python/gem5/components/processors/switchable_processor.py
@@ -121,7 +121,11 @@ class SwitchableProcessor(AbstractProcessor):
     def switch_to_processor(self, switchable_core_key: str):
         # Run various checks.
         if not hasattr(self, "_board"):
-            raise AssertionError("The processor has not been incorporated.")
+            raise AssertionError(
+                "The processor has not been incorporated. "
+                "If you are using multisim, please use "
+                "simulator.switch_processor() instead of processor.switch()."
+            )
 
         if switchable_core_key not in self._switchable_cores.keys():
             raise AssertionError(


### PR DESCRIPTION
This commit adds an additional message to the assert that occurs when processor.switch() is used with multisim. When processor.switch() is used, only the last simulation to be run will have its processors switched correctly.