### PR TITLE
arch-vega: Included modifiers support in vop3_cmp instructions

### DIFF
--- a/src/arch/amdgpu/vega/insts/vop3_cmp.cc
+++ b/src/arch/amdgpu/vega/insts/vop3_cmp.cc
@@ -1381,6 +1381,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, src0[lane] == src1[lane] ? 1 : 0);
@@ -1451,6 +1473,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, src0[lane] > src1[lane] ? 1 : 0);
@@ -1520,6 +1564,28 @@ namespace VegaISA
 
         src0.readSrc();
         src1.readSrc();
+
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
@@ -1626,6 +1692,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, !(src0[lane] >= src1[lane]) ? 1 : 0);
@@ -1696,6 +1784,28 @@ namespace VegaISA
 
         src0.readSrc();
         src1.readSrc();
+
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {

--- a/src/arch/amdgpu/vega/insts/vop3_cmp.cc
+++ b/src/arch/amdgpu/vega/insts/vop3_cmp.cc
@@ -1346,6 +1346,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, src0[lane] < src1[lane] ? 1 : 0);
@@ -1437,6 +1459,28 @@ namespace VegaISA
 
         src0.readSrc();
         src1.readSrc();
+
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
@@ -1530,6 +1574,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, src0[lane] != src1[lane] ? 1 : 0);
@@ -1621,6 +1687,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, (!std::isnan(src0[lane])
@@ -1655,6 +1743,28 @@ namespace VegaISA
 
         src0.readSrc();
         src1.readSrc();
+
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
@@ -1749,6 +1859,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, !(src0[lane] < src1[lane]
@@ -1842,6 +1974,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, !(src0[lane] <= src1[lane]) ? 1 : 0);
@@ -1877,6 +2031,28 @@ namespace VegaISA
         src0.readSrc();
         src1.readSrc();
 
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
+
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {
                 sdst.setBit(lane, src0[lane] != src1[lane] ? 1 : 0);
@@ -1911,6 +2087,28 @@ namespace VegaISA
 
         src0.readSrc();
         src1.readSrc();
+
+        if (instData.ABS & 0x1) {
+            src0.absModifier();
+        }
+
+        if (instData.ABS & 0x2) {
+            src1.absModifier();
+        }
+
+        if (extData.NEG & 0x1) {
+            src0.negModifier();
+        }
+
+        if (extData.NEG & 0x2) {
+            src1.negModifier();
+        }
+
+        /**
+         * input modifiers are supported by FP operations only
+         */
+        assert(!(instData.ABS & 0x4));
+        assert(!(extData.NEG & 0x4));
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
             if (wf->execMask(lane)) {


### PR DESCRIPTION
Includes support for abs and neg modifiers in five F32 vop3_cmp instructions (GE, NGE, GT, NGT, EQ)