### PR TITLE
stdlib: Add estimated instructions to WorkloadResource

### DIFF
--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -874,6 +874,15 @@ class WorkloadResource(AbstractResource):
         self._id = id
         self._func = function
         self._params = parameters
+        try:
+            self._estimated_instructions = int(
+                kwargs.get("simulation_run_results")["total_instructions"]
+            )
+        except:
+            self._estimated_instructions = None
+
+    def get_estimated_instructions(self) -> Optional[int]:
+        return self._estimated_instructions
 
     def get_id(self) -> str:
         """Returns the ID of the workload."""

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -875,14 +875,14 @@ class WorkloadResource(AbstractResource):
         self._func = function
         self._params = parameters
         try:
-            self._estimated_instructions = int(
+            self._estimated_total_instructions = int(
                 kwargs.get("simulation_run_results")["total_instructions"]
             )
         except:
-            self._estimated_instructions = None
+            self._estimated_total_instructions = None
 
-    def get_estimated_instructions(self) -> Optional[int]:
-        return self._estimated_instructions
+    def get_estimated_total_instructions(self) -> Optional[int]:
+        return self._estimated_total_instructions
 
     def get_id(self) -> str:
         """Returns the ID of the workload."""


### PR DESCRIPTION
This PR modifies WorkloadResource so it stores the number of estimated instructions, which is provided by the workload JSON. It also adds a getter function. This is needed to support the addition of the gem5 dashboard.