### PR TITLE
dev-amdgpu: Update GPU SDMA model to support non-zero VMID packets, MMIOs, and fix SDMA poll livelock

### DIFF
--- a/src/dev/amdgpu/amdgpu_nbio.hh
+++ b/src/dev/amdgpu/amdgpu_nbio.hh
@@ -103,6 +103,19 @@ class AMDGPUDevice;
 #define MI300X_INV_ENG17_ACK11                            0x1e2f98
 #define MI300X_EPF0_STRAP0                                0x34d8
 
+//Range of register addresses to store the base addresses of
+//page tables for contexts 0-15
+#define MI200_REG_BM_PAGE_TABLE_BASE_ADDR_START           0x6b0ac
+#define MI200_REG_BM_PAGE_TABLE_BASE_ADDR_END             0x6b128
+//Range of register addresses to store the starting addresses of
+//page tables for contexts 0-15
+#define MI200_REG_BM_PAGE_TABLE_START_ADDR_START          0x6b12c
+#define MI200_REG_BM_PAGE_TABLE_START_ADDR_END            0x6b1a8
+//Range of register addresses to store the ending addresses of
+//page tables for contexts 0-15
+#define MI200_REG_BM_PAGE_TABLE_END_ADDR_START            0x6b1ac
+#define MI200_REG_BM_PAGE_TABLE_END_ADDR_END              0x6b1c8
+
 class AMDGPUNbio
 {
   public:
@@ -115,6 +128,41 @@ class AMDGPUNbio
 
     bool readFrame(PacketPtr pkt, Addr offset);
     void writeFrame(PacketPtr pkt, Addr offset);
+
+    bool is_MI200_regBM_PAGE_TABLE_BASE_ADDR(Addr offset) {
+        return ((offset >= MI200_REG_BM_PAGE_TABLE_BASE_ADDR_START &&
+                    offset <= MI200_REG_BM_PAGE_TABLE_BASE_ADDR_END) ?
+                true : false);
+    }
+
+    bool is_MI200_regBM_PAGE_TABLE_START_ADDR(Addr offset) {
+        return ((offset >= MI200_REG_BM_PAGE_TABLE_START_ADDR_START
+                    && offset <= MI200_REG_BM_PAGE_TABLE_START_ADDR_END) ?
+                true : false);
+    }
+
+    bool is_MI200_regBM_PAGE_TABLE_END_ADDR(Addr offset) {
+        return ((offset >= MI200_REG_BM_PAGE_TABLE_END_ADDR_START
+                    && offset <= MI200_REG_BM_PAGE_TABLE_END_ADDR_END) ?
+                true : false);
+    }
+
+    // The MMIO offsets that correspond to the page table registers in MI200
+    // are shifted left by the driver. The offsets are also in a range where
+    // each subsequent offset corresponds to the register for the next context.
+    // This function right shifts the MMIO offsets to get the register offset,
+    // and extracts context number out of it
+    uint16_t get_context_from_MI200_regBM_PAGE_TABLE_BASE_ADDR(Addr offset) {
+        return (((offset - MI200_REG_BM_PAGE_TABLE_BASE_ADDR_START) >> 2)/2);
+    }
+
+    uint16_t get_context_from_MI200_regBM_PAGE_TABLE_START_ADDR(Addr offset) {
+        return (((offset - MI200_REG_BM_PAGE_TABLE_START_ADDR_START) >> 2)/2);
+    }
+
+    uint16_t get_context_from_MI200_regBM_PAGE_TABLE_END_ADDR(Addr offset) {
+        return (((offset - MI200_REG_BM_PAGE_TABLE_END_ADDR_START) >> 2)/2);
+    }
 
   private:
     AMDGPUDevice *gpuDevice;

--- a/src/dev/amdgpu/amdgpu_vm.hh
+++ b/src/dev/amdgpu/amdgpu_vm.hh
@@ -307,6 +307,18 @@ class AMDGPUVM : public Serializable
         vmContexts[vmid].ptBase = ptBase;
     }
 
+    void
+    setPageTableBaseL(uint16_t vmid, uint32_t ptBaseL)
+    {
+        vmContexts[vmid].ptBaseL = ptBaseL;
+    }
+
+    void
+    setPageTableBaseH(uint16_t vmid, uint32_t ptBaseH)
+    {
+        vmContexts[vmid].ptBaseH = ptBaseH;
+    }
+
     Addr
     getPageTableBase(uint16_t vmid)
     {
@@ -314,11 +326,47 @@ class AMDGPUVM : public Serializable
         return vmContexts[vmid].ptBase;
     }
 
