### PR TITLE
dev: Make sid, ssid optional

### DIFF
--- a/src/dev/dma_device.hh
+++ b/src/dev/dma_device.hh
@@ -42,6 +42,7 @@
 #define __DEV_DMA_DEVICE_HH__
 
 #include <deque>
+#include <optional>
 #include <memory>
 
 #include "base/addr_range_map.hh"
@@ -113,16 +114,16 @@ class DmaPort : public RequestPort, public Drainable
         const RequestorID id;
 
         /** Stream IDs. */
-        const uint32_t sid;
-        const uint32_t ssid;
+        const std::optional<uint32_t> sid;
+        const std::optional<uint32_t> ssid;
 
         /** Command for the request. */
         const Packet::Command cmd;
 
         DmaReqState(Packet::Command _cmd, Addr addr, Addr chunk_sz, Addr tb,
                     uint8_t *_data, Request::Flags _flags, RequestorID _id,
-                    uint32_t _sid, uint32_t _ssid, Event *ce, Tick _delay,
-                    Event *ae=nullptr)
+                    std::optional<uint32_t> _sid, std::optional<uint32_t> _ssid,
+                    Event *ce, Tick _delay, Event *ae=nullptr)
             : completionEvent(ce), abortEvent(ae), totBytes(tb), delay(_delay),
               gen(addr, tb, chunk_sz), data(_data), flags(_flags), id(_id),
               sid(_sid), ssid(_ssid), cmd(_cmd)
@@ -182,10 +183,10 @@ class DmaPort : public RequestPort, public Drainable
     bool retryPending = false;
 
     /** Default streamId */
-    const uint32_t defaultSid;
+    const std::optional<uint32_t> defaultSid;
 
     /** Default substreamId */
-    const uint32_t defaultSSid;
+    const std::optional<uint32_t> defaultSSid;
 
     const Addr cacheLineSize;
 
@@ -196,7 +197,8 @@ class DmaPort : public RequestPort, public Drainable
 
   public:
 
-    DmaPort(ClockedObject *dev, System *s, uint32_t sid=0, uint32_t ssid=0);
+    DmaPort(ClockedObject *dev, System *s, std::optional<uint32_t> sid=0,
+            std::optional<uint32_t> ssid=0);
 
     void
     dmaAction(Packet::Command cmd, Addr addr, int size, Event *event,
@@ -204,8 +206,8 @@ class DmaPort : public RequestPort, public Drainable
 
     void
     dmaAction(Packet::Command cmd, Addr addr, int size, Event *event,
-              uint8_t *data, uint32_t sid, uint32_t ssid, Tick delay,
-              Request::Flags flag=0);
+              uint8_t *data, std::optional<uint32_t> sid,
+              std::optional<uint32_t> ssid, Tick delay, Request::Flags flag=0);
 
     // Abort and remove any pending DMA transmissions.
     void abortPending();


### PR DESCRIPTION
In some use cases, we don't want sid or ssid. For example, if we configure SMMU to look up SID only, then we can't set SSID.

This CL makes sid, ssid field std::optional to support the use case.