### PR TITLE
dev: Update MI300X model to use real firmware

### DIFF
--- a/configs/example/gpufs/mi200.py
+++ b/configs/example/gpufs/mi200.py
@@ -50,11 +50,17 @@ export HCC_AMDGPU_TARGET=gfx90a
 free -m
 dmesg -n8
 dd if=/root/roms/mi200.rom of=/dev/mem bs=1k seek=768 count=128
-if [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then
+
+if [ -f /home/gem5/load_amdgpu.sh ]; then
+    sh /home/gem5/load_amdgpu.sh
+elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then
     echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."
     /sbin/m5 exit
+else
+    # Backward compatibility with old disk images (ROCm 6.1)
+    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0
 fi
-modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0
+
 echo "Running {} {}"
 echo "{}" | base64 -d > myapp
 chmod +x myapp

--- a/configs/example/gpufs/mi300.py
+++ b/configs/example/gpufs/mi300.py
@@ -56,15 +56,20 @@ demo_runscript_without_checkpoint = """\
 export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 export HSA_ENABLE_INTERRUPT=0
 export HCC_AMDGPU_TARGET=gfx942
-export HSA_OVERRIDE_GFX_VERSION="9.4.2"
 dmesg -n8
 cat /proc/cpuinfo
-dd if=/root/roms/mi200.rom of=/dev/mem bs=1k seek=768 count=128
-if [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then
+dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128
+
+if [ -f /home/gem5/load_amdgpu.sh ]; then
+    sh /home/gem5/load_amdgpu.sh
+elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then
     echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."
     /sbin/m5 exit
+else
+    # Backward compatibility with old disk images (ROCm 6.1)
+    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2
 fi
-modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0
+
 echo "Running {} {}"
 echo "{}" | base64 -d > myapp
 chmod +x myapp
@@ -78,12 +83,12 @@ export HSA_ENABLE_INTERRUPT=0
 export HCC_AMDGPU_TARGET=gfx942
 export HSA_OVERRIDE_GFX_VERSION="9.4.2"
 dmesg -n8
-dd if=/root/roms/mi200.rom of=/dev/mem bs=1k seek=768 count=128
+dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128
 if [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then
     echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."
     /sbin/m5 exit
 fi
-modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0
+modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2
 echo "Running {} {}"
 echo "{}" | base64 -d > myapp
 chmod +x myapp

--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -83,6 +83,11 @@ def addRunFSOptions(parser):
     )
     parser.add_argument("--kernel", default=None, help="Linux kernel to boot")
     parser.add_argument(
+        "--gpu-ipt",
+        default=None,
+        help="Intended only for gem5 developers. IP discovery table to load",
+    )
+    parser.add_argument(
         "--checkpoint-before-mmios",
         default=False,
         action="store_true",

--- a/configs/example/gpufs/system/amdgpu.py
+++ b/configs/example/gpufs/system/amdgpu.py
@@ -184,6 +184,7 @@ def createGPU(system, args):
 def connectGPU(system, args):
     system.pc.south_bridge.gpu = AMDGPUDevice(pci_func=0, pci_dev=8, pci_bus=0)
 
+    system.pc.south_bridge.gpu.ipt_binary = args.gpu_ipt
     system.pc.south_bridge.gpu.checkpoint_before_mmios = (
         args.checkpoint_before_mmios
     )
@@ -199,9 +200,10 @@ def connectGPU(system, args):
         system.pc.south_bridge.gpu.SubsystemVendorID = 0x1002
         system.pc.south_bridge.gpu.SubsystemID = 0x0C34
     elif args.gpu_device == "MI300X":
-        system.pc.south_bridge.gpu.DeviceID = 0x740F
+        system.pc.south_bridge.gpu.DeviceID = 0x74A1
         system.pc.south_bridge.gpu.SubsystemVendorID = 0x1002
         system.pc.south_bridge.gpu.SubsystemID = 0x0C34
+        system.pc.south_bridge.gpu.BAR5 = PciMemBar(size="2MiB")
     elif args.gpu_device == "Vega10":
         system.pc.south_bridge.gpu.DeviceID = 0x6863
     else:

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -161,7 +161,7 @@ def makeGpuFSSystem(args):
             0x7D000,
         ]
         sdma_sizes = [0x1000] * 8
-    elif args.gpu_device == "MI200" or args.gpu_device == "MI300X":
+    elif args.gpu_device == "MI200":
         num_sdmas = 5
         sdma_bases = [
             0x4980,
@@ -171,6 +171,30 @@ def makeGpuFSSystem(args):
             0x7A000,
         ]
         sdma_sizes = [0x1000] * 5
+    elif args.gpu_device == "MI300X":
+        # These MMIO addresses are based on the IP discovery file associated
+        # with the disk image. Changes to these values require changes to the
+        # discovery file base addresses.
+        num_sdmas = 16
+        sdma_bases = [
+            0x4980,
+            0x6180,
+            0x65000,
+            0x66000,
+            0x84980,
+            0x86180,
+            0xE5000,
+            0xE6000,
+            0x104980,
+            0x106180,
+            0x165000,
+            0x166000,
+            0x184980,
+            0x186180,
+            0x1E5000,
+            0x1E6000,
+        ]
+        sdma_sizes = [0x1000] * num_sdmas
     else:
         m5.util.panic(f"Unknown GPU device {args.gpu_device}")
 
@@ -190,11 +214,56 @@ def makeGpuFSSystem(args):
 
     # Setup PM4 packet processors
     pm4_procs = []
-    pm4_procs.append(
-        PM4PacketProcessor(
-            ip_id=0, mmio_range=AddrRange(start=0xC000, end=0xD000)
+    if args.gpu_device == "MI300X":
+        # These MMIO addresses are based on the IP discovery file associated
+        # with the disk image. Changes to these values require changes to the
+        # discovery file base addresses.
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=0, mmio_range=AddrRange(start=0xC000, end=0xD000)
+            )
         )
-    )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=1, mmio_range=AddrRange(start=0x4C000, end=0x4D000)
+            )
+        )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=2, mmio_range=AddrRange(start=0x8C000, end=0x8D000)
+            )
+        )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=3, mmio_range=AddrRange(start=0xCC000, end=0xCD000)
+            )
+        )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=4, mmio_range=AddrRange(start=0x10C000, end=0x10D000)
+            )
+        )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=5, mmio_range=AddrRange(start=0x14C000, end=0x14D000)
+            )
+        )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=6, mmio_range=AddrRange(start=0x18C000, end=0x18D000)
+            )
+        )
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=7, mmio_range=AddrRange(start=0x1CC000, end=0x1CD000)
+            )
+        )
+    else:
+        pm4_procs.append(
+            PM4PacketProcessor(
+                ip_id=0, mmio_range=AddrRange(start=0xC000, end=0xD000)
+            )
+        )
 
     system.pc.south_bridge.gpu.pm4_pkt_procs = pm4_procs
 

--- a/src/dev/amdgpu/AMDGPU.py
+++ b/src/dev/amdgpu/AMDGPU.py
@@ -81,6 +81,7 @@ class AMDGPUDevice(PciEndpoint):
     InterruptPin = 2
     ExpansionROM = 0
 
+    ipt_binary = Param.String("", "IP table dump from hardware")
     checkpoint_before_mmios = Param.Bool(
         False, "Take a checkpoint before the device begins sending MMIOs"
     )

--- a/src/dev/amdgpu/amdgpu_nbio.cc
+++ b/src/dev/amdgpu/amdgpu_nbio.cc
@@ -98,6 +98,17 @@ AMDGPUNbio::readMMIO(PacketPtr pkt, Addr offset)
       case MI100_INV_ENG17_ACK2:
       case MI100_INV_ENG17_ACK3:
       case MI200_INV_ENG17_ACK2:
+      case MI300X_INV_ENG17_ACK1:
+      case MI300X_INV_ENG17_ACK2:
+      case MI300X_INV_ENG17_ACK3:
+      case MI300X_INV_ENG17_ACK4:
+      case MI300X_INV_ENG17_ACK5:
+      case MI300X_INV_ENG17_ACK6:
+      case MI300X_INV_ENG17_ACK7:
+      case MI300X_INV_ENG17_ACK8:
+      case MI300X_INV_ENG17_ACK9:
+      case MI300X_INV_ENG17_ACK10:
+      case MI300X_INV_ENG17_ACK11:
         pkt->setLE<uint32_t>(0x10001);
         break;
       case VEGA10_INV_ENG17_SEM1:
@@ -113,6 +124,15 @@ AMDGPUNbio::readMMIO(PacketPtr pkt, Addr offset)
         break;
       case AMDGPU_MP1_SMN_C2PMSG_90:
         pkt->setLE<uint32_t>(0x1);
+        break;
+      case MI300X_EPF0_STRAP0:
+        // This contains a revision ID for the chip. It is required for MI300X
+        // to see the GFX target as gfx942 instead of gfx941.
+        if (gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
+          pkt->setLE<uint32_t>(2 << 24);
+        } else {
+          pkt->setLE<uint32_t>(0);
+        }
         break;
       default:
         if (triggered_reads.count(offset)) {

--- a/src/dev/amdgpu/amdgpu_nbio.hh
+++ b/src/dev/amdgpu/amdgpu_nbio.hh
@@ -90,6 +90,19 @@ class AMDGPUDevice;
 #define MI200_INV_ENG17_SEM1                              0x0a288
 #define MI200_INV_ENG17_SEM2                              0x6af88
 
+#define MI300X_INV_ENG17_ACK1                             0x4a298
+#define MI300X_INV_ENG17_ACK2                             0x62f98
+#define MI300X_INV_ENG17_ACK3                             0x8a298
+#define MI300X_INV_ENG17_ACK4                             0xca298
+#define MI300X_INV_ENG17_ACK5                             0x10a298
+#define MI300X_INV_ENG17_ACK6                             0x14a298
+#define MI300X_INV_ENG17_ACK7                             0x18a298
+#define MI300X_INV_ENG17_ACK8                             0x1ca298
+#define MI300X_INV_ENG17_ACK9                             0xe2f98
+#define MI300X_INV_ENG17_ACK10                            0x162f98
+#define MI300X_INV_ENG17_ACK11                            0x1e2f98
+#define MI300X_EPF0_STRAP0                                0x34d8
+
 class AMDGPUNbio
 {
   public:

--- a/src/dev/amdgpu/amdgpu_vm.hh
+++ b/src/dev/amdgpu/amdgpu_vm.hh
@@ -59,6 +59,13 @@
 #define mmVM_CONTEXT0_PAGE_TABLE_END_ADDR_LO32                        0x092b
 #define mmVM_CONTEXT0_PAGE_TABLE_END_ADDR_HI32                        0x092c
 
+#define MI300X_CONTEXT0_PAGE_TABLE_BASE_ADDR_LO32                     0x08cb
+#define MI300X_CONTEXT0_PAGE_TABLE_BASE_ADDR_HI32                     0x08cc
+#define MI300X_CONTEXT0_PAGE_TABLE_START_ADDR_LO32                    0x08eb
+#define MI300X_CONTEXT0_PAGE_TABLE_START_ADDR_HI32                    0x08ec
+#define MI300X_CONTEXT0_PAGE_TABLE_END_ADDR_LO32                      0x090b
+#define MI300X_CONTEXT0_PAGE_TABLE_END_ADDR_HI32                      0x090c
+
 #define mmMC_VM_FB_OFFSET                                             0x096b
 #define mmMC_VM_FB_LOCATION_BASE                                      0x0980
 #define mmMC_VM_FB_LOCATION_TOP                                       0x0981
@@ -67,6 +74,15 @@
 #define mmMC_VM_AGP_BASE                                              0x0984
 #define mmMC_VM_SYSTEM_APERTURE_LOW_ADDR                              0x0985
 #define mmMC_VM_SYSTEM_APERTURE_HIGH_ADDR                             0x0986
+
+#define MI300X_VM_FB_OFFSET                                           0x0947
+#define MI300X_VM_FB_LOCATION_BASE                                    0x095c
+#define MI300X_VM_FB_LOCATION_TOP                                     0x095d
+#define MI300X_VM_AGP_TOP                                             0x095e
+#define MI300X_VM_AGP_BOT                                             0x095f
+#define MI300X_VM_AGP_BASE                                            0x0960
+#define MI300X_VM_SYSTEM_APERTURE_LOW_ADDR                            0x0961
+#define MI300X_VM_SYSTEM_APERTURE_HIGH_ADDR                           0x0962
 
 #define mmMMHUB_VM_INVALIDATE_ENG17_SEM                               0x06e2
 #define mmMMHUB_VM_INVALIDATE_ENG17_REQ                               0x06f4
@@ -84,6 +100,11 @@
 #define MI200_MEM_SIZE_REG                                           0x0378c
 #define MI200_FB_LOCATION_BASE                                       0x6b300
 #define MI200_FB_LOCATION_TOP                                        0x6b304
+
+#define MI300X_MEM_SIZE_REG                                          0x0378c
+#define MI300X_FB_LOCATION_BASE                                      0x63270
+#define MI300X_FB_LOCATION_TOP                                       0x63274
+#define MI300X_VM_INVALIDATE_ENG17_ACK                                0x08a6
 
 // AMD GPUs support 16 different virtual address spaces
 static constexpr int AMDGPU_VM_COUNT = 16;
@@ -173,6 +194,13 @@ class AMDGPUVM : public Serializable
      * the TLBs upon a driver request.
      */
     std::vector<VegaISA::GpuTLB *> gpu_tlbs;
+
+    /**
+     * Different MMIO implements for different GFX versions with overlapping
+     * MMIO addresses.
+     */
+    void writeMMIOGfx900(PacketPtr pkt, Addr offset);
+    void writeMMIOGfx940(PacketPtr pkt, Addr offset);
 
     std::array<AddrRange, NUM_MMIO_RANGES> mmioRanges;
 

--- a/src/dev/amdgpu/pm4_packet_processor.cc
+++ b/src/dev/amdgpu/pm4_packet_processor.cc
@@ -574,7 +574,7 @@ PM4PacketProcessor::releaseMemDone(PM4Queue *q, PM4ReleaseMem *pkt, Addr addr)
         }
         gpuDevice->getIH()->prepareInterruptCookie(pkt->intCtxId, ringId,
                                             SOC15_IH_CLIENTID_GRBM_CP, CP_EOP,
-                                            0);
+                                            2 * getIpId());
         gpuDevice->getIH()->submitInterruptCookie();
     }
 

--- a/src/python/gem5/prebuilt/viper/board.py
+++ b/src/python/gem5/prebuilt/viper/board.py
@@ -176,8 +176,6 @@ class ViperBoard(X86Board):
     # application or script into a bash script setting up the environment and
     # loading the GPU driver.
     def make_gpu_app(self, gpu: BaseViperGPU, app: str, debug: bool = False):
-        driver_load_command = gpu.get_driver_command(debug=debug)
-
         with open(os.path.abspath(app), "rb") as binfile:
             encodedBin = base64.b64encode(binfile.read()).decode()
 
@@ -188,4 +186,4 @@ class ViperBoard(X86Board):
             "/sbin/m5 exit\n"
         )
 
-        return driver_load_command + application_command
+        return application_command


### PR DESCRIPTION
The MI300X model currently is using an MI210 VBIOS and overriding the GFX version to run MI300X ISA. This change updates the config to use a real MI300X VBIOS and discovery table taken from real hardware. This is mostly changing a few IDs and adding MI300X specific MMIOs.

Major differences are multiple command processors will be seen and allows research to experiment with different ways of partitioning the GPUs chiplets into NUMA domains as is possible on hardware.

This requires a new disk image which will be posted on gem5-resources.