### PR TITLE
misc tests: Set specific versions in GH Action workflows

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
     pre-commit:
     # runs on github hosted runner
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
     # `src` directory contents and use it as a hash. We found there to be bugs
     # with the hash function where this task would timeout. This approach is
     # simple, works, and still provides some level of caching.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         outputs:
             date: ${{ steps.date.outputs.date }}
         steps:
@@ -66,7 +66,7 @@ jobs:
             - run: echo "This job's status is ${{ job.status }}."
 
     testlib-quick-matrix:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         if: github.event.pull_request.draft == false
     # In order to make sure the environment is exactly the same, we run in
     # the same container we use to build gem5 and run the testlib tests. This
@@ -249,7 +249,7 @@ jobs:
     ci-tests:
     # It is 'testlib-quick' which needs to pass for the pull request to be
     # merged. This job is a dummy job that depends on all the other jobs.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         needs:
             - testlib-quick-execution
             - clang-fast-compilation

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -19,6 +19,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v5
+              with:
+                  python-version: '3.10'
             - uses: pre-commit/action@v3.0.1
 
     get-date:

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
 
     get-date:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         outputs:
             date: ${{ steps.date.outputs.date }}
         steps:
@@ -53,7 +53,7 @@ jobs:
               run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
 
     get-testlib-long-dirs:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         outputs:
             test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
 
     obtain-targets:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         outputs:
             targets: ${{ steps.generate.outputs.targets }}
 

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
     schedule-workflows:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             # This step is necessary to allow the `gh` CLI to be used in the
             # following steps. The `gh` CLI is used to trigger the workflows.

--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -10,7 +10,7 @@ jobs:
   # This job runs the stale action to close issues that have been inactive for 30 days.
   # It is scheduled to run every day at 1:30 AM UTC.
     close-stale-issues:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/stale@v8.0.0
               with:

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
 
     get-date:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         outputs:
             date: ${{ steps.date.outputs.date }}
         steps:
@@ -19,7 +19,7 @@ jobs:
               run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     get-testlib-very-long-dirs:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         outputs:
             test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}


### PR DESCRIPTION
Setting these explicit will avoid our testing environments changing without our knowledge thereby improving the stability of the workflows.

In the case of setting 'python-version' ( used in 'pre-commit'), doing  also avoids the following warning:

```
The `python-version` input is not set. The version of Python currently in `PATH` will be used.
```