### PR TITLE
dev: Make DmaPort can be inherited

### DIFF
--- a/src/dev/dma_device.hh
+++ b/src/dev/dma_device.hh
@@ -61,7 +61,7 @@ class ClockedObject;
 
 class DmaPort : public RequestPort, public Drainable
 {
-  private:
+  protected:
     AddrRangeMap<MemBackdoorPtr, 1> memBackdoors;
 
     /**
@@ -80,6 +80,11 @@ class DmaPort : public RequestPort, public Drainable
      */
     void sendDma();
 
+    /**
+     * DmaReqState contains data of a DMA request and is responsible for
+     * creating gem5 requests accordingly. The class can be extended to
+     * generate different kinds of DMA traffic.
+     */
     struct DmaReqState : public Packet::SenderState
     {
         /** Event to call on the device when this transaction (all packets)
@@ -129,7 +134,11 @@ class DmaPort : public RequestPort, public Drainable
               sid(_sid), ssid(_ssid), cmd(_cmd)
         {}
 
-        PacketPtr createPacket();
+        /**
+         * Create a gem5 packet according to DmaReqState. The function can be
+         * overrided for different kinds of DMA traffic.
+         */
+        virtual PacketPtr createPacket();
     };
 
     /** Send the next packet from a DMA request in atomic mode. */


### PR DESCRIPTION
DmaPort is a base class for modeling a port with DMA ability. It's possible that the port needing to support different kinds of protocol with different kinds of metadata. For example for modeling AXI, we need to add AxCache and AxDomain in the request.

To make the base class be able to extend, I made the private fields to protected. Secondly, I made DmaReqState::createPacket be able to override which allows creating a packet with extra information.

Change-Id: I32d4ab1b6388c460d80769969bbbee3b824d2c50