### PR TITLE
base, cpu-o3: Use string_view in Named constructor

### DIFF
--- a/src/base/cache/associative_cache.hh
+++ b/src/base/cache/associative_cache.hh
@@ -42,6 +42,7 @@
 #ifndef __BASE_CACHE_ASSOCIATIVE_CACHE_HH__
 #define __BASE_CACHE_ASSOCIATIVE_CACHE_HH__
 
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -102,7 +103,7 @@ class AssociativeCache : public Named
     /**
      * Empty constructor - need to call init() later with all args
      */
-    AssociativeCache(const char *name) : Named(std::string(name)) {}
+    AssociativeCache(std::string_view name) : Named(name) {}
 
     /**
      * Public constructor
@@ -113,12 +114,12 @@ class AssociativeCache : public Named
      * @param repl_policy replacement policy
      * @param indexing_policy indexing policy
      */
-    AssociativeCache(const char *name, const size_t num_entries,
+    AssociativeCache(std::string_view name, const size_t num_entries,
                      const size_t associativity_,
                      BaseReplacementPolicy *repl_policy,
                      IndexingPolicy *indexing_policy,
                      Entry const &init_val = Entry())
-        : Named(std::string(name)),
+        : Named(name),
           associativity(associativity_),
           replPolicy(repl_policy),
           indexingPolicy(indexing_policy),

--- a/src/base/named.hh
+++ b/src/base/named.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2025 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2021 Daniel R. Carvalho
  * All rights reserved
  *
@@ -30,6 +42,7 @@
 #define __BASE_NAMED_HH__
 
 #include <string>
+#include <string_view>
 
 namespace gem5
 {
@@ -41,7 +54,7 @@ class Named
     const std::string _name;
 
   public:
-    Named(const std::string &name_) : _name(name_) { }
+    Named(std::string_view name_) : _name(name_) { }
     virtual ~Named() = default;
 
     virtual std::string name() const { return _name; }

--- a/src/cpu/o3/store_set.cc
+++ b/src/cpu/o3/store_set.cc
@@ -40,11 +40,11 @@ namespace gem5
 namespace o3
 {
 
-StoreSet::StoreSet(std::string name_, uint64_t clear_period,
+StoreSet::StoreSet(std::string_view name_, uint64_t clear_period,
                    size_t _SSIT_entries, int _SSIT_assoc,
                    replacement_policy::Base *_replPolicy,
                    BaseIndexingPolicy *_indexingPolicy, int _LFST_size)
-  : Named(std::string(name_)),
+  : Named(name_),
     SSIT("SSIT", _SSIT_entries, _SSIT_assoc,
 	 _replPolicy, _indexingPolicy,
 	 SSITEntry(genTagExtractor(_indexingPolicy))),

--- a/src/cpu/o3/store_set.hh
+++ b/src/cpu/o3/store_set.hh
@@ -31,6 +31,7 @@
 
 #include <list>
 #include <map>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -91,7 +92,7 @@ class StoreSet : public Named
     StoreSet() : Named("StoreSets"), SSIT("SSIT") {};
 
     /** Creates store set predictor with given table sizes. */
-    StoreSet(std::string name, uint64_t clear_period,
+    StoreSet(std::string_view name, uint64_t clear_period,
              size_t SSIT_entries, int SSIT_assoc,
              replacement_policy::Base *replPolicy,
              BaseIndexingPolicy *indexingPolicy, int LFST_size);


### PR DESCRIPTION
By replacing the string reference with string_view we effectively allow string literals
to be passed directly to the constructor without requiring an expensive
conversion to std::string.

In the PR we modify some Named subclasses to exploit the new interface