### PR TITLE
mem-ruby: Revert "mem-ruby: return early response for software prefetches"

### DIFF
--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -258,25 +258,6 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
         panic("RubyPort should never see request with the "
               "cacheResponding flag set\n");
 
-    // For software prefetches, immediately respond to avoid stalling on the
-    // core while still processing the prefetch by passing a copy of the
-    // request through
-    if (pkt->cmd.isSWPrefetch()) {
-        RequestPtr req = std::make_shared<Request>(pkt->req->getPaddr(),
-                                                   pkt->req->getSize(),
-                                                   pkt->req->getFlags(),
-                                                   pkt->req->requestorId());
-        PacketPtr pf = new Packet(req, pkt->cmd);
-        pf->allocate();
-        assert(pf->matchAddr(pkt));
-        assert(pf->getSize() == pkt->getSize());
-
-        pkt->makeResponse();
-        schedTimingResp(pkt, curTick());
-
-        pkt = pf;
-    }
-
     // ruby doesn't support cache maintenance operations at the
     // moment, as a workaround, we respond right away
     if (pkt->req->isCacheMaintenance()) {

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -367,14 +367,6 @@ Sequencer::insertRequest(PacketPtr pkt, RubyRequestType primary_type,
     Addr line_addr = makeLineAddress(pkt->getAddr());
     // Check if there is any outstanding request for the same cache line.
     auto &seq_req_list = m_RequestTable[line_addr];
-
-    // For software prefetches, if the same cache line is already requested we
-    // can return aliased and skip emplacing it on the request table, this way
-    // we won't need to handle any response at all
-    if (pkt->cmd.isSWPrefetch() && seq_req_list.size() > 1) {
-        return RequestStatus_Aliased;
-    }
-
     // Create a default entry
     seq_req_list.emplace_back(pkt, primary_type,
         secondary_type, curCycle());
@@ -745,14 +737,6 @@ Sequencer::hitCallback(SequencerRequest* srequest, DataBlock& data,
             (type == RubyRequestType_Locked_RMW_Read) ||
             (type == RubyRequestType_Load_Linked) ||
             (type == RubyRequestType_ATOMIC_RETURN)) {
-
-            // For software prefetches, since we've already sent an early
-            // response back to the core, we can just ignore this
-            if (pkt->cmd.isSWPrefetch()) {
-                delete pkt;
-                return;
-            }
-
             pkt->setData(
                 data.getData(getOffset(request_address), pkt->getSize()));
 


### PR DESCRIPTION
Reverts gem5/gem5#2174

@saul44203 Thank you for your contribution! Unfortunately, PR 2174 is causing failures in the daily tests. The details are as follows:

For `testlib-long-tests (fs)`,  `realview64-o3-dual-ruby-ARM_X86-x86_64-opt` and its MatchRegex are failing. The following is printed in simerr:
```
src/mem/ruby/system/RubyPort.cc:283: warn: Cache maintenance operations are not supported in Ruby.
gem5.opt: src/cpu/o3/lsq.cc:1164: virtual bool gem5::o3::LSQ::SingleDataRequest::recvTimingResp(gem5::PacketPtr): Assertion `_numOutstandingPackets == 1' failed.
Program aborted at tick 4489520001
--- BEGIN LIBC BACKTRACE ---
```
For `testlib-long-tests (x86_boot_tests)`, `timing-cpu_1-cores_mesi_two_level_DualChannelDDR3_1600_systemd_x86-boot-test-ALL-x86_64-opt` is failing. The following is printed in simerr:

```
src/arch/generic/debugfaults.hh:145: warn: MOVNTDQ: Ignoring non-temporal hint, modeling as cacheable!
build/ALL/mem/ruby/protocol/MESI_Two_Level/Directory_Transitions.cc:268: panic: Invalid transition
board.cache_hierarchy.ruby_system.directory_controllers0 time: 15159272260 addr: 0xba174e00 event: CleanReplacement state: M_DRD
Memory Usage: 4323588 KBytes
Program aborted at tick 5048037662580
--- BEGIN LIBC BACKTRACE ---
```