### PR TITLE
mem: Remove deprecated method

### DIFF
--- a/src/mem/qos/QoSPolicy.py
+++ b/src/mem/qos/QoSPolicy.py
@@ -63,14 +63,6 @@ class QoSFixedPriorityPolicy(QoSPolicy):
 
         self._requestor_priorities.append([request_port, priority])
 
-    def setMasterPriority(self, request_port, priority):
-        warn(
-            "QosFixedPriority.setMasterPriority is deprecated in favor of "
-            "setRequestorPriority. See src/mem/qos/QoSPolicy.py for more "
-            "information"
-        )
-        self.setRequestorPriority(request_port, priority)
-
     def init(self):
         if not self._requestor_priorities:
             print(


### PR DESCRIPTION
The method has been marked as deprecated long ago. We can safely remove it at this point

Change-Id: I3f86baeb76ce1d5861d031709a9eead82ecff800