### PR TITLE
cpu,sim,switch: Fix assertion failure in switchable CPUs due to doClone

### DIFF
--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -629,6 +629,33 @@ class BaseCPU : public ClockedObject
     }
 
     static int numSimulatedCPUs() { return cpuList.size(); }
+    
+    /**
+     * Get access to the global CPU list for switchable CPU synchronization.
+     * @return Reference to the static CPU list
+     */
+    static const std::vector<BaseCPU *>& getCpuList() { return cpuList; }
+    
+    /**
+     * Get the number of thread contexts for this CPU.
+     * @return Number of thread contexts
+     */
+    size_t numThreadContexts() const { return threadContexts.size(); }
+    
+    /**
+     * Get a thread context by index for switchable CPU synchronization.
+     * @param tid Thread ID to retrieve
+     * @return Pointer to thread context or nullptr if index is invalid
+     */
+    ThreadContext*
+    getThreadContext(ThreadID tid) const
+    {
+        if (tid < threadContexts.size()) {
+            return threadContexts[tid];
+        }
+        return nullptr;
+    }
+    
     static Counter
     totalNumSimulatedInsts()
     {

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -629,19 +629,19 @@ class BaseCPU : public ClockedObject
     }
 
     static int numSimulatedCPUs() { return cpuList.size(); }
-    
+
     /**
      * Get access to the global CPU list for switchable CPU synchronization.
      * @return Reference to the static CPU list
      */
     static const std::vector<BaseCPU *>& getCpuList() { return cpuList; }
-    
+
     /**
      * Get the number of thread contexts for this CPU.
      * @return Number of thread contexts
      */
     size_t numThreadContexts() const { return threadContexts.size(); }
-    
+
     /**
      * Get a thread context by index for switchable CPU synchronization.
      * @param tid Thread ID to retrieve
@@ -655,7 +655,7 @@ class BaseCPU : public ClockedObject
         }
         return nullptr;
     }
-    
+
     static Counter
     totalNumSimulatedInsts()
     {

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -634,20 +634,28 @@ class BaseCPU : public ClockedObject
      * Get access to the global CPU list for switchable CPU synchronization.
      * @return Reference to the static CPU list
      */
-    static const std::vector<BaseCPU *>& getCpuList() { return cpuList; }
+    static const std::vector<BaseCPU *> &
+    getCpuList()
+    {
+        return cpuList;
+    }
 
     /**
      * Get the number of thread contexts for this CPU.
      * @return Number of thread contexts
      */
-    size_t numThreadContexts() const { return threadContexts.size(); }
+    size_t
+    numThreadContexts() const
+    {
+        return threadContexts.size();
+    }
 
     /**
      * Get a thread context by index for switchable CPU synchronization.
      * @param tid Thread ID to retrieve
      * @return Pointer to thread context or nullptr if index is invalid
      */
