### PR TITLE
arch-vega: MI350 microscaling updates

### DIFF
--- a/src/arch/amdgpu/common/dtype/fp4_e2m1.hh
+++ b/src/arch/amdgpu/common/dtype/fp4_e2m1.hh
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_AMDGPU_COMMON_DTYPE_FP4_E2M1_HH__
+#define __ARCH_AMDGPU_COMMON_DTYPE_FP4_E2M1_HH__
+
+#include <cassert>
+
+namespace gem5
+{
+
+namespace AMDGPU
+{
+
+typedef union
+{
+    enum bitSizes
+    {
+        ebits = 2,
+        mbits = 1,
+        sbits = 1,
+        zbits = 28,
+        bias = 1,
+
+        inf = (0x7 << 28),
+        nan = (0x7 << 28),
+        max = (0x7 << 28)
+    };
+
+    uint32_t storage;
+    struct
+    {
+        unsigned zero : zbits;
+        unsigned mant : mbits;
+        unsigned exp  : ebits;
+        unsigned sign : sbits;
+    };
+} fp4_e2m1_info;
+static_assert(sizeof(fp4_e2m1_info) == 4);
+
+} // namespace AMDGPU
+
+} // namespace gem5
+
+
+// std library cmath definitions
+namespace std
+{
+
+// Inf not defined
+constexpr bool isinf(gem5::AMDGPU::fp4_e2m1_info a) { return false; }
+
+// NaN not defined
+constexpr bool isnan(gem5::AMDGPU::fp4_e2m1_info a) { return false; }
+
+constexpr bool isnormal(gem5::AMDGPU::fp4_e2m1_info a)
+{
+    return !(a.exp == 0 && a.mant != 0);
+}
+
+template<>
+class numeric_limits<gem5::AMDGPU::fp4_e2m1_info>
+{
+  public:
+    static constexpr bool has_quiet_NaN = false;
+    static gem5::AMDGPU::fp4_e2m1_info quiet_NaN()
+    {
+        assert(has_quiet_NaN);
+        gem5::AMDGPU::fp4_e2m1_info tmp;
+        tmp.storage = gem5::AMDGPU::fp4_e2m1_info::nan;
+        return tmp;
+    }
+
+    static constexpr bool has_infinity = false;
+    static gem5::AMDGPU::fp4_e2m1_info infinity()
+    {
+        assert(has_infinity);
+        gem5::AMDGPU::fp4_e2m1_info tmp;
+        tmp.storage = gem5::AMDGPU::fp4_e2m1_info::inf;
+        return tmp;
+    }
+
+    static gem5::AMDGPU::fp4_e2m1_info max()
+    {
+        gem5::AMDGPU::fp4_e2m1_info tmp;
+        tmp.storage = gem5::AMDGPU::fp4_e2m1_info::max;
+        return tmp;
+    }
+};
+
+} // namespace std
+
+#endif // __ARCH_AMDGPU_COMMON_DTYPE_FP4_E2M1_HH__

--- a/src/arch/amdgpu/common/dtype/fp6_e2m3.hh
+++ b/src/arch/amdgpu/common/dtype/fp6_e2m3.hh
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_AMDGPU_COMMON_DTYPE_FP6_E2M3_HH__
+#define __ARCH_AMDGPU_COMMON_DTYPE_FP6_E2M3_HH__
+
+#include <cassert>
+
+namespace gem5
+{
+
+namespace AMDGPU
+{
+
+typedef union
+{
+    enum bitSizes
+    {
+        ebits = 2,
+        mbits = 3,
+        sbits = 1,
+        zbits = 26,
+        bias = 1,
+
+        inf = (0x1f << 26),
+        nan = (0x1f << 26),
+        max = (0x1f << 26)
+    };
+
+    uint32_t storage;
+    struct
+    {
+        unsigned zero : zbits;
+        unsigned mant : mbits;
+        unsigned exp  : ebits;
+        unsigned sign : sbits;
+    };
+} fp6_e2m3_info;
+static_assert(sizeof(fp6_e2m3_info) == 4);
+
+} // namespace AMDGPU
+
+} // namespace gem5
+
+
+// std library cmath definitions
+namespace std
+{
+
+// Inf not defined
+constexpr bool isinf(gem5::AMDGPU::fp6_e2m3_info a) { return false; }
+
+// NaN not defined
+constexpr bool isnan(gem5::AMDGPU::fp6_e2m3_info a) { return false; }
+
+constexpr bool isnormal(gem5::AMDGPU::fp6_e2m3_info a)
+{
+    return !(a.exp == 0 && a.mant != 0);
+}
+
+template<>
+class numeric_limits<gem5::AMDGPU::fp6_e2m3_info>
+{
+  public:
+    static constexpr bool has_quiet_NaN = false;
+    static gem5::AMDGPU::fp6_e2m3_info quiet_NaN()
+    {
+        assert(has_quiet_NaN);
+        gem5::AMDGPU::fp6_e2m3_info tmp;
+        tmp.storage = gem5::AMDGPU::fp6_e2m3_info::nan;
+        return tmp;
+    }
+
+    static constexpr bool has_infinity = false;
+    static gem5::AMDGPU::fp6_e2m3_info infinity()
+    {
+        assert(has_infinity);
+        gem5::AMDGPU::fp6_e2m3_info tmp;
+        tmp.storage = gem5::AMDGPU::fp6_e2m3_info::inf;
+        return tmp;
+    }
+
+    static gem5::AMDGPU::fp6_e2m3_info max()
+    {
+        gem5::AMDGPU::fp6_e2m3_info tmp;
+        tmp.storage = gem5::AMDGPU::fp6_e2m3_info::max;
+        return tmp;
+    }
+};
+
+} // namespace std
+
+#endif // __ARCH_AMDGPU_COMMON_DTYPE_FP6_E2M3_HH__

