### PR TITLE
cpu: fix memory leak on indirect branch prediction

### DIFF
--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -262,9 +262,9 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
 
         ++stats.indirectLookups;
 
-        const PCStateBase *itarget = iPred->lookup(tid, seqNum,
-                                            pc.instAddr(),
-                                    hist->indirectHistory);
+        std::unique_ptr<const PCStateBase> itarget(
+            iPred->lookup(tid, seqNum, pc.instAddr(),
+                          hist->indirectHistory));
 
         if (itarget) {
             // Indirect predictor hit


### PR DESCRIPTION
Fix #2219. Fixes memory leak on indirect branch prediction by wrapping the raw pointer returned by the
IndirectPredictor::lookup() method.

Change-Id: I15d5066e4854c0e521a6cee6460b9ab5be031df1