### PR TITLE
stdlib: correct memory range check in dramsim3

### DIFF
--- a/src/python/gem5/components/memory/dramsim_3.py
+++ b/src/python/gem5/components/memory/dramsim_3.py
@@ -131,7 +131,7 @@ class SingleChannel(AbstractMemorySystem):
 
     @overrides(AbstractMemorySystem)
     def set_memory_range(self, ranges: List[AddrRange]) -> None:
-        if len(ranges != 1) or ranges[0].size != self._size:
+        if len(ranges) != 1 or ranges[0].size() != self._size:
             raise Exception(
                 "Single channel DRAMSim memory controller requires a single "
                 "range which matches the memory's size."


### PR DESCRIPTION
This pull request addresses a bug in the `set_memory_range` method within `src/python/gem5/components/memory/dramsim_3.py`.

**Description of the issues fixed:**

1.  **Incorrect argument type for `len()` function:**
    The original code `len(ranges != 1)` passed a boolean expression to `len()`. This has been corrected to `len(ranges) != 1` to properly check the number of elements in the `ranges` list.

2.  **Incorrect access to `AddrRange` size:**
    The original code `ranges[0].size` attempted to access `size` as an attribute of an `AddrRange` object. This has been corrected to `ranges[0].size()` to call the appropriate method for retrieving the size.

**Reference to Issue:**
#2273

**Code changes:**

The following line in `src/python/gem5/components/memory/dramsim_3.py`:
```python
if len(ranges != 1) or ranges[0].size != self._size:
```

has been changed to:

```python
if len(ranges) != 1 or ranges[0].size() != self._size:
```

This ensures that the memory range validation logic operates as intended.