### PR TITLE
scons,arch-arm: Fix clang 18 build issues

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -706,6 +706,8 @@ for variant_path in variant_paths:
         with gem5_scons.Configure(env) as conf:
             conf.CheckCxxFlag('-Wno-c99-designator')
             conf.CheckCxxFlag('-Wno-defaulted-function-deleted')
+        if compareVersions(env['CXXVERSION'], '18') > 0:
+            env.Append(CCFLAGS=['-Wno-vla-cxx-extension'])
 
         env.Append(TCMALLOC_CCFLAGS=['-fno-builtin'])
 

--- a/src/arch/arm/kvm/gic.hh
+++ b/src/arch/arm/kvm/gic.hh
@@ -248,15 +248,17 @@ class KvmKernelGicV3 : public KvmKernelGic, public Gicv3Registers
     const AddrRange distRange;
 };
 
-struct GicV2Types
+class GicV2Types
 {
+  public:
     using SimGic = GicV2;
     using KvmGic = KvmKernelGicV2;
     using Params = MuxingKvmGicV2Params;
 };
 
-struct GicV3Types
+class GicV3Types
 {
+  public:
     using SimGic = Gicv3;
     using KvmGic = KvmKernelGicV3;
     using Params = MuxingKvmGicV3Params;


### PR DESCRIPTION
Ubuntu 24.04 LTS ships with clang 18, and Ubuntu 24.10 ships with clang 19.

Clang 18 switches on some new `-W` warnings by default which cause gem5 build failures thanks to `-Werror`.

This patchset and #2127 fixes these.