### PR TITLE
stdlib: return ticks to seconds conversion in exit handler

### DIFF
--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -322,6 +322,8 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
 class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
 
     def _get_status(self, simulator: "Simulator") -> Dict[str, str]:
+        import _m5.core
+
         if not simulator.get_workload():
             workload_id = "No workload set"
         else:
@@ -329,6 +331,7 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         return {
             "workload": workload_id,
             "tick": simulator.get_current_tick(),
+            "ticks_per_second": _m5.core.getClockFrequency(),
             "sim_id": simulator.get_id(),
             "curr_instructions_executed": simulator.get_instruction_count(),
         }


### PR DESCRIPTION
This commit modifies the orchestrator exit handler so it also returns the ticks to seconds conversion for the simulation. This will be used by the gem5 dashboard.