### PR TITLE
tests: CHI_ prefix needed after ALL protocol PR

### DIFF
--- a/tests/gem5/chi_tlm_tests/configs/ruby_mem_test.py
+++ b/tests/gem5/chi_tlm_tests/configs/ruby_mem_test.py
@@ -68,7 +68,7 @@ class TLM_RNF(CHI_Node):
         super().__init__(ruby_system)
 
         self._cntrl = TlmController(
-            version=Versions.getVersion(Cache_Controller),
+            version=Versions.getVersion(CHI_Cache_Controller),
             ruby_system=ruby_system,
         )
 


### PR DESCRIPTION
The issue has been informally reported within a discussion [1]. The error is caused by an incorrect version due to missing CHI specifier.

[1]: https://github.com/orgs/gem5/discussions/2347
[2]: 2c9a72edeabd564d4bddf62231d07ebd6692fc11


Change-Id: Idc327cd4b7a5bf7528b4d6497565b0555d4e84e4