### PR TITLE
tests: Reduce Nightly/Weekly X86/ARM Boot tests

### DIFF
--- a/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
+++ b/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
@@ -93,6 +93,18 @@ parser.add_argument(
     help="The python class for the memory interface to use",
 )
 
+systemd_group = parser.add_mutually_exclusive_group(required=True)
+systemd_group.add_argument(
+    "--systemd",
+    action="store_true",
+    help="Enable systemd on boot.",
+)
+systemd_group.add_argument(
+    "--no-systemd",
+    action="store_true",
+    help="Disable systemd on boot.",
+)
+
 parser.add_argument(
     "-t",
     "--tick-exit",
@@ -203,9 +215,13 @@ board = ArmBoard(
 # Set the Full System workload.
 board.set_workload(
     obtain_resource(
-        "arm-ubuntu-24.04-boot-with-systemd",
+        (
+            "arm-ubuntu-24.04-boot-systemd"
+            if args.systemd
+            else "arm-ubuntu-24.04-boot-no-systemd"
+        ),
         resource_directory=args.resource_directory,
-        resource_version="3.0.0",
+        resource_version=("3.0.0" if args.systemd else "2.0.0"),
     ),
 )
 

--- a/tests/gem5/arm_boot_tests/test_linux_boot.py
+++ b/tests/gem5/arm_boot_tests/test_linux_boot.py
@@ -41,6 +41,7 @@ def test_boot(
     mem_system: str,
     memory_class: str,
     length: str,
+    systemd: bool,
     to_tick: Optional[int] = None,
 ):
     name = f"{cpu}-cpu_{num_cpus}-cores_{mem_system}_{memory_class}_\
@@ -59,6 +60,7 @@ arm_boot_test"
         memory_class,
         "--resource-directory",
         resource_path,
+        "--systemd" if systemd else "--no-systemd",
     ]
 
     if to_tick:
@@ -99,6 +101,7 @@ test_boot(
     memory_class="SingleChannelDDR3_1600",
     length=constants.quick_tag,
     to_tick=10000000000,
+    systemd=False,
 )
 
 test_boot(
@@ -108,6 +111,7 @@ test_boot(
     memory_class="SingleChannelDDR3_2133",
     length=constants.quick_tag,
     to_tick=10000000000,
+    systemd=False,
 )
 
 test_boot(
@@ -117,6 +121,7 @@ test_boot(
     memory_class="DualChannelDDR3_1600",
     length=constants.quick_tag,
     to_tick=10000000000,
+    systemd=False,
 )
 
 test_boot(
@@ -126,6 +131,7 @@ test_boot(
     memory_class="DualChannelDDR4_2400",
     length=constants.quick_tag,
     to_tick=10000000000,
+    systemd=False,
 )
 
 test_boot(
@@ -135,6 +141,7 @@ test_boot(
     memory_class="DualChannelDDR4_2400",
     length=constants.quick_tag,
     to_tick=10000000000,
+    systemd=False,
 )
 
 
@@ -145,6 +152,7 @@ test_boot(
     memory_class="DualChannelDDR4_2400",
     length=constants.quick_tag,
     to_tick=10000000000,
+    systemd=False,
 )
 
 
@@ -152,10 +160,11 @@ test_boot(
 
 test_boot(
     cpu="atomic",
-    num_cpus=4,
+    num_cpus=1,
     mem_system="no_cache",
     memory_class="HBM2Stack",
     length=constants.long_tag,
+    systemd=True,
 )
 
 test_boot(
@@ -164,4 +173,5 @@ test_boot(
     mem_system="chi",
     memory_class="DualChannelDDR4_2400",
     length=constants.long_tag,
+    systemd=False,
 )

--- a/tests/gem5/x86_boot_tests/test_linux_boot.py
+++ b/tests/gem5/x86_boot_tests/test_linux_boot.py
@@ -147,7 +147,7 @@ test_boot(
     num_cpus=1,
     mem_system="mesi_two_level",
     memory_class="DualChannelDDR3_1600",
-    boot_type="systemd",
+    boot_type="init",
     length=constants.long_tag,
 )
 
@@ -173,13 +173,13 @@ run_map = {
         # The CPU Type.
         "atomic": {
             # The number of cores.
-            1: True,
-            2: True,
+            1: False,  # Redundant
+            2: False,  # Redundant
             4: False,  # We already run this in the long (Nightly) tests.
             8: False,  # Jira: https://gem5.atlassian.net/browse/GEM5-1217
         },
         "timing": {
-            1: True,
+            1: False,  # Redundant
             2: False,  # Removed as already doing 4-cores
             4: True,
             8: False,  # Jira: https://gem5.atlassian.net/browse/GEM5-1217
@@ -219,7 +219,7 @@ run_map = {
             8: False,  # Not Supported
         },
         "timing": {
-            1: True,
+            1: False,  # Redundant,
             2: False,  # Disabled due to
             # https://gem5.atlassian.net/browse/GEM5-1219.
             4: False,  # Disabled as we already do 8-cores
@@ -250,14 +250,6 @@ for mem_system in run_map:
 # To ensure the O3 CPU is working correctly, we include some "init" tests here.
 # There were not included above as booting to "systemd" takes too long with
 # o3 CPUs
-test_boot(
-    cpu="o3",
-    num_cpus=1,
-    mem_system="classic",
-    memory_class="DualChannelDDR4_2400",
-    boot_type="init",
-    length=constants.very_long_tag,
-)
 
 test_boot(
     cpu="o3",


### PR DESCRIPTION
Attemps to reduce the execution time of the X86/ARM boot tests for the Nightly (long) and Weekly (very-long) suites. The changes reduce the number and length of tests with the goal of achieving the same coverage.

The main mains to do this are:

- Where appropriate, exclude systemd from the boot, just boot to the `init` script then exit.
- Remove redundant tests (e.g.., no point in testing 2 cores sim of also testing 8 core sim with all else equal).