### PR TITLE
arch-arm,configs: Add option to populate PMU statCounters in baremetal.py

### DIFF
--- a/configs/example/arm/baremetal.py
+++ b/configs/example/arm/baremetal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2017,2019-2023 Arm Limited
+# Copyright (c) 2016-2017,2019-2023, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -190,6 +190,7 @@ def create(args):
             interrupt_numbers = [args.pmu_ppi_number] * len(cluster)
             cluster.addPMUs(
                 interrupt_numbers,
+                stat_counters=args.pmu_stat_counters,
                 exit_sim_on_control=exit_sim_on_control,
                 exit_sim_on_interrupt=exit_sim_on_interrupt,
             )
@@ -353,6 +354,16 @@ def main():
         action="append",
         choices=pmu_stats_events.keys(),
         help="Specify the PMU events on which to reset the gem5 stats. "
+        "This option may be specified multiple times to enable multiple "
+        "PMU events.",
+    )
+    parser.add_argument(
+        "--pmu-stat-counters",
+        type=str,
+        action="append",
+        default=[],
+        choices=EventTypeId.vals + ["ALL"],
+        help="Specify the PMU events on which to dump the gem5 stats. "
         "This option may be specified multiple times to enable multiple "
         "PMU events.",
     )

--- a/configs/example/arm/devices.py
+++ b/configs/example/arm/devices.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2017, 2019, 2021-2023 Arm Limited
+# Copyright (c) 2016-2017, 2019, 2021-2023, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -151,6 +151,7 @@ class ArmCpuCluster(CpuCluster):
         self,
         ints,
         events=[],
+        stat_counters=[],
         exit_sim_on_control=False,
         exit_sim_on_interrupt=False,
     ):
@@ -173,6 +174,11 @@ class ArmCpuCluster(CpuCluster):
         :type exit_on_control: bool
 
         """
+        # If ALL option has been passed, simply enable everything
+        stat_counters = (
+            EventTypeId.vals if "ALL" in stat_counters else stat_counters
+        )
+
         assert len(ints) == len(self.cpus)
         for cpu, pint in zip(self.cpus, ints):
             int_cls = ArmPPI if pint < 32 else ArmSPI
@@ -191,6 +197,8 @@ class ArmCpuCluster(CpuCluster):
                 )
                 for ev in events:
                     isa.pmu.addEvent(ev)
+
+                isa.pmu.statCounters = isa.pmu.archStatCounters(*stat_counters)
 
     def connectMemSide(self, bus):
         try:

--- a/src/arch/arm/ArmPMU.py
+++ b/src/arch/arm/ArmPMU.py
@@ -265,6 +265,25 @@ class ArmPMU(SimObject):
 
         yield node
 
+    def archStatCounters(self, *args):
+        """
+        This method accepts a list of strings and it matches them with
+        their related EventTypeId integer value (id). It returns
+        the generated dictionary but it does not assigns it directly to
+        the param.  This is because we want to be able to provide the
+        user with the possibility of amending the dictionary (e.g. to
+        include implementation defined events) before the assignment is
+        made.
+        """
+        statCounters = {}
+        for event_str in args:
+            assert (
+                event_str in EventTypeId.vals
+            ), f"{event_str} is not a EventTypeId value"
+            statCounters[EventTypeId.map[event_str]] = event_str
+
+        return statCounters
+
     cycleEventId = Param.EventTypeId("CPU_CYCLES", "Cycle event id")
     platform = Param.Platform(Parent.any, "Platform this device is part of.")
     eventCounters = Param.Int(31, "Number of supported PMU counters")


### PR DESCRIPTION
This allows a user to select from the command line which
stat counters should be enabled in the simulation.

example:

```
$build/ARM/gem5.opt \
    ./configs/baremetal/baremetal.py \
    --pmu-stat-counters INST_RETIRED \
    --pmu-stat-counters LD_RETIRED \
    <benchmark>
```

To use none (default behaviour):

```
$build/ARM/gem5.opt \
    ../gem5-obj/configs/baremetal/baremetal.py \
    <benchmark>
```

To use all:

```
$build/ARM/gem5.opt \
    ../gem5-obj/configs/baremetal/baremetal.py \
    --pmu-stat-counters ALL \
    <benchmark>
```

(bearing in mind enabling all means having a slower gem5)