### PR TITLE
sim: convert entering event queue message to debug flag

### DIFF
--- a/src/sim/SConscript
+++ b/src/sim/SConscript
@@ -164,5 +164,6 @@ DebugFlag('VoltageDomain')
 DebugFlag('DVFS')
 DebugFlag('Vma')
 DebugFlag('PowerDomain')
+DebugFlag('EnteringEventQueue')
 
 CompoundFlag('SyscallAll', [ 'SyscallBase', 'SyscallVerbose'])

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -47,7 +47,9 @@
 
 #include "base/logging.hh"
 #include "base/pollevent.hh"
+#include "base/trace.hh"
 #include "base/types.hh"
+#include "debug/EnteringEventQueue.hh"
 #include "sim/async.hh"
 #include "sim/eventq.hh"
 #include "sim/init_signals.hh"
@@ -197,7 +199,8 @@ simulate(Tick num_cycles)
         global_exit_event->clean();
     std::unique_ptr<GlobalSyncEvent, DescheduleDeleter> quantum_event;
 
-    inform("Entering event queue @ %d.  Starting simulation...\n", curTick());
+    DPRINTF(EnteringEventQueue, "Entering event queue @ %d. Starting "
+        "simulation...\n", curTick());
 
     if (!simulatorThreads)
         simulatorThreads.reset(new SimulatorThreads(numMainEventQueues));


### PR DESCRIPTION
This commit converts an inform(...) message for entering event queue and starting simulation to a debug flag. This prevents the message from cluttering simerr when the simulation is frequently started and stopped.