### PR TITLE
sim: Add semihosting ExitEvent

### DIFF
--- a/src/python/gem5/simulate/exit_event.py
+++ b/src/python/gem5/simulate/exit_event.py
@@ -56,6 +56,7 @@ class ExitEvent(Enum):
     PERF_COUNTER_INTERRUPT = "performance counter interrupt"
     KERNEL_PANIC = "kernel panic in simulated system"
     KERNEL_OOPS = "kernel oops in simulated system"
+    SEMI_EXIT = "semihosting exit"
 
     @classmethod
     def translate_exit_status(cls, exit_string: str) -> "ExitEvent":
@@ -118,6 +119,8 @@ class ExitEvent(Enum):
             return ExitEvent.EXIT
         elif exit_string.endswith("received all expected responses."):
             return ExitEvent.SPATTER_EXIT
+        elif exit_string == "semi:ADP_Stopped_ApplicationExit":
+            return ExitEvent.SEMI_EXIT
         raise NotImplementedError(
             f"Exit event '{exit_string}' not implemented"
         )


### PR DESCRIPTION
Semihosting is a common feature between gem5 and QEMU. While working with a coworker with both simulators, we found the necessity to act on semihosting exit, leading to the addition of this event to our configuration scripts.

This PR adds a SEMI_EXIT item to the ExitEvent enum allowing semihosting to exit without a NotImplementedError.
