### PR TITLE
tests: fix kernel panic on kvm switch tests

### DIFF
--- a/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
+++ b/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
@@ -163,13 +163,20 @@ motherboard = X86Board(
     cache_hierarchy=cache_hierarchy,
 )
 
-kernal_args = motherboard.get_default_kernel_args() + [args.kernel_args]
 workload = obtain_resource(
     "x86-ubuntu-24.04-boot-with-systemd",
     resource_directory=args.resource_directory,
     resource_version="5.0.0",
 )
-workload.set_parameter("kernel_args", kernal_args)
+
+if "kernel_args" in workload.get_parameters():
+    kernel_args = workload.get_parameters()["kernel_args"]
+else:
+    kernel_args = motherboard.get_default_kernel_args()
+
+kernel_args += [args.kernel_args]
+
+workload.set_parameter("kernel_args", kernel_args)
 # Set the Full System workload.
 motherboard.set_workload(workload)
 

--- a/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
+++ b/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
@@ -169,17 +169,10 @@ workload = obtain_resource(
     resource_version="5.0.0",
 )
 
-if "kernel_args" in workload.get_parameters():
-    kernel_args = workload.get_parameters()["kernel_args"]
-else:
-    kernel_args = motherboard.get_default_kernel_args()
-
-kernel_args += [args.kernel_args]
-
-workload.set_parameter("kernel_args", kernel_args)
 # Set the Full System workload.
 motherboard.set_workload(workload)
 
+motherboard.append_kernel_arg(args.kernel_args)
 
 # Begin running of the simulation. This will exit once the Linux system boot
 # is complete.


### PR DESCRIPTION
The resource used for kvm switch tests as kernel arguments set to force the "root=/dev/sda2" ([x86-ubuntu-24.04-boot-with-systemd](https://resources.gem5.org/resources/x86-ubuntu-24.04-boot-with-systemd/raw?database=gem5-resources&version=5.0.0)). The kvm switch test adds some kernel arguments, but use the X86Board default kernel arguments. Which leads to "root=/dev/hda1" and a kernel panic occurs as it cannot mount root fs.

This commits fix that by getting the kernel arguments from the workload instead of the default ones.