### PR TITLE
arch-power: Add Initial Support for VSX Instructions (mtvsrd, mfvsrd) in Power ISA

### DIFF
--- a/build_errors_June22.txt
+++ b/build_errors_June22.txt
@@ -1,0 +1,8 @@
+/usr/bin/ld: build/POWER/arch/power/generated/inst-constrs.o: warning: relocation against `_ZTVN4gem512PowerISAInst6MfvsrdE' in read-only section `.text'
+/usr/bin/ld: build/POWER/arch/power/generated/inst-constrs.o: in function `gem5::PowerISAInst::Mtvsrd::Mtvsrd(gem5::bitfield_backend::BitUnionOperators<gem5::PowerISA::BitfieldUnderlyingClassesExtMachInst>)':
+/home/divyangthakkar/ibm_project/gem5/build/POWER/arch/power/generated/decoder-ns.cc.inc:4394: undefined reference to `vtable for gem5::PowerISAInst::Mtvsrd'
+/usr/bin/ld: build/POWER/arch/power/generated/inst-constrs.o: in function `gem5::PowerISAInst::Mfvsrd::Mfvsrd(gem5::bitfield_backend::BitUnionOperators<gem5::PowerISA::BitfieldUnderlyingClassesExtMachInst>)':
+/home/divyangthakkar/ibm_project/gem5/build/POWER/arch/power/generated/decoder-ns.cc.inc:4409: undefined reference to `vtable for gem5::PowerISAInst::Mfvsrd'
+/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
+collect2: error: ld returned 1 exit status
+scons: *** [build/POWER/gem5.opt] Error 1

--- a/gem5_run_output_June29.txt
+++ b/gem5_run_output_June29.txt
@@ -1,0 +1,22 @@
+warn: The se.py script is deprecated. It will be removed in future releases of  gem5.
+Global frequency set at 1000000000000 ticks per second
+warn: No dot file generated. Please install pydot to generate the dot file and pdf.
+src/mem/dram_interface.cc:690: warn: DRAM device capacity (8192 Mbytes) does not match the address range assigned (512 Mbytes)
+src/base/statistics.hh:279: warn: One of the stats is a legacy stat. Legacy stat is a stat that does not belong to any statistics::Group. Legacy stat is deprecated.
+IndexError: vector::_M_range_check: __n (which is 6) >= this->size() (which is 6)
+
+At:
+  src/python/m5/SimObject.py(1270): getCCObject
+  src/python/m5/SimObject.py(1290): createCCObject
+  src/python/m5/simulate.py(135): instantiate
+  /home/divyangthakkar/ibm_project/gem5/configs/common/Simulation.py(685): run
+  configs/deprecated/example/se.py(298): <module>
+  src/python/m5/main.py(675): main
+gem5 Simulator System.  https://www.gem5.org
+gem5 is copyrighted software; use the --copyright option for details.
+
+gem5 version 24.1.0.1
+gem5 compiled Jun 29 2025 04:57:20
+gem5 started Jun 30 2025 07:05:29
+gem5 executing on ibm-proj, pid 13475
+command line: ./build/POWER/gem5.opt --debug-flags=Exec,Power configs/deprecated/example/se.py -c ./tests/power_test/mtvsrd_mfvsrd_test

--- a/src/arch/README_VSX_INSTS
+++ b/src/arch/README_VSX_INSTS
@@ -1,3 +1,6 @@
+### Version History
+v0.1 29th June 2025: The compilation errors faced during the gem5 build are resolved. A unit-level test is created to test the 'mtvsrd' and 'mfvsrd' instructions of POWER ISA. Currently, facing run-time errors. For more details refer section Test Case at the bottom of this file.
+
 # Adding Power ISA VSX Instructions: mtvsrd and mfvsrd
 
 This README documents the changes made to gem5 source files to support the addition of two new Power ISA VSX instructions: `mtvsrd` (Move to Vector-Scalar Register Doubleword) and `mfvsrd` (Move from Vector-Scalar Register Doubleword). These changes were modeled according to the POWER ISA specification and integrated within gem5's existing vector register infrastructure.
@@ -83,6 +86,14 @@ Header('insts/vector_scalar.hh')
 * No debug flags were required to be enabled.
 * TODO: Validate with a small test binary that executes `mtvsrd` and `mfvsrd`.
 
+---
+## Test Case
+
+A test case C program using inline assembly for mtvsrd and mfvsrd has been created.
+
+The binary compiles correctly using a PowerPC cross-compiler.
+
+Currently facing issues while executing the binary in gem5 due to simulation runtime errors — under investigation.
 ---
 
 ## Notes

--- a/src/arch/README_VSX_INSTS
+++ b/src/arch/README_VSX_INSTS
@@ -99,7 +99,7 @@ Currently facing issues while executing the binary in gem5 due to simulation run
 ## Notes
 
 * The implementation omits `debug::VecRegs` to avoid namespace/flag conflict.
-* Currently, facing the compilation error mentioned in the `gem5/uild_errors_June22.txt` file.
+* Currently facing issues while executing the binary in gem5 due to simulation runtime errors — under investigation.
 
 ---
 

