### PR TITLE
arch-x86: Don't use non ISO C++ variable length arrays

### DIFF
--- a/src/arch/x86/bios/intelmp.cc
+++ b/src/arch/x86/bios/intelmp.cc
@@ -85,22 +85,17 @@ writeOutField(PortProxy& proxy, Addr addr, T val)
 uint8_t
 writeOutString(PortProxy& proxy, Addr addr, std::string str, int length)
 {
-    char cleanedString[length + 1];
-    cleanedString[length] = 0;
-
+    std::string nullPadded(length, '\0');
+    memcpy(nullPadded.data(), str.data(), std::min<int>(str.length(), length));
     if (str.length() > length) {
-        memcpy(cleanedString, str.c_str(), length);
         warn("Intel MP configuration table string \"%s\" "
-             "will be truncated to \"%s\".\n", str, (char *)&cleanedString);
-    } else {
-        memcpy(cleanedString, str.c_str(), str.length());
-        memset(cleanedString + str.length(), 0, length - str.length());
+             "will be truncated to \"%s\".\n", str, nullPadded);
     }
-    proxy.writeBlob(addr, &cleanedString, length);
+    proxy.writeBlob(addr, nullPadded.data(), length);
 
     uint8_t checkSum = 0;
     for (int i = 0; i < length; i++)
-        checkSum += cleanedString[i];
+        checkSum += nullPadded[i];
 
     return checkSum;
 }

--- a/src/arch/x86/linux/se_workload.cc
+++ b/src/arch/x86/linux/se_workload.cc
@@ -159,10 +159,10 @@ EmuLinux::pageFault(ThreadContext *tc)
         SETranslatingPortProxy proxy(tc);
         // at this point we should have 6 values on the interrupt stack
         int size = 6;
-        uint64_t is[size];
+        size_t is_bytes = sizeof(uint64_t) * size;
+        auto is = std::make_unique<uint64_t[]>(size);
         // reading the interrupt handler stack
-        proxy.readBlob(ISTVirtAddr + PageBytes - size * sizeof(uint64_t),
-                       &is, sizeof(is));
+        proxy.readBlob(ISTVirtAddr + PageBytes - is_bytes, is.get(), is_bytes);
         panic("Page fault at addr %#x\n\tInterrupt handler stack:\n"
                 "\tss: %#x\n"
                 "\trsp: %#x\n"


### PR DESCRIPTION
Remove uses of (stack allocated) variable length arrays. This isn't portable ISO C++ code, and clang 18 complains about it unless you switch off the warning.