### PR TITLE
dev: Make sid, ssid option in dmaRead, dmaWrite

### DIFF
--- a/src/dev/dma_device.hh
+++ b/src/dev/dma_device.hh
@@ -229,7 +229,8 @@ class DmaDevice : public PioDevice
 
     void
     dmaWrite(Addr addr, int size, Event *event, uint8_t *data,
-             uint32_t sid, uint32_t ssid, Tick delay=0)
+             std::optional<uint32_t> sid, std::optional<uint32_t> ssid,
+             Tick delay=0)
     {
         dmaPort.dmaAction(MemCmd::WriteReq, addr, size, event, data,
                           sid, ssid, delay);
@@ -243,7 +244,8 @@ class DmaDevice : public PioDevice
 
     void
     dmaRead(Addr addr, int size, Event *event, uint8_t *data,
-            uint32_t sid, uint32_t ssid, Tick delay=0)
+            std::optional<uint32_t> sid, std::optional<uint32_t> ssid,
+            Tick delay=0)
     {
         dmaPort.dmaAction(MemCmd::ReadReq, addr, size, event, data,
                           sid, ssid, delay);


### PR DESCRIPTION
This CL makes sid, ssid parameter std::optional in dmaRead, dmaWrite function.

The intention is that in some use cases, we don't want sid or ssid. For example, if we configure SMMU to look up SID only, then we can't set SSID in this use case.

Previous PR: https://github.com/gem5/gem5/pull/2230