--- a/src/arch/README_VSX_INSTS
+++ b/src/arch/README_VSX_INSTS
@@ -1,0 +1,97 @@
+# Adding Power ISA VSX Instructions: mtvsrd and mfvsrd
+
+This README documents the changes made to gem5 source files to support the addition of two new Power ISA VSX instructions: `mtvsrd` (Move to Vector-Scalar Register Doubleword) and `mfvsrd` (Move from Vector-Scalar Register Doubleword). These changes were modeled according to the POWER ISA specification and integrated within gem5's existing vector register infrastructure.
+
+### Reference Pull Request:
+
+[https://github.com/gem5/gem5/pull/2339](https://github.com/gem5/gem5/pull/2339)
+
+---
+
+## Modified Files and Changes
+
+### 1. `src/arch/power/regs/vec.hh`
+
+* Defined the `vecRegClass` to represent 64 vector-scalar (VSX) registers.
+* Declared all 64 `VSR` registers: `V0` through `V63`.
+* Avoided use of `debug::VecRegs` due to conflict (unresolved compilation error); debug flag omitted intentionally.
+
+### 2. `src/arch/power/isa/operands.isa`
+
+* Defined new operand extractors for `t_s`, `ra_vsx`, and `tx_sx` to extract instruction fields needed for VSX register indexing.
+
+### 3. `src/arch/power/isa/includes.isa`
+
+* Included the header file `vector_scalar.hh` for use in decoded instruction execution.
+
+### 4. `src/arch/power/isa/formats/vector_scalar.isa`
+
+* Added new format handler function `VSRTransferOp()` to generate `PowerStaticInst` for `mtvsrd` and `mfvsrd`.
+
+### 5. `src/arch/power/isa/formats/util.isa`
+
+* Implemented `GenVSRTransferOp()` to define class logic and execution body for `mtvsrd` and `mfvsrd`.
+* This generates the C++ class with `execute()` and `generateDisassembly()` implementations.
+
+### 6. `src/arch/power/isa/formats/formats.isa`
+
+* Included `vector_scalar.isa` to register the custom instruction format.
+
+### 7. `src/arch/power/isa/decoder.isa`
+
+* Registered `mtvsrd` and `mfvsrd` using the `VSRTransferOp` format with opcodes 179 and 51 respectively.
+
+```python
+format VSRTransferOp {
+    179: mtvsrd({});
+    51:  mfvsrd({});
+}
+```
+
+### 8. `src/arch/power/isa/bitfields.isa`
+
+* No direct changes needed unless custom bitfield names were added (typically optional if bits() used inline).
+
+### 9. `src/arch/power/isa.cc`
+
+* Ensured the instruction classes are registered during initialization.
+* No major structural changes required here.
+
+### 10. `src/arch/power/insts/vector_scalar.hh`
+
+* Declared the execution functions `mtvsrd_exec()` and `mfvsrd_exec()`.
+
+### 11. `src/arch/power/insts/vector_scalar.cc`
+
+* Implemented logic for `mtvsrd_exec()` and `mfvsrd_exec()`.
+* Properly handles mapping between GPRs and VSRs, including VSR0-31 (vector) and VSR32-63 (mapped to FPRs).
+
+### 12. `src/arch/power/SConscript`
+
+* Added `vector_scalar.cc` and `vector_scalar.hh` to the build.
+
+```python
+Source('insts/vector_scalar.cc')
+Header('insts/vector_scalar.hh')
+```
+
+---
+
+## Build & Validation
+
+* Run `scons build/POWER/gem5.opt -j$(nproc)` after making changes.
+* No debug flags were required to be enabled.
+* TODO: Validate with a small test binary that executes `mtvsrd` and `mfvsrd`.
+
+---
+
+## Notes
+
+* The implementation omits `debug::VecRegs` to avoid namespace/flag conflict.
+* Currently, facing the compilation error mentioned in the `gem5/uild_errors_June22.txt` file.
+
+---
+
+For questions or review, refer to the discussions in the [PR #2339](https://github.com/gem5/gem5/pull/2339).
+
+Maintainer: @divyangthakkar

--- a/src/arch/README_VSX_INSTS
+++ b/src/arch/README_VSX_INSTS
@@ -100,6 +100,7 @@ Currently facing issues while executing the binary in gem5 due to simulation run
 
 * The implementation omits `debug::VecRegs` to avoid namespace/flag conflict.
 * Currently facing issues while executing the binary in gem5 due to simulation runtime errors — under investigation.
+* Errors can be found here: gem5/gem5_run_output_June29.txt
 
 ---
 

--- a/src/arch/power/SConscript
+++ b/src/arch/power/SConscript
@@ -36,6 +36,7 @@ if env['CONF']['USE_POWER_ISA']:
 Source('decoder.cc', tags='power isa')
 Source('faults.cc', tags='power isa')
 Source('insts/branch.cc', tags='power isa')
+Source('insts/vector_scalar.cc', tags='power isa')
 Source('insts/mem.cc', tags='power isa')
 Source('insts/integer.cc', tags='power isa')
 Source('insts/floating.cc', tags='power isa')

--- a/src/arch/power/insts/vector_scalar.cc
+++ b/src/arch/power/insts/vector_scalar.cc
@@ -38,15 +38,23 @@
 #include "cpu/thread_context.hh"
 #include "vector_scalar.hh"
 
-using namespace gem5;
+namespace gem5
+{
 
 // Define 128-bit unsigned int if not already available
+#if defined(__SIZEOF_INT128__)
 typedef __uint128_t uint128_t;
+#else
+#warning "128-bit integer type not supported on this compiler"
+#endif
 
 // Register classes are in PowerISA namespace (from src/arch/power/regs/)
-using namespace PowerISA;
+namespace PowerISA
+{
 
-void mtvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx) {
+void
+mtvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx)
+{
     // Compute effective VSX register index (0-63)
     const RegIndex vsr_idx = (tx_sx << 5) | t_s;
 
@@ -67,7 +75,9 @@ void mtvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx) {
     }
 }
 
-void mfvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx) {
+void
+mfvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx)
+{
     // Compute effective VSX register index (0-63)
     const RegIndex vsr_idx = (tx_sx << 5) | t_s;
     uint64_t val;
@@ -82,4 +92,8 @@ void mfvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx) {
     }
 
     tc->setReg(intRegClass[ra_vsx], val);
+}
+
+}
+
 }

