### PR TITLE
scons: Update build_tools to enable importing

### DIFF
--- a/build_tools/debugflagcc.py
+++ b/build_tools/debugflagcc.py
@@ -39,12 +39,32 @@ import argparse
 
 from code_formatter import code_formatter
 
-parser = argparse.ArgumentParser()
-parser.add_argument("cc", help="the path of the debug flag cc file")
-parser.add_argument("name", help="the name of the debug flag")
 
-args = parser.parse_args()
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cc", help="the path of the debug flag cc file")
+    parser.add_argument("name", help="the name of the debug flag")
+    args = parser.parse_args()
+    return args
 
-code = code_formatter()
-code('#include "debug/${{args.name}}.hh"')
-code.write(args.cc)
+
+def write_cc_file(cc: str, name: str):
+    """
+    Generates the C++ source file for a debug flag.
+
+    This function creates a C++ source file that simply includes the
+    corresponding debug flag header file. This is often all that's needed
+    for flags that are defined entirely within their header.
+
+    Args:
+        cc: The path to the C++ source file to generate.
+        name: The name of the debug flag.
+    """
+    code = code_formatter()
+    code(f'#include "debug/{name}.hh"')
+    code.write(cc)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    write_cc_file(args.cc, args.name)

--- a/build_tools/enum_cc.py
+++ b/build_tools/enum_cc.py
@@ -40,89 +40,87 @@ import argparse
 import importlib
 import os.path
 import sys
+from typing import Type
 
-import importer
 from code_formatter import code_formatter
 
-parser = argparse.ArgumentParser()
-parser.add_argument("modpath", help="module the enum belongs to")
-parser.add_argument("enum_cc", help="enum cc file to generate")
-parser.add_argument(
-    "use_python", help="whether python is enabled in gem5 (True or False)"
-)
 
-args = parser.parse_args()
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("modpath", help="module the enum belongs to")
+    parser.add_argument("enum_cc", help="enum cc file to generate")
+    parser.add_argument(
+        "use_python", help="whether python is enabled in gem5 (True or False)"
+    )
+    args = parser.parse_args()
+    return args
 
-use_python = args.use_python.lower()
-if use_python == "true":
-    use_python = True
-elif use_python == "false":
-    use_python = False
-else:
-    print(f'Unrecognized "use_python" value {use_python}', file=sys.stderr)
-    sys.exit(1)
 
-basename = os.path.basename(args.enum_cc)
-enum_name = os.path.splitext(basename)[0]
+def write_cc_file(enum: Type, use_python: bool, enum_cc: str):
+    """Write the C++ source file for an Enum.
 
-importer.install()
-module = importlib.import_module(args.modpath)
-enum = getattr(module, enum_name)
+    This function generates a C++ source file that defines the
+    string array for an enum. If python is enabled, it also generates
+    the pybind11 bindings for the enum.
 
-code = code_formatter()
+    Args:
+        enum: The Enum class for which to generate the source file.
+        use_python: A boolean indicating whether Python support is enabled.
+        enum_cc: The path to the C++ source file to write.
+    """
+    code = code_formatter()
 
-wrapper_name = enum.wrapper_name
-file_name = enum.__name__
-name = enum.__name__ if enum.enum_name is None else enum.enum_name
+    wrapper_name = enum.wrapper_name
+    file_name = enum.__name__
+    name = enum.__name__ if enum.enum_name is None else enum.enum_name
 
