### PR TITLE
scons: Use two return booleans for DictParams in cxx_config

### DIFF
--- a/build_tools/cxx_config_cc.py
+++ b/build_tools/cxx_config_cc.py
@@ -319,8 +319,13 @@ for param in sim_object._params.values():
         code.indent()
         code("${{param.key_desc.ptype.cxx_type}} key;")
         code("${{param.val_desc.ptype.cxx_type}} val;")
-        param.key_desc.ptype.cxx_ini_parse(code, "i->first", "key", "ret =")
-        param.val_desc.ptype.cxx_ini_parse(code, "i->second", "val", "ret =")
+        param.key_desc.ptype.cxx_ini_parse(
+            code, "i->first", "key", "bool key_ret ="
+        )
+        param.val_desc.ptype.cxx_ini_parse(
+            code, "i->second", "val", "bool val_ret ="
+        )
+        code("ret = key_ret && val_ret;")
         code("if (ret)")
         code("    this->${{param.name}}[key] = val;")
         code.dedent()


### PR DESCRIPTION
As we are currently reusing the boolean ret local variable to capture the unserialization of both keys and values of a DictParam, we can be in the situation where a failure on extracting the key gets overwritten by the success in extracting the value.

We should use key_ret and val_ret instead, and fail param setup if one of the two extraction fails (& condition)


Change-Id: I26405c4fd563c99f4ff6762a4d4ac3e54a098603