### PR TITLE
arch-riscv: Fix read permission for mstatus.mxr

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -253,7 +253,7 @@ TLB::checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
 {
     Fault fault = NoFault;
 
-    if (mode == BaseMMU::Read && !pte.r) {
+    if (mode == BaseMMU::Read && !pte.r && !(pte.x && status.mxr)) {
         DPRINTF(TLB, "PTE has no read perm, raising PF\n");
         fault = createPagefault(vaddr, mode);
     }


### PR DESCRIPTION
The page can also be read when pte.x and mstatus.mxr https://github.com/riscv/riscv-isa-manual/blob/main/src/machine.adoc#memory-privilege-in-mstatus-register

Change-Id: Id236d10e9e1b2a1f0a7df7a0b26dcf665607212f