### PR TITLE
mem: Make PortTerminator create resp_ports as well as req_ports

### DIFF
--- a/src/mem/port_terminator.cc
+++ b/src/mem/port_terminator.cc
@@ -37,7 +37,7 @@ PortTerminator::PortTerminator(const PortTerminatorParams &params):
         reqPorts.emplace_back(name() + ".req_ports" + std::to_string(i));
     }
     for (int j = 0; j < params.port_resp_ports_connection_count; ++j) {
-        reqPorts.emplace_back(name() + ".resp_ports" +
+        respPorts.emplace_back(name() + ".resp_ports" +
                                 std::to_string(j));
     }
 }

--- a/src/mem/port_terminator.hh
+++ b/src/mem/port_terminator.hh
@@ -100,6 +100,31 @@ class PortTerminator : public SimObject
         RespPort(const std::string &name):
             ResponsePort(name)
         {}
+
+        Tick recvAtomic(PacketPtr) override
+        {
+            panic("PortTerminator recvAtomic should never be called");
+        }
+
+        bool recvTimingReq(PacketPtr) override
+        {
+            panic("PortTerminator recvTimingReq should never be called");
+        }
+
+        void recvRespRetry() override
+        {
+            panic("PortTerminator recvRespRetry should never be called");
+        }
+
+        void recvFunctional(PacketPtr) override
+        {
+            panic("PortTerminator recvFunctional should never be called");
+        }
+
+        AddrRangeList getAddrRanges() const override
+        {
+            panic("PortTerminator getAddrRanges should never be called");
+        }
     };
 
     std::vector<ReqPort> reqPorts;


### PR DESCRIPTION
The bug in the ctor caused fatal errors if a Python config tried to use pt.resp_ports.connect(...).

Change-Id: Ie38ba553a04afce23095f790193a82f1784370f0