### PR TITLE
arch-vega: Add pagetable walker buffer

### DIFF
--- a/src/arch/amdgpu/vega/SConscript
+++ b/src/arch/amdgpu/vega/SConscript
@@ -38,7 +38,8 @@ if not env['CONF']['BUILD_GPU']:
 
 SimObject('VegaGPUTLB.py', sim_objects=['VegaPagetableWalker',
                                         'VegaGPUTLB',
-                                        'VegaTLBCoalescer'])
+                                        'VegaTLBCoalescer',
+                                        'VegaPWCIndexingPolicy',])
 
 Source('faults.cc')
 Source('pagetable.cc')

--- a/src/arch/amdgpu/vega/VegaGPUTLB.py
+++ b/src/arch/amdgpu/vega/VegaGPUTLB.py
@@ -41,6 +41,8 @@ class VegaPagetableWalker(ClockedObject):
     cxx_header = "arch/amdgpu/vega/pagetable_walker.hh"
     port = RequestPort("Port for the hardware table walker")
     system = Param.System(Parent.any, "system object")
+    b_size = Param.Int(64, "Page walk cache size")
+    enable_pte_buffer = Param.Bool(True, "Enable page walk cache")
 
 
 class VegaGPUTLB(ClockedObject):

--- a/src/arch/amdgpu/vega/VegaGPUTLB.py
+++ b/src/arch/amdgpu/vega/VegaGPUTLB.py
@@ -30,6 +30,11 @@
 from m5.defines import buildEnv
 from m5.objects.AMDGPU import AMDGPUDevice
 from m5.objects.ClockedObject import ClockedObject
+from m5.objects.IndexingPolicies import (
+    BaseIndexingPolicy,
+    SetAssociative,
+)
+from m5.objects.ReplacementPolicies import LRURP
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject
@@ -41,7 +46,17 @@ class VegaPagetableWalker(ClockedObject):
     cxx_header = "arch/amdgpu/vega/pagetable_walker.hh"
     port = RequestPort("Port for the hardware table walker")
     system = Param.System(Parent.any, "system object")
-    page_walk_cache_size = Param.Int(64, "Page walk cache size")
+
+    page_walk_cache_entires = Param.Int(64, "Page walk cache entries")
+    pwc_replacement_policy = Param.BaseReplacementPolicy(
+        LRURP(), "Replacement policy of the PWC"
+    )
+    pwc_indexing_policy = Param.SetAssociative(
+        SetAssociative(
+            assoc=Parent.page_walk_cache_entires, size="512", entry_size=8
+        ),
+        "Indexing policy of the PWC, should be SetAssociative.",
+    )
     enable_pwc = Param.Bool(True, "Enable page walk cache")
 
 

--- a/src/arch/amdgpu/vega/VegaGPUTLB.py
+++ b/src/arch/amdgpu/vega/VegaGPUTLB.py
@@ -41,8 +41,8 @@ class VegaPagetableWalker(ClockedObject):
     cxx_header = "arch/amdgpu/vega/pagetable_walker.hh"
     port = RequestPort("Port for the hardware table walker")
     system = Param.System(Parent.any, "system object")
-    b_size = Param.Int(64, "Page walk cache size")
-    enable_pte_buffer = Param.Bool(True, "Enable page walk cache")
+    page_walk_cache_size = Param.Int(64, "Page walk cache size")
+    enable_pwc = Param.Bool(True, "Enable page walk cache")
 
 
 class VegaGPUTLB(ClockedObject):

