### PR TITLE
arm: Replace variable length arrays with strings/heap allocs

### DIFF
--- a/src/arch/arm/nativetrace.cc
+++ b/src/arch/arm/nativetrace.cc
@@ -91,8 +91,8 @@ ArmNativeTrace::ThreadState::update(NativeTrace *parent)
         diffVector >>= 1;
     }
 
-    uint64_t values[changes];
-    parent->read(values, sizeof(values));
+    auto values = std::make_unique<uint64_t[]>(changes);
+    parent->read(values.get(), changes * sizeof(uint64_t));
     int pos = 0;
     for (int i = 0; i < STATE_NUMVALS; i++) {
         if (changed[i]) {

--- a/src/arch/generic/linux/threadinfo.hh
+++ b/src/arch/generic/linux/threadinfo.hh
@@ -159,9 +159,10 @@ class ThreadInfo
         if (!get_data("task_struct_comm_size", size))
             return "FailureIn_curTaskName";
 
-        char buffer[size + 1];
+        std::string buffer;
+        buffer.reserve(size + 1);
         TranslatingPortProxy(tc).readString(
-                buffer, task_struct + offset, size);
+                buffer.data(), task_struct + offset, size);
 
         return buffer;
     }

--- a/src/dev/arm/gic_v3_its.cc
+++ b/src/dev/arm/gic_v3_its.cc
@@ -1276,21 +1276,22 @@ Gicv3Its::moveAllPendingState(
     Gicv3Redistributor *rd1, Gicv3Redistributor *rd2)
 {
     const uint64_t largest_lpi_id = 1ULL << (rd1->lpiIDBits + 1);
-    uint8_t lpi_pending_table[largest_lpi_id / 8];
+    const uint64_t table_size = largest_lpi_id / 8;
+    auto lpi_pending_table = std::make_unique<uint8_t[]>(table_size);
 
     // Copying the pending table from redistributor 1 to redistributor 2
     rd1->memProxy->readBlob(
-        rd1->lpiPendingTablePtr, (uint8_t *)lpi_pending_table,
-        sizeof(lpi_pending_table));
+        rd1->lpiPendingTablePtr, lpi_pending_table.get(),
+        table_size);
 
     rd2->memProxy->writeBlob(
-        rd2->lpiPendingTablePtr, (uint8_t *)lpi_pending_table,
-        sizeof(lpi_pending_table));
+        rd2->lpiPendingTablePtr, lpi_pending_table.get(),
+        table_size);
 
     // Clearing pending table in redistributor 2
     rd1->memProxy->memsetBlob(
-        rd1->lpiPendingTablePtr,
-        0, sizeof(lpi_pending_table));
+        rd1->lpiPendingTablePtr, 0,
+        table_size);
 
     rd2->updateDistributor();
 }

--- a/src/dev/arm/gic_v3_redistributor.cc
+++ b/src/dev/arm/gic_v3_redistributor.cc
@@ -830,17 +830,17 @@ Gicv3Redistributor::update()
 
         const uint32_t largest_lpi_id = 1 << (lpiIDBits + 1);
         const uint32_t number_lpis = largest_lpi_id - SMALLEST_LPI_ID + 1;
-
-        uint8_t lpi_pending_table[largest_lpi_id / 8];
-        uint8_t lpi_config_table[number_lpis];
+        const size_t table_size = largest_lpi_id / 8;
+        auto lpi_pending_table = std::make_unique<uint8_t[]>(table_size);
+        auto lpi_config_table = std::make_unique<uint8_t[]>(number_lpis);
 
         memProxy->readBlob(lpiPendingTablePtr,
-                           lpi_pending_table,
-                           sizeof(lpi_pending_table));
+                           lpi_pending_table.get(),
+                           table_size);
 
         memProxy->readBlob(lpiConfigurationTablePtr,
-                           lpi_config_table,
-                           sizeof(lpi_config_table));
+                           lpi_config_table.get(),
+                           number_lpis);
 
         for (int lpi_id = SMALLEST_LPI_ID; lpi_id < largest_lpi_id;
              lpi_id++) {


### PR DESCRIPTION
Fixing all these will let us remove clang's -Wno-vla-cxx-extension