### PR TITLE
scons: Fix gcc version compare

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -674,7 +674,7 @@ for variant_path in variant_paths:
 
     if env['GCC']:
         gcc_min_version = "11"
-        gcc_max_version = "14"
+        gcc_max_version = "14.2"
         gcc_version = env['CXXVERSION']
         if compareVersions(gcc_version, gcc_min_version) < 0 or \
               compareVersions(gcc_version, gcc_max_version) > 0:


### PR DESCRIPTION
Got warning when compiling with gcc 14.2
```
Warning: Detected GCC version 14.2.0 is not officially supported.
         gem5 supports GCC v11 up to v14.
```

Also show in compiler test
https://github.com/gem5/gem5/actions/runs/15148339286/job/42589316993

Change-Id: Ifd35c3426101b396cade0aa940d3b13731630902