### PR TITLE
arch-riscv: Raise PF when execute user page in S-mode

### DIFF
--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -272,7 +272,8 @@ TLB::checkPermissions(STATUS status, PrivilegeMode pmode, Addr vaddr,
             DPRINTF(TLB, "PTE is not user accessible, raising PF\n");
             fault = createPagefault(vaddr, mode);
         }
-        else if (pmode == PrivilegeMode::PRV_S && pte.u && status.sum == 0) {
+        else if (pmode == PrivilegeMode::PRV_S && pte.u &&
+                 (mode == BaseMMU::Execute || status.sum == 0)) {
             DPRINTF(TLB, "PTE is only user accessible, raising PF\n");
             fault = createPagefault(vaddr, mode);
         }


### PR DESCRIPTION
See spec:
https://github.com/riscv/riscv-isa-manual/blob/main/src/supervisor.adoc#memory-privilege-in-sstatus-register

Change-Id: I22ea05a8fa43d89dd7a012a568e00dfdab73e620