### PR TITLE
cpu-o3: put unsent mem req to retry queue

### DIFF
--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -550,6 +550,12 @@ IEW::blockMemInst(const DynInstPtr& inst)
 }
 
 void
+IEW::retryMemInst(const DynInstPtr& inst)
+{
+    instQueue.retryMemInst(inst);
+}
+
+void
 IEW::cacheUnblocked()
 {
     instQueue.cacheUnblocked();

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -182,6 +182,9 @@ class IEW
     /** Moves memory instruction onto the list of cache blocked instructions */
     void blockMemInst(const DynInstPtr &inst);
 
+    /** Moves memory instruction onto the list of retry memory instructions */
+    void retryMemInst(const DynInstPtr &inst);
+
     /** Notifies that the cache has become unblocked */
     void cacheUnblocked();
 

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1129,6 +1129,12 @@ InstructionQueue::blockMemInst(const DynInstPtr &blocked_inst)
 }
 
 void
+InstructionQueue::retryMemInst(const DynInstPtr &retry_inst)
+{
+    retryMemInsts.push_back(retry_inst);
+}
+
+void
 InstructionQueue::cacheUnblocked()
 {
     DPRINTF(IQ, "Cache is unblocked, rescheduling blocked memory "

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -259,6 +259,9 @@ class InstructionQueue
     /**  Defers a memory instruction when it is cache blocked. */
     void blockMemInst(const DynInstPtr &blocked_inst);
 
+    /**  Retries a memory instruction in the next cycle. */
+    void retryMemInst(const DynInstPtr &retry_inst);
+
     /**  Notify instruction queue that a previous blockage has resolved */
     void cacheUnblocked();
 

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1601,11 +1601,12 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
     // an exta cycle to re-issue and execute
     request->buildPackets();
     request->sendPacketToCache();
-    if (!request->isSent()){
-        if (!lsq->cacheBlocked())
+    if (!request->isSent()) {
+        if (!lsq->cacheBlocked()) {
             iewStage->retryMemInst(load_inst);
-        else
+       } else {
             iewStage->blockMemInst(load_inst);
+       }
     }
 
     return NoFault;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -1596,10 +1596,17 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
     // and arbitrate between loads and stores.
 
     // if we the cache is not blocked, do cache access
+    // if the request is not sent and cache is unblocked
+    // then put the instruction into retry queue so we do not need
+    // an exta cycle to re-issue and execute
     request->buildPackets();
     request->sendPacketToCache();
-    if (!request->isSent())
-        iewStage->blockMemInst(load_inst);
+    if (!request->isSent()){
+        if (!lsq->cacheBlocked())
+            iewStage->retryMemInst(load_inst);
+        else
+            iewStage->blockMemInst(load_inst);
+    }
 
     return NoFault;
 }


### PR DESCRIPTION
ISSUE: Currently if a load instruction is performed, it is broken into message requests to be sent to available cache ports which is a limitation on how many requests can be sent in a single cycle.
If the requests are more than the available ports, then the instruction is put into the blockedMemInst queue. This makes the instruction to be re-issued in the next cycle and executed in the cycle after (basically using an extra cycle to re-issue). 

I feel there is a slight misunderstanding in the two queues, namely blockedMemInsts and retryMemInsts. In the current scenario, we do not need to put the instruction in the blocked queue. Also, at certain places the usage of blockedMemInst is not justified. I can clarify more with the exact lines of code if required. 

THIS COMMIT: If a load memory instruction is not sent due to occupied ports then put it in retryMemInst queue (if cache is unblocked) instead of blockedMemInst queue. This saves an unnecessary cycle used to re-issue. The commit adds the necessary declarations and definitions needed to perform this. 