+    void
+    setPageTableStart(uint16_t vmid, Addr ptStart)
+    {
+        vmContexts[vmid].ptStart = ptStart;
+    }
+
+    void
+    setPageTableStartL(uint16_t vmid, uint32_t ptStartL)
+    {
+        vmContexts[vmid].ptStartL = ptStartL;
+    }
+
+    void
+    setPageTableStartH(uint16_t vmid, uint32_t ptStartH)
+    {
+        vmContexts[vmid].ptStartH = ptStartH;
+    }
+
     Addr
     getPageTableStart(uint16_t vmid)
     {
         assert(vmid > 0 && vmid < vmContexts.size());
         return vmContexts[vmid].ptStart;
+    }
+
+    void
+    setPageTableEnd(uint16_t vmid, Addr ptEnd)
+    {
+        vmContexts[vmid].ptEnd = ptEnd;
+    }
+
+    void
+    setPageTableEndL(uint16_t vmid, uint32_t ptEndL)
+    {
+        vmContexts[vmid].ptEndL = ptEndL;
+    }
+
+    void
+    setPageTableEndH(uint16_t vmid, uint32_t ptEndH)
+    {
+        vmContexts[vmid].ptEndH = ptEndH;
     }
 
     /**

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -366,7 +366,8 @@ SDMAEngine::decodeNext(SDMAQueue *q)
         auto cb = new DmaVirtCallback<uint32_t>(
             [ = ] (const uint32_t &header)
                 { decodeHeader(q, header); });
-        dmaReadVirt(q->rptr(), sizeof(uint32_t), cb, &cb->dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(uint32_t), cb, &cb->dmaBuffer,
+                sdma_delay);
     } else {
         // The driver expects the rptr to be written back to host memory
         // periodically. In simulation, we writeback rptr after each burst of
@@ -425,7 +426,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
             cb = new DmaVirtCallback<uint64_t>(
                 [ = ] (const uint64_t &)
                     { copy(q, (sdmaCopy *)dmaBuffer); });
-            dmaReadVirt(q->rptr(), sizeof(sdmaCopy), cb, dmaBuffer);
+            dmaReadVirt(q->rptr(), sizeof(sdmaCopy), cb, dmaBuffer,
+                    sdma_delay);
             } break;
           case SDMA_SUBOP_COPY_LINEAR_SUB_WIND: {
             panic("SDMA_SUBOP_COPY_LINEAR_SUB_WIND not implemented");
@@ -461,7 +463,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
             cb = new DmaVirtCallback<uint64_t>(
                 [ = ] (const uint64_t &)
                     { write(q, (sdmaWrite *)dmaBuffer); });
-            dmaReadVirt(q->rptr(), sizeof(sdmaWrite), cb, dmaBuffer);
+            dmaReadVirt(q->rptr(), sizeof(sdmaWrite), cb, dmaBuffer,
+                    sdma_delay);
             } break;
           case SDMA_SUBOP_WRITE_TILED: {
             panic("SDMA_SUBOP_WRITE_TILED not implemented.\n");
@@ -476,7 +479,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { indirectBuffer(q, (sdmaIndirectBuffer *)dmaBuffer); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaIndirectBuffer), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaIndirectBuffer), cb, dmaBuffer,
+                sdma_delay);
         } break;
       case SDMA_OP_FENCE: {
         DPRINTF(SDMAEngine, "SDMA Fence packet\n");
@@ -484,7 +488,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { fence(q, (sdmaFence *)dmaBuffer); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaFence), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaFence), cb, dmaBuffer,
+                sdma_delay);
         } break;
       case SDMA_OP_TRAP: {
         DPRINTF(SDMAEngine, "SDMA Trap packet\n");
@@ -492,7 +497,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { trap(q, (sdmaTrap *)dmaBuffer); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaTrap), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaTrap), cb, dmaBuffer,
+                sdma_delay);
         } break;
       case SDMA_OP_SEM: {
         q->incRptr(sizeof(sdmaSemaphore));
@@ -505,7 +511,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { pollRegMem(q, header, (sdmaPollRegMem *)dmaBuffer); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaPollRegMem), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaPollRegMem), cb, dmaBuffer,
+                sdma_delay);
         switch (sub_opcode) {
           case SDMA_SUBOP_POLL_REG_WRITE_MEM: {
             panic("SDMA_SUBOP_POLL_REG_WRITE_MEM not implemented");
@@ -531,7 +538,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { atomic(q, header, (sdmaAtomic *)dmaBuffer); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaAtomic), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaAtomic), cb, dmaBuffer,
+                sdma_delay);
         } break;
       case SDMA_OP_CONST_FILL: {
         DPRINTF(SDMAEngine, "SDMA Constant fill packet\n");
@@ -539,7 +547,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { constFill(q, (sdmaConstFill *)dmaBuffer, header); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaConstFill), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaConstFill), cb, dmaBuffer,
+                sdma_delay);
         } break;
       case SDMA_OP_PTEPDE: {
         DPRINTF(SDMAEngine, "SDMA PTEPDE packet\n");
@@ -550,7 +559,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
             cb = new DmaVirtCallback<uint64_t>(
                 [ = ] (const uint64_t &)
                     { ptePde(q, (sdmaPtePde *)dmaBuffer); });
-            dmaReadVirt(q->rptr(), sizeof(sdmaPtePde), cb, dmaBuffer);
+            dmaReadVirt(q->rptr(), sizeof(sdmaPtePde), cb, dmaBuffer,
+                    sdma_delay);
             break;
           case SDMA_SUBOP_PTEPDE_COPY:
             panic("SDMA_SUBOP_PTEPDE_COPY not implemented");
@@ -589,7 +599,8 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &)
                 { srbmWrite(q, header, (sdmaSRBMWrite *)dmaBuffer); });
-        dmaReadVirt(q->rptr(), sizeof(sdmaSRBMWrite), cb, dmaBuffer);
+        dmaReadVirt(q->rptr(), sizeof(sdmaSRBMWrite), cb, dmaBuffer,
+                sdma_delay);
         } break;
       case SDMA_OP_PRE_EXE: {
         q->incRptr(sizeof(sdmaPredExec));
@@ -621,7 +632,7 @@ SDMAEngine::write(SDMAQueue *q, sdmaWrite *pkt)
     auto cb = new DmaVirtCallback<uint64_t>(
         [ = ] (const uint64_t &) { writeReadData(q, pkt, dmaBuffer); });
     dmaReadVirt(q->rptr(), sizeof(uint32_t) * pkt->count, cb,
-                (void *)dmaBuffer);
+                (void *)dmaBuffer, sdma_delay);
 }
 
 /* Completion of data reading for a write packet. */
