### PR TITLE
systemc: Export simple arithmetic operations in sc_time pybind

### DIFF
--- a/src/systemc/core/sc_time_python.cc
+++ b/src/systemc/core/sc_time_python.cc
@@ -64,6 +64,10 @@ namespace
         .def(pybind11::self -= pybind11::self)
         .def(pybind11::self *= double())
         .def(pybind11::self /= double())
+        .def(pybind11::self + pybind11::self)
+        .def(pybind11::self - pybind11::self)
+        .def(pybind11::self * double())
+        .def(pybind11::self / double())
         ;
 
     pybind11::enum_<sc_core::sc_time_unit>(sc_time, "sc_time_unit")


### PR DESCRIPTION
This commit exports + - * / operations to sc_time's PyBind.

Change-Id: Id71865e0083a4a331ea7b46611b08fe5b1feb019