### PR TITLE
mem: Skip redundant test in AddrRange::isSubset in 1-byte ranges.

### DIFF
--- a/src/base/addr_range.hh
+++ b/src/base/addr_range.hh
@@ -452,8 +452,17 @@ class AddrRange
         // whether it would fit in a continuous segment of the input
         // addr range.
         if (r.interleaved()) {
-            return r.contains(_start) && r.contains(_end - 1) &&
-                size() <= r.granularity();
+          if (r.contains(_start) && size() <= r.granularity()) {
+            // simplify checking for 1 element ranges
+            // no need to re-check r.contains(_end -1) if
+            // it is the same as _start
+            if (_start == _end - 1) {
+              return true;
+            }
+            //otherwise check if it also contains the end.
+            return r.contains(_end -1);
+          }
+          return false;
         } else {
 
             if (_end <= _start){


### PR DESCRIPTION
AddrRange::isSubset checks if both the start and (end - 1) of one range are contained within another range.  In the case of single-byte ranges (start = end - 1) the second check is redundant and contains may be computationally intensive in some situations. Note that single byte ranges are common as other parts of the code generate them to convert one Addr into an AddrRange.