### PR TITLE
misc: Hotfix v24.1.0.3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+# Version 24.1.0.3
+
+**[HOTFIX]** This hotfix release adds `#import <algorithm>` to "src/base/random.cc" to fix a compilation error affecting some systems (compilation error: "‘remove_if’ is not a member of ‘std’.").
+
 # Version 24.1.0.2
 
 **[HOTFIX]** Adds PR <https://github.com/gem5/gem5/pull/1930> as a hotfix to v24.1.0.

--- a/src/Doxyfile
+++ b/src/Doxyfile
@@ -31,7 +31,7 @@ PROJECT_NAME           = gem5
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = v24.1.0.2
+PROJECT_NUMBER         = v24.1.0.3
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/src/base/random.cc
+++ b/src/base/random.cc
@@ -40,6 +40,7 @@
 
 #include "base/random.hh"
 
+#include <algorithm>
 #include <sstream>
 
 namespace gem5

--- a/src/base/version.cc
+++ b/src/base/version.cc
@@ -32,6 +32,6 @@ namespace gem5
 /**
  * @ingroup api_base_utils
  */
-const char *gem5Version = "24.1.0.2";
+const char *gem5Version = "24.1.0.3";
 
 } // namespace gem5


### PR DESCRIPTION
Fixes Issue #2045.

This issue caused gem5 compilation failures with complaints `‘remove_if’ is not a member of ‘std’` on some systems. This is resolved by including `<algorithm>` in src/base/random.cc.