### PR TITLE
dev-amdgpu: Remove SDMA header heap allocations

### DIFF
--- a/src/dev/amdgpu/sdma_engine.hh
+++ b/src/dev/amdgpu/sdma_engine.hh
@@ -245,20 +245,18 @@ class SDMAEngine : public DmaVirtDevice
     void fence(SDMAQueue *q, sdmaFence *pkt);
     void fenceDone(SDMAQueue *q, sdmaFence *pkt);
     void trap(SDMAQueue *q, sdmaTrap *pkt);
-    void srbmWrite(SDMAQueue *q, sdmaSRBMWriteHeader *header,
-                    sdmaSRBMWrite *pkt);
-    void pollRegMem(SDMAQueue *q, sdmaPollRegMemHeader *header,
-                    sdmaPollRegMem *pkt);
-    void pollRegMemRead(SDMAQueue *q, sdmaPollRegMemHeader *header,
-                        sdmaPollRegMem *pkt, uint32_t dma_buffer, int count);
+    void srbmWrite(SDMAQueue *q, uint32_t header, sdmaSRBMWrite *pkt);
+    void pollRegMem(SDMAQueue *q, uint32_t header, sdmaPollRegMem *pkt);
+    void pollRegMemRead(SDMAQueue *q, uint32_t header, sdmaPollRegMem *pkt,
+                        uint32_t dma_buffer, int count);
     bool pollRegMemFunc(uint32_t value, uint32_t reference, uint32_t func);
     void ptePde(SDMAQueue *q, sdmaPtePde *pkt);
     void ptePdeDone(SDMAQueue *q, sdmaPtePde *pkt, uint64_t *dmaBuffer);
     void ptePdeCleanup(uint64_t *dmaBuffer);
-    void atomic(SDMAQueue *q, sdmaAtomicHeader *header, sdmaAtomic *pkt);
-    void atomicData(SDMAQueue *q, sdmaAtomicHeader *header, sdmaAtomic *pkt,
+    void atomic(SDMAQueue *q, uint32_t header, sdmaAtomic *pkt);
+    void atomicData(SDMAQueue *q, uint32_t header, sdmaAtomic *pkt,
                     uint64_t *dmaBuffer);
-    void atomicDone(SDMAQueue *q, sdmaAtomicHeader *header, sdmaAtomic *pkt,
+    void atomicDone(SDMAQueue *q, uint32_t header, sdmaAtomic *pkt,
                     uint64_t *dmaBuffer);
     void constFill(SDMAQueue *q, sdmaConstFill *pkt, uint32_t header);
     void constFillDone(SDMAQueue *q, sdmaConstFill *pkt, uint8_t *fill_data);

--- a/src/dev/amdgpu/sdma_packets.hh
+++ b/src/dev/amdgpu/sdma_packets.hh
@@ -217,8 +217,15 @@ static_assert(sizeof(sdmaSRBMWrite) == 8);
 
 typedef struct GEM5_PACKED
 {
-    uint32_t reserved : 28;
-    uint32_t byteEnable : 4;
+    union
+    {
+        struct
+        {
+            uint32_t reserved : 28;
+            uint32_t byteEnable : 4;
+        };
+        uint32_t ordinal;
+    };
 }  sdmaSRBMWriteHeader;
 static_assert(sizeof(sdmaSRBMWriteHeader) == 4);
 
@@ -235,10 +242,17 @@ static_assert(sizeof(sdmaPollRegMem) == 20);
 
 typedef struct GEM5_PACKED
 {
-    uint32_t reserved : 26;
-    uint32_t op : 2;            // Operation
-    uint32_t func : 3;          // Comparison function
-    uint32_t mode : 1;          // Mode: register or memory polling
+    union
+    {
+        struct
+        {
+            uint32_t reserved : 26;
+            uint32_t op : 2;            // Operation
+            uint32_t func : 3;          // Comparison function
+            uint32_t mode : 1;          // Mode: register or memory polling
+        };
+        uint32_t ordinal;
+    };
 }  sdmaPollRegMemHeader;
 static_assert(sizeof(sdmaPollRegMemHeader) == 4);
 
@@ -302,10 +316,17 @@ static_assert(sizeof(sdmaAtomic) == 28);
 
 typedef struct GEM5_PACKED
 {
-    int unused2 : 16;
-    int loop : 1;
-    int unused1 : 8;
-    int opcode : 7;
+    union
+    {
+        struct
+        {
+            int unused2 : 16;
+            int loop : 1;
+            int unused1 : 8;
+            int opcode : 7;
+        };
+        uint32_t ordinal;
+    };
 }  sdmaAtomicHeader;
 static_assert(sizeof(sdmaAtomicHeader) == 4);
 


### PR DESCRIPTION
Some SDMA packets require headers. For those that do, a header struct is allocated on the heap and assigned to the header dword read during packet decoding. The heap allocation is unnecessary and has a second issue of assigning to a local variable that goes out of scope by the time the callback is called.

This commit simply passes the header as a dword to the callback methods which can then reinterpret the dword as a struct to access the fields needed. Fixes possibly bug related to the memory pointed to on the heap being recycled.