### PR TITLE
sim-se: load dynamic executable at 0x0000555555554000

### DIFF
--- a/src/arch/arm/process.cc
+++ b/src/arch/arm/process.cc
@@ -386,7 +386,8 @@ ArmProcess::argsInit(int pageSize, const RegId &spId)
         auxv.emplace_back(gem5::auxv::Pagesz, ArmISA::PageBytes);
         // For statically linked executables, this is the virtual address of
         // the program header tables if they appear in the executable image
-        auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Phdr,
+                          elfObject->programHeaderTableBiased());
         // This is the size of a program header entry from the elf file.
         auxv.emplace_back(gem5::auxv::Phent, elfObject->programHeaderSize());
         // This is the number of program headers from the original elf file.

--- a/src/arch/mips/process.cc
+++ b/src/arch/mips/process.cc
@@ -103,7 +103,8 @@ MipsProcess::argsInit(int pageSize)
         // For statically linked executables, this is the virtual
         // address of the program header tables if they appear in the
         // executable image.
-        auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Phdr,
+                          elfObject->programHeaderTableBiased());
         DPRINTF(Loader, "auxv at PHDR %08p\n",
                 elfObject->programHeaderTable());
         // This is the size of a program header entry from the elf file.

--- a/src/arch/power/process.cc
+++ b/src/arch/power/process.cc
@@ -180,7 +180,8 @@ PowerProcess::argsInit(int pageSize)
         auxv.emplace_back(gem5::auxv::Clktck, 0x64);
         // For statically linked executables, this is the virtual address of
         // the program header tables if they appear in the executable image
-        auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Phdr,
+                          elfObject->programHeaderTableBiased());
         // This is the size of a program header entry from the elf file.
         auxv.emplace_back(gem5::auxv::Phent, elfObject->programHeaderSize());
         // This is the number of program headers from the original elf file.

--- a/src/arch/riscv/process.cc
+++ b/src/arch/riscv/process.cc
@@ -153,7 +153,8 @@ RiscvProcess::argsInit(int pageSize)
         auxv.emplace_back(gem5::auxv::Entry, objFile->entryPoint());
         auxv.emplace_back(gem5::auxv::Phnum, elfObject->programHeaderCount());
         auxv.emplace_back(gem5::auxv::Phent, elfObject->programHeaderSize());
-        auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Phdr,
+                          elfObject->programHeaderTableBiased());
         auxv.emplace_back(gem5::auxv::Pagesz, PageBytes);
         auxv.emplace_back(gem5::auxv::Secure, 0);
         auxv.emplace_back(gem5::auxv::Random, stack_top);

--- a/src/arch/sparc/process.cc
+++ b/src/arch/sparc/process.cc
@@ -195,7 +195,8 @@ SparcProcess::argsInit(int pageSize)
         auxv.emplace_back(gem5::auxv::Clktck, 100);
         // For statically linked executables, this is the virtual address of
         // the program header tables if they appear in the executable image
-        auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Phdr,
+                          elfObject->programHeaderTableBiased());
         // This is the size of a program header entry from the elf file.
         auxv.emplace_back(gem5::auxv::Phent, elfObject->programHeaderSize());
         // This is the number of program headers from the original elf file.

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -864,7 +864,8 @@ X86Process::argsInit(int pageSize,
         auxv.emplace_back(gem5::auxv::Clktck, 100);
         // This is the virtual address of the program header tables if they
         // appear in the executable image.
-        auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Phdr,
+                          elfObject->programHeaderTableBiased());
         // This is the size of a program header entry from the elf file.
         auxv.emplace_back(gem5::auxv::Phent, elfObject->programHeaderSize());
         // This is the number of program headers from the original elf file.

--- a/src/base/loader/elf_object.hh
+++ b/src/base/loader/elf_object.hh
@@ -121,9 +121,14 @@ class ElfObject : public ObjectFile
 
     bool hasTLS() override { return sectionExists(".tbss"); }
 
-    Addr programHeaderTable() {return _programHeaderTable;}
-    uint16_t programHeaderSize() {return _programHeaderSize;}
-    uint16_t programHeaderCount() {return _programHeaderCount;}
+    Addr programHeaderTable() const { return _programHeaderTable; }
+    Addr
+    programHeaderTableBiased() const
+    {
+        return programHeaderTable() + bias();
+    }
+    uint16_t programHeaderSize() const { return _programHeaderSize; }
+    uint16_t programHeaderCount() const { return _programHeaderCount; }
 };
 
 /**

--- a/src/sim/process.cc
+++ b/src/sim/process.cc
@@ -158,6 +158,13 @@ Process::Process(const ProcessParams &params, EmulationPageTable *pTable,
     exitGroup = new bool();
     sigchld = new bool();
 
+    /**
+     * Set the base of dynamically linked executables to Linux's default
+     * (when ASLR is disabled).
+     */
+    if (objFile->getInterpreter())
+        objFile->updateBias(0x0000555555554000ULL);
+
     image = objFile->buildImage();
 
     if (loader::debugSymbolTable.empty())


### PR DESCRIPTION
Fix #2133. Load dynamically linked images at base address 0x0000555555554000, like Linux does (when ASLR is disabled).

Change-Id: Ib637414d5d558fa1d348b2dbc81213f86cb82674