### PR TITLE
misc: Modify clang-format to no break in method declarations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -69,7 +69,8 @@ AllowShortLoopsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: InlineOnly
 
 # Return‐type / function‐name separation
-AlwaysBreakAfterReturnType: All              # Return on its own line (sec. Functions)
+AlwaysBreakAfterReturnType: None             # Do not break after return type
+AlwaysBreakAfterDefinitionReturnType: All    # Unless it is a definition
 
 # Pointer/reference alignment
 DerivePointerAlignment: false


### PR DESCRIPTION
With the current clang-format configuration, the following method:

void method1(int val);

Will be reformatted to

void
method1(int val);

While this is somehow used in some gem5 files, the majority of our method declaration have the return type on the same line of the method name

By relying on AlwaysBreakAfterDefinitionReturnType we make sure we only break on method definitions


Change-Id: Ib6252dfa847710f988aece116d74a3de28f67be3