### PR TITLE
Fix-orchestrator-workload-id

### DIFF
--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -322,8 +322,12 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
 class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
 
     def _get_status(self, simulator: "Simulator") -> Dict[str, str]:
+        if not simulator.get_workload():
+            workload_id = "No workload set"
+        else:
+            workload_id = simulator.get_workload().get_id()
         return {
-            "workload": simulator.get_workload().get_id(),
+            "workload": workload_id,
             "tick": simulator.get_current_tick(),
             "sim_id": simulator.get_id(),
             "curr_instructions_executed": simulator.get_instruction_count(),


### PR DESCRIPTION
The `workload` member of `Simulator` can be None (e.g., when
someone manually calls `set_kernel_disk_workload`). This
change updates the logic so that it doesn't cause an error.

Signed-off-by: Jason Lowe-Power <jlowepower@google.com>