### PR TITLE
cpu: Add user-mode stats

### DIFF
--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -219,6 +219,10 @@ BaseCPU::BaseCPU(const Params &p, bool is_checker)
         CommitCPUStats* commitStatptr = new CommitCPUStats(this, i);
         commitStatptr->ipc = commitStatptr->numInsts / baseStats.numCycles;
         commitStatptr->cpi = baseStats.numCycles / commitStatptr->numInsts;
+        commitStatptr->ratioUserInsts = commitStatptr->numUserInsts /
+            commitStatptr->numInsts;
+        commitStatptr->ratioUserOps = commitStatptr->numUserOps /
+            commitStatptr->numOps;
         commitStats.emplace_back(commitStatptr);
     }
 }
@@ -1018,6 +1022,14 @@ CommitCPUStats::CommitCPUStats(statistics::Group *parent, int thread_id)
              "Number of instructions committed excluding NOPs or prefetches"),
     ADD_STAT(numOpsNotNOP, statistics::units::Count::get(),
              "Number of Ops (including micro ops) Simulated"),
+    ADD_STAT(numUserInsts, statistics::units::Count::get(),
+             "Numbrer of instructions committed in user mode"),
+    ADD_STAT(numUserOps, statistics::units::Count::get(),
+            "Number of ops committed in user mode"),
+    ADD_STAT(ratioUserInsts, statistics::units::Ratio::get(),
+             "Ratio of instructions committed in user mode"),
+    ADD_STAT(ratioUserOps, statistics::units::Ratio::get(),
+             "Ratio of ops committed in user mode"),
     ADD_STAT(cpi, statistics::units::Rate<
                 statistics::units::Cycle, statistics::units::Count>::get(),
              "CPI: cycles per instruction (thread level)"),

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -812,6 +812,14 @@ class BaseCPU : public ClockedObject
         statistics::Scalar numInstsNotNOP;
         statistics::Scalar numOpsNotNOP;
 
+        /* Number of instructions committed in user mode */
+        statistics::Scalar numUserInsts;
+        statistics::Scalar numUserOps;
+
+        /* Ratio of instructions committed in user mode */
+        statistics::Formula ratioUserInsts;
+        statistics::Formula ratioUserOps;
+
         /* CPI/IPC for total cycle counts and macro insts */
         statistics::Formula cpi;
         statistics::Formula ipc;

--- a/src/cpu/kvm/base.cc
+++ b/src/cpu/kvm/base.cc
@@ -806,10 +806,16 @@ BaseKvmCPU::kvmRun(Tick ticks)
         ticksExecuted = runTimer->ticksFromHostCycles(hostCyclesExecuted);
 
         /* Update statistics */
-        baseStats.numCycles += simCyclesExecuted;;
-        commitStats[thread->threadId()]->numInsts += instsExecuted;
+        baseStats.numCycles += simCyclesExecuted;
         baseStats.numInsts += instsExecuted;
         ctrInsts += instsExecuted;
+
+        const ThreadID tid = thread->threadId();
+        const bool in_user_mode = thread->getIsaPtr()->inUserMode();
+        commitStats[tid]->numInsts += instsExecuted;
+        if (in_user_mode) {
+            commitStats[tid]->numUserInsts += instsExecuted;
+        }
 
         DPRINTF(KvmRun,
                 "KVM: Executed %i instructions in %i cycles "

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1324,13 +1324,21 @@ Commit::markCompletedInsts()
 void
 Commit::updateComInstStats(const DynInstPtr &inst)
 {
-    ThreadID tid = inst->threadNumber;
+    const ThreadID tid = inst->threadNumber;
+    const bool in_user_mode = cpu->inUserMode(tid);
 
     if (!inst->isMicroop() || inst->isLastMicroop()) {
         cpu->commitStats[tid]->numInsts++;
         cpu->baseStats.numInsts++;
+        if (in_user_mode) {
+            cpu->commitStats[tid]->numUserInsts++;
+        }
     }
+
     cpu->commitStats[tid]->numOps++;
+    if (in_user_mode) {
+        cpu->commitStats[tid]->numUserOps++;
+    }
 
     // To match the old model, don't count nops and instruction
     // prefetches towards the total commit count.

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1349,6 +1349,12 @@ CPU::getFreeTid()
     return InvalidThreadID;
 }
 
+bool
+CPU::inUserMode(ThreadID tid)
+{
+    return isa[tid]->inUserMode();
+}
+
 void
 CPU::updateThreadPriority()
 {

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -509,6 +509,14 @@ class CPU : public BaseCPU
     /** Gets a free thread id. Use if thread ids change across system. */
     ThreadID getFreeTid();
 
+    /**
+     * Get whether a thread is in user mode.
+     *
+     * @param tid The thread id
+     * @return true if the thread is in user mode, false otherwise
+     */
+    bool inUserMode(ThreadID tid);
+
   public:
     /** Returns a pointer to a thread context. */
     gem5::ThreadContext *

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -175,14 +175,23 @@ void
 BaseSimpleCPU::countCommitInst()
 {
     SimpleExecContext& t_info = *threadInfo[curThread];
+    const ThreadID tid = t_info.thread->threadId();
+    const bool in_user_mode = t_info.thread->getIsaPtr()->inUserMode();
 
     if (!curStaticInst->isMicroop() || curStaticInst->isLastMicroop()) {
         // increment thread level and core level numInsts count
-        commitStats[t_info.thread->threadId()]->numInsts++;
+        commitStats[tid]->numInsts++;
         baseStats.numInsts++;
+        if (in_user_mode) {
+            commitStats[tid]->numUserInsts++;
+        }
     }
+
     // increment thread level numOps count
-    commitStats[t_info.thread->threadId()]->numOps++;
+    commitStats[tid]->numOps++;
+    if (in_user_mode) {
+        commitStats[tid]->numUserOps++;
+    }
 }
 
 Counter


### PR DESCRIPTION
One major concern when running simulations, especially in FS mode, is whether a simulation's ROI actually executes the benchmark of interest. One major problem here is _kernel foo_: instructions executed by the kernel that don't relate to the benchmark of interest.

This PR tries to make kernel foo more transparent by exposing the number of instructions and ops committed in user and kernel mode. In most cases, a simulation should ideally have few kernel-mode instructions (say, <5%). This PR uses an existing method, `inUserMode()` in gem5's ISA class, to determine if a thread is in user-mode every time it commits an op. From this, we can track the number of user- and kernel-mode instructions and ops committed by each thread.

**Some considerations:**
- Is `inUserMode()` reliable and correct?
- Do the calls to `getIsaPtr()` and `inUserMode()` harm performance? This code is run on every op commit, so ideally we don't want to slow it down. Alternatively, we could track each thread's mode as a boolean variable and flip it when its mode changes.
- It would be nice to have an event similar to MAX_INSTS, but for user-mode instructions only.

Thanks for taking a look at this, I hope it's helpful!