### PR TITLE
arch-riscv: fix bug about never start next PTW

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -295,10 +295,18 @@ Walker::startWalkWrapper()
     if (currState && !currState->wasStarted()) {
         if (!e || fault != NoFault) {
             Fault timingFault = currState->walk();
-            if (timingFault != NoFault) {
+
+            // Catch all walker states that have early fault!
+            while (!currStates.empty() && timingFault != NoFault) {
+                // Delete currState due to early fault
                 currStates.pop_front();
                 delete currState;
-                currState = NULL;
+
+                // Get next currState & walk
+                if (currStates.size() > 0) {
+                    currState = currStates.front();
+                    timingFault = currState->walk();
+                }
             }
         }
         else {


### PR DESCRIPTION
When performing PTW on an illegal address, it return with a early fault and page table walker will not send any packets and delete this PTW immediately. In this case, startWalkWrapperEvent will no longer be scheduled. If there are anthor PTW is blocked, it will never be processed.