### PR TITLE
cpu: Free memory allocated by indirect predictor lookup

### DIFF
--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -271,7 +271,7 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
             ++stats.indirectHits;
             hist->targetProvider = TargetProvider::Indirect;
             set(hist->target, *itarget);
-
+            delete itarget;
             DPRINTF(Branch,
                     "[tid:%i, sn:%llu] Instruction %s predicted "
                     "indirect target is %s\n",


### PR DESCRIPTION
A memory leak occurred during indirect branch prediction lookups. When `SimpleIndirectPredictor::lookup` resulted in a hit, it would allocate a new `PCStateBase` object via `PCState::clone()` (using `new`). The pointer to this object (`itarget`) was returned to the caller.

However, the caller used the object's data but did not `delete` the allocated memory before the `itarget` pointer went out of scope. This led to memory accumulating on each predictor hit.

This commit fixes the leak by adding `delete itarget;` after the object pointed to by `itarget` is no longer needed within the relevant code block.

This PR impacts long-running MINOR/O3 simulations and significantly lowers memory usage.

This resolves #2058, MINOR/O3 memory consumption is now pretty close to ATOMIC/TIMING models and does not creep up with time.