### PR TITLE
arch-riscv: Fix SVNAPOT PPN encoding

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -415,7 +415,8 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         assert(!(pte.n) || level == 0);
                         entry.logBytes = (pte.n) ? PageShift + NapotShift :
                                             PageShift + (level * LEVEL_BITS);
-                        entry.paddr = pte.ppn;
+                        entry.paddr = (!pte.n) ? pte.ppn :
+                                        pte.ppn & ~((1UL << NapotShift) - 1);
                         entry.vaddr &= ~((1 << entry.logBytes) - 1);
                         entry.pte = pte;
                         // put it non-writable into the TLB to detect

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -415,8 +415,8 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         assert(!(pte.n) || level == 0);
                         entry.logBytes = (pte.n) ? PageShift + NapotShift :
                                             PageShift + (level * LEVEL_BITS);
-                        entry.paddr = (!pte.n) ? pte.ppn :
-                                        pte.ppn & ~((1UL << NapotShift) - 1);
+                        entry.paddr = (pte.n) ? pte.ppn & ~mask(NapotShift) :
+                                                pte.ppn;
                         entry.vaddr &= ~((1 << entry.logBytes) - 1);
                         entry.pte = pte;
                         // put it non-writable into the TLB to detect


### PR DESCRIPTION
Set the last 4 bits of the SVNAPOT PPN to 0000
instead of 1000 before inserting it into the TLB