### PR TITLE
arch-arm: Add read/write function to FPCR/FPSR.

### DIFF
--- a/src/arch/arm/fastmodel/CortexA76/thread_context.cc
+++ b/src/arch/arm/fastmodel/CortexA76/thread_context.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2025 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2019 Google, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -166,7 +178,7 @@ CortexA76TC::setCCRegFlat(RegIndex idx, RegVal val)
         break;
       case ArmISA::cc_reg::Fp:
         {
-            ArmISA::FPSCR fpscr = readMiscRegNoEffect(ArmISA::MISCREG_FPSCR);
+            ArmISA::FPSCR fpscr = readMiscReg(ArmISA::MISCREG_FPSCR);
             val = insertBits(fpscr, 31, 28, val);
         }
         break;

--- a/src/arch/arm/fastmodel/CortexR52/thread_context.cc
+++ b/src/arch/arm/fastmodel/CortexR52/thread_context.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2025 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2020 Google, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,7 +140,7 @@ CortexR52TC::setCCRegFlat(RegIndex idx, RegVal val)
         break;
       case ArmISA::cc_reg::Fp:
         {
-            ArmISA::FPSCR fpscr = readMiscRegNoEffect(ArmISA::MISCREG_FPSCR);
+            ArmISA::FPSCR fpscr = readMiscReg(ArmISA::MISCREG_FPSCR);
             val = insertBits(fpscr, 31, 28, val);
         }
         break;

--- a/src/arch/arm/isa/operands.isa
+++ b/src/arch/arm/isa/operands.isa
@@ -1,5 +1,5 @@
 // -*- mode:c++ -*-
-// Copyright (c) 2010-2014, 2016-2018, 2021-2022, 2024 Arm Limited
+// Copyright (c) 2010-2014, 2016-2018, 2021-2022, 2024-2025 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -486,6 +486,7 @@ def operands {{
     'Fpscr': CntrlRegNC('MISCREG_FPSCR'),
     'FpscrQc': CntrlRegNC('MISCREG_FPSCR_QC'),
     'FpscrExc': CntrlRegNC('MISCREG_FPSCR_EXC'),
+    'Fpcr': CntrlRegNC('MISCREG_FPCR'),
     'Cpacr': CntrlReg('MISCREG_CPACR'),
     'Cpacr64': CntrlReg64('MISCREG_CPACR_EL1'),
     'Fpexc': CntrlRegNC('MISCREG_FPEXC'),

--- a/src/arch/arm/nativetrace.cc
+++ b/src/arch/arm/nativetrace.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2011, 2014, 2016-2017 ARM Limited
+ * Copyright (c) 2010-2011, 2014, 2016-2017, 2025 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -136,7 +136,7 @@ ArmNativeTrace::ThreadState::update(ThreadContext *tc)
         newState[STATE_F0 + 2*i] = vec[0];
         newState[STATE_F0 + 2*i + 1] = vec[1];
     }
-    newState[STATE_FPSCR] = tc->readMiscRegNoEffect(MISCREG_FPSCR) |
+    newState[STATE_FPSCR] = tc->readMiscReg(MISCREG_FPSCR) |
                             tc->getReg(cc_reg::Fp);
 }
 

--- a/src/arch/arm/regs/misc.hh
+++ b/src/arch/arm/regs/misc.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024 Arm Limited
+ * Copyright (c) 2010-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -3019,6 +3019,10 @@ namespace ArmISA
     static const uint32_t FpscrAhpMask = 0x04000000;
     // This mask selects the cumulative FP exception flags of the FPSCR.
     static const uint32_t FpscrExcMask = 0x0000009F;
