### PR TITLE
mem-garnet,mem-ruby: Fixed Garnet_standalone simulation

### DIFF
--- a/configs/ruby/Garnet_standalone.py
+++ b/configs/ruby/Garnet_standalone.py
@@ -78,7 +78,11 @@ def create_system(
         # Only one cache exists for this protocol, so by default use the L1D
         # config parameters.
         #
-        cache = L1Cache(size=options.l1d_size, assoc=options.l1d_assoc)
+        cache = L1Cache(
+            size=options.l1d_size,
+            assoc=options.l1d_assoc,
+            block_size=f"{options.cacheline_size}B",
+        )
 
         #
         # Only one unified L1 cache exists.  Can cache instructions and data.

--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -822,6 +822,10 @@ $c_ident::init()
                     if "non_obj" not in vtype and not vtype.isEnumeration:
                         args = var.get("constructor", "")
 
+                    if args == "" and "DataBlock" in vtype.c_ident:
+                        # DataBlock constructor requires a blk_size argument
+                        args = "m_ruby_system->getBlockSizeBytes()"
+
                     code("$expr($args);")
                     code("assert($vid != NULL);")
 


### PR DESCRIPTION
The current version of gem5 encounters some assertions because of recent changes related to DataBlock.

To reproduce the current issue, compile with Garnet_standalone as:

```python3 `which scons` build/Garnet_standalone/gem5.opt -j12```

To reproduce and verify the bug fix, run the following command for a 4 × 4 mesh:

```
./build/Garnet_standalone/gem5.opt configs/example/garnet_synth_traffic.py \
                --num-cpus=16 \
                --num-dirs=16 \
                --network=garnet \
                --topology=Mesh_XY \
                --mesh-rows=4 \
                --synthetic=uniform_random \
                --injectionrate=0.1 \
                --sim-cycles=50000
```

This issue and its fix stems from PR #1453, which removed static methods from RubySystem and inadvertently broke the Garnet_standalone SLICC protocol.