### PR TITLE
cpu: Replace uses of variable length arrays with heap allocs

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -1100,9 +1100,10 @@ class DynInst : public ExecContext, public RefCounted
                 setRegOperand(staticInst.get(), idx,
                         cpu->getReg(prev_phys_reg, threadNumber));
             } else {
-                uint8_t val[original_dest_reg.regClass().regBytes()];
-                cpu->getReg(prev_phys_reg, val, threadNumber);
-                setRegOperand(staticInst.get(), idx, val);
+                const size_t size = original_dest_reg.regClass().regBytes();
+                auto val = std::make_unique<uint8_t[]>(size);
+                cpu->getReg(prev_phys_reg, val.get(), threadNumber);
+                setRegOperand(staticInst.get(), idx, val.get());
             }
         }
     }

--- a/src/cpu/testers/traffic_gen/gups_gen.cc
+++ b/src/cpu/testers/traffic_gen/gups_gen.cc
@@ -79,17 +79,17 @@ GUPSGen::startup()
 {
     int block_size = 64; // Write the initial values in 64 byte blocks.
     uint64_t stride_size = block_size / elementSize;
+    auto write_data = std::make_unique<uint8_t[]>(block_size);
     if (initMemory) {
         for (uint64_t start_index = 0; start_index < tableSize;
                                     start_index += stride_size) {
-            uint8_t write_data[block_size];
             for (uint64_t offset = 0; offset < stride_size; offset++) {
                 uint64_t value = start_index + offset;
-                std::memcpy(write_data + offset * elementSize,
+                std::memcpy(write_data.get() + offset * elementSize,
                             &value, elementSize);
             }
             Addr addr = indexToAddr(start_index);
-            PacketPtr pkt = getWritePacket(addr, block_size, write_data);
+            PacketPtr pkt = getWritePacket(addr, block_size, write_data.get());
             port.sendFunctionalPacket(pkt);
             delete pkt;
         }

--- a/src/cpu/thread_context.cc
+++ b/src/cpu/thread_context.cc
@@ -202,14 +202,14 @@ serialize(const ThreadContext &tc, CheckpointOut &cp)
         const size_t reg_count = reg_class->numRegs();
         const size_t array_bytes = reg_bytes * reg_count;
 
-        uint8_t regs[array_bytes];
-        auto *reg_ptr = regs;
+        auto regs = std::make_unique<uint8_t[]>(array_bytes);
+        auto *reg_ptr = regs.get();
         for (const auto &id: *reg_class) {
             tc.getReg(id, reg_ptr);
             reg_ptr += reg_bytes;
         }
 
-        arrayParamOut(cp, std::string("regs.") + reg_class->name(), regs,
+        arrayParamOut(cp, std::string("regs.") + reg_class->name(), regs.get(),
                 array_bytes);
     }
 
@@ -230,11 +230,11 @@ unserialize(ThreadContext &tc, CheckpointIn &cp)
         const size_t reg_count = reg_class->numRegs();
         const size_t array_bytes = reg_bytes * reg_count;
 
-        uint8_t regs[array_bytes];
-        arrayParamIn(cp, std::string("regs.") + reg_class->name(), regs,
+        auto regs = std::make_unique<uint8_t[]>(array_bytes);
+        arrayParamIn(cp, std::string("regs.") + reg_class->name(), regs.get(),
                 array_bytes);
 
-        auto *reg_ptr = regs;
+        auto *reg_ptr = regs.get();
         for (const auto &id: *reg_class) {
             tc.setReg(id, reg_ptr);
             reg_ptr += reg_bytes;


### PR DESCRIPTION
Fixing all these will let us remove clang's `-Wno-vla-cxx-extension`