### PR TITLE
cpu-o3: Print OpClass name instead of number for debug purposes

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -948,12 +948,12 @@ Commit::commitInsts()
         // so panic.
         } else if (head_inst->noCapableFU() &&
             head_inst->getFault() == NoFault)  {
-            panic("CPU cannot execute [sn:%llu] op_class: %u but"
-              " did not trigger a fault. Do you need to update"
-              " the configuration and add a functional unit for"
-              " that op class?\n",
-              head_inst->seqNum,
-              head_inst->opClass());
+            panic("CPU cannot execute [sn:%llu] op_class: %s but"
+                  " did not trigger a fault. Do you need to update"
+                  " the configuration and add a functional unit for"
+                  " that op class?\n",
+                  head_inst->seqNum,
+                  enums::OpClassStrings[head_inst->opClass()]);
         } else {
             set(pc[tid], head_inst->pcState());
 


### PR DESCRIPTION
A recent PR [1] introduced a panic to catch the case where the O3 model does not have a capable FU to execute a particular instruction.

At the moment we exit simulation and we print the OpClass enum number. This is not particularly useful for a user as it requires the user to manually extract the OpClass name from the number [2] and it can be a bit tedious.

With this PR we print the OpClass name directly

[1]: https://github.com/gem5/gem5/pull/1516
[2]: https://github.com/gem5/gem5/blob/stable/src/cpu/FuncUnit.py

Change-Id: I5a9aaa7c569e67a87400d240b40e9d2a9147cad8