### PR TITLE
arch-riscv: populate logBytes/paddr after functional pt walk

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -637,7 +637,11 @@ Walker::WalkerState::startFunctional(Addr &addr, unsigned &logBytes)
     // just call walk
     // it takes care to do the right thing
     // when functional is true
-    return walk();
+    Fault fault = walk();
+    logBytes = entry.logBytes;
+    addr = entry.paddr << PageShift;
+
+    return fault;
 }
 
 


### PR DESCRIPTION
Both `logBytes` and `addr` references were not updated after finishing a functional translation walk in the RISC-V page table walker.

Should fix #2410.