### PR TITLE
arch-vega: Ignore EXEC SGPR dest for VOP3 V_CMPX_*

### DIFF
--- a/src/arch/amdgpu/vega/insts/op_encodings.cc
+++ b/src/arch/amdgpu/vega/insts/op_encodings.cc
@@ -977,7 +977,7 @@ namespace VegaISA
         int opNum = 0;
 
         int numSrc = numSrcRegOperands() - readsVCC();
-        int numDst = numDstRegOperands() - writesVCC();
+        int numDst = numDstRegOperands() - writesVCC() - writesEXEC();
 
         for (opNum = 0; opNum < numSrc; opNum++) {
             srcOps.emplace_back(srcs[opNum], getOperandSize(opNum), true,
@@ -1004,8 +1004,12 @@ namespace VegaISA
                                   true, false, false);
         }
 
+        // Completely ignore if writesEXEC() is true. Instructions which write
+        // EXEC do so by writing to a wavefront register rather than SGPRs.
+        // The SGPR index values for EXEC are used as aliases to the wavefront
+        // register in gem5.
         assert(srcOps.size() == numSrcRegOperands());
-        assert(dstOps.size() == numDstRegOperands());
+        assert(dstOps.size() == numDst);
     }
 
     int


### PR DESCRIPTION
These instructions write *both* EXEC and either VCC or SGPR. Currently the special EXEC register is not being ignored, causing gem5 to think s126/s127 are user SGPRs that are out of range. This causes a panic.

The commit checks for VOP3 instructions writing EXEC (only V_CMPX_* instructions do this) and decrements the number of destinations that need to be added to the user GPR destinations for virtual to physical mapping.

Note that the actually write to EXEC happens by writing the wavefront class directly and is not done through SGPRs. VCC on the other hand is handled using SGPRs.