### PR TITLE
tests: Update pyunit tests to work with v25.0

### DIFF
--- a/tests/pyunit/stdlib/resources/pyunit_obtain_resources_check.py
+++ b/tests/pyunit/stdlib/resources/pyunit_obtain_resources_check.py
@@ -60,10 +60,6 @@ mock_config_json = {
     "gem5.resources.client._create_clients",
     side_effect=lambda x: _create_clients(mock_config_json),
 )
-@unittest.skip(
-    "These fail due to changes in client API in gem5 stdlib. "
-    "Unknown reason. To be fixed at a later date."
-)
 class TestObtainResourcesCheck(unittest.TestCase):
     def get_resource_dir(cls) -> str:
         """To ensure the resources are cached to the same directory as all

--- a/tests/pyunit/stdlib/resources/pyunit_resource_specialization.py
+++ b/tests/pyunit/stdlib/resources/pyunit_resource_specialization.py
@@ -60,10 +60,6 @@ mock_config_json = {
     "gem5.resources.client._create_clients",
     side_effect=lambda x: _create_clients(mock_config_json),
 )
-@unittest.skip(
-    "These fail due to changes in client API in gem5 stdlib. "
-    "Unknown reason. To be fixed at a later date."
-)
 class ResourceSpecializationSuite(unittest.TestCase):
     """This suite tests that `gem5.resource.resource` casts to the correct
     `AbstractResource` specialization when using the `obtain_resource`

--- a/tests/pyunit/stdlib/resources/pyunit_suite_checks.py
+++ b/tests/pyunit/stdlib/resources/pyunit_suite_checks.py
@@ -50,10 +50,6 @@ mock_config_json = {
 }
 
 
-@unittest.skip(
-    "These fail due to changes in client API in gem5 stdlib. "
-    "Unknown reason. To be fixed at a later date."
-)
 class CustomSuiteResourceTestSuite(unittest.TestCase):
     @classmethod
     @patch(

--- a/tests/pyunit/stdlib/resources/refs/obtain-resource.json
+++ b/tests/pyunit/stdlib/resources/refs/obtain-resource.json
@@ -12,7 +12,8 @@
         "gem5_versions": [
             "25.0",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -28,7 +29,8 @@
         "gem5_versions": [
             "23.0",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -45,7 +47,8 @@
             "develop",
             "develop-2",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -61,7 +64,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -77,7 +81,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -92,7 +97,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -107,7 +113,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -122,7 +129,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -138,20 +146,21 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
         "id": "tests-no-workload-field-suite",
         "category": "suite",
         "resource_version": "1.0.0",
-        "gem5_versions": ["develop","23.1", "24.0", "24.1"]
+        "gem5_versions": ["develop","23.1", "24.0", "24.1","25.0"]
     },
     {
         "id": "tests-no-id-in-workload-field-suite",
         "category": "suite",
         "resource_version": "1.0.0",
-        "gem5_versions": ["develop","23.1", "24.0", "24.1"],
+        "gem5_versions": ["develop","23.1", "24.0", "24.1","25.0"],
         "workloads": [
             {
                 "resource_version": "1.0.0",
@@ -163,7 +172,7 @@
         "id": "tests-no-input-group-in-workload-field-suite",
         "category": "suite",
         "resource_version": "1.0.0",
-        "gem5_versions": ["develop","23.1", "24.0", "24.1"],
+        "gem5_versions": ["develop","23.1", "24.0", "24.1","25.0"],
         "workloads": [
             {
                 "id": "simple-workload-1",

--- a/tests/pyunit/stdlib/resources/refs/resource-specialization.json
+++ b/tests/pyunit/stdlib/resources/refs/resource-specialization.json
@@ -11,7 +11,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -27,7 +28,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -42,7 +44,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -55,7 +58,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -71,7 +75,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -85,7 +90,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -99,7 +105,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -116,7 +123,8 @@
             "develop",
             "23.0",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -136,7 +144,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -160,7 +169,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -174,7 +184,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     },
     {
@@ -189,7 +200,8 @@
         "resource_version": "1.0.0",
         "gem5_versions": [
             "develop",
-            "23.0"
+            "23.0",
+            "25.0"
         ]
     }
 ]

--- a/tests/pyunit/stdlib/resources/refs/suite-checks.json
+++ b/tests/pyunit/stdlib/resources/refs/suite-checks.json
@@ -3,7 +3,7 @@
         "id": "suite-example",
         "category": "suite",
         "resource_version": "1.0.0",
-        "gem5_versions": ["develop","23.1", "24.0", "24.1"],
+        "gem5_versions": ["develop","23.1", "24.0", "24.1","25.0"],
         "workloads": [
             {
                 "id": "simple-workload-1",
@@ -39,7 +39,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -64,7 +65,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -80,7 +82,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -97,7 +100,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     },
     {
@@ -113,7 +117,8 @@
         "gem5_versions": [
             "develop",
             "24.0",
-            "24.1"
+            "24.1",
+            "25.0"
         ]
     }
 ]


### PR DESCRIPTION
- This change updates the gem5_versions compatibility in the mocked resources used in pyunit tests to include gem5 version 25.0

- This change also enables the skipped pyunit tests as they should work with gem5 version 25.0