### PR TITLE
arch-sparc: Fix SyntaxWarnings in sparc/isa/base.isa

### DIFF
--- a/src/arch/sparc/isa/base.isa
+++ b/src/arch/sparc/isa/base.isa
@@ -87,7 +87,7 @@ let {{
                 raise Exception("Inconsistent extensions in double filter")
 
         # Get rid of any unwanted extension
-        code = operandsRE.sub('\g<name>', code)
+        code = operandsRE.sub(r'\g<name>', code)
 
         for op in operands.values():
             is_int = op.ext in int_extensions
@@ -112,7 +112,7 @@ let {{
         if rOrImmMatch == None:
             return code, None, None
         orig_code = code
-        reg_code = matcher.sub('Rs\g<rNum>\g<typeQual>', code)
+        reg_code = matcher.sub(r'Rs\g<rNum>\g<typeQual>', code)
         imm_code = matcher.sub('imm', code)
         return reg_code, imm_code, rOrImmMatch.group('iNum')
 }};


### PR DESCRIPTION
In `re.sub`, the literal `\g<FOO>` is used to reference a capture group in the regexp by name/number. In ordinary Python strings `\g` is not a valid escape sequence, and so is passed through directly. In Python 3.12 this becomes a SyntaxWarning. Make explicit the fact that we really want the two characters `\g` with no unescaping by using raw strings.

Change-Id: I2ca8cf3c37e0d6e27baec661ee2c9fb840fb2432