@@ -730,7 +741,8 @@ SDMAEngine::copy(SDMAQueue *q, sdmaCopy *pkt)
     } else {
         auto cb = new DmaVirtCallback<uint64_t>(
             [ = ] (const uint64_t &) { copyReadData(q, pkt, dmaBuffer); });
-        dmaReadVirt(pkt->source, pkt->count, cb, (void *)dmaBuffer);
+        dmaReadVirt(pkt->source, pkt->count, cb, (void *)dmaBuffer,
+                sdma_delay);
     }
 }
 
@@ -964,7 +976,7 @@ SDMAEngine::pollRegMem(SDMAQueue *q, uint32_t header, sdmaPollRegMem *pkt)
                 [ = ] (const uint32_t &dma_buffer) {
                     pollRegMemRead(q, header, pkt, dma_buffer, 0); });
             dmaReadVirt(pkt->address, sizeof(uint32_t), cb,
-                        (void *)&cb->dmaBuffer);
+                        (void *)&cb->dmaBuffer, sdma_delay);
         } else {
             panic("SDMA poll mem operation not implemented.");
             skip = true;
@@ -1003,7 +1015,7 @@ SDMAEngine::pollRegMemRead(SDMAQueue *q, uint32_t header, sdmaPollRegMem *pkt,
             [ = ] (const uint32_t &dma_buffer) {
                 pollRegMemRead(q, header, pkt, dma_buffer, count + 1); });
         dmaReadVirt(pkt->address, sizeof(uint32_t), cb,
-                    (void *)&cb->dmaBuffer);
+                    (void *)&cb->dmaBuffer, sdma_delay);
     } else {
         DPRINTF(SDMAEngine, "SDMA polling mem addr %p, val %d ref %d done.\n",
                 pkt->address, dma_buffer, pkt->ref);
@@ -1130,7 +1142,8 @@ SDMAEngine::atomic(SDMAQueue *q, uint32_t header, sdmaAtomic *pkt)
     auto cb = new DmaVirtCallback<uint64_t>(
         [ = ] (const uint64_t &)
             { atomicData(q, header, pkt, dmaBuffer); });
-    dmaReadVirt(pkt->addr, sizeof(uint64_t), cb, (void *)dmaBuffer);
+    dmaReadVirt(pkt->addr, sizeof(uint64_t), cb, (void *)dmaBuffer,
+            sdma_delay);
 }
 
 void

--- a/src/dev/amdgpu/sdma_engine.hh
+++ b/src/dev/amdgpu/sdma_engine.hh
@@ -243,7 +243,8 @@ class SDMAEngine : public DmaVirtDevice
     void copyReadData(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer);
     void copyDone(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer);
     void copyCleanup(uint8_t *dmaBuffer);
-    void indirectBuffer(SDMAQueue *q, sdmaIndirectBuffer *pkt);
+    void indirectBuffer(SDMAQueue *q, sdmaIndirectBuffer *pkt,
+                        uint32_t header);
     void fence(SDMAQueue *q, sdmaFence *pkt);
     void fenceDone(SDMAQueue *q, sdmaFence *pkt);
     void trap(SDMAQueue *q, sdmaTrap *pkt);

--- a/src/dev/amdgpu/sdma_engine.hh
+++ b/src/dev/amdgpu/sdma_engine.hh
@@ -171,6 +171,8 @@ class SDMAEngine : public DmaVirtDevice
     Addr mmioBase = 0;
     Addr mmioSize = 0;
 
+    static constexpr Tick sdma_delay = 1e9;
+
   public:
     SDMAEngine(const SDMAEngineParams &p);
 


### PR DESCRIPTION
This PR adds three fixes:

1. Fix a livelock in GPU SDMA where the SDMA polls memory locations continuously without allowing the Linux drivers to update the location
2. Add support for handling MMIO writes to non-zero VMID page tables
3. Add support for translation non-zero VMID SDMA packets