### PR TITLE
arch-riscv: Fix bootloader & kernel load address

### DIFF
--- a/src/arch/riscv/RiscvFsWorkload.py
+++ b/src/arch/riscv/RiscvFsWorkload.py
@@ -89,7 +89,7 @@ class RiscvBootloaderKernelWorkload(Workload):
         "", "File that contains the bootloader. Don't use bootloader if empty."
     )
     bootloader_addr = Param.Addr(
-        0x0, "Where to place the bootloader in memory."
+        0x80000000, "Where to place the bootloader in memory."
     )
     object_file = Param.String("", "vmlinux file. Don't use kernel if empty.")
     kernel_addr = Param.Addr(

--- a/src/arch/riscv/linux/fs_workload.cc
+++ b/src/arch/riscv/linux/fs_workload.cc
@@ -153,15 +153,15 @@ void
 BootloaderKernelWorkload::loadBootloader()
 {
     if (params().bootloader_filename != "") {
-        Addr bootloader_addr_offset = params().bootloader_addr;
-        bootloader->buildImage().offset(bootloader_addr_offset).write(
-            system->physProxy
-        );
+        loader::MemoryImage image = bootloader->buildImage();
+        Addr bootloader_addr_offset = \
+            params().bootloader_addr - image.minAddr();
+        image.offset(bootloader_addr_offset).write(system->physProxy);
         delete bootloader;
 
         inform("Loaded bootloader \'%s\' at 0x%llx\n",
                params().bootloader_filename,
-               bootloader_addr_offset);
+               params().bootloader_addr);
     } else {
         inform("Bootloader is not specified.\n");
     }
@@ -171,15 +171,14 @@ void
 BootloaderKernelWorkload::loadKernel()
 {
     if (params().object_file != "") {
-        Addr kernel_paddr_offset = params().kernel_addr;
-        kernel->buildImage().offset(kernel_paddr_offset).write(
-            system->physProxy
-        );
+        loader::MemoryImage image = kernel->buildImage();
+        Addr kernel_paddr_offset = params().kernel_addr - image.minAddr();
+        image.offset(kernel_paddr_offset).write(system->physProxy);
         delete kernel;
 
         inform("Loaded kernel \'%s\' at 0x%llx\n",
                 params().object_file,
-                kernel_paddr_offset);
+                params().kernel_addr);
     } else {
         inform("Kernel is not specified.\n");
     }

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -532,14 +532,14 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         # all boards support both FS and SE modes.
         if self.is_fullsystem():
             if len(self._bootloader) > 0:
-                self.workload.bootloader_addr = 0x0
+                self.workload.bootloader_addr = 0x80000000
                 self.workload.bootloader_filename = self._bootloader[0]
                 self.workload.kernel_addr = 0x80200000
                 self.workload.entry_point = (
                     0x80000000  # Bootloader starting point
                 )
             else:
-                self.workload.kernel_addr = 0x0
+                self.workload.kernel_addr = 0x80000000
                 self.workload.entry_point = 0x80000000
 
             # Set up the device tree. We need to wait until pre-instantiate to

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -316,14 +316,14 @@ class RISCVMatchedBoard(
     def _pre_instantiate(self, full_system: Optional[bool] = None) -> None:
         if self._fs:
             if len(self._bootloader) > 0:
-                self.workload.bootloader_addr = 0x0
+                self.workload.bootloader_addr = 0x80000000
                 self.workload.bootloader_filename = self._bootloader[0]
                 self.workload.kernel_addr = 0x80200000
                 self.workload.entry_point = (
                     0x80000000  # Bootloader starting point
                 )
             else:
-                self.workload.kernel_addr = 0x0
+                self.workload.kernel_addr = 0x80000000
                 self.workload.entry_point = 0x80000000
 
         super()._pre_instantiate(full_system=full_system)


### PR DESCRIPTION
The bootloader_addr should be expect where the bootloader address put. The bootloader_addr only place expect location only if the base address of firmware is zero. If the base address is not zero, we should subtrace the elf offset

Change-Id: I66025659d80ae2c34821d665e351f9e96f4384d6