### PR TITLE
arch-riscv: set 0 PMP entries as default

### DIFF
--- a/src/arch/riscv/PMP.py
+++ b/src/arch/riscv/PMP.py
@@ -34,4 +34,4 @@ class PMP(SimObject):
     cxx_header = "arch/riscv/pmp.hh"
     cxx_class = "gem5::RiscvISA::PMP"
 
-    pmp_entries = Param.Int(16, "Maximum PMP Entries Supported")
+    pmp_entries = Param.Int(0, "Maximum PMP Entries Supported")


### PR DESCRIPTION
With #2376 a PMP check will now fail if there's at least one entry but no rules are implemented. 

Right now the default number of entries is 16, so this means that if the PMP is not to be used, the number of entries will need to get 0'd explicitly. This patch puts 0 as the default value to effectively disable the PMP by default.