### PR TITLE
mem-ruby: Fix misprint in RubyRequest sequencer ostream<<

### DIFF
--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -1171,14 +1171,13 @@ template <class KEY, class VALUE>
 std::ostream &
 operator<<(std::ostream &out, const std::unordered_map<KEY, VALUE> &map)
 {
-    for (const auto &table_entry : map) {
-        out << "[ " << table_entry.first << " =";
-        for (const auto &seq_req : table_entry.second) {
+    for (const auto &[key, values] : map) {
+        out << "[ " << key << " =";
+        for (const auto &seq_req : values) {
             out << " " << RubyRequestType_to_string(seq_req.m_second_type);
         }
+        out << " ]";
     }
-    out << " ]";
-
     return out;
 }
 

--- a/src/mem/ruby/system/Sequencer.hh
+++ b/src/mem/ruby/system/Sequencer.hh
@@ -82,8 +82,6 @@ struct SequencerRequest
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const SequencerRequest& obj);
-
 class Sequencer : public RubyPort
 {
   public:


### PR DESCRIPTION
It was printing [ k = v v[ k = v v ] ]
instead of      [ k = v v ] [ k = v v ]

Remove an unused and undefined declaration in Sequencer.hh while we're here.

Change-Id: I7d250e40490b4840c288678979fbc1809ac592d8