### PR TITLE
mem-ruby: Fix Ruby MemCtrl functionalRead

### DIFF
--- a/src/mem/ruby/common/WriteMask.hh
+++ b/src/mem/ruby/common/WriteMask.hh
@@ -47,6 +47,7 @@
 #include <vector>
 
 #include "base/amo.hh"
+#include "base/intmath.hh"
 #include "mem/ruby/common/DataBlock.hh"
 #include "mem/ruby/common/TypeDefines.hh"
 
@@ -89,6 +90,7 @@ class WriteMask
         mSize = size;
         clear();
     }
+    int getBlockSizeBits() const { return floorLog2(mSize); }
 
     void
     clear()

--- a/src/mem/ruby/protocol/RubySlicc_Exports.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Exports.sm
@@ -74,6 +74,7 @@ structure(WriteMask, external="yes", desc="...") {
   bool test(int);
   int getBlockSize();
   void setBlockSize(int);
+  int getBlockSizeBits();
 }
 
 structure(DataBlock, external = "yes", desc="..."){

--- a/src/mem/ruby/protocol/RubySlicc_MemControl.sm
+++ b/src/mem/ruby/protocol/RubySlicc_MemControl.sm
@@ -91,7 +91,7 @@ structure(MemoryMsg, desc="...", interface="Message") {
       WriteMask read_mask;
       read_mask.setBlockSize(mask.getBlockSize());
       read_mask.setMask(addressOffset(addr,
-        makeLineAddress(addr, mask.getBlockSize())), Len, true);
+        makeLineAddress(addr, mask.getBlockSizeBits())), Len, true);
       if (MessageSize != MessageSizeType:Writeback_Data) {
         read_mask.setInvertedMask(mask);
       }


### PR DESCRIPTION
The makeLineAddress() function takes the number of bits to offset the block as a parameter, not the size of the block.