### PR TITLE
misc: Increase Clang support to v19; Drop GCC v10 support

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -101,7 +101,7 @@ jobs:
         # for compilation error to be exposed.
         runs-on: [self-hosted, linux, x64]
         if: github.event.pull_request.draft == false
-        container: ghcr.io/gem5/clang-version-18:latest
+        container: ghcr.io/gem5/clang-version-19:latest
         needs: [pre-commit]
         timeout-minutes: 90
         steps:

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -13,8 +13,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                image: [gcc-version-14, gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-18, clang-version-17, clang-version-16,
-                    clang-version-15, clang-version-14, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
+                image: [gcc-version-14, gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-19, clang-version-18, clang-version-17,
+                    clang-version-16, clang-version-15, clang-version-14, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
                 opts: [.opt, .fast]
         runs-on: [self-hosted, linux, x64]
         timeout-minutes: 2880 # 48 hours
@@ -32,7 +32,7 @@ jobs:
             matrix:
                 gem5-compilation: [ARM, ARM_MESI_Three_Level, ARM_MESI_Three_Level_HTM, ARM_MOESI_hammer, Garnet_standalone, MIPS, 'NULL', NULL_MESI_Two_Level,
                     NULL_MOESI_CMP_directory, NULL_MOESI_CMP_token, NULL_MOESI_hammer, POWER, RISCV, SPARC, X86, X86_MI_example, X86_MOESI_AMD_Base, VEGA_X86]
-                image: [gcc-version-14, clang-version-18]
+                image: [gcc-version-14, clang-version-19]
                 opts: [.opt]
         runs-on: [self-hosted, linux, x64]
         timeout-minutes: 2880 # 48 hours

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -13,8 +13,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                image: [gcc-version-14, gcc-version-13, gcc-version-12, gcc-version-11, gcc-version-10, clang-version-19, clang-version-18, clang-version-17,
-                    clang-version-16, clang-version-15, clang-version-14, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
+                image: [gcc-version-14, gcc-version-13, gcc-version-12, gcc-version-11, clang-version-19, clang-version-18, clang-version-17, clang-version-16,
+                    clang-version-15, clang-version-14, ubuntu-22.04_all-dependencies, ubuntu-24.04_all-dependencies, ubuntu-24.04_min-dependencies]
                 opts: [.opt, .fast]
         runs-on: [self-hosted, linux, x64]
         timeout-minutes: 2880 # 48 hours

--- a/SConstruct
+++ b/SConstruct
@@ -673,7 +673,7 @@ for variant_path in variant_paths:
               "src/SConscript to support that compiler.")))
 
     if env['GCC']:
-        gcc_min_version = "10"
+        gcc_min_version = "11"
         gcc_max_version = "14"
         gcc_version = env['CXXVERSION']
         if compareVersions(gcc_version, gcc_min_version) < 0 or \

--- a/SConstruct
+++ b/SConstruct
@@ -707,8 +707,8 @@ for variant_path in variant_paths:
             '-fno-builtin-realloc', '-fno-builtin-free'])
 
     elif env['CLANG']:
-        clang_min_version = "10"
-        clang_max_version = "14"
+        clang_min_version = "14"
+        clang_max_version = "19"
         clang_version = env['CXXVERSION']
         if compareVersions(clang_version, clang_min_version) < 0 or \
               compareVersions(clang_version, clang_max_version) > 0:

--- a/SConstruct
+++ b/SConstruct
@@ -731,18 +731,6 @@ for variant_path in variant_paths:
 
         env.Append(TCMALLOC_CCFLAGS=['-fno-builtin'])
 
-        if not want_libcxx and compareVersions(env['CXXVERSION'], "11") < 0:
-            # `libstdc++fs`` must be explicitly linked for `std::filesystem``
-            # in clang versions 6 through 10.
-            #
-            # In addition, for these versions, the
-            # `std::filesystem` is under the `experimental`
-            # namespace(`std::experimental::filesystem`).
-            #
-            # Note: gem5 does not support clang versions < 6.
-            env.Append(LIBS=['stdc++fs'])
-
-
         # On Mac OS X/Darwin we need to also use libc++ (part of XCode) as
         # opposed to libstdc++, as the later is dated.
         if not want_libcxx and sys.platform == "darwin":

--- a/SConstruct
+++ b/SConstruct
@@ -680,7 +680,7 @@ for variant_path in variant_paths:
               compareVersions(gcc_version, gcc_max_version) > 0:
             warn(
                 f'Detected GCC version {gcc_version} is not officially '
-                f'supported.\n'f'gem5 supports GCC v{gcc_min_version} up '\
+                f'supported.\n'f'gem5 supports GCC v{gcc_min_version} up '
                 f'to v{gcc_max_version}.\n'
             )
 
@@ -714,7 +714,7 @@ for variant_path in variant_paths:
               compareVersions(clang_version, clang_max_version) > 0:
             warn(
                 f'Detected Clang version {clang_version} is not officially '
-                f'supported.\n'f'gem5 supports Clang v{clang_min_version} up '\
+                f'supported.\n'f'gem5 supports Clang v{clang_min_version} up '
                 f'to v{clang_max_version}.\n'
             )
         # Set the Link-Time Optimization (LTO) flags if enabled.