--- a/src/arch/amdgpu/vega/page_walk_cache.hh
+++ b/src/arch/amdgpu/vega/page_walk_cache.hh
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Jason Lowe-Power
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_AMDGPU_VEGA_PAGE_WALK_CACHE_HH__
+#define __ARCH_AMDGPU_VEGA_PAGE_WALK_CACHE_HH__
+
+
+#include "arch/amdgpu/vega/pagetable.hh"
+#include "base/cache/associative_cache.hh"
+#include "mem/cache/replacement_policies/replaceable_entry.hh"
+#include "mem/cache/tags/indexing_policies/set_associative.hh"
+#include "params/VegaPWCIndexingPolicy.hh"
+
+namespace gem5
+{
+
+
+namespace VegaISA
+{
+
+// Page walk cache entry
+struct PWCEntry : public ReplaceableEntry
+{
+  public:
+    using IndexingPolicy = VegaPWCIndexingPolicy;
+    using KeyType = Addr;
+
+    // The data stored in PTE
+    PageTableEntry pteEntry;
+
+    // The physical address of the page table entry
+    Addr paddr;
+
+    bool valid;
+
+    void
+    invalidate()
+    {
+        valid = false;
+    }
+
+    void insert(const KeyType &key) {}
+    bool isValid() const { return valid; }
+
+    bool
+    match(const KeyType &key) const
+    {
+        return valid && paddr == key;
+    }
+};
+
+/**
+ * Set associative indexing policy for the page walk cache.
+ * This policy differs from the standard set associative policy in that it
+ * hard codes the size of the entry to be 8 bytes (1 PTE).
+ * Note that other PWC designs may need to extend or modify this policy.
+ */
+class VegaPWCIndexingPolicy : public BaseIndexingPolicy
+{
+  protected:
+    virtual uint32_t extractSet(const Addr addr) const
+    {
+        // Extract the set bits from the address
+        return (addr >> setShift) & setMask;
+    }
+
+  public:
+    /**
+     * Convenience typedef.
+     */
+    typedef VegaPWCIndexingPolicyParams Params;
+
+    /**
+     * Construct and initialize this policy.
+     * Assume that all PTEs are 8 bytes so the set shift is 3 bits.
+     */
+    VegaPWCIndexingPolicy(const Params &p) :
+        BaseIndexingPolicy(p, p.entries, 3)
+    {}
+
+    /**
+     * Destructor.
+     */
+    ~VegaPWCIndexingPolicy() {};
+
+    std::vector<ReplaceableEntry*> getPossibleEntries(const Addr &addr) const
+                                                                     override
+    {
+        return sets[extractSet(addr)];
+    }
+
+    Addr regenerateAddr(const Addr &tag,
+                        const ReplaceableEntry* entry) const override
+    {
+        panic("PWCSetAssociative::regenerateAddr() not implemented");
+        return 0;
+    }
+};
+
+// Page walk cache
+class PageWalkCache : public AssociativeCache<PWCEntry>
+{
+  public:
+    using AssociativeCache<PWCEntry>::AssociativeCache;
+    using AssociativeCache<PWCEntry>::accessEntry;
+
+    PWCEntry* accessEntry(const KeyType &key) override
+    {
+        auto entry = findEntry(key);
+        accessEntry(entry);
+        return entry;
+    }
+    PWCEntry* findEntry(const KeyType &key) const override
+    {
+        for (auto candidate : indexingPolicy->getPossibleEntries(key)) {
+        auto entry = static_cast<PWCEntry*>(candidate);
+        if (entry->match(key))
+            return entry;
+        }
+        return nullptr;
+    }
+    void insert(const KeyType &key, const PageTableEntry &pte_entry) {
+        PWCEntry *vict = findVictim(key);
+        vict->pteEntry = pte_entry;
+        vict->paddr = key;
+        vict->valid = true;
+        insertEntry(key, vict);
+    }
+};
+
+} // namespace VegaISA
+} // namespace gem5
+
+#endif // __ARCH_AMDGPU_VEGA_PAGE_WALK_CACHE_HH__

--- a/src/arch/amdgpu/vega/pagetable_walker.cc
+++ b/src/arch/amdgpu/vega/pagetable_walker.cc
@@ -385,11 +385,10 @@ bool Walker::sendTiming(WalkerState* sending_walker, PacketPtr pkt)
     pkt->pushSenderState(walker_state);
 
     // If hit, send the response pkt immediately.
