### PR TITLE
gpu-compute: Fix kernarg preload address

### DIFF
--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -348,7 +348,7 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
                 break;
               case KernargPreload:
                 DPRINTF(GPUInitAbi, "Preload %d user SGPRs starting at virtual"
-                        "SGPR %d\n", task->preloadLength(), regInitIdx);
+                        " SGPR s[%d]\n", task->preloadLength(), regInitIdx);
 
                 for (int idx = 0; idx < task->preloadLength(); ++idx) {
                     uint32_t finalValue = task->preloadArgs()[idx];


### PR DESCRIPTION
Currently preloaded kernel arguments are being read from the added padding to the code object which is not correct. The arguments should be read from the kernarg segment. This commit fixes the preload address.

This was retested with hipblaslt. The previous testing appeared to work because one preloaded argument (a loop boundary) happened to work. However after detailed tracing it was clear the loop boundary was not correct. The application under test now loops the correct number of times.