### PR TITLE
sim: remove cerr and improve macOS support in init_signals.cc

### DIFF
--- a/src/sim/init_signals.cc
+++ b/src/sim/init_signals.cc
@@ -242,21 +242,23 @@ externalProcessHandler(int sigtype)
 void
 processExternalSignal(void)
 {
-    std::string shared_mem_name_str = "shared_gem5_signal_mem_" +
+    std::string shared_mem_name_str = "/shared_gem5_signal_mem_" +
         std::to_string(getpid());
     const char* shared_mem_name = shared_mem_name_str.c_str();
     const std::size_t shared_mem_size = 4096;
 
     int shm_fd = shm_open(shared_mem_name, O_RDWR, 0666); //0666 = rw-rw-rw-
     if (shm_fd == -1) {
-        std::cerr << "Error: Unable to open shared memory" << std::endl;
+        DPRINTF(ExternalSignal, "Error: Unable to open shared memory: %s\n",
+                std::strerror(errno));
         return;
     }
 
     void* shm_ptr = mmap(0, shared_mem_size, PROT_READ | PROT_WRITE,
         MAP_SHARED, shm_fd, 0);
     if (shm_ptr == MAP_FAILED) {
-        std::cerr << "Error: Unable to map shared memory" << std::endl;
+        DPRINTF(ExternalSignal, "Error: Unable to map shared memory: %s\n",
+                std::strerror(errno));
         close(shm_fd);
         return;
     }


### PR DESCRIPTION
This commit modifies error messages that previously used cerr to instead use DPRINTF. It also fixes a bug with the external process handler on macOS. Previously, gem5 was unable to open shared memory on macOS when handling an external signal because the shared memory name didn't start with a '/'.