### PR TITLE
configs: Allow GPU-FS to use HBMCtrl memory controller

### DIFF
--- a/configs/example/gpufs/Disjoint_VIPER.py
+++ b/configs/example/gpufs/Disjoint_VIPER.py
@@ -107,8 +107,17 @@ class Disjoint_VIPER(RubySystem):
         system.memories = cpu_abstract_mems
 
         gpu_abstract_mems = []
+
         for mem_ctrl in gpu_mem_ctrls:
-            gpu_abstract_mems.append(mem_ctrl.dram)
+            # memctrl
+            if hasattr(mem_ctrl, "dram"):
+                gpu_abstract_mems.append(mem_ctrl.dram)
+            else:
+                gpu_abstract_mems.append(mem_ctrl)
+            # hbmctrl
+            if hasattr(mem_ctrl, "dram_2"):
+                gpu_abstract_mems.append(mem_ctrl.dram_2)
+
         system.pc.south_bridge.gpu.memories = gpu_abstract_mems
 
         # Setup DMA controllers

--- a/configs/example/gpufs/amd/AmdGPUOptions.py
+++ b/configs/example/gpufs/amd/AmdGPUOptions.py
@@ -314,3 +314,10 @@ def addAmdGPUOptions(parser):
         default=1,
         help="Scale how long an mfma consumes the matrix core unit",
     )
+
+    parser.add_argument(
+        "--hbm-ctrl",
+        action="store_true",
+        default=False,
+        help="Use HBMCtrl",
+    )


### PR DESCRIPTION
This commit adds a command line argument --hbm-ctrl to enable HBMCtrl in GPU-FS. HBM_2000_4H_1x64 is tested.