### PR TITLE
sim, util: changes to the external signal handler

### DIFF
--- a/src/sim/async.cc
+++ b/src/sim/async.cc
@@ -35,5 +35,6 @@ volatile bool async_statreset = false;
 volatile bool async_exit = false;
 volatile bool async_io = false;
 volatile bool async_exception = false;
+volatile bool async_hypercall = false;
 
 } // namespace gem5

--- a/src/sim/async.hh
+++ b/src/sim/async.hh
@@ -47,7 +47,9 @@ extern volatile bool async_statreset;   ///< Async request to reset stats.
 extern volatile bool async_exit;        ///< Async request to exit simulator.
 extern volatile bool async_io;          ///< Async I/O request (SIGIO).
 extern volatile bool async_exception;   ///< Python exception.
+extern volatile bool async_hypercall;
 //@}
+
 
 } // namespace gem5
 

--- a/src/sim/init_signals.cc
+++ b/src/sim/init_signals.cc
@@ -233,7 +233,15 @@ static void
 externalProcessHandler(int sigtype)
 {
     async_event = true;
+    async_hypercall = true;
+    /* Wake up some event queue to handle event */
+    getEventQueue(0)->wakeup();
 
+}
+
+void
+processExternalSignal(void)
+{
     std::string shared_mem_name_str = "shared_gem5_signal_mem_" +
         std::to_string(getpid());
     const char* shared_mem_name = shared_mem_name_str.c_str();
@@ -381,7 +389,8 @@ externalProcessHandler(int sigtype)
     munmap(shm_ptr, shared_mem_size);
     close(shm_fd);
 
-    exitSimulationLoopNow(hypercall_id, payload_map);
+    exitSimLoopWithHypercall("Handling external signal!", 0, curTick(), 0,
+                             payload_map, hypercall_id, false);
 }
 
 std::string

--- a/src/sim/init_signals.cc
+++ b/src/sim/init_signals.cc
@@ -462,9 +462,9 @@ initSignals()
     installSignalHandler(SIGIO, ioHandler);
 }
 
-void initSigRtmin()
+void initSigCont()
 {
-    installSignalHandler(SIGHUP, externalProcessHandler);
+    installSignalHandler(SIGCONT, externalProcessHandler);
 }
 
 struct sigaction old_int_sa;

--- a/src/sim/init_signals.hh
+++ b/src/sim/init_signals.hh
@@ -42,7 +42,7 @@ void initSignals();
 
 // separate out sigint handler so that we can restore the python one
 void initSigInt();
-void initSigRtmin();
+void initSigCont();
 std::string extractStringFromJSON(std::string& full_str, std::string start_str,
     std::string end_str, size_t& search_start);
 void processExternalSignal(void);

--- a/src/sim/init_signals.hh
+++ b/src/sim/init_signals.hh
@@ -45,6 +45,7 @@ void initSigInt();
 void initSigRtmin();
 std::string extractStringFromJSON(std::string& full_str, std::string start_str,
     std::string end_str, size_t& search_start);
+void processExternalSignal(void);
 void restoreSigInt();
 
 } // namespace gem5

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -191,7 +191,7 @@ simulate(Tick num_cycles)
     // install the sigint handler to catch ctrl-c and exit the sim loop cleanly
     // Note: This should be done before initializing the threads
     initSigInt();
-    initSigRtmin();
+    initSigCont();
 
     if (global_exit_event)//cleaning last global exit event
         global_exit_event->clean();

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -327,6 +327,10 @@ doSimLoop(EventQueue *eventq)
                 async_exception = false;
                 return NULL;
             }
+            if (async_hypercall) {
+                async_hypercall = false;
+                processExternalSignal();
+            }
         }
 
         Event *exit_event = eventq->serviceOne();

--- a/util/hypercall_external_signal/transmitter.py
+++ b/util/hypercall_external_signal/transmitter.py
@@ -98,16 +98,19 @@ def send_signal(pid: int, id: int, payload: str) -> None:
     try:
         final_payload = create_json(id, payload)
         shm.buf[: len(final_payload.encode())] = final_payload.encode()
-        # Note: SIGHUP is used as SIGUSR1 and SIGUSR2 are already in used by
+        # Note: SIGCONT is used as SIGUSR1 and SIGUSR2 are already in used by
         # gem5 for other purposes. SIGRTMIN and SIGRTMAX (usually the suggested
         # alternative when SIGUSR1 and SIGUSR2 unavailable) cannot be used in
         # this case as they are not supported on MacOS.
         #
-        # SIGHUP is compatible with both Linux and MacOS and was not otherwise
-        # used by gem5. In general, SIGHUP is a signal that is
-        # for use in interacting with system daemons to request reloading of
-        # their configurations.
-        os.kill(pid, signal.SIGHUP)
+        # SIGCONT is compatible with both Linux and MacOS and was not otherwise
+        # used by gem5. In general, SIGCONT is used to continue a process if it
+        # was stopped. It is ignored by default, which makes it preferable to
+        # signals that kill processes by default, as this means it won't kill
+        # newly launched gem5 simulations that haven't registered signal
+        # handlers yet.
+
+        os.kill(pid, signal.SIGCONT)
     except ProcessLookupError:
         logger.error(
             "Process does not exist! Check that you are using the correct PID."


### PR DESCRIPTION
This PR changes the signal handler for external gem5 orchestrator signals so that it matches the format of the other signal handlers. It was previously set up incorrectly, which occasionally caused seg faults when the hypercall_external_signal utility was used to communicate with gem5. This PR also changes the signal used for external signals from SIGHUP to SIGCONT to prevent gem5 processes from being killed if they receive a signal before the signal handlers are registered.