### PR TITLE
scons: Add cxx_config support for OptionalParams

### DIFF
--- a/build_tools/cxx_config_cc.py
+++ b/build_tools/cxx_config_cc.py
@@ -238,9 +238,24 @@ for param in sim_object._params.values():
         if not is_simobj and not is_vector:
             code('} else if (name == "${{param.name}}") {')
             code.indent()
-            param.ptype.cxx_ini_parse(
-                code, "value", "this->%s" % param.name, "ret ="
-            )
+            if isinstance(param, m5.params.OptionalParamDesc):
+                nullopt_str = str(m5.params.NullOpt)
+                code('if (value == "${{nullopt_str}}") {')
+                code.indent()
+                code("this->${{param.name}} = std::nullopt;")
+                code("ret = true;")
+                code.dedent()
+                code("} else {")
+                code.indent()
+                param.ptype.cxx_ini_parse(
+                    code, "value", "this->%s.value()" % param.name, "ret ="
+                )
+                code.dedent()
+                code("}")
+            else:
+                param.ptype.cxx_ini_parse(
+                    code, "value", "this->%s" % param.name, "ret ="
+                )
             code.dedent()
 code.dedent()
 


### PR DESCRIPTION
The initial implementation of OptionalParams [1] does not support cxx_config builds and therefore breaks some of our CI tests, as reported by a recent PR [2].

The issue is trying to unserialize a std::optional<int> from a config file (ini). The to_number does not allow a std::optional parameter.

While at the beginning I thought about specializing to_number, I realised this is not generic enough as it covers the std::optional<int/unsigned etc> only cases and it does not cover when the parameter is not a number.

[1]: https://github.com/gem5/gem5/pull/2252
[2]: https://github.com/gem5/gem5/pull/2270


Change-Id: Ibb03e26b9390fbdc5b7a369a1c00d5ff625923ce