+    // This mask selects FPCR bits from FPSCR.
+    static const uint32_t FpscrFpcrMask = 0x07FF9F00;
+    // This mask selects FPSR bits from FPSCR.
+    static const uint32_t FpscrFpsrMask = 0xF800009F;
 
     /**
      * Check for permission to read coprocessor registers.

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024 Arm Limited
+ * Copyright (c) 2010-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -514,6 +514,26 @@ namespace ArmISA
         Bitfield<12> ext;
         Bitfield<13> cm;  // LPAE
     EndBitUnion(FSR)
+
+    BitUnion32(FPCR)
+        Bitfield<0> fiz;
+        Bitfield<1> ah;
+        Bitfield<2> nep;
+        Bitfield<8> ioe;
+        Bitfield<9> dze;
+        Bitfield<10> ofe;
+        Bitfield<11> ufe;
+        Bitfield<12> ixe;
+        Bitfield<13> ebf;
+        Bitfield<15> ide;
+        Bitfield<18, 16> len;
+        Bitfield<19> fz16;
+        Bitfield<21, 20> stride;
+        Bitfield<23, 22> rMode;
+        Bitfield<24> fz;
+        Bitfield<25> dn;
+        Bitfield<26> ahp;
+    EndBitUnion(FPCR)
 
     BitUnion32(FPSCR)
         Bitfield<0> ioc;

--- a/src/arch/arm/remote_gdb.cc
+++ b/src/arch/arm/remote_gdb.cc
@@ -1,7 +1,7 @@
 /*
  * Copyright 2015 LabWare
  * Copyright 2014 Google Inc.
- * Copyright (c) 2010, 2013, 2016, 2018-2019 ARM Limited
+ * Copyright (c) 2010, 2013, 2016, 2018-2019, 2025 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -312,7 +312,7 @@ RemoteGDB::AArch32GdbRegCache::getRegs(ThreadContext *context)
     for (int i = 0; i < 32; i++)
         r.fpr[i] = 0;
 
-    r.fpscr = context->readMiscRegNoEffect(MISCREG_FPSCR);
+    r.fpscr = context->readMiscReg(MISCREG_FPSCR);
 }
 
 void

--- a/src/arch/arm/tracers/tarmac_parser.cc
+++ b/src/arch/arm/tracers/tarmac_parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011,2017-2020 ARM Limited
+ * Copyright (c) 2011,2017-2020, 2025 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -851,40 +851,13 @@ TarmacParserRecord::TarmacParserRecordEvent::process()
                 cpsr.v = thread->getReg(cc_reg::V);
                 values.push_back(cpsr);
             } else if (it->index == MISCREG_FPCR) {
-                // Read FPSCR and extract FPCR value
-                FPSCR fpscr = thread->readMiscRegNoEffect(MISCREG_FPSCR);
-                const uint32_t ones = (uint32_t)(-1);
-                FPSCR fpcrMask  = 0;
-                fpcrMask.ioe = ones;
-                fpcrMask.dze = ones;
-                fpcrMask.ofe = ones;
-                fpcrMask.ufe = ones;
-                fpcrMask.ixe = ones;
-                fpcrMask.ide = ones;
-                fpcrMask.len    = ones;
-                fpcrMask.stride = ones;
-                fpcrMask.rMode  = ones;
-                fpcrMask.fz     = ones;
-                fpcrMask.dn     = ones;
-                fpcrMask.ahp    = ones;
-                values.push_back(fpscr & fpcrMask);
+                // Directly Read FPCR
+                FPCR fpcr = thread->readMiscReg(MISCREG_FPCR);
+                values.push_back(fpcr);
             } else if (it->index == MISCREG_FPSR) {
-                // Read FPSCR and extract FPSR value
-                FPSCR fpscr = thread->readMiscRegNoEffect(MISCREG_FPSCR);
-                const uint32_t ones = (uint32_t)(-1);
-                FPSCR fpsrMask  = 0;
-                fpsrMask.ioc = ones;
-                fpsrMask.dzc = ones;
-                fpsrMask.ofc = ones;
-                fpsrMask.ufc = ones;
-                fpsrMask.ixc = ones;
-                fpsrMask.idc = ones;
-                fpsrMask.qc = ones;
-                fpsrMask.v = ones;
-                fpsrMask.c = ones;
-                fpsrMask.z = ones;
-                fpsrMask.n = ones;
-                values.push_back(fpscr & fpsrMask);
+                // Directly Read FPSR
+                FPSCR fpsr = thread->readMiscReg(MISCREG_FPSR);
+                values.push_back(fpsr);
             } else {
                 values.push_back(thread->readMiscRegNoEffect(it->index));
             }


### PR DESCRIPTION
Most bits in FPCR and FPSR are architectural mapping to FPSCR. But, FPCR has more control bits. Therefore, FPCR should be update as well so that FPCR.FIZ, FPCR.AH and FPCR.NEP can be enabled.

Use FPCR and FPSR as the physical registers. Treat FPSCR as a mirror register.

Additionally, replace readMiscRegNoEffect(MISCREG_FPSCR) with readMiscReg(MISCREG_FPSCR)
replace setMiscRegNoEffect(MISCREG_FPSCR) with
setMiscReg(MISCREG_FPSCR)

Change-Id: I27a8f8700eb1f224ceb8e54f73080b9d80a17cff
Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>