### PR TITLE
cpu: move conditional pred out of bpred_unit

### DIFF
--- a/configs/common/cores/arm/HPI.py
+++ b/configs/common/cores/arm/HPI.py
@@ -1694,16 +1694,18 @@ class HPI_BTB(SimpleBTB):
     )
 
 
-class HPI_BP(TournamentBP):
+class HPI_BP(BranchPredictor):
+    conditionalBranchPred = TournamentBP(
+        localPredictorSize=64,
+        localCtrBits=2,
+        localHistoryTableSize=64,
+        globalPredictorSize=1024,
+        globalCtrBits=2,
+        choicePredictorSize=1024,
+        choiceCtrBits=2,
+    )
     btb = HPI_BTB()
     ras = ReturnAddrStack(numEntries=8)
-    localPredictorSize = 64
-    localCtrBits = 2
-    localHistoryTableSize = 64
-    globalPredictorSize = 1024
-    globalCtrBits = 2
-    choicePredictorSize = 1024
-    choiceCtrBits = 2
     instShiftAmt = 2
 
 

--- a/configs/common/cores/arm/O3_ARM_v7a.py
+++ b/configs/common/cores/arm/O3_ARM_v7a.py
@@ -123,13 +123,15 @@ class O3_ARM_v7a_BTB(SimpleBTB):
 
 
 # Bi-Mode Branch Predictor
-class O3_ARM_v7a_BP(BiModeBP):
+class O3_ARM_v7a_BP(BranchPredictor):
+    conditionalBranchPred = BiModeBP(
+        globalPredictorSize=8192,
+        globalCtrBits=2,
+        choicePredictorSize=8192,
+        choiceCtrBits=2,
+    )
     btb = O3_ARM_v7a_BTB()
     ras = ReturnAddrStack(numEntries=16)
-    globalPredictorSize = 8192
-    globalCtrBits = 2
-    choicePredictorSize = 8192
-    choiceCtrBits = 2
     instShiftAmt = 2
 
 

--- a/configs/common/cores/arm/ex5_big.py
+++ b/configs/common/cores/arm/ex5_big.py
@@ -120,13 +120,15 @@ class ex5_big_BTB(SimpleBTB):
 
 
 # Bi-Mode Branch Predictor
-class ex5_big_BP(BiModeBP):
+class ex5_big_BP(BranchPredictor):
+    conditionalBranchPred = BiModeBP(
+        globalPredictorSize=4096,
+        globalCtrBits=2,
+        choicePredictorSize=1024,
+        choiceCtrBits=3,
+    )
     btb = ex5_big_BTB()
     ras = ReturnAddrStack(numEntries=48)
-    globalPredictorSize = 4096
-    globalCtrBits = 2
-    choicePredictorSize = 1024
-    choiceCtrBits = 3
     instShiftAmt = 2
 
 

--- a/src/cpu/minor/BaseMinorCPU.py
+++ b/src/cpu/minor/BaseMinorCPU.py
@@ -426,7 +426,10 @@ class BaseMinorCPU(BaseCPU):
     )
 
     branchPred = Param.BranchPredictor(
-        TournamentBP(numThreads=Parent.numThreads), "Branch Predictor"
+        BranchPredictor(
+            conditionalBranchPred=TournamentBP(numThreads=Parent.numThreads)
+        ),
+        "Branch Predictor",
     )
 
     def addCheckerCpu(self):

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -203,7 +203,10 @@ class BaseO3CPU(BaseCPU):
     smtCommitPolicy = Param.CommitPolicy("RoundRobin", "SMT Commit Policy")
 
     branchPred = Param.BranchPredictor(
-        TournamentBP(numThreads=Parent.numThreads), "Branch Predictor"
+        BranchPredictor(
+            conditionalBranchPred=TournamentBP(numThreads=Parent.numThreads)
+        ),
+        "Branch Predictor",
     )
     needsTSO = Param.Bool(False, "Enable TSO Memory model")
 

