### PR TITLE
util: Update upstream_msg_filter.sed to support macOS

### DIFF
--- a/util/maint/upstream_msg_filter.sed
+++ b/util/maint/upstream_msg_filter.sed
@@ -1,6 +1,6 @@
-#!/bin/sed -f
+#!/usr/bin/env -S sed -f
 #
-# Copyright (c) 2016 ARM Limited
+# Copyright (c) 2016, 2025 Arm Limited
 # All rights reserved
 #
 # The license below extends only to copyright in the software and shall


### PR DESCRIPTION
macOS places `sed` at `/usr/bin/sed`, not `/bin/sed`. This causes `upstream_msg_filter.sed`, called by the
`util/maint/create_patches.sh` tool, to fail on macOS.

This commit updates the shebang line of `upstream_msg_filter.sed` to call via `/usr/bin/env` to support all locations of `sed`.

This fix is not completely portable because it uses the non-standard `-S` option of `/usr/bin/env`. However it should work for recent versions of coreutils (>= 8.30), including all the gem5 supported versions of Ubuntu, as well as macOS.

Change-Id: I53a2efa3def4f30bbebcd7b67c69dd8baf07e220