### PR TITLE
arch-riscv: Fix move scalar to vector tail agnostic behaviour

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -54,6 +54,8 @@ let {{
         '''
     def copyOldVd(vd_idx):
         return 'COPY_OLD_VD(%d);' % vd_idx
+    def copyOldVdIfVL(vd_idx):
+        return 'COPY_OLD_VD_IF_VL(%d);' % vd_idx
     def loopWrapper(code, micro_inst = True):
         if micro_inst:
             upper_bound = "this->microVl"
@@ -1125,14 +1127,23 @@ def format VectorNonSplitFormat(code, category, *flags) {{
     if inst_name == "vfmv" :
         code = fflags_wrapper(code)
 
+    copy_old_vd = ""
+    set_src_reg_idx = ""
+    if name in ["vfmv_s_f", "vmv_s_x"]:
+        copy_old_vd = copyOldVdIfVL(1)
+        set_src_reg_idx = "if(!(machInst.vtype8.vta && this->vl))\n"
+        set_src_reg_idx += setSrcWrapper("vecRegClass[VD]")
+
     if inst_name == "vfmv" :
         varith_template = declareVArithTemplate(Name, 'float', 16)
         iop = InstObjParams(name,
             Name,
             'VectorNonSplitInst',
             {'code': code,
+             'set_src_reg_idx': set_src_reg_idx,
              'vm_decl_rd': vm_decl_rd,
              'set_vm_idx': set_vm_idx,
+             'copy_old_vd': copy_old_vd,
              'declare_varith_template': varith_template},
             flags)
         header_output = VectorNonSplitDeclare.subst(iop)
@@ -1144,8 +1155,10 @@ def format VectorNonSplitFormat(code, category, *flags) {{
             Name,
             'VectorNonSplitInst',
             {'code': code,
+             'set_src_reg_idx': set_src_reg_idx,
              'vm_decl_rd': vm_decl_rd,
              'set_vm_idx': set_vm_idx,
+             'copy_old_vd': copy_old_vd,
              'declare_varith_template': declareVArithTemplate(Name)},
             flags)
         header_output = VectorNonSplitDeclare.subst(iop)

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -31,6 +31,13 @@ output header {{
 #define ASSIGN_VD_BIT(idx, bit) \
     ((Vd[(idx)/8] & ~(1 << (idx)%8)) | ((bit) << (idx)%8))
 
+#define COPY_OLD_VD_IF_VL(idx)                                            \
+    if (machInst.vtype8.vta && this->vl) {                                \
+        tmp_d0.set(0xff);                                                 \
+    } else {                                                              \
+        xc->getRegOperand(this, idx, &tmp_d0);                            \
+    }                                                                     \
+
 #define COPY_OLD_VD(idx)                                                  \
     if (!machInst.vtype8.vta || (!machInst.vm && !machInst.vtype8.vma)) { \
         RiscvISA::vreg_t old_vd;                                          \
@@ -1649,6 +1656,7 @@ template<typename ElemType>
     %(set_reg_idx_arr)s;
     %(constructor)s;
     %(set_vm_idx)s;
+    %(set_src_reg_idx)s;
 }
 
 %(declare_varith_template)s;
@@ -1680,6 +1688,7 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(vm_decl_rd)s;
+    %(copy_old_vd)s;
     %(code)s;
     %(op_wb)s;
     return NoFault;
@@ -1714,6 +1723,7 @@ Fault
     %(op_decl)s;
     %(op_rd)s;
     %(vm_decl_rd)s;
+    %(copy_old_vd)s;
     %(code)s;
     %(op_wb)s;
     return NoFault;


### PR DESCRIPTION
When executing the move scalar to vector instructions with the tail-agnostic policy enabled in RISC-V vector instructions, the tail elements are not being set correctly.

Current Behavior (without patch):

Simulation run with vlen=128 and elen=64.

- Output shows tail elements are all zeros (0x00), whereas in other instructions using the tail-agnostic policy, the tail elements are filled with 0xff.

```
81000: board.processor.cores.core: A0 T0 : 0x80000000 @_start    : c_li t1, 1                 : IntAlu :  D=0x0000000000000001  FetchSeq=1  CPSeq=1  flags=(IsInteger)
81000: board.processor.cores.core: A0 T0 : 0x80000002 @_start+2    : c_li t2, 2                 : IntAlu :  D=0x0000000000000002  FetchSeq=2  CPSeq=2  flags=(IsInteger)
81000: board.processor.cores.core: A0 T0 : 0x80000004 @_start+4    : vsetvli zero, t1, e64, m1, ta, ma : SimdConfig :  D=0x0000000000000001  FetchSeq=3  CPSeq=3  flags=(IsInteger|IsVector|IsControl|IsIndirectControl|IsUncondControl)
90000: board.processor.cores.core: A0 T0 : 0x80000008 @_start+8    : vmv_s_x v0, t1             : SimdMisc :  D=[01000000_00000000_00000000_00000000]  FetchSeq=8  CPSeq=4  flags=(IsInteger|IsVector)
90000: board.processor.cores.core: A0 T0 : 0x8000000c @_start+12    : vmv_s_x v25, t2            : SimdMisc :  D=[02000000_00000000_00000000_00000000]  FetchSeq=9  CPSeq=5  flags=(IsInteger|IsVector)
```
Behavior (with patch):

While the spec doesn't mandate tail elements to be all 1s under a tail-agnostic policy, the typical and expected behavior (as seen in other instructions) is to write 0xff to those elements.

When vl = 1
```
81000: board.processor.cores.core: A0 T0 : 0x80000000 @_start    : c_li t1, 1                 : IntAlu :  D=0x0000000000000001  FetchSeq=1  CPSeq=1  flags=(IsInteger)
81000: board.processor.cores.core: A0 T0 : 0x80000002 @_start+2    : c_li t2, 2                 : IntAlu :  D=0x0000000000000002  FetchSeq=2  CPSeq=2  flags=(IsInteger)
81000: board.processor.cores.core: A0 T0 : 0x80000004 @_start+4    : vsetvli zero, t1, e64, m1, ta, ma : SimdConfig :  D=0x0000000000000001  FetchSeq=3  CPSeq=3  flags=(IsInteger|IsVector|IsControl|IsIndirectControl|IsUncondControl)
90000: board.processor.cores.core: A0 T0 : 0x80000008 @_start+8    : vmv_s_x v0, t1             : SimdMisc :  D=[01000000_00000000_ffffffff_ffffffff]  FetchSeq=8  CPSeq=4  flags=(IsInteger|IsVector)
90000: board.processor.cores.core: A0 T0 : 0x8000000c @_start+12    : vmv_s_x v25, t2            : SimdMisc :  D=[02000000_00000000_ffffffff_ffffffff]  FetchSeq=9  CPSeq=5  flags=(IsInteger|IsVector)
```
As you can see the tail elements are all ffs.
The spec also mentions that if the vl is 0, no elements are updated.Hence I had to create a different copyvd macro which takes the vl into account.

![image](https://github.com/user-attachments/assets/3a577440-3042-459f-a0e4-b91ca57efa99)

When vl = 0 
```
81000: board.processor.cores.core: A0 T0 : 0x80000000 @_start    : c_li t1, 0                 : IntAlu :  D=0x0000000000000000  FetchSeq=1  CPSeq=1  flags=(IsInteger)
81000: board.processor.cores.core: A0 T0 : 0x80000002 @_start+2    : c_li t2, 2                 : IntAlu :  D=0x0000000000000002  FetchSeq=2  CPSeq=2  flags=(IsInteger)
81000: board.processor.cores.core: A0 T0 : 0x80000004 @_start+4    : vsetvli zero, t1, e64, m1, ta, ma : SimdConfig :  D=0x0000000000000000  FetchSeq=3  CPSeq=3  flags=(IsInteger|IsVector|IsControl|IsIndirectControl|IsUncondControl)
90000: board.processor.cores.core: A0 T0 : 0x80000008 @_start+8    : vmv_s_x v0, t1             : SimdMisc :  D=[00000000_00000000_00000000_00000000]  FetchSeq=8  CPSeq=4  flags=(IsInteger|IsVector)
90000: board.processor.cores.core: A0 T0 : 0x8000000c @_start+12    : vmv_s_x v25, t2            : SimdMisc :  D=[00000000_00000000_00000000_00000000]  FetchSeq=9  CPSeq=5  flags=(IsInteger|IsVector)
```

To maintain consistency with other instructions behavior during vector operations, the tail elements should be set to 0xff.






Change-Id: I1e8aa27c0d8ca06a1d45f8ea2d701da1e4013242