### PR TITLE
cpu: Fix looppoint analysis v25

### DIFF
--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -73,7 +73,7 @@ LooppointAnalysis::updateLocalBBV(const Addr pc)
 
 void
 LooppointAnalysis::checkPc(
-    const std::pair<SimpleThread*,StaticInstPtr>& inst_pair
+    const std::pair<SimpleThread*,const StaticInstPtr>& inst_pair
 )
 {
     const StaticInstPtr &inst = inst_pair.second;

--- a/src/cpu/simple/probes/looppoint_analysis.hh
+++ b/src/cpu/simple/probes/looppoint_analysis.hh
@@ -62,7 +62,8 @@ class LooppointAnalysis : public ProbeListenerObject
      * @param inst_pair A pair that contains the SimpleThread pointer and the
      * StaticInstPtr of the commited instruction from the atomic CPU.
      */
-    void checkPc(const std::pair<SimpleThread*, StaticInstPtr>& inst_pair);
+    void checkPc(const std::pair<SimpleThread*,
+        const StaticInstPtr>& inst_pair);
 
     /**
      * When this function is called, it sets the class variable ifListening to
@@ -77,8 +78,8 @@ class LooppointAnalysis : public ProbeListenerObject
      */
     void stopListening();
 
-    typedef ProbeListenerArg<LooppointAnalysis,
-        std::pair<SimpleThread*, StaticInstPtr>> looppointAnalysisListener;
+    typedef ProbeListenerArg<LooppointAnalysis, std::pair<SimpleThread*,
+        const StaticInstPtr>> looppointAnalysisListener;
 
   private:
 


### PR DESCRIPTION
This is a PR for the issue: https://github.com/gem5/gem5/issues/2395

The new probe structure uses ```dynamic_cast``` to check the```ProbeListener```, which caused a casting mismatch with the LoopPoint Analysis ProbeListener, because the LoopPoint Analysis ProbeListener uses ```StaticInstPtr``` instead of ```const StaticInstPtr``` as part of its Arg while the Probe Point that it is listening to, ```Commit```, uses ```const StaticInstPtr```.
This commit fixes the issue.