### PR TITLE
tests: Add tests for running binaries via readfile

### DIFF
--- a/tests/gem5/readfile_tests/README.md
+++ b/tests/gem5/readfile_tests/README.md
@@ -1,6 +1,6 @@
 # Readfile Tests
 
-These tests run a series of full-system simulations to verify whether a binary can be executed inside the simulation via the `readfile` argument.
+These tests run a series of full-system simulations to verify whether a script can be executed inside the simulation via the `readfile` argument.
 
 The tests boot an Ubuntu 24.04 image (without systemd) for the X86, RISC-V, and ARM ISAs.
 

--- a/tests/gem5/readfile_tests/README.md
+++ b/tests/gem5/readfile_tests/README.md
@@ -1,0 +1,11 @@
+# Readfile Tests
+
+These tests run a series of full-system simulations to verify whether a binary can be executed inside the simulation via the `readfile` argument.
+
+The tests boot an Ubuntu 24.04 image (without systemd) for the X86, RISC-V, and ARM ISAs.
+
+To run these tests independently, execute the following command from the `tests` directory:
+
+```bash
+./main.py run gem5/readfile_tests --length=long
+```

--- a/tests/gem5/readfile_tests/configs/test_script.sh
+++ b/tests/gem5/readfile_tests/configs/test_script.sh
@@ -1,0 +1,2 @@
+echo "running test script from readfile_tests"
+sleep 5 #sleeping for 5 seconds to let gem5 write terminal output to output directory

--- a/tests/gem5/readfile_tests/configs/ubuntu-run-with-readfile.py
+++ b/tests/gem5/readfile_tests/configs/ubuntu-run-with-readfile.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import re
+from pathlib import Path
+
+import m5.options
+
+from gem5.prebuilt.demo.arm_demo_board import ArmDemoBoard
+from gem5.prebuilt.demo.riscv_demo_board import RiscvDemoBoard
+from gem5.prebuilt.demo.x86_demo_board import X86DemoBoard
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.simulator import Simulator
+
+config_dir = Path(__file__).resolve().parent
+script_path = str(config_dir / "test_script.sh")
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--isa",
+    help="The isa of the simulation to run. Options: x86, arm and riscv",
+    choices=["x86", "riscv", "arm"],
+    required=True,
+)
+parser.add_argument(
+    "-r",
+    "--resource-directory",
+    type=str,
+    required=False,
+    help="The directory in which resources will be downloaded or exist.",
+)
+args = parser.parse_args()
+isa = args.isa
+resource_directory = args.resource_directory
+board = None
+
+match isa:
+    case "x86":
+        board = X86DemoBoard()
+        workload = obtain_resource(
+            "x86-ubuntu-24.04-boot-no-systemd",
+            resource_version="4.0.0",
+            resource_directory=resource_directory,
+        )
+    case "arm":
+        board = ArmDemoBoard()
+        workload = obtain_resource(
+            "arm-ubuntu-24.04-boot-no-systemd",
+            resource_version="2.0.0",
+            resource_directory=resource_directory,
+        )
+    case "riscv":
+        board = RiscvDemoBoard()
+        workload = obtain_resource(
+            "riscv-ubuntu-24.04-boot-no-systemd",
+            resource_version="2.0.0",
+            resource_directory=resource_directory,
+        )
+    case _:
+        raise Exception("The isa must be arm, x86 or riscv")
+
+workload.set_parameter("readfile", script_path)
+board.set_workload(workload=workload)
+simulator = Simulator(board=board)
+
+simulator.run()
+
+out_dir = m5.options.outdir
+terminal_out_path = None
+
+match isa:
+    case "x86":
+        terminal_out_path = Path(out_dir) / "board.pc.com_1.device"
+
+    case "arm":
+        terminal_out_path = Path(out_dir) / "board.terminal"
+
+    case "riscv":
+        terminal_out_path = Path(out_dir) / "board.platform.terminal"
+
+    case _:
+        raise Exception("The isa must be arm, x86 or riscv")
+
+expected_binary_output = "running test script from readfile_tests"
+
+with open(terminal_out_path) as file:
+    terminal_output = file.read()
+
+    if re.search(expected_binary_output, terminal_output):
+        print("Readfile test passed!")
+    else:
+        print("Readfile test failed!")

--- a/tests/gem5/readfile_tests/configs/ubuntu-run-with-readfile.py
+++ b/tests/gem5/readfile_tests/configs/ubuntu-run-with-readfile.py
@@ -105,12 +105,12 @@ match isa:
     case _:
         raise Exception("The isa must be arm, x86 or riscv")
 
-expected_binary_output = "running test script from readfile_tests"
+expected_script_output = "running test script from readfile_tests"
 
 with open(terminal_out_path) as file:
     terminal_output = file.read()
 
-    if re.search(expected_binary_output, terminal_output):
+    if re.search(expected_script_output, terminal_output):
         print("Readfile test passed!")
     else:
         print("Readfile test failed!")

--- a/tests/gem5/readfile_tests/test-readfile.py
+++ b/tests/gem5/readfile_tests/test-readfile.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This runs simple tests to ensure that running binaries via readfile works.
+"""
+import os
+import re
+
+from testlib import *
+
+if config.bin_path:
+    resource_path = config.bin_path
+else:
+    resource_path = joinpath(absdirpath(__file__), "..", "resources")
+
+readfile_verifier = verifier.MatchRegex(re.compile(r"Readfile test passed!"))
+
+
+def test_readfile(isa: str, length: str):
+    gem5_verify_config(
+        name=f"test_readfile_{isa}",
+        fixtures=(),
+        verifiers=(readfile_verifier,),
+        config=joinpath(
+            config.base_dir,
+            "tests",
+            "gem5",
+            "readfile_tests",
+            "configs",
+            "ubuntu-run-with-readfile.py",
+        ),
+        config_args=[
+            "--isa",
+            isa,
+            "--resource-directory",
+            resource_path,
+        ],
+        valid_isas=(constants.all_compiled_tag,),
+        valid_hosts=constants.supported_hosts,
+        length=length,
+    )
+
+
+test_readfile(isa="x86", length=constants.long_tag)
+
+test_readfile(isa="riscv", length=constants.long_tag)
+
+test_readfile(isa="arm", length=constants.long_tag)


### PR DESCRIPTION
This PR adds tests to verify that executing binaries, that are on the host, on the simulated system via the `readfile` argument works as intended.