### PR TITLE
sim, stdlib: Add progress bar for simulation progress

### DIFF
--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -874,6 +874,12 @@ class WorkloadResource(AbstractResource):
         self._id = id
         self._func = function
         self._params = parameters
+        self._estimated_instructions = kwargs.get("simulation_run_results")[
+            "total_instructions"
+        ]
+
+    def get_estimated_instructions(self):
+        return self._estimated_instructions
 
     def get_id(self) -> str:
         """Returns the ID of the workload."""

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -292,6 +292,32 @@ class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
         return True
 
 
+class ProgressBarExitEventHandler(ExitHandler, hypercall_num=1100):
+    """This is a specialized version of ScheduledExitEventHandler for the
+    progress bar implementation. It continues simulation instead of exiting.
+    """
+
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        pass
+
+    def scheduled_at_tick(self) -> Optional[int]:
+        """Returns the tick in which the event was scheduled on (not scheduled
+        to occur, but the tick the event was created).
+
+        Returns "None" if this information is not available.
+        """
+        return (
+            None
+            if "scheduled_at_tick" not in self._payload
+            else int(self._payload["scheduled_at_tick"])
+        )
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return False
+
+
 class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
 
     @overrides(ExitHandler)

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -24,6 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import math
 import os
 import sys
 from pathlib import Path
@@ -559,8 +560,40 @@ class Simulator:
         # We instantiate the board if it has not already been instantiated.
         self._instantiate()
 
+        total_insts = int(self._board.get_workload()._estimated_instructions)
+
         # This while loop will continue until an a generator yields True.
         while True:
+            # If the workload provides the estimated number of total
+            # instructions, print a progress bar.
+            if total_insts:
+                curr_insts = self.get_instruction_count()
+                completion_fraction = curr_insts / total_insts
+                bar_length = 80
+                complete_bar = (
+                    int(math.floor(completion_fraction * bar_length)) * "#"
+                )
+                incomplete_bar = (
+                    int(
+                        math.ceil(
+                            bar_length - completion_fraction * bar_length
+                        )
+                    )
+                    * "-"
+                )
+                if not m5.options.redirect_stdout:
+                    sys.stdout.write(
+                        f"\rProgress: {curr_insts} / {total_insts} instructions, {completion_fraction:.4%}\n[{complete_bar}{incomplete_bar}]\033[1A"
+                    )
+                    sys.stdout.flush()
+                else:
+                    with open(
+                        f"{m5.options.outdir}/progress_bar.log", "w"
+                    ) as f:
+                        f.write(
+                            f"Progress: {curr_insts} / {total_insts} instructions, {completion_fraction:.4%}\n[{complete_bar}{incomplete_bar}]"
+                        )
+                m5.progressBarTickExit(200_000_000)
             self._last_exit_event = m5.simulate(self.get_max_ticks())
             exit_event_hypercall_id = self._last_exit_event.getHypercallId()
             if (

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -289,6 +289,19 @@ def scheduleTickExitAbsolute(
         )
 
 
+def progressBarTickExit(tick: int) -> None:
+    if tick + curTick() <= curTick():
+        warn("Tick exit scheduled for the past. This will not be triggered.")
+
+    _m5.event.exitSimulationLoop(
+        1100,
+        {
+            "scheduled_at_tick": str(curTick()),
+        },
+        tick + curTick(),
+    )
+
+
 def drain():
     """Drain the simulator in preparation of a checkpoint or memory mode
     switch.

--- a/src/sim/SConscript
+++ b/src/sim/SConscript
@@ -164,5 +164,6 @@ DebugFlag('VoltageDomain')
 DebugFlag('DVFS')
 DebugFlag('Vma')
 DebugFlag('PowerDomain')
+DebugFlag('EnteringEventQueue')
 
 CompoundFlag('SyscallAll', [ 'SyscallBase', 'SyscallVerbose'])

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -47,7 +47,9 @@
 
 #include "base/logging.hh"
 #include "base/pollevent.hh"
+#include "base/trace.hh"
 #include "base/types.hh"
+#include "debug/EnteringEventQueue.hh"
 #include "sim/async.hh"
 #include "sim/eventq.hh"
 #include "sim/init_signals.hh"
@@ -197,7 +199,8 @@ simulate(Tick num_cycles)
         global_exit_event->clean();
     std::unique_ptr<GlobalSyncEvent, DescheduleDeleter> quantum_event;
 
-    inform("Entering event queue @ %d.  Starting simulation...\n", curTick());
+    DPRINTF(EnteringEventQueue, "Entering event queue @ %d. Starting "
+        "simulation...\n", curTick());
 
     if (!simulatorThreads)
         simulatorThreads.reset(new SimulatorThreads(numMainEventQueues));


### PR DESCRIPTION
This commit adds a progress bar to show how many instructions have executed compared to the total number of instructions for the workload. If -r is passed, the progress bar will be outputted to progress_bar.log in the m5out directory. Otherwise, it will be outputted to the terminal. This progress bar is only shown if simulation_run_results is part of the workload's JSON. This commit also converts an inform statement to a debug flag.