### PR TITLE
arch-arm: Generate disable PMU ExitEvent when local disable

### DIFF
--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -212,12 +212,14 @@ PMU::setMiscReg(int misc_reg, RegVal val)
       case MISCREG_PMCNTENSET:
         reg_pmcnten |= val;
         updateAllCounters();
+        pmuExitEvent(false);
         return;
 
       case MISCREG_PMCNTENCLR_EL0:
       case MISCREG_PMCNTENCLR:
         reg_pmcnten &= ~val;
         updateAllCounters();
+        pmuExitEvent(false);
         return;
 
       case MISCREG_PMOVSCLR_EL0:
@@ -428,23 +430,36 @@ PMU::setControlReg(PMCR_t val)
     if (reg_pmcr.d != val.d)
         clock_remainder = 0;
 
-    // Optionally exit the simulation on various PMU control events.
-    // Exit on enable/disable takes precedence over exit on reset.
-    if (exitOnPMUControl) {
-        if (!reg_pmcr.e && val.e) {
-            inform("Exiting simulation: PMU enable detected");
-            exitSimLoop("performance counter enabled", 0);
-        } else if (reg_pmcr.e && !val.e) {
-            inform("Exiting simulation: PMU disable detected");
-            exitSimLoop("performance counter disabled", 0);
-        } else if (val.p) {
-            inform("Exiting simulation: PMU reset detected");
-            exitSimLoop("performance counter reset", 0);
-        }
+    reg_pmcr = val & reg_pmcr_wr_mask;
+
+    updateAllCounters();
+    pmuExitEvent(true);
+}
+
+void
+PMU::pmuExitEvent(bool check_reset)
+{
+    if (!exitOnPMUControl) {
+        return;
     }
 
-    reg_pmcr = val & reg_pmcr_wr_mask;
-    updateAllCounters();
+    // Optionally exit the simulation on various PMU control events.
+    // Exit on enable/disable takes precedence over exit on reset.
+    if (bool any_counter_enabled = reg_pmcr.e && reg_pmcnten;
+        any_counter_enabled != pmuEnabled) {
+
+        pmuEnabled = any_counter_enabled;
+        if (pmuEnabled) {
+            inform("Exiting simulation: PMU enable detected");
+            exitSimLoop("performance counter enabled", 0);
+        } else {
+            inform("Exiting simulation: PMU disable detected");
+            exitSimLoop("performance counter disabled", 0);
+        }
+    } else if (check_reset && reg_pmcr.p) {
+        inform("Exiting simulation: PMU reset detected");
+        exitSimLoop("performance counter reset", 0);
+    }
 }
 
 void
@@ -766,6 +781,8 @@ PMU::unserialize(CheckpointIn &cp)
     UNSERIALIZE_SCALAR(reg_pmselr);
     UNSERIALIZE_SCALAR(reg_pminten);
     UNSERIALIZE_SCALAR(reg_pmovsr);
+
+    pmuEnabled = reg_pmcr.e && reg_pmcnten;
 
     // Old checkpoints used to store the entire PMCEID value in a
     // single 64-bit entry (reg_pmceid). The register was extended in

--- a/src/arch/arm/pmu.hh
+++ b/src/arch/arm/pmu.hh
@@ -602,9 +602,22 @@ class PMU : public SimObject, public ArmISA::BaseISADevice
      */
     void updateAllCounters();
 
+    /**
+     * Checks if a PMU exit event needs to be generated. This
+     * should be called after a write to the following PMU
+     * control registers: PMCR, PMCNTENSET, PMCNTENCLR.
+     *
+     * @param check_reset if true, check for reset event. Only
+     * used after a write to PMCR register
+     */
+    void pmuExitEvent(bool check_reset);
+
   protected: /* State that needs to be serialized */
     /** Determine whether to use 64-bit or 32-bit counters. */
     bool use64bitCounters;
+
+    /** Is there an enabled counter */
+    bool pmuEnabled;
 
     /**
      * Determine whether we merge event counting with


### PR DESCRIPTION
With the ArmPMU it is possible to generate an exit event whenever the PMU gets enabled/disabled. The obvious way to check for it is to catch writes to the PMCR register and generate the exit event accordingly.

While this works well for enabling events, we have seen cases where userspace does not disable the PMU globally at the end of the region of interest, and instead simply disables all counters by writing 0xffff_ffff to the PMCNTENCLR register.

We now cover this case by generating an exit event provided all counters are disabled

Change-Id: I9c487f8dc8e423a3c86ac7bbd7af90b5d0fb9e4d

Reviewed-by: Andreas Sandberg <andreas.sandberg@arm.com>