### PR TITLE
cpu: Prevent re-executing load instruction

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -601,6 +601,11 @@ LSQUnit::executeLoad(const DynInstPtr &inst)
 
     assert(!inst->isSquashed());
 
+    if (inst->isExecuted()) {
+        DPRINTF(LSQUnit, "Load [sn:%lli] already executed\n", inst->seqNum);
+        return NoFault;
+    }
+
     load_fault = inst->initiateAcc();
 
     if (load_fault == NoFault && !inst->readMemAccPredicate()) {


### PR DESCRIPTION
After executing a load, it is sent to commit, which will eventually remove the load from the LSQ. However, the IEW might attempt to re-execute the commit if it's not removed early enough from the LSQ.

See #2238 for detailed bug description.

Fixes #2238 