### PR TITLE
stdlib, tests: Fix ruby cache init signature

### DIFF
--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
@@ -64,13 +64,13 @@ class MESIThreeLevelCacheHierarchy(
     def __init__(
         self,
         l1i_size: str,
-        l1i_assoc: str,
+        l1i_assoc: int,
         l1d_size: str,
-        l1d_assoc: str,
+        l1d_assoc: int,
         l2_size: str,
-        l2_assoc: str,
+        l2_assoc: int,
         l3_size: str,
-        l3_assoc: str,
+        l3_assoc: int,
         num_l3_banks: int,
     ):
         AbstractRubyCacheHierarchy.__init__(self=self)

--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_two_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_two_level_cache_hierarchy.py
@@ -64,11 +64,11 @@ class MESITwoLevelCacheHierarchy(
     def __init__(
         self,
         l1i_size: str,
-        l1i_assoc: str,
+        l1i_assoc: int,
         l1d_size: str,
-        l1d_assoc: str,
+        l1d_assoc: int,
         l2_size: str,
-        l2_assoc: str,
+        l2_assoc: int,
         num_l2_banks: int,
     ):
         AbstractRubyCacheHierarchy.__init__(self=self)

--- a/src/python/gem5/components/cachehierarchies/ruby/mi_example_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mi_example_cache_hierarchy.py
@@ -54,7 +54,7 @@ class MIExampleCacheHierarchy(AbstractRubyCacheHierarchy):
     simple point-to-point topology.
     """
 
-    def __init__(self, size: str, assoc: str):
+    def __init__(self, size: str, assoc: int):
         """
         :param size: The size of each cache in the heirarchy.
         :param assoc: The associativity of each cache.

--- a/tests/gem5/replacement_policies/configs/cache_hierarchies.py
+++ b/tests/gem5/replacement_policies/configs/cache_hierarchies.py
@@ -38,7 +38,7 @@ from gem5.utils.override import overrides
 
 class ModMIExampleCacheHierarchy(MIExampleCacheHierarchy):
     def __init__(self, replacement_policy_class: Type[BaseReplacementPolicy]):
-        super().__init__(size="512B", assoc="4")
+        super().__init__(size="512B", assoc=4)
         self._replacement_policy_class = replacement_policy_class
 
     @overrides(MIExampleCacheHierarchy)

--- a/tests/gem5/traffic_gen/configs/simple_traffic_run.py
+++ b/tests/gem5/traffic_gen/configs/simple_traffic_run.py
@@ -126,11 +126,11 @@ def cache_factory(cache_class: str):
 
         return MESITwoLevelCacheHierarchy(
             l1i_size="32KiB",
-            l1i_assoc="8",
+            l1i_assoc=8,
             l1d_size="32KiB",
-            l1d_assoc="8",
+            l1d_assoc=8,
             l2_size="256KiB",
-            l2_assoc="4",
+            l2_assoc=4,
             num_l2_banks=1,
         )
     elif cache_class == "MIExample":
@@ -158,13 +158,13 @@ def cache_factory(cache_class: str):
 
         return MESIThreeLevelCacheHierarchy(
             l1i_size="32KiB",
-            l1i_assoc="8",
+            l1i_assoc=8,
             l1d_size="32KiB",
-            l1d_assoc="8",
+            l1d_assoc=8,
             l2_size="256KiB",
-            l2_assoc="4",
+            l2_assoc=4,
             l3_size="16MiB",
-            l3_assoc="16",
+            l3_assoc=16,
             num_l3_banks=1,
         )
     elif cache_class == "OctopiCache":


### PR DESCRIPTION
The {`l1i`/`l1d`/`l2`/`l3`}`_assoc` arguments in `__init__()` of MESI cache classes have type `str`, which is not consistent with other cache classes in the stdlib (e.g., `AbstractTwoLevelCacheHierarchy`). I have changed the type hints of these arguments to `int`.

Also changed 2 files in `tests` to use `int` instead of `str` to be consistent with the change above.