### PR TITLE
arch-x86: automatically exit X86 simulations on kernel panic

### DIFF
--- a/src/arch/x86/SConscript
+++ b/src/arch/x86/SConscript
@@ -106,9 +106,6 @@ SimObject('X86CPU.py', sim_objects=[], tags=['x86 isa'])
 DebugFlag('LocalApic', "Local APIC debugging", tags=['x86 isa'])
 DebugFlag('X86', "Generic X86 ISA debugging", tags=['x86 isa'])
 DebugFlag('ACPI', "ACPI debugging", tags=['x86 isa'])
-DebugFlag(
-    'X86KernelPanicExit', "Exit simulation if kernel panics", tags=['x86 isa']
-    )
 
 python_files = (
     '__init__.py',

--- a/src/arch/x86/SConscript
+++ b/src/arch/x86/SConscript
@@ -106,6 +106,9 @@ SimObject('X86CPU.py', sim_objects=[], tags=['x86 isa'])
 DebugFlag('LocalApic', "Local APIC debugging", tags=['x86 isa'])
 DebugFlag('X86', "Generic X86 ISA debugging", tags=['x86 isa'])
 DebugFlag('ACPI', "ACPI debugging", tags=['x86 isa'])
+DebugFlag(
+    'X86KernelPanicExit', "Exit simulation if kernel panics", tags=['x86 isa']
+    )
 
 python_files = (
     '__init__.py',

--- a/src/arch/x86/X86FsWorkload.py
+++ b/src/arch/x86/X86FsWorkload.py
@@ -74,6 +74,12 @@ class X86FsWorkload(KernelWorkload):
         X86ACPIRSDP(), "ACPI root description pointer structure"
     )
     enable_osxsave = Param.Bool(False, "Enable OSXSAVE in CR4 register")
+    exit_on_kernel_panic = Param.Bool(
+        True, "Generate gem5 panic upon the guest's kernel panic."
+    )
+    exit_on_kernel_oops = Param.Bool(
+        True, "Generate gem5 panic upon the guest's kernel oops."
+    )
 
 
 class X86FsLinux(X86FsWorkload):
@@ -83,4 +89,22 @@ class X86FsLinux(X86FsWorkload):
 
     e820_table = Param.X86E820Table(
         X86E820Table(), "E820 map of physical memory"
+    )
+    exit_on_kernel_panic = Param.Bool(
+        True, "Generate gem5 panic upon the guest's kernel panic."
+    )
+    exit_on_kernel_oops = Param.Bool(
+        True, "Generate gem5 panic upon the guest's kernel oops."
+    )
+    # Note: Duplicated from KernelWorkload for now
+    on_panic = Param.KernelPanicOopsBehaviour(
+        "DumpDmesgAndExit",
+        "Define how gem5 should behave after a Linux Kernel Panic. "
+        "Handler might not be implemented for all architectures.",
+    )
+
+    on_oops = Param.KernelPanicOopsBehaviour(
+        "DumpDmesgAndExit",
+        "Define how gem5 should behave after a Linux Kernel Oops. "
+        "Handler might not be implemented for all architectures.",
     )

--- a/src/arch/x86/X86FsWorkload.py
+++ b/src/arch/x86/X86FsWorkload.py
@@ -78,7 +78,7 @@ class X86FsWorkload(KernelWorkload):
         True, "Generate gem5 panic upon the guest's kernel panic."
     )
     exit_on_kernel_oops = Param.Bool(
-        True, "Generate gem5 panic upon the guest's kernel oops."
+        False, "Generate gem5 panic upon the guest's kernel oops."
     )
 
 
@@ -94,9 +94,10 @@ class X86FsLinux(X86FsWorkload):
         True, "Generate gem5 panic upon the guest's kernel panic."
     )
     exit_on_kernel_oops = Param.Bool(
-        True, "Generate gem5 panic upon the guest's kernel oops."
+        False, "Generate gem5 panic upon the guest's kernel oops."
     )