--- a/src/arch/amdgpu/common/dtype/fp6_e3m2.hh
+++ b/src/arch/amdgpu/common/dtype/fp6_e3m2.hh
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_AMDGPU_COMMON_DTYPE_FP6_E3M2_HH__
+#define __ARCH_AMDGPU_COMMON_DTYPE_FP6_E3M2_HH__
+
+#include <cassert>
+
+namespace gem5
+{
+
+namespace AMDGPU
+{
+
+typedef union
+{
+    enum bitSizes
+    {
+        ebits = 3,
+        mbits = 2,
+        sbits = 1,
+        zbits = 26,
+        bias = 3,
+
+        inf = (0x1f << 26),
+        nan = (0x1f << 26),
+        max = (0x1f << 26)
+    };
+
+    uint32_t storage;
+    struct
+    {
+        unsigned zero : zbits;
+        unsigned mant : mbits;
+        unsigned exp  : ebits;
+        unsigned sign : sbits;
+    };
+} fp6_e3m2_info;
+static_assert(sizeof(fp6_e3m2_info) == 4);
+
+} // namespace AMDGPU
+
+} // namespace gem5
+
+
+// std library cmath definitions
+namespace std
+{
+
+// Inf not defined
+constexpr bool isinf(gem5::AMDGPU::fp6_e3m2_info a) { return false; }
+
+// NaN not defined
+constexpr bool isnan(gem5::AMDGPU::fp6_e3m2_info a) { return false; }
+
+constexpr bool isnormal(gem5::AMDGPU::fp6_e3m2_info a)
+{
+    return !(a.exp == 0 && a.mant != 0);
+}
+
+template<>
+class numeric_limits<gem5::AMDGPU::fp6_e3m2_info>
+{
+  public:
+    static constexpr bool has_quiet_NaN = false;
+    static gem5::AMDGPU::fp6_e3m2_info quiet_NaN()
+    {
+        assert(has_quiet_NaN);
+        gem5::AMDGPU::fp6_e3m2_info tmp;
+        tmp.storage = gem5::AMDGPU::fp6_e3m2_info::nan;
+        return tmp;
+    }
+
+    static constexpr bool has_infinity = false;
+    static gem5::AMDGPU::fp6_e3m2_info infinity()
+    {
+        assert(has_infinity);
+        gem5::AMDGPU::fp6_e3m2_info tmp;
+        tmp.storage = gem5::AMDGPU::fp6_e3m2_info::inf;
+        return tmp;
+    }
+
+    static gem5::AMDGPU::fp6_e3m2_info max()
+    {
+        gem5::AMDGPU::fp6_e3m2_info tmp;
+        tmp.storage = gem5::AMDGPU::fp6_e3m2_info::max;
+        return tmp;
+    }
+};
+
+} // namespace std
+
+#endif // __ARCH_AMDGPU_COMMON_DTYPE_FP6_E3M2_HH__

--- a/src/arch/amdgpu/common/dtype/mxfp.test.cc
+++ b/src/arch/amdgpu/common/dtype/mxfp.test.cc
@@ -102,3 +102,30 @@ TEST(MxfpTest, MxFp8Test)
 
     EXPECT_EQ(errors, 0);
 }
+
+TEST(MxfpTest, MxBf6Test)
+{
+    using T = gem5::AMDGPU::mxbf6;
+
+    int errors = test_type<T>(T::size());
+
+    EXPECT_EQ(errors, 0);
+}
+
+TEST(MxfpTest, MxFp6Test)
+{
+    using T = gem5::AMDGPU::mxfp6;
+
+    int errors = test_type<T>(T::size());
+
+    EXPECT_EQ(errors, 0);
+}
+
+TEST(MxfpTest, MxFp4Test)
+{
+    using T = gem5::AMDGPU::mxfp4;
+
+    int errors = test_type<T>(T::size());
+
+    EXPECT_EQ(errors, 0);
+}

--- a/src/arch/amdgpu/common/dtype/mxfp_type_info.hh
+++ b/src/arch/amdgpu/common/dtype/mxfp_type_info.hh
@@ -35,6 +35,9 @@
 #include "arch/amdgpu/common/dtype/binary32.hh"
 #include "arch/amdgpu/common/dtype/fp16_e5m10.hh"
 #include "arch/amdgpu/common/dtype/fp16_e8m7.hh"
+#include "arch/amdgpu/common/dtype/fp4_e2m1.hh"
+#include "arch/amdgpu/common/dtype/fp6_e2m3.hh"
+#include "arch/amdgpu/common/dtype/fp6_e3m2.hh"
 #include "arch/amdgpu/common/dtype/fp8_e4m3.hh"
 #include "arch/amdgpu/common/dtype/fp8_e5m2.hh"
 

--- a/src/arch/amdgpu/common/dtype/mxfp_types.hh
+++ b/src/arch/amdgpu/common/dtype/mxfp_types.hh
@@ -39,6 +39,10 @@ namespace gem5
 namespace AMDGPU
 {
 
+using mxfp4 = mxfp<fp4_e2m1_info>;
+using mxfp6 = mxfp<fp6_e2m3_info>;
+using mxbf6 = mxfp<fp6_e3m2_info>;
+
 using mxbfloat8 = mxfp<fp8_e5m2_info>;
 using mxfloat8 = mxfp<fp8_e4m3_info>;
 


### PR DESCRIPTION
- Adds new data types (mxfp4, mxfp6 e3m2 and e2m3) and unit tests.
- Fixes several issues with denormal aka subnormal FP conversions.
- Helper methods for upcoming instructions.
- Tested by converting to F32 and back and ensure same bit values.