--- a/src/arch/power/insts/vector_scalar.cc
+++ b/src/arch/power/insts/vector_scalar.cc
@@ -1,0 +1,35 @@
+#include "arch/power/insts/misc.hh"
+#include "base/types.hh"
+#include "cpu/reg_class.hh"
+#include "cpu/simple_thread.hh"
+#include "cpu/thread_context.hh"
+
+void mtvsrd(ThreadContext *tc, int xt, int ra) {
+    // Ensure valid register indices
+    assert(xt >= 0 && xt < NumVecRegs);
+    assert(ra >= 0 && ra < NumIntRegs);
+
+    // Read the integer register value from GPR[RA]
+    uint64_t value = tc->getReg(RegId(IntRegClass, ra));
+
+    // Read the current value of the VSR[XT] register (128-bit)
+    uint128_t vsr_value = tc->getReg(RegId(VecRegClass, xt));
+
+    // Mask to preserve the upper 64 bits of the VSR
+    const uint128_t UPPER_MASK = (uint128_t)0xFFFFFFFFFFFFFFFFULL << 64;
+
+    // Replace only the lower 64-bits of VSR with the new value from GPR
+    vsr_value = (vsr_value & UPPER_MASK) | value;
+
+    // Write the updated value back to VSR[XT]
+    tc->setReg(RegId(VecRegClass, xt), vsr_value);
+}
+
+void mfvsrd(ThreadContext *tc, int rt, int xs) {
+    // Read the lower 64 bits of the VSR[XS] register
+    uint128_t vsr_value = tc->getReg(RegId(VecRegClass, xs));
+    uint64_t lower_64_bits = vsr_value & 0xFFFFFFFFFFFFFFFFULL;
+
+    // Write the lower 64 bits to GPR[RT]
+    tc->setReg(RegId(IntRegClass, rt), lower_64_bits);
+}

--- a/src/arch/power/insts/vector_scalar.cc
+++ b/src/arch/power/insts/vector_scalar.cc
@@ -3,6 +3,7 @@
 #include "cpu/reg_class.hh"
 #include "cpu/simple_thread.hh"
 #include "cpu/thread_context.hh"
