### PR TITLE
arch-vega: Implement CDNA4 (MI350) instructions, part 1

### DIFF
--- a/src/arch/amdgpu/common/dtype/packed_types.hh
+++ b/src/arch/amdgpu/common/dtype/packed_types.hh
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_AMDGPU_COMMON_DTYPE_PACKED_TYPES_HH__
+#define __ARCH_AMDGPU_COMMON_DTYPE_PACKED_TYPES_HH__
+
+#include "arch/amdgpu/common/dtype/mxfp_types.hh"
+
+namespace gem5
+{
+
+namespace AMDGPU
+{
+
+class PkBfloat16
+{
+  public:
+    AMDGPU::mxbfloat16 data[2];
+
+    uint32_t get() { return data[0].data | (uint32_t(data[1].data) << 16); }
+
+    PkBfloat16 operator+=(const PkBfloat16& rhs)
+    {
+        data[0] = data[0] + rhs.data[0];
+        data[1] = data[1] + rhs.data[1];
+        return *this;
+    }
+
+    PkBfloat16 operator+(const PkBfloat16& rhs)
+    {
+        data[0] = data[0] + rhs.data[0];
+        data[1] = data[1] + rhs.data[1];
+        return *this;
+    }
+
+    // Conversions
+    PkBfloat16 operator=(const int& rhs)
+    {
+        data[0].data = bits(rhs, 15, 0);
+        data[1].data = bits(rhs, 31, 16);
+        return *this;
+    }
+};
+
+} // namespace AMDGPU
+
+} // namespace gem5
+
+#endif // __ARCH_AMDGPU_COMMON_DTYPE_PACKED_TYPES_HH__

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -3626,7 +3626,7 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_VOP3P__V_DOT2_F32_BF16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -13178,6 +13178,12 @@ namespace VegaISA
     Decoder::decode_OP_VOP3P__V_DOT2_F32_F16(MachInst iFmt)
     {
         return new Inst_VOP3P__V_DOT2_F32_F16(&iFmt->iFmt_VOP3P);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_VOP3P__V_DOT2_F32_BF16(MachInst iFmt)
+    {
+        return new Inst_VOP3P__V_DOT2_F32_BF16(&iFmt->iFmt_VOP3P);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -1703,7 +1703,7 @@ namespace VegaISA
         &Decoder::decode_OP_FLAT__FLAT_ATOMIC_ADD_F64,
         &Decoder::decode_OP_FLAT__FLAT_ATOMIC_MIN_F64,
         &Decoder::decode_OP_FLAT__FLAT_ATOMIC_MAX_F64,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_FLAT__FLAT_ATOMIC_PK_ADD_BF16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -1834,7 +1834,7 @@ namespace VegaISA
         &Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_ADD_F64,
         &Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_MIN_F64,
         &Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_MAX_F64,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_PK_ADD_BF16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -2115,7 +2115,7 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -8512,6 +8512,12 @@ namespace VegaISA
     } // decode_OP_FLAT__FLAT_ATOMIC_MAX_F64
 
     GPUStaticInst*
+    Decoder::decode_OP_FLAT__FLAT_ATOMIC_PK_ADD_BF16(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
     Decoder::decode_OP_FLAT__FLAT_ATOMIC_SWAP_X2(MachInst iFmt)
     {
         return new Inst_FLAT__FLAT_ATOMIC_SWAP_X2(&iFmt->iFmt_FLAT);
@@ -8838,6 +8844,12 @@ namespace VegaISA
     Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_MAX_F64(MachInst iFmt)
     {
         return new Inst_FLAT__FLAT_ATOMIC_MAX_F64(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_PK_ADD_BF16(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16(&iFmt->iFmt_FLAT);
     }
 
     GPUStaticInst*
@@ -9859,6 +9871,12 @@ namespace VegaISA
     {
         return new Inst_MUBUF__BUFFER_ATOMIC_DEC(&iFmt->iFmt_MUBUF);
     } // decode_OP_MUBUF__BUFFER_ATOMIC_DEC
+
+    GPUStaticInst*
+    Decoder::decode_OP_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16(MachInst iFmt)
+    {
+        return new Inst_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16(&iFmt->iFmt_MUBUF);
+    } // decode_OP_MUBUF__BUFFER_ATOMIC_PK_ADD_BF17
 
     GPUStaticInst*
     Decoder::decode_OP_MUBUF__BUFFER_ATOMIC_SWAP_X2(MachInst iFmt)

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -4002,6 +4002,12 @@ namespace VegaISA
     } // decode_OP_VOP2__V_XOR_B32
 
     GPUStaticInst*
+    Decoder::decode_OP_VOP2__V_DOT2C_F32_BF16(MachInst iFmt)
+    {
+        return new Inst_VOP2__V_DOT2C_F32_BF16(&iFmt->iFmt_VOP2);
+    } // decode_OP_VOP2__V_DOT2C_F32_BF16
+
+    GPUStaticInst*
     Decoder::decode_OP_VOP2__V_MAC_F32(MachInst iFmt)
     {
         return new Inst_VOP2__V_MAC_F32(&iFmt->iFmt_VOP2);
@@ -6023,6 +6029,12 @@ namespace VegaISA
     {
         return new Inst_VOP3__V_XOR_B32(&iFmt->iFmt_VOP3A);
     } // decode_OPU_VOP3__V_XOR_B32
+
+    GPUStaticInst*
+    Decoder::decode_OPU_VOP3__V_DOT2C_F32_BF16(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_DOT2C_F32_BF16(&iFmt->iFmt_VOP3A);
+    } // decode_OPU_VOP3__V_DOT2C_F32_BF16
 
     GPUStaticInst*
     Decoder::decode_OPU_VOP3__V_MAC_F32(MachInst iFmt)

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -1154,8 +1154,8 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OPU_VOP3__V_BITOP3_B16,
+        &Decoder::decode_OPU_VOP3__V_BITOP3_B32,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -7101,6 +7101,18 @@ namespace VegaISA
     Decoder::decode_OPU_VOP3__V_LSHL_ADD_U64(MachInst iFmt)
     {
         return new Inst_VOP3__V_LSHL_ADD_U64(&iFmt->iFmt_VOP3A);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OPU_VOP3__V_BITOP3_B16(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_BITOP3_B16(&iFmt->iFmt_VOP3A);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OPU_VOP3__V_BITOP3_B32(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_BITOP3_B32(&iFmt->iFmt_VOP3A);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -1204,8 +1204,8 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OPU_VOP3__V_ASHR_PK_I8_I32,
+        &Decoder::decode_OPU_VOP3__V_ASHR_PK_U8_I32,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -7101,6 +7101,18 @@ namespace VegaISA
     Decoder::decode_OPU_VOP3__V_LSHL_ADD_U64(MachInst iFmt)
     {
         return new Inst_VOP3__V_LSHL_ADD_U64(&iFmt->iFmt_VOP3A);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OPU_VOP3__V_ASHR_PK_I8_I32(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_ASHR_PK_I8_I32(&iFmt->iFmt_VOP3A);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OPU_VOP3__V_ASHR_PK_U8_I32(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_ASHR_PK_U8_I32(&iFmt->iFmt_VOP3A);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -1586,10 +1586,10 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_OP_DS__DS_WRITE_B96,
         &Decoder::decode_OP_DS__DS_WRITE_B128,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_DS__DS_READ_B64_TR_B4,
+        &Decoder::decode_OP_DS__DS_READ_B96_TR_B6,
+        &Decoder::decode_OP_DS__DS_READ_B64_TR_B8,
+        &Decoder::decode_OP_DS__DS_READ_B64_TR_B16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -8287,6 +8287,30 @@ namespace VegaISA
     {
         return new Inst_DS__DS_WRITE_B128(&iFmt->iFmt_DS);
     } // decode_OP_DS__DS_WRITE_B128
+
+    GPUStaticInst*
+    Decoder::decode_OP_DS__DS_READ_B64_TR_B4(MachInst iFmt)
+    {
+        return new Inst_DS__DS_READ_B64_TR_B4(&iFmt->iFmt_DS);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_DS__DS_READ_B96_TR_B6(MachInst iFmt)
+    {
+        return new Inst_DS__DS_READ_B96_TR_B6(&iFmt->iFmt_DS);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_DS__DS_READ_B64_TR_B8(MachInst iFmt)
+    {
+        return new Inst_DS__DS_READ_B64_TR_B8(&iFmt->iFmt_DS);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_DS__DS_READ_B64_TR_B16(MachInst iFmt)
+    {
+        return new Inst_DS__DS_READ_B64_TR_B16(&iFmt->iFmt_DS);
+    }
 
     GPUStaticInst*
     Decoder::decode_OP_DS__DS_READ_B96(MachInst iFmt)

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -1790,11 +1790,11 @@ namespace VegaISA
         &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SBYTE_D16_HI,
         &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SHORT_D16,
         &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SHORT_D16_HI,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_UBYTE,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_SBYTE,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_USHORT,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_SSHORT,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORD,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -1877,8 +1877,8 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORDX4,
+        &Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORDX3,
         &Decoder::decode_invalid
     };
 
@@ -8735,6 +8735,36 @@ namespace VegaISA
     }
 
     GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_UBYTE(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_UBYTE(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_SBYTE(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_SBYTE(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_USHORT(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_USHORT(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_SSHORT(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_SSHORT(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORD(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_DWORD(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
     Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_SWAP(MachInst iFmt)
     {
         return new Inst_FLAT__FLAT_ATOMIC_SWAP(&iFmt->iFmt_FLAT);
@@ -8928,6 +8958,18 @@ namespace VegaISA
     Decoder::decode_OP_GLOBAL__GLOBAL_ATOMIC_DEC_X2(MachInst iFmt)
     {
         return new Inst_FLAT__FLAT_ATOMIC_DEC_X2(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORDX4(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_DWORDX4(&iFmt->iFmt_FLAT);
+    }
+
+    GPUStaticInst*
+    Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORDX3(MachInst iFmt)
+    {
+        return new Inst_FLAT__FLAT_LOAD_LDS_DWORDX3(&iFmt->iFmt_FLAT);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -302,6 +302,7 @@ namespace VegaISA
         GPUStaticInst* decode_OPU_VOP3__V_OR_B32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_XOR_B32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_MAC_F32(MachInst);
+        GPUStaticInst* decode_OPU_VOP3__V_DOT2C_F32_BF16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_ADD_CO_U32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_SUB_CO_U32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_SUBREV_CO_U32(MachInst);
@@ -1344,6 +1345,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_VOP2__V_OR_B32(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_XOR_B32(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_MAC_F32(MachInst);
+        GPUStaticInst* decode_OP_VOP2__V_DOT2C_F32_BF16(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_MADMK_F32(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_MADAK_F32(MachInst);
         GPUStaticInst* decode_OP_VOP2__V_ADD_CO_U32(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -710,6 +710,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_ADD_F64(MachInst);
         GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_MIN_F64(MachInst);
         GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_MAX_F64(MachInst);
+        GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_PK_ADD_BF16(MachInst);
         GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_SWAP_X2(MachInst);
         GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_CMPSWAP_X2(MachInst);
         GPUStaticInst* decode_OP_FLAT__FLAT_ATOMIC_ADD_X2(MachInst);
@@ -763,6 +764,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_ADD_F64(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_MIN_F64(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_MAX_F64(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_PK_ADD_BF16(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_SWAP_X2(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_CMPSWAP_X2(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_ADD_X2(MachInst);
@@ -941,6 +943,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_XOR(MachInst);
         GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_INC(MachInst);
         GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_DEC(MachInst);
+        GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16(MachInst);
         GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_SWAP_X2(MachInst);
         GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_CMPSWAP_X2(MachInst);
         GPUStaticInst* decode_OP_MUBUF__BUFFER_ATOMIC_ADD_X2(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -1611,6 +1611,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_VOP3P__V_PK_ADD_F32(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_PK_MOV_B32(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_DOT2_F32_F16(MachInst);
+        GPUStaticInst* decode_OP_VOP3P__V_DOT2_F32_BF16(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_DOT2_I32_I16(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_DOT2_U32_U16(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_DOT4_I32_I8(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -478,6 +478,8 @@ namespace VegaISA
         GPUStaticInst* decode_OPU_VOP3__V_FMA_F16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_DIV_FIXUP_F16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_LSHL_ADD_U64(MachInst);
+        GPUStaticInst* decode_OPU_VOP3__V_BITOP3_B16(MachInst);
+        GPUStaticInst* decode_OPU_VOP3__V_BITOP3_B32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_ASHR_PK_I8_I32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_ASHR_PK_U8_I32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_INTERP_P1_F32(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -478,6 +478,8 @@ namespace VegaISA
         GPUStaticInst* decode_OPU_VOP3__V_FMA_F16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_DIV_FIXUP_F16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_LSHL_ADD_U64(MachInst);
+        GPUStaticInst* decode_OPU_VOP3__V_ASHR_PK_I8_I32(MachInst);
+        GPUStaticInst* decode_OPU_VOP3__V_ASHR_PK_U8_I32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_INTERP_P1_F32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_INTERP_P2_F32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_INTERP_MOV_F32(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -673,6 +673,10 @@ namespace VegaISA
         GPUStaticInst* decode_OP_DS__DS_MAX_SRC2_F64(MachInst);
         GPUStaticInst* decode_OP_DS__DS_WRITE_B96(MachInst);
         GPUStaticInst* decode_OP_DS__DS_WRITE_B128(MachInst);
+        GPUStaticInst* decode_OP_DS__DS_READ_B64_TR_B4(MachInst);
+        GPUStaticInst* decode_OP_DS__DS_READ_B96_TR_B6(MachInst);
+        GPUStaticInst* decode_OP_DS__DS_READ_B64_TR_B8(MachInst);
+        GPUStaticInst* decode_OP_DS__DS_READ_B64_TR_B16(MachInst);
         GPUStaticInst* decode_OP_DS__DS_READ_B96(MachInst);
         GPUStaticInst* decode_OP_DS__DS_READ_B128(MachInst);
         GPUStaticInst* decode_OP_EXP(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -746,6 +746,11 @@ namespace VegaISA
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_SBYTE_D16_HI(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_SHORT_D16(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_SHORT_D16_HI(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_UBYTE(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_SBYTE(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_USHORT(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_SSHORT(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORD(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_SWAP(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_CMPSWAP(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_ADD(MachInst);
@@ -778,6 +783,8 @@ namespace VegaISA
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_XOR_X2(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_INC_X2(MachInst);
         GPUStaticInst* decode_OP_GLOBAL__GLOBAL_ATOMIC_DEC_X2(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORDX4(MachInst);
+        GPUStaticInst* decode_OP_GLOBAL__GLOBAL_LOAD_LDS_DWORDX3(MachInst);
         GPUStaticInst* decode_OP_MIMG__IMAGE_LOAD(MachInst);
         GPUStaticInst* decode_OP_MIMG__IMAGE_LOAD_MIP(MachInst);
         GPUStaticInst* decode_OP_MIMG__IMAGE_LOAD_PCK(MachInst);

--- a/src/arch/amdgpu/vega/insts/flat.cc
+++ b/src/arch/amdgpu/vega/insts/flat.cc
@@ -2227,5 +2227,39 @@ namespace VegaISA
     {
         atomicComplete<VecOperandF64, VecElemF64>(gpuDynInst);
     } // completeAcc
+    // --- Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16 class methods ---
+
+    Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16::Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16(
+        InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_atomic_pk_add_bf16")
+    {
+        setFlag(AtomicPkAddBF16);
+
+        // MI300 spec: "Float atomics must set SC[0]=0 (no return value)."
+        panic_if(instData.GLC, "Saw float atomic with return set!");
+
+        setFlag(AtomicNoReturn);
+    } // Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16
+
+    Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16::~Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16()
+    {
+    } // ~Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16
+
+    void
+    Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16::execute(GPUDynInstPtr gpuDynInst)
+    {
+        atomicExecute<ConstVecOperandU32, VecElemU32>(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initAtomicAccess<VecElemU32>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+    } // completeAcc
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/flat.cc
+++ b/src/arch/amdgpu/vega/insts/flat.cc
@@ -988,6 +988,246 @@ namespace VegaISA
     Inst_FLAT__FLAT_STORE_DWORDX4::completeAcc(GPUDynInstPtr gpuDynInst)
     {
     } // completeAcc
+    // --- Inst_FLAT__FLAT_LOAD_LDS_UBYTE class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_UBYTE::
+        Inst_FLAT__FLAT_LOAD_LDS_UBYTE(InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_ubyte")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal() || isFlatScratch());
+    } // Inst_FLAT__FLAT_LOAD_LDS_UBYTE
+
+    Inst_FLAT__FLAT_LOAD_LDS_UBYTE::~Inst_FLAT__FLAT_LOAD_LDS_UBYTE()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_UBYTE
+
+    // --- description from .arch file ---
+    // Untyped buffer load unsigned byte (zero extend to VGPR destination).
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_UBYTE::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_UBYTE::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<VecElemU8>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_UBYTE::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        // Align to dword.
+        ldsComplete<1>(gpuDynInst);
+    } // execute
+    // --- Inst_FLAT__FLAT_LOAD_LDS_SBYTE class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_SBYTE::
+        Inst_FLAT__FLAT_LOAD_LDS_SBYTE(InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_sbyte")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal() || isFlatScratch());
+    } // Inst_FLAT__FLAT_LOAD_LDS_SBYTE
+
+    Inst_FLAT__FLAT_LOAD_LDS_SBYTE::~Inst_FLAT__FLAT_LOAD_LDS_SBYTE()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_SBYTE
+
+    // --- description from .arch file ---
+    // Untyped buffer load signed byte (sign extend to VGPR destination).
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_SBYTE::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_SBYTE::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<VecElemI8>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_SBYTE::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        // Align to dword.
+        ldsComplete<1, 8>(gpuDynInst);
+    } // execute
+    // --- Inst_FLAT__FLAT_LOAD_LDS_USHORT class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_USHORT::
+        Inst_FLAT__FLAT_LOAD_LDS_USHORT(InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_ushort")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal() || isFlatScratch());
+    } // Inst_FLAT__FLAT_LOAD_LDS_USHORT
+
+    Inst_FLAT__FLAT_LOAD_LDS_USHORT::~Inst_FLAT__FLAT_LOAD_LDS_USHORT()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_USHORT
+
+    // --- description from .arch file ---
+    // Untyped buffer load unsigned short (zero extend to VGPR destination).
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_USHORT::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_USHORT::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<VecElemU16>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_USHORT::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        // Align to dword.
+        ldsComplete<1>(gpuDynInst);
+    } // execute
+
+    // --- Inst_FLAT__FLAT_LOAD_LDS_SSHORT class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_SSHORT::
+        Inst_FLAT__FLAT_LOAD_LDS_SSHORT(InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_sshort")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal() || isFlatScratch());
+    } // Inst_FLAT__FLAT_LOAD_LDS_SSHORT
+
+    Inst_FLAT__FLAT_LOAD_LDS_SSHORT::~Inst_FLAT__FLAT_LOAD_LDS_SSHORT()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_SSHORT
+
+    // --- description from .arch file ---
+    // Untyped buffer load signed short (sign extend to VGPR destination).
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_SSHORT::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_SSHORT::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<VecElemI16>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_SSHORT::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        // Align to dword.
+        ldsComplete<1, 16>(gpuDynInst);
+    } // execute
+    // --- Inst_FLAT__FLAT_LOAD_LDS_DWORD class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_DWORD::
+        Inst_FLAT__FLAT_LOAD_LDS_DWORD(InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_dword")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal() || isFlatScratch());
+    } // Inst_FLAT__FLAT_LOAD_LDS_DWORD
+
+    Inst_FLAT__FLAT_LOAD_LDS_DWORD::~Inst_FLAT__FLAT_LOAD_LDS_DWORD()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_DWORD
+
+    // --- description from .arch file ---
+    // Untyped buffer load dword.
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORD::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORD::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<VecElemU32>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORD::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        ldsComplete<1>(gpuDynInst);
+    } // completeAcc
     // --- Inst_FLAT__FLAT_ATOMIC_SWAP class methods ---
 
     Inst_FLAT__FLAT_ATOMIC_SWAP::Inst_FLAT__FLAT_ATOMIC_SWAP(InFmt_FLAT *iFmt)
@@ -2260,6 +2500,100 @@ namespace VegaISA
     void
     Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16::completeAcc(GPUDynInstPtr gpuDynInst)
     {
+    } // completeAcc
+    // --- Inst_FLAT__FLAT_LOAD_LDS_DWORDX3 class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX3::Inst_FLAT__FLAT_LOAD_LDS_DWORDX3(
+          InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_dwordx3")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal());
+    } // Inst_FLAT__FLAT_LOAD_LDS_DWORDX3
+
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX3::~Inst_FLAT__FLAT_LOAD_LDS_DWORDX3()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_DWORDX3
+
+    // --- description from .arch file ---
+    // Untyped buffer load 3 dwords.
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX3::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX3::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<3>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX3::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        ldsComplete<3>(gpuDynInst);
+    } // completeAcc
+    // --- Inst_FLAT__FLAT_LOAD_LDS_DWORDX4 class methods ---
+
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX4::Inst_FLAT__FLAT_LOAD_LDS_DWORDX4(
+          InFmt_FLAT *iFmt)
+        : Inst_FLAT(iFmt, "flat_load_lds_dwordx4")
+    {
+        setFlag(Load);
+
+        assert(isFlatGlobal());
+    } // Inst_FLAT__FLAT_LOAD_LDS_DWORDX4
+
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX4::~Inst_FLAT__FLAT_LOAD_LDS_DWORDX4()
+    {
+    } // ~Inst_FLAT__FLAT_LOAD_LDS_DWORDX4
+
+    // --- description from .arch file ---
+    // Untyped buffer load 4 dwords.
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX4::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+
+        if (gpuDynInst->exec_mask.none()) {
+            wf->decVMemInstsIssued();
+            return;
+        }
+
+        gpuDynInst->execUnitId = wf->execUnitId;
+        gpuDynInst->latency.init(gpuDynInst->computeUnit());
+        gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+        calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+        issueRequestHelper(gpuDynInst);
+    } // execute
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX4::initiateAcc(GPUDynInstPtr gpuDynInst)
+    {
+        initMemRead<4>(gpuDynInst);
+    } // initiateAcc
+
+    void
+    Inst_FLAT__FLAT_LOAD_LDS_DWORDX4::completeAcc(GPUDynInstPtr gpuDynInst)
+    {
+        ldsComplete<4>(gpuDynInst);
     } // completeAcc
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -6960,6 +6960,40 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP2__V_XOR_B32
 
+    class Inst_VOP2__V_DOT2C_F32_BF16 : public Inst_VOP2
+    {
+      public:
+        Inst_VOP2__V_DOT2C_F32_BF16(InFmt_VOP2*);
+        ~Inst_VOP2__V_DOT2C_F32_BF16();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 4;
+              case 1: //src_1
+                return 4;
+              case 2: //vdst
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP2__V_DOT2C_F32_BF16
+
     class Inst_VOP2__V_MAC_F32 : public Inst_VOP2
     {
       public:
@@ -24981,6 +25015,40 @@ namespace VegaISA
 
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP3__V_XOR_B32
+
+    class Inst_VOP3__V_DOT2C_F32_BF16 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_DOT2C_F32_BF16(InFmt_VOP3A*);
+        ~Inst_VOP3__V_DOT2C_F32_BF16();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 4;
+              case 1: //src_1
+                return 4;
+              case 2: //vdst
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_DOT2C_F32_BF16
 
     class Inst_VOP3__V_MAC_F32 : public Inst_VOP3A
     {

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -38080,6 +38080,44 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_MUBUF__BUFFER_ATOMIC_DEC
 
+    class Inst_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16 : public Inst_MUBUF
+    {
+      public:
+        Inst_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16(InFmt_MUBUF*);
+        ~Inst_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 3; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_a
+                return 8;
+              case 1: //sgpr_r
+                return 16;
+              case 2: //sgpr_o
+                return 4;
+              case 3: //vgpr_d
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_MUBUF__BUFFER_ATOMIC_PK_ADD_BF16
+
     class Inst_MUBUF__BUFFER_ATOMIC_SWAP_X2 : public Inst_MUBUF
     {
       public:
@@ -44133,6 +44171,45 @@ namespace VegaISA
         void initiateAcc(GPUDynInstPtr) override;
         void completeAcc(GPUDynInstPtr) override;
     }; // Inst_FLAT__FLAT_ATOMIC_MAX_F64
+
+    class Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16 : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return isFlat() ? 2 : 3; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //vgpr_src
+                return 8;
+              case 2: //vgpr_dst or saddr
+                return isFlat() ? 8 : 8;
+              case 3: //vgpr_dst
+                assert(!isFlat());
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16
 
     class Inst_VOP3P__V_PK_FMA_F32 : public Inst_VOP3P
     {

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -30468,6 +30468,78 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP3__V_CVT_PKACCUM_U8_F32
 
+    class Inst_VOP3__V_BITOP3_B16 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_BITOP3_B16(InFmt_VOP3A*);
+        ~Inst_VOP3__V_BITOP3_B16();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 3; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 4;
+              case 1: //src_1
+                return 4;
+              case 2: //src_2
+                return 4;
+              case 3: //vdst
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_BITOP3_B16
+
+    class Inst_VOP3__V_BITOP3_B32 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_BITOP3_B32(InFmt_VOP3A*);
+        ~Inst_VOP3__V_BITOP3_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 3; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 4;
+              case 1: //src_1
+                return 4;
+              case 2: //src_2
+                return 4;
+              case 3: //vdst
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_BITOP3_B32
+
     class Inst_VOP3__V_ASHR_PK_I8_I32 : public Inst_VOP3A
     {
       public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -36430,6 +36430,142 @@ namespace VegaISA
         void completeAcc(GPUDynInstPtr) override;
     }; // Inst_DS__DS_READ_B128
 
+    class Inst_DS__DS_READ_B64_TR_B4 : public Inst_DS
+    {
+      public:
+        Inst_DS__DS_READ_B64_TR_B4(InFmt_DS*);
+        ~Inst_DS__DS_READ_B64_TR_B4();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 1; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_a
+                return 4;
+              case 1: //vgpr_rtn
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_DS__DS_READ_B64_TR_B4
+
+    class Inst_DS__DS_READ_B96_TR_B6 : public Inst_DS
+    {
+      public:
+        Inst_DS__DS_READ_B96_TR_B6(InFmt_DS*);
+        ~Inst_DS__DS_READ_B96_TR_B6();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 1; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_a
+                return 4;
+              case 1: //vgpr_rtn
+                return 12;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_DS__DS_READ_B96_TR_B6
+
+    class Inst_DS__DS_READ_B64_TR_B8 : public Inst_DS
+    {
+      public:
+        Inst_DS__DS_READ_B64_TR_B8(InFmt_DS*);
+        ~Inst_DS__DS_READ_B64_TR_B8();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 1; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_a
+                return 4;
+              case 1: //vgpr_rtn
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_DS__DS_READ_B64_TR_B8
+
+    class Inst_DS__DS_READ_B64_TR_B16 : public Inst_DS
+    {
+      public:
+        Inst_DS__DS_READ_B64_TR_B16(InFmt_DS*);
+        ~Inst_DS__DS_READ_B64_TR_B16();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 1; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_a
+                return 4;
+              case 1: //vgpr_rtn
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_DS__DS_READ_B64_TR_B16
+
     class Inst_MUBUF__BUFFER_LOAD_FORMAT_X : public Inst_MUBUF
     {
       public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -30468,6 +30468,78 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP3__V_CVT_PKACCUM_U8_F32
 
+    class Inst_VOP3__V_ASHR_PK_I8_I32 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_ASHR_PK_I8_I32(InFmt_VOP3A*);
+        ~Inst_VOP3__V_ASHR_PK_I8_I32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 3; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 4;
+              case 1: //src_1
+                return 4;
+              case 2: //src_2
+                return 4;
+              case 3: //vdst
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_ASHR_PK_I8_I32
+
+    class Inst_VOP3__V_ASHR_PK_U8_I32 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_ASHR_PK_U8_I32(InFmt_VOP3A*);
+        ~Inst_VOP3__V_ASHR_PK_U8_I32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 1; }
+        int numSrcRegOperands() override { return 3; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //src_0
+                return 4;
+              case 1: //src_1
+                return 4;
+              case 2: //src_2
+                return 4;
+              case 3: //vdst
+                return 4;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_ASHR_PK_U8_I32
+
     class Inst_VOP3__V_INTERP_P1_F32 : public Inst_VOP3A
     {
       public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -42963,6 +42963,176 @@ namespace VegaISA
         void completeAcc(GPUDynInstPtr) override;
     }; // Inst_FLAT__FLAT_STORE_DWORDX4
 
+    class Inst_FLAT__FLAT_LOAD_LDS_UBYTE : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_UBYTE(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_UBYTE();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_UBYTE
+
+    class Inst_FLAT__FLAT_LOAD_LDS_SBYTE : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_SBYTE(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_SBYTE();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_SBYTE
+
+    class Inst_FLAT__FLAT_LOAD_LDS_USHORT : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_USHORT(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_USHORT();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_USHORT
+
+    class Inst_FLAT__FLAT_LOAD_LDS_SSHORT : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_SSHORT(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_SSHORT();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_SSHORT
+
+    class Inst_FLAT__FLAT_LOAD_LDS_DWORD : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_DWORD(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_DWORD();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_DWORD
+
     class Inst_FLAT__FLAT_ATOMIC_SWAP : public Inst_FLAT
     {
       public:
@@ -44210,6 +44380,74 @@ namespace VegaISA
         void initiateAcc(GPUDynInstPtr) override;
         void completeAcc(GPUDynInstPtr) override;
     }; // Inst_FLAT__FLAT_ATOMIC_PK_ADD_BF16
+
+    class Inst_FLAT__FLAT_LOAD_LDS_DWORDX3 : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_DWORDX3(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_DWORDX3();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //vgpr_dst or saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_DWORDX3
+
+    class Inst_FLAT__FLAT_LOAD_LDS_DWORDX4 : public Inst_FLAT
+    {
+      public:
+        Inst_FLAT__FLAT_LOAD_LDS_DWORDX4(InFmt_FLAT*);
+        ~Inst_FLAT__FLAT_LOAD_LDS_DWORDX4();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int numDstRegOperands() override { return 0; }
+        int numSrcRegOperands() override { return 2; }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+              case 0: //vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+              case 1: //vgpr_dst or saddr
+                return 8;
+              default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+        void initiateAcc(GPUDynInstPtr) override;
+        void completeAcc(GPUDynInstPtr) override;
+    }; // Inst_FLAT__FLAT_LOAD_LDS_DWORDX4
 
     class Inst_VOP3P__V_PK_FMA_F32 : public Inst_VOP3P
     {

--- a/src/arch/amdgpu/vega/insts/mubuf.cc
+++ b/src/arch/amdgpu/vega/insts/mubuf.cc
@@ -649,6 +649,12 @@ namespace VegaISA
     void
     Inst_MUBUF__BUFFER_LOAD_UBYTE::completeAcc(GPUDynInstPtr gpuDynInst)
     {
+        if (instData.LDS) {
+            ldsComplete<1>(gpuDynInst);
+
+            return;
+        }
+
         VecOperandU32 vdst(gpuDynInst, extData.VDATA);
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
@@ -777,6 +783,12 @@ namespace VegaISA
     void
     Inst_MUBUF__BUFFER_LOAD_USHORT::completeAcc(GPUDynInstPtr gpuDynInst)
     {
+        if (instData.LDS) {
+            ldsComplete<1>(gpuDynInst);
+
+            return;
+        }
+
         VecOperandU32 vdst(gpuDynInst, extData.VDATA);
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
@@ -1114,6 +1126,12 @@ namespace VegaISA
     void
     Inst_MUBUF__BUFFER_LOAD_DWORD::completeAcc(GPUDynInstPtr gpuDynInst)
     {
+        if (instData.LDS) {
+            ldsComplete<1>(gpuDynInst);
+
+            return;
+        }
+
         VecOperandU32 vdst(gpuDynInst, extData.VDATA);
 
         for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
@@ -1137,11 +1155,9 @@ namespace VegaISA
     {
         setFlag(MemoryRef);
         setFlag(Load);
-        if (instData.LDS) {
-            setFlag(GroupSegment);
-        } else {
-            setFlag(GlobalSegment);
-        }
+        setFlag(GlobalSegment);
+
+        panic_if(instData.LDS, "Return to LDS not supported for %s", _opcode);
     } // Inst_MUBUF__BUFFER_LOAD_DWORDX2
 
     Inst_MUBUF__BUFFER_LOAD_DWORDX2::~Inst_MUBUF__BUFFER_LOAD_DWORDX2()
@@ -1309,6 +1325,12 @@ namespace VegaISA
     void
     Inst_MUBUF__BUFFER_LOAD_DWORDX3::completeAcc(GPUDynInstPtr gpuDynInst)
     {
+        if (instData.LDS) {
+            ldsComplete<4>(gpuDynInst);
+
+            return;
+        }
+
         VecOperandU32 vdst0(gpuDynInst, extData.VDATA);
         VecOperandU32 vdst1(gpuDynInst, extData.VDATA + 1);
         VecOperandU32 vdst2(gpuDynInst, extData.VDATA + 2);
@@ -1414,6 +1436,12 @@ namespace VegaISA
     void
     Inst_MUBUF__BUFFER_LOAD_DWORDX4::completeAcc(GPUDynInstPtr gpuDynInst)
     {
+        if (instData.LDS) {
+            ldsComplete<4>(gpuDynInst);
+
+            return;
+        }
+
         VecOperandU32 vdst0(gpuDynInst, extData.VDATA);
         VecOperandU32 vdst1(gpuDynInst, extData.VDATA + 1);
         VecOperandU32 vdst2(gpuDynInst, extData.VDATA + 2);

--- a/src/arch/amdgpu/vega/insts/vop2.cc
+++ b/src/arch/amdgpu/vega/insts/vop2.cc
@@ -718,24 +718,16 @@ namespace VegaISA
     void
     Inst_VOP2__V_LSHRREV_B32::execute(GPUDynInstPtr gpuDynInst)
     {
-        Wavefront *wf = gpuDynInst->wavefront();
-        ConstVecOperandU32 src0(gpuDynInst, instData.SRC0);
-        ConstVecOperandU32 src1(gpuDynInst, instData.VSRC1);
-        VecOperandU32 vdst(gpuDynInst, instData.VDST);
-
-        src0.readSrc();
-        src1.read();
-
-        panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
-        panic_if(isDPPInst(), "DPP not implemented for %s", _opcode);
-
-        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
-            if (wf->execMask(lane)) {
-                vdst[lane] = src1[lane] >> bits(src0[lane], 4, 0);
+        auto opImpl = [](VecOperandU32& src0, VecOperandU32& src1,
+                         VecOperandU32& vdst, Wavefront* wf) {
+            for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+                if (wf->execMask(lane)) {
+                    vdst[lane] = src1[lane] >> bits(src0[lane], 4, 0);
+                }
             }
-        }
+        };
 
-        vdst.write();
+        vop2Helper<ConstVecOperandU32, VecOperandU32>(gpuDynInst, opImpl);
     } // execute
     // --- Inst_VOP2__V_ASHRREV_I32 class methods ---
 
@@ -870,49 +862,16 @@ namespace VegaISA
     void
     Inst_VOP2__V_AND_B32::execute(GPUDynInstPtr gpuDynInst)
     {
-        Wavefront *wf = gpuDynInst->wavefront();
-        ConstVecOperandU32 src0(gpuDynInst, instData.SRC0);
-        VecOperandU32 src1(gpuDynInst, instData.VSRC1);
-        VecOperandU32 vdst(gpuDynInst, instData.VDST);
-
-        src0.readSrc();
-        src1.read();
-
-        panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
-
-        if (isDPPInst()) {
-            VecOperandU32 src0_dpp(gpuDynInst, extData.iFmt_VOP_DPP.SRC0);
-            src0_dpp.read();
-
-            DPRINTF(VEGA, "Handling V_AND_B32 SRC DPP. SRC0: register v[%d], "
-                    "DPP_CTRL: 0x%#x, SRC0_ABS: %d, SRC0_NEG: %d, "
-                    "SRC1_ABS: %d, SRC1_NEG: %d, BC: %d, "
-                    "BANK_MASK: %d, ROW_MASK: %d\n", extData.iFmt_VOP_DPP.SRC0,
-                    extData.iFmt_VOP_DPP.DPP_CTRL,
-                    extData.iFmt_VOP_DPP.SRC0_ABS,
-                    extData.iFmt_VOP_DPP.SRC0_NEG,
-                    extData.iFmt_VOP_DPP.SRC1_ABS,
-                    extData.iFmt_VOP_DPP.SRC1_NEG,
-                    extData.iFmt_VOP_DPP.BC,
-                    extData.iFmt_VOP_DPP.BANK_MASK,
-                    extData.iFmt_VOP_DPP.ROW_MASK);
-
-            processDPP(gpuDynInst, extData.iFmt_VOP_DPP, src0_dpp, src1);
-
-            for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
-                if (wf->execMask(lane)) {
-                    vdst[lane] = src0_dpp[lane] & src1[lane];
-                }
-            }
-        } else {
+        auto opImpl = [](VecOperandU32& src0, VecOperandU32& src1,
+                         VecOperandU32& vdst, Wavefront* wf) {
             for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
                 if (wf->execMask(lane)) {
                     vdst[lane] = src0[lane] & src1[lane];
                 }
             }
-        }
+        };
 
-        vdst.write();
+        vop2Helper<ConstVecOperandU32, VecOperandU32>(gpuDynInst, opImpl);
     } // execute
     // --- Inst_VOP2__V_OR_B32 class methods ---
 
@@ -1823,24 +1782,16 @@ namespace VegaISA
     void
     Inst_VOP2__V_LSHLREV_B16::execute(GPUDynInstPtr gpuDynInst)
     {
-        Wavefront *wf = gpuDynInst->wavefront();
-        ConstVecOperandU16 src0(gpuDynInst, instData.SRC0);
-        ConstVecOperandU16 src1(gpuDynInst, instData.VSRC1);
-        VecOperandU16 vdst(gpuDynInst, instData.VDST);
-
-        src0.readSrc();
-        src1.read();
-
-        panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
-        panic_if(isDPPInst(), "DPP not implemented for %s", _opcode);
-
-        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
-            if (wf->execMask(lane)) {
-                vdst[lane] = src1[lane] << bits(src0[lane], 3, 0);
+        auto opImpl = [](VecOperandU32& src0, VecOperandU32& src1,
+                         VecOperandU32& vdst, Wavefront* wf) {
+            for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+                if (wf->execMask(lane)) {
+                    vdst[lane] = src1[lane] << bits(src0[lane], 3, 0);
+                }
             }
-        }
+        };
 
-        vdst.write();
+        vop2Helper<ConstVecOperandU32, VecOperandU32>(gpuDynInst, opImpl);
     } // execute
     // --- Inst_VOP2__V_LSHRREV_B16 class methods ---
 

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -1224,6 +1224,51 @@ namespace VegaISA
 
         vdst.write();
     } // execute
+    // --- Inst_VOP3__V_DOT2C_F32_BF16 class methods ---
+
+    Inst_VOP3__V_DOT2C_F32_BF16::Inst_VOP3__V_DOT2C_F32_BF16(InFmt_VOP3A *iFmt)
+        : Inst_VOP3A(iFmt, "v_dot2c_f32_bf16", false)
+    {
+        setFlag(ALU);
+    } // Inst_VOP3__V_DOT2C_F32_BF16
+
+    Inst_VOP3__V_DOT2C_F32_BF16::~Inst_VOP3__V_DOT2C_F32_BF16()
+    {
+    } // ~Inst_VOP3__V_DOT2C_F32_BF16
+
+    void
+    Inst_VOP3__V_DOT2C_F32_BF16::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+        ConstVecOperandU32 src0(gpuDynInst, extData.SRC0);
+        ConstVecOperandU32 src1(gpuDynInst, extData.SRC1);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src0.readSrc();
+        src1.readSrc();
+        vdst.read();
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                AMDGPU::mxbfloat16 a1, a2, b1, b2;
+                a1.data = uint16_t(bits(src0[lane], 15, 0));
+                a2.data = uint16_t(bits(src0[lane], 31, 16));
+                b1.data = uint16_t(bits(src1[lane], 15, 0));
+                b2.data = uint16_t(bits(src1[lane], 31, 16));
+
+                // ABS treated as NEG_HI
+                if (instData.ABS & 0x1) a2 = -a2;
+                if (instData.ABS & 0x2) b2 = -b2;
+                if (extData.NEG & 0x1) a1 = -a1;
+                if (extData.NEG & 0x2) b1 = -b1;
+
+                vdst[lane] += float(a1) * float(b1);
+                vdst[lane] += float(a2) * float(b2);
+            }
+        }
+
+        vdst.write();
+    } // execute
     // --- Inst_VOP3__V_MAC_F32 class methods ---
 
     Inst_VOP3__V_MAC_F32::Inst_VOP3__V_MAC_F32(InFmt_VOP3A *iFmt)

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -9098,8 +9098,8 @@ namespace VegaISA
                 if (neg & 1) tmp0 = -tmp0;
                 if (neg & 2) tmp1 = -tmp1;
 
-                uint16_t packed_data = (bits(tmp0.data, 31, 24) << 8)
-                                     | bits(tmp1.data, 31, 24);
+                uint16_t packed_data = (bits(tmp1.data, 31, 24) << 8)
+                                     | bits(tmp0.data, 31, 24);
 
                 if (opsel & 8) {
                     replaceBits(vdst[lane], 31, 16, packed_data);

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -7874,6 +7874,118 @@ namespace VegaISA
     {
         panicUnimplemented();
     } // execute
+    // --- Inst_VOP3__V_ASHR_PK_I8_I32 class methods ---
+
+    Inst_VOP3__V_ASHR_PK_I8_I32::Inst_VOP3__V_ASHR_PK_I8_I32(InFmt_VOP3A *iFmt)
+        : Inst_VOP3A(iFmt, "v_ashr_pk_i8_i32", false)
+    {
+        setFlag(ALU);
+    } // Inst_VOP3__V_ASHR_PK_I8_I32
+
+    Inst_VOP3__V_ASHR_PK_I8_I32::~Inst_VOP3__V_ASHR_PK_I8_I32()
+    {
+    } // ~Inst_VOP3__V_ASHR_PK_I8_I32
+
+    void
+    Inst_VOP3__V_ASHR_PK_I8_I32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+        ConstVecOperandI32 src0(gpuDynInst, extData.SRC0);
+        ConstVecOperandI32 src1(gpuDynInst, extData.SRC1);
+        ConstVecOperandU32 src2(gpuDynInst, extData.SRC2);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src0.readSrc();
+        src1.readSrc();
+        src2.readSrc();
+        vdst.read();
+
+        auto sat8 = [](int32_t n) -> uint8_t {
+            if (n <= -128) return 0x80;
+            else if (n >= 127) return 0x7f;
+            else return n & 0xff;
+        };
+
+        panic_if(isSDWAInst(), "SDWA not supported for %s", _opcode);
+        panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+
+        int opsel = instData.OPSEL;
+        panic_if(opsel & 0x7, "Source OPSEL not supported for %s", _opcode);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                uint8_t lower = sat8(src0[lane] >> bits(src2[lane], 4, 0));
+                uint8_t upper = sat8(src0[lane] >> bits(src2[lane], 4, 0));
+
+                // Don't clobber unwritten bits according to pgm guide.
+                uint16_t result = uint16_t(upper) << 8 | uint16_t(lower);
+                if (opsel & 0x8) {
+                    replaceBits(vdst[lane], 31, 16, result);
+                } else {
+                    replaceBits(vdst[lane], 15, 0, result);
+                }
+            }
+        }
+
+        vdst.write();
+
+    } // execute
+    // --- Inst_VOP3__V_ASHR_PK_U8_I32 class methods ---
+
+    Inst_VOP3__V_ASHR_PK_U8_I32::Inst_VOP3__V_ASHR_PK_U8_I32(InFmt_VOP3A *iFmt)
+        : Inst_VOP3A(iFmt, "v_ashr_pk_u8_i32", false)
+    {
+        setFlag(ALU);
+    } // Inst_VOP3__V_ASHR_PK_U8_I32
+
+    Inst_VOP3__V_ASHR_PK_U8_I32::~Inst_VOP3__V_ASHR_PK_U8_I32()
+    {
+    } // ~Inst_VOP3__V_ASHR_PK_U8_I32
+
+    void
+    Inst_VOP3__V_ASHR_PK_U8_I32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+        ConstVecOperandI32 src0(gpuDynInst, extData.SRC0);
+        ConstVecOperandI32 src1(gpuDynInst, extData.SRC1);
+        ConstVecOperandU32 src2(gpuDynInst, extData.SRC2);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src0.readSrc();
+        src1.readSrc();
+        src2.readSrc();
+        vdst.read();
+
+        auto sat8 = [](int32_t n) -> uint8_t {
+            if (n <= 0) return 0;
+            else if (n >= 255) return 0xff;
+            else return n & 0xff;
+        };
+
+        panic_if(isSDWAInst(), "SDWA not supported for %s", _opcode);
+        panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+
+        int opsel = instData.OPSEL;
+        panic_if(opsel & 0x7, "Source OPSEL not supported for %s", _opcode);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                uint8_t lower = sat8(src0[lane] >> bits(src2[lane], 4, 0));
+                uint8_t upper = sat8(src0[lane] >> bits(src2[lane], 4, 0));
+
+                // Don't clobber unwritten bits according to pgm guide.
+                uint16_t result = uint16_t(upper) << 8 | uint16_t(lower);
+                if (opsel & 0x8) {
+                    replaceBits(vdst[lane], 31, 16, result);
+                } else {
+                    replaceBits(vdst[lane], 15, 0, result);
+                }
+            }
+        }
+
+        vdst.write();
+
+    } // execute
     // --- Inst_VOP3__V_INTERP_P1_F32 class methods ---
 
     Inst_VOP3__V_INTERP_P1_F32::Inst_VOP3__V_INTERP_P1_F32(InFmt_VOP3A *iFmt)

--- a/src/arch/amdgpu/vega/insts/vop3p.hh
+++ b/src/arch/amdgpu/vega/insts/vop3p.hh
@@ -356,6 +356,16 @@ namespace VegaISA
         void execute(GPUDynInstPtr gpuDynInst) override;
     };
 
+    class Inst_VOP3P__V_DOT2_F32_BF16 : public Inst_VOP3P__3OP_X16
+    {
+      public:
+        Inst_VOP3P__V_DOT2_F32_BF16(InFmt_VOP3P *iFmt)
+            : Inst_VOP3P__3OP_X16(iFmt, "v_dot2_f32_bf16")
+        { }
+
+        void execute(GPUDynInstPtr gpuDynInst) override;
+    };
+
     class Inst_VOP3P__V_DOT2_I32_I16 : public Inst_VOP3P__3OP_X16
     {
       public:

--- a/src/gpu-compute/GPUStaticInstFlags.py
+++ b/src/gpu-compute/GPUStaticInstFlags.py
@@ -85,6 +85,7 @@ class GPUStaticInstFlags(Enum):
         "AtomicDec",
         "AtomicMax",
         "AtomicMin",
+        "AtomicPkAddBF16",
         # Segment access flags
         "ArgSegment",  # Accesses the arg segment
         "GlobalSegment",  # Accesses global memory

--- a/src/gpu-compute/gpu_dyn_inst.cc
+++ b/src/gpu-compute/gpu_dyn_inst.cc
@@ -654,6 +654,12 @@ GPUDynInst::isAtomicMin() const
 }
 
 bool
+GPUDynInst::isAtomicPkAddBF16() const
+{
+    return _staticInst->isAtomicPkAddBF16();
+}
+
+bool
 GPUDynInst::isArgLoad() const
 {
     return _staticInst->isArgLoad();

--- a/src/gpu-compute/gpu_static_inst.hh
+++ b/src/gpu-compute/gpu_static_inst.hh
@@ -167,6 +167,7 @@ class GPUStaticInst : public GPUStaticInstFlags
     bool isAtomicDec() const { return _flags[AtomicDec]; }
     bool isAtomicMax() const { return _flags[AtomicMax]; }
     bool isAtomicMin() const { return _flags[AtomicMin]; }
+    bool isAtomicPkAddBF16() const { return _flags[AtomicPkAddBF16]; }
 
     bool
     isArgLoad() const


### PR DESCRIPTION
- Add SDWA to a few instructions and fix one MI300 instruction.
- Add new BF16 DOT product instructions.
- Add packed BF16 atomics.
- Implement load VRAM-to-LDS.
- Implement LDS transpose read instructions.
- Add misc. AHSR_PK and BITOP3 instructions.

This is about 1/4th of new instructions described here: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-cdna4-instruction-set-architecture.pdf 