### PR TITLE
mem-ruby: return early response for software prefetches

### DIFF
--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -258,6 +258,25 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
         panic("RubyPort should never see request with the "
               "cacheResponding flag set\n");
 
+    // For software prefetches, immediately respond to avoid stalling on the
+    // core while still processing the prefetch by passing a copy of the
+    // request through
+    if (pkt->cmd.isSWPrefetch()) {
+        RequestPtr req = std::make_shared<Request>(pkt->req->getPaddr(),
+                                                   pkt->req->getSize(),
+                                                   pkt->req->getFlags(),
+                                                   pkt->req->requestorId());
+        PacketPtr pf = new Packet(req, pkt->cmd);
+        pf->allocate();
+        assert(pf->matchAddr(pkt));
+        assert(pf->getSize() == pkt->getSize());
+
+        pkt->makeResponse();
+        schedTimingResp(pkt, curTick());
+
+        pkt = pf;
+    }
+
     // ruby doesn't support cache maintenance operations at the
     // moment, as a workaround, we respond right away
     if (pkt->req->isCacheMaintenance()) {


### PR DESCRIPTION
This patch adds support for early response of software prefetches for ruby in a similar way as it's done in the classic cache, preventing these instructions from stalling on the pipeline. This is, sending an early response back to the core just as the request arrives, and pass through a copy of the request whose response will be catched and deleted before it's sent back to the core.