--- a/src/cpu/pred/2bit_local.cc
+++ b/src/cpu/pred/2bit_local.cc
@@ -52,7 +52,7 @@ namespace branch_prediction
 {
 
 LocalBP::LocalBP(const LocalBPParams &params)
-    : BPredUnit(params),
+    : ConditionalPredictor(params),
       localPredictorSize(params.localPredictorSize),
       localCtrBits(params.localCtrBits),
       localPredictorSets(localPredictorSize / localCtrBits),
@@ -76,6 +76,12 @@ LocalBP::LocalBP(const LocalBPParams &params)
 
     DPRINTF(Fetch, "instruction shift amount: %i\n",
             instShiftAmt);
+}
+
+void LocalBP::branchPlaceholder(ThreadID tid, Addr pc,
+                                bool uncond, void * &bpHistory)
+{
+// Placeholder for a function that only returns history items
 }
 
 void

--- a/src/cpu/pred/2bit_local.hh
+++ b/src/cpu/pred/2bit_local.hh
@@ -46,7 +46,7 @@
 
 #include "base/sat_counter.hh"
 #include "base/types.hh"
-#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/conditional.hh"
 #include "params/LocalBP.hh"
 
 namespace gem5
@@ -62,7 +62,7 @@ namespace branch_prediction
  * predictor state that needs to be recorded or updated; the update can be
  * determined solely by the branch being taken or not taken.
  */
