### PR TITLE
arch-riscv: Allow load-reserved accesses to use the TLB

### DIFF
--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -67,6 +67,12 @@ class MemAccessInfo
     MemAccessInfo(
       PrivilegeMode priv, bool virt, bool force_virt, bool hlvx, bool lr) :
       priv(priv), virt(virt), force_virt(force_virt), hlvx(hlvx), lr(lr) {}
+
+    bool
+    bypassTLB() const
+    {
+        return (force_virt || hlvx);
+    }
 };
 
 enum XlateStage


### PR DESCRIPTION
PR #1387 modified the TLB logic such that load-reserved memory access commands to skip the TLB. This caused problems after the page table walk. This change modifies the logic to allow them to use the TLB as before #1387.

This change also refactors `special_access` variable to be a function in the `MemAccessInfo` object to reduce code duplication.