### PR TITLE
cpu: Fix bug exposed by clang 18's -Woverloaded-virtual

### DIFF
--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -239,7 +239,8 @@ TAGE_SC_L_TAGE::bindex(Addr pc) const
 
 void
 TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
-    ThreadID tid, int brtype, bool taken, Addr branch_pc, Addr target)
+    ThreadID tid, int brtype, bool taken, Addr branch_pc, Addr target,
+    TAGEBase::BranchInfo *bi)
 {
     ThreadHistory& tHist = threadHistory[tid];
     // TAGE update
@@ -265,6 +266,7 @@ TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
     }
 
     updateGHist(tid, tmp, maxt);
+    bi->modified = true;
 }
 
 void
@@ -285,7 +287,7 @@ TAGE_SC_L_TAGE::updateHistories(ThreadID tid, Addr branch_pc,
     if (! inst->isUncondCtrl()) {
         ++brtype;
     }
-    updatePathAndGlobalHistory(tid, brtype, taken, branch_pc, target);
+    updatePathAndGlobalHistory(tid, brtype, taken, branch_pc, target, bi);
 
     DPRINTF(TageSCL, "Updating global histories with branch:%lx; taken?:%d, "
             "path Hist: %x; pointer:%d\n", branch_pc, taken, tHist.pathHist,

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -137,7 +137,7 @@ class TAGE_SC_L_TAGE : public TAGEBase
 
     void updatePathAndGlobalHistory(
         ThreadID tid, int brtype, bool taken,
-        Addr branch_pc, Addr target);
+        Addr branch_pc, Addr target, TAGEBase::BranchInfo* bi) override;
 
     void adjustAlloc(bool & alloc, bool taken, bool pred_taken) override;
 


### PR DESCRIPTION
It looks like TAGE_SC_L's updatePathAndGlobalHistory wasn't updated with the extra TAGEBase::BranchInfo *bi argument added in 09c7e0f1800.

Clang sees this as a mismatch between the number of args in the base virtual function (with 6 args) and the overriden function (with 5 args)

The override fails to set `bi->modified = true` as the base implementation updatePathAndGlobalHistory does.

To avoid this happening again with other compilers, add the `override` specifier in the class definition.

Change-Id: I861aad0e471e7d690273bdd8f3e3fbde3d8ab13a