### PR TITLE
dev: reworks PCI to add a PCI host bridge

### DIFF
--- a/configs/example/arm/devices.py
+++ b/configs/example/arm/devices.py
@@ -501,7 +501,7 @@ class SimpleSystem(BaseSimpleSystem):
         self.system_port = self.membus.cpu_side_ports
 
     def attach_pci(self, dev):
-        self.realview.attachPciDevice(dev, self.iobus)
+        self.realview.attachPciDevice(dev)
 
 
 class ArmRubySystem(BaseSimpleSystem):

--- a/configs/example/gpufs/system/amdgpu.py
+++ b/configs/example/gpufs/system/amdgpu.py
@@ -182,7 +182,7 @@ def createGPU(system, args):
 
 
 def connectGPU(system, args):
-    system.pc.south_bridge.gpu = AMDGPUDevice(pci_func=0, pci_dev=8, pci_bus=0)
+    system.pc.south_bridge.gpu = AMDGPUDevice(pci_func=0, pci_dev=8)
 
     system.pc.south_bridge.gpu.ipt_binary = args.gpu_ipt
     system.pc.south_bridge.gpu.checkpoint_before_mmios = (

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -275,10 +275,12 @@ def makeGpuFSSystem(args):
     system_hub = AMDGPUSystemHub()
     shader.system_hub = system_hub
 
+    # Attach the GPU PCI device to the bus
+    system.pc.attachPciDevice(system.pc.south_bridge.gpu)
+
     # GPU, HSAPP, and GPUCommandProc are DMA devices
     system._dma_ports.append(gpu_hsapp)
     system._dma_ports.append(gpu_cmd_proc)
-    system._dma_ports.append(system.pc.south_bridge.gpu)
     for sdma in sdma_engines:
         system._dma_ports.append(sdma)
     system._dma_ports.append(device_ih)
@@ -293,7 +295,6 @@ def makeGpuFSSystem(args):
 
     gpu_hsapp.pio = system.iobus.mem_side_ports
     gpu_cmd_proc.pio = system.iobus.mem_side_ports
-    system.pc.south_bridge.gpu.pio = system.iobus.mem_side_ports
     for sdma in sdma_engines:
         sdma.pio = system.iobus.mem_side_ports
     device_ih.pio = system.iobus.mem_side_ports

--- a/configs/example/sst/riscv_fs.py
+++ b/configs/example/sst/riscv_fs.py
@@ -102,8 +102,6 @@ def createHiFivePlatform(system):
 
     system.platform = HiFive()
 
-    system.platform.pci_host.pio = system.membus.mem_side_ports
-
     system.platform.rtc = RiscvRTC(frequency=Frequency("10MHz"))
     system.platform.clint.int_pin = system.platform.rtc.int_pin
 
@@ -112,6 +110,9 @@ def createHiFivePlatform(system):
     system.bridge.mem_side_port = system.iobus.cpu_side_ports
     system.bridge.cpu_side_port = system.membus.mem_side_ports
     system.bridge.ranges = system.platform._off_chip_ranges()
+
+    system.iobus.cpu_side_ports = system.platform.pci_host.up_request_port()
+    system.iobus.mem_side_ports = system.platform.pci_host.up_response_port()
 
     system.platform.setNumCores(1)
 

--- a/src/dev/amdgpu/amdgpu_device.cc
+++ b/src/dev/amdgpu/amdgpu_device.cc
@@ -293,25 +293,28 @@ AMDGPUDevice::readConfig(PacketPtr pkt)
                 case sizeof(uint8_t):
                     pkt->setLE<uint8_t>(pxcap.data[pxcap_offset]);
                     DPRINTF(AMDGPUDevice,
-                        "Read PXCAP:  dev %#x func %#x reg %#x 1 bytes: data "
-                        "= %#x\n", _busAddr.dev, _busAddr.func, pxcap_offset,
-                        (uint32_t)pkt->getLE<uint8_t>());
+                            "Read PXCAP:  dev %#x func %#x reg %#x 1 bytes: "
+                            "data = %#x\n",
+                            _devAddr.dev, _devAddr.func, pxcap_offset,
+                            (uint32_t)pkt->getLE<uint8_t>());
                     break;
                 case sizeof(uint16_t):
                     pkt->setLE<uint16_t>(
                         *(uint16_t*)&pxcap.data[pxcap_offset]);
                     DPRINTF(AMDGPUDevice,
-                        "Read PXCAP:  dev %#x func %#x reg %#x 2 bytes: data "
-                        "= %#x\n", _busAddr.dev, _busAddr.func, pxcap_offset,
-                        (uint32_t)pkt->getLE<uint16_t>());
+                            "Read PXCAP:  dev %#x func %#x reg %#x 2 bytes: "
+                            "data = %#x\n",
+                            _devAddr.dev, _devAddr.func, pxcap_offset,
+                            (uint32_t)pkt->getLE<uint16_t>());
                     break;
                 case sizeof(uint32_t):
                     pkt->setLE<uint32_t>(
                         *(uint32_t*)&pxcap.data[pxcap_offset]);
                     DPRINTF(AMDGPUDevice,
-                        "Read PXCAP:  dev %#x func %#x reg %#x 4 bytes: data "
-                        "= %#x\n",_busAddr.dev, _busAddr.func, pxcap_offset,
-                        (uint32_t)pkt->getLE<uint32_t>());
+                            "Read PXCAP:  dev %#x func %#x reg %#x 4 bytes: "
+                            "data = %#x\n",
+                            _devAddr.dev, _devAddr.func, pxcap_offset,
+                            (uint32_t)pkt->getLE<uint32_t>());
                     break;
                 default:
                     panic("Invalid access size (%d) for amdgpu PXCAP %#x\n",
@@ -622,7 +625,7 @@ AMDGPUDevice::writeMMIO(PacketPtr pkt, Addr offset)
 }
 
 Tick
