### PR TITLE
arch-x86: Return early from MWAIT if address monitor is not armed

### DIFF
--- a/src/arch/x86/isa/formats/monitor_mwait.isa
+++ b/src/arch/x86/isa/formats/monitor_mwait.isa
@@ -64,6 +64,9 @@ def template MwaitInitiateAcc {{
     {
         unsigned s = 0x8;        //size
         unsigned f = 0;          //flags
+        if (!xc->getAddrMonitor()->armed) {
+            return NoFault;
+        }
         initiateMemRead(xc, traceData, xc->getAddrMonitor()->vAddr, s, f);
         return NoFault;
     }


### PR DESCRIPTION
This PR fixes #2043 by adding the suggested change in the issue.