### PR TITLE
tests: Fix x86 boot test by removing overriding of kernel args

### DIFF
--- a/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
+++ b/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
@@ -179,7 +179,6 @@ motherboard = X86Board(
     cache_hierarchy=cache_hierarchy,
 )
 
-kernal_args = motherboard.get_default_kernel_args()
 
 # Set the workload.
 workload = None
@@ -195,7 +194,7 @@ else:
         resource_directory=args.resource_directory,
         resource_version="5.0.0",
     )
-workload.set_parameter("kernel_args", kernal_args)
+
 motherboard.set_workload(workload)
 
 # Begin running of the simulation. This will exit once the Linux system boot


### PR DESCRIPTION
This was causing the kernel arguments, derived from information in the workload, to be overridden with the defaults. This caused the test to hang indefinitely when it was unable to find disk.