### PR TITLE
dev: Export reg bank's offsetMap

### DIFF
--- a/src/dev/reg_bank.hh
+++ b/src/dev/reg_bank.hh
@@ -1026,6 +1026,8 @@ class RegisterBank : public RegisterBankBase
     Addr base() const { return _base; }
     Addr size() const { return _size; }
     const std::string &name() const { return _name; }
+    const std::map<Addr, std::reference_wrapper<RegisterBase>> &
+    offsetMap() const { return _offsetMap; }
 
     virtual void
     read(Addr addr, void *buf, Addr bytes)


### PR DESCRIPTION
This can be useful in some cases. For example, we have a bank of double buffered registers and on some condition, we need to iterate through all registers in the bank to sync the buffered state to active state.

Instead of maintaining another list of register references, having this field exported would help simplify the implementation.