### PR TITLE
sim: Add warning for non-default create function

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -145,6 +145,7 @@ class MetaSimObject(type):
         "cxx_exports": list,
         "cxx_param_exports": list,
         "cxx_template_params": list,
+        "override_create": bool,  # True if overrides the default create()
     }
     # Attributes that can be set any time
     keywords = {"check": FunctionType}
@@ -186,6 +187,8 @@ class MetaSimObject(type):
             value_dict["cxx_param_exports"] = []
         if "cxx_template_params" not in value_dict:
             value_dict["cxx_template_params"] = []
+        if "override_create" not in value_dict:
+            value_dict["override_create"] = False
         cls_dict["_value_dict"] = value_dict
         cls = super().__new__(mcls, name, bases, cls_dict)
         if "type" in value_dict:

--- a/src/sim/Process.py
+++ b/src/sim/Process.py
@@ -35,6 +35,7 @@ class Process(SimObject):
     type = "Process"
     cxx_header = "sim/process.hh"
     cxx_class = "gem5::Process"
+    override_create = True
 
     @cxxMethod
     def map(self, vaddr, paddr, size, cacheable=False):

--- a/src/sim/Root.py
+++ b/src/sim/Root.py
@@ -58,6 +58,7 @@ class Root(SimObject):
     type = "Root"
     cxx_header = "sim/root.hh"
     cxx_class = "gem5::Root"
+    override_create = True
 
     # By default, root sim object and hence all other sim objects schedule
     # event on the eventq with index 0.

--- a/src/systemc/core/SystemC.py
+++ b/src/systemc/core/SystemC.py
@@ -36,6 +36,7 @@ class SystemC_Kernel(SimObject):
     type = "SystemC_Kernel"
     cxx_class = "sc_gem5::Kernel"
     cxx_header = "systemc/core/kernel.hh"
+    override_create = True
 
 
 # This class represents systemc sc_object instances in python config files. It

