### PR TITLE
arch-riscv: Fix atomic ops on big endian hosts

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1636,7 +1636,11 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     TypedAtomicOpFunctor<int32_t> *amo_op =
                           new AtomicGenericOp<int32_t>(Rs2_sw,
-                                  [](int32_t* b, int32_t a){ *b += a; });
+                                  [](int32_t* b, int32_t a){
+                                      int32_t mem_data = letoh(*b);
+                                      int32_t new_data = mem_data + a;
+                                      *b = htole(new_data);
+                                  });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x1: AtomicMemOp::amoswap_w({{
                     Rd_sd = Mem_sw;
@@ -1650,49 +1654,77 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     TypedAtomicOpFunctor<uint32_t> *amo_op =
                           new AtomicGenericOp<uint32_t>(Rs2_uw,
-                                  [](uint32_t* b, uint32_t a){ *b ^= a; });
+                                  [](uint32_t* b, uint32_t a){
+                                      uint32_t mem_data = letoh(*b);
+                                      uint32_t new_data = mem_data ^ a;
+                                      *b = htole(new_data);
+                                  });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x8: AtomicMemOp::amoor_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
                     TypedAtomicOpFunctor<uint32_t> *amo_op =
                           new AtomicGenericOp<uint32_t>(Rs2_uw,
-                                  [](uint32_t* b, uint32_t a){ *b |= a; });
+                                  [](uint32_t* b, uint32_t a){
+                                      uint32_t mem_data = letoh(*b);
+                                      uint32_t new_data = mem_data | a;
+                                      *b = htole(new_data);
+                                  });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0xc: AtomicMemOp::amoand_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
                     TypedAtomicOpFunctor<uint32_t> *amo_op =
                           new AtomicGenericOp<uint32_t>(Rs2_uw,
-                                  [](uint32_t* b, uint32_t a){ *b &= a; });
+                                  [](uint32_t* b, uint32_t a){
+                                      uint32_t mem_data = letoh(*b);
+                                      uint32_t new_data = mem_data & a;
+                                      *b = htole(new_data);
+                                  });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x10: AtomicMemOp::amomin_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
                     TypedAtomicOpFunctor<int32_t> *amo_op =
                       new AtomicGenericOp<int32_t>(Rs2_sw,
-                        [](int32_t* b, int32_t a){ if (a < *b) *b = a; });
+                        [](int32_t* b, int32_t a){
+                            int32_t mem_data = letoh(*b);
+                            int32_t new_data = (a < mem_data) ? a : mem_data;
+                            *b = htole(new_data);
+                        });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x14: AtomicMemOp::amomax_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
                     TypedAtomicOpFunctor<int32_t> *amo_op =
                       new AtomicGenericOp<int32_t>(Rs2_sw,
-                        [](int32_t* b, int32_t a){ if (a > *b) *b = a; });
+                        [](int32_t* b, int32_t a){
+                            int32_t mem_data = letoh(*b);
+                            int32_t new_data = (a > mem_data) ? a : mem_data;
+                            *b = htole(new_data);
+                        });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x18: AtomicMemOp::amominu_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
                     TypedAtomicOpFunctor<uint32_t> *amo_op =
                       new AtomicGenericOp<uint32_t>(Rs2_uw,
-                        [](uint32_t* b, uint32_t a){ if (a < *b) *b = a; });
+                        [](uint32_t* b, uint32_t a){
+                            uint32_t mem_data = letoh(*b);
+                            uint32_t new_data = (a < mem_data) ? a : mem_data;
+                            *b = htole(new_data);
+                        });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x1c: AtomicMemOp::amomaxu_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
                     TypedAtomicOpFunctor<uint32_t> *amo_op =
                       new AtomicGenericOp<uint32_t>(Rs2_uw,
-                        [](uint32_t* b, uint32_t a){ if (a > *b) *b = a; });
+                        [](uint32_t* b, uint32_t a){
+                            uint32_t mem_data = letoh(*b);
+                            uint32_t new_data = (a > mem_data) ? a : mem_data;
+                            *b = htole(new_data);
+                        });
                 }}, mem_flags=ATOMIC_RETURN_OP);
             }
             0x3: decode RVTYPE {
@@ -1710,7 +1742,11 @@ decode QUADRANT default Unknown::unknown() {
                     }}, {{
                         TypedAtomicOpFunctor<int64_t> *amo_op =
                               new AtomicGenericOp<int64_t>(Rs2_sd,
-                                      [](int64_t* b, int64_t a){ *b += a; });
+                                      [](int64_t* b, int64_t a){
+                                          int64_t mem_data = letoh(*b);
+                                          int64_t new_data = mem_data + a;
+                                          *b = htole(new_data);
+                                      });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x1: AtomicMemOp::amoswap_d({{
                         Rd_sd = Mem_sd;
@@ -1724,35 +1760,57 @@ decode QUADRANT default Unknown::unknown() {
                     }}, {{
                         TypedAtomicOpFunctor<uint64_t> *amo_op =
                               new AtomicGenericOp<uint64_t>(Rs2_ud,
-                                     [](uint64_t* b, uint64_t a){ *b ^= a; });
+                                     [](uint64_t* b, uint64_t a){
+                                         uint64_t mem_data = letoh(*b);
+                                         uint64_t new_data = mem_data ^ a;
+                                         *b = htole(new_data);
+                                     });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x8: AtomicMemOp::amoor_d({{
                         Rd_sd = Mem_sd;
                     }}, {{
                         TypedAtomicOpFunctor<uint64_t> *amo_op =
                               new AtomicGenericOp<uint64_t>(Rs2_ud,
-                                     [](uint64_t* b, uint64_t a){ *b |= a; });
+                                     [](uint64_t* b, uint64_t a){
+                                         uint64_t mem_data = letoh(*b);
+                                         uint64_t new_data = mem_data | a;
+                                         *b = htole(new_data);
+                                     });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0xc: AtomicMemOp::amoand_d({{
                         Rd_sd = Mem_sd;
                     }}, {{
                         TypedAtomicOpFunctor<uint64_t> *amo_op =
                               new AtomicGenericOp<uint64_t>(Rs2_ud,
-                                     [](uint64_t* b, uint64_t a){ *b &= a; });
+                                     [](uint64_t* b, uint64_t a){
+                                         uint64_t mem_data = letoh(*b);
+                                         uint64_t new_data = mem_data & a;
+                                         *b = htole(new_data);
+                                     });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x10: AtomicMemOp::amomin_d({{
                         Rd_sd = Mem_sd;
                     }}, {{
                         TypedAtomicOpFunctor<int64_t> *amo_op =
                           new AtomicGenericOp<int64_t>(Rs2_sd,
-                            [](int64_t* b, int64_t a){ if (a < *b) *b = a; });
+                            [](int64_t* b, int64_t a){
+                                int64_t mem_data = letoh(*b);
+                                int64_t new_data = (a < mem_data) ?
+                                                    a : mem_data;
+                                *b = htole(new_data);
+                            });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x14: AtomicMemOp::amomax_d({{
                         Rd_sd = Mem_sd;
                     }}, {{
                         TypedAtomicOpFunctor<int64_t> *amo_op =
                           new AtomicGenericOp<int64_t>(Rs2_sd,
-                            [](int64_t* b, int64_t a){ if (a > *b) *b = a; });
+                            [](int64_t* b, int64_t a){
+                                int64_t mem_data = letoh(*b);
+                                int64_t new_data = (a > mem_data) ?
+                                                    a : mem_data;
+                                *b = htole(new_data);
+                            });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x18: AtomicMemOp::amominu_d({{
                         Rd_sd = Mem_sd;
@@ -1760,7 +1818,10 @@ decode QUADRANT default Unknown::unknown() {
                         TypedAtomicOpFunctor<uint64_t> *amo_op =
                           new AtomicGenericOp<uint64_t>(Rs2_ud,
                             [](uint64_t* b, uint64_t a){
-                              if (a < *b) *b = a;
+                                uint64_t mem_data = letoh(*b);
+                                uint64_t new_data = (a < mem_data) ?
+                                                     a : mem_data;
+                                *b = htole(new_data);
                             });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x1c: AtomicMemOp::amomaxu_d({{
@@ -1769,7 +1830,10 @@ decode QUADRANT default Unknown::unknown() {
                         TypedAtomicOpFunctor<uint64_t> *amo_op =
                           new AtomicGenericOp<uint64_t>(Rs2_ud,
                             [](uint64_t* b, uint64_t a){
-                              if (a > *b) *b = a;
+                                uint64_t mem_data = letoh(*b);
+                                uint64_t new_data = (a > mem_data) ?
+                                                     a : mem_data;
+                                *b = htole(new_data);
                             });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                 }


### PR DESCRIPTION
RISC-V atomic operations pass a functor which operates on the data. Previously, this functor ignored the endianness of the host and just directly operated on the data. This change ensures that when reading data from the guest memory into host variables that we set the endianness correctly.

A small number of these operations were tested on a BE host by ensuring the execution trace was the same on both the BE host and a LE host.