### PR TITLE
tests: Reduce the gpu_ruby_rand Daily tests to 1h

### DIFF
--- a/tests/gem5/gpu/test_gpu_ruby_random.py
+++ b/tests/gem5/gpu/test_gpu_ruby_random.py
@@ -74,7 +74,7 @@ gem5_verify_config(
 #    faster sim)
 #  - use small address range to encourage more races
 #  - use small episode length to encourage more races
-#  - 1.5M tests runs in ~30 minutes on Action runners with reasonably good
+#  - 150k tests runs in ~1 hour on Action runners with reasonably good
 #    coverage
 #  - num-dmas = 0 because VIPER doesn't support partial cache line writes,
 #    which DMAs need
@@ -87,7 +87,7 @@ gem5_verify_config(
     ),
     config_args=[
         "--test-length",
-        "1500000",
+        "150000",
         "--num-dmas",
         "0",
         "--protocol",

--- a/tests/gem5/gpu/test_gpu_ruby_random_wbL2.py
+++ b/tests/gem5/gpu/test_gpu_ruby_random_wbL2.py
@@ -75,7 +75,7 @@ gem5_verify_config(
 #    faster sim)
 #  - use small address range to encourage more races
 #  - use small episode length to encourage more races
-#  - 1.5M tests runs in ~30 minutes on GH runners with reasonably good coverage
+#  - 150k tests runs in 1 hour on GH runners with reasonably good coverage
 #  - num-dmas = 0 because VIPER doesn't support partial cache line writes,
 #    which DMAs need
 gem5_verify_config(
@@ -88,7 +88,7 @@ gem5_verify_config(
     config_args=[
         "--WB_L2",
         "--test-length",
-        "1500000",
+        "150000",
         "--num-dmas",
         "0",
         "--protocol",


### PR DESCRIPTION
These tests were taking about 12 hours to run on our GitHub Action runners. This commit reduces this to around an hour by dividing the input size by 10.

.