-code(
-    """#include "base/compiler.hh"
+    code(
+        """#include "base/compiler.hh"
 #include "enums/$file_name.hh"
 
 namespace gem5
 {
 
 """
-)
+    )
 
-if enum.wrapper_is_struct:
-    code("const char *${wrapper_name}::${name}Strings[Num_${name}] =")
-else:
-    if enum.is_class:
-        code(
-            """\
+    if enum.wrapper_is_struct:
+        code("const char *${wrapper_name}::${name}Strings[Num_${name}] =")
+    else:
+        if enum.is_class:
+            code(
+                """\
 const char *${name}Strings[static_cast<int>(${name}::Num_${name})] =
 """
-        )
-    else:
-        code(
-            """namespace ${wrapper_name}
+            )
+        else:
+            code(
+                """namespace ${wrapper_name}
 {"""
-        )
-        code.indent(1)
-        code("const char *${name}Strings[Num_${name}] =")
+            )
+            code.indent(1)
+            code("const char *${name}Strings[Num_${name}] =")
 
-code("{")
-code.indent(1)
-for val in enum.vals:
-    code('"$val",')
-code.dedent(1)
-code("};")
-
-if not enum.wrapper_is_struct and not enum.is_class:
+    code("{")
+    code.indent(1)
+    for val in enum.vals:
+        code('"$val",')
     code.dedent(1)
-    code("} // namespace ${wrapper_name}")
+    code("};")
 
-code("} // namespace gem5")
+    if not enum.wrapper_is_struct and not enum.is_class:
+        code.dedent(1)
+        code("} // namespace ${wrapper_name}")
 
+    code("} // namespace gem5")
 
-if use_python:
-    name = enum.__name__
-    enum_name = enum.__name__ if enum.enum_name is None else enum.enum_name
-    wrapper_name = enum_name if enum.is_class else enum.wrapper_name
+    if use_python:
+        name = enum.__name__
+        enum_name = enum.__name__ if enum.enum_name is None else enum.enum_name
+        wrapper_name = enum_name if enum.is_class else enum.wrapper_name
 
-    code(
-        """#include "pybind11/pybind11.h"
+        code(
+            """#include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
 #include <sim/init.hh>
@@ -138,30 +136,55 @@ module_init(py::module_ &m_internal)
     py::module_ m = m_internal.def_submodule("enum_${name}");
 
 """
-    )
-    if enum.is_class:
-        code('py::enum_<${enum_name}>(m, "enum_${name}")')
-    else:
-        code('py::enum_<${wrapper_name}::${enum_name}>(m, "enum_${name}")')
+        )
+        if enum.is_class:
+            code('py::enum_<${enum_name}>(m, "enum_${name}")')
+        else:
+            code('py::enum_<${wrapper_name}::${enum_name}>(m, "enum_${name}")')
 
-    code.indent()
-    code.indent()
-    for val in enum.vals:
-        code('.value("${val}", ${wrapper_name}::${val})')
-    code('.value("Num_${name}", ${wrapper_name}::Num_${enum_name})')
-    if not enum.is_class:
-        code(".export_values()")
-    code(";")
-    code.dedent()
+        code.indent()
+        code.indent()
+        for val in enum.vals:
+            code('.value("${val}", ${wrapper_name}::${val})')
+        code('.value("Num_${name}", ${wrapper_name}::Num_${enum_name})')
+        if not enum.is_class:
+            code(".export_values()")
+        code(";")
+        code.dedent()
 
-    code("}")
-    code.dedent()
-    code(
-        """
+        code("}")
+        code.dedent()
+        code(
+            """
 static EmbeddedPyBind embed_enum("enum_${name}", module_init);
 
 } // namespace gem5
     """
-    )
+        )
 
-code.write(args.enum_cc)
+    code.write(enum_cc)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    use_python = args.use_python.lower()
+    if use_python == "true":
+        use_python = True
+    elif use_python == "false":
+        use_python = False
+    else:
+        print(f'Unrecognized "use_python" value {use_python}', file=sys.stderr)
+        sys.exit(1)
+
+    basename = os.path.basename(args.enum_cc)
+    enum_name = os.path.splitext(basename)[0]
+
+    # Note: Import here to remove dependence if importing from this file
+    import importer
+
+    importer.install()
+    module = importlib.import_module(args.modpath)
+    enum = getattr(module, enum_name)
+
+    write_cc_file(enum, use_python, args.enum_cc)

--- a/build_tools/sim_object_param_struct_hh.py
+++ b/build_tools/sim_object_param_struct_hh.py
@@ -39,195 +39,217 @@
 import argparse
 import importlib
 import os.path
-import sys
+from typing import Type
 
-import importer
 from code_formatter import code_formatter
 
-parser = argparse.ArgumentParser()
-parser.add_argument("modpath", help="module the simobject belongs to")
-parser.add_argument("param_hh", help="parameter header file to generate")
 
-args = parser.parse_args()
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("modpath", help="module the simobject belongs to")
+    parser.add_argument("param_hh", help="parameter header file to generate")
 
-basename = os.path.basename(args.param_hh)
-sim_object_name = os.path.splitext(basename)[0]
-
-importer.install()
-module = importlib.import_module(args.modpath)
-sim_object = getattr(module, sim_object_name)
-
-from m5.objects.SimObject import SimObject
-from m5.params import Enum
-
-code = code_formatter()
-
-# The 'local' attribute restricts us to the params declared in
-# the object itself, not including inherited params (which
-# will also be inherited from the base class's param struct
-# here). Sort the params based on their key
-params = list(
-    map(lambda k_v: k_v[1], sorted(sim_object._params.local.items()))
-)
-ports = sim_object._ports.local
-try:
-    ptypes = [single_type for p in params for single_type in p.ptypes]
-except:
-    print(sim_object)
-    print(params)
-    raise
-
-warned_about_nested_templates = False
+    args = parser.parse_args()
+    return args
 
 
-class CxxClass:
-    def __init__(self, sig, template_params=[]):
-        # Split the signature into its constituent parts. This could
-        # potentially be done with regular expressions, but
-        # it's simple enough to pick appart a class signature
-        # manually.
-        parts = sig.split("<", 1)
-        base = parts[0]
-        t_args = []
-        if len(parts) > 1:
-            # The signature had template arguments.
-            text = parts[1].rstrip(" \t\n>")
-            arg = ""
-            # Keep track of nesting to avoid splitting on ","s embedded
-            # in the arguments themselves.
-            depth = 0
-            for c in text:
-                if c == "<":
-                    depth = depth + 1
-                    if depth > 0 and not warned_about_nested_templates:
-                        warned_about_nested_templates = True
-                        print(
-                            "Nested template argument in cxx_class."
-                            " This feature is largely untested and "
-                            " may not work."
-                        )
-                elif c == ">":
-                    depth = depth - 1
-                elif c == "," and depth == 0:
+def write_header_file(sim_object: Type, param_hh: str):
+    """Write the parameter header file for a SimObject.
+
+    This function generates a C++ header file that declares the
+    parameter struct for a given SimObject. It includes necessary
+    preprocessor directives, includes, and the struct definition
+    with its parameters and ports.
+
+    Args:
+        sim_object: The SimObject class for which to generate the header.
+        param_hh: The path to the header file to write.
+    """
+
+    # Need to import after the importer is installed
+    from m5.objects.SimObject import SimObject
+    from m5.params import Enum
+
+    code = code_formatter()
+
+    # The 'local' attribute restricts us to the params declared in
+    # the object itself, not including inherited params (which
+    # will also be inherited from the base class's param struct
+    # here). Sort the params based on their key
+    params = list(
+        map(lambda k_v: k_v[1], sorted(sim_object._params.local.items()))
+    )
+    ports = sim_object._ports.local
+    try:
+        ptypes = [single_type for p in params for single_type in p.ptypes]
+    except:
+        print(sim_object)
+        print(params)
+        raise
+
+    warned_about_nested_templates = False
+
+    class CxxClass:
+        def __init__(self, sig, template_params=[]):
+            # Split the signature into its constituent parts. This could
+            # potentially be done with regular expressions, but
+            # it's simple enough to pick appart a class signature
+            # manually.
+            parts = sig.split("<", 1)
+            base = parts[0]
+            t_args = []
+            if len(parts) > 1:
+                # The signature had template arguments.
+                text = parts[1].rstrip(" \t\n>")
+                arg = ""
+                # Keep track of nesting to avoid splitting on ","s embedded
+                # in the arguments themselves.
+                depth = 0
+                for c in text:
+                    if c == "<":
+                        depth = depth + 1
+                        if depth > 0 and not warned_about_nested_templates:
+                            warned_about_nested_templates = True
+                            print(
+                                "Nested template argument in cxx_class."
+                                " This feature is largely untested and "
+                                " may not work."
+                            )
+                    elif c == ">":
+                        depth = depth - 1
+                    elif c == "," and depth == 0:
+                        t_args.append(arg.strip())
+                        arg = ""
+                    else:
+                        arg = arg + c
+                if arg:
                     t_args.append(arg.strip())
-                    arg = ""
+            # Split the non-template part on :: boundaries.
+            class_path = base.split("::")
+
+            # The namespaces are everything except the last part of the class path.
+            self.namespaces = class_path[:-1]
+            # And the class name is the last part.
+            self.name = class_path[-1]
+
+            self.template_params = template_params
+            self.template_arguments = []
+            # Iterate through the template arguments and their values. This
+            # will likely break if parameter packs are used.
+            for arg, param in zip(t_args, template_params):
+                type_keys = ("class", "typename")
+                # If a parameter is a type, parse it recursively. Otherwise
+                # assume it's a constant, and store it verbatim.
+                if any(param.strip().startswith(kw) for kw in type_keys):
+                    self.template_arguments.append(CxxClass(arg))
                 else:
-                    arg = arg + c
-            if arg:
-                t_args.append(arg.strip())
-        # Split the non-template part on :: boundaries.
-        class_path = base.split("::")
+                    self.template_arguments.append(arg)
 
-        # The namespaces are everything except the last part of the class path.
-        self.namespaces = class_path[:-1]
-        # And the class name is the last part.
-        self.name = class_path[-1]
+        def declare(self, code):
+            # First declare any template argument types.
+            for arg in self.template_arguments:
+                if isinstance(arg, CxxClass):
+                    arg.declare(code)
+            # Re-open the target namespace.
+            for ns in self.namespaces:
+                code("namespace $ns {")
+            # If this is a class template...
+            if self.template_params:
+                code('template <${{", ".join(self.template_params)}}>')
+            # The actual class declaration.
+            code("class ${{self.name}};")
+            # Close the target namespaces.
+            for ns in reversed(self.namespaces):
+                code("} // namespace $ns")
 
-        self.template_params = template_params
-        self.template_arguments = []
-        # Iterate through the template arguments and their values. This
-        # will likely break if parameter packs are used.
-        for arg, param in zip(t_args, template_params):
-            type_keys = ("class", "typename")
-            # If a parameter is a type, parse it recursively. Otherwise
-            # assume it's a constant, and store it verbatim.
-            if any(param.strip().startswith(kw) for kw in type_keys):
-                self.template_arguments.append(CxxClass(arg))
-            else:
-                self.template_arguments.append(arg)
-
-    def declare(self, code):
-        # First declare any template argument types.
-        for arg in self.template_arguments:
-            if isinstance(arg, CxxClass):
-                arg.declare(code)
-        # Re-open the target namespace.
-        for ns in self.namespaces:
-            code("namespace $ns {")
-        # If this is a class template...
-        if self.template_params:
-            code('template <${{", ".join(self.template_params)}}>')
-        # The actual class declaration.
-        code("class ${{self.name}};")
-        # Close the target namespaces.
-        for ns in reversed(self.namespaces):
-            code("} // namespace $ns")
-
-
-code(
-    """\
-#ifndef __PARAMS__${sim_object}__
-#define __PARAMS__${sim_object}__
-
-"""
-)
-
-
-# The base SimObject has a couple of params that get
-# automatically set from Python without being declared through
-# the normal Param mechanism; we slip them in here (needed
-# predecls now, actual declarations below)
-if sim_object == SimObject:
-    code("""#include <string>""", add_once=True)
-
-cxx_class = CxxClass(
-    sim_object._value_dict["cxx_class"],
-    sim_object._value_dict["cxx_template_params"],
-)
-
-# A forward class declaration is sufficient since we are just
-# declaring a pointer.
-cxx_class.declare(code)
-
-for param in params:
-    param.cxx_predecls(code)
-for port in ports.values():
-    port.cxx_predecls(code)
-code()
-
-if sim_object._base:
-    code('#include "params/${{sim_object._base.type}}.hh"', add_once=True)
-    code()
-
-for ptype in ptypes:
-    if issubclass(ptype, Enum):
-        code('#include "enums/${{ptype.__name__}}.hh"', add_once=True)
-        code()
-
-code("namespace gem5")
-code("{")
-code("")
-
-# now generate the actual param struct
-code("struct ${sim_object}Params")
-if sim_object._base:
-    code("    : public ${{sim_object._base.type}}Params")
-code("{")
-if not hasattr(sim_object, "abstract") or not sim_object.abstract:
-    if "type" in sim_object.__dict__:
-        code("    ${{sim_object.cxx_type}} create() const;")
-
-code.indent()
-if sim_object == SimObject:
     code(
-        """
-virtual ~SimObjectParams() = default;
+        """\
+    #ifndef __PARAMS__${sim_object}__
+    #define __PARAMS__${sim_object}__
 
-std::string name;
     """
     )
 
-for param in params:
-    param.cxx_decl(code)
-for port in ports.values():
-    port.cxx_decl(code)
+    # The base SimObject has a couple of params that get
+    # automatically set from Python without being declared through
+    # the normal Param mechanism; we slip them in here (needed
+    # predecls now, actual declarations below)
+    if sim_object == SimObject:
+        code("""#include <string>""", add_once=True)
 
-code.dedent()
-code("};")
-code()
-code("} // namespace gem5")
+    cxx_class = CxxClass(
+        sim_object._value_dict["cxx_class"],
+        sim_object._value_dict["cxx_template_params"],
+    )
 
-code()
-code("#endif // __PARAMS__${sim_object}__")
+    # A forward class declaration is sufficient since we are just
+    # declaring a pointer.
+    cxx_class.declare(code)
 
-code.write(args.param_hh)
+    for param in params:
+        param.cxx_predecls(code)
+    for port in ports.values():
+        port.cxx_predecls(code)
+    code()
+
+    if sim_object._base:
+        code('#include "params/${{sim_object._base.type}}.hh"', add_once=True)
+        code()
+
+    for ptype in ptypes:
+        if issubclass(ptype, Enum):
+            code('#include "enums/${{ptype.__name__}}.hh"', add_once=True)
+            code()
+
+    code("namespace gem5")
+    code("{")
+    code("")
+
+    # now generate the actual param struct
+    code("struct ${sim_object}Params")
+    if sim_object._base:
+        code("    : public ${{sim_object._base.type}}Params")
+    code("{")
+    if not hasattr(sim_object, "abstract") or not sim_object.abstract:
+        if "type" in sim_object.__dict__:
+            code("    ${{sim_object.cxx_type}} create() const;")
+
+    code.indent()
+    if sim_object == SimObject:
+        code(
+            """
+    virtual ~SimObjectParams() = default;
+
+    std::string name;
+        """
+        )
+
+    for param in params:
+        param.cxx_decl(code)
+    for port in ports.values():
+        port.cxx_decl(code)
+
+    code.dedent()
+    code("};")
+    code()
+    code("} // namespace gem5")
+
+    code()
+    code("#endif // __PARAMS__${sim_object}__")
+
+    code.write(param_hh)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    basename = os.path.basename(args.param_hh)
+    sim_object_name = os.path.splitext(basename)[0]
+
+    # Note: Import here to remove dependence if importing from this file
+    import importer
+
+    importer.install()
+    module = importlib.import_module(args.modpath)
+    sim_object = getattr(module, sim_object_name)
+    write_header_file(sim_object, args.param_hh)


### PR DESCRIPTION
This updates the scripts in build_tools to use `if __name__=="__main__"`. It factors out the main functions to allow them to be used from other scripts. The purpose is to enable code sharing in the case we're not using the importer.