### PR TITLE
mem-ruby,scons: Disable verbose SLICC output unless flag set

### DIFF
--- a/src/mem/ruby/protocol/SConscript
+++ b/src/mem/ruby/protocol/SConscript
@@ -82,7 +82,7 @@ def slicc_emitter(target, source, env):
                 )
             ],
             protocol_base.abspath,
-            verbose=False,
+            verbose=GetOption("verbose"),
         )
         slicc.process()
         slicc.writeCodeFiles(output_dir.abspath, slicc_includes)
@@ -112,7 +112,7 @@ def slicc_action(target, source, env):
                 )
             ],
             protocol_base.abspath,
-            verbose=True,
+            verbose=GetOption("verbose"),
         )
         slicc.process()
         slicc.writeCodeFiles(output_dir.abspath, slicc_includes)


### PR DESCRIPTION
The verbose SLICC warning is unneeded information in most cases. This change only enables the verbose output when `--verbose` is passed via Scons. This removes it as an "always-on" feature and makes it more consisten with the rest of the build system.