### PR TITLE
arch-arm: Enable new FP extensions in SE mode

### DIFF
--- a/src/arch/arm/ArmISA.py
+++ b/src/arch/arm/ArmISA.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2013, 2015-2022, 2024 Arm Limited
+# Copyright (c) 2012-2013, 2015-2022, 2024-2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -60,18 +60,21 @@ class ArmDefaultSERelease(ArmRelease):
         # Armv8.1
         "FEAT_LSE",
         "FEAT_RDM",
+        "FEAT_FHM",
         # Armv8.2
         "FEAT_F32MM",
         "FEAT_F64MM",
         "FEAT_SVE",
         "FEAT_I8MM",
         "FEAT_DOTPROD",
+        "FEAT_FP16",
         # Armv8.3
         "FEAT_FCMA",
         "FEAT_JSCVT",
         "FEAT_PAuth",
         # Armv8.4
         "FEAT_FLAGM",
+        "FEAT_FRINTTS",
         # Armv8.5
         "FEAT_FLAGM2",
         # Armv9.2

--- a/src/arch/arm/process.cc
+++ b/src/arch/arm/process.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012, 2017-2018, 2023 Arm Limited
+ * Copyright (c) 2010, 2012, 2017-2018, 2023, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -322,6 +322,7 @@ ArmProcess64::armHwcapImpl2() const
 
     const AA64ISAR1 isa_r1 = tc->readMiscReg(MISCREG_ID_AA64ISAR1_EL1);
     hwcap |= (isa_r1.i8mm >= 1) ? Arm_I8mm : Arm_None;
+    hwcap |= (isa_r1.frintts == 1) ? Arm_Frint : Arm_None;
 
     const AA64ZFR0 zf_r0 = tc->readMiscReg(MISCREG_ID_AA64ZFR0_EL1);
     hwcap |= (zf_r0.f32mm >= 1) ? Arm_Svef32mm : Arm_None;


### PR DESCRIPTION
The following FP&SIMD Arm extensions:

* FEAT_FP16
* FEAT_FRINTTS
* FEAT_FHM

Have been recently implemented in gem5.  While they had been automatically enabled in FS, they weren't added to the default ArmDefaultSE release object. This commit is adding them so that they can be used in SE as well.


Change-Id: Ib903760f5ef84b9b5c69461bc2e874605d0b7281