### PR TITLE
configs: Enable bootloader argument for RISCV simulations

### DIFF
--- a/configs/common/Options.py
+++ b/configs/common/Options.py
@@ -808,6 +808,11 @@ def addFSOptions(parser):
             help="Specifies device tree blob file to use with device-tree-"
             "enabled kernels",
         )
+        parser.add_argument(
+            "--bootloader",
+            action="append",
+            help="executable file that runs before the --kernel",
+        )
     if buildEnv["USE_ARM_ISA"]:
         parser.add_argument(
             "--list-machine-types",
@@ -828,11 +833,6 @@ def addFSOptions(parser):
             "switches and dump tasks file (required for Streamline)",
         )
         parser.add_argument("--vio-9p", action="store_true", help=vio_9p_help)
-        parser.add_argument(
-            "--bootloader",
-            action="append",
-            help="executable file that runs before the --kernel",
-        )
 
     # Benchmark options
     parser.add_argument(


### PR DESCRIPTION
A recent patch (PR #2231) removed the bootloader argument from `configs/example/riscv/fs_linux.py` due to the entry already being present in `Options.py`. However, the entry is under an `if buildEnv["USE_ARM_ISA"]` condition, making it unavailable for RISCV. This patch moves the argument to a different position in the `Options.py` file to enable it for RISCV simulations too.