### PR TITLE
mem-cache: Fix FIFO RP invalidation

### DIFF
--- a/src/mem/cache/replacement_policies/fifo_rp.cc
+++ b/src/mem/cache/replacement_policies/fifo_rp.cc
@@ -59,12 +59,16 @@ FIFO::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 void
 FIFO::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 {
-    // A touch does not modify the insertion tick
+    // A touch does not modify the insertion tick. We still check if the data
+    // exists to standardize the API
+    assert(replacement_data);
 }
 
 void
 FIFO::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
 {
+    assert(replacement_data);
+
     // Set insertion tick
     std::static_pointer_cast<FIFOReplData>(
         replacement_data)->tickInserted = ++timeTicks;

--- a/src/mem/cache/replacement_policies/fifo_rp.cc
+++ b/src/mem/cache/replacement_policies/fifo_rp.cc
@@ -48,9 +48,12 @@ FIFO::FIFO(const Params &p)
 void
 FIFO::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 {
-    // Reset insertion tick
+    assert(replacement_data);
+
+    // To prioritize these entries to be selected during victimization
+    // we set their insertion tick as 0
     std::static_pointer_cast<FIFOReplData>(
-        replacement_data)->tickInserted = ++timeTicks;
+        replacement_data)->tickInserted = 0;
 }
 
 void


### PR DESCRIPTION
Prioritize invalid entries when victimizing. To do so, reset the tick to 0, instead of keeping it unmodified. As a bonus add a couple of assertions for when repl data is a nullptr.