### PR TITLE
misc: Update protobuf files to remove required

### DIFF
--- a/src/proto/inst.proto
+++ b/src/proto/inst.proto
@@ -42,14 +42,14 @@ package ProtoMessage;
 // the trace, the version of this file format, and the tick frequency
 // for all the packet time stamps.
 message InstHeader {
-  required string obj_id = 1;
-  required uint32 ver = 2 [default = 0];
-  required uint64 tick_freq = 3;
-  required bool has_mem = 4;
+  optional string obj_id = 1;
+  optional uint32 ver = 2 [default = 0];
+  optional uint64 tick_freq = 3;
+  optional bool has_mem = 4;
 }
 
 message Inst {
-  required uint64 pc = 1;
+  optional uint64 pc = 1;
 
   // Either inst or inst_bytes must be used, but never both. That should be
   // enforced by the oneof keyword, but that's not supported in all versions
@@ -106,8 +106,8 @@ message Inst {
 
   // If the operation does one or more memory accesses
   message MemAccess {
-      required uint64 addr = 1;
-      required uint32 size = 2;
+      optional uint64 addr = 1;
+      optional uint32 size = 2;
       optional uint32 mem_flags = 3;
   }
   repeated MemAccess mem_access = 8;

--- a/src/proto/inst_dep_record.proto
+++ b/src/proto/inst_dep_record.proto
@@ -43,14 +43,14 @@ package ProtoMessage;
 // file format, the tick frequency of the object and the window size used to
 // limit the register dependencies during capture.
 message InstDepRecordHeader {
-  required string obj_id = 1;
+  optional string obj_id = 1;
   optional uint32 ver = 2 [default = 0];
-  required uint64 tick_freq = 3;
-  required uint32 window_size = 4;
+  optional uint64 tick_freq = 3;
+  optional uint32 window_size = 4;
 }
 
 // Packet to encapsulate an instruction in the o3cpu data dependency trace.
-// The required fields include the instruction sequence number and the type
+// The optional fields include the instruction sequence number and the type
 // of the record associated with the instruction e.g. load. The request related
 // fields are optional, namely address, size and flags. The dependency related
 // information includes a repeated field for order dependencies and register
@@ -68,13 +68,13 @@ message InstDepRecord {
     STORE = 2;
     COMP = 3;
   }
-  required uint64 seq_num = 1;
-  required RecordType type = 2 [default = INVALID];
+  optional uint64 seq_num = 1;
+  optional RecordType type = 2 [default = INVALID];
   optional uint64 p_addr = 3;
   optional uint32 size = 4;
   optional uint32 flags = 5;
   repeated uint64 rob_dep = 6;
-  required uint64 comp_delay = 7;
+  optional uint64 comp_delay = 7;
   repeated uint64 reg_dep = 8;
   optional uint32 weight = 9;
   optional uint64 pc = 10;

--- a/src/proto/packet.proto
+++ b/src/proto/packet.proto
@@ -42,9 +42,9 @@ package ProtoMessage;
 // the trace, the version of this file format, and the tick frequency
 // for all the packet time stamps.
 message PacketHeader {
-  required string obj_id = 1;
+  optional string obj_id = 1;
   optional uint32 ver = 2 [default = 0];
-  required uint64 tick_freq = 3;
+  optional uint64 tick_freq = 3;
 
   // This is supposed to be wire equivalent to the "map" construct supported
   // by the proto3 version of the protobuf description syntax. When that
@@ -68,10 +68,10 @@ message PacketHeader {
 // An optional field for PC of the instruction for which this request is made
 // is provided.
 message Packet {
-  required uint64 tick = 1;
-  required uint32 cmd = 2;
-  required uint64 addr = 3;
-  required uint32 size = 4;
+  optional uint64 tick = 1;
+  optional uint32 cmd = 2;
+  optional uint64 addr = 3;
+  optional uint32 size = 4;
   optional uint32 flags = 5;
   optional uint64 pkt_id = 6;
   optional uint64 pc = 7;


### PR DESCRIPTION
The "required" statement is considered bad practice now. So much so that proto3 removed "required" as an option. See the discussion: https://stackoverflow.com/questions/31801257/why-required-and-optional-is-removed-in-protocol-buffers-3

This change converts required to optional. This shouldn't affect any existing traces or gem5's code in any way.