### PR TITLE
Add missing operands to disassembly for common arm instructions

### DIFF
--- a/src/arch/arm/insts/macromem.cc
+++ b/src/arch/arm/insts/macromem.cc
@@ -246,7 +246,12 @@ PairMemOp::PairMemOp(const char *mnem, ExtMachInst machInst, OpClass __opClass,
                      bool signExt, bool exclusive, bool acrel,
                      int64_t imm, AddrMode mode,
                      RegIndex rn, RegIndex rt, RegIndex rt2) :
-    PredMacroOp(mnem, machInst, __opClass)
+    PredMacroOp(mnem, machInst, __opClass),
+    mode(mode),
+    rn(rn),
+    rt(rt),
+    rt2(rt2),
+    imm(imm)
 {
     bool post = (mode == AddrMd_PostIndex);
     bool writeback = (mode != AddrMd_Offset);
@@ -1640,6 +1645,32 @@ MicroMemPairOp::generateDisassembly(
     ss << ", ";
     ccprintf(ss, "#%d", imm);
     ss << "]";
+    return ss.str();
+}
+
+std::string
+PairMemOp::generateDisassembly(
+        Addr pc, const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss);
+    printIntReg(ss, rt);
+    ss << ", ";
+    printIntReg(ss, rt2);
+    ss << ", [";
+    printIntReg(ss, rn, 64);
+    if (mode == AddrMd_PostIndex) {
+        ss << "]";
+    }
+    if (imm) {
+        ccprintf(ss, ", #%d", imm);
+    }
+    if (mode != AddrMd_PostIndex) {
+        ss << "]";
+    }
+    if (mode == AddrMd_PreIndex) {
+        ss << "!";
+    }
     return ss.str();
 }
 

--- a/src/arch/arm/insts/macromem.hh
+++ b/src/arch/arm/insts/macromem.hh
@@ -481,10 +481,16 @@ class PairMemOp : public PredMacroOp
     };
 
   protected:
+    AddrMode mode;
+    RegIndex rn, rt, rt2;
+    int32_t imm;
     PairMemOp(const char *mnem, ExtMachInst machInst, OpClass __opClass,
               uint32_t size, bool fp, bool load, bool noAlloc, bool signExt,
               bool exclusive, bool acrel, int64_t imm, AddrMode mode,
               RegIndex rn, RegIndex rt, RegIndex rt2);
+
+    std::string generateDisassembly(
+            Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
 class BigFpMemImmOp : public PredMacroOp

--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -155,9 +155,9 @@ MemoryPostIndex64::generateDisassembly(
 {
     std::stringstream ss;
     startDisassembly(ss);
-    if (imm)
-        ccprintf(ss, "], #%d", imm);
     ccprintf(ss, "]");
+    if (imm)
+        ccprintf(ss, ", #%d", imm);
     return ss.str();
 }
 

--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -51,8 +51,7 @@ std::string
 SysDC64::generateDisassembly(Addr pc, const loader::SymbolTable *symtab) const
 {
     std::stringstream ss;
-    printMnemonic(ss, "", false);
-    ccprintf(ss, ", ");
+    ss << "  " << mnemonic << ", ";
     printIntReg(ss, base);
     return ss.str();
 }

--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -2643,4 +2643,15 @@ AtOp64::addressTranslation64(ThreadContext* tc,
     return std::make_pair(fault, par);
 }
 
+std::string
+IsbOp64::generateDisassembly(Addr pc, const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    printMnemonic(ss, "", false);
+    if (imm != 15) {
+        ccprintf(ss, "#%d", imm);
+    }
+    return ss.str();
+}
+
 } // namespace gem5

--- a/src/arch/arm/insts/misc64.cc
+++ b/src/arch/arm/insts/misc64.cc
@@ -2654,4 +2654,27 @@ IsbOp64::generateDisassembly(Addr pc, const loader::SymbolTable *symtab) const
     return ss.str();
 }
 
+std::string
+DsbOp64::generateDisassembly(Addr pc, const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    ss << "  " << mnemonic << "   ";
+    switch (imm) {
+        case 1:  ss << "OSHLD"; break;
+        case 2:  ss << "OSHST"; break;
+        case 3:  ss << "OSH";   break;
+        case 5:  ss << "NSHLD"; break;
+        case 6:  ss << "NSHST"; break;
+        case 7:  ss << "NSH";   break;
+        case 9:  ss << "ISHLD"; break;
+        case 10: ss << "ISHST"; break;
+        case 11: ss << "ISH";   break;
+        case 13: ss << "LD";    break;
+        case 14: ss << "ST";    break;
+        case 15: ss << "SY";    break;
+        default: ss << "#" << imm; break;
+    }
+    return ss.str();
+}
+
 } // namespace gem5

