### PR TITLE
util: Add feature to update debug flags in external hypercall util

### DIFF
--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -392,12 +392,40 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
             "instruction_count": simulator.get_instruction_count(),
         }
 
+    def _add_debug_flags(self, debug_flags: [List]) -> Dict[str, str]:
+        from m5 import debug
+
+        flags_disabled = []
+        flags_enabled = []
+        invalid_flags = []
+        for flag in debug_flags:
+            off = False
+            if flag.startswith("-"):
+                flag = flag[1:]
+                off = True
+
+            if flag not in debug.flags:
+                invalid_flags.append(flag)
+                continue
+
+            if off:
+                flags_disabled.append(flag)
+                debug.flags[flag].disable()
+            else:
+                flags_enabled.append(flag)
+                debug.flags[flag].enable()
+        return {
+            "flags_enabled": str(flags_enabled),
+            "flags_disabled": str(flags_disabled),
+            "invalid_flags": str(invalid_flags),
+        }
+
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         try:
             socket_path = self._payload.get("response_socket")
             function = self._payload.get("function", "status")
-
+            debug_flags_to_add = self._payload.get("debug_flags_to_add")
             if socket_path:
                 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 sock.connect(socket_path)
@@ -407,6 +435,9 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
                 elif function == "get_stats":
                     stats = simulator.get_stats()
                     response = json.dumps(stats)
+                elif function == "add_debug_flags":
+                    debug_flags = debug_flags_to_add.split(",")
+                    response = json.dumps(self._add_debug_flags(debug_flags))
                 else:
                     response = json.dumps(
                         {"error": f"Unknown function: {function}"}

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -392,7 +392,7 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
             "instruction_count": simulator.get_instruction_count(),
         }
 
-    def _add_debug_flags(self, debug_flags: [List]) -> Dict[str, str]:
+    def _add_debug_flags(self, debug_flags: List[str]) -> Dict[str, str]:
         from m5 import debug
 
         flags_disabled = []
@@ -414,6 +414,7 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
             else:
                 flags_enabled.append(flag)
                 debug.flags[flag].enable()
