### PR TITLE
mem: fixed bug with prefetcher probes

### DIFF
--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, 2022-2024 Arm Limited
+ * Copyright (c) 2013-2014, 2022-2025 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -280,9 +280,9 @@ Base::regProbeListeners()
         listeners.push_back(probeManager->connect<PrefetchListener>(
             *this, "Miss", false, true));
         listeners.push_back(probeManager->connect<PrefetchListener>(
-            *this, "Fill", false, true));
+            *this, "Fill", true, false));
         listeners.push_back(probeManager->connect<PrefetchListener>(
-            *this, "Hit", false, true));
+            *this, "Hit", false, false));
         listeners.push_back(probeManager->connect<PrefetchEvictListener>(
             *this, "Data Update"));
     }


### PR DESCRIPTION
A bug was introduced in [1] causing prefetcher probes to be misconfigured. 
[1] https://github.com/gem5/gem5/pull/1439

Change-Id: I38ff5d95bb7321ba345c7c758e70ef24f25a3582
Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>
Reviewed-by: Richard Cooper <richard.cooper@arm.com>