### PR TITLE
use mkdtemp for tmpfile in SerializationFixture

### DIFF
--- a/src/base/gtest/serialization_fixture.hh
+++ b/src/base/gtest/serialization_fixture.hh
@@ -29,6 +29,7 @@
 #include <gtest/gtest.h>
 
 #include <cassert>
+#include <cstdlib>
 #include <cerrno>
 #include <fstream>
 #include <string>
@@ -52,24 +53,11 @@ namespace gem5
 class SerializationFixture : public ::testing::Test
 {
   private:
-    /**
-     * Temporary directory names are generated based on this number, which
-     * is updated every time the generator function is called.
-     */
-    static unsigned dirNumber;
-
     /** The name of the temporary directory. */
-    std::string dirName;
+    std::string dirName = "/tmp/temp_dir_test_XXXXXX";
 
   public:
     using ::testing::Test::Test;
-
-    /** Generate a temporary directory name. */
-    static std::string
-    generateTempDirName()
-    {
-        return "/tmp/temp_dir_test" + std::to_string(dirNumber++) + "/";
-    }
 
     /** Get the name of the directory we have created on SetUp. */
     std::string getDirName() const { return dirName; }
@@ -78,7 +66,7 @@ class SerializationFixture : public ::testing::Test
     std::string
     getCptPath() const
     {
-        return getDirName() + std::string(CheckpointIn::baseFilename);
+        return getDirName() + '/' + std::string(CheckpointIn::baseFilename);
     }
 
     /**
@@ -98,9 +86,8 @@ class SerializationFixture : public ::testing::Test
     SetUp() override
     {
         // Create the directory
-        dirName = generateTempDirName();
-        [[maybe_unused]] int success = mkdir(dirName.c_str(), 0775);
-        assert(!(success == -1 && errno != EEXIST));
+        [[maybe_unused]] char* ret = mkdtemp(dirName.data());
+        assert(ret != nullptr);
     }
 
     void
@@ -114,6 +101,5 @@ class SerializationFixture : public ::testing::Test
         assert(success == 0);
     }
 };
-unsigned SerializationFixture::dirNumber = 0;
 
 } // anonymous namespace

--- a/src/sim/serialize.test.cc
+++ b/src/sim/serialize.test.cc
@@ -36,6 +36,7 @@
 #include <cassert>
 #include <cstdint>
 #include <deque>
+#include <cstdio>
 #include <fstream>
 #include <list>
 #include <memory>
@@ -201,7 +202,8 @@ TEST_F(SerializeFixture, ConstructorSuccess)
     CheckpointIn cpt(getDirName());
 
     // When a new CheckpointIn instance is created the static cpt dir changes
-    EXPECT_EQ(CheckpointIn::dir(), getDirName());
+    // Return value from getDirName() doesn't have trailing '/', hence add one.
+    EXPECT_EQ(CheckpointIn::dir(), getDirName() + '/');
 }
 
 /**
@@ -451,9 +453,7 @@ TEST_F(SerializableFixture, SCSChangeCptOutLarge)
 TEST(SerializableDeathTest, GenerateCptOutFail)
 {
     std::ofstream cpt;
-    const std::string dir_name =
-        SerializeFixture::generateTempDirName();
-    ASSERT_FALSE(dirExists(dir_name));
+    const std::string dir_name = std::tmpnam(nullptr);
 
     ASSERT_ANY_THROW(Serializable::generateCheckpointOut(
         dir_name + "/b/a/n/a/n/a/", cpt));


### PR DESCRIPTION
SerializationFixture has been used in:
* src/sim/globals.test.cc
* src/sim/serialize.test.cc
* src/base/loader/symtab.test.cc

The original implementation may cause those tests to operate on the same files.
Hence, use mkdtemp to prevent multiple gtest executable use the same
temporary directory name.

generateTempDirName() is remained for the test that needs non-exists
directory name.
