### PR TITLE
configs,mem-ruby: Update ruby configs for ALL target

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -368,7 +368,7 @@ class CHI_MNController(CHI_MiscNode_Controller):
         self, ruby_system, addr_range, l1d_caches, early_nonsync_comp
     ):
         super().__init__(
-            version=Versions.getVersion(MiscNode_Controller),
+            version=Versions.getVersion(CHI_MiscNode_Controller),
             ruby_system=ruby_system,
             mandatoryQueue=MessageBuffer(),
             triggerQueue=TriggerMessageBuffer(),

--- a/configs/ruby/MESI_Three_Level.py
+++ b/configs/ruby/MESI_Three_Level.py
@@ -151,7 +151,7 @@ def create_system(
                 block_size=options.cacheline_size,
             )
 
-            l0_cntrl = L0Cache_Controller(
+            l0_cntrl = MESI_Three_Level_L0Cache_Controller(
                 version=i * num_cpus_per_cluster + j,
                 Icache=l0i_cache,
                 Dcache=l0d_cache,
@@ -179,7 +179,7 @@ def create_system(
                 is_icache=False,
             )
 
-            l1_cntrl = L1Cache_Controller(
+            l1_cntrl = MESI_Three_Level_L1Cache_Controller(
                 version=i * num_cpus_per_cluster + j,
                 cache=l1_cache,
                 l2_select_num_bits=l2_bits,
@@ -232,7 +232,7 @@ def create_system(
                 start_index_bit=l2_index_start,
             )
 
-            l2_cntrl = L2Cache_Controller(
+            l2_cntrl = MESI_Three_Level_L2Cache_Controller(
                 version=i * num_l2caches_per_cluster + j,
                 L2cache=l2_cache,
                 cluster_id=i,
@@ -295,7 +295,7 @@ def create_system(
         #
         dma_seq = DMASequencer(version=i, ruby_system=ruby_system)
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MESI_Three_Level_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -325,7 +325,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MESI_Three_Level_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/MESI_Three_Level_HTM.py
+++ b/configs/ruby/MESI_Three_Level_HTM.py
@@ -151,7 +151,7 @@ def create_system(
                 block_size=options.cacheline_size,
             )
 
-            l0_cntrl = L0Cache_Controller(
+            l0_cntrl = MESI_Three_Level_HTM_L0Cache_Controller(
                 version=i * num_cpus_per_cluster + j,
                 Icache=l0i_cache,
                 Dcache=l0d_cache,
@@ -179,7 +179,7 @@ def create_system(
                 is_icache=False,
             )
 
-            l1_cntrl = L1Cache_Controller(
+            l1_cntrl = MESI_Three_Level_HTM_L1Cache_Controller(
                 version=i * num_cpus_per_cluster + j,
                 cache=l1_cache,
                 l2_select_num_bits=l2_bits,
@@ -232,7 +232,7 @@ def create_system(
                 start_index_bit=l2_index_start,
             )
 
-            l2_cntrl = L2Cache_Controller(
+            l2_cntrl = MESI_Three_Level_HTM_L2Cache_Controller(
                 version=i * num_l2caches_per_cluster + j,
                 L2cache=l2_cache,
                 cluster_id=i,
@@ -295,7 +295,7 @@ def create_system(
         #
         dma_seq = DMASequencer(version=i, ruby_system=ruby_system)
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MESI_Three_Level_HTM_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -325,7 +325,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MESI_Three_Level_HTM_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/MESI_Two_Level.py
+++ b/configs/ruby/MESI_Two_Level.py
@@ -98,7 +98,7 @@ def create_system(
 
         clk_domain = cpus[i].clk_domain
 
-        l1_cntrl = L1Cache_Controller(
+        l1_cntrl = MESI_Two_Level_L1Cache_Controller(
             version=i,
             L1Icache=l1i_cache,
             L1Dcache=l1d_cache,
@@ -153,7 +153,7 @@ def create_system(
             start_index_bit=l2_index_start,
         )
 
-        l2_cntrl = L2Cache_Controller(
+        l2_cntrl = MESI_Two_Level_L2Cache_Controller(
             version=i,
             L2cache=l2_cache,
             transitions_per_cycle=options.ports,
@@ -208,7 +208,7 @@ def create_system(
             version=i, ruby_system=ruby_system, in_ports=dma_port
         )
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MESI_Two_Level_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -233,7 +233,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MESI_Two_Level_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/MI_example.py
+++ b/configs/ruby/MI_example.py
@@ -86,7 +86,7 @@ def create_system(
         clk_domain = cpus[i].clk_domain
 
         # Only one unified L1 cache exists. Can cache instructions and data.
-        l1_cntrl = L1Cache_Controller(
+        l1_cntrl = MI_example_L1Cache_Controller(
             version=i,
             cacheMemory=cache,
             send_evictions=send_evicts(options),
@@ -159,7 +159,7 @@ def create_system(
         #
         dma_seq = DMASequencer(version=i, ruby_system=ruby_system)
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MI_example_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -183,7 +183,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MI_example_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/MOESI_CMP_directory.py
+++ b/configs/ruby/MOESI_CMP_directory.py
@@ -111,7 +111,7 @@ def create_system(
 
         clk_domain = cpus[i].clk_domain
 
-        l1_cntrl = L1Cache_Controller(
+        l1_cntrl = MOESI_CMP_directory_L1Cache_Controller(
             version=i,
             L1Icache=l1i_cache,
             L1Dcache=l1d_cache,
@@ -177,7 +177,7 @@ def create_system(
             start_index_bit=block_size_bits + l2_bits,
         )
 
-        l2_cntrl = L2Cache_Controller(
+        l2_cntrl = MOESI_CMP_directory_L2Cache_Controller(
             version=i,
             L2cache=l2_cache,
             transitions_per_cycle=options.ports,
@@ -241,7 +241,7 @@ def create_system(
             version=i, ruby_system=ruby_system, in_ports=dma_port
         )
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MOESI_CMP_directory_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -269,7 +269,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MOESI_CMP_directory_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/MOESI_CMP_token.py
+++ b/configs/ruby/MOESI_CMP_token.py
@@ -121,7 +121,7 @@ def create_system(
 
         clk_domain = cpus[i].clk_domain
 
-        l1_cntrl = L1Cache_Controller(
+        l1_cntrl = MOESI_CMP_token_L1Cache_Controller(
             version=i,
             L1Icache=l1i_cache,
             L1Dcache=l1d_cache,
@@ -179,7 +179,7 @@ def create_system(
             start_index_bit=l2_index_start,
         )
 
-        l2_cntrl = L2Cache_Controller(
+        l2_cntrl = MOESI_CMP_token_L2Cache_Controller(
             version=i,
             L2cache=l2_cache,
             N_tokens=n_tokens,
@@ -253,7 +253,7 @@ def create_system(
             version=i, ruby_system=ruby_system, in_ports=dma_port
         )
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MOESI_CMP_token_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -278,7 +278,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MOESI_CMP_token_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/MOESI_hammer.py
+++ b/configs/ruby/MOESI_hammer.py
@@ -119,7 +119,7 @@ def create_system(
 
         clk_domain = cpus[i].clk_domain
 
-        l1_cntrl = L1Cache_Controller(
+        l1_cntrl = MOESI_hammer_L1Cache_Controller(
             version=i,
             L1Icache=l1i_cache,
             L1Dcache=l1d_cache,
@@ -241,7 +241,7 @@ def create_system(
             version=i, ruby_system=ruby_system, in_ports=dma_port
         )
 
-        dma_cntrl = DMA_Controller(
+        dma_cntrl = MOESI_hammer_DMA_Controller(
             version=i,
             dma_sequencer=dma_seq,
             transitions_per_cycle=options.ports,
@@ -267,7 +267,7 @@ def create_system(
     if full_system:
         io_seq = DMASequencer(version=len(dma_ports), ruby_system=ruby_system)
         ruby_system._io_port = io_seq
-        io_controller = DMA_Controller(
+        io_controller = MOESI_hammer_DMA_Controller(
             version=len(dma_ports),
             dma_sequencer=io_seq,
             ruby_system=ruby_system,

--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -305,6 +305,12 @@ def create_system(
 
 
 def create_directories(options, bootmem, ruby_system, system):
+    import importlib
+
+    Directory_Controller = getattr(
+        importlib.import_module("m5.objects"),
+        f"{options.protocol}_Directory_Controller",
+    )
     dir_cntrl_nodes = []
     for i in range(options.num_dirs):
         dir_cntrl = Directory_Controller()


### PR DESCRIPTION
Use the full names for all of the controllers in the ruby scripts.
Now the `ruby_random_test.py` script will work with all of the ruby
protocols except for CHI.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>