--- a/src/arch/arm/insts/misc64.hh
+++ b/src/arch/arm/insts/misc64.hh
@@ -357,6 +357,20 @@ class AtOp64 : public MiscRegRegImmOp64
         BaseMMU::Mode mode, Request::Flags flags, RegVal val) const;
 };
 
+class IsbOp64 : public ArmISA::ArmStaticInst
+{
+  protected:
+    uint64_t imm;
+
+    IsbOp64(const char *mnem, ArmISA::ExtMachInst _machInst,
+            OpClass __opClass, uint64_t _imm) :
+        ArmISA::ArmStaticInst(mnem, _machInst, __opClass), imm(_imm)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const loader::SymbolTable *symtab) const override;
+};
+
 } // namespace gem5
 
 #endif

--- a/src/arch/arm/insts/misc64.hh
+++ b/src/arch/arm/insts/misc64.hh
@@ -371,6 +371,20 @@ class IsbOp64 : public ArmISA::ArmStaticInst
             Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
+class DsbOp64 : public ArmISA::ArmStaticInst
+{
+  protected:
+    uint64_t imm;
+
+    DsbOp64(const char *mnem, ArmISA::ExtMachInst _machInst,
+            OpClass __opClass, uint64_t _imm) :
+        ArmISA::ArmStaticInst(mnem, _machInst, __opClass), imm(_imm)
+    {}
+
+    std::string generateDisassembly(
+            Addr pc, const loader::SymbolTable *symtab) const override;
+};
+
 } // namespace gem5
 
 #endif

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -428,7 +428,7 @@ namespace Aarch64
                           case 0x5:
                             return new Dmb64(machInst);
                           case 0x6:
-                            return new Isb64(machInst);
+                            return new Isb64(machInst, crm);
                           default:
                             return new Unknown64(machInst);
                         }

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -399,12 +399,12 @@ namespace Aarch64
                             if (bits(crm, 1, 0) == 0b10) {
                                 switch (bits(crm, 3, 2)) {
                                   case 0x1: // Non-Shareable
-                                    return new Dsb64Local(machInst);
+                                    return new Dsb64Local(machInst, crm);
                                   case 0x0: // OuterShareable
                                   case 0x2: // InnerShareable
                                   case 0x3: // FullSystem
                                     return new Dsb64Shareable(
-                                        machInst, dec.dvmEnabled);
+                                        machInst, crm, dec.dvmEnabled);
                                   default:
                                     GEM5_UNREACHABLE;
                                 }
@@ -416,12 +416,12 @@ namespace Aarch64
                           case 0x4:
                             switch (bits(crm, 3, 2)) {
                               case 0x1: // Non-Shareable
-                                return new Dsb64Local(machInst);
+                                return new Dsb64Local(machInst, crm);
                               case 0x0: // OuterShareable
                               case 0x2: // InnerShareable
                               case 0x3: // FullSystem
                                 return new Dsb64Shareable(
-                                    machInst, dec.dvmEnabled);
+                                    machInst, crm, dec.dvmEnabled);
                               default:
                                 GEM5_UNREACHABLE;
                             }

