### PR TITLE
arch-arm: Update bootloader to set SCR_EL3.HXEN bit to 1

### DIFF
--- a/system/arm/bootloader/arm64/boot.S
+++ b/system/arm/bootloader/arm64/boot.S
@@ -61,6 +61,7 @@ _start:
         orr	x0, x0, #(1 << 10)		// 64-bit EL2
         orr	x0, x0, #(1 << 16)		// Disable FEAT_PAuth traps (APK)
         orr	x0, x0, #(1 << 17)		// Disable FEAT_PAuth traps (API)
+        orr     x0, x0, #(1 << 38)              // Enable HXEn
         msr	scr_el3, x0
 
         mov	x0, #(1 << 8)			// Disable SVE trap to EL3


### PR DESCRIPTION

This PR updates the ARM bootloader to set the `SCR_EL3.HXEN` bit (bit 38) to `1`.

### Details  
- Sets `SCR_EL3.HXEN` (bit 38) to `1` in the bootloader.  
- Aligns with ARM's specifications:  
  [ARM Documentation – SCR_EL3 Register](https://developer.arm.com/documentation/ddi0601/2025-03/AArch64-Registers/SCR-EL3--Secure-Configuration-Register)

### Fixes  
Fixes #2116.  
