### PR TITLE
arch-vega,gpu-compute: Opcode overrides based on gfx version

### DIFF
--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -50,6 +50,26 @@ namespace VegaISA
     {
     } // ~Decoder
 
+    void Decoder::fixupGfx90a()
+    {
+        tableDecodePrimary[16] = &Decoder::decode_OP_VOP2__V_FMAC_F64;
+        tableDecodePrimary[17] = &Decoder::decode_OP_VOP2__V_FMAC_F64;
+        tableDecodePrimary[18] = &Decoder::decode_OP_VOP2__V_FMAC_F64;
+        tableDecodePrimary[19] = &Decoder::decode_OP_VOP2__V_FMAC_F64;
+    }
+
+    void Decoder::setGfxVersion(GfxVersion gfxVersion)
+    {
+        // Some ISA have recycled opcodes and are using those going forward.
+        // Here we replace those entries in the decoder table.
+        if (gfxVersion == GfxVersion::gfx90a) {
+            fixupGfx90a();
+        } else if (gfxVersion == GfxVersion::gfx942) {
+            fixupGfx90a();
+            // No further changes beyond changes in gfx90a
+        }
+    }
+
     /*
      * These will probably have to be updated according to the Vega ISA manual:
      * https://developer.amd.com/wp-content/resources/
@@ -3872,6 +3892,12 @@ namespace VegaISA
     {
         return new Inst_VOP2__V_MUL_LEGACY_F32(&iFmt->iFmt_VOP2);
     } // decode_OP_VOP2__V_MUL_LEGACY_F32
+
+    GPUStaticInst*
+    Decoder::decode_OP_VOP2__V_FMAC_F64(MachInst iFmt)
+    {
+        return new Inst_VOP2__V_FMAC_F64(&iFmt->iFmt_VOP2);
+    }
 
     GPUStaticInst*
     Decoder::decode_OP_VOP2__V_MUL_F32(MachInst iFmt)

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "arch/amdgpu/vega/gpu_types.hh"
+#include "enums/GfxVersion.hh"
 
 namespace gem5
 {
@@ -55,9 +56,13 @@ namespace VegaISA
         Decoder();
         ~Decoder();
 
+        void setGfxVersion(GfxVersion gfxVersion);
+
         GPUStaticInst* decode(MachInst mach_inst);
 
       private:
+        void fixupGfx90a();
+
         static IsaDecodeMethod tableDecodePrimary[512];
         static IsaDecodeMethod tableSubDecode_OPU_VOP3[768];
         static IsaDecodeMethod tableSubDecode_OP_DS[256];
@@ -1376,6 +1381,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_VOP2__V_DOT4C_I32_I8(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_DOT8C_I32_I4(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_FMAC_F32(MachInst);
+        GPUStaticInst* decode_OP_VOP2__V_FMAC_F64(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_PK_FMAC_F16(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_XNOR_B32(MachInst);
         GPUStaticInst* decode_OP_VOPC__V_CMP_CLASS_F32(MachInst);

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -8138,6 +8138,40 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP2__V_FMAC_F32
 
+    class Inst_VOP2__V_FMAC_F64 : public Inst_VOP2
+    {
+      public:
+        Inst_VOP2__V_FMAC_F64(InFmt_VOP2*);
+        ~Inst_VOP2__V_FMAC_F64();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 8;
+              case 1: //src_1
+                return 8;
+              case 2: //vdst
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP2__V_FMAC_F64
+
     class Inst_VOP2__V_XNOR_B32 : public Inst_VOP2
     {
       public:

--- a/src/arch/amdgpu/vega/insts/vop2.cc
+++ b/src/arch/amdgpu/vega/insts/vop2.cc
@@ -2311,6 +2311,43 @@ namespace VegaISA
 
         vdst.write();
     } // execute
+    // --- Inst_VOP2__V_FMAC_F64 class methods ---
+
+    Inst_VOP2__V_FMAC_F64::Inst_VOP2__V_FMAC_F64(InFmt_VOP2 *iFmt)
+        : Inst_VOP2(iFmt, "v_fmac_f64")
+    {
+        setFlag(ALU);
+    } // Inst_VOP2__V_FMAC_F64
+
+    Inst_VOP2__V_FMAC_F64::~Inst_VOP2__V_FMAC_F64()
+    {
+    } // ~Inst_VOP2__V_FMAC_F64
+
+    // --- description from .arch file ---
+    // D0.f64 = fma(S0.f64, S1.f64, D0.f64)
+    void
+    Inst_VOP2__V_FMAC_F64::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+        ConstVecOperandF64 src0(gpuDynInst, instData.SRC0);
+        ConstVecOperandF64 src1(gpuDynInst, instData.VSRC1);
+        VecOperandF64 vdst(gpuDynInst, instData.VDST);
+
+        src0.readSrc();
+        src1.read();
+        vdst.read();
+
+        panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
+        panic_if(isDPPInst(), "DPP not implemented for %s", _opcode);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                vdst[lane] = std::fma(src0[lane], src1[lane], vdst[lane]);
+            }
+        }
+
+        vdst.write();
+    } // execute
     // --- Inst_VOP2__V_XNOR_B32 class methods ---
 
     Inst_VOP2__V_XNOR_B32::Inst_VOP2__V_XNOR_B32(InFmt_VOP2 *iFmt)

--- a/src/gpu-compute/fetch_unit.cc
+++ b/src/gpu-compute/fetch_unit.cc
@@ -75,6 +75,7 @@ FetchUnit::init()
         fetchStatusQueue[i] = std::make_pair(wf, false);
         fetchBuf[i].allocateBuf(fetchDepth, computeUnit.cacheLineSize(), wf);
         fetchBuf[i].decoder(&decoder);
+        decoder.setGfxVersion(computeUnit.shader->getGfxVersion());
     }
 
     fetchScheduler.bindList(&fetchQueue);

--- a/src/gpu-compute/gpu_command_processor.cc
+++ b/src/gpu-compute/gpu_command_processor.cc
@@ -988,4 +988,10 @@ GPUCommandProcessor::shader()
     return _shader;
 }
 
+GfxVersion
+GPUCommandProcessor::getGfxVersion() const
+{
+    return FullSystem ? gpuDevice->getGfxVersion() : _driver->getGfxVersion();
+}
+
 } // namespace gem5

--- a/src/gpu-compute/gpu_command_processor.hh
+++ b/src/gpu-compute/gpu_command_processor.hh
@@ -79,6 +79,7 @@ class GPUCommandProcessor : public DmaVirtDevice
 
     HSAPacketProcessor& hsaPacketProc();
     RequestorID vramRequestorId();
+    GfxVersion getGfxVersion() const;
 
     void setGPUDevice(AMDGPUDevice *gpu_device);
     void setShader(Shader *shader);

--- a/src/gpu-compute/shader.cc
+++ b/src/gpu-compute/shader.cc
@@ -589,6 +589,12 @@ Shader::vramRequestorId()
     return gpuCmdProc.vramRequestorId();
 }
 
+GfxVersion
+Shader::getGfxVersion() const
+{
+    return gpuCmdProc.getGfxVersion();
+}
+
 Shader::ShaderStats::ShaderStats(statistics::Group *parent, int wf_size)
     : statistics::Group(parent),
       ADD_STAT(allLatencyDist, "delay distribution for all"),

--- a/src/gpu-compute/shader.hh
+++ b/src/gpu-compute/shader.hh
@@ -226,6 +226,7 @@ class Shader : public ClockedObject
     }
 
     RequestorID vramRequestorId();
+    GfxVersion getGfxVersion() const;
 
     EventFunctionWrapper tickEvent;
 


### PR DESCRIPTION
Some newer gfx9 ISAs reuse opcodes from previous generations to implement completely different instructions. In order to support this, make the decoder object take the gfx version from the shader and override specific opcodes rather than duplicate the entire decoder table.

Implement the new V_FMAC_F64 instruction which replaces the old V_MUL_LEGACY_F32.