--- a/src/arch/arm/isa/insts/misc64.isa
+++ b/src/arch/arm/isa/insts/misc64.isa
@@ -188,10 +188,10 @@ let {{
     decoder_output += BasicConstructor64.subst(unknown64Iop)
     exec_output += BasicExecute.subst(unknown64Iop)
 
-    isbIop = ArmInstObjParams("isb", "Isb64", "ArmStaticInst", "",
+    isbIop = ArmInstObjParams("isb", "Isb64", "IsbOp64", "",
                               ['IsSquashAfter'])
-    header_output += BasicDeclare.subst(isbIop)
-    decoder_output += BasicConstructor64.subst(isbIop)
+    header_output += ImmOp64Declare.subst(isbIop)
+    decoder_output += ImmOp64Constructor.subst(isbIop)
     exec_output += BasicExecute.subst(isbIop)
 
     dsbLocalIop = ArmInstObjParams("dsb", "Dsb64Local", "ArmStaticInst", "",

--- a/src/arch/arm/isa/insts/misc64.isa
+++ b/src/arch/arm/isa/insts/misc64.isa
@@ -194,11 +194,11 @@ let {{
     decoder_output += ImmOp64Constructor.subst(isbIop)
     exec_output += BasicExecute.subst(isbIop)
 
-    dsbLocalIop = ArmInstObjParams("dsb", "Dsb64Local", "ArmStaticInst", "",
+    dsbLocalIop = ArmInstObjParams("dsb", "Dsb64Local", "DsbOp64", "",
                                    ['IsReadBarrier', 'IsWriteBarrier',
                                    'IsSerializeAfter'])
-    header_output += BasicDeclare.subst(dsbLocalIop)
-    decoder_output += BasicConstructor64.subst(dsbLocalIop)
+    header_output += ImmOp64Declare.subst(dsbLocalIop)
+    decoder_output += ImmOp64Constructor.subst(dsbLocalIop)
     exec_output += BasicExecute.subst(dsbLocalIop)
 
     dvmCode = '''
@@ -215,7 +215,7 @@ let {{
             PendingDvm = false;
         }
     '''
-    dsbShareableIop = ArmInstObjParams("dsb", "Dsb64Shareable", "ArmStaticInst",
+    dsbShareableIop = ArmInstObjParams("dsb", "Dsb64Shareable", "DsbOp64",
                                        { "code" : "", "dvm_code" : dvmCode },
                                        ['IsReadBarrier', 'IsWriteBarrier',
                                         'IsSerializeAfter'])

--- a/src/arch/arm/isa/templates/misc64.isa
+++ b/src/arch/arm/isa/templates/misc64.isa
@@ -331,7 +331,7 @@ def template DvmDeclare {{
 
       public:
         /// Constructor.
-        %(class_name)s(ExtMachInst machInst, bool dvm_enabled);
+        %(class_name)s(ExtMachInst machInst, uint64_t imm, bool dvm_enabled);
         Fault initiateAcc(ExecContext *, trace::InstRecord *) const override;
         Fault completeAcc(PacketPtr, ExecContext *,
                           trace::InstRecord *) const override;
@@ -368,8 +368,9 @@ def template AtConstructor {{
 }};
 
 def template DvmConstructor {{
-    %(class_name)s::%(class_name)s(ExtMachInst machInst, bool dvm_enabled) :
-        %(base_class)s("%(mnemonic)s", machInst, %(op_class)s),
+    %(class_name)s::%(class_name)s(ExtMachInst machInst, uint64_t imm,
+                                   bool dvm_enabled) :
+        %(base_class)s("%(mnemonic)s", machInst, %(op_class)s, imm),
         dvmEnabled(dvm_enabled)
     {
         %(set_reg_idx_arr)s;


### PR DESCRIPTION
For a number of common instructions, gem5's built-in ARM disassembler doesn't print the instruction operands. This can be a bit of a headache when you don't want to use libcapstone, and are looking at instruction traces.

Reproducer:

test.S
```
    .text
    .globl _start
_start:
    ldr x30, [sp]
    ldr x30, [sp], #16
    str x30, [sp]
    str x30, [sp], #16

    ldp x10, x20, [x30]
    stp x10, x20, [x30]
    ldp w10, w20, [x30]
    stp w10, w20, [x30]
    ldp x10, x20, [x30], #-8  // post-index, negative
    stp x10, x20, [x30, #16]! // pre-index, write-back
    ldp w10, w20, [x30, #32]  // pre-index, no write-back
    stp w10, w20, [x30], #128 // post-index, positive

    dc zva, x17
    dc cvac, x17

    isb
    isb #10

    dsb nsh
    dsb sy
    dsb #8

    .long 0xff210110 // m5_op EXIT
```

```
# Build binary
aarch64-linux-gnu-gcc -c test.S -o test.o
aarch64-linux-gnu-ld -o test.arm64 test.o -N -Ttext 0x10 -static

# objdump disassembly
aarch64-linux-gnu-objdump -D test.arm64

# gem5 disassembly
./build/ARM/gem5.opt configs/example/arm/baremetal.py --tarmac-gen --kernel test.arm64 | grep ' IT '
```