-class LocalBP : public BPredUnit
+class LocalBP : public ConditionalPredictor
 {
   public:
     /**
@@ -72,6 +72,9 @@ class LocalBP : public BPredUnit
 
     // Overriding interface functions
     bool lookup(ThreadID tid, Addr pc, void * &bp_history) override;
+
+    void branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
+                           void * &bpHistory) override;
 
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
                          Addr target, const StaticInstPtr &inst,

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -143,6 +143,22 @@ class SimpleBTB(BranchTargetBuffer):
     )
 
 
+class ConditionalPredictor(SimObject):
+    type = "ConditionalPredictor"
+    cxx_class = "gem5::branch_prediction::ConditionalPredictor"
+    cxx_header = "cpu/pred/conditional.hh"
+    abstract = True
+
+    numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
+    instShiftAmt = Param.Unsigned(
+        Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )
+    speculativeHistUpdate = Param.Bool(
+        Parent.speculativeHistUpdate,
+        "Use speculative update for the conditional predictor",
+    )
+
+
 class IndirectPredictor(SimObject):
     type = "IndirectPredictor"
     cxx_class = "gem5::branch_prediction::IndirectPredictor"
@@ -182,7 +198,6 @@ class BranchPredictor(SimObject):
     type = "BranchPredictor"
     cxx_class = "gem5::branch_prediction::BPredUnit"
     cxx_header = "cpu/pred/bpred_unit.hh"
-    abstract = True
 
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
     instShiftAmt = Param.Unsigned(
@@ -213,6 +228,9 @@ class BranchPredictor(SimObject):
     ras = Param.ReturnAddrStack(
         ReturnAddrStack(), "Return address stack, set to NULL to disable RAS."
     )
+    conditionalBranchPred = Param.ConditionalPredictor(
+        "Conditional branch predictor"
+    )
     indirectBranchPred = Param.IndirectPredictor(
         SimpleIndirectPredictor(),
         "Indirect branch predictor, set to NULL to disable "
@@ -228,7 +246,7 @@ class BranchPredictor(SimObject):
     )
 
 
-class LocalBP(BranchPredictor):
+class LocalBP(ConditionalPredictor):
     type = "LocalBP"
     cxx_class = "gem5::branch_prediction::LocalBP"
     cxx_header = "cpu/pred/2bit_local.hh"
@@ -237,7 +255,7 @@ class LocalBP(BranchPredictor):
     localCtrBits = Param.Unsigned(2, "Bits per counter")
 
 
-class TournamentBP(BranchPredictor):
+class TournamentBP(ConditionalPredictor):
     type = "TournamentBP"
     cxx_class = "gem5::branch_prediction::TournamentBP"
     cxx_header = "cpu/pred/tournament.hh"
@@ -251,7 +269,7 @@ class TournamentBP(BranchPredictor):
     choiceCtrBits = Param.Unsigned(2, "Bits of choice counters")
 
 
-class BiModeBP(BranchPredictor):
+class BiModeBP(ConditionalPredictor):
     type = "BiModeBP"
     cxx_class = "gem5::branch_prediction::BiModeBP"
     cxx_header = "cpu/pred/bi_mode.hh"
@@ -326,7 +344,7 @@ class TAGEBase(SimObject):
 
 # TAGE branch predictor as described in https://www.jilp.org/vol8/v8paper1.pdf
 # The default sizes below are for the 8C-TAGE configuration (63.5 Kbits)
-class TAGE(BranchPredictor):
+class TAGE(ConditionalPredictor):
     type = "TAGE"
     cxx_class = "gem5::branch_prediction::TAGE"
     cxx_header = "cpu/pred/tage.hh"
@@ -790,7 +808,7 @@ class TAGE_SC_L_8KB(TAGE_SC_L):
     statistical_corrector = TAGE_SC_L_8KB_StatisticalCorrector()
 
 
-class MultiperspectivePerceptron(BranchPredictor):
+class MultiperspectivePerceptron(ConditionalPredictor):
     type = "MultiperspectivePerceptron"
     cxx_class = "gem5::branch_prediction::MultiperspectivePerceptron"
     cxx_header = "cpu/pred/multiperspective_perceptron.hh"

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -44,6 +44,7 @@ Import('*')
 SimObject('BranchPredictor.py',
     sim_objects=[
     'BranchPredictor',
+    'ConditionalPredictor',
     'IndirectPredictor', 'SimpleIndirectPredictor',
     'BranchTargetBuffer', 'SimpleBTB', 'BTBIndexingPolicy', 'BTBSetAssociative',
     'ReturnAddrStack',
@@ -64,6 +65,7 @@ SimObject('BranchPredictor.py',
 Source('bpred_unit.cc')
 Source('2bit_local.cc')
 Source('simple_indirect.cc')
+Source('conditional.cc')
 Source('indirect.cc')
 Source('ras.cc')
 Source('tournament.cc')

--- a/src/cpu/pred/bi_mode.cc
+++ b/src/cpu/pred/bi_mode.cc
@@ -54,7 +54,7 @@ namespace branch_prediction
 {
 
 BiModeBP::BiModeBP(const BiModeBPParams &params)
-    : BPredUnit(params),
+    : ConditionalPredictor(params),
       globalHistoryReg(params.numThreads, 0),
       globalHistoryBits(ceilLog2(params.globalPredictorSize)),
       choicePredictorSize(params.choicePredictorSize),

--- a/src/cpu/pred/bi_mode.hh
+++ b/src/cpu/pred/bi_mode.hh
@@ -46,7 +46,7 @@
 #define __CPU_PRED_BI_MODE_PRED_HH__
 
 #include "base/sat_counter.hh"
-#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/conditional.hh"
 #include "params/BiModeBP.hh"
 
 namespace gem5
@@ -69,7 +69,7 @@ namespace branch_prediction
  * the branch's PC to choose between the two, destructive aliasing is reduced.
  */
 
-class BiModeBP : public BPredUnit
+class BiModeBP : public ConditionalPredictor
 {
   public:
     BiModeBP(const BiModeBPParams &params);

--- a/src/cpu/pred/conditional.cc
+++ b/src/cpu/pred/conditional.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Technical University of Munich
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* @file
+ * Conditional branch predictor interface
+ */
+
+#include "cpu/pred/conditional.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+ConditionalPredictor::ConditionalPredictor(const Params &params)
+    : SimObject(params),
+      instShiftAmt(params.instShiftAmt)
+{
+}
+
+
+void
+ConditionalPredictor::branchPlaceholder(ThreadID tid, Addr pc,
+                             bool uncond, void * &bp_history)
+{
+    panic("BPredUnit::branchPlaceholder() not implemented for this BP.\n");
+}
+
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/cpu/pred/conditional.hh
+++ b/src/cpu/pred/conditional.hh
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025 Technical University of Munich
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* @file
+ * Conditional branch predictor interface
+ */
+
+#ifndef __CPU_PRED_CONDITIONAL_BASE_HH__
+#define __CPU_PRED_CONDITIONAL_BASE_HH__
+
+#include "arch/generic/pcstate.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/pred/branch_type.hh"
+#include "params/ConditionalPredictor.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+class ConditionalPredictor : public SimObject
+{
+  public:
+
+    typedef ConditionalPredictorParams Params;
+
+    ConditionalPredictor(const Params &params);
+
+
+    /**
+     * Looks up a given conditional branch PC of in the BP to see if it
+     * is taken or not taken.
+     * @param tid The thread id.
+     * @param pc The PC to look up.
+     * @param bp_history Pointer that will be set to an object that
+     * has the branch predictor state associated with the lookup.
+     * @return Whether the branch is taken or not taken.
+     */
+    virtual bool lookup(ThreadID tid, Addr pc, void * &bp_history) = 0;
+
+    /**
+     * Ones done with the prediction this function updates the
+     * path and global history. All branches call this function
+     * including unconditional once.
+     * @param tid The thread id.
+     * @param pc The branch's pc that will be updated.
+     * @param uncond Wheather or not this branch is an unconditional branch.
+     * @param taken Whether or not the branch was taken
+     * @param target The final target of branch. Some modern
+     * predictors use the target in their history.
+     * @param inst Static instruction information
+     * @param bp_history Pointer that will be set to an object that
+     * has the branch predictor state associated with the lookup.
+     *
+     */
+    virtual void updateHistories(ThreadID tid, Addr pc, bool uncond,
+                                 bool taken, Addr target,
+                                 const StaticInstPtr &inst,
+                                 void * &bp_history) = 0;
+
+    /**
+     * @param tid The thread id.
+     * @param bp_history Pointer to the history object.  The predictor
+     * will need to update any state and delete the object.
+     */
+    virtual void squash(ThreadID tid, void * &bp_history) = 0;
+
+
+    /**
+     * Updates the BP with taken/not taken information.
+     * @param tid The thread id.
+     * @param pc The branch's PC that will be updated.
+     * @param taken Whether the branch was taken or not taken.
+     * @param bp_history Pointer to the branch predictor state that is
+     * associated with the branch lookup that is being updated.
+     * @param squashed Set to true when this function is called during a
+     * squash operation.
+     * @param inst Static instruction information
+     * @param target The resolved target of the branch (only needed
+     * for squashed branches)
+     * @todo Make this update flexible enough to handle a global predictor.
+     */
+    virtual void update(ThreadID tid, Addr pc, bool taken,
+                        void * &bp_history, bool squashed,
+                        const StaticInstPtr &inst, Addr target) = 0;
+
+    /**
+     * Special function for the decoupled front-end. In it there can be
+     * branches which are not detected by the BPU in the first place as it
+     * requires a BTB hit. This function will generate a placeholder for
+     * such a branch once it is pre-decoded in the fetch stage. It will
+     * only create the branch history object but not update any internal state
+     * of the BPU.
+     * If the branch turns to be wrong then decode or commit will
+     * be able to use the normal squash functionality to correct the branch.
+     * Note that not all branch predictors implement this functionality.
+     * @param tid The thread id.
+     * @param pc The branch's PC.
+     * @param uncond Whether or not this branch is an unconditional branch.
+     * @param bp_history Pointer that will be set to an branch history object.
+     */
+    virtual void branchPlaceholder(ThreadID tid, Addr pc,
+                                   bool uncond, void * &bp_history);
+  protected:
+
+    /** Number of bits to shift instructions by for predictor addresses. */
+    const unsigned instShiftAmt;
+};
+
+} // namespace branch_prediction
+} // namespace gem5
+
+#endif // __CPU_PRED_CONDITIONAL_BASE_HH__