+#include "vector_scalar.hh"
 
 void mtvsrd(ThreadContext *tc, int xt, int ra) {
     // Ensure valid register indices
@@ -25,11 +26,21 @@ void mtvsrd(ThreadContext *tc, int xt, int ra) {
     tc->setReg(RegId(VecRegClass, xt), vsr_value);
 }
 
-void mfvsrd(ThreadContext *tc, int rt, int xs) {
-    // Read the lower 64 bits of the VSR[XS] register
-    uint128_t vsr_value = tc->getReg(RegId(VecRegClass, xs));
-    uint64_t lower_64_bits = vsr_value & 0xFFFFFFFFFFFFFFFFULL;
 
-    // Write the lower 64 bits to GPR[RT]
+void mfvsrd(ThreadContext *tc, int rt, int xs) {
+    // Ensure valid register indices
+    assert(rt >= 0 && rt < NumIntRegs);
+    assert(xs >= 0 && xs < NumVecRegs);
+
+    // Read the current value of the VSR[XS] register (128-bit)
+    uint128_t vsr_value = tc->getReg(RegId(VecRegClass, xs));
+
+    // Extract only the lower 64 bits of the VSR[XS]
+    uint64_t lower_64_bits = static_cast<uint64_t>(
+    vsr_value & 0xFFFFFFFFFFFFFFFFULL
+    );
+
+
+    // Write the extracted lower 64 bits to GPR[RT]
     tc->setReg(RegId(IntRegClass, rt), lower_64_bits);
 }

--- a/src/arch/power/insts/vector_scalar.cc
+++ b/src/arch/power/insts/vector_scalar.cc
@@ -1,46 +1,56 @@
 #include "arch/power/insts/misc.hh"
+#include "arch/power/isa.hh"
+#include "arch/power/regs/float.hh"  // Defines floatRegClass
+#include "arch/power/regs/int.hh"  // Defines intRegClass
+#include "arch/power/regs/vec.hh"
 #include "base/types.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/simple_thread.hh"
 #include "cpu/thread_context.hh"
 #include "vector_scalar.hh"
 
-void mtvsrd(ThreadContext *tc, int xt, int ra) {
-    // Ensure valid register indices
-    assert(xt >= 0 && xt < NumVecRegs);
-    assert(ra >= 0 && ra < NumIntRegs);
+using namespace gem5;
 
-    // Read the integer register value from GPR[RA]
-    uint64_t value = tc->getReg(RegId(IntRegClass, ra));
+// Define 128-bit unsigned int if not already available
+typedef __uint128_t uint128_t;
 
-    // Read the current value of the VSR[XT] register (128-bit)
-    uint128_t vsr_value = tc->getReg(RegId(VecRegClass, xt));
+// Register classes are in PowerISA namespace (from src/arch/power/regs/)
+using namespace PowerISA;
 
-    // Mask to preserve the upper 64 bits of the VSR
-    const uint128_t UPPER_MASK = (uint128_t)0xFFFFFFFFFFFFFFFFULL << 64;
+void mtvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx) {
+    // Compute effective VSX register index (0-63)
+    const RegIndex vsr_idx = (tx_sx << 5) | t_s;
 
-    // Replace only the lower 64-bits of VSR with the new value from GPR
-    vsr_value = (vsr_value & UPPER_MASK) | value;
+    // Get integer register value
+    uint64_t int_val = tc->getReg(intRegClass[ra_vsx]);
 
-    // Write the updated value back to VSR[XT]
-    tc->setReg(RegId(VecRegClass, xt), vsr_value);
+    // For VSR0-VSR31 (vector registers)
+    if (vsr_idx < 32) {
+        // Read existing VSR value (preserve upper 64 bits)
+        uint128_t vsr_val = tc->getReg(vecRegClass[vsr_idx]);
+        vsr_val = (vsr_val & ((uint128_t)0xFFFFFFFFFFFFFFFFULL << 64)) |
+        int_val;
+        tc->setReg(vecRegClass[vsr_idx], vsr_val);
+    }
+    // For VSR32-VSR63 (map to FPRs)
+    else {
+        tc->setReg(floatRegClass[vsr_idx - 32], int_val);
+    }
 }
 
+void mfvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx) {
+    // Compute effective VSX register index (0-63)
+    const RegIndex vsr_idx = (tx_sx << 5) | t_s;
+    uint64_t val;
 
-void mfvsrd(ThreadContext *tc, int rt, int xs) {
-    // Ensure valid register indices
-    assert(rt >= 0 && rt < NumIntRegs);
-    assert(xs >= 0 && xs < NumVecRegs);
+    // For VSR0-VSR31 (vector registers)
+    if (vsr_idx < 32) {
+        val = static_cast<uint64_t>(tc->getReg(vecRegClass[vsr_idx]));
+    }
+    // For VSR32-VSR63 (map to FPRs)
+    else {
+        val = tc->getReg(floatRegClass[vsr_idx - 32]);
+    }
 
-    // Read the current value of the VSR[XS] register (128-bit)
-    uint128_t vsr_value = tc->getReg(RegId(VecRegClass, xs));
-
-    // Extract only the lower 64 bits of the VSR[XS]
-    uint64_t lower_64_bits = static_cast<uint64_t>(
-    vsr_value & 0xFFFFFFFFFFFFFFFFULL
-    );
-
-
-    // Write the extracted lower 64 bits to GPR[RT]
-    tc->setReg(RegId(IntRegClass, rt), lower_64_bits);
+    tc->setReg(intRegClass[ra_vsx], val);
 }

--- a/src/arch/power/insts/vector_scalar.cc
+++ b/src/arch/power/insts/vector_scalar.cc
@@ -1,3 +1,32 @@
+/*
+ * Copyright (c) 2024 The University of Michigan Ann Arbor
+ * Copyright (c) 2024 IBM Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "arch/power/insts/misc.hh"
 #include "arch/power/isa.hh"
 #include "arch/power/regs/float.hh"  // Defines floatRegClass

--- a/src/arch/power/insts/vector_scalar.hh
+++ b/src/arch/power/insts/vector_scalar.hh
@@ -1,0 +1,17 @@
+#ifndef __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__
+#define __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__
+
+#include "cpu/thread_context.hh"
+
+namespace gem5
+{
+namespace PowerISA
+{
+
+void mtvsrd(ThreadContext *tc, int xt, int ra);
+void mfvsrd(ThreadContext *tc, int rt, int xs);
+
+} // namespace PowerISA
+} // namespace gem5
+
+#endif // __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__

--- a/src/arch/power/insts/vector_scalar.hh
+++ b/src/arch/power/insts/vector_scalar.hh
@@ -1,3 +1,31 @@
+// Copyright (c) 2025 The Regents of the University of Michigan Ann Arbor
+// All rights reserved.
+//
+// This file is part of gem5.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the University nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__
 #define __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__
 

--- a/src/arch/power/insts/vector_scalar.hh
+++ b/src/arch/power/insts/vector_scalar.hh
@@ -1,6 +1,9 @@
 #ifndef __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__
 #define __ARCH_POWER_INSTS_VECTOR_SCALAR_HH__
 
+#include "arch/power/regs/float.hh"
+#include "arch/power/regs/int.hh"
+#include "arch/power/regs/vec.hh"
 #include "cpu/thread_context.hh"
 
 namespace gem5
@@ -8,8 +11,8 @@ namespace gem5
 namespace PowerISA
 {
 
-void mtvsrd(ThreadContext *tc, int xt, int ra);
-void mfvsrd(ThreadContext *tc, int rt, int xs);
+void mtvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx);
+void mfvsrd_exec(ThreadContext *tc, int t_s, int ra_vsx, int tx_sx);
 
 } // namespace PowerISA
 } // namespace gem5

--- a/src/arch/power/isa.cc
+++ b/src/arch/power/isa.cc
@@ -40,6 +40,7 @@
 #include "arch/power/regs/float.hh"
 #include "arch/power/regs/int.hh"
 #include "arch/power/regs/misc.hh"
+#include "arch/power/regs/vec.hh"
 #include "cpu/thread_context.hh"
 #include "debug/MatRegs.hh"
 #include "params/PowerISA.hh"
@@ -52,14 +53,8 @@ namespace PowerISA
 
 namespace
 {
-
-RegClass vecRegClass(VecRegClass, VecRegClassName, 1, debug::IntRegs);
-RegClass vecElemClass(VecElemClass, VecElemClassName, 2, debug::IntRegs);
-RegClass vecPredRegClass(VecPredRegClass, VecPredRegClassName, 1,
-        debug::IntRegs);
 RegClass matRegClass(MatRegClass, MatRegClassName, 0, debug::MatRegs);
 RegClass ccRegClass(CCRegClass, CCRegClassName, 0, debug::IntRegs);
-
 } // anonymous namespace
 
 ISA::ISA(const Params &p) : BaseISA(p, "power")
@@ -67,8 +62,6 @@ ISA::ISA(const Params &p) : BaseISA(p, "power")
     _regClasses.push_back(&intRegClass);
     _regClasses.push_back(&floatRegClass);
     _regClasses.push_back(&vecRegClass);
-    _regClasses.push_back(&vecElemClass);
-    _regClasses.push_back(&vecPredRegClass);
     _regClasses.push_back(&matRegClass);
     _regClasses.push_back(&ccRegClass);
     _regClasses.push_back(&miscRegClass);

--- a/src/arch/power/isa/bitfields.isa
+++ b/src/arch/power/isa/bitfields.isa
@@ -61,6 +61,11 @@ def bitfield FRC           <10:6>;
 def bitfield FRS           <25:21>;
 def bitfield FRT           <25:21>;
 
+// VSX Fields
+def bitfield RA_vsx         <15:11>;
+def bitfield T_S            <10:6>;
+def bitfield TX_SX          <31>;
+
 // The record bit can be in two positions
 // Used to enable setting of the condition register
 def bitfield RC31          <0>;

--- a/src/arch/power/isa/decoder.isa
+++ b/src/arch/power/isa/decoder.isa
@@ -37,6 +37,38 @@
 //
 decode PO default Unknown::unknown() {
 
+    def mtvsrd : PowerInst_VSX
+    {
+        bits<5> XT, RA;
+        format ("mtvsrd", XT, ",", RA);
+
+        decode OPCD == 31 & XO == 179
+        // Opcode is 31 and Extended Opcode is 179
+        {
+            execute
+            {
+                VSR[XT][0] = GPR[RA];
+                // Move GPR to lower 64-bits of VSR
+            }
+        }
+    };
+
+    def mfvsrd : PowerInst_VSX
+    {
+        bits<5> RT, XS;
+        format ("mfvsrd", RT, ",", XS);
+
+        decode OPCD == 31 & XO == 51
+        // Opcode is 31 and Extended Opcode is 51
+        {
+            execute
+            {
+                GPR[RT] = VSR[XS][0];
+                // Move the lower 64 bits of VSR[XS] to GPR[RT]
+            }
+        }
+    };
+
     format IntImmTrapOp {
         2: tdi({{ Ra }});
         3: twi({{ Ra_sw }});

--- a/src/arch/power/isa/decoder.isa
+++ b/src/arch/power/isa/decoder.isa
@@ -37,24 +37,6 @@
 //
 decode PO default Unknown::unknown() {
 
-    31: decode VSX_INST {  // Grouping VSX-related instructions
-
-    format ("mtvsrd", XT, ",", RA") {
-        179: mtvsrd({{
-            // Move GPR to lower 64-bits of VSR
-            VSR[XT][0] = GPR[RA];
-        }});
-    }
-
-    format ("mfvsrd", RT, ",", XS") {
-        51: mfvsrd({{
-            // Move lower 64 bits of VSR to GPR
-            GPR[RT] = VSR[XS][0];
-        }});
-    }
-}
-
-
     format IntImmTrapOp {
         2: tdi({{ Ra }});
         3: twi({{ Ra_sw }});
@@ -803,6 +785,12 @@ decode PO default Unknown::unknown() {
 
         // These instructions are of XO form with bit 21 as the OE bit.
         default: decode XO_XO {
+
+            format VSRTransferOp {
+                    179: mtvsrd({{ }});
+                    51:  mfvsrd({{ }});
+            }
+
             8: IntSumOp::subfc({{ ~Ra }}, {{ Rb }}, {{ 1 }}, true);
 
             9: IntArithCheckRcOp::mulhdu({{

--- a/src/arch/power/isa/decoder.isa
+++ b/src/arch/power/isa/decoder.isa
@@ -37,37 +37,23 @@
 //
 decode PO default Unknown::unknown() {
 
-    def mtvsrd : PowerInst_VSX
-    {
-        bits<5> XT, RA;
-        format ("mtvsrd", XT, ",", RA);
+    31: decode VSX_INST {  // Grouping VSX-related instructions
 
-        decode OPCD == 31 & XO == 179
-        // Opcode is 31 and Extended Opcode is 179
-        {
-            execute
-            {
-                VSR[XT][0] = GPR[RA];
-                // Move GPR to lower 64-bits of VSR
-            }
-        }
-    };
+    format ("mtvsrd", XT, ",", RA") {
+        179: mtvsrd({{
+            // Move GPR to lower 64-bits of VSR
+            VSR[XT][0] = GPR[RA];
+        }});
+    }
 
-    def mfvsrd : PowerInst_VSX
-    {
-        bits<5> RT, XS;
-        format ("mfvsrd", RT, ",", XS);
+    format ("mfvsrd", RT, ",", XS") {
+        51: mfvsrd({{
+            // Move lower 64 bits of VSR to GPR
+            GPR[RT] = VSR[XS][0];
+        }});
+    }
+}
 
-        decode OPCD == 31 & XO == 51
-        // Opcode is 31 and Extended Opcode is 51
-        {
-            execute
-            {
-                GPR[RT] = VSR[XS][0];
-                // Move the lower 64 bits of VSR[XS] to GPR[RT]
-            }
-        }
-    };
 
     format IntImmTrapOp {
         2: tdi({{ Ra }});

--- a/src/arch/power/isa/formats/formats.isa
+++ b/src/arch/power/isa/formats/formats.isa
@@ -39,6 +39,9 @@
 //Include utility functions
 ##include "util.isa"
 
+//Include the Vector Scalar formats
+##include "vector_scalar.isa"
+
 //Include the float formats
 ##include "fp.isa"
 

--- a/src/arch/power/isa/formats/util.isa
+++ b/src/arch/power/isa/formats/util.isa
@@ -146,54 +146,124 @@ def template CheckRaZeroDecode {{
 
 let {{
 
-def LoadStoreBase(name, Name, ea_code, memacc_code, update_code,
-                  mem_flags, inst_flags, base_class = 'MemOp',
-                  decode_template = BasicDecode, exec_template_base = ''):
-    # Make sure flags are in lists (convert to lists if not).
-    mem_flags = makeList(mem_flags)
-    inst_flags = makeList(inst_flags)
+    def LoadStoreBase(name, Name, ea_code, memacc_code, update_code,
+                    mem_flags, inst_flags, base_class = 'MemOp',
+                    decode_template = BasicDecode, exec_template_base = ''):
+        # Make sure flags are in lists (convert to lists if not).
+        mem_flags = makeList(mem_flags)
+        inst_flags = makeList(inst_flags)
 
-    # Generate InstObjParams for the memory access.
-    iop = InstObjParams(name, Name, base_class,
-                        {'ea_code': ea_code,
-                         'memacc_code': memacc_code,
-                         'update_code': update_code},
-                        inst_flags)
+        # Generate InstObjParams for the memory access.
+        iop = InstObjParams(name, Name, base_class,
+                            {'ea_code': ea_code,
+                            'memacc_code': memacc_code,
+                            'update_code': update_code},
+                            inst_flags)
 
-    if mem_flags:
-        s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
-        iop.constructor += s
+        if mem_flags:
+            s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
+            iop.constructor += s
 
-    fullExecTemplate = eval(exec_template_base + 'Execute')
-    initiateAccTemplate = eval(exec_template_base + 'InitiateAcc')
-    completeAccTemplate = eval(exec_template_base + 'CompleteAcc')
+        fullExecTemplate = eval(exec_template_base + 'Execute')
+        initiateAccTemplate = eval(exec_template_base + 'InitiateAcc')
+        completeAccTemplate = eval(exec_template_base + 'CompleteAcc')
 
-    # (header_output, decoder_output, decode_block, exec_output)
-    return (LoadStoreDeclare.subst(iop),
-            LoadStoreConstructor.subst(iop),
-            decode_template.subst(iop),
-            fullExecTemplate.subst(iop)
-            + initiateAccTemplate.subst(iop)
-            + completeAccTemplate.subst(iop))
+        # (header_output, decoder_output, decode_block, exec_output)
+        return (LoadStoreDeclare.subst(iop),
+                LoadStoreConstructor.subst(iop),
+                decode_template.subst(iop),
+                fullExecTemplate.subst(iop)
+                + initiateAccTemplate.subst(iop)
+                + completeAccTemplate.subst(iop))
 
 
-# The generic ALU instruction generator. Integer and fp formats calls this
-# to generate the different output sections.
-def GenAluOp(name, Name, base_class, code, inst_flags, decode_template,
-             constructor_template):
-    iop = InstObjParams(name, Name, base_class,
-                        {"code": code},
-                        inst_flags)
-    header_output = BasicDeclare.subst(iop)
-    exec_output = BasicExecute.subst(iop)
+    # The generic ALU instruction generator. Integer and fp formats calls this
+    # to generate the different output sections.
+    def GenAluOp(name, Name, base_class, code, inst_flags, decode_template,
+                constructor_template):
+        iop = InstObjParams(name, Name, base_class,
+                            {"code": code},
+                            inst_flags)
+        header_output = BasicDeclare.subst(iop)
+        exec_output = BasicExecute.subst(iop)
 
-    # We use constructors dependent on the Rc and OE bits being set
-    decoder_output = constructor_template.subst(iop)
+        # We use constructors dependent on the Rc and OE bits being set
+        decoder_output = constructor_template.subst(iop)
 
-    # The decode block defines which version to use
-    decode_block = decode_template.subst(iop)
-    return (header_output, decoder_output, decode_block, exec_output)
+        # The decode block defines which version to use
+        decode_block = decode_template.subst(iop)
+        return (header_output, decoder_output, decode_block, exec_output)
 
+    def GenBasicOp(name, Name, base_class, code, inst_flags,
+                decode_template, constructor_template) :
+        iop = InstObjParams(name, Name, base_class, code, inst_flags)
+        header_output = BasicDeclare.subst(iop)
+        decoder_output = constructor_template.subst(iop)
+        decode_block = decode_template.subst(iop)
+        exec_output = BasicExecute.subst(iop)
+        return (header_output, decoder_output, decode_block, exec_output)
+
+    def GenVSRTransferOp(name, Name, code, inst_flags):
+        iop = InstObjParams(name, Name, "PowerStaticInst", code, inst_flags)
+
+        header_output = """
+        #include "base/compiler.hh"
+        #include "cpu/static_inst.hh"
+        #include "sim/serialize.hh"
+        #include "arch/power/regs/vec.hh"
+        #include "arch/power/insts/vector_scalar.hh"
+        """ + BasicDeclare.subst(iop)
+
+        decoder_output = BasicConstructor.subst(iop)
+        decode_block = BasicDecode.subst(iop)
+
+        # Common VSX register index calculation
+        vsr_idx_calc = """
+        const RegIndex vsr_idx = (tx_sx << 5) | t_s;
+        """
+        if name == "mtvsrd":
+            exec_body = """\
+            uint32_t t_s = bits(machInst, 10, 6);
+            uint32_t ra_vsx = bits(machInst, 15, 11);
+            uint32_t tx_sx = bits(machInst, 31);
+            mtvsrd_exec(tc, t_s, ra_vsx, tx_sx);"""
+        elif name == "mfvsrd":
+            exec_body = """\
+            uint32_t t_s = bits(machInst, 10, 6);
+            uint32_t ra_vsx = bits(machInst, 15, 11);
+            uint32_t tx_sx = bits(machInst, 31);
+            mfvsrd_exec(tc, t_s, ra_vsx, tx_sx);"""
+        else:
+            exec_body = "// Unknown instruction"
+
+        exec_output = """
+            class %(name)s : public PowerStaticInst
+            {
+            public:
+                using PowerStaticInst::PowerStaticInst;
+
+                Fault
+                execute(ExecContext *xc, trace::InstRecord *traceData)
+                const override
+                {
+                    ThreadContext *tc = xc->tcBase();
+                    if (traceData)
+                        traceData->setPredicate(true);
+                    %(exec_body)s
+                    return NoFault;
+                }
+                std::string generateDisassembly(Addr pc,
+                const loader::SymbolTable *symtab) const override
+                {
+                    std::stringstream ss;
+                    ccprintf(ss, "%%-10s ", mnemonic);
+                    // Add disassembly formatting here
+                    return ss.str();
+                }
+            };
+            """ % {'name': name, 'exec_body': exec_body}
+
+        return (header_output, decoder_output, decode_block, exec_output)
 }};
 
 

--- a/src/arch/power/isa/formats/util.isa
+++ b/src/arch/power/isa/formats/util.isa
@@ -204,7 +204,16 @@ let {{
         return (header_output, decoder_output, decode_block, exec_output)
 
     def GenVSRTransferOp(name, Name, code, inst_flags):
-        iop = InstObjParams(name, Name, "PowerStaticInst", code, inst_flags)
+
+        iop = InstObjParams(name, Name, "PowerStaticInst",
+        {
+        "code": code,
+        "reg_idx_arr_decl": "RegId srcRegIdxArr[1]; RegId destRegIdxArr[1]"
+        },
+        inst_flags)
+        # Manually add a top-level key for template use
+        iop.reg_idx_arr_decl = iop.snippets['reg_idx_arr_decl']
+        print(iop.__dict__)
 
         header_output = """
         #include "base/compiler.hh"
@@ -215,6 +224,7 @@ let {{
         """ + BasicDeclare.subst(iop)
 
         decoder_output = BasicConstructor.subst(iop)
+
         decode_block = BasicDecode.subst(iop)
 
         # Common VSX register index calculation
@@ -237,14 +247,10 @@ let {{
             exec_body = "// Unknown instruction"
 
         exec_output = """
-            class %(name)s : public PowerStaticInst
-            {
-            public:
-                using PowerStaticInst::PowerStaticInst;
-
                 Fault
-                execute(ExecContext *xc, trace::InstRecord *traceData)
-                const override
+                %(Name)s::execute(ExecContext *xc,
+                trace::InstRecord *traceData)
+                const
                 {
                     ThreadContext *tc = xc->tcBase();
                     if (traceData)
@@ -252,16 +258,7 @@ let {{
                     %(exec_body)s
                     return NoFault;
                 }
-                std::string generateDisassembly(Addr pc,
-                const loader::SymbolTable *symtab) const override
-                {
-                    std::stringstream ss;
-                    ccprintf(ss, "%%-10s ", mnemonic);
-                    // Add disassembly formatting here
-                    return ss.str();
-                }
-            };
-            """ % {'name': name, 'exec_body': exec_body}
+            """ % {'Name': Name, 'exec_body': exec_body}
 
         return (header_output, decoder_output, decode_block, exec_output)
 }};

--- a/src/arch/power/isa/formats/vector_scalar.isa
+++ b/src/arch/power/isa/formats/vector_scalar.isa
@@ -1,31 +1,30 @@
-
-# Copyright (c) 2025 The Regents of the University of Michigan Ann Arbor
-# All rights reserved.
-#
-# This file is part of gem5.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the University nor the
-#       names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2025 The Regents of the University of Michigan Ann Arbor
+// All rights reserved.
+//
+// This file is part of gem5.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the University nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 def format VSRTransferOp(code, inst_flags = []) {{
     (header_output, decoder_output, decode_block, exec_output) = \

--- a/src/arch/power/isa/formats/vector_scalar.isa
+++ b/src/arch/power/isa/formats/vector_scalar.isa
@@ -1,3 +1,32 @@
+
+# Copyright (c) 2025 The Regents of the University of Michigan Ann Arbor
+# All rights reserved.
+#
+# This file is part of gem5.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the University nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 def format VSRTransferOp(code, inst_flags = []) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         GenVSRTransferOp(name, Name, code, inst_flags)

--- a/src/arch/power/isa/formats/vector_scalar.isa
+++ b/src/arch/power/isa/formats/vector_scalar.isa
@@ -1,0 +1,4 @@
+def format VSRTransferOp(code, inst_flags = []) {{
+    (header_output, decoder_output, decode_block, exec_output) = \
+        GenVSRTransferOp(name, Name, code, inst_flags)
+}};

--- a/src/arch/power/isa/includes.isa
+++ b/src/arch/power/isa/includes.isa
@@ -59,8 +59,8 @@ output decoder {{
 #include "arch/power/faults.hh"
 #include "arch/power/regs/float.hh"
 #include "arch/power/regs/int.hh"
-#include "base/loader/symtab.hh"
 #include "base/cprintf.hh"
+#include "base/loader/symtab.hh"
 #include "cpu/thread_context.hh"
 
 namespace gem5::PowerISAInst
@@ -74,9 +74,11 @@ output exec {{
 
 #include "arch/generic/memhelpers.hh"
 #include "arch/power/faults.hh"
+#include "arch/power/insts/vector_scalar.hh"
 #include "arch/power/regs/float.hh"
 #include "arch/power/regs/int.hh"
 #include "arch/power/regs/misc.hh"
+#include "arch/power/regs/vec.hh"
 #include "base/condcodes.hh"
 #include "cpu/base.hh"
 #include "cpu/exetrace.hh"

--- a/src/arch/power/isa/operands.isa
+++ b/src/arch/power/isa/operands.isa
@@ -55,6 +55,10 @@ def operands {{
     'Fs': FloatRegOp('df', 'FRS', 'IsFloating', 4),
     'Ft': FloatRegOp('df', 'FRT', 'IsFloating', 5),
 
+    # Vector Registers
+    'Xt': VecRegOp('ud', 'XT', 'VecRegClass', 5),
+    'Xs': VecRegOp('ud', 'XS', 'VecRegClass', 3),
+
     # Memory Operand
     'Mem': MemOp('ud', None, (None, 'IsLoad', 'IsStore'), 8),
 

--- a/src/arch/power/regs/vec.hh
+++ b/src/arch/power/regs/vec.hh
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Regents of the University of XYZ
+// Copyright (c) 2025 The Regents of the University of Michigan Ann Arbor
 // All rights reserved.
 //
 // This file is part of gem5.

--- a/src/arch/power/regs/vec.hh
+++ b/src/arch/power/regs/vec.hh
@@ -1,3 +1,31 @@
+// Copyright (c) 2025 The Regents of the University of XYZ
+// All rights reserved.
+//
+// This file is part of gem5.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the University nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #ifndef __ARCH_POWER_REGS_VEC_HH__
 #define __ARCH_POWER_REGS_VEC_HH__
 

--- a/src/arch/power/regs/vec.hh
+++ b/src/arch/power/regs/vec.hh
@@ -1,0 +1,113 @@
+#ifndef __ARCH_POWER_REGS_VEC_HH__
+#define __ARCH_POWER_REGS_VEC_HH__
+
+#include "cpu/reg_class.hh"
+
+//#include "debug/VecRegs.hh"
+#include "debug/IntRegs.hh"
+
+namespace gem5
+{
+namespace PowerISA
+{
+
+namespace vsr_reg
+{
+    // Primary definition as constexpr
+    constexpr unsigned NumRegs = 64;
+    constexpr unsigned FPR_OFFSET = 32; // VSR32-63 overlap with FPR0-31
+
+    enum : RegIndex
+    {
+    _V0Idx, _V1Idx, _V2Idx, _V3Idx, _V4Idx, _V5Idx, _V6Idx, _V7Idx,
+    _V8Idx, _V9Idx, _V10Idx, _V11Idx, _V12Idx, _V13Idx, _V14Idx, _V15Idx,
+    _V16Idx, _V17Idx, _V18Idx, _V19Idx, _V20Idx, _V21Idx, _V22Idx, _V23Idx,
+    _V24Idx, _V25Idx, _V26Idx, _V27Idx, _V28Idx, _V29Idx, _V30Idx, _V31Idx,
+    _V32Idx, _V33Idx, _V34Idx, _V35Idx, _V36Idx, _V37Idx, _V38Idx, _V39Idx,
+    _V40Idx, _V41Idx, _V42Idx, _V43Idx, _V44Idx, _V45Idx, _V46Idx, _V47Idx,
+    _V48Idx, _V49Idx, _V50Idx, _V51Idx, _V52Idx, _V53Idx, _V54Idx, _V55Idx,
+    _V56Idx, _V57Idx, _V58Idx, _V59Idx, _V60Idx, _V61Idx, _V62Idx, _V63Idx,
+
+    _NumRegsEnum    //Renamed to avoid conflict
+};
+
+} // namespace vsr_reg
+
+inline constexpr RegClass vecRegClass(VecRegClass, "vsr",
+                                    vsr_reg::_NumRegsEnum,
+                                    debug::IntRegs);    //Placeholder
+
+namespace vsr_reg
+{
+   inline constexpr RegId
+    V0 = vecRegClass[_V0Idx],
+    V1 = vecRegClass[_V1Idx],
+    V2 = vecRegClass[_V2Idx],
+    V3 = vecRegClass[_V3Idx],
+    V4 = vecRegClass[_V4Idx],
+    V5 = vecRegClass[_V5Idx],
+    V6 = vecRegClass[_V6Idx],
+    V7 = vecRegClass[_V7Idx],
+    V8 = vecRegClass[_V8Idx],
+    V9 = vecRegClass[_V9Idx],
+    V10 = vecRegClass[_V10Idx],
+    V11 = vecRegClass[_V11Idx],
+    V12 = vecRegClass[_V12Idx],
+    V13 = vecRegClass[_V13Idx],
+    V14 = vecRegClass[_V14Idx],
+    V15 = vecRegClass[_V15Idx],
+    V16 = vecRegClass[_V16Idx],
+    V17 = vecRegClass[_V17Idx],
+    V18 = vecRegClass[_V18Idx],
+    V19 = vecRegClass[_V19Idx],
+    V20 = vecRegClass[_V20Idx],
+    V21 = vecRegClass[_V21Idx],
+    V22 = vecRegClass[_V22Idx],
+    V23 = vecRegClass[_V23Idx],
+    V24 = vecRegClass[_V24Idx],
+    V25 = vecRegClass[_V25Idx],
+    V26 = vecRegClass[_V26Idx],
+    V27 = vecRegClass[_V27Idx],
+    V28 = vecRegClass[_V28Idx],
+    V29 = vecRegClass[_V29Idx],
+    V30 = vecRegClass[_V30Idx],
+    V31 = vecRegClass[_V31Idx],
+    V32 = vecRegClass[_V32Idx],
+    V33 = vecRegClass[_V33Idx],
+    V34 = vecRegClass[_V34Idx],
+    V35 = vecRegClass[_V35Idx],
+    V36 = vecRegClass[_V36Idx],
+    V37 = vecRegClass[_V37Idx],
+    V38 = vecRegClass[_V38Idx],
+    V39 = vecRegClass[_V39Idx],
+    V40 = vecRegClass[_V40Idx],
+    V41 = vecRegClass[_V41Idx],
+    V42 = vecRegClass[_V42Idx],
+    V43 = vecRegClass[_V43Idx],
+    V44 = vecRegClass[_V44Idx],
+    V45 = vecRegClass[_V45Idx],
+    V46 = vecRegClass[_V46Idx],
+    V47 = vecRegClass[_V47Idx],
+    V48 = vecRegClass[_V48Idx],
+    V49 = vecRegClass[_V49Idx],
+    V50 = vecRegClass[_V50Idx],
+    V51 = vecRegClass[_V51Idx],
+    V52 = vecRegClass[_V52Idx],
+    V53 = vecRegClass[_V53Idx],
+    V54 = vecRegClass[_V54Idx],
+    V55 = vecRegClass[_V55Idx],
+    V56 = vecRegClass[_V56Idx],
+    V57 = vecRegClass[_V57Idx],
+    V58 = vecRegClass[_V58Idx],
+    V59 = vecRegClass[_V59Idx],
+    V60 = vecRegClass[_V60Idx],
+    V61 = vecRegClass[_V61Idx],
+    V62 = vecRegClass[_V62Idx],
+    V63 = vecRegClass[_V63Idx];
+
+} // namespace vsr_reg
+
+} // namespace PowerISA
+} // namespace gem5
+
+#endif // __ARCH_POWER_REGS_VEC_HH__

--- a/tests/power_test/mtvsrd_mfvsrd_test.c
+++ b/tests/power_test/mtvsrd_mfvsrd_test.c
@@ -1,0 +1,29 @@
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int main() {
+    uint64_t input = 0x1234567890abcdef;
+    uint64_t output;
+
+    // Store input into VSR (vector-scalar register) using mtvsrd
+    __asm__ volatile (
+        "mtvsrd 0, %0\n\t" // VSR0 <- input
+        :
+        : "r" (input)
+        : "v0" // clobber VSR0
+    );
+
+    // Load from VSR back into output using mfvsrd
+    __asm__ volatile (
+        "mfvsrd %0, 0\n\t" // output <- VSR0
+        : "=r" (output)
+        :
+        : "v0" // clobber VSR0
+    );
+
+    printf("Input:  0x%016" PRIx64 "\n", input);
+    printf("Output: 0x%016" PRIx64 "\n", output);
+
+    return 0;
+}


### PR DESCRIPTION
Summary

This Pull Request introduces initial support for the `mtvsrd` and `mfvsrd` instructions within the Power ISA in gem5. These instructions belong to the VSX (Vector-Scalar Extension) instruction set and represent a step toward broader VSX coverage.
-----------------------

Implementation Details

a. Implemented decode logic and execution behavior for `mtvsrd` and `mfvsrd`
b. Updated instruction formatting and register handling in relevant ISA files
c. Integrated bitfield mapping and symbol resolution
d. Temporarily disabled vector debug flags due to unresolved initialization issues
------------

Context

This work stems from discussions during Gem5 BootCamp 2024 and aims to contribute to ongoing support for the Power ISA's VSX feature set. Further instructions and full vector support are planned.
----------

Request for Review

@power-isa-maintainers, I am seeking your feedback on the following:
a. Symbol resolution conventions used for VSX
b. Register file usage (scalar vs. vector overlap handling)
c. Whether the approach aligns with existing ISA extension patterns

Please let me know if any structural changes are required or if there's an internal checklist you would prefer me to follow.

Thank you!
Divyang
