### PR TITLE
arch-x86: apply fix for pack micro-op on duplicated code

### DIFF
--- a/src/arch/x86/isa/microops/mediaop.isa
+++ b/src/arch/x86/isa/microops/mediaop.isa
@@ -420,17 +420,20 @@ let {{
                     bits(FpSrcReg2_uqw, (i - items + 1) * srcBits - 1,
                                         (i - items + 0) * srcBits);
                 unsigned signBit = bits(picked, srcBits - 1);
-                uint64_t overflow = bits(picked, srcBits - 1, destBits - 1);
 
                 // Handle saturation.
                 if (signBit) {
-                    if (overflow != mask(srcBits - destBits + 1)) {
-                        if (signedOp())
+                    if (signedOp()) {
+                        uint64_t overflow = bits(picked, srcBits - 1,
+                                                 destBits - 1);
+                        if (overflow != mask(srcBits - destBits + 1)) {
                             picked = (1ULL << (destBits - 1));
-                        else
-                            picked = 0;
+                        }
+                    } else {
+                        picked = 0;
                     }
                 } else {
+                    uint64_t overflow = bits(picked, srcBits - 1, destBits);
                     if (overflow != 0) {
                         if (signedOp())
                             picked = mask(destBits - 1);


### PR DESCRIPTION
Fixes https://github.com/gem5/gem5/issues/1951. https://github.com/gem5/gem5/pull/1952 fixes an issue with the pack micro-op, but the change also needed to applied to a section of duplicate code to fully fix the issue. This commit applies the change in PR 1952 to the duplicate code.