### PR TITLE
mem,cpu: Make load-to-use constant when L1D hit

### DIFF
--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -275,7 +275,7 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
                "Number of loads and stores written to the Load Store Queue")
 {
     loadToUse
-        .init(0, 299, 10)
+        .init(0, 299, 1)
         .flags(statistics::nozero);
 }
 

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -266,6 +266,13 @@ class BaseCache : public ClockedObject
 
         bool isBlocked() const { return blocked; }
 
+        void schedTimingResp(PacketPtr pkt, Tick when) override {
+            // Do when + 1 to avoid misschedule.
+            // This is the case when several schedules have to be carried out
+            // in the same cycle
+            QueuedResponsePort::schedTimingResp(pkt, when + 1);
+        }
+
       protected:
 
         CacheResponsePort(const std::string &_name, BaseCache& _cache,

--- a/src/mem/qport.hh
+++ b/src/mem/qport.hh
@@ -91,7 +91,7 @@ class QueuedResponsePort : public ResponsePort
      * @param pkt Packet to send
      * @param when Absolute time (in ticks) to send packet
      */
-    void schedTimingResp(PacketPtr pkt, Tick when)
+    virtual void schedTimingResp(PacketPtr pkt, Tick when)
     { respQueue.schedSendTiming(pkt, when); }
 
     /** Check the list of buffered packets against the supplied


### PR DESCRIPTION
**Problem**

We have observed that L1D hit cache latency is not always the same when several requests are made during the same cycle. The first response will be executed before the pipeline `tick()` and the others will be executed with a tick increment.

**Exemple**

```
# Cycle 1054000 : cache schedule 3 resps at 1057000 tick
1054000: system.cpu.dcache: access for ReadReq [800000c8:800000cb] hit state: 6 (E) writable: 1 readable: 1 dirty: 0 prefetched: 0 | tag: 0x40000 secure: 0 valid: 1 | set: 0x3 way: 0
1054000: system.cpu.dcache: handleTimingReqHit: schedule resps : 1057000 tick [REQ A]
1054000: system.cpu.dcache: access for ReadReq [800000c8:800000cb] hit state: 6 (E) writable: 1 readable: 1 dirty: 0 prefetched: 0 | tag: 0x40000 secure: 0 valid: 1 | set: 0x3 way: 0
1054000: system.cpu.dcache: handleTimingReqHit: schedule resps : 1057000 tick [REQ B]
1054000: system.cpu.dcache: access for ReadReq [800000c8:800000cb] hit state: 6 (E) writable: 1 readable: 1 dirty: 0 prefetched: 0 | tag: 0x40000 secure: 0 valid: 1 | set: 0x3 way: 0
1054000: system.cpu.dcache: handleTimingReqHit: schedule resps : 1057000 tick [REQ C]


# Cycle 1057000 Before pipeline evaluate: the first req is received
1057000: system.cpu: Dreq(_____InMemory,Vx800000c8,#x4,[R],Dx1000): Received load/store response [REQ A]
1057000: system.cpu.dcache.cpu_side_port-CpuSidePort: schedule : 1057001

# Cycle 1057000: Evaluate the pipeline (WB loads)
1057000: global: -------------- PIPELINE EVALUATE ---------------

# Cycle 1057000 After pipeline evaluate: the second and third req are received
1057001: system.cpu: Dreq(_____InMemory,Vx800000c8,#x4,[R],Dx1000): Received load/store response [REQ B]
1057001: system.cpu.dcache.cpu_side_port-CpuSidePort: schedule : 1057002

1057002: system.cpu: Dreq(_____InMemory,Vx800000c8,#x4,[R],Dx1000): Received load/store response [REQ C]
1057002: system.cpu.dcache.cpu_side_port-CpuSidePort: schedule : 1057003
```

**Solution**

To fix it, we've increased by one tick the scheduling of the response.

Before applying the patch, the distribution of the load-to-use (O3 model) is as follow (for a loop of load hit):
```
system.cpu.lsq0.loadToUse::4                      739     35.94%     35.94% # Distribution of cycle latency between the first time a load is issued and its completion (Unspecified)
system.cpu.lsq0.loadToUse::5                     1285     62.50%     98.44% # Distribution of cycle latency between the first time a load is issued and its completion (Unspecified)
```

After patch:
```
system.cpu.lsq0.loadToUse::5                     2024     98.44%     98.44% # Distribution of cycle latency between the first time a load is issued and its completion (Unspecified)
```

This patch ensures a constant time between send and recv in case of L1D hit.
Note that this patch increases the latency of a single load by 1.

Another implementation might be to unlock all the ready packets (in `transmitList` in `PacketQueue::sendDeferredPacket()`) in one tick without `schedSendEvent`.