-AMDGPUDevice::read(PacketPtr pkt)
+AMDGPUDevice::readDevice(PacketPtr pkt)
 {
     if (isROM(pkt->getAddr())) {
         readROM(pkt);
@@ -651,7 +654,7 @@ AMDGPUDevice::read(PacketPtr pkt)
 }
 
 Tick
-AMDGPUDevice::write(PacketPtr pkt)
+AMDGPUDevice::writeDevice(PacketPtr pkt)
 {
     if (isROM(pkt->getAddr())) {
         writeROM(pkt);

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -160,6 +160,16 @@ class AMDGPUDevice : public PciEndpoint
     /* Device information */
     GfxVersion gfx_version = GfxVersion::gfx900;
 
+  protected:
+    /**
+     * Methods inherited from PciEndpoint
+     */
+    Tick writeConfig(PacketPtr pkt) override;
+    Tick readConfig(PacketPtr pkt) override;
+
+    Tick readDevice(PacketPtr pkt) override;
+    Tick writeDevice(PacketPtr pkt) override;
+
   public:
     AMDGPUDevice(const AMDGPUDeviceParams &p);
 
@@ -167,12 +177,6 @@ class AMDGPUDevice : public PciEndpoint
      * Methods inherited from PciEndpoint
      */
     void intrPost();
-
-    Tick writeConfig(PacketPtr pkt) override;
-    Tick readConfig(PacketPtr pkt) override;
-
-    Tick read(PacketPtr pkt) override;
-    Tick write(PacketPtr pkt) override;
 
     AddrRangeList getAddrRanges() const override;
 

--- a/src/dev/arm/RealView.py
+++ b/src/dev/arm/RealView.py
@@ -75,6 +75,7 @@ from m5.objects.PciDevice import (
     PciLegacyIoBar,
 )
 from m5.objects.PciHost import *
+from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.PS2 import *
 from m5.objects.Scmi import *
@@ -847,6 +848,9 @@ class RealView(Platform):
     def _off_chip_memory(self):
         return []
 
+    def _platform_pci_devices(self):
+        return []
+
     _off_chip_ranges = []
 
     def _attach_memory(self, mem, bus, mem_ports=None):
@@ -865,6 +869,11 @@ class RealView(Platform):
             else:
                 dma_ports.append(device.dma)
 
+    def _attach_pci_device(self, device, upstream, bus):
+        device.pio = bus.mem_side_ports
+        device.dma = bus.cpu_side_ports
+        device.upstream = upstream
+
     def _attach_io(self, devices, *args, **kwargs):
         for d in devices:
             self._attach_device(d, *args, **kwargs)
@@ -873,12 +882,18 @@ class RealView(Platform):
         for mem in memories:
             self._attach_memory(mem, *args, **kwargs)
 
+    def _attach_pci(self, devices, bus, dma_ports=None):
+        pass
+
     def _attach_clk(self, devices, clkdomain):
         for d in devices:
             if hasattr(d, "clk_domain"):
                 d.clk_domain = clkdomain
 
-    def attachPciDevices(self):
+    def attachPciDevice(self, device):
+        pass
+
+    def attachPlatformPciDevices(self):
         pass
 
     def enableMSIX(self):
@@ -899,6 +914,7 @@ class RealView(Platform):
     def attachIO(self, bus, dma_ports=None, mem_ports=None):
         self._attach_mem(self._off_chip_memory(), bus, mem_ports)
         self._attach_io(self._off_chip_devices(), bus, dma_ports)
+        self._attach_pci(self._platform_pci_devices(), bus, dma_ports)
 
     def setupBootLoader(self, cur_sys, boot_loader, dtb_addr, load_offset):
         cur_sys.workload.boot_loader = boot_loader
@@ -996,6 +1012,7 @@ class VExpress_EMM(RealView):
         conf_device_bits=16,
         pci_pio_base=0,
     )
+    pci_bus = PciBus()
 
     sys_counter = SystemCounter()
     generic_timer = GenericTimer(
@@ -1033,7 +1050,6 @@ class VExpress_EMM(RealView):
         disks=[],
         pci_func=0,
         pci_dev=0,
-        pci_bus=2,
         io_shift=2,
         ctrl_offset=2,
         Command=0x1,
@@ -1063,13 +1079,11 @@ class VExpress_EMM(RealView):
         devices = [
             self.uart,
             self.realview_io,
-            self.pci_host,
             self.timer0,
             self.timer1,
             self.clcd,
             self.kmi0,
             self.kmi1,
-            self.cf_ctrl,
             self.rtc,
             self.vram,
             self.l2x0_fake,
@@ -1084,6 +1098,12 @@ class VExpress_EMM(RealView):
             self.mmc_fake,
             self.energy_ctrl,
         ]
+        return devices
+
+    def _platform_pci_devices(self):
+        devices = [
+            self.cf_ctrl,
+        ]
         # Try to attach the I/O if it exists
         if hasattr(self, "ide"):
             devices.append(self.ide)
@@ -1092,18 +1112,33 @@ class VExpress_EMM(RealView):
         return devices
 
     # Attach any PCI devices that are supported
-    def attachPciDevices(self):
+    def attachPlatformPciDevices(self):
         self.ethernet = IGbE_e1000(
-            pci_bus=0, pci_dev=0, pci_func=0, InterruptLine=1, InterruptPin=1
+            pci_dev=0, pci_func=0, InterruptLine=1, InterruptPin=1
         )
         self.ide = IdeController(
             disks=[],
-            pci_bus=0,
             pci_dev=1,
             pci_func=0,
             InterruptLine=2,
             InterruptPin=2,
         )
+
+    def attachPciDevice(self, device):
+        self._attach_pci_device(device, self.pci_host, self.pci_bus)
+
+    def _attach_pci(self, devices, bus, dma_ports=None):
+        self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
+        self.pci_bus.mem_side_ports = self.pci_host.down_response_port()
+
+        bus.mem_side_ports = self.pci_host.up_response_port()
+        if dma_ports is None:
+            bus.cpu_side_ports = self.pci_host.up_request_port()
+        else:
+            dma_ports.append(self.pci_host.up_request_port())
+
+        for d in devices:
+            self._attach_pci_device(d, self.pci_host, self.pci_bus)
 
     def enableMSIX(self):
         self.gic = Gic400(
@@ -1433,6 +1468,7 @@ class VExpress_GEM5_Base(RealView):
         int_base=100,
         int_count=4,
     )
+    pci_bus = PciBus()
 
     energy_ctrl = EnergyCtrl(pio_addr=0x10000000)
 
@@ -1464,7 +1500,6 @@ class VExpress_GEM5_Base(RealView):
             self.kmi1,
             self.watchdog,
             self.rtc,
-            self.pci_host,
             self.energy_ctrl,
             self.pwr_ctrl,
             self.clock32KHz,
@@ -1483,13 +1518,24 @@ class VExpress_GEM5_Base(RealView):
         self.system_watchdog.clk_domain = self.dcc.osc_sys
         self.watchdog.clk_domain = self.clock32KHz
 
-    def attachPciDevice(self, device, *args, **kwargs):
-        device.host = self.pci_host
+    def attachPciDevice(self, device):
         self._num_pci_dev += 1
-        device.pci_bus = 0
         device.pci_dev = self._num_pci_dev
         device.pci_func = 0
-        self._attach_device(device, *args, **kwargs)
+        self._attach_pci_device(device, self.pci_host, self.pci_bus)
+
+    def _attach_pci(self, devices, bus, dma_ports=None):
+        self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
+        self.pci_bus.mem_side_ports = self.pci_host.down_response_port()
+
+        bus.mem_side_ports = self.pci_host.up_response_port()
+        if dma_ports is None:
+            bus.cpu_side_ports = self.pci_host.up_request_port()
+        else:
+            dma_ports.append(self.pci_host.up_request_port())
+
+        for d in devices:
+            self._attach_pci_device(d, self.pci_host, self.pci_bus)
 
     def attachSmmu(self, devices, bus):
         """

--- a/src/dev/arm/pci_host.cc
+++ b/src/dev/arm/pci_host.cc
@@ -49,13 +49,12 @@ GenericArmPciHost::GenericArmPciHost(const GenericArmPciHostParams &p)
 {
 }
 
-
 uint32_t
-GenericArmPciHost::mapPciInterrupt(const PciBusAddr &addr, PciIntPin pin) const
+GenericArmPciHost::mapPciInterrupt(const PciDevAddr &addr, PciIntPin pin) const
 {
     fatal_if(pin == PciIntPin::NO_INT,
              "%02x:%02x.%i: Interrupt from a device without interrupts\n",
-             addr.bus, addr.dev, addr.func);
+             getBusNum(), addr.dev, addr.func);
 
     switch (intPolicy) {
       case enums::ARM_PCI_INT_STATIC:

--- a/src/dev/arm/pci_host.hh
+++ b/src/dev/arm/pci_host.hh
@@ -55,7 +55,7 @@ class GenericArmPciHost
     virtual ~GenericArmPciHost() {}
 
   protected:
-    uint32_t mapPciInterrupt(const PciBusAddr &addr,
+    uint32_t mapPciInterrupt(const PciDevAddr &addr,
                              PciIntPin pin) const override;
 
   protected:

--- a/src/dev/net/i8254xGBe.cc
+++ b/src/dev/net/i8254xGBe.cc
@@ -167,7 +167,7 @@ IGbE::writeConfig(PacketPtr pkt)
 #define IN_RANGE(val, base, len) (val >= base && val < (base + len))
 
 Tick
-IGbE::read(PacketPtr pkt)
+IGbE::readDevice(PacketPtr pkt)
 {
     int bar;
     Addr daddr;
@@ -355,7 +355,7 @@ IGbE::read(PacketPtr pkt)
 }
 
 Tick
-IGbE::write(PacketPtr pkt)
+IGbE::writeDevice(PacketPtr pkt)
 {
     int bar;
     Addr daddr;

--- a/src/dev/net/i8254xGBe.hh
+++ b/src/dev/net/i8254xGBe.hh
@@ -475,6 +475,12 @@ class IGbE : public EtherDevice
 
     TxDescCache txDescCache;
 
+  protected:
+    Tick readDevice(PacketPtr pkt) override;
+    Tick writeDevice(PacketPtr pkt) override;
+
+    Tick writeConfig(PacketPtr pkt) override;
+
   public:
     PARAMS(IGbE);
 
@@ -486,11 +492,6 @@ class IGbE : public EtherDevice
                   PortID idx=InvalidPortID) override;
 
     Tick lastInterrupt;
-
-    Tick read(PacketPtr pkt) override;
-    Tick write(PacketPtr pkt) override;
-
-    Tick writeConfig(PacketPtr pkt) override;
 
     bool ethRxPkt(EthPacketPtr packet);
     void ethTxDone();

--- a/src/dev/net/ns_gige.cc
+++ b/src/dev/net/ns_gige.cc
@@ -184,7 +184,7 @@ NSGigE::getPort(const std::string &if_name, PortID idx)
  * spec sheet
  */
 Tick
-NSGigE::read(PacketPtr pkt)
+NSGigE::readDevice(PacketPtr pkt)
 {
     assert(ioEnable);
 
@@ -406,7 +406,7 @@ NSGigE::read(PacketPtr pkt)
 }
 
 Tick
-NSGigE::write(PacketPtr pkt)
+NSGigE::writeDevice(PacketPtr pkt)
 {
     assert(ioEnable);
 

--- a/src/dev/net/ns_gige.hh
+++ b/src/dev/net/ns_gige.hh
@@ -330,6 +330,12 @@ class NSGigE : public EtherDevBase
     EventFunctionWrapper *intrEvent;
     NSGigEInt *interface;
 
+  protected:
+    Tick writeConfig(PacketPtr pkt) override;
+
+    Tick readDevice(PacketPtr pkt) override;
+    Tick writeDevice(PacketPtr pkt) override;
+
   public:
     PARAMS(NSGigE);
 
@@ -338,11 +344,6 @@ class NSGigE : public EtherDevBase
 
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
-
-    Tick writeConfig(PacketPtr pkt) override;
-
-    Tick read(PacketPtr pkt) override;
-    Tick write(PacketPtr pkt) override;
 
     bool cpuIntrPending() const;
     void cpuIntrAck() { cpuIntrClear(); }

--- a/src/dev/net/sinic.cc
+++ b/src/dev/net/sinic.cc
@@ -196,7 +196,7 @@ Device::prepareWrite(ContextID cpu, int index)
  * I/O read of device register
  */
 Tick
-Device::read(PacketPtr pkt)
+Device::readDevice(PacketPtr pkt)
 {
     assert(config().command & PCI_CMD_MSE);
 
@@ -287,7 +287,7 @@ Device::iprRead(Addr daddr, ContextID cpu, uint64_t &result)
  * I/O write of device register
  */
 Tick
-Device::write(PacketPtr pkt)
+Device::writeDevice(PacketPtr pkt)
 {
     assert(config().command & PCI_CMD_MSE);
 

--- a/src/dev/net/sinic.hh
+++ b/src/dev/net/sinic.hh
@@ -266,8 +266,8 @@ class Device : public Base
  * Memory Interface
  */
   public:
-    Tick read(PacketPtr pkt) override;
-    Tick write(PacketPtr pkt) override;
+    Tick readDevice(PacketPtr pkt) override;
+    Tick writeDevice(PacketPtr pkt) override;
     virtual void drainResume() override;
 
     void prepareIO(ContextID cpu, int index);

--- a/src/dev/pci/PciDevice.py
+++ b/src/dev/pci/PciDevice.py
@@ -37,7 +37,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.Device import DmaDevice
-from m5.objects.PciHost import PciHost
+from m5.objects.PciUpstream import PciUpstream
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject
@@ -96,8 +96,7 @@ class PciDevice(DmaDevice):
     cxx_header = "dev/pci/device.hh"
     abstract = True
 
-    host = Param.PciHost(Parent.any, "PCI host")
-    pci_bus = Param.Int("PCI bus")
+    upstream = Param.PciUpstream(Parent.any, "PCI upstream")
     pci_dev = Param.Int("PCI device number")
     pci_func = Param.Int("PCI function code")
 

--- a/src/dev/pci/PciHost.py
+++ b/src/dev/pci/PciHost.py
@@ -33,14 +33,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects.Device import PioDevice
+from m5.objects.PciUpstream import PciUpstream
 from m5.objects.Platform import Platform
 from m5.params import *
 from m5.proxy import *
-from m5.SimObject import SimObject
 
 
-class PciHost(PioDevice):
+class PciHost(PciUpstream):
     type = "PciHost"
     cxx_class = "gem5::PciHost"
     cxx_header = "dev/pci/host.hh"

--- a/src/dev/pci/copy_engine.cc
+++ b/src/dev/pci/copy_engine.cc
@@ -168,7 +168,7 @@ CopyEngine::CopyEngineChannel::recvCommand()
 }
 
 Tick
-CopyEngine::read(PacketPtr pkt)
+CopyEngine::readDevice(PacketPtr pkt)
 {
     int bar;
     Addr daddr;
@@ -289,9 +289,8 @@ CopyEngine::CopyEngineChannel::channelRead(Packet *pkt, Addr daddr, int size)
     }
 }
 
-
 Tick
-CopyEngine::write(PacketPtr pkt)
+CopyEngine::writeDevice(PacketPtr pkt)
 {
     int bar;
     Addr daddr;

--- a/src/dev/pci/copy_engine.hh
+++ b/src/dev/pci/copy_engine.hh
@@ -164,6 +164,10 @@ class CopyEngine : public PciEndpoint
     // Array of channels each one with regs/dma port/etc
     std::vector<CopyEngineChannel*> chan;
 
+  protected:
+    Tick readDevice(PacketPtr pkt) override;
+    Tick writeDevice(PacketPtr pkt) override;
+
   public:
     PARAMS(CopyEngine);
     CopyEngine(const Params &params);
@@ -171,9 +175,6 @@ class CopyEngine : public PciEndpoint
 
     Port &getPort(const std::string &if_name,
             PortID idx = InvalidPortID) override;
-
-    Tick read(PacketPtr pkt) override;
-    Tick write(PacketPtr pkt) override;
 
     void serialize(CheckpointOut &cp) const override;
     void unserialize(CheckpointIn &cp) override;

--- a/src/dev/pci/device.hh
+++ b/src/dev/pci/device.hh
@@ -49,8 +49,9 @@
 #include <vector>
 
 #include "dev/dma_device.hh"
-#include "dev/pci/host.hh"
 #include "dev/pci/pcireg.h"
+#include "dev/pci/types.hh"
+#include "dev/pci/upstream.hh"
 #include "params/PciBar.hh"
 #include "params/PciBarNone.hh"
 #include "params/PciBridge.hh"
@@ -84,7 +85,7 @@ class PciBar : public SimObject
     // Accepts a value written to config space, consumes it, and returns what
     // value config space should actually be set to. Both should be in host
     // endian format.
-    virtual uint32_t write(const PciHost::DeviceInterface &host,
+    virtual uint32_t write(const PciUpstream::DeviceInterface &interface,
                            uint32_t val) = 0;
 
     AddrRange range() const { return AddrRange(_addr, _addr + _size); }
@@ -103,7 +104,7 @@ class PciBarNone : public PciBar
     PciBarNone(const PciBarNoneParams &p) : PciBar(p) {}
 
     uint32_t
-    write(const PciHost::DeviceInterface &host, uint32_t val) override
+    write(const PciUpstream::DeviceInterface &interface, uint32_t val) override
     {
         return 0;
     }
@@ -132,7 +133,7 @@ class PciIoBar : public PciBar
     bool isIo() const override { return true; }
 
     uint32_t
-    write(const PciHost::DeviceInterface &host, uint32_t val) override
+    write(const PciUpstream::DeviceInterface &interface, uint32_t val) override
     {
         // Mask away the bits fixed by hardware.
         Bar bar = val & ~(_size - 1);
@@ -141,7 +142,7 @@ class PciIoBar : public PciBar
         bar.io = 1;
 
         // Update our address.
-        _addr = host.pioAddr(bar.addr << 2);
+        _addr = interface.pioAddr(bar.addr << 2);
 
         // Return what should go into config space.
         return bar;
@@ -161,10 +162,10 @@ class PciLegacyIoBar : public PciIoBar
     }
 
     uint32_t
-    write(const PciHost::DeviceInterface &host, uint32_t val) override
+    write(const PciUpstream::DeviceInterface &interface, uint32_t val) override
     {
         // Update the address now that we have a host to translate it.
-        _addr = host.pioAddr(fixedAddr);
+        _addr = interface.pioAddr(fixedAddr);
         // Ignore writes.
         return 0;
     }
@@ -198,7 +199,7 @@ class PciMemBar : public PciBar
     bool isMem() const override { return true; }
 
     uint32_t
-    write(const PciHost::DeviceInterface &host, uint32_t val) override
+    write(const PciUpstream::DeviceInterface &interface, uint32_t val) override
     {
         // Mask away the bits fixed by hardware.
         Bar bar = val & ~(_size - 1);
@@ -211,7 +212,7 @@ class PciMemBar : public PciBar
         _lower = bar.addr << 3;
 
         // Update our address.
-        _addr = host.memAddr(upper() + lower());
+        _addr = interface.memAddr(upper() + lower());
 
         // Return what should go into config space.
         return bar;
@@ -221,13 +222,14 @@ class PciMemBar : public PciBar
     void wide(bool val) { _wide = val; }
 
     uint64_t upper() const { return _upper; }
+
     void
-    upper(const PciHost::DeviceInterface &host, uint32_t val)
+    upper(const PciUpstream::DeviceInterface &interface, uint32_t val)
     {
         _upper = (uint64_t)val << 32;
 
         // Update our address.
-        _addr = host.memAddr(upper() + lower());
+        _addr = interface.memAddr(upper() + lower());
     }
 
     uint64_t lower() const { return _lower; }
@@ -251,7 +253,7 @@ class PciMemUpperBar : public PciBar
     }
 
     uint32_t
-    write(const PciHost::DeviceInterface &host, uint32_t val) override
+    write(const PciUpstream::DeviceInterface &interface, uint32_t val) override
     {
         assert(_lower);
 
@@ -259,7 +261,7 @@ class PciMemUpperBar : public PciBar
         Addr upper = val & ~((_lower->size() - 1) >> 32);
 
         // Let our lower half know about the update.
-        _lower->upper(host, upper);
+        _lower->upper(interface, upper);
 
         return upper;
     }
@@ -288,7 +290,7 @@ class PciDevice : public DmaDevice
     }
 
   protected:
-    const PciBusAddr _busAddr;
+    const PciDevAddr _devAddr;
 
     /** The capability list structures and base addresses
      * @{
@@ -346,26 +348,58 @@ class PciDevice : public DmaDevice
         return false;
     }
 
-  public: // Host configuration interface
+  public:
+    /**
+     * Final implementation of write access from DmaDevice. This function
+     * should not be overriden by the device. For device access
+     * the function PciDevice::writeDevice() should be overriden.
+     * @param pkt Packet describing this request
+     * @return number of ticks it took to complete
+     */
+    Tick write(PacketPtr pkt) final;
+
+    /**
+     * Final implementation of read access from PioDevice. This function
+     * should not be overriden by the device. For device access
+     * the function PciDevice::readDevice() should be overriden.
+     * @param pkt Packet describing this request
+     * @return number of ticks it took to complete
+     */
+    Tick read(PacketPtr pkt) final;
+
+  protected:
     /**
      * Write to the PCI config space data that is stored locally. This may be
      * overridden by the device but at some point it will eventually call this
      * for normal operations that it does not need to override.
-     * @param pkt packet containing the write the offset into config space
+     * @param pkt packet containing the write offset into config space
      */
     virtual Tick writeConfig(PacketPtr pkt);
-
 
     /**
      * Read from the PCI config space data that is stored locally. This may be
      * overridden by the device but at some point it will eventually call this
      * for normal operations that it does not need to override.
-     * @param pkt packet containing the write the offset into config space
+     * @param pkt packet containing the read offset into config space
      */
     virtual Tick readConfig(PacketPtr pkt);
 
+    /**
+     * Write to the PCI device. This must be implemented by the device to
+     * respond to IO, memory, ... request.
+     * @param pkt packet containing the write request
+     */
+    virtual Tick writeDevice(PacketPtr pkt) = 0;
+
+    /**
+     * Read from the PCI device. This must be implemented by the device to
+     * respond to IO, memory, ... request.
+     * @param pkt packet containing the read request
+     */
+    virtual Tick readDevice(PacketPtr pkt) = 0;
+
   protected:
-    PciHost::DeviceInterface hostInterface;
+    PciUpstream::DeviceInterface upstreamInterface;
 
     Tick pioDelay;
     Tick configDelay;
@@ -374,11 +408,20 @@ class PciDevice : public DmaDevice
     Addr
     pciToDma(Addr pci_addr) const
     {
-        return hostInterface.dmaAddr(pci_addr);
+        return upstreamInterface.dmaAddr(pci_addr);
     }
 
-    void intrPost() { hostInterface.postInt(); }
-    void intrClear() { hostInterface.clearInt(); }
+    void
+    intrPost()
+    {
+        upstreamInterface.postInt();
+    }
+
+    void
+    intrClear()
+    {
+        upstreamInterface.clearInt();
+    }
 
     uint8_t
     interruptLine() const
@@ -414,7 +457,19 @@ class PciDevice : public DmaDevice
      */
     void unserialize(CheckpointIn &cp) override;
 
-    const PciBusAddr &busAddr() const { return _busAddr; }
+    const PciDevAddr &
+    devAddr() const
+    {
+        return _devAddr;
+    }
+
+    /**
+     * Called to receive a bus number change from the PCI upstream.
+     * A bus number change means that all address ranges
+     * (configuration, ...) can be changed, so this will send a range
+     * change to the peer request port.
+     */
+    void recvBusChange();
 };
 
 class PciEndpoint : public PciDevice
@@ -426,14 +481,6 @@ class PciEndpoint : public PciDevice
         return _config.type0;
     }
 
-  public:
-    /**
-     * Constructor for PCI Dev. This function copies data from the
-     * config file object PCIConfigData and registers the device with
-     * a PciHost object.
-     */
-    PciEndpoint(const PciEndpointParams &params);
-
     /**
      * Write to the PCI config space data that is stored locally. This may be
      * overridden by the device but at some point it will eventually call this
@@ -441,6 +488,14 @@ class PciEndpoint : public PciDevice
      * @param pkt packet containing the write the offset into config space
      */
     Tick writeConfig(PacketPtr pkt) override;
+
+  public:
+    /**
+     * Constructor for PCI Dev. This function copies data from the
+     * config file object PCIConfigData and registers the device with
+     * a PciHost object.
+     */
+    PciEndpoint(const PciEndpointParams &params);
 
     /**
      * Reconstruct the state of this object from a checkpoint.
@@ -459,14 +514,6 @@ class PciBridge : public PciDevice
         return _config.type1;
     }
 
-  public:
-    /**
-     * Constructor for PCI Dev. This function copies data from the
-     * config file object PCIConfigData and registers the device with
-     * a PciHost object.
-     */
-    PciBridge(const PciBridgeParams &params);
-
     /**
      * Write to the PCI config space data that is stored locally. This may be
      * overridden by the device but at some point it will eventually call this
@@ -474,6 +521,14 @@ class PciBridge : public PciDevice
      * @param pkt packet containing the write the offset into config space
      */
     Tick writeConfig(PacketPtr pkt) override;
+
+  public:
+    /**
+     * Constructor for PCI Dev. This function copies data from the
+     * config file object PCIConfigData and registers the device with
+     * a PciHost object.
+     */
+    PciBridge(const PciBridgeParams &params);
 
     /**
      * Reconstruct the state of this object from a checkpoint.

--- a/src/dev/pci/one_way_bridge.hh
+++ b/src/dev/pci/one_way_bridge.hh
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 REDS institute of the HEIG-VD
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_PCI_ONE_WAY_BRIDGE_HH__
+#define __DEV_PCI_ONE_WAY_BRIDGE_HH__
+
+#include "mem/bridge.hh"
+#include "params/PciOneWayBridge.hh"
+
+namespace gem5
+{
+
+/**
+ * PCI one way bridge is used to connect upstream bus and downstream bus
+ * together and let packet passing through. To fully connect up and down buses,
+ * two of this bridge must be used, one letting packet pass from up to down and
+ * the other from down to up.
+ *
+ * All the address ranges are dynamically determined based on the connected
+ * bus. A PCI configuration range can be set, the bridge will be able to
+ * respond to any of the address in that range. It will either let the packet
+ * pass through if a PCI device is able to answer to it, or respond with the
+ * error code (all bits set to one).
+ */
+class PciOneWayBridge : public BridgeBase
+{
+  private:
+    /** Bridge handling packets for the reverse way, used to avoid creating
+     * loop of ranges between the two bridges. */
+    PciOneWayBridge *reverseBridge;
+
+    /** Addresses ranges that the memory side buses can respond to. */
+    AddrRangeList memSideRanges;
+
+    /** PCI configuration range that is behind the bridge. */
+    AddrRange configRange;
+
+  protected:
+    /**
+     * Get a list of the non-overlapping address ranges the bridge is
+     * responsible for.
+     *
+     * @return a list of ranges responded to
+     */
+    AddrRangeList getAddrRanges() const override;
+
+    /**
+     * Called when the memory side port receives an address range change from
+     * the peer response port. This allows the bridge to dynamically update
+     * address ranges that can pass through with the new ones.
+     */
+    void recvRangeChange() override;
+
+  public:
+    void init() override;
+
+    /**
+     * Set the bridge handlig packet for the reverse way.
+     * This shoudl be called before the init phase.
+     */
+    void
+    setReverseBridge(PciOneWayBridge *reverse_bridge)
+    {
+        reverseBridge = reverse_bridge;
+    }
+
+    /**
+     * Set the PCI configuration range that is behind the bridge.
+     */
+    void setConfigRange(AddrRange config_range);
+
+    PARAMS(PciOneWayBridge);
+
+    PciOneWayBridge(const Params &p);
+};
+
+} // namespace gem5
+
+#endif //__DEV_PCI_ONE_WAY_BRIDGE_HH__

--- a/src/dev/pci/types.hh
+++ b/src/dev/pci/types.hh
@@ -38,28 +38,35 @@
 #ifndef __DEV_PCI_TYPES_HH__
 #define __DEV_PCI_TYPES_HH__
 
+#include <cstdint>
+
 namespace gem5
 {
 
-struct PciBusAddr
+typedef uint8_t PciBusNum;
+
+struct PciDevAddr
 {
   public:
-    PciBusAddr() = delete;
+    PciDevAddr() = delete;
 
-    constexpr PciBusAddr(uint8_t _bus, uint8_t _dev, uint8_t _func)
-        : bus(_bus), dev(_dev), func(_func) {}
+    constexpr PciDevAddr(uint8_t _dev, uint8_t _func) : dev(_dev), func(_func)
+    {}
 
-    constexpr bool operator<(const PciBusAddr &rhs) const {
+    constexpr bool
+    operator<(const PciDevAddr &rhs) const
+    {
         return sortValue() < rhs.sortValue();
     }
 
-    uint8_t bus;
     uint8_t dev;
     uint8_t func;
 
   protected:
-    constexpr uint32_t sortValue() const {
-        return (bus << 16) | (dev << 8) | func;
+    constexpr uint32_t
+    sortValue() const
+    {
+        return (dev << 8) | func;
     }
 };
 

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2025 REDS institute of the HEIG-VD
+ * All rights reserved
+ *
+ * Copyright (c) 2015 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_PCI_UPSTREAM_HH__
+#define __DEV_PCI_UPSTREAM_HH__
+
+#include <map>
+
+#include "base/addr_range.hh"
+#include "dev/pci/one_way_bridge.hh"
+#include "dev/pci/types.hh"
+#include "params/PciUpstream.hh"
+#include "sim/clocked_object.hh"
+
+namespace gem5
+{
+
+class PciDevice;
+
+/**
+ * The PCI upstream describes any device (PCI host bridge, PCI-PCI bridge)
+ * that are connected upstream of PCI devices (endpoint or bridge).
+ *
+ * The PCI upstream controller has three main responsibilities:
+ * <ol>
+ *     <li>Bridge all packets between two buses (e.g. system and PCI bus)
+ *     <li>Map and deliver interrupts to the next upstream or CPU.
+ *     <li>Map memory addresses from the PCI bus's various memory
+ *         spaces (Configuration, legacy IO, non-prefetchable memory, and
+ *         prefetchable memory) to physical memory.
+ * </ol>
+ *
+ * PCI devices need to register themselves with a PCI upstream using the
+ * PciUpstream::registerDevice() call. This call returns a
+ * PciUpstream::DeviceInterface that provides for common functionality
+ * such as interrupt delivery and memory mapping.
+ *
+ * The PciUpstream is an abstract class that provides the device registering
+ * part and should be inherited by the actual upstream classes, which must
+ * provides implementation for the interrupts and memory mapping.
+ */
+class PciUpstream : public ClockedObject
+{
+  public:
+    PARAMS(PciUpstream);
+
+    PciUpstream(const Params &p);
+
+    void init() override;
+
+    /**
+     * @{
+     * @name Device interface
+     */
+
+    /**
+     * Callback interface from PCI devices to the upstream.
+     *
+     * Devices get an instance of this object by calling
+     * PciUpstream::registerDevice() on their direct upstream.
+     */
+    class DeviceInterface
+    {
+        friend class gem5::PciUpstream;
+
+      protected:
+        /**
+         * Instantiate a device interface
+         *
+         * @param upstream PCI upstream that this device belongs to.
+         * @param dev_addr The device's position on the PCI bus
+         * @param pin Interrupt pin
+         */
+        DeviceInterface(PciUpstream &upstream, const PciDevAddr &dev_addr,
+                        PciIntPin pin);
+
+      public:
+        DeviceInterface() = delete;
+        void operator=(const DeviceInterface &) = delete;
+
+        const std::string name() const;
+
+        /**
+         * Post a PCI interrupt to the CPU.
+         */
+        void postInt();
+
+        /**
+         * Clear a posted PCI interrupt
+         */
+        void clearInt();
+
+        /**
+         * Calculate the physical address range of the PCI device
+         * configuration space.
+         *
+         * @return Address range in the system's physical address space.
+         */
+        AddrRange
+        configRange() const
+        {
+            return upstream.interfaceConfigRange(devAddr);
+        }
+
+        /**
+         * Calculate the physical address of an IO location on the PCI
+         * bus.
+         *
+         * @param addr Address in the PCI IO address space
+         * @return Address in the system's physical address space.
+         */
+        Addr
+        pioAddr(Addr addr) const
+        {
+            return upstream.interfacePioAddr(devAddr, addr);
+        }
+
+        /**
+         * Calculate the physical address of a non-prefetchable memory
+         * location in the PCI address space.
+         *
+         * @param addr Address in the PCI memory address space
+         * @return Address in the system's physical address space.
+         */
+        Addr
+        memAddr(Addr addr) const
+        {
+            return upstream.interfaceMemAddr(devAddr, addr);
+        }
+
+        /**
+         * Calculate the physical address of a prefetchable memory
+         * location in the PCI address space.
+         *
+         * @param addr Address in the PCI DMA memory address space
+         * @return Address in the system's physical address space.
+         */
+        Addr
+        dmaAddr(Addr addr) const
+        {
+            return upstream.interfaceDmaAddr(devAddr, addr);
+        }
+
+      protected:
+        PciUpstream &upstream;
+
+        const PciDevAddr devAddr;
+        const PciIntPin interruptPin;
+    };
+
+    /**
+     * Register a PCI device with the host.
+     *
+     * @param device Device to register
+     * @param dev_addr The device's position on the PCI bus
+     * @param pin Interrupt pin
+     * @return A device-specific DeviceInterface instance.
+     */
+    virtual DeviceInterface registerDevice(PciDevice *device,
+                                           PciDevAddr dev_addr, PciIntPin pin);
+
+    /** @} */
+
+    /**
+     * Inform each PCI devices connected to this upstream of a bus number
+     * change.
+     */
+    void sendBusChange();
+
+  protected:
+    /**
+     * Get the range for the configuration memory space for which this PCI
+     * upstream is responsible. The range should include the full configuration
+     * space even where no bus/device are present.
+     */
+    virtual AddrRange getConfigAddrRange() const = 0;
+
+    /**
+     * @{
+     * @name PciUpstream controller interface
+     */
+
+    /**
+     * Post an interrupt to the CPU.
+     *
+     * @param dev_addr The device's position on the PCI bus
+     * @param pin PCI interrupt pin
+     */
+    virtual void interfacePostInt(const PciDevAddr &dev_addr,
+                                  PciIntPin pin) = 0;
+
+    /**
+     * Post an interrupt to the CPU.
+     *
+     * @param dev_addr The device's position on the PCI bus
+     * @param pin PCI interrupt pin
+     */
+    virtual void interfaceClearInt(const PciDevAddr &dev_addr,
+                                   PciIntPin pin) = 0;
+
+    /**
+     * Calculate the physical address range of the PCI device
+     * configuration space.
+     *
+     * @param dev_addr The device's position on the PCI bus
+     * @return Configuration address range in the system's physical address
+     *         space.
+     */
+    virtual AddrRange
+    interfaceConfigRange(const PciDevAddr &dev_addr) const = 0;
+
+    /**
+     * Calculate the physical address of an IO location on the PCI
+     * bus.
+     *
+     * @param dev_addr The device's position on the PCI bus
+     * @param pci_addr Address in the PCI IO address space
+     * @return Address in the system's physical address space.
+     */
+    virtual Addr interfacePioAddr(const PciDevAddr &dev_addr,
+                                  Addr pci_addr) const = 0;
+
+    /**
+     * Calculate the physical address of a non-prefetchable memory
+     * location in the PCI address space.
+     *
+     * @param dev_addr The device's position on the PCI bus
+     * @param pci_addr Address in the PCI memory address space
+     * @return Address in the system's physical address space.
+     */
+    virtual Addr interfaceMemAddr(const PciDevAddr &dev_addr,
+                                  Addr pci_addr) const = 0;
+
+    /**
+     * Calculate the physical address of a prefetchable memory
+     * location in the PCI address space.
+     *
+     * @param dev_addr The device's position on the PCI bus
+     * @param pci_addr Address in the PCI DMA memory address space
+     * @return Address in the system's physical address space.
+     */
+    virtual Addr interfaceDmaAddr(const PciDevAddr &dev_addr,
+                                  Addr pci_addr) const = 0;
+
+    /** @} */
+
+    /**
+     * Get the PCI bus number assign to that upstream.
+     */
+    virtual PciBusNum getBusNum() const = 0;
+
+  protected:
+    /**
+     * Retrieve a PCI device from its bus address.
+     *
+     * @return Pointer to a PciDevice instance or nullptr if the
+     *         device doesn't exist.
+     */
+    PciDevice *getDevice(const PciDevAddr &addr);
+
+    /**
+     * Retrieve a PCI device from its bus address.
+     *
+     * @return Pointer to a constant PciDevice instance or nullptr if
+     *         the device doesn't exist.
+     */
+    const PciDevice *getDevice(const PciDevAddr &addr) const;
+
+  private:
+    /** Currently registered PCI interfaces */
+    std::map<PciDevAddr, PciDevice *> devices;
+
+    /** The two one way bridges to connect both side buses */
+    PciOneWayBridge *upToDown;
+    PciOneWayBridge *downToUp;
+};
+
+} // namespace gem5
+
+#endif // __DEV_PCI_UPSTREAM_HH__

--- a/src/dev/riscv/HiFive.py
+++ b/src/dev/riscv/HiFive.py
@@ -37,6 +37,7 @@
 
 from m5.objects.Clint import Clint
 from m5.objects.PciHost import GenericPciHost
+from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.Plic import Plic
 from m5.objects.PMAChecker import PMAChecker
@@ -188,6 +189,7 @@ class HiFive(HiFiveBase):
         pci_pio_base=0x2F000000,
         pci_mem_base=0x40000000,
     )
+    pci_bus = PciBus()
 
     # Uart
     uart = RiscvUart8250(pio_addr=0x10000000)

--- a/src/dev/riscv/pci_host.cc
+++ b/src/dev/riscv/pci_host.cc
@@ -47,12 +47,12 @@ GenericRiscvPciHost::GenericRiscvPciHost(const GenericRiscvPciHostParams &p)
 }
 
 uint32_t
-GenericRiscvPciHost::mapPciInterrupt(
-    const PciBusAddr &addr, PciIntPin pin) const
+GenericRiscvPciHost::mapPciInterrupt(const PciDevAddr &addr,
+                                     PciIntPin pin) const
 {
     fatal_if(pin == PciIntPin::NO_INT,
              "%02x:%02x.%i: Interrupt from a device without interrupts\n",
-             addr.bus, addr.dev, addr.func);
+             getBusNum(), addr.dev, addr.func);
 
     return intBase + (addr.dev % intCount);
 }

--- a/src/dev/riscv/pci_host.hh
+++ b/src/dev/riscv/pci_host.hh
@@ -56,7 +56,7 @@ class GenericRiscvPciHost : public GenericPciHost
     GenericRiscvPciHost(const GenericRiscvPciHostParams &p);
 
   protected:
-    uint32_t mapPciInterrupt(const PciBusAddr &addr,
+    uint32_t mapPciInterrupt(const PciDevAddr &addr,
                              PciIntPin pin) const override;
 };
 

--- a/src/dev/storage/ide_ctrl.cc
+++ b/src/dev/storage/ide_ctrl.cc
@@ -384,14 +384,14 @@ IdeController::Channel::setDmaComplete()
 }
 
 Tick
-IdeController::read(PacketPtr pkt)
+IdeController::readDevice(PacketPtr pkt)
 {
     dispatchAccess(pkt, true);
     return pioDelay;
 }
 
 Tick
-IdeController::write(PacketPtr pkt)
+IdeController::writeDevice(PacketPtr pkt)
 {
     dispatchAccess(pkt, false);
     return pioDelay;

--- a/src/dev/storage/ide_ctrl.hh
+++ b/src/dev/storage/ide_ctrl.hh
@@ -196,18 +196,19 @@ class IdeController : public PciEndpoint
 
     void dispatchAccess(PacketPtr pkt, bool read);
 
+  protected:
+    Tick writeConfig(PacketPtr pkt) override;
+    Tick readConfig(PacketPtr pkt) override;
+
+    Tick readDevice(PacketPtr pkt) override;
+    Tick writeDevice(PacketPtr pkt) override;
+
   public:
     PARAMS(IdeController);
     IdeController(const Params &p);
 
     virtual void postInterrupt(bool is_primary);
     virtual void clearInterrupt(bool is_primary);
-
-    Tick writeConfig(PacketPtr pkt) override;
-    Tick readConfig(PacketPtr pkt) override;
-
-    Tick read(PacketPtr pkt) override;
-    Tick write(PacketPtr pkt) override;
 
     void serialize(CheckpointOut &cp) const override;
     void unserialize(CheckpointIn &cp) override;

--- a/src/dev/virtio/pci.cc
+++ b/src/dev/virtio/pci.cc
@@ -67,7 +67,7 @@ PciVirtIO::~PciVirtIO()
 }
 
 Tick
-PciVirtIO::read(PacketPtr pkt)
+PciVirtIO::readDevice(PacketPtr pkt)
 {
     [[maybe_unused]] const unsigned size(pkt->getSize());
     int bar;
@@ -148,7 +148,7 @@ PciVirtIO::read(PacketPtr pkt)
 }
 
 Tick
-PciVirtIO::write(PacketPtr pkt)
+PciVirtIO::writeDevice(PacketPtr pkt)
 {
     [[maybe_unused]] const unsigned size(pkt->getSize());
     int bar;

--- a/src/dev/x86/Pc.py
+++ b/src/dev/x86/Pc.py
@@ -29,6 +29,7 @@ from m5.objects.Device import (
     IsaFake,
 )
 from m5.objects.PciHost import GenericPciHost
+from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.SouthBridge import SouthBridge
 from m5.objects.Terminal import Terminal
@@ -58,6 +59,7 @@ class Pc(Platform):
 
     south_bridge = Param.SouthBridge(SouthBridge(), "Southbridge")
     pci_host = PcPciHost()
+    pci_bus = PciBus()
 
     # Serial port and terminal
     com_1 = Uart8250()
@@ -90,12 +92,22 @@ class Pc(Platform):
     bad_addr = BadAddr(pio=default_bus.default)
 
     def attachIO(self, bus, dma_ports=[]):
-        self.south_bridge.attachIO(bus, dma_ports)
+        self.south_bridge.attachIO(bus, self.pci_bus, dma_ports)
         self.com_1.pio = bus.mem_side_ports
         self.fake_com_2.pio = bus.mem_side_ports
         self.fake_com_3.pio = bus.mem_side_ports
         self.fake_com_4.pio = bus.mem_side_ports
         self.fake_floppy.pio = bus.mem_side_ports
-        self.pci_host.pio = bus.mem_side_ports
+
+        self.pci_bus.mem_side_ports = self.pci_host.down_response_port()
+        self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
+        bus.mem_side_ports = self.pci_host.up_response_port()
+
+        if dma_ports.count(self.pci_host.up_request_port()) == 0:
+            bus.cpu_side_ports = self.pci_host.up_request_port()
 
         self.default_bus.cpu_side_ports = bus.default
+
+    def attachPciDevice(self, device):
+        self.pci_bus.cpu_side_ports = device.dma
+        self.pci_bus.mem_side_ports = device.pio

--- a/src/dev/x86/SouthBridge.py
+++ b/src/dev/x86/SouthBridge.py
@@ -77,9 +77,9 @@ class SouthBridge(SimObject):
     io_apic = Param.I82094AA(I82094AA(pio_addr=0xFEC00000), "I/O APIC")
 
     # IDE controller
-    ide = X86IdeController(disks=[], pci_func=0, pci_dev=4, pci_bus=0)
+    ide = X86IdeController(disks=[], pci_func=0, pci_dev=4)
 
-    def attachIO(self, bus, dma_ports):
+    def attachIO(self, bus, pci_bus, dma_ports):
         # Route interrupt signals
         self.pic1.output = self.io_apic.inputs[0]
         self.pic2.output = self.pic1.inputs[2]
@@ -98,9 +98,6 @@ class SouthBridge(SimObject):
         # Connect to the bus
         self.cmos.pio = bus.mem_side_ports
         self.dma1.pio = bus.mem_side_ports
-        self.ide.pio = bus.mem_side_ports
-        if dma_ports.count(self.ide.dma) == 0:
-            self.ide.dma = bus.cpu_side_ports
         self.keyboard.pio = bus.mem_side_ports
         self.pic1.pio = bus.mem_side_ports
         self.pic2.pio = bus.mem_side_ports
@@ -108,3 +105,6 @@ class SouthBridge(SimObject):
         self.speaker.pio = bus.mem_side_ports
         self.io_apic.pio = bus.mem_side_ports
         self.io_apic.int_requestor = bus.cpu_side_ports
+        # Connect PCI devices
+        self.ide.pio = pci_bus.mem_side_ports
+        self.ide.dma = pci_bus.cpu_side_ports

--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -40,6 +40,7 @@ from m5.objects import (
     AddrRange,
     ClockDomain,
     IOXBar,
+    PciBus,
     Port,
     Root,
     SrcClockDomain,
@@ -318,6 +319,28 @@ class AbstractBoard:
         controllers on each core).
 
         :returns: The I/O Bus.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def has_pci_bus(self) -> bool:
+        """Determine whether the board has an PCI bus or not.
+
+        :returns: ``True`` if the board has an PCI bus, otherwise ``False``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_pci_bus(self) -> PciBus:
+        """Get the board's main PCI Bus.
+
+        This abstract method must be implemented within the subclasses if they
+        support PCI and/or full system simulation.
+
+        The PCI bus is a non-coherent bus (in the classic caches). This bus is
+        connected to the PCI host bridge and to each PCI devices of the system.
+
+        :returns: The PCI Bus.
         """
         raise NotImplementedError
 

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -45,6 +45,7 @@ from m5.objects import (
     CowDiskImage,
     GenericTimer,
     IOXBar,
+    PciBus,
     PciVirtIO,
     Port,
     RawDiskImage,
@@ -294,6 +295,14 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         return self.iobus
 
     @overrides(AbstractBoard)
+    def has_pci_bus(self) -> bool:
+        return True
+
+    @overrides(AbstractBoard)
+    def get_pci_bus(self) -> PciBus:
+        return self.realview.pci_bus
+
+    @overrides(AbstractBoard)
     def has_coherent_io(self) -> bool:
         # The setup of the caches gets a little tricky here. We need to
         # override the default cache_hierarchy.iobridge due to different delay
@@ -373,9 +382,7 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
 
         # For every PCI device, we need to get its dma_port so that we
         # can setup dma_controllers correctly.
-        self.realview.attachPciDevice(
-            pci_device, self.iobus, dma_ports=self.get_dma_ports()
-        )
+        self.realview.attachPciDevice(pci_device)
 
     @overrides(KernelDiskWorkload)
     def get_disk_device(self):

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -44,6 +44,7 @@ from m5.objects import (
     LupioTMR,
     LupioTTY,
     LupV,
+    PciBus,
     Plic,
     PMAChecker,
     Port,
@@ -265,6 +266,17 @@ class LupvBoard(AbstractSystemBoard, KernelDiskWorkload):
     @overrides(AbstractSystemBoard)
     def get_io_bus(self) -> IOXBar:
         return self.iobus
+
+    @overrides(AbstractSystemBoard)
+    def has_pci_bus(self) -> bool:
+        return False
+
+    @overrides(AbstractSystemBoard)
+    def get_pci_bus(self) -> PciBus:
+        raise NotImplementedError(
+            "The LupvBoard does not have PCI bus. "
+            "Use `has_pci_bus()` to check this."
+        )
 
     def has_coherent_io(self) -> bool:
         return True

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -42,6 +42,7 @@ from m5.objects import (
     HiFive,
     IGbE_e1000,
     IOXBar,
+    PciBus,
     PMAChecker,
     Port,
     RawDiskImage,
@@ -153,16 +154,23 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
     def _setup_io_devices(self) -> None:
         """Connect the I/O devices to the I/O bus."""
         # Add PCI
-        self.platform.pci_host.pio = self.iobus.mem_side_ports
+        self.iobus.mem_side_ports = self.platform.pci_host.up_response_port()
+        self.iobus.cpu_side_ports = self.platform.pci_host.up_request_port()
+        self.platform.pci_bus.mem_side_ports = (
+            self.platform.pci_host.down_response_port()
+        )
+        self.platform.pci_bus.cpu_side_ports = (
+            self.platform.pci_host.down_request_port()
+        )
 
         # Add Ethernet card
         self.ethernet = IGbE_e1000(
-            pci_bus=0, pci_dev=0, pci_func=0, InterruptLine=1, InterruptPin=1
+            pci_dev=0, pci_func=0, InterruptLine=1, InterruptPin=1
         )
 
-        self.ethernet.host = self.platform.pci_host
-        self.ethernet.pio = self.iobus.mem_side_ports
-        self.ethernet.dma = self.iobus.cpu_side_ports
+        self.ethernet.upstream = self.platform.pci_host
+        self.ethernet.pio = self.platform.pci_bus.mem_side_ports
+        self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
 
         if self.get_cache_hierarchy().is_ruby():
             for device in self._off_chip_devices + self._on_chip_devices:
@@ -231,6 +239,20 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
             raise Exception(
                 "Cannot execute `get_io_bus()`: Board does not have an I/O "
                 "bus to return. Use `has_io_bus()` to check this."
+            )
+
+    @overrides(AbstractSystemBoard)
+    def has_pci_bus(self) -> bool:
+        return self.is_fullsystem()
+
+    @overrides(AbstractSystemBoard)
+    def get_pci_bus(self) -> PciBus:
+        if self.has_pci_bus():
+            return self.platform.pci_bus
+        else:
+            raise Exception(
+                "Cannot execute `get_pci_bus()`: Board does not have an PCI "
+                "bus to return. Use `has_pci_bus()` to check this."
             )
 
     @overrides(AbstractSystemBoard)

--- a/src/python/gem5/components/boards/simple_board.py
+++ b/src/python/gem5/components/boards/simple_board.py
@@ -29,6 +29,7 @@ from typing import List
 from m5.objects import (
     AddrRange,
     IOXBar,
+    PciBus,
     Port,
 )
 
@@ -78,6 +79,17 @@ class SimpleBoard(AbstractSystemBoard, SEBinaryWorkload):
         raise NotImplementedError(
             "SimpleBoard does not have an IO Bus. "
             "Use `has_io_bus()` to check this."
+        )
+
+    @overrides(AbstractSystemBoard)
+    def has_pci_bus(self) -> bool:
+        return False
+
+    @overrides(AbstractSystemBoard)
+    def get_pci_bus(self) -> PciBus:
+        raise NotImplementedError(
+            "SimpleBoard does not have an PCI Bus. "
+            "Use `has_pci_bus()` to check this."
         )
 
     @overrides(AbstractSystemBoard)

--- a/src/python/gem5/components/boards/test_board.py
+++ b/src/python/gem5/components/boards/test_board.py
@@ -32,6 +32,7 @@ from typing import (
 from m5.objects import (
     AddrRange,
     IOXBar,
+    PciBus,
     Port,
 )
 
@@ -83,6 +84,17 @@ class TestBoard(AbstractSystemBoard):
         raise NotImplementedError(
             "The TestBoard does not have an IO Bus. "
             "Use `has_io_bus()` to check this."
+        )
+
+    @overrides(AbstractSystemBoard)
+    def has_pci_bus(self) -> bool:
+        return False
+
+    @overrides(AbstractSystemBoard)
+    def get_pci_bus(self) -> PciBus:
+        raise NotImplementedError(
+            "The TestBoard does not have an PCI Bus. "
+            "Use `has_pci_bus()` to check this."
         )
 
     @overrides(AbstractSystemBoard)

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -39,6 +39,7 @@ from m5.objects import (
     IdeDisk,
     IOXBar,
     Pc,
+    PciBus,
     Port,
     RawDiskImage,
     X86ACPIMadt,
@@ -128,7 +129,9 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
 
         # Setup memory system specific settings.
         if self.get_cache_hierarchy().is_ruby():
-            self.pc.attachIO(self.get_io_bus(), [self.pc.south_bridge.ide.dma])
+            self.pc.attachIO(
+                self.get_io_bus(), [self.pc.pci_host.mem_request_port()]
+            )
         else:
             self.bridge = Bridge(delay="50ns")
             self.bridge.mem_side_port = self.get_io_bus().cpu_side_ports
@@ -306,13 +309,30 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
             )
 
     @overrides(AbstractSystemBoard)
+    def has_pci_bus(self) -> bool:
+        return self.is_fullsystem()
+
+    @overrides(AbstractSystemBoard)
+    def get_pci_bus(self) -> PciBus:
+        if self.has_pci_bus():
+            return self.pc.pci_bus
+        else:
+            raise Exception(
+                "Cannot execute `get_pci_bus()`: Board does not have a PCI "
+                "bus to return. Use `has_pci_bus()` to check this."
+            )
+
+    @overrides(AbstractSystemBoard)
     def has_dma_ports(self) -> bool:
         return self.is_fullsystem()
 
     @overrides(AbstractSystemBoard)
     def get_dma_ports(self) -> Sequence[Port]:
         if self.has_dma_ports():
-            return [self.pc.south_bridge.ide.dma, self.iobus.mem_side_ports]
+            return [
+                self.pc.pci_host.mem_request_port(),
+                self.iobus.mem_side_ports,
+            ]
         else:
             raise Exception(
                 "Cannot execute `get_dma_ports()`: Board does not have DMA "

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -66,7 +66,7 @@ class BaseViperGPU(SubSystem):
         self._my_id = self.get_gpu_count()
         pci_dev = self.next_pci_dev()
 
-        self.device = AMDGPUDevice(pci_func=0, pci_dev=pci_dev, pci_bus=0)
+        self.device = AMDGPUDevice(pci_func=0, pci_dev=pci_dev)
 
     def set_shader(self, shader: ViperShader):
         self.shader = shader
@@ -81,7 +81,7 @@ class BaseViperGPU(SubSystem):
         self.shader.set_cpu_pointer(cpus.cores[0].core)
 
         # Connect all PIO buses
-        self.shader.connect_iobus(board.get_io_bus())
+        self.shader.connect_iobus(board.get_io_bus(), board.get_pci_bus())
 
         # Make the cache hierarchy. This will create an independent RubySystem
         # class containing only the GPU caches with no network connection to
@@ -110,7 +110,7 @@ class BaseViperGPU(SubSystem):
         # pointer required by the AbstractMemory class is set by AMDGPUDevice.
         self.device.memories = self._memory.get_mem_interfaces()
 
-        self.device.host = board.get_pci_host()
+        self.device.upstream = board.get_pci_host()
 
 
 # A scaled down MI210-like device. Defaults to ~1/4th of an MI210.

--- a/src/python/gem5/components/devices/gpus/viper_shader.py
+++ b/src/python/gem5/components/devices/gpus/viper_shader.py
@@ -360,12 +360,12 @@ class ViperShader(Shader):
 
         self._gpu_dma_ports.append(self.l3_tlb.walker.port)
 
-    def connect_iobus(self, iobus: BaseXBar):
+    def connect_iobus(self, iobus: BaseXBar, pci_bus: BaseXBar):
         """Connect the GPU objects to the IO bus."""
         self.gpu_cmd_proc.pio = iobus.mem_side_ports
         self.gpu_cmd_proc.hsapp.pio = iobus.mem_side_ports
         self.system_hub.pio = iobus.mem_side_ports
-        self._device.pio = iobus.mem_side_ports
+        self._device.pio = pci_bus.mem_side_ports
         self._device.device_ih.pio = iobus.mem_side_ports
         for sdma in self._device.sdmas:
             sdma.pio = iobus.mem_side_ports


### PR DESCRIPTION
Due to mishandling on our original fork, which led us to delete it to start over a clean one, this PR is a repost of #2204. Sorry for the inconvenience.

This commit reworks the PCI architecture to:

  - Add a PCI host bridge
  - Add the possibility to have different upstream between multiple
    `PciDevice` (for future PCI-PCI bridge implementation)
  - Moves the responsibility to response a PCI configuration request in
    `PciDevice` instead of `PciHost`.

For that, the `PciUpstream` class is added and works like the old
`PciHost`, which now inherit from it. `PciDevice` will now need to
register to a `PciUpstream` instead of `PciHost` to get an instance of
`DeviceInterface`, this allows for the future implementation of a
PCI-to-PCI bridge. Also, bus number is now given to the device by its
upstream and not by the gem5 configuration which allow it to be changed
by the OS on boot for PCI-PCI bridge.

`PciUpstream` implementation has two member of the new class
`PciOneWayBridge` to implement the two way bridge two buses (e.g. system
and PCI bus). That class is a bridge with dynamic address ranges
depending on the ones from the connected buses.

The python `PciBus` class is also added, which simply inherit
from `NoncoherentXBar` and set the default port to an `IsaFake` to
answer to configuration request where no device respond.

So, the new PCI architecture is composed of a `PciHost`, connected to a
`PciBus` on PCI side to which all `PciDevice` are connected.

PCI configuration request are now handled by each `PciDevice` instead
of `PciHost` to mimic real PCI configuration.

This is another big step related to #1862.

It has an impact on existing gem5 configuration as now all PCI devices need to be connected behind the `PciHost`. All configurations on the repo have been updated to account that.
However, I'm not sure to understand correctly systems using Ruby and how to connect on it, like with the GPU. For now, I connected PCI device's indirectly through the bridge to Ruby, which works fine.