### PR TITLE
cpu-o3: stall fetch from commit when trap event is pending

### DIFF
--- a/src/cpu/o3/comm.hh
+++ b/src/cpu/o3/comm.hh
@@ -208,6 +208,8 @@ struct TimeStruct
         bool interruptPending = false; // *F
         /// If the interrupt ended up being cleared before being handled
         bool clearInterrupt = false; // *F
+        /// If a trap is pending
+        bool trapPending = false; // *F
 
         /// Hack for now to send back an strictly ordered access to
         /// the IEW stage.

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -465,6 +465,7 @@ Commit::generateTrapEvent(ThreadID tid, Fault inst_fault)
     cpu->schedule(trap, cpu->clockEdge(latency));
     trapInFlight[tid] = true;
     thread[tid]->trapPending = true;
+    toIEW->commitInfo[tid].trapPending = true;
 }
 
 void
@@ -521,6 +522,7 @@ Commit::squashFromTrap(ThreadID tid)
     thread[tid]->trapPending = false;
     thread[tid]->noSquashFromTC = false;
     trapInFlight[tid] = false;
+    toIEW->commitInfo[tid].trapPending = false;
 
     trapSquash[tid] = false;
 


### PR DESCRIPTION
This commit stalls O3's fetch stage when a trap event is signaled to be pending from commit. Fixes #2344.