### PR TITLE
misc: Introduce dictionary parameters (DictParam) in gem5

### DIFF
--- a/build_tools/cxx_config_cc.py
+++ b/build_tools/cxx_config_cc.py
@@ -1,7 +1,7 @@
 # Copyright 2004-2006 The Regents of The University of Michigan
 # Copyright 2010-20013 Advanced Micro Devices, Inc.
 # Copyright 2013 Mark D. Hill and David A. Wood
-# Copyright 2017-2020 ARM Limited
+# Copyright 2017-2020, 2025 Arm Limited
 # Copyright 2021 Google, Inc.
 # Copyright 2023 COSEDA Technologies GmbH
 #
@@ -74,11 +74,12 @@ def cxx_bool(b):
 code('#include "params/%s.hh"' % sim_object_name)
 
 for param in sim_object._params.values():
-    if isSimObjectClass(param.ptype):
-        code('#include "%s"' % param.ptype._value_dict["cxx_header"])
-        code('#include "params/%s.hh"' % param.ptype.__name__)
-    else:
-        param.ptype.cxx_ini_predecls(code)
+    for ptype in param.ptypes:
+        if isSimObjectClass(ptype):
+            code('#include "%s"' % ptype._value_dict["cxx_header"])
+            code('#include "params/%s.hh"' % ptype.__name__)
+        else:
+            ptype.cxx_ini_predecls(code)
 
 code(
     """#include "${{sim_object._value_dict['cxx_header']}}"
@@ -94,12 +95,22 @@ ${param_class}::DirectoryEntry::DirectoryEntry()
 )
 code.indent()
 for param in sim_object._params.values():
+    is_dict = isinstance(param, m5.params.DictParamDesc)
     is_vector = isinstance(param, m5.params.VectorParamDesc)
-    is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
-
+    is_simobj = (
+        issubclass(param.ptype, m5.SimObject.SimObject)
+        if not is_dict
+        else False
+    )
     code(
-        'parameters["%s"] = new ParamDesc("%s", %s, %s);'
-        % (param.name, param.name, cxx_bool(is_vector), cxx_bool(is_simobj))
+        'parameters["%s"] = new ParamDesc("%s", %s, %s, %s);'
+        % (
+            param.name,
+            param.name,
+            cxx_bool(is_vector),
+            cxx_bool(is_dict),
+            cxx_bool(is_simobj),
+        )
     )
 
 for port in sim_object._ports.values():
@@ -126,19 +137,21 @@ ${param_class}::setSimObject(const std::string &name, SimObject *simObject)
 
 code.indent()
 for param in sim_object._params.values():
-    is_vector = isinstance(param, m5.params.VectorParamDesc)
-    is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
+    is_dict = isinstance(param, m5.params.DictParamDesc)
+    if not is_dict:
+        is_vector = isinstance(param, m5.params.VectorParamDesc)
+        is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
 
-    if is_simobj and not is_vector:
-        code('} else if (name == "${{param.name}}") {')
-        code.indent()
-        code(
-            "this->${{param.name}} = "
-            "dynamic_cast<${{param.ptype.cxx_type}}>(simObject);"
-        )
-        code("if (simObject && !this->${{param.name}})")
-        code("   ret = false;")
-        code.dedent()
+        if is_simobj and not is_vector:
+            code('} else if (name == "${{param.name}}") {')
+            code.indent()
+            code(
+                "this->${{param.name}} = "
+                "dynamic_cast<${{param.ptype.cxx_type}}>(simObject);"
+            )
+            code("if (simObject && !this->${{param.name}})")
+            code("   ret = false;")
+            code.dedent()
 code.dedent()
 
 code(
@@ -162,30 +175,32 @@ ${param_class}::setSimObjectVector(const std::string &name,
 
 code.indent()
 for param in sim_object._params.values():
-    is_vector = isinstance(param, m5.params.VectorParamDesc)
-    is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
+    is_dict = isinstance(param, m5.params.DictParamDesc)
+    if not is_dict:
+        is_vector = isinstance(param, m5.params.VectorParamDesc)
+        is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
 
-    if is_simobj and is_vector:
-        code('} else if (name == "${{param.name}}") {')
-        code.indent()
-        code("this->${{param.name}}.clear();")
-        code(
-            "for (auto i = simObjects.begin(); "
-            "ret && i != simObjects.end(); i ++)"
-        )
-        code("{")
-        code.indent()
-        code(
-            "${{param.ptype.cxx_type}} object = "
-            "dynamic_cast<${{param.ptype.cxx_type}}>(*i);"
-        )
-        code("if (*i && !object)")
-        code("    ret = false;")
-        code("else")
-        code("    this->${{param.name}}.push_back(object);")
-        code.dedent()
-        code("}")
-        code.dedent()
+        if is_simobj and is_vector:
+            code('} else if (name == "${{param.name}}") {')
+            code.indent()
+            code("this->${{param.name}}.clear();")
+            code(
+                "for (auto i = simObjects.begin(); "
+                "ret && i != simObjects.end(); i ++)"
+            )
+            code("{")
+            code.indent()
+            code(
+                "${{param.ptype.cxx_type}} object = "
+                "dynamic_cast<${{param.ptype.cxx_type}}>(*i);"
+            )
+            code("if (*i && !object)")
+            code("    ret = false;")
+            code("else")
+            code("    this->${{param.name}}.push_back(object);")
+            code.dedent()
+            code("}")
+            code.dedent()
 code.dedent()
 
 code(
@@ -215,16 +230,18 @@ ${param_class}::setParam(const std::string &name,
 
 code.indent()
 for param in sim_object._params.values():
-    is_vector = isinstance(param, m5.params.VectorParamDesc)
-    is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
+    is_dict = isinstance(param, m5.params.DictParamDesc)
+    if not is_dict:
+        is_vector = isinstance(param, m5.params.VectorParamDesc)
+        is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
 
-    if not is_simobj and not is_vector:
-        code('} else if (name == "${{param.name}}") {')
-        code.indent()
-        param.ptype.cxx_ini_parse(
-            code, "value", "this->%s" % param.name, "ret ="
-        )
-        code.dedent()
+        if not is_simobj and not is_vector:
+            code('} else if (name == "${{param.name}}") {')
+            code.indent()
+            param.ptype.cxx_ini_parse(
+                code, "value", "this->%s" % param.name, "ret ="
+            )
+            code.dedent()
 code.dedent()
 
 code(
@@ -248,20 +265,64 @@ ${param_class}::setParamVector(const std::string &name,
 
 code.indent()
 for param in sim_object._params.values():
-    is_vector = isinstance(param, m5.params.VectorParamDesc)
-    is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
+    is_dict = isinstance(param, m5.params.DictParamDesc)
+    if not is_dict:
+        is_vector = isinstance(param, m5.params.VectorParamDesc)
+        is_simobj = issubclass(param.ptype, m5.SimObject.SimObject)
 
-    if not is_simobj and is_vector:
+        if not is_simobj and is_vector:
+            code('} else if (name == "${{param.name}}") {')
+            code.indent()
+            code("${{param.name}}.clear();")
+            code(
+                "for (auto i = values.begin(); ret && i != values.end(); i ++)"
+            )
+            code("{")
+            code.indent()
+            code("${{param.ptype.cxx_type}} elem;")
+            param.ptype.cxx_ini_parse(code, "*i", "elem", "ret =")
+            code("if (ret)")
+            code("    this->${{param.name}}.push_back(elem);")
+            code.dedent()
+            code("}")
+            code.dedent()
+code.dedent()
+
+code(
+    """
+    } else {
+        ret = false;
+    }
+
+    return ret;
+}
+
+bool
+${param_class}::setParamDict(const std::string &name,
+    const std::unordered_map<std::string, std::string> &values, const Flags flags)
+{
+    bool ret = true;
+
+    if (false) {
+"""
+)
+
+code.indent()
+for param in sim_object._params.values():
+    is_dict = isinstance(param, m5.params.DictParamDesc)
+    if is_dict:
         code('} else if (name == "${{param.name}}") {')
         code.indent()
         code("${{param.name}}.clear();")
         code("for (auto i = values.begin(); ret && i != values.end(); i ++)")
         code("{")
         code.indent()
-        code("${{param.ptype.cxx_type}} elem;")
-        param.ptype.cxx_ini_parse(code, "*i", "elem", "ret =")
+        code("${{param.key_desc.ptype.cxx_type}} key;")
+        code("${{param.val_desc.ptype.cxx_type}} val;")
+        param.key_desc.ptype.cxx_ini_parse(code, "i->first", "key", "ret =")
+        param.val_desc.ptype.cxx_ini_parse(code, "i->second", "val", "ret =")
         code("if (ret)")
-        code("    this->${{param.name}}.push_back(elem);")
+        code("    this->${{param.name}}[key] = val;")
         code.dedent()
         code("}")
         code.dedent()

--- a/build_tools/cxx_config_hh.py
+++ b/build_tools/cxx_config_hh.py
@@ -1,7 +1,7 @@
 # Copyright 2004-2006 The Regents of The University of Michigan
 # Copyright 2010-20013 Advanced Micro Devices, Inc.
 # Copyright 2013 Mark D. Hill and David A. Wood
-# Copyright 2017-2020 ARM Limited
+# Copyright 2017-2020, 2025 Arm Limited
 # Copyright 2021 Google, Inc.
 #
 # The license below extends only to copyright in the software and shall
@@ -103,6 +103,10 @@ class ${param_class} : public CxxConfigParams, public ${sim_object_name}Params
 
     bool setParamVector(const std::string &name,
         const std::vector<std::string> &values, const Flags flags);
+
+    bool setParamDict(const std::string &name,
+        const std::unordered_map<std::string, std::string> &values,
+        const Flags flags);
 
     bool setPortConnectionCount(const std::string &name, unsigned int count);
 

--- a/build_tools/sim_object_param_struct_hh.py
+++ b/build_tools/sim_object_param_struct_hh.py
@@ -1,7 +1,7 @@
 # Copyright 2004-2006 The Regents of The University of Michigan
 # Copyright 2010-20013 Advanced Micro Devices, Inc.
 # Copyright 2013 Mark D. Hill and David A. Wood
-# Copyright 2017-2020 ARM Limited
+# Copyright 2017-2020, 2025 Arm Limited
 # Copyright 2021 Google, Inc.
 #
 # The license below extends only to copyright in the software and shall
@@ -71,7 +71,7 @@ params = list(
 )
 ports = sim_object._ports.local
 try:
-    ptypes = [p.ptype for p in params]
+    ptypes = [single_type for p in params for single_type in p.ptypes]
 except:
     print(sim_object)
     print(params)

--- a/configs/example/read_config.py
+++ b/configs/example/read_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014,2019 ARM Limited
+# Copyright (c) 2014,2019, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -208,21 +208,37 @@ class ConfigManager:
         parsed_params = {}
 
         for param_name, param in list(object_class._params.items()):
-            if issubclass(param.ptype, m5.params.ParamValue):
-                if isinstance(param, m5.params.VectorParamDesc):
-                    param_values = self.config.get_param_vector(
-                        object_name, param_name
-                    )
+            if isinstance(param, m5.params.VectorParamDesc) and issubclass(
+                param.ptype, m5.params.ParamValue
+            ):
+                param_values = self.config.get_param_vector(
+                    object_name, param_name
+                )
 
-                    param_value = [
-                        param.ptype.parse_ini(self.flags, value)
-                        for value in param_values
-                    ]
-                else:
-                    param_value = param.ptype.parse_ini(
-                        self.flags,
-                        self.config.get_param(object_name, param_name),
-                    )
+                param_value = [
+                    param.ptype.parse_ini(self.flags, value)
+                    for value in param_values
+                ]
+
+                parsed_params[param_name] = param_value
+            elif isinstance(param, m5.params.DictParamDesc):
+                param_values = self.config.get_param_dict(
+                    object_name, param_name
+                )
+
+                param_value = {
+                    param.key_desc.ptype.parse_ini(
+                        self.flags, key
+                    ): param.val_desc.ptype.parse_ini(self.flags, val)
+                    for key, val in param_values.items()
+                }
+
+                parsed_params[param_name] = param_value
+            elif issubclass(param.ptype, m5.params.ParamValue):
+                param_value = param.ptype.parse_ini(
+                    self.flags,
+                    self.config.get_param(object_name, param_name),
+                )
 
                 parsed_params[param_name] = param_value
 
@@ -439,6 +455,11 @@ class ConfigFile:
         configuration as a list of strings"""
         pass
 
+    def get_param_dict(self, object_name, param_name):
+        """Get a vector param or vector of SimObject references from the
+        configuration as a list of strings"""
+        pass
+
     def get_object_children(self, object_name):
         """Get a list of (name, paths) for each child of this object.
         paths is either a single string object path or a list of object
@@ -466,6 +487,21 @@ class ConfigIniFile(ConfigFile):
 
     def get_param_vector(self, object_name, param_name):
         return self.parser.get(object_name, param_name).split()
+
+    def get_param_dict(self, object_name, param_name):
+        """
+        DictParams in the ini file are stored as a flat list
+        of objects, with keys in the even indices and values
+        in the odd indices. The method is unflattening the
+        list into the matching dictionary
+        """
+        ret = dict()
+        flat_list = self.parser.get(object_name, param_name).split()
+        keys = flat_list[0::2]
+        vals = flat_list[1::2]
+        for key, val in zip(keys, vals):
+            ret[key] = val
+        return ret
 
     def get_object_children(self, object_name):
         if self.parser.has_option(object_name, "children"):

--- a/src/python/m5/params.py
+++ b/src/python/m5/params.py
@@ -57,6 +57,7 @@
 import copy
 import datetime
 import math
+import pprint
 import re
 import sys
 import time
@@ -286,6 +287,34 @@ class VectorParamValue(list, metaclass=MetaParamValue):
             return [v.unproxy(base) for v in self]
 
 
+class DictParamValue(dict, metaclass=MetaParamValue):
+    def __setattr__(self, attr, value):
+        raise AttributeError(
+            f"Not allowed to set {attr} on '{type(self).__name__}'"
+        )
+
+    def config_value(self):
+        return {
+            key.config_value(): value.config_value()
+            for key, value in self.items()
+        }
+
+    def ini_str(self):
+        # This is flattening the dictionary as a sequence of key, value pairs
+        return " ".join([elem.ini_str() for kv in self.items() for elem in kv])
+
+    def getValue(self):
+        return {
+            key.getValue(): value.getValue() for key, value in self.items()
+        }
+
+    def unproxy(self, base):
+        return {
+            key.unproxy(base): value.unproxy(base)
+            for key, value in self.items()
+        }
+
+
 class SimObjectVector(VectorParamValue):
     # support clone operation
     def __call__(self, **kwargs):
@@ -435,7 +464,7 @@ class VectorParamDesc(SingleTypeParamDesc):
         code("std::vector< ${{self.ptype.cxx_type}} > ${{self.name}};")
 
 
-class OptionalParamDesc(ParamDesc):
+class OptionalParamDesc(SingleTypeParamDesc):
     def __init__(self, ptype_str, ptype, *args, **kwargs):
         if len(args) != 1:
             raise TypeError(
@@ -452,7 +481,7 @@ class OptionalParamDesc(ParamDesc):
         if isNullOpt(value):
             return value
         else:
-            return ParamDesc.convert(self, value)
+            return SingleTypeParamDesc.convert(self, value)
 
     def cxx_predecls(self, code):
         code("#include <optional>", add_once=True)
@@ -464,6 +493,93 @@ class OptionalParamDesc(ParamDesc):
 
     def cxx_decl(self, code):
         code("std::optional< ${{self.ptype.cxx_type}} > ${{self.name}};")
+
+
+class DictParamDesc(ParamDesc):
+    def __init__(
+        self,
+        key_ptype_str,
+        key_ptype,
+        val_ptype_str,
+        val_ptype,
+        *args,
+        **kwargs,
+    ):
+        if isSimObjectClass(key_ptype) or isSimObjectClass(val_ptype):
+            raise TypeError(
+                f"Can't use a SimObject in '{type(self).__name__}'"
+            )
+
+        super().__init__(*args, **kwargs)
+        self.key_desc = SingleTypeParamDesc(
+            key_ptype_str, key_ptype, desc=self.desc
+        )
+        self.val_desc = SingleTypeParamDesc(
+            val_ptype_str, val_ptype, desc=self.desc
+        )
+
+    @property
+    def ptypes(self):
+        return [self.key_desc.ptype, self.val_desc.ptype]
+
+    # Convert assigned value to appropriate type.  If the RHS is not a
+    # list or tuple, it generates a single-element list.
+    def convert(self, value):
+        if not isinstance(value, dict):
+            raise TypeError("Should be a dict")
+
+        tmp_dict = {
+            self.key_desc.convert(key): self.val_desc.convert(val)
+            for key, val in value.items()
+        }
+
+        return DictParamValue(tmp_dict)
+
+    # Produce a human readable example string that describes
+    # how to set this vector parameter in the absence of a default
+    # value.
+    def example_str(self):
+        k = self.key_desc.example_str()
+        v = self.val_desc.example_str()
+        help_str = "{" + k + ":" + v + ", ...}"
+        return help_str
+
+    # Is the param available to be exposed on the command line
+    def isCmdLineSettable(self):
+        return getattr(
+            self.key_desc.ptype, "cmd_line_settable", False
+        ) and getattr(self.val_desc.ptype, "cmd_line_settable", False)
+
+    # Produce a human readable representation of the value of this vector param.
+    def pretty_print(self, value):
+        if not isinstance(value, dict):
+            raise TypeError("Should be a dict")
+
+        tmp_dict = {
+            self.key_desc.pretty_print(key): self.val_desc.pretty_print(val)
+            for key, val in value.items()
+        }
+
+        return pprint.pformat(tmp_dict)
+
+    # This is a helper function for the new config system
+    def __call__(self, value):
+        return self.convert(value)
+
+    def cxx_predecls(self, code):
+        code("#include <unordered_map>", add_once=True)
+        self.key_desc.ptype.cxx_predecls(code)
+        self.val_desc.ptype.cxx_predecls(code)
+
+    def pybind_predecls(self, code):
+        code("#include <unordered_map>", add_once=True)
+        self.key_desc.ptype.pybind_predecls(code)
+        self.val_desc.ptype.pybind_predecls(code)
+
+    def cxx_decl(self, code):
+        ktype = self.key_desc.ptype.cxx_type
+        vtype = self.val_desc.ptype.cxx_type
+        code("std::unordered_map<${{ktype}}, ${{vtype}}> ${{self.name}};")
 
 
 class ParamFactory:
@@ -488,9 +604,77 @@ class ParamFactory:
         return self.param_desc_class(self.ptype_str, ptype, *args, **kwargs)
 
 
+class DictParamFactory:
+    """
+    Factory class whose purpose is to store the (descriptor
+    class+key_type+value_type), and to generate the descriptor object
+    once arguments are passed (via the __call__). Last item in the
+    chain of factory classes
+
+    DictParamKeyFactory -> DictParamValueFactory -> DictParamFactory
+    """
+
+    def __init__(self, param_desc_class, key_ptype_str, val_ptype_str):
+        self.param_desc_class = param_desc_class
+        self.key_ptype_str = key_ptype_str
+        self.val_ptype_str = val_ptype_str
+
+    # E.g., DictParam.Int.String({5: "example string"}, "map of widgets")
+    def __call__(self, *args, **kwargs):
+        key_ptype = None
+        val_ptype = None
+        try:
+            key_ptype = allParams[self.key_ptype_str]
+            val_ptype = allParams[self.val_ptype_str]
+        except KeyError:
+            # if name isn't defined yet, assume it's a SimObject, and
+            # try to resolve it later
+            pass
+        return self.param_desc_class(
+            self.key_ptype_str,
+            key_ptype,
+            self.val_ptype_str,
+            val_ptype,
+            *args,
+            **kwargs,
+        )
+
+
+class DictParamValueFactory:
+    """
+    Factory class whose purpose is to store the (descriptor
+    class+key_type), and to generate a new factory object (DictParamFactory)
+    once a value type is given (via the __getattr__)
+    """
+
+    def __init__(self, param_desc_class, key_ptype_str):
+        self.param_desc_class = param_desc_class
+        self.key_ptype_str = key_ptype_str
+
+    def __getattr__(self, val_ptype_str):
+        return DictParamFactory(
+            self.param_desc_class, self.key_ptype_str, val_ptype_str
+        )
+
+
+class DictParamKeyFactory:
+    """
+    Factory class whose purpose is to store the (descriptor class) and to
+    generate a new factory object DictParamValueFactory once a key type is
+    given (via the __getattr__)
+    """
+
+    def __init__(self, param_desc_class):
+        self.param_desc_class = param_desc_class
+
+    def __getattr__(self, key_ptype_str):
+        return DictParamValueFactory(self.param_desc_class, key_ptype_str)
+
+
 Param = ParamFactory(SingleTypeParamDesc)
 VectorParam = ParamFactory(VectorParamDesc)
 OptionalParam = ParamFactory(OptionalParamDesc)
+DictParam = DictParamKeyFactory(DictParamDesc)
 
 #####################################################################
 #
@@ -2565,6 +2749,7 @@ __all__ = [
     "Param",
     "VectorParam",
     "OptionalParam",
+    "DictParam",
     "Enum",
     "ScopedEnum",
     "Bool",

--- a/src/sim/cxx_config.hh
+++ b/src/sim/cxx_config.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 ARM Limited
+ * Copyright (c) 2014, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -79,13 +79,17 @@ class CxxConfigDirectoryEntry
         /* Is this a vector or singleton parameters/SimObject */
         const bool isVector;
 
+        /* Is this a dictionary */
+        const bool isDict;
+
         /** Is this a SimObject, and so is to be set with setSimObject...
          *  or another from-string parameter set with setParam... */
         const bool isSimObject;
 
         ParamDesc(const std::string &name_,
-            bool isVector_, bool isSimObject_) :
-            name(name_), isVector(isVector_), isSimObject(isSimObject_)
+            bool is_vector, bool is_dict, bool is_simobj)
+          : name(name_), isVector(is_vector),
+            isDict(is_dict), isSimObject(is_simobj)
         { }
     };
 
@@ -179,10 +183,17 @@ class CxxConfigParams
         const std::string &value, const Flags flags)
     { return false; }
 
-    /** As setParamVector but for parameters given as vectors pre-separated
+    /** As setParam but for parameters given as vectors pre-separated
      *  into elements */
     virtual bool setParamVector(const std::string &name,
         const std::vector<std::string> &values, const Flags flags)
+    { return false; }
+
+    /** As setParamVector but for parameters given as dictionaries
+     * pre-separated into elements */
+    virtual bool setParamDict(const std::string &name,
+        const std::unordered_map<std::string, std::string> &values,
+        const Flags flags)
     { return false; }
 
     /** Set the number of connections expected for the named port.  Returns
@@ -217,6 +228,11 @@ class CxxConfigFileBase
     virtual bool getParamVector(const std::string &object_name,
         const std::string &param_name,
         std::vector<std::string> &values) const = 0;
+
+    /** Get a dictionary parameter */
+    virtual bool getParamDict(const std::string &object_name,
+        const std::string &param_name,
+        std::unordered_map<std::string, std::string> &values) const = 0;
 
     /** Get the peer (connected) ports of the named ports */
     virtual bool getPortPeers(const std::string &object_name,

--- a/src/sim/cxx_config_ini.cc
+++ b/src/sim/cxx_config_ini.cc
@@ -35,6 +35,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cassert>
+
 #include "sim/cxx_config_ini.hh"
 
 #include "base/str.hh"
@@ -62,6 +64,32 @@ CxxIniFile::getParamVector(const std::string &object_name,
         std::vector<std::string> sub_object_names;
 
         tokenize(values, value, ' ', true);
+    }
+
+    return ret;
+}
+
+bool
+CxxIniFile::getParamDict(const std::string &object_name,
+    const std::string &param_name,
+    std::unordered_map<std::string, std::string> &values) const
+{
+    std::vector<std::string> vec_values;
+    auto ret = getParamVector(object_name, param_name, vec_values);
+
+    // Fail if number of vector entries is odd as it means we are
+    // missing a key or a value
+    assert(vec_values.size() % 2 == 0);
+
+    if (ret) {
+        for (auto idx = 0; idx < vec_values.size(); idx+=2) {
+            const std::string &key = vec_values[idx];
+            const std::string &val = vec_values[idx + 1];
+
+            panic_if(values.find(key) != values.end(),
+                "Key %s already present in Dict", key);
+            values[key] = val;
+        }
     }
 
     return ret;

--- a/src/sim/cxx_config_ini.hh
+++ b/src/sim/cxx_config_ini.hh
@@ -44,6 +44,10 @@
 #ifndef __SIM_CXX_CONFIG_INI_HH__
 #define __SIM_CXX_CONFIG_INI_HH__
 
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "base/inifile.hh"
 #include "sim/cxx_config.hh"
 
@@ -68,6 +72,15 @@ class CxxIniFile : public CxxConfigFileBase
     bool getParamVector(const std::string &object_name,
         const std::string &param_name,
         std::vector<std::string> &values) const;
+
+    /**
+     * Finds the dictionary parameter of the object in the ini file
+     * and unserializes it into the values argument which is
+     * passed by reference.
+     */
+    bool getParamDict(const std::string &object_name,
+        const std::string &param_name,
+        std::unordered_map<std::string, std::string> &values) const;
 
     bool getPortPeers(const std::string &object_name,
         const std::string &port_name,

--- a/src/sim/cxx_manager.hh
+++ b/src/sim/cxx_manager.hh
@@ -210,6 +210,13 @@ class CxxConfigManager
     SimObject *findObject(const std::string &object_name,
         bool visit_children = false);
 
+    /** Assign a parameter to the named object.
+     *  This is called from within the findObject method */
+    void populateParams(const std::string &object_name,
+        const std::string &instance_name,
+        CxxConfigParams *object_params,
+        const CxxConfigDirectoryEntry::ParamDesc *param);
+
     /** Find the parameters for the named object.  Returns NULL if the
      *  object isn't in the configuration.  For the first call with a
      *  particular object name, a new CxxConfigParams descended object


### PR DESCRIPTION
Until now only two types of SimObject parameters existed in gem5:
Params and VectorParams.

```
class MySimObject:
    [...]
    s_param = Param.Int()
    v_param = VectorParam.Int()
```

If users wanted to have a parameter which associated one piece
of data to another (potentially of different type), they would
have resorted to one of the following solutions:

* bind data together with python methods
* bind data together with 2 VectorParam
* bind data together with VectorParam of SimObject

With this commit we add DictParam, which allows to have dictionaries
as parameters.

A DictParam will have the following syntax:

`v_param = VectorParam.KeyType.ValType()`

This will instruct the build system to add an unordered_map member to the
SimObjectParam struct with matching key/value types:

`std::unordered_map<key.ptype, val.ptype> d_param;`

This effectively means using an integral key type comes for free.
If willing to use a custom type, a hash function has to be provided.
This hasn't been currently tested