+
         return {
             "flags_enabled": str(flags_enabled),
             "flags_disabled": str(flags_disabled),
@@ -425,7 +426,7 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         try:
             socket_path = self._payload.get("response_socket")
             function = self._payload.get("function", "status")
-            debug_flags_to_add = self._payload.get("debug_flags_to_add")
+            arguments = self._payload.get("arguments")
             if socket_path:
                 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 sock.connect(socket_path)
@@ -435,8 +436,8 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
                 elif function == "get_stats":
                     stats = simulator.get_stats()
                     response = json.dumps(stats)
-                elif function == "add_debug_flags":
-                    debug_flags = debug_flags_to_add.split(",")
+                elif function == "update_debug_flags":
+                    debug_flags = arguments.split(",")
                     response = json.dumps(self._add_debug_flags(debug_flags))
                 else:
                     response = json.dumps(

--- a/util/hypercall_external_signal/orchestrator-request.py
+++ b/util/hypercall_external_signal/orchestrator-request.py
@@ -171,7 +171,9 @@ def receive_full_message(conn: socket.socket, timeout: float = 30.0) -> str:
     return b"".join(chunks).decode()
 
 
-def send_and_receive_hypercall(pid: int, function: str) -> str:
+def send_and_receive_hypercall(
+    pid: int, function: str, debug_flags_to_add: str = None
+) -> str:
     """
     Send a hypercall to gem5 and wait for response.
 
@@ -180,8 +182,10 @@ def send_and_receive_hypercall(pid: int, function: str) -> str:
 
     :param pid: Process ID of gem5 instance
     :type pid: int
-    :param function: Hypercall function to execute ('status'|'get_stats')
+    :param function: Hypercall function to execute ('status'|'get_stats'|'add_debug_flags')
     :type function: str
+    :param debug_flags_to_add: Contains a ',' separated string of debug flags to add to the simulation. This field will be only work if the value of the 'function' argument is 'add_debug_flags'.
+    :type debug_flags_to_add: str
     :return: JSON response from gem5
     :rtype: str
     :raises TimeoutError: If gem5 doesn't respond within timeout
@@ -202,7 +206,11 @@ def send_and_receive_hypercall(pid: int, function: str) -> str:
 
     try:
         payload = json.dumps(
-            {"function": function, "response_socket": socket_path}
+            {
+                "function": function,
+                "debug_flags_to_add": debug_flags_to_add,
+                "response_socket": socket_path,
+            }
         )
         send_signal(pid, 1000, payload)
 
@@ -241,7 +249,14 @@ def main():
         "(auto-detected if not specified)",
     )
     parser.add_argument(
-        "function", choices=["status", "get_stats"], help="Function to execute"
+        "function",
+        choices=["status", "get_stats", "add_debug_flags"],
+        help="Function to execute",
+    )
+    parser.add_argument(
+        "--debug-flags-to-add",
+        metavar="FLAG1,FLAG2,..",
+        help="Sets the flags for debug output. This flag will only work if positional argument 'add_debug_flags' is passed",
     )
     parser.add_argument(
         "--output", type=str, help="Write response to specified file"
@@ -250,7 +265,9 @@ def main():
 
     try:
         pid = args.pid if args.pid is not None else find_gem5_pid()
-        response = send_and_receive_hypercall(pid, args.function)
+        response = send_and_receive_hypercall(
+            pid, args.function, args.debug_flags_to_add
+        )
         if args.output:
             write_response_to_file(response, args.output)
         else:

--- a/util/hypercall_external_signal/orchestrator-request.py
+++ b/util/hypercall_external_signal/orchestrator-request.py
@@ -172,7 +172,7 @@ def receive_full_message(conn: socket.socket, timeout: float = 30.0) -> str:
 
 
 def send_and_receive_hypercall(
-    pid: int, function: str, debug_flags_to_add: str = None
+    pid: int, function: str, arguments: str = None
 ) -> str:
     """
     Send a hypercall to gem5 and wait for response.
@@ -182,10 +182,10 @@ def send_and_receive_hypercall(
 
     :param pid: Process ID of gem5 instance
     :type pid: int
-    :param function: Hypercall function to execute ('status'|'get_stats'|'add_debug_flags')
+    :param function: Hypercall function to execute ('status'|'get_stats'|'update_debug_flags')
     :type function: str
-    :param debug_flags_to_add: Contains a ',' separated string of debug flags to add to the simulation. This field will be only work if the value of the 'function' argument is 'add_debug_flags'.
-    :type debug_flags_to_add: str
+    :param arguments: This parameter contains the arguments for the function. The functions 'status' and 'get_stats' dont expect any arguments. The 'update_debug_flags' function expects a ',' separated string of debug flags to update on the simulation. If the debug flag starts with '-' then the flag will be disabled.
+    :type debug_flags_to_update: str
     :return: JSON response from gem5
     :rtype: str
     :raises TimeoutError: If gem5 doesn't respond within timeout
@@ -208,7 +208,7 @@ def send_and_receive_hypercall(
         payload = json.dumps(
             {
                 "function": function,
-                "debug_flags_to_add": debug_flags_to_add,
+                "arguments": arguments,
                 "response_socket": socket_path,
             }
         )
@@ -250,13 +250,13 @@ def main():
     )
     parser.add_argument(
         "function",
-        choices=["status", "get_stats", "add_debug_flags"],
+        choices=["status", "get_stats", "update_debug_flags"],
         help="Function to execute",
     )
     parser.add_argument(
-        "--debug-flags-to-add",
+        "--debug-flags-to-update",
         metavar="FLAG1,FLAG2,..",
-        help="Sets the flags for debug output. This flag will only work if positional argument 'add_debug_flags' is passed",
+        help="Sets the flags for debug output. This flag will only work if positional argument 'update_debug_flags' is passed. To disable a flag you can pass the flag name starting with '-' for example -FLAG1. If an invalid flag is passed the flag will be skipped.",
     )
     parser.add_argument(
         "--output", type=str, help="Write response to specified file"
@@ -266,7 +266,7 @@ def main():
     try:
         pid = args.pid if args.pid is not None else find_gem5_pid()
         response = send_and_receive_hypercall(
-            pid, args.function, args.debug_flags_to_add
+            pid, args.function, args.debug_flags_to_update
         )
         if args.output:
             write_response_to_file(response, args.output)


### PR DESCRIPTION
**Add utility to update debug flags during simulation**

This PR introduces a utility that enables users to dynamically update debug flags during a running simulation using the `hypercall_external_signal` utility.

The utility is executed via `orchestrator-request.py` located in `util/hypercall_external_signal`. To use it, run the following command:

```
python3 ./orchestrator-request.py update_debug_flags --debug-flags-to-update=Flag1,Flag2,...
```

If you want to disable an already enabled debug flag, simply prepend the flag with a `-`. For example, passing `-Exec` will disable the `Exec` debug flag.

### Example Usage

1. **Start a simulation:**
   ```bash
   ./build/ALL/gem5.opt configs/example/gem5_library/x86-ubuntu-run.py
   ```

2. **To enable the `Exec` debug flag mid-simulation:**
   ```bash
   python3 ./orchestrator-request.py update_debug_flags --debug-flags-to-update=Exec
   ```

3. **To disable the `Exec` flag and enable the `Fetch` debug flag:**
   ```bash
   python3 ./orchestrator-request.py update_debug_flags --debug-flags-to-update=-Exec,Fetch
   ```

This utility makes it easy to modify debug flags without the need to restart the simulation.