### PR TITLE
cpu-o3: break Request::NO_ACCESS reference cycle

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1079,7 +1079,7 @@ LSQ::LSQRequest::addReq(Addr addr, unsigned size,
            const std::vector<bool>& byte_enable)
 {
     if (isAnyActiveElement(byte_enable.begin(), byte_enable.end())) {
-        auto req = std::make_shared<Request>(
+        auto req = new Request(
                 addr, size, _flags, _inst->requestorId(),
                 _inst->pcState().instAddr(), _inst->contextId(),
                 std::move(_amo_op));
@@ -1101,7 +1101,7 @@ LSQ::LSQRequest::addReq(Addr addr, unsigned size,
             );
         }
 
-        _reqs.push_back(req);
+        _reqs.emplace_back(req);
     }
 }
 


### PR DESCRIPTION
Fix #2213. Break the reference cycle created by the lambda capture of the shared pointer `req` when
setting up a local access for LSQ requests that are marked as NO_ACCESS.

Change-Id: I2ba1cabefe8347ab53d624aea8e11887ae57c2d4