### PR TITLE
cpu: Fix Clang compilation error for TAGE-SC-L

### DIFF
--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -239,7 +240,8 @@ TAGE_SC_L_TAGE::bindex(Addr pc) const
 
 void
 TAGE_SC_L_TAGE::updatePathAndGlobalHistory(
-    ThreadID tid, int brtype, bool taken, Addr branch_pc, Addr target)
+    ThreadID tid, int brtype, bool taken,
+    Addr branch_pc, Addr target, TAGEBase::BranchInfo* bi)
 {
     ThreadHistory& tHist = threadHistory[tid];
     // TAGE update
@@ -285,7 +287,7 @@ TAGE_SC_L_TAGE::updateHistories(ThreadID tid, Addr branch_pc,
     if (! inst->isUncondCtrl()) {
         ++brtype;
     }
-    updatePathAndGlobalHistory(tid, brtype, taken, branch_pc, target);
+    updatePathAndGlobalHistory(tid, brtype, taken, branch_pc, target, bi);
 
     DPRINTF(TageSCL, "Updating global histories with branch:%lx; taken?:%d, "
             "path Hist: %x; pointer:%d\n", branch_pc, taken, tHist.pathHist,

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -137,7 +138,7 @@ class TAGE_SC_L_TAGE : public TAGEBase
 
     void updatePathAndGlobalHistory(
         ThreadID tid, int brtype, bool taken,
-        Addr branch_pc, Addr target);
+        Addr branch_pc, Addr target, TAGEBase::BranchInfo* bi) override;
 
     void adjustAlloc(bool & alloc, bool taken, bool pred_taken) override;
 


### PR DESCRIPTION
PR #499 introduced a shadowing of virtual method
`TAGEBase::updatePathAndGlobalHistory` in `TAGE_SC_L_TAGE` that should have been an overload. This shadow method works in the context that it is currently used, but causes a warning-as-error in Clang, which is more proactive about warning of potentially unwanted shadowing.

This patch matches the prototype to overload the existing virtual method, avoiding the error in Clang and fixing the build.

Change-Id: If4296f9b6d6154066567a58dc9cbdcd4fc44f425