--- a/src/systemc/tlm_bridge/TlmBridge.py
+++ b/src/systemc/tlm_bridge/TlmBridge.py
@@ -62,6 +62,7 @@ class Gem5ToTlmBridge32(Gem5ToTlmBridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::Gem5ToTlmBridge<32>"
     cxx_header = "systemc/tlm_bridge/gem5_to_tlm.hh"
+    override_create = True
 
     tlm = TlmInitiatorSocket(32, "TLM initiator socket")
 
@@ -71,6 +72,7 @@ class Gem5ToTlmBridge64(Gem5ToTlmBridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::Gem5ToTlmBridge<64>"
     cxx_header = "systemc/tlm_bridge/gem5_to_tlm.hh"
+    override_create = True
 
     tlm = TlmInitiatorSocket(64, "TLM initiator socket")
 
@@ -80,6 +82,7 @@ class Gem5ToTlmBridge128(Gem5ToTlmBridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::Gem5ToTlmBridge<128>"
     cxx_header = "systemc/tlm_bridge/gem5_to_tlm.hh"
+    override_create = True
 
     tlm = TlmInitiatorSocket(128, "TLM initiator socket")
 
@@ -89,6 +92,7 @@ class Gem5ToTlmBridge256(Gem5ToTlmBridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::Gem5ToTlmBridge<256>"
     cxx_header = "systemc/tlm_bridge/gem5_to_tlm.hh"
+    override_create = True
 
     tlm = TlmInitiatorSocket(256, "TLM initiator socket")
 
@@ -98,6 +102,7 @@ class Gem5ToTlmBridge512(Gem5ToTlmBridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::Gem5ToTlmBridge<512>"
     cxx_header = "systemc/tlm_bridge/gem5_to_tlm.hh"
+    override_create = True
 
     tlm = TlmInitiatorSocket(512, "TLM initiator socket")
 
@@ -107,6 +112,7 @@ class TlmToGem5Bridge32(TlmToGem5BridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::TlmToGem5Bridge<32>"
     cxx_header = "systemc/tlm_bridge/tlm_to_gem5.hh"
+    override_create = True
 
     tlm = TlmTargetSocket(32, "TLM target socket")
 
@@ -116,6 +122,7 @@ class TlmToGem5Bridge64(TlmToGem5BridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::TlmToGem5Bridge<64>"
     cxx_header = "systemc/tlm_bridge/tlm_to_gem5.hh"
+    override_create = True
 
     tlm = TlmTargetSocket(64, "TLM target socket")
 
@@ -125,6 +132,7 @@ class TlmToGem5Bridge128(TlmToGem5BridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::TlmToGem5Bridge<128>"
     cxx_header = "systemc/tlm_bridge/tlm_to_gem5.hh"
+    override_create = True
 
     tlm = TlmTargetSocket(128, "TLM target socket")
 
@@ -134,6 +142,7 @@ class TlmToGem5Bridge256(TlmToGem5BridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::TlmToGem5Bridge<256>"
     cxx_header = "systemc/tlm_bridge/tlm_to_gem5.hh"
+    override_create = True
 
     tlm = TlmTargetSocket(256, "TLM target socket")
 
@@ -143,5 +152,6 @@ class TlmToGem5Bridge512(TlmToGem5BridgeBase):
     cxx_template_params = ["unsigned int BITWIDTH"]
     cxx_class = "sc_gem5::TlmToGem5Bridge<512>"
     cxx_header = "systemc/tlm_bridge/tlm_to_gem5.hh"
+    override_create = True
 
     tlm = TlmTargetSocket(512, "TLM target socket")


### PR DESCRIPTION
It is very difficult to track down the problem when the empty dummy shunt is chosen. It turns out, this is usually because your SimObject has pure virtual functions, but the error message from the compiler simply says the create function can't be found. This commit adds a warning and explanation for this case.

Note: there are a number of places in the codebase where we use non-standard create functions. Mostly it's in the SystemC and TLM integrations. 

This set of changes eliminates false positives by allowing the developer to specify that the SimObject has an explicit create function instead of the default of an implicit (auto generated) create function.

Since there are so few places that we use an explicit create function, with this change we can discuss eliminating the (brittle and difficult to debug) template magic that we currently use. One possible future implementation could eliminate the templates and auto-generate the create function for SimObjects that don't override and not auto-generate only when the developer specifies they want to override it.

I have personally wasted at least 4-8 hours (and you can triple that for my students) on this relatively common error. I think it's best for the community to merge something like this change to give a better warning.

### Old error

```
/usr/bin/ld: build/CXL/python/_m5/param_MSI_L1Cache_Controller.o: in function `void pybind11::cpp_function::initialize<pybind11::cpp_function::initialize<gem5::ruby::MSI::L1Cache_Controller*, gem5::MSI_L1Cache_ControllerParams, , pybind11::name, pybind11::is_method, pybind11::sibling>(gem5::ruby::MSI::L1Cache_Controller* (gem5::MSI_L1Cache_ControllerParams::*)() const, pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(gem5::MSI_L1Cache_ControllerParams const*)#1}, gem5::ruby::MSI::L1Cache_Controller*, gem5::MSI_L1Cache_ControllerParams const*, pybind11::name, pybind11::is_method, pybind11::sibling>(pybind11::cpp_function::initialize<gem5::ruby::MSI::L1Cache_Controller*, gem5::MSI_L1Cache_ControllerParams, , pybind11::name, pybind11::is_method, pybind11::sibling>(gem5::ruby::MSI::L1Cache_Controller* (gem5::MSI_L1Cache_ControllerParams::*)() const, pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)::{lambda(gem5::MSI_L1Cache_ControllerParams const*)#1}&&, gem5::ruby::MSI::L1Cache_Controller* (*)(gem5::MSI_L1Cache_ControllerParams const*), pybind11::name const&, pybind11::is_method const&, pybind11::sibling const&)':
/home/jlp/Code/gem5/gem5/ext/pybind11/include/pybind11/pybind11.h:223:(.text+0x20c6): undefined reference to `gem5::MSI_L1Cache_ControllerParams::create() const'
collect2: error: ld returned 1 exit status
```

### New warning (error is unchanged)

```
build/CXL/python/_m5/param_MSI_L1Cache_Controller.cc:145:69: warning: ‘NonDefaultCreate’ is deprecated: Warning: MSI_L1Cache_Controller is not constructible from MSI_L1Cache_ControllerParams. It is deprecated to use non-standard `create()` methods. If you see this warning followed by a linking error, the most likely problem is MSI_L1Cache_Controller has a parent class with pure virtual functions. [-Wdeprecated-declarations]
  145 |                              const MSI_L1Cache_ControllerParams &>> warning_instance;
      |                                                                     ^~~~~~~~~~~~~~~~
build/CXL/python/_m5/param_MSI_L1Cache_Controller.cc:141:38: note: declared here
  141 |         "pure virtual functions.")]] NonDefaultCreate<true> {};
      |
```