### PR TITLE
mem: Set default panic callback in port_wrapper

### DIFF
--- a/src/mem/port_wrapper.cc
+++ b/src/mem/port_wrapper.cc
@@ -48,16 +48,12 @@ RequestPortWrapper::recvRangeChange()
 bool
 RequestPortWrapper::recvTimingResp(PacketPtr packet)
 {
-    panic_if(!recvTimingRespCb,
-             "RecvTimingRespCallback in port %s is empty.", name());
     return recvTimingRespCb(packet);
 }
 
 void
 RequestPortWrapper::recvReqRetry()
 {
-    panic_if(!recvReqRetryCb,
-             "RecvReqRetryCallback in port %s is empty.", name());
     recvReqRetryCb();
 }
 
@@ -83,31 +79,24 @@ ResponsePortWrapper::ResponsePortWrapper(const std::string& name, PortID id)
 AddrRangeList
 ResponsePortWrapper::getAddrRanges() const
 {
-    panic_if(!getAddrRangesCb,
-             "GetAddrRangesCallback in port %s is empty.", name());
     return getAddrRangesCb();
 }
 
 bool
 ResponsePortWrapper::recvTimingReq(PacketPtr packet)
 {
-    panic_if(!recvTimingReqCb,
-             "RecvTimingReqCallback in port %s is empty.", name());
     return recvTimingReqCb(packet);
 }
 
 void
 ResponsePortWrapper::recvRespRetry()
 {
-    panic_if(!recvRespRetryCb,
-             "RecvRespRetryCallback in port %s is empty.", name());
     recvRespRetryCb();
 }
 
 Tick
 ResponsePortWrapper::recvAtomic(PacketPtr packet)
 {
-    panic_if(!recvAtomicCb, "RecvAtomicCallback in port %s is empty.", name());
     return recvAtomicCb(packet);
 }
 
@@ -124,8 +113,6 @@ ResponsePortWrapper::recvAtomicBackdoor(PacketPtr packet,
 void
 ResponsePortWrapper::recvFunctional(PacketPtr packet)
 {
-    panic_if(!recvFunctionalCb,
-             "RecvFunctionalCallback in port %s is empty.", name());
     recvFunctionalCb(packet);
 }
 

--- a/src/mem/port_wrapper.hh
+++ b/src/mem/port_wrapper.hh
@@ -93,8 +93,13 @@ class RequestPortWrapper : public RequestPort
 
   private:
     RecvRangeChangeCallback recvRangeChangeCb = nullptr;
-    RecvTimingRespCallback recvTimingRespCb = nullptr;
-    RecvReqRetryCallback recvReqRetryCb = nullptr;
+    RecvTimingRespCallback recvTimingRespCb = [this](PacketPtr) {
+        panic("RecvTimingRespCallback in port %s is empty.", name());
+        return false;
+    };
+    RecvReqRetryCallback recvReqRetryCb = [this]() {
+        panic("RecvReqRetryCallback in port %s is empty.", name());
+    };
 };
 
 /**
@@ -143,12 +148,25 @@ class ResponsePortWrapper : public ResponsePort
                                 RecvMemBackdoorReqCallback = nullptr);
 
   private:
-    GetAddrRangesCallback getAddrRangesCb = nullptr;
-    RecvTimingReqCallback recvTimingReqCb = nullptr;
-    RecvRespRetryCallback recvRespRetryCb = nullptr;
-    RecvAtomicCallback recvAtomicCb = nullptr;
+    GetAddrRangesCallback getAddrRangesCb = [this]() {
+        panic("GetAddrRangesCallback in port %s is empty.", name());
+        return AddrRangeList();
+    };
+    RecvTimingReqCallback recvTimingReqCb = [this](PacketPtr) {
+        panic("RecvTimingReqCallback in port %s is empty.", name());
+        return false;
+    };
+    RecvRespRetryCallback recvRespRetryCb = [this]() {
+        panic("RecvRespRetryCallback in port %s is empty.", name());
+    };
+    RecvAtomicCallback recvAtomicCb = [this](PacketPtr) {
+        panic("RecvAtomicCallback in port %s is empty.", name());
+        return 0;
+    };
     RecvAtomicBackdoorCallback recvAtomicBackdoorCb = nullptr;
-    RecvFunctionalCallback recvFunctionalCb = nullptr;
+    RecvFunctionalCallback recvFunctionalCb = [this](PacketPtr) {
+        panic("RecvFunctionalCallback in port %s is empty.", name());
+    };
     RecvMemBackdoorReqCallback recvMemBackdoorReqCb = nullptr;
 };
 


### PR DESCRIPTION
Context recorded in:
https://github.com/gem5/gem5/pull/2294#pullrequestreview-2861043281

This CL sets the default panic function in each callback function, so that we can reduce the panic_if check during runtime :)

Change-Id: Ie2f14df88b485889cd3a708140b52dc4dddddddd