-    # Note: Duplicated from KernelWorkload for now
+    # Note: Taken from the RISC-V implementation, which obtained the following
+    # from KernelWorkload
     on_panic = Param.KernelPanicOopsBehaviour(
         "DumpDmesgAndExit",
         "Define how gem5 should behave after a Linux Kernel Panic. "

--- a/src/arch/x86/fs_workload.cc
+++ b/src/arch/x86/fs_workload.cc
@@ -64,14 +64,10 @@ FsWorkload::FsWorkload(const Params &p) : KernelWorkload(p),
     mpFloatingPointer(p.intel_mp_pointer),
     mpConfigTable(p.intel_mp_table),
     rsdp(p.acpi_description_table_pointer),
-    enable_osxsave(p.enable_osxsave),
-    exit_on_kernel_panic(p.exit_on_kernel_panic),
-    exit_on_kernel_oops(p.exit_on_kernel_oops)
-{
-    // addExitOnKernelPanicEvent();
-    // addExitOnKernelOopsEvent();
-
-}
+    enable_osxsave(p.enable_osxsave)
+    // exit_on_kernel_panic(p.exit_on_kernel_panic),
+    // exit_on_kernel_oops(p.exit_on_kernel_oops)
+{}
 
 void
 installSegDesc(ThreadContext *tc, int seg, SegDescriptor desc, bool longmode)
@@ -126,29 +122,31 @@ void
 FsWorkload::addExitOnKernelPanicEvent()
 {
     const std::string dmesg_output = name() + ".dmesg";
-    // if (params().exit_on_kernel_panic) {
+    DPRINTF(
+        X86KernelPanicExit, "FsWorkload::addExitOnKernelPanicEvent called!"
+    );
+    DPRINTF(
+        X86KernelPanicExit, "FsWorkload: is params().exit_on_kernel_panic "
+        "true? %d", params().exit_on_kernel_panic
+    );
+    if (params().exit_on_kernel_panic) {
     // if (exit_on_kernel_panic) {
+        // This was adapted from the RISCV implementation. The issue is that
+        // the kernel table, `kernelSymtab`, which addKernelFuncEvent tries
+        // to access, is empty
         kernelPanicPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
             "panic", "Kernel panic in simulated system.",
             dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
-            // params().on_panic
         );
         warn_if(!kernelPanicPcEvent, "Failed to find kernel symbol 'panic'");
         DPRINTF(
             X86KernelPanicExit, "FsWorkload: is kernelPanicPcEvent set? %d",
             kernelPanicPcEvent != nullptr);
-    // }
-    DPRINTF(
-        X86KernelPanicExit, "FsWorkload::addExitOnKernelPanicEvent called!"
-    );
-    DPRINTF(
-        X86KernelPanicExit, "is params().exit_on_kernel_panic true? %d",
-        params().exit_on_kernel_panic
-    );
-    DPRINTF(
-        X86KernelPanicExit, "is exit_on_kernel_panic true? %d",
-        exit_on_kernel_panic
-    );
+    }
+    // DPRINTF(
+    //     X86KernelPanicExit, "is exit_on_kernel_panic true? %d",
+    //     exit_on_kernel_panic
+    // );
 
 }
 
@@ -156,19 +154,15 @@ void
 FsWorkload::addExitOnKernelOopsEvent()
 {
     const std::string dmesg_output = name() + ".dmesg";
-    // if (params().exit_on_kernel_oops) {
-    if (exit_on_kernel_oops) {
-
+    if (params().exit_on_kernel_oops) {
+    // if (exit_on_kernel_oops) {
         kernelOopsPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
             "oops_exit", "Kernel oops in simulated system.",
             dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
-            // params().on_oops
         );
         warn_if(!kernelOopsPcEvent,
                 "Failed to find kernel symbol 'oops_exit'");
     }
-    // DPRINTF(X86KernelPanicExit,
-    // "FsWorkload::addExitOnKernelOopsEvent called!");
 
 }
 

--- a/src/arch/x86/fs_workload.cc
+++ b/src/arch/x86/fs_workload.cc
@@ -120,14 +120,14 @@ FsWorkload::addExitOnKernelPanicEvent()
 {
     const std::string dmesg_output = name() + ".dmesg";
     if (params().exit_on_kernel_panic) {
-        // This was adapted from the RISCV implementation. Some kernels may not
+        // This was taken from the RISCV implementation. Some kernels may not
         // have kernel symbols, causing `kernelSymtab` to be empty.
         // In that case, addKernelFuncEvent tries to access the "panic" symbol
         // in the symbol table but can't, so the event won't be added and the
         // simulation will hang upon kernel panic.
         kernelPanicPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
             "panic", "Kernel panic in simulated system.",
-            dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
+            dmesg_output, params().on_panic
         );
         warn_if(!kernelPanicPcEvent, "Failed to find kernel symbol 'panic'");
     }
