### PR TITLE
gpu-compute,arch-vega: Included two new DS instructions

### DIFF
--- a/src/arch/amdgpu/vega/gpu_registers.cc
+++ b/src/arch/amdgpu/vega/gpu_registers.cc
@@ -86,6 +86,9 @@ namespace VegaISA
           case REG_EXEC_LO:
             reg_sym = "exec";
             break;
+          case REG_EXEC_HI:
+            reg_sym = "exec";
+            break;
           case REG_ZERO:
             reg_sym = "0";
             break;

--- a/src/arch/amdgpu/vega/insts/ds.cc
+++ b/src/arch/amdgpu/vega/insts/ds.cc
@@ -986,6 +986,9 @@ namespace VegaISA
     Inst_DS__DS_ADD_RTN_U32::Inst_DS__DS_ADD_RTN_U32(InFmt_DS *iFmt)
         : Inst_DS(iFmt, "ds_add_rtn_u32")
     {
+        setFlag(MemoryRef);
+        setFlag(AtomicAdd);
+        setFlag(AtomicReturn);
     } // Inst_DS__DS_ADD_RTN_U32
 
     Inst_DS__DS_ADD_RTN_U32::~Inst_DS__DS_ADD_RTN_U32()
@@ -1000,8 +1003,60 @@ namespace VegaISA
     void
     Inst_DS__DS_ADD_RTN_U32::execute(GPUDynInstPtr gpuDynInst)
     {
-        panicUnimplemented();
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decLGKMInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(
+                gpuDynInst->computeUnit()->cyclesToTicks(Cycles(24)));
+        ConstVecOperandU32 addr(gpuDynInst, extData.ADDR);
+        ConstVecOperandU32 data(gpuDynInst, extData.DATA0);
+
+        addr.read();
+        data.read();
+
+        calcAddr(gpuDynInst, addr);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (gpuDynInst->exec_mask[lane]) {
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->a_data))[lane]
+                    = data[lane];
+            }
+        }
+
+        gpuDynInst->computeUnit()->localMemoryPipe.issueRequest(gpuDynInst);
     } // execute
+
+    void
+    Inst_DS__DS_ADD_RTN_U32::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        Addr offset0 = instData.OFFSET0;
+        Addr offset1 = instData.OFFSET1;
+        Addr offset = (offset1 << 8) | offset0;
+
+        initAtomicAccess<VecElemU32>(gpuDynInst, offset);
+    } // initiateAcc
+
+    void
+    Inst_DS__DS_ADD_RTN_U32::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (gpuDynInst->exec_mask[lane]) {
+                // vdst[lane] = 10;
+                vdst[lane] = (reinterpret_cast<VecElemU32*>(
+                    gpuDynInst->d_data))[lane];
+            }
+        }
+
+        vdst.write();
+    } // completeAcc
     // --- Inst_DS__DS_SUB_RTN_U32 class methods ---
 
     Inst_DS__DS_SUB_RTN_U32::Inst_DS__DS_SUB_RTN_U32(InFmt_DS *iFmt)
@@ -1319,6 +1374,9 @@ namespace VegaISA
     Inst_DS__DS_CMPST_RTN_B32::Inst_DS__DS_CMPST_RTN_B32(InFmt_DS *iFmt)
         : Inst_DS(iFmt, "ds_cmpst_rtn_b32")
     {
+        setFlag(MemoryRef);
+        setFlag(AtomicCAS);
+        setFlag(AtomicReturn);
     } // Inst_DS__DS_CMPST_RTN_B32
 
     Inst_DS__DS_CMPST_RTN_B32::~Inst_DS__DS_CMPST_RTN_B32()
@@ -1338,8 +1396,66 @@ namespace VegaISA
     void
     Inst_DS__DS_CMPST_RTN_B32::execute(GPUDynInstPtr gpuDynInst)
     {
-        panicUnimplemented();
+        //panicUnimplemented();
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decLGKMInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(
+                gpuDynInst->computeUnit()->cyclesToTicks(Cycles(24)));
+
+        ConstVecOperandU32 addr(gpuDynInst, extData.ADDR);
+        ConstVecOperandU32 src(gpuDynInst, extData.DATA1);
+        ConstVecOperandU32 cmp(gpuDynInst, extData.DATA0);
+
+        addr.read();
+        src.read();
+        cmp.read();
+        calcAddr(gpuDynInst, addr);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (gpuDynInst->exec_mask[lane]) {
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->x_data))[lane]
+                    = src[lane];
+                (reinterpret_cast<VecElemU32*>(gpuDynInst->a_data))[lane]
+                    = cmp[lane];
+            }
+        }
+
+        gpuDynInst->computeUnit()->localMemoryPipe.issueRequest(gpuDynInst);
+
     } // execute
+    // --- Inst_DS__DS_CMPST_RTN_F32 class methods ---
+
+    void
+    Inst_DS__DS_CMPST_RTN_B32::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        Addr offset0 = instData.OFFSET0;
+        Addr offset1 = instData.OFFSET1;
+        Addr offset = (offset1 << 8) | offset0;
+
+        initAtomicAccess<VecElemU32>(gpuDynInst, offset);
+    } // initiateAcc
+
+    void
+    Inst_DS__DS_CMPST_RTN_B32::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (gpuDynInst->exec_mask[lane]) {
+                vdst[lane] = (reinterpret_cast<VecElemU32*>(
+                    gpuDynInst->d_data))[lane];
+            }
+        }
+
+        vdst.write();
+    } // completeAcc
     // --- Inst_DS__DS_CMPST_RTN_F32 class methods ---
 
     Inst_DS__DS_CMPST_RTN_F32::Inst_DS__DS_CMPST_RTN_F32(InFmt_DS *iFmt)

--- a/src/arch/amdgpu/vega/insts/ds.cc
+++ b/src/arch/amdgpu/vega/insts/ds.cc
@@ -1049,7 +1049,6 @@ namespace VegaISA
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (gpuDynInst->exec_mask[lane]) {
-                // vdst[lane] = 10;
                 vdst[lane] = (reinterpret_cast<VecElemU32*>(
                     gpuDynInst->d_data))[lane];
             }

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -32276,6 +32276,8 @@ namespace VegaISA
         } // getOperandSize
 
         void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
     }; // Inst_DS__DS_ADD_RTN_U32
 
     class Inst_DS__DS_SUB_RTN_U32 : public Inst_DS
@@ -32809,9 +32811,11 @@ namespace VegaISA
             switch (opIdx) {
               case 0: //vgpr_a
                 return 4;
-              case 1: //vgpr_d1
+              case 1: //vgpr_d0
                 return 4;
-              case 2: //vgpr_rtn
+              case 2: //vgpr_d1
+                return 4;
+              case 3: //vgpr_rtn
                 return 4;
               default:
                 fatal("op idx %i out of bounds\n", opIdx);
@@ -32820,6 +32824,8 @@ namespace VegaISA
         } // getOperandSize
 
         void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
     }; // Inst_DS__DS_CMPST_RTN_B32
 
     class Inst_DS__DS_CMPST_RTN_F32 : public Inst_DS


### PR DESCRIPTION
While testing benchmarks on the FS gfx90a model, I needed to add support for two new ds instructions to ensure correct execution. Additionally, since the benchmarks made use of both v_mbcnt_lo_u32_b32 and v_mbcnt_hi_u32_b32, I added REG_EXEC_HI to the relevant register switch-case to properly support these instructions.