-    ThreadContext*
+    ThreadContext *
     getThreadContext(ThreadID tid) const
     {
         if (tid < threadContexts.size()) {

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -1832,8 +1832,7 @@ doClone(SyscallDesc *desc, ThreadContext *tc, RegVal flags, RegVal newStack,
     for (BaseCPU *cpu : BaseCPU::getCpuList()) {
         // Skip the current CPU and only consider switched-out CPUs with
         // matching ID
-        if (cpu != current_cpu &&
-            cpu->switchedOut() &&
+        if (cpu != current_cpu && cpu->switchedOut() &&
             cpu->cpuId() == current_cpu->cpuId()) {
 
             // Find the corresponding thread context on the switched-out CPU
@@ -1843,7 +1842,8 @@ doClone(SyscallDesc *desc, ThreadContext *tc, RegVal flags, RegVal newStack,
 
                 // Update the process pointer to match the active CPU
                 if (switched_tc) {
-                    DPRINTF(SyscallVerbose, "doClone: Updating switched-out "
+                    DPRINTF(SyscallVerbose,
+                            "doClone: Updating switched-out "
                             "CPU %d thread %d process pointer from %p to %p\n",
                             cpu->cpuId(), current_thread_id,
                             switched_tc->getProcessPtr(), cp);

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -1827,25 +1827,25 @@ doClone(SyscallDesc *desc, ThreadContext *tc, RegVal flags, RegVal newStack,
     // takeOverFrom().
     BaseCPU *current_cpu = ctc->getCpuPtr();
     ThreadID current_thread_id = ctc->threadId();
-    
+
     // Iterate through all CPUs in the system to find switchable partners
     for (BaseCPU *cpu : BaseCPU::getCpuList()) {
         // Skip the current CPU and only consider switched-out CPUs with
         // matching ID
-        if (cpu != current_cpu && 
-            cpu->switchedOut() && 
+        if (cpu != current_cpu &&
+            cpu->switchedOut() &&
             cpu->cpuId() == current_cpu->cpuId()) {
-            
+
             // Find the corresponding thread context on the switched-out CPU
             if (current_thread_id < cpu->numThreadContexts()) {
-                ThreadContext *switched_tc = 
+                ThreadContext *switched_tc =
                     cpu->getThreadContext(current_thread_id);
-                
+
                 // Update the process pointer to match the active CPU
                 if (switched_tc) {
                     DPRINTF(SyscallVerbose, "doClone: Updating switched-out "
                             "CPU %d thread %d process pointer from %p to %p\n",
-                            cpu->cpuId(), current_thread_id, 
+                            cpu->cpuId(), current_thread_id,
                             switched_tc->getProcessPtr(), cp);
                     switched_tc->setProcessPtr(cp);
                 }

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -1820,6 +1820,39 @@ doClone(SyscallDesc *desc, ThreadContext *tc, RegVal flags, RegVal newStack,
     cp->assignThreadContext(ctc->contextId());
     owner->revokeThreadContext(ctc->contextId());
 
+    // For switchable CPU configurations, we need to also set the process
+    // pointer on any switched-out CPUs that have the same CPU ID and thread
+    // context ID. This ensures that when CPU switching occurs, both CPUs
+    // have consistent process pointers, preventing assertion failures in
+    // takeOverFrom().
+    BaseCPU *current_cpu = ctc->getCpuPtr();
+    ThreadID current_thread_id = ctc->threadId();
+    
+    // Iterate through all CPUs in the system to find switchable partners
+    for (BaseCPU *cpu : BaseCPU::getCpuList()) {
+        // Skip the current CPU and only consider switched-out CPUs with
+        // matching ID
+        if (cpu != current_cpu && 
+            cpu->switchedOut() && 
+            cpu->cpuId() == current_cpu->cpuId()) {
+            
+            // Find the corresponding thread context on the switched-out CPU
+            if (current_thread_id < cpu->numThreadContexts()) {
+                ThreadContext *switched_tc = 
+                    cpu->getThreadContext(current_thread_id);
+                
+                // Update the process pointer to match the active CPU
+                if (switched_tc) {
+                    DPRINTF(SyscallVerbose, "doClone: Updating switched-out "
+                            "CPU %d thread %d process pointer from %p to %p\n",
+                            cpu->cpuId(), current_thread_id, 
+                            switched_tc->getProcessPtr(), cp);
+                    switched_tc->setProcessPtr(cp);
+                }
+            }
+        }
+    }
+
     if (flags & OS::TGT_CLONE_PARENT_SETTID) {
         BufferArg ptidBuf(ptidPtr, sizeof(long));
         long *ptid = (long *)ptidBuf.bufferPtr();


### PR DESCRIPTION
When using SimpleSwitchableProcessor with multithreaded programs an assertion failure occurs in takeOverFrom() due to mismatched process pointers between active and switched-out CPUs.

The issue arises because clone() syscall creates new threads on active CPUs (starting cores) but doesn't update corresponding switched-out CPUs (switch cores) with the new process pointers. Later CPU switching triggers the assertion failure:
`ntc.getProcessPtr() == otc.getProcessPtr()' failed`

This patch synchronizes process pointers during clone operations by:
- Adding public getter methods to BaseCPU for thread context access
- Updating doClone() to set process pointers on switched-out CPUs with matching CPU IDs

Github Issue: https://github.com/gem5/gem5/issues/2446