--- a/SConstruct
+++ b/SConstruct
@@ -673,9 +673,17 @@ for variant_path in variant_paths:
               "src/SConscript to support that compiler.")))
 
     if env['GCC']:
-        if compareVersions(env['CXXVERSION'], "10") < 0:
-            error('gcc version 10 or newer required.\n'
-                  'Installed version:', env['CXXVERSION'])
+        gcc_min_version = "10"
+        gcc_max_version = "14"
+        gcc_version = env['CXXVERSION']
+        if compareVersions(gcc_version, gcc_min_version) < 0 or \
+              compareVersions(gcc_version, gcc_max_version) > 0:
+            warn(
+                f'Detected GCC version {gcc_version} is not officially '
+                f'supported.\n'f'gem5 supports GCC v{gcc_min_version} up '\
+                f'to v{gcc_max_version}.\n'
+            )
+
 
         # Add the appropriate Link-Time Optimization (LTO) flags if
         # `--with-lto` is set.
@@ -699,10 +707,16 @@ for variant_path in variant_paths:
             '-fno-builtin-realloc', '-fno-builtin-free'])
 
     elif env['CLANG']:
-        if compareVersions(env['CXXVERSION'], "6") < 0:
-            error('clang version 6 or newer required.\n'
-                  'Installed version:', env['CXXVERSION'])
-
+        clang_min_version = "10"
+        clang_max_version = "14"
+        clang_version = env['CXXVERSION']
+        if compareVersions(clang_version, clang_min_version) < 0 or \
+              compareVersions(clang_version, clang_max_version) > 0:
+            warn(
+                f'Detected Clang version {clang_version} is not officially '
+                f'supported.\n'f'gem5 supports Clang v{clang_min_version} up '\
+                f'to v{clang_max_version}.\n'
+            )
         # Set the Link-Time Optimization (LTO) flags if enabled.
         if GetOption('with_lto'):
             for var in 'LTO_CCFLAGS', 'LTO_LINKFLAGS':

--- a/SConstruct
+++ b/SConstruct
@@ -678,7 +678,7 @@ for variant_path in variant_paths:
         gcc_version = env['CXXVERSION']
         if compareVersions(gcc_version, gcc_min_version) < 0 or \
               compareVersions(gcc_version, gcc_max_version) > 0:
-            warn(
+            warning(
                 f'Detected GCC version {gcc_version} is not officially '
                 f'supported.\n'f'gem5 supports GCC v{gcc_min_version} up '
                 f'to v{gcc_max_version}.\n'
@@ -712,7 +712,7 @@ for variant_path in variant_paths:
         clang_version = env['CXXVERSION']
         if compareVersions(clang_version, clang_min_version) < 0 or \
               compareVersions(clang_version, clang_max_version) > 0:
-            warn(
+            warning(
                 f'Detected Clang version {clang_version} is not officially '
                 f'supported.\n'f'gem5 supports Clang v{clang_min_version} up '
                 f'to v{clang_max_version}.\n'

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -93,7 +93,8 @@ group "clang-compilers" {
     "clang-version-15",
     "clang-version-16",
     "clang-version-17",
-    "clang-version-18"
+    "clang-version-18",
+    "clang-version-19"
   ]
 }
 
@@ -155,6 +156,18 @@ target "clang-version-18" {
   cache-from = ["${CACHE_PREFIX}/clang-version-18:${CACHE_TAG}"]
   cache-to = ["${CACHE_PREFIX}/clang-version-18:${CACHE_TAG}"]
   tags = ["${IMAGE_URI}/clang-version-18:${TAG}"]
+}
+
+target "clang-version-19" {
+  inherits = ["common"]
+  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a Clang v19 compiler."]
+  args = {
+    version = "19"
+  }
+  context = "clang-compiler"
+  cache-from = ["${CACHE_PREFIX}/clang-version-19:${CACHE_TAG}"]
+  cache-to = ["${CACHE_PREFIX}/clang-version-19:${CACHE_TAG}"]
+  tags = ["${IMAGE_URI}/clang-version-19:${TAG}"]
 }
 
 group "gcc-compilers" {

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -172,26 +172,12 @@ target "clang-version-19" {
 
 group "gcc-compilers" {
   targets = [
-    "gcc-version-10",
     "gcc-version-11",
     "gcc-version-12",
     "gcc-version-13",
     "gcc-version-14"
   ]
 }
-
-target "gcc-version-10" {
-  inherits = ["common"]
-  annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v10 compiler"]
-  args = {
-    version = "10"
-  }
-  context = "gcc-compiler"
-  cache-from = ["${CACHE_PREFIX}/gcc-version-10:${CACHE_TAG}"]
-  cache-to = ["${CACHE_PREFIX}/gcc-version-10:${CACHE_TAG}"]
-  tags = ["${IMAGE_URI}/gcc-version-10:${TAG}"]
-}
-
 target "gcc-version-11" {
   inherits = ["common"]
   annotations = ["index,manifest:org.opencontainers.image.description=An image with all dependencies for building gem5 with a GCC v11 compiler."]


### PR DESCRIPTION
- Increases the supported Clang version to 19.
- Removes support for GCC v10, making the oldest supported version v11.
- Converts compiler version errors to warnings, thus allowing use of unsupported compilers with just a warning thrown.