### PR TITLE
arch-riscv: Fix interupt delegation

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -493,11 +493,14 @@ ISA::readMiscReg(RegIndex idx)
         }
       case MISCREG_UIP:
         {
-            return readMiscReg(MISCREG_IP) & UI_MASK[getPrivilegeModeSet()];
+            RegVal mask = readMiscRegNoEffect(MISCREG_SIDELEG);
+            mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
+            return readMiscReg(MISCREG_IP) & mask;
         }
       case MISCREG_SIP:
         {
-            return readMiscReg(MISCREG_IP) & SI_MASK[getPrivilegeModeSet()];
+            RegVal mask = readMiscRegNoEffect(MISCREG_MIDELEG);
+            return readMiscReg(MISCREG_IP) & mask;
         }
       case MISCREG_IE:
         {
@@ -507,11 +510,14 @@ ISA::readMiscReg(RegIndex idx)
         }
       case MISCREG_UIE:
         {
-            return readMiscReg(MISCREG_IE) & UI_MASK[getPrivilegeModeSet()];
+            RegVal mask = readMiscRegNoEffect(MISCREG_SIDELEG);
+            mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
+            return readMiscReg(MISCREG_IE) & mask;
         }
       case MISCREG_SIE:
         {
-            return readMiscReg(MISCREG_IE) & SI_MASK[getPrivilegeModeSet()];
+            RegVal mask = readMiscRegNoEffect(MISCREG_MIDELEG);
+            return readMiscReg(MISCREG_IE) & mask;
         }
       case MISCREG_SEPC:
       case MISCREG_MEPC:
@@ -753,7 +759,18 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                 }
             }
             break;
-
+          case MISCREG_MIDELEG:
+            {
+                setMiscRegNoEffect(
+                    idx, val & MIDELEG_MASK[getPrivilegeModeSet()]);
+            }
+            break;
+          case MISCREG_SIDELEG:
+            {
+                setMiscRegNoEffect(
+                    idx, val & SIDELEG_MASK[getPrivilegeModeSet()]);
+            }
+            break;
           case MISCREG_IP:
             {
                 RegVal mask = MIP_MASK[getPrivilegeModeSet()];
@@ -765,7 +782,8 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
             break;
           case MISCREG_UIP:
             {
-                RegVal mask = UI_MASK[getPrivilegeModeSet()];
+                RegVal mask = readMiscRegNoEffect(MISCREG_SIDELEG);
+                mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
                 val = (val & mask) | (readMiscReg(MISCREG_IP) & ~mask);
                 setMiscReg(MISCREG_IP, val);
             }
@@ -773,6 +791,7 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
           case MISCREG_SIP:
             {
                 RegVal mask = SIP_MASK[getPrivilegeModeSet()];
+                mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
                 val = (val & mask) | (readMiscReg(MISCREG_IP) & ~mask);
                 setMiscReg(MISCREG_IP, val);
             }
@@ -787,14 +806,15 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
             break;
           case MISCREG_UIE:
             {
-                RegVal mask = UI_MASK[getPrivilegeModeSet()];
+                RegVal mask = readMiscRegNoEffect(MISCREG_SIDELEG);
+                mask &= readMiscRegNoEffect(MISCREG_MIDELEG);
                 val = (val & mask) | (readMiscReg(MISCREG_IE) & ~mask);
                 setMiscReg(MISCREG_IE, val);
             }
             break;
           case MISCREG_SIE:
             {
-                RegVal mask = SI_MASK[getPrivilegeModeSet()];
+                RegVal mask = readMiscRegNoEffect(MISCREG_MIDELEG);
                 val = (val & mask) | (readMiscReg(MISCREG_IE) & ~mask);
                 setMiscReg(MISCREG_IE, val);
             }

--- a/src/arch/riscv/regs/misc.hh
+++ b/src/arch/riscv/regs/misc.hh
@@ -1551,27 +1551,41 @@ const RegVal MI_MASK[enums::Num_PrivilegeModeSet] = {
                     MSI_MASK | SSI_MASK | USI_MASK,
 };
 const RegVal SIP_MASK[enums::Num_PrivilegeModeSet] = {
-    [enums::M] = 0ULL,
-    [enums::MU] = 0ULL,
-    [enums::MNU] = UEI_MASK | UTI_MASK | USI_MASK,
-    [enums::MSU] = SSI_MASK,
-    [enums::MNSU] = UEI_MASK | UTI_MASK | SSI_MASK | USI_MASK,
+    [enums::M] = LOCAL_MASK,
+    [enums::MU] = LOCAL_MASK,
+    [enums::MNU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = LOCAL_MASK | SSI_MASK,
+    [enums::MNSU] = LOCAL_MASK | UEI_MASK | UTI_MASK | SSI_MASK | USI_MASK,
 };
 const RegVal SI_MASK[enums::Num_PrivilegeModeSet] = {
-    [enums::M] = 0ULL,
-    [enums::MU] = 0ULL,
-    [enums::MNU] = UEI_MASK | UTI_MASK | USI_MASK,
-    [enums::MSU] = SEI_MASK | STI_MASK | SSI_MASK,
-    [enums::MNSU] = SEI_MASK | UEI_MASK |
-                    STI_MASK | UTI_MASK |
+    [enums::M] = LOCAL_MASK,
+    [enums::MU] = LOCAL_MASK,
+    [enums::MNU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = LOCAL_MASK | SEI_MASK | STI_MASK | SSI_MASK,
+    [enums::MNSU] = LOCAL_MASK | SEI_MASK | UEI_MASK | STI_MASK | UTI_MASK |
+                    SSI_MASK | USI_MASK,
+};
+const RegVal MIDELEG_MASK[enums::Num_PrivilegeModeSet] = {
+    [enums::M] = LOCAL_MASK,
+    [enums::MU] = LOCAL_MASK,
+    [enums::MNU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = LOCAL_MASK | SEI_MASK | STI_MASK | SSI_MASK,
+    [enums::MNSU] = LOCAL_MASK | SEI_MASK | UEI_MASK | STI_MASK | UTI_MASK |
                     SSI_MASK | USI_MASK,
 };
 const RegVal UI_MASK[enums::Num_PrivilegeModeSet] = {
-    [enums::M] = 0ULL,
-    [enums::MU] = 0ULL,
-    [enums::MNU] = UEI_MASK | UTI_MASK | USI_MASK,
-    [enums::MSU] = 0ULL,
-    [enums::MNSU] = UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::M] = LOCAL_MASK,
+    [enums::MU] = LOCAL_MASK,
+    [enums::MNU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = LOCAL_MASK,
+    [enums::MNSU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+};
+const RegVal SIDELEG_MASK[enums::Num_PrivilegeModeSet] = {
+    [enums::M] = LOCAL_MASK,
+    [enums::MU] = LOCAL_MASK,
+    [enums::MNU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
+    [enums::MSU] = LOCAL_MASK,
+    [enums::MNSU] = LOCAL_MASK | UEI_MASK | UTI_MASK | USI_MASK,
 };
 const RegVal FFLAGS_MASK = (1 << FRM_OFFSET) - 1;
 const RegVal FRM_MASK = 0x7;


### PR DESCRIPTION
1. Delegated interrupts will be masked in delegator interrupt level
2. If the interrupt is delegated by mideleg. The delegated interrupt is visible in sip/sie, otherwise read-only zero in sip/sie

Spec: https://github.com/riscv/riscv-isa-manual/blob/main/src/machine.adoc
Change-Id: If68fbb7fc4d98a9ecb7d4b0506b6251010daf1bb