### PR TITLE
arch-vega: Improve MFMA precision to match MI300X hardware

### DIFF
--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -45412,8 +45412,9 @@ namespace VegaISA
                         int lane_A = i + M * (block + B * (k / K_L));
                         int lane_B = j + N * (block + B * (k / K_L));
                         int item = k % K_L;
-                        result[i][j] +=
-                          src0[item][lane_A] * src1[item][lane_B];
+                        result[i][j] =
+                            std::fma(src0[item][lane_A], src1[item][lane_B],
+                                     result[i][j]);
                     }
                 }
             }


### PR DESCRIPTION
When comparing the precision of CPU FMA and MI300X MFMA instructions, we found that gem5’s results had 3~4 more ulp errors than the hardware.Because showed that gem5’s MFMA used separate multiply and add steps,
leading to lower precision. Using std::fma() instead improved the precision to match real hardware.