### PR TITLE
arch-riscv: Add RVV support for riscv32 ISA

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -367,13 +367,13 @@ void ISA::clear()
         case RV64:
           misa.rv64_mxl = 2;
           status.uxl = status.sxl = 2;
-          if (getEnableRvv()) {
-              status.vs = VPUStatus::INITIAL;
-              misa.rvv = 1;
-          }
           break;
         default:
           panic("%s: Unknown _rvType: %d", name(), (int)_rvType);
+    }
+    if (getEnableRvv()) {
+        status.vs = VPUStatus::INITIAL;
+        misa.rvv = 1;
     }
 
     miscRegFile[MISCREG_ISA] = misa;


### PR DESCRIPTION
Previous version configure the mstatus and misa only in riscv64, illegal instruction exception occurs when simulate workload which compiled as riscv-32 target, this commit set the CSR once _'enable_rvv'_ is true
