### PR TITLE
arch-vega: GPU TLB Multi Page Size Support

### DIFF
--- a/src/arch/amdgpu/vega/tlb.cc
+++ b/src/arch/amdgpu/vega/tlb.cc
@@ -153,12 +153,18 @@ GpuTLB::pageAlign(Addr vaddr)
     return (vaddr & ~pageMask);
 }
 
+int
+GpuTLB::getSet(Addr va, unsigned int page_shift)
+{
+    return (va >> page_shift) & setMask;
+}
+
 VegaTlbEntry*
 GpuTLB::insert(Addr vpn, VegaTlbEntry &entry)
 {
     VegaTlbEntry *newEntry = nullptr;
 
-    int set = (entry.vaddr >> VegaISA::PageShift) & setMask;
+    int set = getSet(entry.vaddr, entry.logBytes);
 
     if (!freeList[set].empty()) {
         newEntry = freeList[set].front();
@@ -178,9 +184,9 @@ GpuTLB::insert(Addr vpn, VegaTlbEntry &entry)
 }
 
 GpuTLB::EntryList::iterator
-GpuTLB::lookupIt(Addr va, bool update_lru)
+GpuTLB::lookupIt(Addr va, unsigned int ps, bool update_lru)
 {
-    int set = (va >> VegaISA::PageShift) & setMask;
+    int set = getSet(va, ps);
 
     if (FA) {
         assert(!set);
@@ -190,7 +196,8 @@ GpuTLB::lookupIt(Addr va, bool update_lru)
     for (; entry != entryList[set].end(); ++entry) {
         int page_size = (*entry)->size();
 
-        if ((*entry)->vaddr <= va && (*entry)->vaddr + page_size > va) {
+        if ((*entry)->vaddr <= va && (*entry)->vaddr + page_size > va &&
+            ps == (*entry)->logBytes) {
             DPRINTF(GPUTLB, "Matched vaddr %#x to entry starting at %#x "
                     "with size %#x.\n", va, (*entry)->vaddr, page_size);
 
@@ -210,14 +217,17 @@ GpuTLB::lookupIt(Addr va, bool update_lru)
 VegaTlbEntry*
 GpuTLB::lookup(Addr va, bool update_lru)
 {
-    int set = (va >> VegaISA::PageShift) & setMask;
+    for (auto ps : logPageShiftList) {
+        int set = getSet(va, ps);
 
-    auto entry = lookupIt(va, update_lru);
+        auto entry = lookupIt(va, ps, update_lru);
 
-    if (entry == entryList[set].end())
-        return nullptr;
-    else
-        return *entry;
+        if (entry == entryList[set].end())
+            continue;
+        else
+            return *entry;
+    }
+    return nullptr;
 }
 
 void
@@ -237,13 +247,15 @@ GpuTLB::invalidateAll()
 void
 GpuTLB::demapPage(Addr va, uint64_t asn)
 {
+    DPRINTF(GPUTLB, "Demapping vaddr %#x.\n", va);
+    for (auto ps : logPageShiftList) {
+        int set = getSet(va, ps);
+        auto entry = lookupIt(va, ps, false);
 
-    int set = (va >> VegaISA::PageShift) & setMask;
-    auto entry = lookupIt(va, false);
-
-    if (entry != entryList[set].end()) {
-        freeList[set].push_back(*entry);
-        entryList[set].erase(entry);
+        if (entry != entryList[set].end()) {
+            freeList[set].push_back(*entry);
+            entryList[set].erase(entry);
+        }
     }
 }
 
@@ -483,7 +495,7 @@ GpuTLB::handleTranslationReturn(Addr virt_page_addr,
         local_entry = safe_cast<VegaTlbEntry *>(sender_state->tlbEntry);
     } else {
         DPRINTF(GPUTLB, "Translation Done - TLB Miss for addr %#x\n",
-                vaddr);
+            vaddr);
 
         /**
          * We are returning either from a page walk or from a hit at a

--- a/src/arch/amdgpu/vega/tlb.hh
+++ b/src/arch/amdgpu/vega/tlb.hh
@@ -105,9 +105,16 @@ class GpuTLB : public ClockedObject
 
   protected:
     typedef std::list<VegaTlbEntry*> EntryList;
-    EntryList::iterator lookupIt(Addr va, bool update_lru=true);
+    EntryList::iterator lookupIt(Addr va, unsigned int ps,
+                                 bool update_lru=true);
     Walker *walker;
     AMDGPUDevice *gpuDevice;
+
+    int getSet(Addr va, unsigned int page_shift);
+
+    //List of possible page size, 4k and 2m for now
+    const std::array<unsigned int, 2>
+    logPageShiftList = {VegaISA::PageShift, 21};
 
     int size;
     int assoc;


### PR DESCRIPTION
This patch modifies the GPU TLB implementation to properly account for page sizes during both insertion and lookup operations, enabling better handling of mixed page sizes. This increase TLB hit rate. List of supported pagesize can be simply expanded in tlb.hh