### PR TITLE
arch-arm: Initialize the BaseMMU::Mode in TLBTypes::KeyType

### DIFF
--- a/src/arch/arm/pagetable.cc
+++ b/src/arch/arm/pagetable.cc
@@ -495,7 +495,8 @@ TLBTypes::KeyType::KeyType(const TlbEntry &entry)
     vmid(entry.vmid), ss(entry.ss),
     functional(false),
     targetRegime(entry.regime),
-    mode(BaseMMU::Read)
+    mode(entry.type == TypeTLB::instruction ?
+        BaseMMU::Execute : BaseMMU::Read)
 {}
 
 } // namespace ArmISA


### PR DESCRIPTION
The KeyType constructor was not fully initialized when inserting a new TlbEntry from the table walker.

This didn't have a tangible effect as the KeyType::mode was not really used during insertion, and the entry type (instruction/data) is stored in the TlbEntry itself anyway.

Change-Id: I9fe42068806f46e32ccff14d3dfe3a01f5bba053