### PR TITLE
cpu-o3: Replace C++03 boilerplate with range-based for loops

### DIFF
--- a/src/cpu/func_unit.hh
+++ b/src/cpu/func_unit.hh
@@ -87,9 +87,6 @@ class FUDesc : public SimObject
         : SimObject(p), opDescList(p.opList), number(p.count) {};
 };
 
-typedef std::vector<OpDesc *>::const_iterator OPDDiterator;
-typedef std::vector<FUDesc *>::const_iterator FUDDiterator;
-
 
 
 

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -371,8 +371,8 @@ Commit::takeOverFrom()
 void
 Commit::deactivateThread(ThreadID tid)
 {
-    std::list<ThreadID>::iterator thread_it = std::find(priority_list.begin(),
-            priority_list.end(), tid);
+    auto thread_it = std::find(
+            priority_list.begin(), priority_list.end(), tid);
 
     if (thread_it != priority_list.end()) {
         priority_list.erase(thread_it);
@@ -403,12 +403,7 @@ void
 Commit::updateStatus()
 {
     // reset ROB changed variable
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         changedROBNumEntries[tid] = false;
 
         // Also check if any of the threads has a trap pending
@@ -432,12 +427,7 @@ Commit::updateStatus()
 bool
 Commit::changedROBEntries()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (changedROBNumEntries[tid]) {
             return true;
         }
@@ -591,14 +581,9 @@ Commit::tick()
     if (activeThreads->empty())
         return;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
     // Check if any of the threads are done squashing.  Change the
     // status if they are done.
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         // Clear the bit saying if the thread has committed stores
         // this cycle.
         committedStores[tid] = false;
@@ -621,11 +606,7 @@ Commit::tick()
 
     markCompletedInsts();
 
-    threads = activeThreads->begin();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!rob->isEmpty(tid) && rob->readHeadInst(tid)->readyToCommit()) {
             // The ROB has more instructions it can commit. Its next status
             // will be active.
@@ -749,14 +730,9 @@ Commit::commit()
     ////////////////////////////////////
     // Check for any possible squashes, handle them first
     ////////////////////////////////////
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
 
     int num_squashing_threads = 0;
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         // Not sure which one takes priority.  I think if we have
         // both, that's a bad sign.
         if (trapSquash[tid]) {
@@ -863,11 +839,7 @@ Commit::commit()
     }
 
     //Check for any activity
-    threads = activeThreads->begin();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (changedROBNumEntries[tid]) {
             toIEW->commitInfo[tid].usedROB = true;
             toIEW->commitInfo[tid].freeROBEntries = rob->numFreeEntries(tid);
@@ -1464,8 +1436,8 @@ Commit::getCommittingThread()
 ThreadID
 Commit::roundRobin()
 {
-    std::list<ThreadID>::iterator pri_iter = priority_list.begin();
-    std::list<ThreadID>::iterator end      = priority_list.end();
+    auto pri_iter = priority_list.begin();
+    auto end      = priority_list.end();
 
     while (pri_iter != end) {
         ThreadID tid = *pri_iter;
@@ -1495,12 +1467,7 @@ Commit::oldestReady()
     unsigned oldest_seq_num = 0;
     bool first = true;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!rob->isEmpty(tid) &&
             (commitStatus[tid] == Running ||
              commitStatus[tid] == Idle ||

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -450,13 +450,13 @@ CPU::startup()
 void
 CPU::activateThread(ThreadID tid)
 {
-    std::list<ThreadID>::iterator isActive =
-        std::find(activeThreads.begin(), activeThreads.end(), tid);
+    auto active_it = std::find(
+            activeThreads.begin(), activeThreads.end(), tid);
 
     DPRINTF(O3CPU, "[tid:%i] Calling activate thread.\n", tid);
     assert(!switchedOut());
 
-    if (isActive == activeThreads.end()) {
+    if (active_it == activeThreads.end()) {
         DPRINTF(O3CPU, "[tid:%i] Adding to active threads list\n", tid);
 
         activeThreads.push_back(tid);
@@ -471,16 +471,16 @@ CPU::deactivateThread(ThreadID tid)
     assert(!commit.executingHtmTransaction(tid));
 
     //Remove From Active List, if Active
-    std::list<ThreadID>::iterator thread_it =
-        std::find(activeThreads.begin(), activeThreads.end(), tid);
+    auto active_it = std::find(
+            activeThreads.begin(), activeThreads.end(), tid);
 
     DPRINTF(O3CPU, "[tid:%i] Calling deactivate thread.\n", tid);
     assert(!switchedOut());
 
-    if (thread_it != activeThreads.end()) {
+    if (active_it != activeThreads.end()) {
         DPRINTF(O3CPU,"[tid:%i] Removing from active threads list\n",
                 tid);
-        activeThreads.erase(thread_it);
+        activeThreads.erase(active_it);
     }
 
     fetch.deactivateThread(tid);
@@ -1355,7 +1355,7 @@ CPU::updateThreadPriority()
     if (activeThreads.size() > 1) {
         //DEFAULT TO ROUND ROBIN SCHEME
         //e.g. Move highest priority to end of thread list
-        std::list<ThreadID>::iterator list_begin = activeThreads.begin();
+        auto list_begin = activeThreads.begin();
 
         unsigned high_thread = *list_begin;
 

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -427,11 +427,7 @@ Decode::skidInsert(ThreadID tid)
 bool
 Decode::skidsEmpty()
 {
-    list<ThreadID>::iterator threads = activeThreads->begin();
-    list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    for (ThreadID tid : *activeThreads) {
         if (!skidBuffer[tid].empty())
             return false;
     }
@@ -444,12 +440,7 @@ Decode::updateStatus()
 {
     bool any_unblocking = false;
 
-    list<ThreadID>::iterator threads = activeThreads->begin();
-    list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (decodeStatus[tid] == Unblocking) {
             any_unblocking = true;
             break;
@@ -564,15 +555,10 @@ Decode::tick()
 
     toRenameIndex = 0;
 
-    list<ThreadID>::iterator threads = activeThreads->begin();
-    list<ThreadID>::iterator end = activeThreads->end();
-
     sortInsts();
 
     //Check stall and squash signals.
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         DPRINTF(Decode,"Processing [tid:%i]\n",tid);
         status_change =  checkSignalsAndUpdate(tid) || status_change;
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -771,12 +771,7 @@ Fetch::FetchStatus
 Fetch::updateFetchStatus()
 {
     //Check Running
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (fetchStatus[tid] == Running ||
             fetchStatus[tid] == Squashing ||
             fetchStatus[tid] == IcacheAccessComplete) {
@@ -821,8 +816,6 @@ Fetch::squash(const PCStateBase &new_pc, const InstSeqNum seq_num,
 void
 Fetch::tick()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
     bool status_change = false;
 
     wroteToTimeBuffer = false;
@@ -831,9 +824,7 @@ Fetch::tick()
         issuePipelinedIfetch[i] = false;
     }
 
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         // Check the signals for each thread to determine the proper status
         // for each thread.
         bool updated_status = checkSignalsAndUpdate(tid);
@@ -1383,7 +1374,7 @@ Fetch::getFetchingThread()
             return InvalidThreadID;
         }
     } else {
-        std::list<ThreadID>::iterator thread = activeThreads->begin();
+        auto thread = activeThreads->begin();
         if (thread == activeThreads->end()) {
             return InvalidThreadID;
         }
@@ -1404,8 +1395,8 @@ Fetch::getFetchingThread()
 ThreadID
 Fetch::roundRobin()
 {
-    std::list<ThreadID>::iterator pri_iter = priorityList.begin();
-    std::list<ThreadID>::iterator end      = priorityList.end();
+    auto pri_iter = priorityList.begin();
+    auto end      = priorityList.end();
 
     ThreadID high_pri;
 
@@ -1438,11 +1429,7 @@ Fetch::iqCount()
                         std::greater<unsigned> > PQ;
     std::map<unsigned, ThreadID> threadMap;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    for (ThreadID tid : *activeThreads) {
         unsigned iqCount = fromIEW->iewInfo[tid].iqCount;
 
         //we can potentially get tid collisions if two threads
@@ -1474,11 +1461,7 @@ Fetch::lsqCount()
                         std::greater<unsigned> > PQ;
     std::map<unsigned, ThreadID> threadMap;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    for (ThreadID tid : *activeThreads) {
         unsigned ldstqCount = fromIEW->iewInfo[tid].ldstqCount;
 
         //we can potentially get tid collisions if two threads

--- a/src/cpu/o3/fu_pool.cc
+++ b/src/cpu/o3/fu_pool.cc
@@ -75,10 +75,9 @@ FUPool::FUIdxQueue::getFU()
 
 FUPool::~FUPool()
 {
-    fuListIterator i = funcUnits.begin();
-    fuListIterator end = funcUnits.end();
-    for (; i != end; ++i)
-        delete *i;
+    for (FuncUnit* fu : funcUnits) {
+        delete fu;
+    }
 }
 
 
@@ -96,13 +95,11 @@ FUPool::FUPool(const Params &p)
     //
     //  Iterate through the list of FUDescData structures
     //
-    const std::vector<FUDesc *> &paramList =  p.FUList;
-    for (FUDDiterator i = paramList.begin(); i != paramList.end(); ++i) {
-
+    for (FUDesc *i : p.FUList) {
         //
         //  Don't bother with this if we're not going to create any FU's
         //
-        if ((*i)->number) {
+        if (i->number) {
             //
             //  Create the FuncUnit object from this structure
             //   - add the capabilities listed in the FU's operation
@@ -112,39 +109,37 @@ FUPool::FUPool(const Params &p)
             //
             FuncUnit *fu = new FuncUnit;
 
-            OPDDiterator j = (*i)->opDescList.begin();
-            OPDDiterator end = (*i)->opDescList.end();
-            for (; j != end; ++j) {
+            for (OpDesc *j : i->opDescList) {
                 // indicate that this pool has this capability
-                capabilityList.set((*j)->opClass);
+                capabilityList.set(j->opClass);
 
                 // Add each of the FU's that will have this capability to the
                 // appropriate queue.
-                for (int k = 0; k < (*i)->number; ++k)
-                    fuPerCapList[(*j)->opClass].addFU(numFU + k);
+                for (int k = 0; k < i->number; ++k)
+                    fuPerCapList[j->opClass].addFU(numFU + k);
 
                 // indicate that this FU has the capability
-                fu->addCapability((*j)->opClass, (*j)->opLat, (*j)->pipelined);
+                fu->addCapability(j->opClass, j->opLat, j->pipelined);
 
-                if ((*j)->opLat > maxOpLatencies[(*j)->opClass])
-                    maxOpLatencies[(*j)->opClass] = (*j)->opLat;
+                if (j->opLat > maxOpLatencies[j->opClass])
+                    maxOpLatencies[j->opClass] = j->opLat;
 
-                if (!(*j)->pipelined)
-                    pipelined[(*j)->opClass] = false;
+                if (!j->pipelined)
+                    pipelined[j->opClass] = false;
             }
 
             numFU++;
 
             //  Add the appropriate number of copies of this FU to the list
-            fu->name = (*i)->name() + "(0)";
+            fu->name = i->name() + "(0)";
             funcUnits.push_back(fu);
 
-            for (int c = 1; c < (*i)->number; ++c) {
+            for (int c = 1; c < i->number; ++c) {
                 std::ostringstream s;
                 numFU++;
                 FuncUnit *fu2 = new FuncUnit(*fu);
 
-                s << (*i)->name() << "(" << c << ")";
+                s << i->name() << "(" << c << ")";
                 fu2->name = s.str();
                 funcUnits.push_back(fu2);
             }

--- a/src/cpu/o3/fu_pool.hh
+++ b/src/cpu/o3/fu_pool.hh
@@ -131,8 +131,6 @@ class FUPool : public SimObject
     /** Functional units. */
     std::vector<FuncUnit *> funcUnits;
 
-    typedef std::vector<FuncUnit *>::iterator fuListIterator;
-
   public:
     typedef FUPoolParams Params;
     /** Constructs a FU pool. */

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -609,11 +609,7 @@ IEW::skidCount()
 {
     int max=0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    for (ThreadID tid : *activeThreads) {
         unsigned thread_count = skidBuffer[tid].size();
         if (max < thread_count)
             max = thread_count;
@@ -625,12 +621,7 @@ IEW::skidCount()
 bool
 IEW::skidsEmpty()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!skidBuffer[tid].empty())
             return false;
     }
@@ -643,12 +634,7 @@ IEW::updateStatus()
 {
     bool any_unblocking = false;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (dispatchStatus[tid] == Unblocking) {
             any_unblocking = true;
             break;
@@ -1129,11 +1115,7 @@ IEW::executeInsts()
     wbNumInst = 0;
     wbCycle = 0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
+    for (ThreadID tid : *activeThreads) {
         fetchRedirect[tid] = false;
     }
 
@@ -1435,14 +1417,9 @@ IEW::tick()
     // Free function units marked as being freed this cycle.
     fuPool->processFreeUnits();
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
     // Check stall and squash signals, dispatch any instructions.
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
-        DPRINTF(IEW,"Issue: Processing [tid:%i]\n",tid);
+    for (ThreadID tid : *activeThreads) {
+        DPRINTF(IEW,"Issue: Processing [tid:%i]\n", tid);
 
         checkSignalsAndUpdate(tid);
         dispatch(tid);
@@ -1479,12 +1456,8 @@ IEW::tick()
     // or store to commit.  Also check if it's being told to execute a
     // nonspeculative instruction.
     // This is pretty inefficient...
-
-    threads = activeThreads->begin();
-    while (threads != end) {
-        ThreadID tid = (*threads++);
-
-        DPRINTF(IEW,"Processing [tid:%i]\n",tid);
+    for (ThreadID tid : *activeThreads) {
+        DPRINTF(IEW,"Processing [tid:%i]\n", tid);
 
         // Update structures based on instructions committed.
         if (fromCommit->commitInfo[tid].doneSeqNum != 0 &&

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -493,12 +493,7 @@ InstructionQueue::resetEntries()
     if (iqPolicy != SMTQueuePolicy::Dynamic || numThreads > 1) {
         int active_threads = activeThreads->size();
 
-        list<ThreadID>::iterator threads = activeThreads->begin();
-        list<ThreadID>::iterator end = activeThreads->end();
-
-        while (threads != end) {
-            ThreadID tid = *threads++;
-
+        for (ThreadID tid : *activeThreads) {
             if (iqPolicy == SMTQueuePolicy::Partitioned) {
                 maxEntries[tid] = numEntries / active_threads;
             } else if (iqPolicy == SMTQueuePolicy::Threshold &&

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -311,12 +311,7 @@ LSQ::commitStores(InstSeqNum &youngest_inst, ThreadID tid)
 void
 LSQ::writebackStores()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (numStoresToWB(tid) > 0) {
             DPRINTF(Writeback,"[tid:%i] Writing back stores. %i stores "
                 "available for Writeback.\n", tid, numStoresToWB(tid));
@@ -336,12 +331,7 @@ bool
 LSQ::violation()
 {
     /* Answers: Does Anybody Have a Violation?*/
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (thread[tid].violation())
             return true;
     }
@@ -527,12 +517,7 @@ LSQ::getCount()
 {
     unsigned total = 0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         total += getCount(tid);
     }
 
@@ -544,12 +529,7 @@ LSQ::numLoads()
 {
     unsigned total = 0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         total += numLoads(tid);
     }
 
@@ -561,12 +541,7 @@ LSQ::numStores()
 {
     unsigned total = 0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         total += thread[tid].numStores();
     }
 
@@ -578,12 +553,7 @@ LSQ::numFreeLoadEntries()
 {
     unsigned total = 0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         total += thread[tid].numFreeLoadEntries();
     }
 
@@ -595,12 +565,7 @@ LSQ::numFreeStoreEntries()
 {
     unsigned total = 0;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         total += thread[tid].numFreeStoreEntries();
     }
 
@@ -622,12 +587,7 @@ LSQ::numFreeStoreEntries(ThreadID tid)
 bool
 LSQ::isFull()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!(thread[tid].lqFull() || thread[tid].sqFull()))
             return false;
     }
@@ -655,12 +615,7 @@ LSQ::isEmpty() const
 bool
 LSQ::lqEmpty() const
 {
-    std::list<ThreadID>::const_iterator threads = activeThreads->begin();
-    std::list<ThreadID>::const_iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!thread[tid].lqEmpty())
             return false;
     }
@@ -671,12 +626,7 @@ LSQ::lqEmpty() const
 bool
 LSQ::sqEmpty() const
 {
-    std::list<ThreadID>::const_iterator threads = activeThreads->begin();
-    std::list<ThreadID>::const_iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!thread[tid].sqEmpty())
             return false;
     }
@@ -687,12 +637,7 @@ LSQ::sqEmpty() const
 bool
 LSQ::lqFull()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!thread[tid].lqFull())
             return false;
     }
@@ -714,12 +659,7 @@ LSQ::lqFull(ThreadID tid)
 bool
 LSQ::sqFull()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!sqFull(tid))
             return false;
     }
@@ -741,12 +681,7 @@ LSQ::sqFull(ThreadID tid)
 bool
 LSQ::isStalled()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!thread[tid].isStalled())
             return false;
     }
@@ -766,12 +701,7 @@ LSQ::isStalled(ThreadID tid)
 bool
 LSQ::hasStoresToWB()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (hasStoresToWB(tid))
             return true;
     }
@@ -794,12 +724,7 @@ LSQ::numStoresToWB(ThreadID tid)
 bool
 LSQ::willWB()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (willWB(tid))
             return true;
     }
@@ -816,12 +741,7 @@ LSQ::willWB(ThreadID tid)
 void
 LSQ::dumpInsts() const
 {
-    std::list<ThreadID>::const_iterator threads = activeThreads->begin();
-    std::list<ThreadID>::const_iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         thread[tid].dumpInsts();
     }
 }

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -425,13 +425,8 @@ Rename::tick()
 
     sortInsts();
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
     // Check stall and squash signals.
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         DPRINTF(Rename, "Processing [tid:%i]\n", tid);
 
         status_change = checkSignalsAndUpdate(tid) || status_change;
@@ -448,11 +443,7 @@ Rename::tick()
         cpu->activityThisCycle();
     }
 
-    threads = activeThreads->begin();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         // If we committed this cycle then doneSeqNum will be > 0
         if (fromCommit->commitInfo[tid].doneSeqNum != 0 &&
             !fromCommit->commitInfo[tid].squash &&
@@ -831,12 +822,7 @@ Rename::sortInsts()
 bool
 Rename::skidsEmpty()
 {
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (!skidBuffer[tid].empty())
             return false;
     }
@@ -849,12 +835,7 @@ Rename::updateStatus()
 {
     bool any_unblocking = false;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (renameStatus[tid] == Unblocking) {
             any_unblocking = true;
             break;

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -150,12 +150,7 @@ ROB::resetEntries()
     if (robPolicy != SMTQueuePolicy::Dynamic || numThreads > 1) {
         auto active_threads = activeThreads->size();
 
-        std::list<ThreadID>::iterator threads = activeThreads->begin();
-        std::list<ThreadID>::iterator end = activeThreads->end();
-
-        while (threads != end) {
-            ThreadID tid = *threads++;
-
+        for (ThreadID tid : *activeThreads) {
             if (robPolicy == SMTQueuePolicy::Partitioned) {
                 maxEntries[tid] = numEntries / active_threads;
             } else if (robPolicy == SMTQueuePolicy::Threshold &&
@@ -279,12 +274,7 @@ bool
 ROB::canCommit()
 {
     //@todo: set ActiveThreads through ROB or CPU
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (isHeadReady(tid)) {
             return true;
         }
@@ -398,12 +388,7 @@ ROB::updateHead()
     bool first_valid = true;
 
     // @todo: set ActiveThreads through ROB or CPU
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (instList[tid].empty())
             continue;
 
@@ -438,12 +423,7 @@ ROB::updateTail()
     tail = instList[0].end();
     bool first_valid = true;
 
-    std::list<ThreadID>::iterator threads = activeThreads->begin();
-    std::list<ThreadID>::iterator end = activeThreads->end();
-
-    while (threads != end) {
-        ThreadID tid = *threads++;
-
+    for (ThreadID tid : *activeThreads) {
         if (instList[tid].empty()) {
             continue;
         }


### PR DESCRIPTION
No functional change.

Removing all these explict std::list<T>::iterator decls will make it easier to change activeThreads to a denser and more cache friendly data structure such as std::array<T> should we want to too.

Change-Id: Ie365e876e387fdcd5eef8f8e3117812fb7056e55