-    // PageTableEntry *entry = pwcLookup(pkt->getAddr());
     PWCEntry *entry = pwc.findEntry(pkt->getAddr());
     if (entry != nullptr) {
         DPRINTF(GPUPTWalker, "PTE found in buffer, skipping timing request.");
-        pkt->setLE<uint64_t>((pwc.accessEntry(pkt->getAddr()))->pteEntry);
+        pkt->setLE<uint64_t>(entry->pteEntry);
 
         recvTimingResp(pkt);
 

--- a/src/arch/amdgpu/vega/pagetable_walker.hh
+++ b/src/arch/amdgpu/vega/pagetable_walker.hh
@@ -177,7 +177,7 @@ class Walker : public ClockedObject
 
   protected:
     //enabling pte buffer
-    bool pte_buffer;
+    bool enable_pwc;
     void pwcInsert(Addr paddr, PageTableEntry entry);
     PageTableEntry* pwcLookup(Addr paddr);
     // The TLB we're supposed to load.
@@ -214,12 +214,12 @@ class Walker : public ClockedObject
         deviceRequestorId(999), system(p.system)
     {
         DPRINTF(GPUPTWalker, "Walker::Walker %p\n", this);
-        pte_buffer = p.enable_pte_buffer;
-        int buf_size = p.b_size;
+        enable_pwc = p.enable_pwc;
+        int buf_size = p.page_walk_cache_size;
         pwcBuffer.assign(buf_size, std::make_pair((Addr)0, (PageTableEntry)0));
         for (int buf_i = 0; buf_i < buf_size; ++buf_i) {
             pwcFreeList.push_back(&pwcBuffer.at(buf_i));
-        if (pte_buffer)
+        if (enable_pwc)
           DPRINTF(GPUPTWalker, "PWC enabled, size %d\n", pwcBuffer.size());
       }
     }

--- a/src/arch/amdgpu/vega/pagetable_walker.hh
+++ b/src/arch/amdgpu/vega/pagetable_walker.hh
@@ -54,14 +54,14 @@ namespace VegaISA
 class Walker : public ClockedObject
 {
   protected:
-  //PTE indexed by paddr
-  typedef std::pair<Addr, PageTableEntry> paddr_pte_t;
-  //the PTE buffer
-  std::vector<paddr_pte_t> pwcBuffer;
-  //List of valid entries in the buffer, LRU ordered
-  std::list<paddr_pte_t*> pwcEntryList;
-  //List of free entries in the buffer
-  std::list<paddr_pte_t*> pwcFreeList;
+    //PTE indexed by paddr
+    typedef std::pair<Addr, PageTableEntry> paddr_pte_t;
+    //the PTE buffer
+    std::vector<paddr_pte_t> pwcBuffer;
+    //List of valid entries in the buffer, LRU ordered
+    std::list<paddr_pte_t*> pwcEntryList;
+    //List of free entries in the buffer
+    std::list<paddr_pte_t*> pwcFreeList;
 
     // Port for accessing memory
     class WalkerPort : public RequestPort
@@ -173,7 +173,7 @@ class Walker : public ClockedObject
     void setDevRequestor(RequestorID mid) { deviceRequestorId = mid; }
     RequestorID getDevRequestor() const { return deviceRequestorId; }
 
-    void invalidateBuffer();
+    void invalidatePWC();
 
   protected:
     //enabling pte buffer
@@ -219,8 +219,9 @@ class Walker : public ClockedObject
         pwcBuffer.assign(buf_size, std::make_pair((Addr)0, (PageTableEntry)0));
         for (int buf_i = 0; buf_i < buf_size; ++buf_i) {
             pwcFreeList.push_back(&pwcBuffer.at(buf_i));
-        if (enable_pwc)
+        if (enable_pwc) {
           DPRINTF(GPUPTWalker, "PWC enabled, size %d\n", pwcBuffer.size());
+        }
       }
     }
 };

--- a/src/arch/amdgpu/vega/tlb.cc
+++ b/src/arch/amdgpu/vega/tlb.cc
@@ -84,6 +84,7 @@ GpuTLB::GpuTLB(const VegaGPUTLBParams &p)
     missLatency1 = p.missLatency1;
     missLatency2 = p.missLatency2;
 
+
     // create the response ports based on the number of connected ports
     for (size_t i = 0; i < p.port_cpu_side_ports_connection_count; ++i) {
         cpuSidePort.push_back(new CpuSidePort(csprintf("%s-port%d",
@@ -104,6 +105,8 @@ GpuTLB::GpuTLB(const VegaGPUTLBParams &p)
     if (gpuDevice) {
         gpuDevice->getVM().registerTLB(this);
     }
+
+    walker->setEnablePTEBuffer(true);
 }
 
 GpuTLB::~GpuTLB()

--- a/src/arch/amdgpu/vega/tlb.cc
+++ b/src/arch/amdgpu/vega/tlb.cc
@@ -84,7 +84,6 @@ GpuTLB::GpuTLB(const VegaGPUTLBParams &p)
     missLatency1 = p.missLatency1;
     missLatency2 = p.missLatency2;
 
-
     // create the response ports based on the number of connected ports
     for (size_t i = 0; i < p.port_cpu_side_ports_connection_count; ++i) {
         cpuSidePort.push_back(new CpuSidePort(csprintf("%s-port%d",
@@ -105,8 +104,6 @@ GpuTLB::GpuTLB(const VegaGPUTLBParams &p)
     if (gpuDevice) {
         gpuDevice->getVM().registerTLB(this);
     }
-
-    walker->setEnablePTEBuffer(true);
 }
 
 GpuTLB::~GpuTLB()


### PR DESCRIPTION
Add a 64-entry PTE buffer to the pagetable walker. It significantly reduces memory accesses, improving address translation performance.