### PR TITLE
dev: Adopt OptionalParam for DmaDevice.

### DIFF
--- a/src/dev/Device.py
+++ b/src/dev/Device.py
@@ -100,13 +100,11 @@ class DmaDevice(PioDevice):
 
     _iommu = None
 
-    sid = Param.Unsigned(
-        0,
+    sid = OptionalParam.Unsigned(
         "Stream identifier used by an IOMMU to distinguish amongst "
         "several devices attached to it",
     )
-    ssid = Param.Unsigned(
-        0,
+    ssid = OptionalParam.Unsigned(
         "Substream identifier used by an IOMMU to distinguish amongst "
         "several devices attached to it",
     )


### PR DESCRIPTION
The DmaPort take optional s(s)id.

We introduced `OptionalParam` in #2252 .
This change adopts `OptionalParam` for `DmaDevice` s(s)id parameter.

BREAKING CHANGE:
Any downstream classes of the `DmaDevice` who depends directly on `params().sid` should handle the type change.

Change-Id: Ibb8627809b1a7b9d3970d8a15f4e12e903fe6ad4