@@ -137,7 +137,7 @@ void
 FsWorkload::addExitOnKernelOopsEvent()
 {
     const std::string dmesg_output = name() + ".dmesg";
-    // This was adapted from the RISCV implementation. Some kernels may not
+    // This was taken from the RISCV implementation. Some kernels may not
     // have kernel symbols, causing `kernelSymtab` to be empty.
     // In that case, addKernelFuncEvent tries to access the "oops_exit" symbol
     // in the symbol table but can't, so the event won't be added and the
@@ -145,7 +145,7 @@ FsWorkload::addExitOnKernelOopsEvent()
     if (params().exit_on_kernel_oops) {
         kernelOopsPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
             "oops_exit", "Kernel oops in simulated system.",
-            dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
+            dmesg_output, params().on_oops
         );
         warn_if(!kernelOopsPcEvent,
                 "Failed to find kernel symbol 'oops_exit'");

--- a/src/arch/x86/fs_workload.cc
+++ b/src/arch/x86/fs_workload.cc
@@ -47,7 +47,6 @@
 #include "cpu/pc_event.hh"
 #include "cpu/thread_context.hh"
 #include "debug/ACPI.hh"
-#include "debug/X86KernelPanicExit.hh"
 #include "kern/linux/events.hh"
 #include "params/X86FsWorkload.hh"
 #include "sim/sim_exit.hh"
@@ -120,13 +119,6 @@ void
 FsWorkload::addExitOnKernelPanicEvent()
 {
     const std::string dmesg_output = name() + ".dmesg";
-    DPRINTF(
-        X86KernelPanicExit, "FsWorkload::addExitOnKernelPanicEvent called!"
-    );
-    DPRINTF(
-        X86KernelPanicExit, "FsWorkload: is params().exit_on_kernel_panic "
-        "true? %d", params().exit_on_kernel_panic
-    );
     if (params().exit_on_kernel_panic) {
         // This was adapted from the RISCV implementation. Some kernels may not
         // have kernel symbols, causing `kernelSymtab` to be empty.
@@ -138,15 +130,7 @@ FsWorkload::addExitOnKernelPanicEvent()
             dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
         );
         warn_if(!kernelPanicPcEvent, "Failed to find kernel symbol 'panic'");
-        DPRINTF(
-            X86KernelPanicExit, "FsWorkload: is kernelPanicPcEvent set? %d",
-            kernelPanicPcEvent != nullptr);
     }
-    // DPRINTF(
-    //     X86KernelPanicExit, "is exit_on_kernel_panic true? %d",
-    //     exit_on_kernel_panic
-    // );
-
 }
 
 void

--- a/src/arch/x86/fs_workload.hh
+++ b/src/arch/x86/fs_workload.hh
@@ -122,8 +122,8 @@ class FsWorkload : public KernelWorkload
     PCEvent *kernelOopsPcEvent = nullptr;
     void addExitOnKernelPanicEvent();
     void addExitOnKernelOopsEvent();
-    bool exit_on_kernel_panic;
-    bool exit_on_kernel_oops;
+    // bool exit_on_kernel_panic;
+    // bool exit_on_kernel_oops;
 };
 
 } // namespace X86ISA

--- a/src/arch/x86/fs_workload.hh
+++ b/src/arch/x86/fs_workload.hh
@@ -122,8 +122,6 @@ class FsWorkload : public KernelWorkload
     PCEvent *kernelOopsPcEvent = nullptr;
     void addExitOnKernelPanicEvent();
     void addExitOnKernelOopsEvent();
-    // bool exit_on_kernel_panic;
-    // bool exit_on_kernel_oops;
 };
 
 } // namespace X86ISA

--- a/src/arch/x86/fs_workload.hh
+++ b/src/arch/x86/fs_workload.hh
@@ -78,10 +78,18 @@ class FsWorkload : public KernelWorkload
   public:
     PARAMS(X86FsWorkload);
     FsWorkload(const Params &p);
-
+    ~FsWorkload()
+    {
+        if (kernelPanicPcEvent != nullptr) {
+            delete kernelPanicPcEvent;
+        }
+        if (kernelOopsPcEvent != nullptr) {
+            delete kernelOopsPcEvent;
+        }
+    }
   public:
     void initState() override;