--- a/src/cpu/pred/multiperspective_perceptron.cc
+++ b/src/cpu/pred/multiperspective_perceptron.cc
@@ -128,7 +128,7 @@ MultiperspectivePerceptron::ThreadData::ThreadData(int num_filters,
 }
 
 MultiperspectivePerceptron::MultiperspectivePerceptron(
-    const MultiperspectivePerceptronParams &p) : BPredUnit(p),
+    const MultiperspectivePerceptronParams &p) : ConditionalPredictor(p),
     blockSize(p.block_size), pcshift(p.pcshift), threshold(p.threshold),
     bias0(p.bias0), bias1(p.bias1), biasmostly0(p.biasmostly0),
     biasmostly1(p.biasmostly1), nbest(p.nbest), tunebits(p.tunebits),

--- a/src/cpu/pred/multiperspective_perceptron.hh
+++ b/src/cpu/pred/multiperspective_perceptron.hh
@@ -55,7 +55,7 @@
 #include <vector>
 
 #include "base/random.hh"
-#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/conditional.hh"
 #include "params/MultiperspectivePerceptron.hh"
 
 namespace gem5
@@ -64,7 +64,7 @@ namespace gem5
 namespace branch_prediction
 {
 
-class MultiperspectivePerceptron : public BPredUnit
+class MultiperspectivePerceptron : public ConditionalPredictor
 {
   protected:
     /**

--- a/src/cpu/pred/tage.cc
+++ b/src/cpu/pred/tage.cc
@@ -62,7 +62,9 @@ namespace gem5
 namespace branch_prediction
 {
 
-TAGE::TAGE(const TAGEParams &params) : BPredUnit(params), tage(params.tage)
+TAGE::TAGE(const TAGEParams &params)
+    : ConditionalPredictor(params),
+      tage(params.tage)
 {
 }
 

--- a/src/cpu/pred/tage.hh
+++ b/src/cpu/pred/tage.hh
@@ -64,7 +64,7 @@
 
 #include "base/random.hh"
 #include "base/types.hh"
-#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/conditional.hh"
 #include "cpu/pred/tage_base.hh"
 #include "params/TAGE.hh"
 
@@ -74,7 +74,7 @@ namespace gem5
 namespace branch_prediction
 {
 
-class TAGE: public BPredUnit
+class TAGE: public ConditionalPredictor
 {
   protected:
     TAGEBase *tage;

--- a/src/cpu/pred/tournament.cc
+++ b/src/cpu/pred/tournament.cc
@@ -51,7 +51,7 @@ namespace branch_prediction
 {
 
 TournamentBP::TournamentBP(const TournamentBPParams &params)
-    : BPredUnit(params),
+    : ConditionalPredictor(params),
       localPredictorSize(params.localPredictorSize),
       localCtrBits(params.localCtrBits),
       localCtrs(localPredictorSize, SatCounter8(localCtrBits)),

--- a/src/cpu/pred/tournament.hh
+++ b/src/cpu/pred/tournament.hh
@@ -46,7 +46,7 @@
 
 #include "base/sat_counter.hh"
 #include "base/types.hh"
-#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/conditional.hh"
 #include "params/TournamentBP.hh"
 
 namespace gem5
@@ -63,7 +63,7 @@ namespace branch_prediction
  * predictor chooses between the two.  Both the global history register
  * and the selected local history are speculatively updated.
  */
-class TournamentBP : public BPredUnit
+class TournamentBP : public ConditionalPredictor
 {
   public:
     /**

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
@@ -90,16 +90,18 @@ class U74FUPool(MinorFUPool):
     ]
 
 
-class U74BP(TournamentBP):
+class U74BP(BranchPredictor):
+    conditionalBranchPred = TournamentBP(
+        localHistoryTableSize=4096,  # is 3.6 KiB but gem5 requires power of 2
+        localPredictorSize=16384,
+        globalPredictorSize=16384,
+        choicePredictorSize=16384,
+        localCtrBits=4,
+        globalCtrBits=4,
+        choiceCtrBits=4,
+    )
     btb = SimpleBTB(numEntries=32)
     ras = ReturnAddrStack(numEntries=12)
-    localHistoryTableSize = 4096  # is 3.6 KiB but gem5 requires power of 2
-    localPredictorSize = 16384
-    globalPredictorSize = 16384
-    choicePredictorSize = 16384
-    localCtrBits = 4
-    globalCtrBits = 4
-    choiceCtrBits = 4
     indirectBranchPred = SimpleIndirectPredictor()
     indirectBranchPred.indirectSets = 16
 


### PR DESCRIPTION
This pull request moves the conditional predictors out of the `bpred_unit.cc` class into a new `conditional.cc` subcomponent.

The aim is to more accurately reflect the relationship between the implemented conditional predictors (TAGE, etc..) and their superclass, and increase consistency with the other components (indirect.cc, btb.cc, etc..)

The existing implementations were adapted to inherit from ConditionalPredictor instead of BranchPredictor.

To configure a custom conditional branch predictor in custom configurations, it may be necessary to change code that looks like this:

```python
class BPTageSCL(TAGE_SC_L_64KB):
    indirectBranchPred = ITTAGE()
    # ... other attributes
```
to this style instead:

```python
class BPTageSCL(BranchPredictor):
    indirectBranchPred = ITTAGE()
    conditionalBranchPred = TAGE_SC_L_64KB()
    # ... other attributes
```