### PR TITLE
dev: Print warn_access message in IsaFake

### DIFF
--- a/src/dev/isa_fake.cc
+++ b/src/dev/isa_fake.cc
@@ -56,8 +56,10 @@ IsaFake::read(PacketPtr pkt)
     pkt->makeAtomicResponse();
 
     if (params().warn_access != "")
-        warn("Device %s accessed by read to address %#x size=%d\n",
-                name(), pkt->getAddr(), pkt->getSize());
+        warn(
+            "Device %s accessed by read to address %#x size=%d. "
+            "Access message: %s\n",
+            name(), pkt->getAddr(), pkt->getSize(), params().warn_access);
     if (params().ret_bad_addr) {
         DPRINTF(IsaFake, "read to bad address va=%#x size=%d\n",
                 pkt->getAddr(), pkt->getSize());
@@ -111,8 +113,10 @@ IsaFake::write(PacketPtr pkt)
           default:
             panic("invalid access size: %u\n", pkt->getSize());
         }
-        warn("Device %s accessed by write to address %#x size=%d data=%#x\n",
-                name(), pkt->getAddr(), pkt->getSize(), data);
+        warn(
+            "Device %s accessed by write to address %#x size=%d data=%#x. "
+            "Access message: %s\n",
+            name(), pkt->getAddr(), pkt->getSize(), data, params().warn_access);
     }
     if (params().ret_bad_addr) {
         DPRINTF(IsaFake, "write to bad address va=%#x size=%d \n",


### PR DESCRIPTION
warn_access parameter is introduced in
https://github.com/gem5/gem5/commit/92c5a5c8cb3a8073546542d67a380ad5ec7d9aee

But actually we didn't print the message. Instead, we use it like a boolean parameter at this moment.

This CL includes hte warn_access message into the warn() message string.

Change-Id: Ie2f14df88b485889cd3a708140b52dc4eeeeffff