-
+    void startup() override;
     void
     setSystem(System *sys) override
     {
@@ -109,6 +117,13 @@ class FsWorkload : public KernelWorkload
 
   private:
     bool enable_osxsave;
+
+    PCEvent *kernelPanicPcEvent = nullptr;
+    PCEvent *kernelOopsPcEvent = nullptr;
+    void addExitOnKernelPanicEvent();
+    void addExitOnKernelOopsEvent();
+    bool exit_on_kernel_panic;
+    bool exit_on_kernel_oops;
 };
 
 } // namespace X86ISA

--- a/src/arch/x86/linux/fs_workload.cc
+++ b/src/arch/x86/linux/fs_workload.cc
@@ -51,18 +51,13 @@
 
 namespace gem5
 {
-
-// using namespace linux;
 namespace X86ISA
 {
 
 FsLinux::FsLinux(const Params &p) :
-    X86ISA::FsWorkload(p), exit_on_kernel_panic(p.exit_on_kernel_panic),
-    exit_on_kernel_oops(p.exit_on_kernel_oops), e820Table(p.e820_table)
-{
-    // addExitOnKernelOopsEvent();
-    // addExitOnKernelPanicEvent();
-}
+    X86ISA::FsWorkload(p), /* exit_on_kernel_panic(p.exit_on_kernel_panic),
+    exit_on_kernel_oops(p.exit_on_kernel_oops), */e820Table(p.e820_table)
+{}
 
 void
 FsLinux::startup()
@@ -74,103 +69,59 @@ FsLinux::startup()
 }
 
 
-// void
-// FsLinux::addExitOnKernelPanicEvent()
-// {
-//     const std::string dmesg_output = name() + ".dmesg";
-//     if (params().exit_on_kernel_panic) {
-//         // kernelPanicPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
-//         //     "panic", "Kernel panic in simulated system.",
-//         //     dmesg_output, params().on_panic
-//         // );
-//         kernelPanicPcEvent = addKernelFuncEventOrPanic<PanicPCEvent>(
-//             "panic", "Kernel panic in simulated kernel");
-//         // warn_if(
-                //!kernelPanicPcEvent, "Failed to find kernel symbol 'panic'");
-//     }
-// }
-
-// void
-// FsLinux::addExitOnKernelOopsEvent()
-// {
-//     // const std::string dmesg_output = name() + ".dmesg";
-//     if (params().exit_on_kernel_oops) {
-//         // kernelOopsPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
-//         //     "oops_exit", "Kernel oops in simulated system.",
-//         //     dmesg_output, params().on_oops
-//         // );
-//         kernelOopsPcEvent = addKernelFuncEventOrPanic<PanicPCEvent>(
-//             "oops_exit", "Kernel oops in guest");
-//         // warn_if(!kernelOopsPcEvent,
-//         //         "Failed to find kernel symbol 'oops_exit'");
-//     }
-// }
-
 void
 FsLinux::addExitOnKernelPanicEvent()
 {
-    const std::string dmesg_output = name() + ".dmesg";
-    // if (params().exit_on_kernel_panic) {
-    // if (exit_on_kernel_panic) {
-        // kernelPanicPcEvent = addFuncEvent<linux::PanicOrOopsEvent>(
-        //     kernelSymtab, "panic", "Kernel panic in simulated system.",
-        //     dmesg_output, params().on_panic
-        // );
+    DPRINTF(X86KernelPanicExit, "FsLinux::addExitOnKernelPanicEvent called!");
+    DPRINTF(X86KernelPanicExit, "FsLinux: is params().exit_on_kernel_panic "
+        "true? %d", params().exit_on_kernel_panic
+    );
 
-        // riscv method
+    const std::string dmesg_output = name() + ".dmesg";
+
+    if (params().exit_on_kernel_panic) {
+        // Adapted from RISCV. Simulation continues if adding the "handler" to
+        // exit simulation on kernel panic fails. Fails to add the handler
+        // because kernelSymtab, which is used by addKernelFuncEvent, is empty
+
         // kernelPanicPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
         //     "panic", "Kernel panic in simulated system.",
         //     dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
         //     // params().on_panic
         // );
 
-        //arm method
+        // Copied from Arm implementation. Simulation fails if the handler
+        // isn't added successfully. Also fails because kernelSymtab is empty
         kernelPanicPcEvent = addKernelFuncEventOrPanic<PanicPCEvent>(
             "panic", "Kernel panic in simulated kernel");
-        DPRINTF(
-            X86KernelPanicExit, "FsLinux panic event has been registered!"
-        );
+
         DPRINTF(
             X86KernelPanicExit, "FsLinux: Is kernelPanicPcEvent set? %d",
             kernelPanicPcEvent != nullptr
         );
-
-    // }
-    DPRINTF(X86KernelPanicExit, "FsLinux::addExitOnKernelPanicEvent called!" );
-    DPRINTF(X86KernelPanicExit, "is params().exit_on_kernel_panic true? %d",
-        params().exit_on_kernel_panic
-    );
-    DPRINTF(X86KernelPanicExit, "is exit_on_kernel_panic true? %d",
-        exit_on_kernel_panic
-    );
-
+    }
 }
 
 void
 FsLinux::addExitOnKernelOopsEvent()
 {
+    DPRINTF(X86KernelPanicExit, "FsLinux::addExitOnKernelOopsEvent called!\n");
+
     const std::string dmesg_output = name() + ".dmesg";
-    // if (params().exit_on_kernel_oops) {
-    // if (exit_on_kernel_oops) {
-        // kernelOopsPcEvent = addFuncEvent<linux::PanicOrOopsEvent>(
-        //     kernelSymtab, "oops_exit", "Kernel oops in simulated system.",
-        //     dmesg_output, params().on_oops
+    if (params().exit_on_kernel_oops) {
+        // riscv method - fails to register the oops event because kernelSymtab
+        // is empty.
+        // kernelOopsPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
+        //     "oops_exit", "Kernel oops in simulated system.",
+        //     dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
+        //     // params().on_oops
         // );
-    // }
-    // riscv method - fails to register the oops event because kernelSymtab
-    // is empty.
-    // kernelOopsPcEvent = addKernelFuncEvent<linux::PanicOrOopsEvent>(
-    //     "oops_exit", "Kernel oops in simulated system.",
-    //     dmesg_output, gem5::KernelPanicOopsBehaviour::DumpDmesgAndExit
-    //     // params().on_oops
-    // );
 
         //arm method - exits with a panic when gem5 tries to register the
         // oops event because kernelSymtab is empty.
         kernelOopsPcEvent = addKernelFuncEventOrPanic<PanicPCEvent>(
             "oops_exit", "Kernel oops in simulated kernel");
-    DPRINTF(X86KernelPanicExit, "FsLinux::addExitOnKernelOopsEvent called!" );
-
+    }
 }
 
 void

--- a/src/arch/x86/linux/fs_workload.cc
+++ b/src/arch/x86/linux/fs_workload.cc
@@ -74,7 +74,7 @@ FsLinux::addExitOnKernelPanicEvent()
     const std::string dmesg_output = name() + ".dmesg";
 
     if (params().exit_on_kernel_panic) {
-        // This was adapted from the RISCV implementation. Some kernels may not
+        // This was taken from the RISCV implementation. Some kernels may not
         // have kernel symbols, causing `kernelSymtab` to be empty.
         // In that case, addKernelFuncEvent tries to access the "panic" symbol
         // in the symbol table but can't, so the event won't be added and the
@@ -91,7 +91,7 @@ FsLinux::addExitOnKernelOopsEvent()
 {
     const std::string dmesg_output = name() + ".dmesg";
     if (params().exit_on_kernel_oops) {
-        // This was adapted from the RISCV implementation. Some kernels may not
+        // This was taken from the RISCV implementation. Some kernels may not
         // have kernel symbols, causing `kernelSymtab` to be empty.
         // In that case, addKernelFuncEvent tries to access the "panic" symbol
         // in the symbol table but can't, so the event won't be added and the

--- a/src/arch/x86/linux/fs_workload.cc
+++ b/src/arch/x86/linux/fs_workload.cc
@@ -41,7 +41,6 @@
 #include "base/trace.hh"
 #include "cpu/pc_event.hh"
 #include "cpu/thread_context.hh"
-#include "debug/X86KernelPanicExit.hh"
 #include "kern/linux/events.hh"
 #include "mem/port_proxy.hh"
 #include "params/X86FsLinux.hh"
@@ -51,6 +50,7 @@
 
 namespace gem5
 {
+
 namespace X86ISA
 {
 
@@ -71,11 +71,6 @@ FsLinux::startup()
 void
 FsLinux::addExitOnKernelPanicEvent()
 {
-    DPRINTF(X86KernelPanicExit, "FsLinux::addExitOnKernelPanicEvent called!");
-    DPRINTF(X86KernelPanicExit, "FsLinux: is params().exit_on_kernel_panic "
-        "true? %d", params().exit_on_kernel_panic
-    );
-
     const std::string dmesg_output = name() + ".dmesg";
 
     if (params().exit_on_kernel_panic) {
@@ -88,19 +83,12 @@ FsLinux::addExitOnKernelPanicEvent()
             "panic", "Kernel panic in simulated system.",
             dmesg_output, params().on_panic
         );
-
-        DPRINTF(
-            X86KernelPanicExit, "FsLinux: Is kernelPanicPcEvent set? %d",
-            kernelPanicPcEvent != nullptr
-        );
     }
 }
 
 void
 FsLinux::addExitOnKernelOopsEvent()
 {
-    DPRINTF(X86KernelPanicExit, "FsLinux::addExitOnKernelOopsEvent called!\n");
-
     const std::string dmesg_output = name() + ".dmesg";
     if (params().exit_on_kernel_oops) {
         // This was adapted from the RISCV implementation. Some kernels may not

--- a/src/arch/x86/linux/fs_workload.hh
+++ b/src/arch/x86/linux/fs_workload.hh
@@ -55,8 +55,8 @@ class FsLinux : public X86ISA::FsWorkload
     PCEvent *kernelOopsPcEvent = nullptr;
     void addExitOnKernelPanicEvent();
     void addExitOnKernelOopsEvent();
-    bool exit_on_kernel_panic;
-    bool exit_on_kernel_oops;
+    // bool exit_on_kernel_panic;
+    // bool exit_on_kernel_oops;
   protected:
     E820Table *e820Table;
 

--- a/src/arch/x86/linux/fs_workload.hh
+++ b/src/arch/x86/linux/fs_workload.hh
@@ -55,14 +55,11 @@ class FsLinux : public X86ISA::FsWorkload
     PCEvent *kernelOopsPcEvent = nullptr;
     void addExitOnKernelPanicEvent();
     void addExitOnKernelOopsEvent();
-    // bool exit_on_kernel_panic;
-    // bool exit_on_kernel_oops;
   protected:
     E820Table *e820Table;
 
   public:
     PARAMS(X86FsLinux);
-    // typedef X86FsLinuxParams Params;
     FsLinux(const Params &p);
     ~FsLinux()
     {

--- a/src/arch/x86/linux/fs_workload.hh
+++ b/src/arch/x86/linux/fs_workload.hh
@@ -50,14 +50,31 @@ namespace X86ISA
 
 class FsLinux : public X86ISA::FsWorkload
 {
+  private:
+    PCEvent *kernelPanicPcEvent = nullptr;
+    PCEvent *kernelOopsPcEvent = nullptr;
+    void addExitOnKernelPanicEvent();
+    void addExitOnKernelOopsEvent();
+    bool exit_on_kernel_panic;
+    bool exit_on_kernel_oops;
   protected:
     E820Table *e820Table;
 
   public:
-    typedef X86FsLinuxParams Params;
+    PARAMS(X86FsLinux);
+    // typedef X86FsLinuxParams Params;
     FsLinux(const Params &p);
-
+    ~FsLinux()
+    {
+        if (kernelPanicPcEvent != nullptr) {
+            delete kernelPanicPcEvent;
+        }
+        if (kernelOopsPcEvent != nullptr) {
+            delete kernelOopsPcEvent;
+        }
+    }
     void initState() override;
+    void startup() override;
 };
 
 } // namespace X86ISA


### PR DESCRIPTION
This PR attempts to make X86 simulations exit automatically upon kernel panic based on the RISCV and Arm implementations of the same thing. This will only work if the kernel used in the workload has symbols; if it doesn't have symbols, the event to exit simulation on kernel panic won't be added and simulations will continue to hang on kernel panic.


Link to the RISC-V implementation of this, which I heavily referenced: https://github.com/gem5/gem5/commit/cf087d4d11155a9d0a7bb33e397678087a6885a8