### PR TITLE
arch-riscv: fix vcpyvs µops for vector indexed loads

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1228,14 +1228,18 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
 
-    const uint32_t vd_vlmax = vlenb / vd_eewb;
-    const uint8_t num_pinvdcpyvs_microops = ceil((float) this->vl/vd_vlmax);
-    for (uint32_t i = 0; i < num_pinvdcpyvs_microops; i++) {
-        uint32_t vdNumElems = (vl >= vd_vlmax*(i+1)) ? vd_vlmax:vl-vd_vlmax*i;
-
+    const uint32_t vs2_vlmax = vlenb / vs2_eewb;
+    const uint8_t num_cpyvs_microops = ceil((float) this->vl/vs2_vlmax);
+    for (uint32_t i = 0; i < num_cpyvs_microops; i++) {
         microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen, vlen);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
+    }
+
+    const uint32_t vd_vlmax = vlenb / vd_eewb;
+    const uint8_t num_pinvd_microops = ceil((float) this->vl/vd_vlmax);
+    for (uint32_t i = 0; i < num_pinvd_microops; i++) {
+        uint32_t vdNumElems = (vl >= vd_vlmax*(i+1)) ? vd_vlmax:vl-vd_vlmax*i;
 
         microop = new VPinVdMicroInst(machInst, i, vdNumElems, elen, vlen);
         microop->setFlag(IsDelayedCommit);


### PR DESCRIPTION
The number of `VCpyVsMicroInst` needed for vector indexed loads was being calculated incorrectly by using the destination's EEW instead of the source index's one. This could cause execution bugs in certain situations (#2248).

This patch fixes the issue by using the source index's EEW when calculating the number of µops needed.
