### PR TITLE
arch-arm: Implement FEAT_FHM and FEAT_FRINTTS.

### DIFF
--- a/src/arch/arm/ArmSystem.py
+++ b/src/arch/arm/ArmSystem.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009, 2012-2013, 2015-2024 Arm Limited
+# Copyright (c) 2009, 2012-2013, 2015-2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -77,6 +77,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_HPDS",
         "FEAT_VMID16",
         "FEAT_RDM",
+        "FEAT_FHM",  # Optional in Armv8.1
         # Armv8.2
         "FEAT_SVE",
         "FEAT_UAO",
@@ -98,6 +99,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_FLAGM",
         "FEAT_IDST",
         "FEAT_TTST",
+        "FEAT_FRINTTS",  # Optional in Armv8.4
         # Armv8.5
         "FEAT_FLAGM2",
         "FEAT_RNG",
@@ -230,6 +232,7 @@ class Armv81(Armv8):
         "FEAT_HPDS",
         "FEAT_VMID16",
         "FEAT_RDM",
+        "FEAT_FHM",
     ]
 
 
@@ -259,6 +262,7 @@ class Armv84(Armv83):
         "FEAT_FLAGM",
         "FEAT_IDST",
         "FEAT_TTST",
+        "FEAT_FRINTTS",
     ]
 
 

--- a/src/arch/arm/insts/fplib.cc
+++ b/src/arch/arm/insts/fplib.cc
@@ -717,6 +717,46 @@ fp64_process_NaNs3(uint64_t a, uint64_t b, uint64_t c, int mode, int *flags)
     return 0;
 }
 
