### PR TITLE
sim-se: execve: make new process inherit max stack size

### DIFF
--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -2408,6 +2408,7 @@ execveFunc(SyscallDesc *desc, ThreadContext *tc,
     pp->cwd.assign(p->tgtCwd);
     pp->system = p->system;
     pp->release = p->release;
+    pp->maxStackSize = p->memState->getMaxStackSize();
     /**
      * Prevent process object creation with identical PIDs (which will trip
      * a fatal check in Process constructor). The execve call is supposed to


### PR DESCRIPTION
Fix #2151. In the execve syscall handler, copy the old process' maxStackSize to the new process.

Change-Id: Id255dbb87b7b4ec10ef34130032c89d2a7ebb841