### PR TITLE
python: improve error message in SimObject __setattr__

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -418,7 +418,9 @@ class MetaSimObject(type):
             return
 
         # no valid assignment... raise exception
-        raise AttributeError(f"Class {cls.__name__} has no parameter '{attr}'")
+        raise AttributeError(
+            f"Invalid assignment for Class {cls.__name__} with parameter {attr}"
+        )
 
     def __getattr__(cls, attr):
         if attr == "cxx_class_path":
@@ -935,7 +937,8 @@ class SimObject(metaclass=MetaSimObject):
 
         # no valid assignment... raise exception
         raise AttributeError(
-            f"Class {self.__class__.__name__} has no parameter {attr}"
+            f"Invalid assignment for Class {self.__class__.__name__} with"
+            f" parameter {attr}"
         )
 
     # this hack allows tacking a '[0]' onto parameters that may or may


### PR DESCRIPTION
This CL improves the error message when the attr doesn't match the cases above in __setattr__.

Example:
One possible scenario is that User might forget to assign the type_signature for SignalPort:

- correct: port = SignalSourcePort("bool")("port description")
- wrong: port = SignalSourcePort("port description")

And the gem5 can sill be built and error only happens on gem5 runtime when it is actually accessing that port, however the original error message is quite misleading. Hence creating this CL to improve the error message so the user is able to identify the issue easily.