+static uint32_t
+fp32_convert_default_nan(uint16_t op)
+{
+    uint32_t sgn = op >> (FP16_BITS - 1);
+    uint32_t mnt = FP16_MANT(op);
+
+    mnt = mnt << (FP32_MANT_BITS - FP16_MANT_BITS);
+
+    return fp32_pack(sgn, FP32_EXP_INF, mnt);
+}
+
+static uint32_t
+fp32_process_NaNs3H(uint32_t a, uint16_t b, uint16_t c, int mode, int *flags)
+{
+    int a_exp = FP32_EXP(a);
+    uint32_t a_mnt = FP32_MANT(a);
+    int b_exp = FP16_EXP(b);
+    uint16_t b_mnt = FP16_MANT(b);
+    int c_exp = FP16_EXP(c);
+    uint16_t c_mnt = FP16_MANT(c);
+
+    // Handle signalling NaNs:
+    if (fp32_is_signalling_NaN(a_exp, a_mnt))
+        return fp32_process_NaN(a, mode, flags);
+    if (fp16_is_signalling_NaN(b_exp, b_mnt))
+        return fp32_convert_default_nan(fp16_process_NaN(b, mode, flags));
+    if (fp16_is_signalling_NaN(c_exp, c_mnt))
+        return fp32_convert_default_nan(fp16_process_NaN(c, mode, flags));
+
+    // Handle quiet NaNs:
+    if (fp32_is_NaN(a_exp, a_mnt))
+        return fp32_process_NaN(a, mode, flags);
+    if (fp16_is_NaN(b_exp, b_mnt))
+        return fp32_convert_default_nan(fp16_process_NaN(b, mode, flags));
+    if (fp16_is_NaN(c_exp, c_mnt))
+        return fp32_convert_default_nan(fp16_process_NaN(c, mode, flags));
+
+    return 0;
+}
+
 static uint16_t
 fp16_round_(int sgn, int exp, uint16_t mnt, int rm, int mode, int *flags)
 {
@@ -1831,6 +1871,103 @@ fp64_muladd(uint64_t a, uint64_t b, uint64_t c, int scale,
     x0_mnt = x1_mnt << 1 | !!x0_mnt;
 
     return fp64_round(x_sgn, x_exp + scale, x0_mnt, mode, flags);
+}
+
+static uint32_t
+fp32_muladdh(uint32_t a, uint16_t b, uint16_t c, int scale,
+            int mode, int *flags, bool rm_odd=false)
+{
+    int a_sgn, a_exp, b_sgn, b_exp, c_sgn, c_exp, x_sgn, x_exp, y_sgn, y_exp;
+    uint16_t b_mnt, c_mnt;
+    uint32_t a_mnt, x;
+    uint64_t x_mnt, y_mnt;
+
+    fp32_unpack(&a_sgn, &a_exp, &a_mnt, a, mode, flags);
+    fp16_unpack(&b_sgn, &b_exp, &b_mnt, b, mode, flags);
+    fp16_unpack(&c_sgn, &c_exp, &c_mnt, c, mode, flags);
+
+    x = fp32_process_NaNs3H(a, b, c, mode, flags);
+
+    // Quiet NaN added to product of zero and infinity:
+    if (fp32_is_quiet_NaN(a_exp, a_mnt) &&
+        ((!b_mnt && fp16_is_infinity(c_exp, c_mnt)) ||
+         (!c_mnt && fp16_is_infinity(b_exp, b_mnt)))) {
+        x = fp32_defaultNaN();
+        *flags |= FPLIB_IOC;
+    }
+
+    if (x) {
+        return x;
+    }
+
+    // Handle infinities and zeroes:
+    if ((b_exp == FP16_EXP_INF && !c_mnt) ||
+        (c_exp == FP16_EXP_INF && !b_mnt) ||
+        (a_exp == FP32_EXP_INF &&
+         (b_exp == FP16_EXP_INF || c_exp == FP16_EXP_INF) &&
+         (a_sgn != (b_sgn ^ c_sgn)))) {
+        *flags |= FPLIB_IOC;
+        return fp32_defaultNaN();
+    }
+    if (a_exp == FP32_EXP_INF)
+        return fp32_infinity(a_sgn);
+    if (b_exp == FP16_EXP_INF || c_exp == FP16_EXP_INF)
+        return fp32_infinity(b_sgn ^ c_sgn);
+    if (!a_mnt && (!b_mnt || !c_mnt) && a_sgn == (b_sgn ^ c_sgn))
+        return fp32_zero(a_sgn);
+
+    x_sgn = a_sgn;
+    x_exp = a_exp + 2 * FP32_EXP_BITS - 3;
+    x_mnt = (uint64_t)a_mnt << (FP32_MANT_BITS + 4);
+
+    // Multiply:
+    y_sgn = b_sgn ^ c_sgn;
+    y_exp = b_exp + c_exp - 2 * FP16_EXP_BIAS + 2 * FP32_EXP_BIAS -
+        FP32_EXP_BIAS + 2 * FP32_EXP_BITS + 1 - 3;
+    y_mnt = (uint64_t)b_mnt * c_mnt << (3 +
+        (FP32_MANT_BITS - FP16_MANT_BITS) * 2);
+    if (!y_mnt) {
+        y_exp = x_exp;
+    }
+
+    // Add:
+    if (x_exp >= y_exp) {
+        y_mnt = (lsr64(y_mnt, x_exp - y_exp) |
+                 !!(y_mnt & (lsl64(1, x_exp - y_exp) - 1)));
+        y_exp = x_exp;
+    } else {
+        x_mnt = (lsr64(x_mnt, y_exp - x_exp) |
+                 !!(x_mnt & (lsl64(1, y_exp - x_exp) - 1)));
+        x_exp = y_exp;
+    }
+    if (x_sgn == y_sgn) {
+        x_mnt = x_mnt + y_mnt;
+    } else if (x_mnt >= y_mnt) {
+        x_mnt = x_mnt - y_mnt;
+    } else {
+        x_sgn ^= 1;
+        x_mnt = y_mnt - x_mnt;
+    }
+
+    if (!x_mnt) {
+        // Sign of exact zero result depends on rounding mode
+        if (rm_odd) {
+            return fp32_zero(x_sgn);
+        } else {
+            return fp32_zero((mode & 3) == 2);
+        }
+    }
+
+    // Normalise into FP32_BITS bits, collapsing error into bottom bit:
+    x_mnt = fp64_normalise(x_mnt, &x_exp);
+    x_mnt = x_mnt >> (FP32_BITS - 1) | !!(uint32_t)(x_mnt << 1);
+
+    if (rm_odd) {
+        return fp32_round_(x_sgn, x_exp + scale, x_mnt,
+                           FPRounding_ODD, mode, flags);
+    } else {
+        return fp32_round(x_sgn, x_exp + scale, x_mnt, mode, flags);
+    }
 }
 
 static uint16_t
@@ -2960,6 +3097,17 @@ fplibMulAdd(uint64_t addend, uint64_t op1, uint64_t op2, FPSCR &fpscr)
 {
     int flags = 0;
     uint64_t result = fp64_muladd(addend, op1, op2, 0, modeConv(fpscr), &flags);
+    set_fpscr0(fpscr, flags);
+    return result;
+}
+
+template <>
+uint32_t
+fplibMulAddH(uint32_t addend, uint16_t op1, uint16_t op2, FPSCR &fpscr)
+{
+    int flags = 0;
+    uint32_t result = fp32_muladdh(addend, op1, op2, 0,
+                                   modeConv(fpscr), &flags);
     set_fpscr0(fpscr, flags);
     return result;
 }
@@ -4327,6 +4475,174 @@ fplibRoundInt(uint64_t op, FPRounding rounding, bool exact, FPSCR &fpscr)
 
         if (err && exact)
             flags |= FPLIB_IXC;
+    }
+
+    set_fpscr0(fpscr, flags);
+
+    return result;
+}
+
+template <>
+uint32_t
+fplibRoundIntN(uint32_t op, FPRounding rounding, bool exact, int intsize,
+               FPSCR &fpscr)
+{
+    int expint = FP32_EXP_BIAS + FP32_MANT_BITS;
+    int mode = modeConv(fpscr);
+    int flags = 0;
+    int sgn, exp;
+    uint32_t mnt, result;
+
+    // Unpack using FPCR to determine if subnormals are flushed-to-zero:
+    fp32_unpack(&sgn, &exp, &mnt, op, mode, &flags);
+
+    // Handle NaNs, infinities and zeroes:
+    if (fp32_is_NaN(exp, mnt)) {
+        result = fp32_pack(1, FP32_EXP_BIAS + intsize - 1, 0);
+        flags |= FPLIB_IOC;
+    } else if (exp == FP32_EXP_INF) {
+        result = fp32_pack(1, FP32_EXP_BIAS + intsize - 1, 0);
+        flags |= FPLIB_IOC;
+    } else if (!mnt) {
+        result = fp32_zero(sgn);
+    } else if (exp >= expint) {
+        // There are no fractional bits
+        result = op;
+        bool overflow = (exp > (FP32_EXP_BIAS + intsize - 2) && !sgn) ||
+                        (exp > (FP32_EXP_BIAS + intsize - 1) && sgn) ||
+                        (exp > (FP32_EXP_BIAS + intsize - 2) &&
+                            FP32_MANT(op) > 0 && sgn);
+        if (overflow) {
+            result = fp32_pack(1, FP32_EXP_BIAS + intsize - 1, 0);
+            flags |= FPLIB_IOC;
+        }
+    } else {
+        // Truncate towards zero:
+        uint32_t x = expint - exp >= FP32_BITS ? 0 : mnt >> (expint - exp);
+        int err = exp < expint - FP32_BITS ? 1 :
+            ((mnt << 1 >> (expint - exp - 1) & 3) |
+             ((uint32_t)(mnt << 2 << (FP32_BITS + exp - expint)) != 0));
+        switch (rounding) {
+          case FPRounding_TIEEVEN:
+            x += (err == 3 || (err == 2 && (x & 1)));
+            break;
+          case FPRounding_POSINF:
+            x += err && !sgn;
+            break;
+          case FPRounding_NEGINF:
+            x += err && sgn;
+            break;
+          case FPRounding_ZERO:
+            break;
+          case FPRounding_TIEAWAY:
+            x += err >> 1;
+            break;
+          default:
+            panic("Unrecognized FP rounding mode");
+        }
+
+        bool overflow = (x > (((uint32_t)1 << (intsize - 1)) - 1) && !sgn) ||
+                        (x > ((uint32_t)1 << (intsize - 1)) && sgn);
+        if (overflow) {
+            result = fp32_pack(1, FP32_EXP_BIAS + intsize - 1, 0);
+            flags |= FPLIB_IOC;
+        } else {
+            if (x == 0) {
+                result = fp32_zero(sgn);
+            } else {
+                exp = expint;
+                mnt = fp32_normalise(x, &exp);
+                result = fp32_pack(sgn, exp + FP32_EXP_BITS,
+                                   mnt >> FP32_EXP_BITS);
+            }
+
+            if (err && exact)
+                flags |= FPLIB_IXC;
+        }
+    }
+
+    set_fpscr0(fpscr, flags);
+
+    return result;
+}
+
+template <>
+uint64_t
+fplibRoundIntN(uint64_t op, FPRounding rounding, bool exact, int intsize,
+               FPSCR &fpscr)
+{
+    int expint = FP64_EXP_BIAS + FP64_MANT_BITS;
+    int mode = modeConv(fpscr);
+    int flags = 0;
+    int sgn, exp;
+    uint64_t mnt, result;
+
+    // Unpack using FPCR to determine if subnormals are flushed-to-zero:
+    fp64_unpack(&sgn, &exp, &mnt, op, mode, &flags);
+
+    // Handle NaNs, infinities and zeroes:
+    if (fp64_is_NaN(exp, mnt)) {
+        result = fp64_pack(1, FP64_EXP_BIAS + intsize - 1, 0);
+        flags |= FPLIB_IOC;
+    } else if (exp == FP64_EXP_INF) {
+        result = fp64_pack(1, FP64_EXP_BIAS + intsize - 1, 0);
+        flags |= FPLIB_IOC;
+    } else if (!mnt) {
+        result = fp64_zero(sgn);
+    } else if (exp >= expint) {
+        // There are no fractional bits
+        result = op;
+        bool overflow = (exp > (FP64_EXP_BIAS + intsize - 2) && !sgn) ||
+                        (exp > (FP64_EXP_BIAS + intsize - 1) && sgn) ||
+                        (exp > (FP64_EXP_BIAS + intsize - 2) &&
+                            FP64_MANT(op) > 0 && sgn);
+        if (overflow && intsize >= 0) {
+            result = fp64_pack(1, FP64_EXP_BIAS + intsize - 1, 0);
+            flags |= FPLIB_IOC;
+        }
+    } else {
+        // Truncate towards zero:
+        uint64_t x = expint - exp >= FP64_BITS ? 0 : mnt >> (expint - exp);
+        int err = exp < expint - FP64_BITS ? 1 :
+            ((mnt << 1 >> (expint - exp - 1) & 3) |
+             ((uint64_t)(mnt << 2 << (FP64_BITS + exp - expint)) != 0));
+        switch (rounding) {
+          case FPRounding_TIEEVEN:
+            x += (err == 3 || (err == 2 && (x & 1)));
+            break;
+          case FPRounding_POSINF:
+            x += err && !sgn;
+            break;
+          case FPRounding_NEGINF:
+            x += err && sgn;
+            break;
+          case FPRounding_ZERO:
+            break;
+          case FPRounding_TIEAWAY:
+            x += err >> 1;
+            break;
+          default:
+            panic("Unrecognized FP rounding mode");
+        }
+
+        bool overflow = (x > (((uint64_t)1 << (intsize - 1)) - 1) && !sgn) ||
+                        (x > ((uint64_t)1 << (intsize - 1)) && sgn);
+        if (overflow) {
+            result = fp64_pack(1, FP64_EXP_BIAS + intsize - 1, 0);
+            flags |= FPLIB_IOC;
+        } else {
+            if (x == 0) {
+                result = fp64_zero(sgn);
+            } else {
+                exp = expint;
+                mnt = fp64_normalise(x, &exp);
+                result = fp64_pack(sgn, exp + FP64_EXP_BITS,
+                                   mnt >> FP64_EXP_BITS);
+            }
+
+            if (err && exact)
+                flags |= FPLIB_IXC;
+        }
     }
 
     set_fpscr0(fpscr, flags);

--- a/src/arch/arm/insts/fplib.hh
+++ b/src/arch/arm/insts/fplib.hh
@@ -121,6 +121,8 @@ T fplibMul(T op1, T op2, FPSCR &fpscr);
 /** Floating-point multiply-add. */
 template <class T>
 T fplibMulAdd(T addend, T op1, T op2, FPSCR &fpscr);
+template <class T1, class T2>
+T2 fplibMulAddH(T2 addend, T1 op1, T1 op2, FPSCR &fpscr);
 /** Floating-point multiply extended. */
 template <class T>
 T fplibMulX(T op1, T op2, FPSCR &fpscr);
@@ -145,6 +147,10 @@ T fplibRecpX(T op, FPSCR &fpscr);
 /**  Floating-point convert to integer. */
 template <class T>
 T fplibRoundInt(T op, FPRounding rounding, bool exact, FPSCR &fpscr);
+/**  Floating-point convert to integer. */
+template <class T>
+T fplibRoundIntN(T op, FPRounding rounding, bool exact, int intsize,
+                 FPSCR &fpscr);
 /** Floating-point adjust exponent. */
 template <class T>
 T fplibScale(T op1, T op2, FPSCR &fpscr);
@@ -291,6 +297,9 @@ template <>
 uint64_t fplibMulAdd(uint64_t addend, uint64_t op1, uint64_t op2,
                      FPSCR &fpscr);
 template <>
+uint32_t fplibMulAddH(uint32_t addend, uint16_t op1, uint16_t op2,
+                      FPSCR &fpscr);
+template <>
 uint16_t fplibMulX(uint16_t op1, uint16_t op2, FPSCR &fpscr);
 template <>
 uint32_t fplibMulX(uint32_t op1, uint32_t op2, FPSCR &fpscr);
@@ -341,6 +350,12 @@ uint32_t fplibRoundInt(uint32_t op, FPRounding rounding, bool exact,
 template <>
 uint64_t fplibRoundInt(uint64_t op, FPRounding rounding, bool exact,
                        FPSCR &fpscr);
+template <>
+uint32_t fplibRoundIntN(uint32_t op, FPRounding rounding, bool exact,
+                        int intsize, FPSCR &fpscr);
+template <>
+uint64_t fplibRoundIntN(uint64_t op, FPRounding rounding, bool exact,
+                        int intsize, FPSCR &fpscr);
 template <>
 uint16_t fplibScale(uint16_t op1, uint16_t op2, FPSCR &fpscr);
 template <>

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -3129,6 +3129,30 @@ namespace Aarch64
             else if (type == 1) // FRINTI Dd = roundToIntegral(Dn)
                 return new FRIntID(machInst, rd, rn);
             break;
+          case 0x10:
+            if (type == 0) // FRINT32Z
+                return new FRInt32ZS(machInst, rd, rn);
+            else if (type == 1) // FRINT32Z
+                return new FRInt32ZD(machInst, rd, rn);
+            break;
+          case 0x11:
+            if (type == 0) // FRINT32X
+                return new FRInt32XS(machInst, rd, rn);
+            else if (type == 1) // FRINT32X
+                return new FRInt32XD(machInst, rd, rn);
+            break;
+          case 0x12:
+            if (type == 0) // FRINT64Z
+                return new FRInt64ZS(machInst, rd, rn);
+            else if (type == 1) // FRINT64Z
+                return new FRInt64ZD(machInst, rd, rn);
+            break;
+          case 0x13:
+            if (type == 0) // FRINT64X
+                return new FRInt64XS(machInst, rd, rn);
+            else if (type == 1) // FRINT64X
+                return new FRInt64XD(machInst, rd, rn);
+            break;
           default:
             return new Unknown64(machInst);
         }

--- a/src/arch/arm/isa/formats/fp.isa
+++ b/src/arch/arm/isa/formats/fp.isa
@@ -373,7 +373,34 @@ let {{
             switch (op1_op2) {
               case 2: case 3: case 6: case 7:
                 if (u) {
-                    return new Unknown64(machInst);
+                    if (op1_op2 == 2) {
+                        if (q) {
+                            return new NVfmalQ<uint16_t>(machInst, vd, vn, vm);
+                        } else {
+                            vn = (RegIndex)((bits(machInst, 19, 16) << 1) |
+                                             bits(machInst, 7));
+                            vm = (RegIndex)((bits(machInst, 3, 0) << 1) |
+                                             bits(machInst, 5));
+                            return new NVfmalD<uint16_t>(machInst, vd, vn, vm);
+                        }
+                    } else if (op1_op2 == 3) {
+                        if (q)
+                            return new VfmatQ<uint32_t>(machInst, vd, vn, vm);
+                        else
+                            return new VfmabQ<uint32_t>(machInst, vd, vn, vm);
+                    } else if (op1_op2 == 6) {
+                        if (q) {
+                            return new NVfmslQ<uint16_t>(machInst, vd, vn, vm);
+                        } else {
+                            vn = (RegIndex)((bits(machInst, 19, 16) << 1) |
+                                             bits(machInst, 7));
+                            vm = (RegIndex)((bits(machInst, 3, 0) << 1) |
+                                             bits(machInst, 5));
+                            return new NVfmslD<uint16_t>(machInst, vd, vn, vm);
+                        }
+                    } else {
+                        return new Unknown64(machInst);
+                    }
                 } else {
                     // VCMLA
                     bool s = bits (machInst, 20);
@@ -505,7 +532,50 @@ let {{
             vm = (RegIndex)(2 * bits(machInst, 2, 0));
 
             if (u) {
-                return new Unknown64(machInst);
+                if (op1_op2 == 0) {
+                    if (q) {
+                        vm = (RegIndex)(2 * bits(machInst, 2, 0));
+                        uint8_t index = (bits(machInst, 5) << 1) |
+                                         bits(machInst, 3);
+                        return new NVfmalElemQ<uint16_t>(
+                            machInst, vd, vn, vm, index);
+                    } else {
+                        vn = (RegIndex)((bits(machInst, 19, 16) << 1) |
+                                          bits(machInst, 7));
+                        vm = (RegIndex)((bits(machInst, 2, 0) << 1) |
+                                          bits(machInst, 5));
+                        uint8_t index = bits(machInst, 3);
+                        return new NVfmalElemD<uint16_t>(
+                            machInst, vd, vn, vm, index);
+                    }
+                } else if (op1_op2 == 1) {
+                    if (q) {
+                        vm = (RegIndex)(2 * bits(machInst, 2, 0));
+                        uint8_t index = (bits(machInst, 5) << 1) |
+                                         bits(machInst, 3);
+                        return new NVfmslElemQ<uint16_t>(
+                            machInst, vd, vn, vm, index);
+                    } else {
+                        vn = (RegIndex)((bits(machInst, 19, 16) << 1) |
+                                          bits(machInst, 7));
+                        vm = (RegIndex)((bits(machInst, 2, 0) << 1) |
+                                          bits(machInst, 5));
+                        uint8_t index = bits(machInst, 3);
+                        return new NVfmslElemD<uint16_t>(
+                            machInst, vd, vn, vm, index);
+                    }
+                } else if (op1_op2 == 3) {
+                    vm = (RegIndex)(2 * bits(machInst, 2, 0));
+                    uint8_t index = bits(machInst, 5);
+                    if (q)
+                        return new VfmatElemQ<uint32_t>(
+                            machInst, vd, vn, vm, index);
+                    else
+                        return new VfmabElemQ<uint32_t>(
+                            machInst, vd, vn, vm, index);
+                } else {
+                    return new Unknown64(machInst);
+                }
             } else {
                 // VCMLA by element
                 bool s = bits (machInst, 23);

--- a/src/arch/arm/isa/formats/neon64.isa
+++ b/src/arch/arm/isa/formats/neon64.isa
@@ -542,17 +542,37 @@ namespace Aarch64
             }
           case 0x19:
             if (size < 0x2) {
-                if (u || sz_q == 0x2)
-                    return new Unknown64(machInst);
-                else
+                if (u) {
+                    if (size == 0) {
+                        if (q)
+                            return new Fmlal2QX<uint16_t>(
+                                machInst, vd, vn, vm);
+                        else
+                            return new Fmlal2DX<uint16_t>(
+                                machInst, vd, vn, vm);
+                    } else {
+                        return new Unknown64(machInst);
+                    }
+                } else {
                     return decodeNeonUThreeFpReg<FmlaDX, FmlaQX>(
                         q, size & 0x1, machInst, vd, vn, vm);
+                }
             } else {
-                if (u || sz_q == 0x2)
-                    return new Unknown64(machInst);
-                else
+                if (u) {
+                    if (size == 2) {
+                        if (q)
+                            return new Fmlsl2QX<uint16_t>(
+                                machInst, vd, vn, vm);
+                        else
+                            return new Fmlsl2DX<uint16_t>(
+                                machInst, vd, vn, vm);
+                    } else {
+                        return new Unknown64(machInst);
+                    }
+                } else {
                     return decodeNeonUThreeFpReg<FmlsDX, FmlsQX>(
                         q, size & 0x1, machInst, vd, vn, vm);
+                }
             }
           case 0x1a:
             if (sz_q == 0x2)
@@ -600,17 +620,33 @@ namespace Aarch64
             }
           case 0x1d:
             if (size < 0x2) {
-                if (u)
+                if (u) {
                     return decodeNeonUThreeFpReg<FacgeDX, FacgeQX>(
                         q, size & 0x1, machInst, vd, vn, vm);
-                else
-                    return new Unknown64(machInst);
+                } else {
+                    if (size == 0) {
+                        if (q)
+                            return new FmlalQX<uint16_t>(machInst, vd, vn, vm);
+                        else
+                            return new FmlalDX<uint16_t>(machInst, vd, vn, vm);
+                    } else {
+                        return new Unknown64(machInst);
+                    }
+                }
             } else {
-                if (u)
+                if (u) {
                     return decodeNeonUThreeFpReg<FacgtDX, FacgtQX>(
                         q, size & 0x1, machInst, vd, vn, vm);
-                else
-                    return new Unknown64(machInst);
+                } else {
+                    if (size == 2) {
+                        if (q)
+                            return new FmlslQX<uint16_t>(machInst, vd, vn, vm);
+                        else
+                            return new FmlslDX<uint16_t>(machInst, vd, vn, vm);
+                    } else {
+                        return new Unknown64(machInst);
+                    }
+                }
             }
           case 0x1e:
             if (sz_q == 0x2)
@@ -1108,6 +1144,20 @@ namespace Aarch64
                 return decodeNeonUTwoMiscFpReg<FrecpeDX, FrecpeQX>(
                     q, size & 0x1, machInst, vd, vn);
             }
+          case 0x1e:
+            if (size < 0x2) {
+                return decodeNeonUTwoMiscFpReg<Frint32zDX, Frint32zQX>(
+                    q, size & 0x1, machInst, vd, vn);
+            } else {
+                return new Unknown64(machInst);
+            }
+          case 0x1f:
+            if (size < 0x2) {
+                return decodeNeonUTwoMiscFpReg<Frint64zDX, Frint64zQX>(
+                    q, size & 0x1, machInst, vd, vn);
+            } else {
+                return new Unknown64(machInst);
+            }
           case 0x20:
             if (op + size >= 3)
                 return new Unknown64(machInst);
@@ -1267,11 +1317,21 @@ namespace Aarch64
             else
                 return decodeNeonUTwoMiscFpReg<FrsqrteDX, FrsqrteQX>(
                     q, size & 0x1, machInst, vd, vn);
-          case 0x3f:
-            if (size < 0x2 || sz_q == 0x2)
+          case 0x3e:
+            if (size < 0x2) {
+                return decodeNeonUTwoMiscFpReg<Frint32xDX, Frint32xQX>(
+                    q, size & 0x1, machInst, vd, vn);
+            } else {
                 return new Unknown64(machInst);
-            return decodeNeonUTwoMiscFpReg<FsqrtDX, FsqrtQX>(
-                q, size & 0x1, machInst, vd, vn);
+            }
+          case 0x3f:
+            if (size < 0x2) {
+                return decodeNeonUTwoMiscFpReg<Frint64xDX, Frint64xQX>(
+                    q, size & 0x1, machInst, vd, vn);
+            } else {
+                return decodeNeonUTwoMiscFpReg<FsqrtDX, FsqrtQX>(
+                    q, size & 0x1, machInst, vd, vn);
+            }
           default:
             return new Unknown64(machInst);
         }
@@ -1610,11 +1670,26 @@ namespace Aarch64
 
         switch (opcode) {
           case 0x0:
-            if (!u || (size == 0x0 || size == 0x3))
-                return new Unknown64(machInst);
-            else
-                return decodeNeonUThreeImmHAndWReg<MlaElemDX, MlaElemQX>(
-                    q, size, machInst, vd, vn, vm, index);
+            if (u) {
+                if (size == 0x0 || size == 0x3) {
+                    return new Unknown64(machInst);
+                } else {
+                    return decodeNeonUThreeImmHAndWReg<MlaElemDX, MlaElemQX>(
+                        q, size, machInst, vd, vn, vm, index);
+                }
+            } else {
+                if (size != 0x2) {
+                    return new Unknown64(machInst);
+                } else {
+                    index = (H << 2) | (L << 1) | M;
+                    if (q)
+                        return new FmlalElemQX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                    else
+                        return new FmlalElemDX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                }
+            }
           case 0x1:
             if (!u && sz_q != 0x2 && sz_L != 0x3) {
                 return decodeNeonUThreeImmFpReg<FmlaElemDX, FmlaElemQX>(
@@ -1677,11 +1752,26 @@ namespace Aarch64
                                                    SqdmlalElem2X>(
                     q, size, machInst, vd, vn, vm, index);
           case 0x4:
-            if (u && !(size == 0x0 || size == 0x3))
-                return decodeNeonUThreeImmHAndWReg<MlsElemDX, MlsElemQX>(
-                    q, size, machInst, vd, vn, vm, index);
-            else
-                return new Unknown64(machInst);
+            if (u) {
+                if (size == 0x0 || size == 0x3) {
+                    return new Unknown64(machInst);
+                } else {
+                    return decodeNeonUThreeImmHAndWReg<MlsElemDX, MlsElemQX>(
+                        q, size, machInst, vd, vn, vm, index);
+                }
+            } else {
+                if (size != 0x2) {
+                    return new Unknown64(machInst);
+                } else {
+                    index = (H << 2) | (L << 1) | M;
+                    if (q)
+                        return new FmlslElemQX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                    else
+                        return new FmlslElemDX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                }
+            }
           case 0x5:
             if (!u && sz_L != 0x3 && sz_q != 0x2) {
                 return decodeNeonUThreeImmFpReg<FmlsElemDX, FmlsElemQX>(
@@ -1743,11 +1833,26 @@ namespace Aarch64
                                                    SqdmlslElem2X>(
                     q, size, machInst, vd, vn, vm, index);
           case 0x8:
-            if (u || (size == 0x0 || size == 0x3))
-                return new Unknown64(machInst);
-            else
-                return decodeNeonUThreeImmHAndWReg<MulElemDX, MulElemQX>(
-                    q, size, machInst, vd, vn, vm, index);
+            if (u) {
+                if (size != 0x2) {
+                    return new Unknown64(machInst);
+                } else {
+                    index = (H << 2) | (L << 1) | M;
+                    if (q)
+                        return new Fmlal2ElemQX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                    else
+                        return new Fmlal2ElemDX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                }
+            } else {
+                if (size == 0x0 || size == 0x3) {
+                    return new Unknown64(machInst);
+                } else {
+                    return decodeNeonUThreeImmHAndWReg<MulElemDX, MulElemQX>(
+                        q, size, machInst, vd, vn, vm, index);
+                }
+            }
           case 0x9:
             if (sz_q != 0x2 && sz_L != 0x3) {
                 if (u)
@@ -1776,12 +1881,27 @@ namespace Aarch64
                     <SqdmullElemX, SqdmullElem2X>(
                         q, size, machInst, vd, vn, vm, index);
           case 0xc:
-            if (u || (size == 0x0 || size == 0x3))
-                return new Unknown64(machInst);
-            else
-                return decodeNeonSThreeImmHAndWReg
-                    <SqdmulhElemDX, SqdmulhElemQX>(
-                        q, size, machInst, vd, vn, vm, index);
+            if (u) {
+                if (size != 0x2) {
+                    return new Unknown64(machInst);
+                } else {
+                    index = (H << 2) | (L << 1) | M;
+                    if (q)
+                        return new Fmlsl2ElemQX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                    else
+                        return new Fmlsl2ElemDX<uint16_t>(machInst,
+                            vd, vn, vm_bf, index);
+                }
+            } else {
+                if (size == 0x0 || size == 0x3) {
+                    return new Unknown64(machInst);
+                } else {
+                    return decodeNeonSThreeImmHAndWReg
+                        <SqdmulhElemDX, SqdmulhElemQX>(
+                            q, size, machInst, vd, vn, vm, index);
+                }
+            }
           case 0xd:
             if (u)
                 return decodeNeonSThreeImmHAndWReg<SqrdmlahElemDX,

--- a/src/arch/arm/isa/insts/fp64.isa
+++ b/src/arch/arm/isa/insts/fp64.isa
@@ -510,6 +510,56 @@ let {{
         "fplibRoundInt<uint16_t>(cOp1, FPCRRounding(fpscr), true, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPCRRounding(fpscr), true, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPCRRounding(fpscr), true, fpscr)")
+
+    def buildSimpleUnaryFpOpFrintts(name, Name, base, opClass, singleOp,
+                              doubleOp = None, isIntConv = True):
+        if doubleOp is None:
+            doubleOp = singleOp
+        global header_output, decoder_output, exec_output
+
+        if isIntConv:
+            sCode = singleIntConvCode
+            dCode = doubleIntConvCode
+        else:
+            sCode = singleCode
+            dCode = doubleCode
+
+        frintts_check = '''
+        AA64ISAR1 isar1 = xc->tcBase()->readMiscReg(MISCREG_ID_AA64ISAR1_EL1);
+        if (!isar1.frintts)
+            return std::make_shared<UndefinedInstruction>(machInst, true);
+        '''
+        for code, op, suffix in [[sCode, singleOp, "S"],
+                                 [dCode, doubleOp, "D"]]:
+            iop = ArmInstObjParams(name, Name + suffix, base,
+                { "code": frintts_check + code % { "op": op },
+                  "op_class": opClass }, [])
+            iop.snippets["code"] += zeroSveVecRegUpperPartCode % "AA64FpDest"
+
+            declareTempl     = eval(         base + "Declare");
+            constructorTempl = eval("AA64" + base + "Constructor");
+
+            header_output  += declareTempl.subst(iop)
+            decoder_output += constructorTempl.subst(iop)
+            exec_output    += BasicExecute.subst(iop)
+
+    buildSimpleUnaryFpOpFrintts("frint32z", "FRInt32Z", "FpRegRegOp",
+        "FloatMiscOp",
+        "fplibRoundIntN<uint32_t>(cOp1, FPRounding_ZERO, true, 32, fpscr)",
+        "fplibRoundIntN<uint64_t>(cOp1, FPRounding_ZERO, true, 32, fpscr)")
+    buildSimpleUnaryFpOpFrintts("frint32x", "FRInt32X", "FpRegRegOp",
+        "FloatMiscOp",
+        "fplibRoundIntN<uint32_t>(cOp1, FPCRRounding(fpscr), true, 32, fpscr)",
+        "fplibRoundIntN<uint64_t>(cOp1, FPCRRounding(fpscr), true, 32, fpscr)")
+
+    buildSimpleUnaryFpOpFrintts("frint64z", "FRInt64Z", "FpRegRegOp",
+        "FloatMiscOp",
+        "fplibRoundIntN<uint32_t>(cOp1, FPRounding_ZERO, true, 64, fpscr)",
+        "fplibRoundIntN<uint64_t>(cOp1, FPRounding_ZERO, true, 64, fpscr)")
+    buildSimpleUnaryFpOpFrintts("frint64x", "FRInt64X", "FpRegRegOp",
+        "FloatMiscOp",
+        "fplibRoundIntN<uint32_t>(cOp1, FPCRRounding(fpscr), true, 64, fpscr)",
+        "fplibRoundIntN<uint64_t>(cOp1, FPCRRounding(fpscr), true, 64, fpscr)")
 }};
 
 let {{

--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -1365,20 +1365,21 @@ let {{
             exec_output += NeonExecDeclare.subst(substDict)
 
     def threeUnequalRegInst(name, Name, opClass, types, op,
-                            bigSrc1, bigSrc2, bigDest, readDest):
+                            bigSrc1, bigSrc2, bigDest, readDest, short=False,
+                            extra_check=''):
         global header_output, exec_output
-        src1Cnt = src2Cnt = destCnt = 2
+        src1Cnt = src2Cnt = destCnt = 1 if short else 2
         src1Prefix = src2Prefix = destPrefix = ''
         if bigSrc1:
-            src1Cnt = 4
+            src1Cnt = 2 if short else 4
             src1Prefix = 'Big'
         if bigSrc2:
-            src2Cnt = 4
+            src2Cnt = 2 if short else 4
             src2Prefix = 'Big'
         if bigDest:
-            destCnt = 4
+            destCnt = 2 if short else 4
             destPrefix = 'Big'
-        eWalkCode = simdEnabledCheckCode + '''
+        eWalkCode = simdEnabledCheckCode + extra_check + '''
             %sRegVect srcReg1;
             %sRegVect srcReg2;
             %sRegVect destReg;
@@ -1418,7 +1419,7 @@ let {{
         iop = ArmInstObjParams(name, Name,
                                "RegRegRegOp",
                                { "code": eWalkCode,
-                                 "r_count": 2,
+                                 "r_count": 1 if short else 2,
                                  "predicate_test": predicateTest,
                                  "op_class": opClass }, [])
         header_output += NeonRegRegRegOpDeclare.subst(iop)
@@ -1428,17 +1429,20 @@ let {{
                           "class_name" : Name }
             exec_output += NeonExecDeclare.subst(substDict)
 
-    def threeRegNarrowInst(name, Name, opClass, types, op, readDest=False):
+    def threeRegNarrowInst(name, Name, opClass, types, op, readDest=False,
+                           extra_check=''):
         threeUnequalRegInst(name, Name, opClass, types, op,
-                            True, True, False, readDest)
+                            True, True, False, readDest, False, extra_check)
 
-    def threeRegLongInst(name, Name, opClass, types, op, readDest=False):
+    def threeRegLongInst(name, Name, opClass, types, op, readDest=False,
+                         short=False, extra_check=''):
         threeUnequalRegInst(name, Name, opClass, types, op,
-                            False, False, True, readDest)
+                            False, False, True, readDest, short, extra_check)
 
-    def threeRegWideInst(name, Name, opClass, types, op, readDest=False):
+    def threeRegWideInst(name, Name, opClass, types, op, readDest=False,
+                         extra_check=''):
         threeUnequalRegInst(name, Name, opClass, types, op,
-                            True, False, True, readDest)
+                            True, False, True, readDest, False, extra_check)
 
     def twoEqualRegInst(name, Name, opClass, types, rCount, op,
                         readDest=False, extra=''):
@@ -1491,10 +1495,11 @@ let {{
                           "class_name" : Name }
             exec_output += NeonExecDeclare.subst(substDict)
 
-    def twoRegLongInst(name, Name, opClass, types, op, readDest=False):
+    def twoRegLongInst(name, Name, opClass, types, op, readDest=False,
+                       short=False, extra_check=''):
         global header_output, exec_output
-        rCount = 2
-        eWalkCode = simdEnabledCheckCode + '''
+        rCount = 1 if short else 2
+        eWalkCode = simdEnabledCheckCode + extra_check + '''
         RegVect srcReg1, srcReg2;
         BigRegVect destReg = {};
         '''
@@ -3039,6 +3044,25 @@ let {{
     threeEqualRegInst("vfma", "NVfmaQFpH", "SimdFloatMultAccOp", ("uint16_t",),
                       4, vfmafpHCode, True)
 
+    fhm_check = '''
+      RegVal isar6 = xc->tcBase()->readMiscReg(MISCREG_ID_ISAR6);
+      if (!(bits(isar6, 11, 8) == 0x1))
+          return std::make_shared<UndefinedInstruction>(machInst, true);
+    '''
+    vfmalfpCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibMulAddH(destElem, srcElem1, srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeRegLongInst("vfmal", "NVfmalD", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmalfpCode, True, short=True, extra_check=fhm_check)
+    threeRegLongInst("vfmal", "NVfmalQ", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmalfpCode, True, extra_check=fhm_check)
+    twoRegLongInst("vfmal", "NVfmalElemD", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmalfpCode, True, short=True, extra_check=fhm_check)
+    twoRegLongInst("vfmal", "NVfmalElemQ", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmalfpCode, True, extra_check=fhm_check)
+
     vfmsfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         destReg = ternaryOp(fpscr, -srcReg1, srcReg2, destReg, fpMulAdd<float>,
@@ -3057,6 +3081,53 @@ let {{
                       2, vfmsfpHCode, True)
     threeEqualRegInst("vfms", "NVfmsQFpH", "SimdFloatMultAccOp", ("uint16_t",),
                       4, vfmsfpHCode, True)
+
+    vfmslfpCode = '''
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibMulAddH(destElem, fplibNeg(srcElem1), srcElem2, fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeRegLongInst("vfmsl", "NVfmslD", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmslfpCode, True, short=True, extra_check=fhm_check)
+    threeRegLongInst("vfmsl", "NVfmslQ", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmslfpCode, True, extra_check=fhm_check)
+    twoRegLongInst("vfmsl", "NVfmslElemD", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmslfpCode, True, short=True, extra_check=fhm_check)
+    twoRegLongInst("vfmsl", "NVfmslElemQ", "SimdFloatMultAccOp", ("uint16_t",),
+                     vfmslfpCode, True, extra_check=fhm_check)
+
+    vfmabtElemBfCode = '''
+        int sel = %(sel)s;
+        int immsel = bits(machInst, 3);
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+
+        uint32_t src1_elem = (uint16_t)(srcElem1 >> (16 * sel));
+        uint32_t src2_elem = (uint16_t)(srcElem2 >> (16 * immsel));
+        destElem = fplibMulAdd(destElem,
+            (uint32_t)src1_elem << 16, (uint32_t)src2_elem << 16, fpscr);
+
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoEqualRegInst("vfmab", "VfmabElemQ", "SimdMultOp", ("uint32_t",), 4,
+        vfmabtElemBfCode % {"sel": "0"}, True)
+    twoEqualRegInst("vfmat", "VfmatElemQ", "SimdMultOp", ("uint32_t",), 4,
+        vfmabtElemBfCode % {"sel": "1"}, True)
+
+    vfmabtBfCode = '''
+        int sel = %(sel)s;
+        FPSCR fpscr = fpVASimdFPSCRValue((FPSCR)FpscrExc);
+
+        uint32_t src1_elem = (uint16_t)(srcElem1 >> (16 * sel));
+        uint32_t src2_elem = (uint16_t)(srcElem2 >> (16 * sel));
+        destElem = fplibMulAdd(destElem,
+            (uint32_t)src1_elem << 16, (uint32_t)src2_elem << 16, fpscr);
+
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    threeEqualRegInst("vfmab", "VfmabQ", "SimdMultOp", ("uint32_t",), 4,
+        vfmabtBfCode % {"sel": "0"}, True)
+    threeEqualRegInst("vfmat", "VfmatQ", "SimdMultOp", ("uint32_t",), 4,
+        vfmabtBfCode % {"sel": "1"}, True)
 
     vmlsfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -152,30 +152,31 @@ let {{
 
     def threeUnequalRegInstX(name, Name, opClass, types, op,
                              bigSrc1, bigSrc2, bigDest, readDest, scalar=False,
-                             byElem=False, hi=False):
+                             byElem=False, hi=False, short=False,
+                             extra_check=''):
         assert not (scalar and hi)
         global header_output, exec_output
-        src1Cnt = src2Cnt = destCnt = 2
+        src1Cnt = src2Cnt = destCnt = 1 if short else 2
         src1Prefix = src2Prefix = destPrefix = ''
         if bigSrc1:
-            src1Cnt = 4
+            src1Cnt = 2 if short else 4
             src1Prefix = 'Big'
         if bigSrc2:
-            src2Cnt = 4
+            src2Cnt = 2 if short else 4
             src2Prefix = 'Big'
         if bigDest:
-            destCnt = 4
+            destCnt = 2 if short else 4
             destPrefix = 'Big'
         if byElem:
             src2Prefix = 'Full'
-        eWalkCode = simd64EnabledCheckCode + '''
+        eWalkCode = simd64EnabledCheckCode + extra_check + '''
         %sRegVect srcReg1;
         %sRegVect srcReg2;
         %sRegVect destReg;
         ''' % (src1Prefix, src2Prefix, destPrefix)
         srcReg1 = 0
         if hi and not bigSrc1:  # long/widening operations
-            srcReg1 = 2
+            srcReg1 = 1 if short else 2
         for reg in range(src1Cnt):
             eWalkCode += '''
         srcReg1.regs[%(reg)d] = htole(AA64FpOp1P%(srcReg1)d_uw);
@@ -183,7 +184,7 @@ let {{
             srcReg1 += 1
         srcReg2 = 0
         if (not byElem) and (hi and not bigSrc2):  # long/widening operations
-            srcReg2 = 2
+            srcReg2 = 1 if short else 2
         for reg in range(src2Cnt):
             eWalkCode += '''
         srcReg2.regs[%(reg)d] = htole(AA64FpOp2P%(srcReg2)d_uw);
@@ -228,14 +229,14 @@ let {{
         destReg = 0
         if hi and not bigDest:
             # narrowing operations
-            destReg = 2
+            destReg = 1 if short else 2
         for reg in range(destCnt):
             eWalkCode += '''
         AA64FpDestP%(destReg)d_uw = letoh(destReg.regs[%(reg)d]);
         ''' % { "reg" : reg, "destReg": destReg }
             destReg += 1
         if destCnt < 4:
-            if hi:  # Explicitly merge with lower half
+            if hi and not bigDest:  # Explicitly merge with lower half
                 for reg in range(0, destCnt):
                     eWalkCode += '''
         AA64FpDestP%(reg)d_uw = AA64FpDestP%(reg)d_uw;''' % { "reg" : reg }
@@ -247,7 +248,7 @@ let {{
         iop = ArmInstObjParams(name, Name,
                                "DataX2RegImmOp" if byElem else "DataX2RegOp",
                                { "code": eWalkCode,
-                                 "r_count": 2,
+                                 "r_count": 1 if short else 2,
                                  "op_class": opClass }, [])
         iop.snippets["code"] += zeroSveVecRegUpperPartCode % "AA64FpDest"
         if byElem:
@@ -261,36 +262,42 @@ let {{
             exec_output += NeonXExecDeclare.subst(substDict)
 
     def threeRegNarrowInstX(name, Name, opClass, types, op, readDest=False,
-                            scalar=False, byElem=False, hi=False):
+                            scalar=False, byElem=False, hi=False,
+                            extra_check=''):
         assert not byElem
         threeUnequalRegInstX(name, Name, opClass, types, op,
-                             True, True, False, readDest, scalar, byElem, hi)
+                             True, True, False, readDest, scalar, byElem, hi,
+                             False, extra_check)
 
     def threeRegLongInstX(name, Name, opClass, types, op, readDest=False,
-                          scalar=False, byElem=False, hi=False):
+                          scalar=False, byElem=False, hi=False, short=False,
+                          extra_check=''):
         threeUnequalRegInstX(name, Name, opClass, types, op,
-                             False, False, True, readDest, scalar, byElem, hi)
+                             False, False, True, readDest, scalar, byElem, hi,
+                             short, extra_check)
 
     def threeRegWideInstX(name, Name, opClass, types, op, readDest=False,
-                          scalar=False, byElem=False, hi=False):
+                          scalar=False, byElem=False, hi=False,
+                          extra_check=''):
         assert not byElem
         threeUnequalRegInstX(name, Name, opClass, types, op,
-                             True, False, True, readDest, scalar, byElem, hi)
+                             True, False, True, readDest, scalar, byElem, hi,
+                             False, extra_check)
 
     def twoEqualRegInstX(name, Name, opClass, types, rCount, op,
                          readDest=False, scalar=False, byElem=False,
-                         hasImm=False, isDup=False):
+                         hasImm=False, isDup=False, extra_check=''):
         global header_output, exec_output
         assert (not isDup) or byElem
         if byElem:
             hasImm = True
         if isDup:
-            eWalkCode = simd64EnabledCheckCode + '''
+            eWalkCode = simd64EnabledCheckCode + extra_check + '''
         FullRegVect srcReg1;
         RegVect destReg;
         '''
         else:
-            eWalkCode = simd64EnabledCheckCode + '''
+            eWalkCode = simd64EnabledCheckCode + extra_check + '''
         RegVect srcReg1, destReg;
         '''
         for reg in range(4 if isDup else rCount):
@@ -349,21 +356,21 @@ let {{
             exec_output += NeonXExecDeclare.subst(substDict)
 
     def twoRegLongInstX(name, Name, opClass, types, op, readDest=False,
-                        hi=False, hasImm=False):
+                        hi=False, hasImm=False, short=False):
         global header_output, exec_output
         eWalkCode = simd64EnabledCheckCode + '''
         RegVect srcReg1;
         BigRegVect destReg = {};
         '''
-        destReg = 0 if not hi else 2
-        for reg in range(2):
+        destReg = 0 if not hi else 1 if short else 2
+        for reg in range(1 if short else 2):
             eWalkCode += '''
         srcReg1.regs[%(reg)d] = htole(AA64FpOp1P%(destReg)d_uw);
         ''' % { "reg" : reg, "destReg": destReg }
             destReg += 1
-        destReg = 0 if not hi else 2
+        destReg = 0 if not hi else 1 if short else 2
         if readDest:
-            for reg in range(4):
+            for reg in range(2 if short else 4):
                 eWalkCode += '''
         destReg.regs[%(reg)d] = htole(AA64FpDestP%(reg)d_uw);
         ''' % { "reg" : reg }
@@ -380,14 +387,14 @@ let {{
             destReg.elements[i] = htole(destElem);
         }
         ''' % { "op" : op, "readDest" : readDestCode }
-        for reg in range(4):
+        for reg in range(2 if short else 4):
             eWalkCode += '''
         AA64FpDestP%(reg)d_uw = letoh(destReg.regs[%(reg)d]);
         ''' % { "reg" : reg }
         iop = ArmInstObjParams(name, Name,
                                "DataX1RegImmOp" if hasImm else "DataX1RegOp",
                                { "code": eWalkCode,
-                                 "r_count": 2,
+                                 "r_count": 1 if short else 2,
                                  "op_class": opClass }, [])
         iop.snippets["code"] += zeroSveVecRegUpperPartCode % "AA64FpDest"
         if hasImm:
@@ -1758,6 +1765,11 @@ let {{
                       ("uint16_t", "uint32_t"), 4,
                       fminAcrossCode, False, False, True)
     # FMLA (by element)
+    fhm_check = '''
+      AA64ISAR0 isar0 = xc->tcBase()->readMiscReg( MISCREG_ID_AA64ISAR0_EL1);
+      if (!isar0.fhm)
+          return std::make_shared<UndefinedInstruction>(machInst, true);
+    '''
     fmlaCode = fpOp % ("fplibMulAdd<Element>("
                        "destElem, srcElem1, srcElem2, fpscr)")
     threeEqualRegInstX("fmla", "FmlaElemDX", "SimdFloatMultAccOp",
@@ -1771,6 +1783,36 @@ let {{
                        2, fmlaCode, True)
     threeEqualRegInstX("fmla", "FmlaQX", "SimdFloatMultAccOp", floatTypes, 4,
                        fmlaCode, True)
+    # FMLAL (by element)
+    fmlalCode = fpOp % ("fplibMulAddH("
+                       "destElem, srcElem1, srcElem2, fpscr)")
+    threeRegLongInstX("fmlal", "FmlalElemDX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, byElem=True, short=True,
+                      extra_check=fhm_check)
+    threeRegLongInstX("fmlal", "FmlalElemQX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, byElem=True,
+                      extra_check=fhm_check)
+    # FMLAL2 (by element)
+    threeRegLongInstX("fmlal2", "Fmlal2ElemDX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, byElem=True, hi=True,
+                      short=True, extra_check=fhm_check)
+    threeRegLongInstX("fmlal2", "Fmlal2ElemQX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, byElem=True, hi=True,
+                      extra_check=fhm_check)
+    # FMLAL (vector)
+    threeRegLongInstX("fmlal", "FmlalDX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, short=True,
+                      extra_check=fhm_check)
+    threeRegLongInstX("fmlal", "FmlalQX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True,
+                      extra_check=fhm_check)
+    # FMLAL2 (vector)
+    threeRegLongInstX("fmlal2", "Fmlal2DX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, hi=True, short=True,
+                      extra_check=fhm_check)
+    threeRegLongInstX("fmlal2", "Fmlal2QX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlalCode, True, hi=True,
+                      extra_check=fhm_check)
     # FMLS (by element)
     fmlsCode = fpOp % ("fplibMulAdd<Element>(destElem,"
                        " fplibNeg<Element>(srcElem1), srcElem2, fpscr)")
@@ -1785,6 +1827,35 @@ let {{
                        2, fmlsCode, True)
     threeEqualRegInstX("fmls", "FmlsQX", "SimdFloatMultAccOp", floatTypes, 4,
                        fmlsCode, True)
+    # FMLSL (by element)
+    fmlslCode = fpOp % ("fplibMulAddH(destElem, "
+                       "fplibNeg<Element>(srcElem1), srcElem2, fpscr)")
+    threeRegLongInstX("fmlsl", "FmlslElemDX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, byElem=True, short=True,
+                      extra_check=fhm_check)
+    threeRegLongInstX("fmlsl", "FmlslElemQX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, byElem=True,
+                      extra_check=fhm_check)
+    # FMLSL2 (by element)
+    threeRegLongInstX("fmlsl2", "Fmlsl2ElemDX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, byElem=True, hi=True,
+                      short=True, extra_check=fhm_check)
+    threeRegLongInstX("fmlsl2", "Fmlsl2ElemQX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, byElem=True, hi=True,
+                      extra_check=fhm_check)
+    # FMLSL (vector)
+    threeRegLongInstX("fmlsl", "FmlslDX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, short=True,
+                      extra_check=fhm_check)
+    threeRegLongInstX("fmlsl", "FmlslQX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, extra_check=fhm_check)
+    # FMLSL2 (vector)
+    threeRegLongInstX("fmlsl2", "Fmlsl2DX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, hi=True, short=True,
+                      extra_check=fhm_check)
+    threeRegLongInstX("fmlsl2", "Fmlsl2QX", "SimdFloatMultAccOp",
+                      ("uint16_t",), fmlslCode, True, hi=True,
+                      extra_check=fhm_check)
     # FMOV
     fmovCode = 'destElem = imm;'
     oneRegImmInstX("fmov", "FmovDX", "SimdMiscOp", smallFloatTypes, 2,
@@ -1887,6 +1958,43 @@ let {{
                      frintzCode)
     twoEqualRegInstX("frintz", "FrintzQX", "SimdCvtOp", floatTypes, 4,
                      frintzCode)
+    # FRINT32X
+    frintts_check = '''
+      AA64ISAR1 isar1 = xc->tcBase()->readMiscReg( MISCREG_ID_AA64ISAR1_EL1);
+      if (!isar1.frintts)
+          return std::make_shared<UndefinedInstruction>(machInst, true);
+    '''
+    frint32xCode = fpOp % ("fplibRoundIntN<Element>"
+                        "(srcElem1, FPCRRounding(fpscr), true, 32, fpscr)")
+    twoEqualRegInstX("frint32x", "Frint32xDX", "SimdCvtOp", ('uint32_t',), 2,
+                     frint32xCode, extra_check=frintts_check)
+    twoEqualRegInstX("frint32x", "Frint32xQX", "SimdCvtOp",
+                     ('uint32_t', 'uint64_t',), 4,
+                     frint32xCode, extra_check=frintts_check)
+    # FRINT32Z
+    frint32zCode = fpOp % ("fplibRoundIntN<Element>"
+                        "(srcElem1, FPRounding_ZERO, true, 32, fpscr)")
+    twoEqualRegInstX("frint32z", "Frint32zDX", "SimdCvtOp", ('uint32_t',), 2,
+                     frint32zCode, extra_check=frintts_check)
+    twoEqualRegInstX("frint32z", "Frint32zQX", "SimdCvtOp",
+                     ('uint32_t', 'uint64_t',), 4,
+                     frint32zCode, extra_check=frintts_check)
+    # FRINT64X
+    frint64xCode = fpOp % ("fplibRoundIntN<Element>"
+                        "(srcElem1, FPCRRounding(fpscr), true, 64, fpscr)")
+    twoEqualRegInstX("frint64x", "Frint64xDX", "SimdCvtOp", ('uint32_t',), 2,
+                     frint64xCode, extra_check=frintts_check)
+    twoEqualRegInstX("frint64x", "Frint64xQX", "SimdCvtOp",
+                     ('uint32_t', 'uint64_t',), 4,
+                     frint64xCode, extra_check=frintts_check)
+    # FRINT64Z
+    frint64zCode = fpOp % ("fplibRoundIntN<Element>"
+                        "(srcElem1, FPRounding_ZERO, true, 64, fpscr)")
+    twoEqualRegInstX("frint64z", "Frint64zDX", "SimdCvtOp", ('uint32_t',), 2,
+                     frint64zCode, extra_check=frintts_check)
+    twoEqualRegInstX("frint64z", "Frint64zQX", "SimdCvtOp",
+                     ('uint32_t', 'uint64_t',), 4,
+                     frint64zCode, extra_check=frintts_check)
     # FRSQRTE
     frsqrteCode = fpOp % "fplibRSqrtEstimate<Element>(srcElem1, fpscr)"
     twoEqualRegInstX("frsqrte", "FrsqrteDX", "SimdFloatSqrtOp",

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -3577,6 +3577,8 @@ ISA::initializeMiscRegMetadata()
       .reset([p,release=release] () {
         ISAR6 isar6 = p.id_isar6;
         isar6.jscvt = release->has(ArmExtension::FEAT_JSCVT) ? 0x1 : 0x0;
+        isar6.fhm = release->has(ArmExtension::FEAT_FP16) ? 0x1 :
+                    (release->has(ArmExtension::FEAT_FHM) ? 0x1 : 0x0);
         return isar6;
       }())
       .allPrivileges().exceptUserMode().writes(0);
@@ -4969,6 +4971,8 @@ ISA::initializeMiscRegMetadata()
               0x2 : release->has(ArmExtension::FEAT_FLAGM) ?
                   0x1 : 0x0;
           isar0_el1.rndr = release->has(ArmExtension::FEAT_RNG) ? 0x1 : 0x0;
+          isar0_el1.fhm = release->has(ArmExtension::FEAT_FP16) ? 0x1 :
+                          (release->has(ArmExtension::FEAT_FHM) ? 0x1 : 0x0);
           return isar0_el1;
       }())
       .faultRead(EL0, faultIdst)
@@ -4983,6 +4987,8 @@ ISA::initializeMiscRegMetadata()
           isar1_el1.jscvt = release->has(ArmExtension::FEAT_JSCVT) ? 0x1 : 0x0;
           isar1_el1.fcma = release->has(ArmExtension::FEAT_FCMA) ? 0x1 : 0x0;
           isar1_el1.gpa = release->has(ArmExtension::FEAT_PAuth) ? 0x1 : 0x0;
+          isar1_el1.frintts =
+              release->has(ArmExtension::FEAT_FRINTTS) ? 0x1 : 0x0;
           return isar1_el1;
       }())
       .faultRead(EL0, faultIdst)


### PR DESCRIPTION
Add the following instructions:

- FMLAL/FMLAL2, FMLSL/FMLSL2 (by element).
- FMLAL/FMLAL2, FMLSL/FMLSL2 (vector).
- VFMAL/VFMAL2, VFMSL/VFMSL2 (by scalar).
- VFMAL/VFMAL2, VFMSL/VFMSL2 (vector).
- FRINT32Z, FRINT32X, FRINT64Z, FRINT64Z (scalar).
- FRINT32Z, FRINT32X, FRINT64Z, FRINT64Z (vector).

Add the following feature codes:

- FEAT_FHM.
- FEAT_FRINTTS

Arthmetic functionality is added in fplib.hh and fplib.cc.

Change-Id: I57f77e44e89d49745cdd5e84fd968124210dd576