### PR TITLE
util, stdlib: changes to hypercall external signal

### DIFF
--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -389,7 +389,7 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
             "workload": simulator.get_workload().get_id(),
             "tick": simulator.get_current_tick(),
             "sim_id": simulator.get_id(),
-            "instruction_count": simulator.get_instruction_count(),
+            "curr_instructions_executed": simulator.get_instruction_count(),
         }
 
     def _add_debug_flags(self, debug_flags: List[str]) -> Dict[str, str]:

--- a/util/hypercall_external_signal/orchestrator-request.py
+++ b/util/hypercall_external_signal/orchestrator-request.py
@@ -63,7 +63,7 @@ Response Format:
             "workload": "x86-ubuntu-22.04",
             "tick": 1234567,
             "sim_id": "abc123",
-            "instruction_count": 9876
+            "curr_instructions_executed": 9876
         }
 
 Error Handling:


### PR DESCRIPTION
This PR makes some small changes to the hypercall external signal utility and orchestrator exit handler. In the orchestrator exit handler, the "instruction_count" stat has been renamed to "curr_instructions_executed". Additionally, transmitter.py has been modified to stop waiting for gem5 if the gem5 simulation exited or if 10 seconds have passed.