### PR TITLE
arch-arm: Add L2D_TLB_REFILL and L2I_TLB_REFILL in PMU

### DIFF
--- a/configs/example/arm/devices.py
+++ b/configs/example/arm/devices.py
@@ -184,6 +184,7 @@ class ArmCpuCluster(CpuCluster):
                     cpu=cpu,
                     itb=cpu.mmu.itb,
                     dtb=cpu.mmu.dtb,
+                    l2_shared=cpu.mmu.l2_shared,
                     icache=getattr(cpu, "icache", None),
                     dcache=getattr(cpu, "dcache", None),
                     l2cache=getattr(self, "l2", None),

--- a/src/arch/arm/ArmPMU.py
+++ b/src/arch/arm/ArmPMU.py
@@ -169,6 +169,7 @@ class ArmPMU(SimObject):
         cpu=None,
         itb=None,
         dtb=None,
+        l2_shared=None,
         icache=None,
         dcache=None,
         l2cache=None,
@@ -191,10 +192,10 @@ class ArmPMU(SimObject):
 
         self.addEvent(SoftwareIncrement(self, "SW_INCR"))
         self.addEvent(ProbeEvent(self, "L1I_CACHE_REFILL", icache, "Fill"))
-        self.addEvent(ProbeEvent(self, "L1I_TLB_REFILL", itb, "Refills"))
+        self.addEvent(ProbeEvent(self, "L1I_TLB_REFILL", itb, "InstRefills"))
         self.addEvent(ProbeEvent(self, "L1D_CACHE_REFILL", dcache, "Fill"))
         self.addEvent(ProbeEvent(self, "L1D_CACHE", dcache, "Hit", "Miss"))
-        self.addEvent(ProbeEvent(self, "L1D_TLB_REFILL", dtb, "Refills"))
+        self.addEvent(ProbeEvent(self, "L1D_TLB_REFILL", dtb, "DataRefills"))
         self.addEvent(ProbeEvent(self, "LD_RETIRED", cpu, "RetiredLoads"))
         self.addEvent(ProbeEvent(self, "ST_RETIRED", cpu, "RetiredStores"))
         self.addEvent(ProbeEvent(self, "INST_RETIRED", cpu, "RetiredInsts"))
@@ -238,8 +239,12 @@ class ArmPMU(SimObject):
         # 0x2A: L3D_CACHE_REFILL
         # 0x2B: L3D_CACHE
         # 0x2C: L3D_CACHE_WB
-        # 0x2D: L2D_TLB_REFILL
-        # 0x2E: L2I_TLB_REFILL
+        self.addEvent(
+            ProbeEvent(self, "L2D_TLB_REFILL", l2_shared, "DataRefills")
+        )
+        self.addEvent(
+            ProbeEvent(self, "L2I_TLB_REFILL", l2_shared, "InstRefills")
+        )
         # 0x2F: L2D_TLB
         # 0x30: L2I_TLB
 

--- a/src/arch/arm/tlb.cc
+++ b/src/arch/arm/tlb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2016-2024 Arm Limited
+ * Copyright (c) 2010-2013, 2016-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -255,7 +255,12 @@ TLB::insert(const Lookup &lookup_data, TlbEntry &entry)
 
     observedPageSizes.insert(entry.N);
     stats.inserts++;
-    ppRefills->notify(1);
+
+    if (lookup_data.mode == BaseMMU::Execute) {
+        ppInstRefills->notify(1);
+    } else {
+        ppDataRefills->notify(1);
+    }
 }
 
 void
@@ -387,7 +392,11 @@ TLB::TlbStats::TlbStats(TLB &parent)
 void
 TLB::regProbePoints()
 {
-    ppRefills.reset(new probing::PMU(getProbeManager(), "Refills"));
+    ppInstRefills.reset(
+        new probing::PMU(getProbeManager(), "InstRefills"));
+
+    ppDataRefills.reset(
+        new probing::PMU(getProbeManager(), "DataRefills"));
 }
 
 Port *

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2016, 2019-2022, 2024 Arm Limited
+ * Copyright (c) 2010-2013, 2016, 2019-2022, 2024-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -174,7 +174,8 @@ class TLB : public BaseTLB
     } stats;
 
     /** PMU probe for TLB refills */
-    probing::PMUUPtr ppRefills;
+    probing::PMUUPtr ppInstRefills;
+    probing::PMUUPtr ppDataRefills;
 
     int rangeMRU; //On lookup, only move entries ahead when outside rangeMRU
     vmid_t vmid;


### PR DESCRIPTION
This commit implements the L2D_TLB_REFILL and L2I_TLB_REFILL events. We amend the addArchEvents method to accept the unified L2 TLB to serve as probe manager.

The existing probe point (ppRefill) stored in the ArmTLB is now replaced by two probe points for data and instruction refills. (ppDataRefill and ppInstRefill).

The unified L2 will make use to both of them

Change-Id: I9c5f8d612733550b23ec16eac040eeeb06de83ed