### PR TITLE
dev: Revert 'Adopt OptionalParam for DmaDevice. (#2260)'

### DIFF
--- a/src/dev/Device.py
+++ b/src/dev/Device.py
@@ -100,11 +100,13 @@ class DmaDevice(PioDevice):
 
     _iommu = None
 
-    sid = OptionalParam.Unsigned(
+    sid = Param.Unsigned(
+        0,
         "Stream identifier used by an IOMMU to distinguish amongst "
         "several devices attached to it",
     )
-    ssid = OptionalParam.Unsigned(
+    ssid = Param.Unsigned(
+        0,
         "Substream identifier used by an IOMMU to distinguish amongst "
         "several devices attached to it",
     )


### PR DESCRIPTION
This reverts commit a06dac9560aa0471ba9d6590294c3a7a5421f435 (#2260).

This was causing the Daily SystemC tests to fail (https://github.com/gem5/gem5/actions/runs/15005141307/job/42161741700).

To reproduce:

```sh
docker run -u $UID:$GID -v $(pwd):/workdir -w /workdir -it --rm ghcr.io/gem5/systemc-env:latest scons build/ARM/gem5.opt -j12
docker run -u $UID:$GID -v $(pwd):/workdir -w /workdir -it --rm ghcr.io/gem5/systemc-env:latest scons setconfig build/ARM --ignore-style USE_SYSTEMC=n
docker run -u $UID:$GID -v $(pwd):/workdir -w /workdir -it --rm ghcr.io/gem5/systemc-env:latest scons build/ARM/libgem5_opt.so --with-cxx-config --without-python --without-tcmalloc -j$(nproc) --duplicate-sources
```

Causes error:


```shell
 [   SHCXX] ARM/cxx_config/DmaVirtDevice.cc -> .os
build/ARM/cxx_config/DmaVirtDevice.cc: In member function ‘virtual bool gem5::DmaVirtDeviceCxxConfigParams::setParam(const std::string&, const std::string&, gem5::CxxConfigParams::Flags)’:
build/ARM/cxx_config/DmaVirtDevice.cc:98:24: error: no matching function for call to ‘to_number(const std::string&, std::optional<unsigned int>&)’
   98 |         ret = to_number(value, this->sid);
      |               ~~~~~~~~~^~~~~~~~~~~~~~~~~~
In file included from build/ARM/sim/serialize_handlers.hh:53,
                 from build/ARM/sim/serialize.hh:61,
                 from build/ARM/base/loader/symtab.hh:54,
                 from build/ARM/sim/system.hh:52,
                 from build/ARM/cxx_config/DmaVirtDevice.cc:8:
build/ARM/base/str.hh:174:1: note: candidate: ‘template<class T> std::enable_if_t<(((is_integral_v<T> || is_floating_point_v<T>) || is_enum_v<T>) && (! is_same_v<bool, T>)), bool> gem5::to_number(const std::string&, T&)’
  174 | to_number(const std::string &value, T &retval)
      | ^~~~~~~~~
build/ARM/base/str.hh:174:1: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/13/optional:37,
                 from build/ARM/params/DmaDevice.hh:13,
                 from build/ARM/params/DmaVirtDevice.hh:14,
                 from build/ARM/cxx_config/DmaVirtDevice.cc:7:
/usr/include/c++/13/type_traits: In substitution of ‘template<bool _Cond, class _Tp> using std::enable_if_t = typename std::enable_if::type [with bool _Cond = false; _Tp = bool]’:
build/ARM/base/str.hh:174:1:   required by substitution of ‘template<class T> std::enable_if_t<(((is_integral_v<T> || is_floating_point_v<T>) || is_enum_v<T>) && (! is_same_v<bool, T>)), bool> gem5::to_number(const std::string&, T&) [with T = std::optional<unsigned int>]’
build/ARM/cxx_config/DmaVirtDevice.cc:98:24:   required from here
/usr/include/c++/13/type_traits:2610:11: error: no type named ‘type’ in ‘struct std::enable_if<false, bool>’
 2610 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
      |           ^~~~~~~~~~~
build/ARM/cxx_config/DmaVirtDevice.cc:100:24: error: no matching function for call to ‘to_number(const std::string&, std::optional<unsigned int>&)’
  100 |         ret = to_number(value, this->ssid);
      |               ~~~~~~~~~^~~~~~~~~~~~~~~~~~~
build/ARM/base/str.hh:174:1: note: candidate: ‘template<class T> std::enable_if_t<(((is_integral_v<T> || is_floating_point_v<T>) || is_enum_v<T>) && (! is_same_v<bool, T>)), bool> gem5::to_number(const std::string&, T&)’
  174 | to_number(const std::string &value, T &retval)
      | ^~~~~~~~~
build/ARM/base/str.hh:174:1: note:   template argument deduction/substitution failed:
 [   SHCXX] ARM/cxx_config/QoSMemSinkInterface.cc -> .os
scons: *** [build/ARM/cxx_config/DmaVirtDevice.os] Error 1
scons: building terminated because of errors.
```
