### PR TITLE
tests: Revert "Update fs tests to use the 24.04 disk images"

### DIFF
--- a/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
+++ b/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
@@ -201,11 +201,21 @@ board = ArmBoard(
 )
 
 # Set the Full System workload.
-board.set_workload(
-    obtain_resource(
-        "arm-ubuntu-24.04-boot-with-systemd",
+board.set_kernel_disk_workload(
+    kernel=obtain_resource(
+        "arm64-linux-kernel-5.4.49",
         resource_directory=args.resource_directory,
-        resource_version="3.0.0",
+        resource_version="1.0.0",
+    ),
+    bootloader=obtain_resource(
+        "arm64-bootloader-foundation",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
+    ),
+    disk_image=obtain_resource(
+        "arm64-ubuntu-20.04-img",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
     ),
 )
 

--- a/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
+++ b/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
@@ -47,7 +47,6 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_event import ExitEvent
-from gem5.simulate.exit_handler import AfterBootExitHandler
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires
 
@@ -164,14 +163,23 @@ motherboard = X86Board(
 )
 
 kernal_args = motherboard.get_default_kernel_args() + [args.kernel_args]
-workload = obtain_resource(
-    "x86-ubuntu-24.04-boot-with-systemd",
-    resource_directory=args.resource_directory,
-    resource_version="5.0.0",
-)
-workload.set_parameter("kernel_args", kernal_args)
+
 # Set the Full System workload.
-motherboard.set_workload(workload)
+motherboard.set_kernel_disk_workload(
+    kernel=obtain_resource(
+        "x86-linux-kernel-5.4.49",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
+    ),
+    disk_image=obtain_resource(
+        "x86-ubuntu-18.04-img",
+        resource_directory=args.resource_directory,
+        resource_version="1.0.0",
+    ),
+    # The first exit signals to switch processors.
+    readfile_contents="m5 exit\nm5 exit\n",
+    kernel_args=kernal_args,
+)
 
 
 # Begin running of the simulation. This will exit once the Linux system boot
@@ -182,18 +190,17 @@ print(
 )
 print()
 
-
-class SwitchProcessorsExitHandler(AfterBootExitHandler):
-    def _process(self, simulator):
-        super()._process(simulator)
-        simulator.switch_processor()
-
-    def _exit_simulation(self):
-        return False
-
-
 simulator = Simulator(
     board=motherboard,
+    on_exit_event={
+        # When we reach the first exit, we switch cores. For the second exit we
+        # simply exit the simulation (default behavior).
+        ExitEvent.EXIT: (i() for i in [processor.switch])
+    },
+    # This parameter allows us to state the expected order-of-execution.
+    # That is, we expect two exit events. If anyother event is triggered, an
+    # exeception will be thrown.
+    expected_execution_order=[ExitEvent.EXIT, ExitEvent.EXIT],
 )
 
 simulator.run()

--- a/tests/gem5/riscv_boot_tests/configs/riscv_boot_exit_run.py
+++ b/tests/gem5/riscv_boot_tests/configs/riscv_boot_exit_run.py
@@ -163,9 +163,9 @@ board = RiscvBoard(
 
 # Set the workload.
 workload = obtain_resource(
-    "riscv-ubuntu-24.04-boot",
+    "riscv-ubuntu-20.04-boot",
     resource_directory=args.resource_directory,
-    resource_version="2.0.0",
+    resource_version="3.0.0",
 )
 board.set_workload(workload)
 

--- a/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
+++ b/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
@@ -180,21 +180,15 @@ motherboard = X86Board(
 )
 
 kernal_args = motherboard.get_default_kernel_args()
+if args.boot_type == "init":
+    kernal_args.append("init=/root/exit.sh")
 
 # Set the workload.
-workload = None
-if args.boot_type == "init":
-    workload = obtain_resource(
-        "x86-ubuntu-24.04-boot-no-systemd",
-        resource_directory=args.resource_directory,
-        resource_version="4.0.0",
-    )
-else:
-    workload = obtain_resource(
-        "x86-ubuntu-24.04-boot-with-systemd",
-        resource_directory=args.resource_directory,
-        resource_version="5.0.0",
-    )
+workload = obtain_resource(
+    "x86-ubuntu-18.04-boot",
+    resource_directory=args.resource_directory,
+    resource_version="2.0.0",
+)
 workload.set_parameter("kernel_args", kernal_args)
 motherboard.set_workload(workload)
 


### PR DESCRIPTION
Reverts gem5/gem5#2356

gem5/gem5#2356 appears to have substantially increased the boot times which has resulted in Daily Test. You can see the ARM, RISK, and X86 boot tests
reaching the 24 hour timeout in our Daily Tests: https://github.com/gem5/gem5/actions/runs/15511028190.

Prior to this PR these tests completed in 4~ish hours (e.g.: https://github.com/gem5/gem5/actions/runs/15498288596).

A >5x execution time going from 20.04 to 24.04 is definitely something that needs fixed. I have not had time to look further into this issue but until there is a fix I think we should revert.