### PR TITLE
mem-ruby: Fix DMA sequencer request size above 64

### DIFF
--- a/src/mem/ruby/system/DMASequencer.hh
+++ b/src/mem/ruby/system/DMASequencer.hh
@@ -88,6 +88,9 @@ class DMASequencer : public RubyPort
     typedef std::unordered_map<Addr, DMARequest> RequestTable;
     RequestTable m_RequestTable;
 
+    // Map from block address to original line address
+    std::unordered_map<Addr, Addr> m_blockToLineMap;
+
     int m_outstanding_count;
     int m_max_outstanding_requests;
 };


### PR DESCRIPTION
Fixes #2218

Previously, when the DMA sequencer had a request for more than a block size it would split up the request, but didn't track outstanding requests correctly. This change adds a new map to track just those requests. If the original request is within 64 bytes, there are no changes.