### PR TITLE
configs,mem-ruby: Fix Directory_Controller fallback logic

### DIFF
--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -310,7 +310,7 @@ def create_directories(options, bootmem, ruby_system, system):
     try:
         # The supported way to use Ruby is now to use the protocol name as
         # part of the names for all of the controllers. This is *required*
-        # when using `MULTIPLE` as the protocl and the `ALL` target.
+        # when using `MULTIPLE` as the protocol and the `ALL` target.
         Directory_Controller = getattr(
             importlib.import_module("m5.objects"),
             f"{options.protocol}_Directory_Controller",

--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -307,10 +307,23 @@ def create_system(
 def create_directories(options, bootmem, ruby_system, system):
     import importlib
 
-    Directory_Controller = getattr(
-        importlib.import_module("m5.objects"),
-        f"{options.protocol}_Directory_Controller",
-    )
+    try:
+        # The supported way to use Ruby is now to use the protocol name as
+        # part of the names for all of the controllers. This is *required*
+        # when using `MULTIPLE` as the protocl and the `ALL` target.
+        Directory_Controller = getattr(
+            importlib.import_module("m5.objects"),
+            f"{options.protocol}_Directory_Controller",
+        )
+    except AttributeError:
+        # This is a fallback for the legacy Ruby protocols. If you can't
+        # find the protocol-specific directory controller, then use the
+        # generic one. This is a hack that only works if you have a single
+        # protocol.
+        Directory_Controller = getattr(
+            importlib.import_module("m5.objects"), "Directory_Controller"
+        )
+
     dir_cntrl_nodes = []
     for i in range(options.num_dirs):
         dir_cntrl = Directory_Controller()


### PR DESCRIPTION
This change corrects the instantiation of the Directory_Controller when
using Ruby protocols. The new behavior attempts to use the
protocol-specific controller class (e.g.,
`MI_example_Directory_Controller`) as required when running with
multiple protocols compiled (typically when using the ALL gem5 binary).
If the protocol-specific controller is not found (the case when working
with a binary compiled to a single protocol), the code falls back to
using the generic Directory_Controller.

This fix resolves an issue that caused the gem5 nightly tests to fail,
as seen in GitHub Actions Run #14650118937.