### PR TITLE
arch: Update ISA parser to be moveable

### DIFF
--- a/src/arch/isa_parser/isa_parser.py
+++ b/src/arch/isa_parser/isa_parser.py
@@ -1078,6 +1078,16 @@ del wrap
         # next split's #define from the parser and add it to the current
         # emission-in-progress.
         try:
+            # x86 requires more python files to be interpreted. To allow this
+            # script to be run from other locations for x86, force adding the
+            # x86 ISA directory to the Python path.
+            import os
+            import sys
+
+            current_file_path = os.path.realpath(__file__)
+            arch_dir = os.path.dirname(os.path.dirname(current_file_path))
+            sys.path.append(arch_dir)
+            sys.path.append(os.path.join(arch_dir, "x86/isa/"))
             exec(split_setup + fixPythonIndentation(t[2]), self.exportContext)
         except Exception as exc:
             traceback.print_exc(file=sys.stdout)

--- a/src/arch/micro_asm.py
+++ b/src/arch/micro_asm.py
@@ -575,7 +575,7 @@ def p_error(t):
 class MicroAssembler:
     def __init__(self, macro_type, microops, rom=None, rom_macroop_type=None):
         self.lexer = lex.lex()
-        self.parser = yacc.yacc(write_tables=False)
+        self.parser = yacc.yacc(write_tables=False, debug=False)
         self.parser.macro_type = macro_type
         self.parser.macroops = {}
         self.parser.microops = microops


### PR DESCRIPTION
This changes allows the ISA parser to run from a directory other than gem5/. This is useful if you want to run this code outside of scons.

The verbosity of x86 is also reduced in this commit. Note that this commit only affects x86 because it is the only ISA that has its own python files.