### PR TITLE
arch-arm: Add FEAT_AFP and enable in AdvSimd instructions

### DIFF
--- a/src/arch/arm/ArmSystem.py
+++ b/src/arch/arm/ArmSystem.py
@@ -107,6 +107,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_EVT",
         # Armv8.6
         "FEAT_FGT",
+        "FEAT_AFP",  # Optional in Armv8.6
         # Armv8.7
         "FEAT_HCX",
         "FEAT_XS",
@@ -278,6 +279,7 @@ class Armv85(Armv84):
 class Armv86(Armv85):
     extensions = Armv85.extensions + [
         "FEAT_FGT",
+        "FEAT_AFP",
     ]
 
 

--- a/src/arch/arm/insts/fplib.hh
+++ b/src/arch/arm/insts/fplib.hh
@@ -75,113 +75,116 @@ FPCRRounding(FPSCR &fpscr)
 
 /** Floating-point absolute value. */
 template <class T>
-T fplibAbs(T op);
+T fplibAbs(T op, FPCR fpcr = 0);
 /** Floating-point add. */
 template <class T>
-T fplibAdd(T op1, T op2, FPSCR &fpscr);
+T fplibAdd(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point compare (quiet and signaling). */
 template <class T>
-int fplibCompare(T op1, T op2, bool signal_nans, FPSCR &fpscr);
+int fplibCompare(T op1, T op2, bool signal_nans, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point compare equal. */
 template <class T>
-bool fplibCompareEQ(T op1, T op2, FPSCR &fpscr);
+bool fplibCompareEQ(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point compare greater than or equal. */
 template <class T>
-bool fplibCompareGE(T op1, T op2, FPSCR &fpscr);
+bool fplibCompareGE(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point compare greater than. */
 template <class T>
-bool fplibCompareGT(T op1, T op2, FPSCR &fpscr);
+bool fplibCompareGT(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point compare unordered. */
 template <class T>
-bool fplibCompareUN(T op1, T op2, FPSCR &fpscr);
+bool fplibCompareUN(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point convert precision. */
 template <class T1, class T2>
-T2 fplibConvert(T1 op, FPRounding rounding, FPSCR &fpscr);
+T2 fplibConvert(T1 op, FPRounding rounding, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point division. */
 template <class T>
-T fplibDiv(T op1, T op2, FPSCR &fpscr);
+T fplibDiv(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point exponential accelerator. */
 template <class T>
 T fplibExpA(T op);
 /** Floating-point maximum. */
 template <class T>
-T fplibMax(T op1, T op2, FPSCR &fpscr);
+T fplibMax(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point maximum number. */
 template <class T>
-T fplibMaxNum(T op1, T op2, FPSCR &fpscr);
+T fplibMaxNum(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point minimum. */
 template <class T>
-T fplibMin(T op1, T op2, FPSCR &fpscr);
+T fplibMin(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point minimum number. */
 template <class T>
-T fplibMinNum(T op1, T op2, FPSCR &fpscr);
+T fplibMinNum(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point multiply. */
 template <class T>
-T fplibMul(T op1, T op2, FPSCR &fpscr);
+T fplibMul(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point multiply-add. */
 template <class T>
-T fplibMulAdd(T addend, T op1, T op2, FPSCR &fpscr);
+T fplibMulAdd(T addend, T op1, T op2, FPSCR &fpscr, FPCR fpcr=0);
 template <class T1, class T2>
-T2 fplibMulAddH(T2 addend, T1 op1, T1 op2, FPSCR &fpscr);
+T2 fplibMulAddH(T2 addend, T1 op1, T1 op2, FPSCR &fpscr, FPCR fpcr=0);
 /** Floating-point multiply extended. */
 template <class T>
-T fplibMulX(T op1, T op2, FPSCR &fpscr);
+T fplibMulX(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point negate. */
 template <class T>
-T fplibNeg(T op);
+T fplibNeg(T op, FPCR fpcr = 0);
 /** Floating-point reciprocal square root estimate. */
 template <class T>
-T fplibRSqrtEstimate(T op, FPSCR &fpscr);
+T fplibRSqrtEstimate(T op, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point reciprocal square root step. */
 template <class T>
-T fplibRSqrtStepFused(T op1, T op2, FPSCR &fpscr);
+T fplibRSqrtStepFused(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point reciprocal estimate. */
 template <class T>
-T fplibRecipEstimate(T op, FPSCR &fpscr);
+T fplibRecipEstimate(T op, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point reciprocal step. */
 template <class T>
-T fplibRecipStepFused(T op1, T op2, FPSCR &fpscr);
+T fplibRecipStepFused(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point reciprocal exponent. */
 template <class T>
-T fplibRecpX(T op, FPSCR &fpscr);
+T fplibRecpX(T op, FPSCR &fpscr, FPCR fpcr = 0);
 /**  Floating-point convert to integer. */
 template <class T>
-T fplibRoundInt(T op, FPRounding rounding, bool exact, FPSCR &fpscr);
+T fplibRoundInt(T op, FPRounding rounding, bool exact, FPSCR &fpscr,
+                FPCR fpcr = 0);
 /**  Floating-point convert to integer. */
 template <class T>
 T fplibRoundIntN(T op, FPRounding rounding, bool exact, int intsize,
-                 FPSCR &fpscr);
+                 FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point adjust exponent. */
 template <class T>
-T fplibScale(T op1, T op2, FPSCR &fpscr);
+T fplibScale(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point square root. */
 template <class T>
-T fplibSqrt(T op, FPSCR &fpscr);
+T fplibSqrt(T op, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point subtract. */
 template <class T>
-T fplibSub(T op1, T op2, FPSCR &fpscr);
+T fplibSub(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point trigonometric multiply-add coefficient. */
 template <class T>
-T fplibTrigMulAdd(uint8_t coeff_index, T op1, T op2, FPSCR &fpscr);
+T fplibTrigMulAdd(uint8_t coeff_index, T op1, T op2, FPSCR &fpscr,
+                  FPCR fpcr = 0);
 /** Floating-point trigonometric starting value. */
 template <class T>
-T fplibTrigSMul(T op1, T op2, FPSCR &fpscr);
+T fplibTrigSMul(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point trigonometric select coefficient. */
 template <class T>
-T fplibTrigSSel(T op1, T op2, FPSCR &fpscr);
+T fplibTrigSSel(T op1, T op2, FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point convert to fixed-point. */
 template <class T1, class T2>
-T2 fplibFPToFixed(T1 op, int fbits, bool u, FPRounding rounding, FPSCR &fpscr);
+T2 fplibFPToFixed(T1 op, int fbits, bool u, FPRounding rounding, FPSCR &fpscr,
+                  FPCR fpcr = 0);
 /** Floating-point convert from fixed-point. */
 template <class T>
 T fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding,
-                 FPSCR &fpscr);
+                 FPSCR &fpscr, FPCR fpcr = 0);
 /** Floating-point value for +/- infinity. */
 template <class T>
 T fplibInfinity(int sgn);
 /** Foating-point value for default NaN. */
 template <class T>
-T fplibDefaultNaN();
+T fplibDefaultNaN(FPCR fpcr = 0);
 /** Floating-point  JS convert to a signed integer, with rounding to zero. */
 uint32_t fplibFPToFixedJS(uint64_t op, FPSCR &fpscr, bool Is64, uint8_t &nz);
 
@@ -192,65 +195,74 @@ T fplib32RecipStep(T op1, T op2, FPSCR &fpscr);
 
 /* Function specializations... */
 template <>
-uint16_t fplibAbs(uint16_t op);
+uint16_t fplibAbs(uint16_t op, FPCR fpcr);
 template <>
-uint32_t fplibAbs(uint32_t op);
+uint32_t fplibAbs(uint32_t op, FPCR fpcr);
 template <>
-uint64_t fplibAbs(uint64_t op);
+uint64_t fplibAbs(uint64_t op, FPCR fpcr);
 template <>
-uint16_t fplibAdd(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibAdd(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibAdd(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibAdd(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibAdd(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibAdd(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-int fplibCompare(uint16_t op1, uint16_t op2, bool signal_nans, FPSCR &fpscr);
+int fplibCompare(uint16_t op1, uint16_t op2, bool signal_nans, FPSCR &fpscr,
+                 FPCR fpcr);
 template <>
-int fplibCompare(uint32_t op1, uint32_t op2, bool signal_nans, FPSCR &fpscr);
+int fplibCompare(uint32_t op1, uint32_t op2, bool signal_nans, FPSCR &fpscr,
+                 FPCR fpcr);
 template <>
-int fplibCompare(uint64_t op1, uint64_t op2, bool signal_nans, FPSCR &fpscr);
+int fplibCompare(uint64_t op1, uint64_t op2, bool signal_nans, FPSCR &fpscr,
+                 FPCR fpcr);
 template <>
-bool fplibCompareEQ(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+bool fplibCompareEQ(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareEQ(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+bool fplibCompareEQ(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareEQ(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+bool fplibCompareEQ(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareGE(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+bool fplibCompareGE(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareGE(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+bool fplibCompareGE(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareGE(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+bool fplibCompareGE(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareGT(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+bool fplibCompareGT(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareGT(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+bool fplibCompareGT(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareGT(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+bool fplibCompareGT(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareUN(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+bool fplibCompareUN(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareUN(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+bool fplibCompareUN(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-bool fplibCompareUN(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+bool fplibCompareUN(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibConvert(uint32_t op, FPRounding rounding, FPSCR &fpscr);
+uint16_t fplibConvert(uint32_t op, FPRounding rounding, FPSCR &fpscr,
+                      FPCR fpcr);
 template <>
-uint16_t fplibConvert(uint64_t op, FPRounding rounding, FPSCR &fpscr);
+uint16_t fplibConvert(uint64_t op, FPRounding rounding, FPSCR &fpscr,
+                      FPCR fpcr);
 template <>
-uint32_t fplibConvert(uint16_t op, FPRounding rounding, FPSCR &fpscr);
+uint32_t fplibConvert(uint16_t op, FPRounding rounding, FPSCR &fpscr,
+                      FPCR fpcr);
 template <>
-uint32_t fplibConvert(uint64_t op, FPRounding rounding, FPSCR &fpscr);
+uint32_t fplibConvert(uint64_t op, FPRounding rounding, FPSCR &fpscr,
+                      FPCR fpcr);
 template <>
-uint64_t fplibConvert(uint16_t op, FPRounding rounding, FPSCR &fpscr);
+uint64_t fplibConvert(uint16_t op, FPRounding rounding, FPSCR &fpscr,
+                      FPCR fpcr);
 template <>
-uint64_t fplibConvert(uint32_t op, FPRounding rounding, FPSCR &fpscr);
+uint64_t fplibConvert(uint32_t op, FPRounding rounding, FPSCR &fpscr,
+                      FPCR fpcr);
 template <>
-uint16_t fplibDiv(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibDiv(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibDiv(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibDiv(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibDiv(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibDiv(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibExpA(uint16_t op);
 template <>
@@ -258,173 +270,179 @@ uint32_t fplibExpA(uint32_t op);
 template <>
 uint64_t fplibExpA(uint64_t op);
 template <>
-uint16_t fplibMax(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibMax(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibMax(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibMax(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibMax(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibMax(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibMaxNum(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibMaxNum(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibMaxNum(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibMaxNum(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibMaxNum(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibMaxNum(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibMin(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibMin(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibMin(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibMin(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibMin(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibMin(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibMinNum(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibMinNum(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibMinNum(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibMinNum(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibMinNum(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibMinNum(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibMul(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibMul(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibMul(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibMul(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibMul(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibMul(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibMulAdd(uint16_t addend, uint16_t op1, uint16_t op2,
-                     FPSCR &fpscr);
+                     FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibMulAdd(uint32_t addend, uint32_t op1, uint32_t op2,
-                     FPSCR &fpscr);
+                     FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibMulAdd(uint64_t addend, uint64_t op1, uint64_t op2,
-                     FPSCR &fpscr);
+                     FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibMulAddH(uint32_t addend, uint16_t op1, uint16_t op2,
-                      FPSCR &fpscr);
+                      FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibMulX(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibMulX(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibMulX(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibMulX(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibMulX(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibMulX(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibNeg(uint16_t op);
+uint16_t fplibNeg(uint16_t op, FPCR fpcr);
 template <>
-uint32_t fplibNeg(uint32_t op);
+uint32_t fplibNeg(uint32_t op, FPCR fpcr);
 template <>
-uint64_t fplibNeg(uint64_t op);
+uint64_t fplibNeg(uint64_t op, FPCR fpcr);
 template <>
-uint16_t fplibRSqrtEstimate(uint16_t op, FPSCR &fpscr);
+uint16_t fplibRSqrtEstimate(uint16_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibRSqrtEstimate(uint32_t op, FPSCR &fpscr);
+uint32_t fplibRSqrtEstimate(uint32_t op, FPSCR &fpscr, FPCR fpcr);
 template<>
-uint64_t fplibRSqrtEstimate(uint64_t op, FPSCR &fpscr);
+uint64_t fplibRSqrtEstimate(uint64_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibRSqrtStepFused(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibRSqrtStepFused(uint16_t op1, uint16_t op2, FPSCR &fpscr,
+                             FPCR fpcr);
 template <>
-uint32_t fplibRSqrtStepFused(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibRSqrtStepFused(uint32_t op1, uint32_t op2, FPSCR &fpscr,
+                             FPCR fpcr);
 template <>
-uint64_t fplibRSqrtStepFused(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibRSqrtStepFused(uint64_t op1, uint64_t op2, FPSCR &fpscr,
+                             FPCR fpcr);
 template <>
-uint16_t fplibRecipEstimate(uint16_t op, FPSCR &fpscr);
+uint16_t fplibRecipEstimate(uint16_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibRecipEstimate(uint32_t op, FPSCR &fpscr);
+uint32_t fplibRecipEstimate(uint32_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibRecipEstimate(uint64_t op, FPSCR &fpscr);
+uint64_t fplibRecipEstimate(uint64_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibRecipStepFused(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibRecipStepFused(uint16_t op1, uint16_t op2, FPSCR &fpscr,
+                             FPCR fpcr);
 template <>
-uint32_t fplibRecipStepFused(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibRecipStepFused(uint32_t op1, uint32_t op2, FPSCR &fpscr,
+                             FPCR fpcr);
 template <>
-uint64_t fplibRecipStepFused(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibRecipStepFused(uint64_t op1, uint64_t op2, FPSCR &fpscr,
+                             FPCR fpcr);
 template <>
-uint16_t fplibRecpX(uint16_t op, FPSCR &fpscr);
+uint16_t fplibRecpX(uint16_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibRecpX(uint32_t op, FPSCR &fpscr);
+uint32_t fplibRecpX(uint32_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibRecpX(uint64_t op, FPSCR &fpscr);
+uint64_t fplibRecpX(uint64_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibRoundInt(uint16_t op, FPRounding rounding, bool exact,
-                       FPSCR &fpscr);
+                       FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibRoundInt(uint32_t op, FPRounding rounding, bool exact,
-                       FPSCR &fpscr);
+                       FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibRoundInt(uint64_t op, FPRounding rounding, bool exact,
-                       FPSCR &fpscr);
+                       FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibRoundIntN(uint32_t op, FPRounding rounding, bool exact,
-                        int intsize, FPSCR &fpscr);
+                        int intsize, FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibRoundIntN(uint64_t op, FPRounding rounding, bool exact,
-                        int intsize, FPSCR &fpscr);
+                        int intsize, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibScale(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibScale(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibScale(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibScale(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibScale(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibScale(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibSqrt(uint16_t op, FPSCR &fpscr);
+uint16_t fplibSqrt(uint16_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibSqrt(uint32_t op, FPSCR &fpscr);
+uint32_t fplibSqrt(uint32_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibSqrt(uint64_t op, FPSCR &fpscr);
+uint64_t fplibSqrt(uint64_t op, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibSub(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibSub(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibSub(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibSub(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibSub(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibSub(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibTrigMulAdd(uint8_t coeff_index, uint16_t op1, uint16_t op2,
-                       FPSCR &fpscr);
+                         FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibTrigMulAdd(uint8_t coeff_index, uint32_t op1, uint32_t op2,
-                         FPSCR &fpscr);
+                         FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibTrigMulAdd(uint8_t coeff_index, uint64_t op1, uint64_t op2,
-                         FPSCR &fpscr);
+                         FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibTrigSMul(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibTrigSMul(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibTrigSMul(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibTrigSMul(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibTrigSMul(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibTrigSMul(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint16_t fplibTrigSSel(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibTrigSSel(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint32_t fplibTrigSSel(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint32_t fplibTrigSSel(uint32_t op1, uint32_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
-uint64_t fplibTrigSSel(uint64_t op1, uint64_t op2, FPSCR &fpscr);
+uint64_t fplibTrigSSel(uint64_t op1, uint64_t op2, FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibFPToFixed(uint16_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibFPToFixed(uint16_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibFPToFixed(uint32_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibFPToFixed(uint64_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibFPToFixed(uint16_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibFPToFixed(uint32_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibFPToFixed(uint64_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint32_t fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint64_t fplibFixedToFP(uint64_t op, int fbits, bool u, FPRounding rounding,
-                        FPSCR &fpscr);
+                        FPSCR &fpscr, FPCR fpcr);
 template <>
 uint16_t fplibInfinity(int sgn);
 template <>
@@ -432,11 +450,11 @@ uint32_t fplibInfinity(int sgn);
 template <>
 uint64_t fplibInfinity(int sgn);
 template <>
-uint16_t fplibDefaultNaN();
+uint16_t fplibDefaultNaN(FPCR fpcr);
 template <>
-uint32_t fplibDefaultNaN();
+uint32_t fplibDefaultNaN(FPCR fpcr);
 template <>
-uint64_t fplibDefaultNaN();
+uint64_t fplibDefaultNaN(FPCR fpcr);
 
 template <>
 uint16_t fplib32RSqrtStep(uint16_t op1, uint16_t op2, FPSCR &fpscr);

--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -508,6 +508,16 @@ ISA::readMiscReg(RegIndex idx)
 
       case MISCREG_CPSR_Q:
         panic("shouldn't be reading this register seperately\n");
+      case MISCREG_FPCR:
+        {
+          FPCR fpcr = readMiscRegNoEffect(MISCREG_FPCR);
+          if (!release->has(ArmExtension::FEAT_AFP)) {
+              fpcr.nep = 0;
+              fpcr.ah = 0;
+              fpcr.fiz = 0;
+          }
+          return fpcr;
+        }
       case MISCREG_FPSCR:
         {
           FPCR fpcr = readMiscRegNoEffect(MISCREG_FPCR);
@@ -858,6 +868,17 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
             warn("Calling DC ZVA! Not Implemeted! Expect WEIRD results\n");
             return;
 
+          case MISCREG_FPCR:
+            {
+                FPCR fpcr_val = (FPCR)newVal;
+                if (!release->has(ArmExtension::FEAT_AFP)) {
+                    fpcr_val.nep = 0;
+                    fpcr_val.ah = 0;
+                    fpcr_val.fiz = 0;
+                }
+                setMiscRegNoEffect(MISCREG_FPCR, fpcr_val);
+            }
+            break;
           case MISCREG_FPSCR:
             tc->getDecoderPtr()->as<Decoder>().setContext(newVal);
             {

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -53,7 +53,7 @@ let {{
     def threeEqualRegInstX(name, Name, opClass, types, rCount, op,
                            readDest=False, pairwise=False, scalar=False,
                            byElem=False, decoder='Generic', complex=False,
-                           extra=''):
+                           extra='', nepSrc=''):
         assert (not pairwise) or ((not byElem) and (not scalar))
         global header_output, exec_output, decoders
         eWalkCode = simd64EnabledCheckCode + '''
@@ -83,6 +83,26 @@ let {{
                 eWalkCode += '''
         srcReg2.regs[%(reg)d] = htole(AA64FpOp2P%(reg)d_uw);
         ''' % { "reg" : reg }
+        if (not readDest) and scalar and nepSrc:
+            eWalkCode += '''
+        if (((FPCR)Fpcr).nep) {
+        '''
+            for reg in range(rCount):
+                if nepSrc == "vn":
+                    eWalkCode += '''
+            destReg.regs[%(reg)d] = htole(AA64FpOp1P%(reg)d_uw);
+            ''' % { "reg" : reg }
+                elif nepSrc == "vm":
+                    eWalkCode += '''
+            destReg.regs[%(reg)d] = htole(AA64FpOp2P%(reg)d_uw);
+            ''' % { "reg" : reg }
+                elif nepSrc == "vd":
+                    eWalkCode += '''
+            destReg.regs[%(reg)d] = htole(AA64FpDestP%(reg)d_uw);
+            ''' % { "reg" : reg }
+            eWalkCode += '''
+        }
+        '''
         readDestCode = ''
         if readDest:
             readDestCode = 'destElem = letoh(destReg.elements[i]);'
@@ -105,7 +125,17 @@ let {{
         }
         ''' % { "op" : op, "readDest" : readDestCode }
         else:
-            scalarCheck = '''
+            if nepSrc:
+                scalarCheck = '''
+            if (i != 0) {
+                if (!((FPCR)Fpcr).nep) {
+                    destReg.elements[i] = 0;
+                }
+                continue;
+            }
+            '''
+            else:
+                scalarCheck = '''
             if (i != 0) {
                 destReg.elements[i] = 0;
                 continue;
@@ -286,7 +316,7 @@ let {{
 
     def twoEqualRegInstX(name, Name, opClass, types, rCount, op,
                          readDest=False, scalar=False, byElem=False,
-                         hasImm=False, isDup=False, extra_check=''):
+                         hasImm=False, isDup=False, extra_check='', nepSrc=''):
         global header_output, exec_output
         assert (not isDup) or byElem
         if byElem:
@@ -308,10 +338,31 @@ let {{
                 eWalkCode += '''
         destReg.regs[%(reg)d] = htole(AA64FpDestP%(reg)d_uw);
         ''' % { "reg" : reg }
+        if (not readDest) and scalar and nepSrc == 'vd':
+            eWalkCode += '''
+        if (((FPCR)Fpcr).nep) {
+        '''
+            for reg in range(4 if isDup else rCount):
+                eWalkCode += '''
+            destReg.regs[%(reg)d] = htole(AA64FpDestP%(reg)d_uw);
+            ''' % { "reg" : reg }
+            eWalkCode += '''
+        }
+        '''
         readDestCode = ''
         if readDest:
             readDestCode = 'destElem = letoh(destReg.elements[i]);'
-        scalarCheck = '''
+        if nepSrc == 'vd':
+            scalarCheck = '''
+            if (i != 0) {
+                if (!((FPCR)Fpcr).nep) {
+                    destReg.elements[i] = 0;
+                }
+                continue;
+            }
+            '''
+        else:
+            scalarCheck = '''
             if (i != 0) {
                 destReg.elements[i] = 0;
                 continue;
@@ -408,7 +459,7 @@ let {{
             exec_output += NeonXExecDeclare.subst(substDict)
 
     def twoRegNarrowInstX(name, Name, opClass, types, op, readDest=False,
-                          scalar=False, hi=False, hasImm=False):
+                          scalar=False, hi=False, hasImm=False, nepSrc=''):
         global header_output, exec_output
         eWalkCode = simd64EnabledCheckCode + '''
         BigRegVect srcReg1;
@@ -427,10 +478,31 @@ let {{
             eWalkCode += '''
         destReg.elements[0] = 0;
         ''' % { "reg" : reg }
+        if (not readDest) and scalar and nepSrc == 'vd':
+            eWalkCode += '''
+        if (((FPCR)Fpcr).nep) {
+        '''
+            for reg in range(2):
+                eWalkCode += '''
+            destReg.regs[%(reg)d] = htole(AA64FpDestP%(reg)d_uw);
+            ''' % { "reg" : reg }
+            eWalkCode += '''
+        }
+        '''
         readDestCode = ''
         if readDest:
             readDestCode = 'destElem = letoh(destReg.elements[i]);'
-        scalarCheck = '''
+        if nepSrc == 'vd':
+            scalarCheck = '''
+            if (i != 0) {
+                if (!((FPCR)Fpcr).nep) {
+                    destReg.elements[i] = 0;
+                }
+                continue;
+            }
+            '''
+        else:
+            scalarCheck = '''
             if (i != 0) {
                 destReg.elements[i] = 0;
                 continue;
@@ -458,8 +530,20 @@ let {{
                 eWalkCode += '''
         AA64FpDestP%(reg)d_uw = AA64FpDestP%(reg)d_uw;''' % { "reg" : reg }
         else:
-            for reg in range(2, 4):  # zero upper half
+            if (not readDest) and scalar and nepSrc == 'vd':
                 eWalkCode += '''
+        if (!((FPCR)Fpcr).nep) {
+        '''
+                for reg in range(2, 4):  # zero upper half
+                    eWalkCode += '''
+            AA64FpDestP%(reg)d_uw = 0;
+            ''' % { "reg" : reg }
+                eWalkCode += '''
+        }
+        '''
+            else:
+                for reg in range(2, 4):  # zero upper half
+                    eWalkCode += '''
         AA64FpDestP%(reg)d_uw = 0;
         ''' % { "reg" : reg }
 
@@ -1008,6 +1092,7 @@ let {{
         Element el3;
         for (int i = 0; i < eCount/2; ++i) {
             FPSCR fpscr = (FPSCR) FpscrExc;
+            FPCR fpcr = (FPCR)Fpcr;
 
             Element srcElem1_1 = letoh(srcReg1.elements[2*i]);
             Element srcElem1_2 = letoh(srcReg1.elements[2*i+1]);
@@ -1017,14 +1102,14 @@ let {{
             Element destElem_2;
             if (rot) {
                 el1 = srcElem2_2;
-                el3 = fplibNeg<Element>(srcElem2_1);
+                el3 = fplibNeg<Element>(srcElem2_1, fpcr);
             } else {
-                el1 = fplibNeg<Element>(srcElem2_2);
+                el1 = fplibNeg<Element>(srcElem2_2, fpcr);
                 el3 = srcElem2_1;
             }
 
-            destElem_1 = fplibAdd<Element>(srcElem1_1, el1, fpscr);
-            destElem_2 = fplibAdd<Element>(srcElem1_2, el3, fpscr);
+            destElem_1 = fplibAdd<Element>(srcElem1_1, el1, fpscr, fpcr);
+            destElem_2 = fplibAdd<Element>(srcElem1_2, el3, fpscr, fpcr);
 
             FpscrExc = fpscr;
 
@@ -1047,6 +1132,7 @@ let {{
         Element el4;
         for (int i = 0; i < eCount/2; ++i) {
             FPSCR fpscr = (FPSCR) FpscrExc;
+            FPCR fpcr = (FPCR)Fpcr;
 
             Element srcElem1_1 = letoh(srcReg1.elements[2*i]);
             Element srcElem1_2 = letoh(srcReg1.elements[2*i+1]);
@@ -1066,7 +1152,7 @@ let {{
                 }
               case 0x1:
                 {
-                  el1 = fplibNeg<Element>(srcElem2_2);
+                  el1 = fplibNeg<Element>(srcElem2_2, fpcr);
                   el2 = srcElem1_2;
                   el3 = srcElem2_1;
                   el4 = srcElem1_2;
@@ -1074,9 +1160,9 @@ let {{
                 }
               case 0x2:
                 {
-                  el1 = fplibNeg<Element>(srcElem2_1);
+                  el1 = fplibNeg<Element>(srcElem2_1, fpcr);
                   el2 = srcElem1_1;
-                  el3 = fplibNeg<Element>(srcElem2_2);
+                  el3 = fplibNeg<Element>(srcElem2_2, fpcr);
                   el4 = srcElem1_1;
                   break;
                 }
@@ -1084,13 +1170,15 @@ let {{
                 {
                   el1 = srcElem2_2;
                   el2 = srcElem1_2;
-                  el3 = fplibNeg<Element>(srcElem2_1);
+                  el3 = fplibNeg<Element>(srcElem2_1, fpcr);
                   el4 = srcElem1_2;
                   break;
                 }
             }
-            destElem_1 = fplibMulAdd<Element>(destElem_1, el2, el1, fpscr);
-            destElem_2 = fplibMulAdd<Element>(destElem_2, el4, el3, fpscr);
+            destElem_1 = fplibMulAdd<Element>(destElem_1, el2, el1, fpscr,
+                                              fpcr);
+            destElem_2 = fplibMulAdd<Element>(destElem_2, el4, el3, fpscr,
+                                              fpcr);
 
             FpscrExc = fpscr;
 
@@ -1406,32 +1494,35 @@ let {{
     # FABD
     fpOp = '''
             FPSCR fpscr = (FPSCR) FpscrExc;
+            [[maybe_unused]] FPCR fpcr = (FPCR)Fpcr;
             destElem = %s;
             FpscrExc = fpscr;
     '''
-    fabdCode = fpOp % "fplibAbs<Element>(fplibSub(srcElem1, srcElem2, fpscr))"
+    fabdCode = fpOp % ("fplibAbs<Element>(fplibSub"
+                        "(srcElem1, srcElem2, fpscr, fpcr), fpcr)")
     threeEqualRegInstX("fabd", "FabdDX", "SimdFloatAddOp", smallFloatTypes, 2,
                        fabdCode)
     threeEqualRegInstX("fabd", "FabdQX", "SimdFloatAddOp", floatTypes, 4,
                        fabdCode)
     threeEqualRegInstX("fabd", "FabdScX", "SimdFloatAddOp", floatTypes, 4,
-                       fabdCode, scalar=True)
+                       fabdCode, scalar=True, nepSrc="vn")
     # FABS
-    fabsCode = fpOp % "fplibAbs<Element>(srcElem1)"
+    fabsCode = fpOp % "fplibAbs<Element>(srcElem1, fpcr)"
     twoEqualRegInstX("Abs", "FabsDX", "SimdFloatAluOp", smallFloatTypes, 2,
                      fabsCode)
     twoEqualRegInstX("Abs", "FabsQX", "SimdFloatAluOp", floatTypes, 4,
                      fabsCode)
     # FACGE
-    fpCmpAbsOp = fpOp % ("fplibCompare%s<Element>(fplibAbs<Element>(srcElem1),"
-                         " fplibAbs<Element>(srcElem2), fpscr) ? -1 : 0")
+    fpCmpAbsOp = fpOp % ("fplibCompare%s<Element>(fplibAbs<Element>"
+                        "(srcElem1, fpcr), fplibAbs<Element>(srcElem2, fpcr),"
+                        " fpscr, fpcr) ? -1 : 0")
     facgeCode = fpCmpAbsOp % "GE"
     threeEqualRegInstX("facge", "FacgeDX", "SimdFloatCmpOp", smallFloatTypes,
                        2, facgeCode)
     threeEqualRegInstX("facge", "FacgeQX", "SimdFloatCmpOp", floatTypes, 4,
                        facgeCode)
     threeEqualRegInstX("facge", "FacgeScX", "SimdFloatCmpOp", floatTypes, 4,
-                       facgeCode, scalar=True)
+                       facgeCode, scalar=True, nepSrc="vm")
     # FACGT
     facgtCode = fpCmpAbsOp % "GT"
     threeEqualRegInstX("facgt", "FacgtDX", "SimdFloatCmpOp", smallFloatTypes,
@@ -1439,9 +1530,9 @@ let {{
     threeEqualRegInstX("facgt", "FacgtQX", "SimdFloatCmpOp", floatTypes, 4,
                        facgtCode)
     threeEqualRegInstX("facgt", "FacgtScX", "SimdFloatCmpOp", floatTypes, 4,
-                       facgtCode, scalar=True)
+                       facgtCode, scalar=True, nepSrc="vm")
     # FADD
-    fpBinOp = fpOp % "fplib%s<Element>(srcElem1, srcElem2, fpscr)"
+    fpBinOp = fpOp % "fplib%s<Element>(srcElem1, srcElem2, fpscr, fpcr)"
     faddCode = fpBinOp % "Add"
     threeEqualRegInstX("fadd", "FaddDX", "SimdFloatAddOp", smallFloatTypes, 2,
                        faddCode)
@@ -1460,17 +1551,18 @@ let {{
     threeEqualRegInstX("faddp", "FaddpQX", "SimdFloatAddOp", floatTypes, 4,
                        faddCode, pairwise=True)
     # FCMEQ (register)
-    fpCmpOp = fpOp % ("fplibCompare%s<Element>(srcElem1, srcElem2, fpscr) ?"
-                      " -1 : 0")
+    fpCmpOp = fpOp % ("fplibCompare%s<Element>"
+                        "(srcElem1, srcElem2, fpscr, fpcr) ? -1 : 0")
     fcmeqCode = fpCmpOp % "EQ"
     threeEqualRegInstX("fcmeq", "FcmeqDX", "SimdFloatCmpOp", smallFloatTypes,
                        2, fcmeqCode)
     threeEqualRegInstX("fcmeq", "FcmeqQX", "SimdFloatCmpOp", floatTypes, 4,
                        fcmeqCode)
     threeEqualRegInstX("fcmeq", "FcmeqScX", "SimdFloatCmpOp", floatTypes, 4,
-                       fcmeqCode, scalar=True)
+                       fcmeqCode, scalar=True, nepSrc="vm")
     # FCMEQ (zero)
-    fpCmpZeroOp = fpOp % "fplibCompare%s<Element>(srcElem1, 0, fpscr) ? -1 : 0"
+    fpCmpZeroOp = fpOp % ("fplibCompare%s<Element>"
+                        "(srcElem1, 0, fpscr, fpcr) ? -1 : 0")
     fcmeqZeroCode = fpCmpZeroOp % "EQ"
     twoEqualRegInstX("fcmeq", "FcmeqZeroDX", "SimdFloatCmpOp", smallFloatTypes,
                      2, fcmeqZeroCode)
@@ -1485,7 +1577,7 @@ let {{
     threeEqualRegInstX("fcmge", "FcmgeQX", "SimdFloatCmpOp", floatTypes, 4,
                        fcmgeCode)
     threeEqualRegInstX("fcmge", "FcmgeScX", "SimdFloatCmpOp", floatTypes, 4,
-                       fcmgeCode, scalar=True)
+                       fcmgeCode, scalar=True, nepSrc="vm")
     # FCMGE (zero)
     fcmgeZeroCode = fpCmpZeroOp % "GE"
     twoEqualRegInstX("fcmge", "FcmgeZeroDX", "SimdFloatCmpOp", smallFloatTypes,
@@ -1501,7 +1593,7 @@ let {{
     threeEqualRegInstX("fcmgt", "FcmgtQX", "SimdFloatCmpOp", floatTypes, 4,
                        fcmgtCode)
     threeEqualRegInstX("fcmgt", "FcmgtScX", "SimdFloatCmpOp", floatTypes, 4,
-                       fcmgtCode, scalar=True)
+                       fcmgtCode, scalar=True, nepSrc="vm")
     # FCMGT (zero)
     fcmgtZeroCode = fpCmpZeroOp % "GT"
     twoEqualRegInstX("fcmgt", "FcmgtZeroDX", "SimdFloatCmpOp", smallFloatTypes,
@@ -1511,8 +1603,8 @@ let {{
     twoEqualRegInstX("fcmgt", "FcmgtZeroScX", "SimdFloatCmpOp", floatTypes, 4,
                      fcmgtZeroCode, scalar=True)
     # FCMLE (zero)
-    fpCmpRevZeroOp = fpOp % ("fplibCompare%s<Element>(0, srcElem1, fpscr) ?"
-                             " -1 : 0")
+    fpCmpRevZeroOp = fpOp % ("fplibCompare%s<Element>"
+                             "(0, srcElem1, fpscr, fpcr) ? -1 : 0")
     fcmleZeroCode = fpCmpRevZeroOp % "GE"
     twoEqualRegInstX("fcmle", "FcmleZeroDX", "SimdFloatCmpOp", smallFloatTypes,
                      2, fcmleZeroCode)
@@ -1530,14 +1622,14 @@ let {{
                      fcmltZeroCode, scalar=True)
     # FCVTAS
     fcvtCode = fpOp % ("fplibFPToFixed<Element, Element>("
-                       "srcElem1, %s, %s, %s, fpscr)")
+                       "srcElem1, %s, %s, %s, fpscr, fpcr)")
     fcvtasCode = fcvtCode % ("0", "false", "FPRounding_TIEAWAY")
     twoEqualRegInstX("fcvtas", "FcvtasDX", "SimdCvtOp", smallFloatTypes, 2,
                      fcvtasCode)
     twoEqualRegInstX("fcvtas", "FcvtasQX", "SimdCvtOp", floatTypes, 4,
                      fcvtasCode)
     twoEqualRegInstX("fcvtas", "FcvtasScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtasCode, scalar=True)
+                     fcvtasCode, scalar=True, nepSrc="vd")
     # FCVTAU
     fcvtauCode = fcvtCode % ("0", "true", "FPRounding_TIEAWAY")
     twoEqualRegInstX("fcvtau", "FcvtauDX", "SimdCvtOp", smallFloatTypes, 2,
@@ -1545,10 +1637,10 @@ let {{
     twoEqualRegInstX("fcvtau", "FcvtauQX", "SimdCvtOp", floatTypes, 4,
                      fcvtauCode)
     twoEqualRegInstX("fcvtau", "FcvtauScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtauCode, scalar=True)
+                     fcvtauCode, scalar=True, nepSrc="vd")
     # FCVTL, FCVTL2
     fcvtlCode = fpOp % ("fplibConvert<Element, BigElement>("
-                        "srcElem1, FPCRRounding(fpscr), fpscr)")
+                        "srcElem1, FPCRRounding(fpscr), fpscr, fpcr)")
     twoRegLongInstX("fcvtl", "FcvtlX", "SimdCvtOp", ("uint16_t", "uint32_t"),
                     fcvtlCode)
     twoRegLongInstX("fcvtl", "Fcvtl2X", "SimdCvtOp", ("uint16_t", "uint32_t"),
@@ -1560,7 +1652,7 @@ let {{
     twoEqualRegInstX("fcvtms", "FcvtmsQX", "SimdCvtOp", floatTypes, 4,
                      fcvtmsCode)
     twoEqualRegInstX("fcvtms", "FcvtmsScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtmsCode, scalar=True)
+                     fcvtmsCode, scalar=True, nepSrc="vd")
     # FCVTMU
     fcvtmuCode = fcvtCode % ("0", "true", "FPRounding_NEGINF")
     twoEqualRegInstX("fcvtmu", "FcvtmuDX", "SimdCvtOp", smallFloatTypes, 2,
@@ -1568,10 +1660,10 @@ let {{
     twoEqualRegInstX("fcvtmu", "FcvtmuQX", "SimdCvtOp", floatTypes, 4,
                      fcvtmuCode)
     twoEqualRegInstX("fcvtmu", "FcvtmuScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtmuCode, scalar=True)
+                     fcvtmuCode, scalar=True, nepSrc="vd")
     # FCVTN, FCVTN2
     fcvtnCode = fpOp % ("fplibConvert<BigElement, Element>("
-                        "srcElem1, FPCRRounding(fpscr), fpscr)")
+                        "srcElem1, FPCRRounding(fpscr), fpscr, fpcr)")
     twoRegNarrowInstX("fcvtn", "FcvtnX", "SimdCvtOp",
                       ("uint16_t", "uint32_t"), fcvtnCode)
     twoRegNarrowInstX("fcvtn", "Fcvtn2X", "SimdCvtOp",
@@ -1583,7 +1675,7 @@ let {{
     twoEqualRegInstX("fcvtns", "FcvtnsQX", "SimdCvtOp", floatTypes, 4,
                      fcvtnsCode)
     twoEqualRegInstX("fcvtns", "FcvtnsScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtnsCode, scalar=True)
+                     fcvtnsCode, scalar=True, nepSrc="vd")
     # FCVTNU
     fcvtnuCode = fcvtCode % ("0", "true", "FPRounding_TIEEVEN")
     twoEqualRegInstX("fcvtnu", "FcvtnuDX", "SimdCvtOp", smallFloatTypes, 2,
@@ -1591,7 +1683,7 @@ let {{
     twoEqualRegInstX("fcvtnu", "FcvtnuQX", "SimdCvtOp", floatTypes, 4,
                      fcvtnuCode)
     twoEqualRegInstX("fcvtnu", "FcvtnuScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtnuCode, scalar=True)
+                     fcvtnuCode, scalar=True, nepSrc="vd")
     # FCVTPS
     fcvtpsCode = fcvtCode % ("0", "false", "FPRounding_POSINF")
     twoEqualRegInstX("fcvtps", "FcvtpsDX", "SimdCvtOp", smallFloatTypes, 2,
@@ -1599,7 +1691,7 @@ let {{
     twoEqualRegInstX("fcvtps", "FcvtpsQX", "SimdCvtOp", floatTypes, 4,
                      fcvtpsCode)
     twoEqualRegInstX("fcvtps", "FcvtpsScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtpsCode, scalar=True)
+                     fcvtpsCode, scalar=True, nepSrc="vd")
     # FCVTPU
     fcvtpuCode = fcvtCode % ("0", "true", "FPRounding_POSINF")
     twoEqualRegInstX("fcvtpu", "FcvtpuDX", "SimdCvtOp", smallFloatTypes, 2,
@@ -1607,16 +1699,16 @@ let {{
     twoEqualRegInstX("fcvtpu", "FcvtpuQX", "SimdCvtOp", floatTypes, 4,
                      fcvtpuCode)
     twoEqualRegInstX("fcvtpu", "FcvtpuScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtpuCode, scalar=True)
+                     fcvtpuCode, scalar=True, nepSrc="vd")
     # FCVTXN, FCVTXN2
     fcvtxnCode = fpOp % ("fplibConvert<BigElement, Element>("
-                         "srcElem1, FPRounding_ODD, fpscr)")
+                         "srcElem1, FPRounding_ODD, fpscr, fpcr)")
     twoRegNarrowInstX("fcvtxn", "FcvtxnX", "SimdCvtOp", smallFloatTypes,
                       fcvtxnCode)
     twoRegNarrowInstX("fcvtxn", "Fcvtxn2X", "SimdCvtOp", smallFloatTypes,
                       fcvtxnCode, hi=True)
     twoRegNarrowInstX("fcvtxn", "FcvtxnScX", "SimdCvtOp", smallFloatTypes,
-                      fcvtxnCode, scalar=True)
+                      fcvtxnCode, scalar=True, nepSrc="vd")
     # FCVTZS (fixed-point)
     fcvtzsCode = fcvtCode % ("imm", "false", "FPRounding_ZERO")
     twoEqualRegInstX("fcvtzs", "FcvtzsFixedDX", "SimdCvtOp", smallFloatTypes,
@@ -1624,7 +1716,7 @@ let {{
     twoEqualRegInstX("fcvtzs", "FcvtzsFixedQX", "SimdCvtOp", floatTypes, 4,
                      fcvtzsCode, hasImm=True)
     twoEqualRegInstX("fcvtzs", "FcvtzsFixedScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtzsCode, hasImm=True, scalar=True)
+                     fcvtzsCode, hasImm=True, scalar=True, nepSrc="vd")
     # FCVTZS (integer)
     fcvtzsIntCode = fcvtCode % ("0", "false", "FPRounding_ZERO")
     twoEqualRegInstX("fcvtzs", "FcvtzsIntDX", "SimdCvtOp", smallFloatTypes,
@@ -1632,7 +1724,7 @@ let {{
     twoEqualRegInstX("fcvtzs", "FcvtzsIntQX", "SimdCvtOp", floatTypes, 4,
                      fcvtzsIntCode)
     twoEqualRegInstX("fcvtzs", "FcvtzsIntScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtzsIntCode, scalar=True)
+                     fcvtzsIntCode, scalar=True, nepSrc="vd")
     # FCVTZU (fixed-point)
     fcvtzuCode = fcvtCode % ("imm", "true", "FPRounding_ZERO")
     twoEqualRegInstX("fcvtzu", "FcvtzuFixedDX", "SimdCvtOp", smallFloatTypes,
@@ -1640,7 +1732,7 @@ let {{
     twoEqualRegInstX("fcvtzu", "FcvtzuFixedQX", "SimdCvtOp", floatTypes, 4,
                      fcvtzuCode, hasImm=True)
     twoEqualRegInstX("fcvtzu", "FcvtzuFixedScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtzuCode, hasImm=True, scalar=True)
+                     fcvtzuCode, hasImm=True, scalar=True, nepSrc="vd")
     # FCVTZU (integer)
     fcvtzuIntCode = fcvtCode % ("0", "true", "FPRounding_ZERO")
     twoEqualRegInstX("fcvtzu", "FcvtzuIntDX", "SimdCvtOp", smallFloatTypes, 2,
@@ -1648,7 +1740,7 @@ let {{
     twoEqualRegInstX("fcvtzu", "FcvtzuIntQX", "SimdCvtOp", floatTypes, 4,
                      fcvtzuIntCode)
     twoEqualRegInstX("fcvtzu", "FcvtzuIntScX", "SimdCvtOp", floatTypes, 4,
-                     fcvtzuIntCode, scalar=True)
+                     fcvtzuIntCode, scalar=True, nepSrc="vd")
     # FDIV
     fdivCode = fpBinOp % "Div"
     threeEqualRegInstX("fdiv", "FdivDX", "SimdFloatDivOp", smallFloatTypes, 2,
@@ -1681,7 +1773,7 @@ let {{
                        fmaxnmCode, pairwise=True)
     # FMAXNMV
     # Note: SimdFloatCmpOp can be a bit optimistic here
-    fpAcrossOp = fpOp % "fplib%s<Element>(destElem, srcElem1, fpscr)"
+    fpAcrossOp = fpOp % "fplib%s<Element>(destElem, srcElem1, fpscr, fpcr)"
     fmaxnmAcrossCode = fpAcrossOp % "MaxNum"
     twoRegAcrossInstX("fmaxnmv", "FmaxnmvDX", "SimdFloatCmpOp",
                       ("uint16_t", "uint32_t"), 2, fmaxnmAcrossCode,
@@ -1771,13 +1863,14 @@ let {{
           return std::make_shared<UndefinedInstruction>(machInst, true);
     '''
     fmlaCode = fpOp % ("fplibMulAdd<Element>("
-                       "destElem, srcElem1, srcElem2, fpscr)")
+                       "destElem, srcElem1, srcElem2, fpscr, fpcr)")
     threeEqualRegInstX("fmla", "FmlaElemDX", "SimdFloatMultAccOp",
                        smallFloatTypes, 2, fmlaCode, True, byElem=True)
     threeEqualRegInstX("fmla", "FmlaElemQX", "SimdFloatMultAccOp", floatTypes,
                        4, fmlaCode, True, byElem=True)
     threeEqualRegInstX("fmla", "FmlaElemScX", "SimdFloatMultAccOp", floatTypes,
-                       4, fmlaCode, True, byElem=True, scalar=True)
+                       4, fmlaCode, True, byElem=True, scalar=True,
+                       nepSrc="vd")
     # FMLA (vector)
     threeEqualRegInstX("fmla", "FmlaDX", "SimdFloatMultAccOp", smallFloatTypes,
                        2, fmlaCode, True)
@@ -1785,7 +1878,7 @@ let {{
                        fmlaCode, True)
     # FMLAL (by element)
     fmlalCode = fpOp % ("fplibMulAddH("
-                       "destElem, srcElem1, srcElem2, fpscr)")
+                       "destElem, srcElem1, srcElem2, fpscr, fpcr)")
     threeRegLongInstX("fmlal", "FmlalElemDX", "SimdFloatMultAccOp",
                       ("uint16_t",), fmlalCode, True, byElem=True, short=True,
                       extra_check=fhm_check)
@@ -1814,22 +1907,23 @@ let {{
                       ("uint16_t",), fmlalCode, True, hi=True,
                       extra_check=fhm_check)
     # FMLS (by element)
-    fmlsCode = fpOp % ("fplibMulAdd<Element>(destElem,"
-                       " fplibNeg<Element>(srcElem1), srcElem2, fpscr)")
+    fmlsCode = fpOp % ("fplibMulAdd<Element>(destElem, fplibNeg<Element>"
+                        "(srcElem1, fpcr), srcElem2, fpscr, fpcr)")
     threeEqualRegInstX("fmls", "FmlsElemDX", "SimdFloatMultAccOp",
                        smallFloatTypes, 2, fmlsCode, True, byElem=True)
     threeEqualRegInstX("fmls", "FmlsElemQX", "SimdFloatMultAccOp", floatTypes,
                        4, fmlsCode, True, byElem=True)
     threeEqualRegInstX("fmls", "FmlsElemScX", "SimdFloatMultAccOp", floatTypes,
-                       4, fmlsCode, True, byElem=True, scalar=True)
+                       4, fmlsCode, True, byElem=True, scalar=True,
+                       nepSrc="vd")
     # FMLS (vector)
     threeEqualRegInstX("fmls", "FmlsDX", "SimdFloatMultAccOp", smallFloatTypes,
                        2, fmlsCode, True)
     threeEqualRegInstX("fmls", "FmlsQX", "SimdFloatMultAccOp", floatTypes, 4,
                        fmlsCode, True)
     # FMLSL (by element)
-    fmlslCode = fpOp % ("fplibMulAddH(destElem, "
-                       "fplibNeg<Element>(srcElem1), srcElem2, fpscr)")
+    fmlslCode = fpOp % ("fplibMulAddH(destElem, fplibNeg<Element>"
+                        "(srcElem1, fpcr), srcElem2, fpscr, fpcr)")
     threeRegLongInstX("fmlsl", "FmlslElemDX", "SimdFloatMultAccOp",
                       ("uint16_t",), fmlslCode, True, byElem=True, short=True,
                       extra_check=fhm_check)
@@ -1868,7 +1962,7 @@ let {{
     threeEqualRegInstX("fmul", "FmulElemQX", "SimdFloatMultOp", floatTypes, 4,
                        fmulCode, byElem=True)
     threeEqualRegInstX("fmul", "FmulElemScX", "SimdFloatMultOp", floatTypes, 4,
-                       fmulCode, byElem=True, scalar=True)
+                       fmulCode, byElem=True, scalar=True, nepSrc="vn")
     # FMUL (vector)
     threeEqualRegInstX("fmul", "FmulDX", "SimdFloatMultOp", smallFloatTypes, 2,
                        fmulCode)
@@ -1881,28 +1975,28 @@ let {{
     threeEqualRegInstX("fmulx", "FmulxQX", "SimdFloatMultOp", floatTypes, 4,
                        fmulxCode)
     threeEqualRegInstX("fmulx", "FmulxScX", "SimdFloatMultOp", floatTypes, 4,
-                       fmulxCode, scalar=True)
+                       fmulxCode, scalar=True, nepSrc="vn")
     # FMULX (by element)
     threeEqualRegInstX("fmulx", "FmulxElemDX", "SimdFloatMultOp",
                        smallFloatTypes, 2, fmulxCode, byElem=True)
     threeEqualRegInstX("fmulx", "FmulxElemQX", "SimdFloatMultOp", floatTypes,
                        4, fmulxCode, byElem=True)
     threeEqualRegInstX("fmulx", "FmulxElemScX", "SimdFloatMultOp", floatTypes,
-                       4, fmulxCode, byElem=True, scalar=True)
+                       4, fmulxCode, byElem=True, scalar=True, nepSrc="vn")
     # FNEG
-    fnegCode = fpOp % "fplibNeg<Element>(srcElem1)"
+    fnegCode = fpOp % "fplibNeg<Element>(srcElem1, fpcr)"
     twoEqualRegInstX("Neg", "FnegDX", "SimdFloatAluOp", smallFloatTypes, 2,
                      fnegCode)
     twoEqualRegInstX("Neg", "FnegQX", "SimdFloatAluOp", floatTypes, 4,
                      fnegCode)
     # FRECPE
-    frecpeCode = fpOp % "fplibRecipEstimate<Element>(srcElem1, fpscr)"
+    frecpeCode = fpOp % "fplibRecipEstimate<Element>(srcElem1, fpscr, fpcr)"
     twoEqualRegInstX("frecpe", "FrecpeDX", "SimdFloatMultAccOp",
                      smallFloatTypes, 2, frecpeCode)
     twoEqualRegInstX("frecpe", "FrecpeQX", "SimdFloatMultAccOp", floatTypes, 4,
                      frecpeCode)
     twoEqualRegInstX("frecpe", "FrecpeScX", "SimdFloatMultAccOp", floatTypes,
-                     4, frecpeCode, scalar=True)
+                     4, frecpeCode, scalar=True, nepSrc="vd")
     # FRECPS
     frecpsCode = fpBinOp % "RecipStepFused"
     threeEqualRegInstX("frecps", "FrecpsDX", "SimdFloatMultAccOp",
@@ -1910,13 +2004,14 @@ let {{
     threeEqualRegInstX("frecps", "FrecpsQX", "SimdFloatMultAccOp", floatTypes,
                        4, frecpsCode)
     threeEqualRegInstX("frecps", "FrecpsScX", "SimdFloatMultAccOp", floatTypes,
-                       4, frecpsCode, scalar=True)
+                       4, frecpsCode, scalar=True, nepSrc="vn")
     # FRECPX
-    frecpxCode = fpOp % "fplibRecpX<Element>(srcElem1, fpscr)"
+    frecpxCode = fpOp % "fplibRecpX<Element>(srcElem1, fpscr, fpcr)"
     twoEqualRegInstX("frecpx", "FrecpxX", "SimdFloatMultAccOp", floatTypes, 4,
-                     frecpxCode, scalar=True)
+                     frecpxCode, scalar=True, nepSrc="vd")
     # FRINTA
-    frintCode = fpOp % "fplibRoundInt<Element>(srcElem1, %s, %s, fpscr)"
+    frintCode = fpOp % ("fplibRoundInt<Element>"
+                        "(srcElem1, %s, %s, fpscr, fpcr)")
     frintaCode = frintCode % ("FPRounding_TIEAWAY", "false")
     twoEqualRegInstX("frinta", "FrintaDX", "SimdCvtOp", smallFloatTypes, 2,
                      frintaCode)
@@ -1965,7 +2060,7 @@ let {{
           return std::make_shared<UndefinedInstruction>(machInst, true);
     '''
     frint32xCode = fpOp % ("fplibRoundIntN<Element>"
-                        "(srcElem1, FPCRRounding(fpscr), true, 32, fpscr)")
+                    "(srcElem1, FPCRRounding(fpscr), true, 32, fpscr, fpcr)")
     twoEqualRegInstX("frint32x", "Frint32xDX", "SimdCvtOp", ('uint32_t',), 2,
                      frint32xCode, extra_check=frintts_check)
     twoEqualRegInstX("frint32x", "Frint32xQX", "SimdCvtOp",
@@ -1973,7 +2068,7 @@ let {{
                      frint32xCode, extra_check=frintts_check)
     # FRINT32Z
     frint32zCode = fpOp % ("fplibRoundIntN<Element>"
-                        "(srcElem1, FPRounding_ZERO, true, 32, fpscr)")
+                        "(srcElem1, FPRounding_ZERO, true, 32, fpscr, fpcr)")
     twoEqualRegInstX("frint32z", "Frint32zDX", "SimdCvtOp", ('uint32_t',), 2,
                      frint32zCode, extra_check=frintts_check)
     twoEqualRegInstX("frint32z", "Frint32zQX", "SimdCvtOp",
@@ -1981,7 +2076,7 @@ let {{
                      frint32zCode, extra_check=frintts_check)
     # FRINT64X
     frint64xCode = fpOp % ("fplibRoundIntN<Element>"
-                        "(srcElem1, FPCRRounding(fpscr), true, 64, fpscr)")
+                    "(srcElem1, FPCRRounding(fpscr), true, 64, fpscr, fpcr)")
     twoEqualRegInstX("frint64x", "Frint64xDX", "SimdCvtOp", ('uint32_t',), 2,
                      frint64xCode, extra_check=frintts_check)
     twoEqualRegInstX("frint64x", "Frint64xQX", "SimdCvtOp",
@@ -1989,20 +2084,20 @@ let {{
                      frint64xCode, extra_check=frintts_check)
     # FRINT64Z
     frint64zCode = fpOp % ("fplibRoundIntN<Element>"
-                        "(srcElem1, FPRounding_ZERO, true, 64, fpscr)")
+                        "(srcElem1, FPRounding_ZERO, true, 64, fpscr, fpcr)")
     twoEqualRegInstX("frint64z", "Frint64zDX", "SimdCvtOp", ('uint32_t',), 2,
                      frint64zCode, extra_check=frintts_check)
     twoEqualRegInstX("frint64z", "Frint64zQX", "SimdCvtOp",
                      ('uint32_t', 'uint64_t',), 4,
                      frint64zCode, extra_check=frintts_check)
     # FRSQRTE
-    frsqrteCode = fpOp % "fplibRSqrtEstimate<Element>(srcElem1, fpscr)"
+    frsqrteCode = fpOp % "fplibRSqrtEstimate<Element>(srcElem1, fpscr, fpcr)"
     twoEqualRegInstX("frsqrte", "FrsqrteDX", "SimdFloatSqrtOp",
                      smallFloatTypes, 2, frsqrteCode)
     twoEqualRegInstX("frsqrte", "FrsqrteQX", "SimdFloatSqrtOp", floatTypes, 4,
                      frsqrteCode)
     twoEqualRegInstX("frsqrte", "FrsqrteScX", "SimdFloatSqrtOp", floatTypes, 4,
-                     frsqrteCode, scalar=True)
+                     frsqrteCode, scalar=True, nepSrc="vd")
     # FRSQRTS
     frsqrtsCode = fpBinOp % "RSqrtStepFused"
     threeEqualRegInstX("frsqrts", "FrsqrtsDX", "SimdFloatMiscOp",
@@ -2010,9 +2105,9 @@ let {{
     threeEqualRegInstX("frsqrts", "FrsqrtsQX", "SimdFloatMiscOp", floatTypes,
                        4, frsqrtsCode)
     threeEqualRegInstX("frsqrts", "FrsqrtsScX", "SimdFloatMiscOp", floatTypes,
-                       4, frsqrtsCode, scalar=True)
+                       4, frsqrtsCode, scalar=True, nepSrc="vn")
     # FSQRT
-    fsqrtCode = fpOp % "fplibSqrt<Element>(srcElem1, fpscr)"
+    fsqrtCode = fpOp % "fplibSqrt<Element>(srcElem1, fpscr, fpcr)"
     twoEqualRegInstX("fsqrt", "FsqrtDX", "SimdFloatSqrtOp", smallFloatTypes, 2,
                      fsqrtCode)
     twoEqualRegInstX("fsqrt", "FsqrtQX", "SimdFloatSqrtOp", floatTypes, 4,
@@ -2276,7 +2371,7 @@ let {{
     # SCVTF (fixed-point)
     scvtfFixedCode = fpOp % ("fplibFixedToFP<Element>("
                              "sext<sizeof(Element) * 8>(srcElem1), imm,"
-                             " false, FPCRRounding(fpscr), fpscr)")
+                             " false, FPCRRounding(fpscr), fpscr, fpcr)")
     twoEqualRegInstX("scvtf", "ScvtfFixedDX", "SimdCvtOp", smallFloatTypes, 2,
                      scvtfFixedCode, hasImm=True)
     twoEqualRegInstX("scvtf", "ScvtfFixedSQX", "SimdCvtOp", smallFloatTypes, 4,
@@ -2284,13 +2379,15 @@ let {{
     twoEqualRegInstX("scvtf", "ScvtfFixedDQX", "SimdCvtOp", ("uint64_t",), 4,
                      scvtfFixedCode, hasImm=True)
     twoEqualRegInstX("scvtf", "ScvtfFixedScSX", "SimdCvtOp", smallFloatTypes,
-                     4, scvtfFixedCode, hasImm=True, scalar=True)
+                     4, scvtfFixedCode, hasImm=True, scalar=True,
+                     nepSrc="vd")
     twoEqualRegInstX("scvtf", "ScvtfFixedScDX", "SimdCvtOp", ("uint64_t",), 4,
-                     scvtfFixedCode, hasImm=True, scalar=True)
+                     scvtfFixedCode, hasImm=True, scalar=True,
+                     nepSrc="vd")
     # SCVTF (integer)
     scvtfIntCode = fpOp % ("fplibFixedToFP<Element>("
                            "sext<sizeof(Element) * 8>(srcElem1), 0,"
-                           " false, FPCRRounding(fpscr), fpscr)")
+                           " false, FPCRRounding(fpscr), fpscr, fpcr)")
     twoEqualRegInstX("scvtf", "ScvtfIntDX", "SimdCvtOp", smallFloatTypes, 2,
                      scvtfIntCode)
     twoEqualRegInstX("scvtf", "ScvtfIntSQX", "SimdCvtOp", smallFloatTypes, 4,
@@ -2298,11 +2395,11 @@ let {{
     twoEqualRegInstX("scvtf", "ScvtfIntDQX", "SimdCvtOp", ("uint64_t",), 4,
                      scvtfIntCode)
     twoEqualRegInstX("scvtf", "ScvtfIntScHX", "SimdCvtOp", ("uint16_t",), 4,
-                     scvtfIntCode, scalar=True)
+                     scvtfIntCode, scalar=True, nepSrc="vd")
     twoEqualRegInstX("scvtf", "ScvtfIntScSX", "SimdCvtOp", ("uint32_t",), 4,
-                     scvtfIntCode, scalar=True)
+                     scvtfIntCode, scalar=True, nepSrc="vd")
     twoEqualRegInstX("scvtf", "ScvtfIntScDX", "SimdCvtOp", ("uint64_t",), 4,
-                     scvtfIntCode, scalar=True)
+                     scvtfIntCode, scalar=True, nepSrc="vd")
     # SHADD
     haddCode = '''
             Element carryBit =
@@ -3444,22 +3541,22 @@ let {{
                       addlwCode, hi=True)
     # UCVTF (fixed-point)
     ucvtfFixedCode = fpOp % ("fplibFixedToFP<Element>(srcElem1, imm, true,"
-                             " FPCRRounding(fpscr), fpscr)")
+                             " FPCRRounding(fpscr), fpscr, fpcr)")
     twoEqualRegInstX("ucvtf", "UcvtfFixedDX", "SimdCvtOp", smallFloatTypes, 2,
                      ucvtfFixedCode, hasImm=True)
     twoEqualRegInstX("ucvtf", "UcvtfFixedQX", "SimdCvtOp", floatTypes, 4,
                      ucvtfFixedCode, hasImm=True)
     twoEqualRegInstX("ucvtf", "UcvtfFixedScX", "SimdCvtOp", floatTypes, 4,
-                     ucvtfFixedCode, hasImm=True, scalar=True)
+                     ucvtfFixedCode, hasImm=True, scalar=True, nepSrc="vd")
     # UCVTF (integer)
     ucvtfIntCode = fpOp % ("fplibFixedToFP<Element>(srcElem1, 0, true,"
-                           " FPCRRounding(fpscr), fpscr)")
+                           " FPCRRounding(fpscr), fpscr, fpcr)")
     twoEqualRegInstX("ucvtf", "UcvtfIntDX", "SimdCvtOp", smallFloatTypes, 2,
                      ucvtfIntCode)
     twoEqualRegInstX("ucvtf", "UcvtfIntQX", "SimdCvtOp", floatTypes, 4,
                      ucvtfIntCode)
     twoEqualRegInstX("ucvtf", "UcvtfIntScX", "SimdCvtOp", floatTypes, 4,
-                     ucvtfIntCode, scalar=True)
+                     ucvtfIntCode, scalar=True, nepSrc="vd")
     # UHADD
     threeEqualRegInstX("uhadd", "UhaddDX", "SimdAddOp", smallUnsignedTypes, 2,
                        haddCode)

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -5013,6 +5013,7 @@ ISA::initializeMiscRegMetadata()
           mmfr1_el1.hpds = release->has(ArmExtension::FEAT_HPDS) ? 0x1 : 0x0;
           mmfr1_el1.pan = release->has(ArmExtension::FEAT_PAN) ? 0x1 : 0x0;
           mmfr1_el1.hcx = release->has(ArmExtension::FEAT_HCX) ? 0x1 : 0x0;
+          mmfr1_el1.afp = release->has(ArmExtension::FEAT_AFP) ? 0x1 : 0x0;
           return mmfr1_el1;
       }())
       .faultRead(EL0, faultIdst)

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -165,6 +165,7 @@ namespace ArmISA
     EndBitUnion(AA64MMFR0)
 
     BitUnion64(AA64MMFR1)
+        Bitfield<47, 44> afp;
         Bitfield<43, 40> hcx;
         Bitfield<31, 28> xnx;
         Bitfield<27, 24> specsei;


### PR DESCRIPTION
Add feature code: FEAT_AFP

Add control bit: FPCR.AH, FPCR.FIZ and FPCR.NEP.

- FPCR.AH provides another model to handle corner value of floating-point operation.
- FPCR.FIZ flushes the denomral input to zero when FPCR.AH is enabled.
- FPCR.NEP controls the merge behavior of the scalar variant of some AdvSimd instructions.

Change-Id: I1798e4a65f421847eafbbe811074efc13685c9c2