### PR TITLE
python: Prevent SimObject from sharing reference of class member.

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -777,6 +777,9 @@ class SimObject(metaclass=MetaSimObject):
         self._hr_values = multidict(ancestor._hr_values)
         # clone SimObject-valued parameters
         for key, val in ancestor._values.items():
+            if val == []:
+                self._values[key] = type(val)()
+                continue
             val = tryAsSimObjectOrVector(val)
             if val is not None:
                 self._values[key] = val(_memo=memo_dict)


### PR DESCRIPTION
The SimObject clones a member if it is a SimObject or a vector
of SimObjects. However, if the member is an empty list. The
current implementation does not clone this member, causing the
instance sharing the reference of the class member.

It causes the following behavior:

a = Obj1()
a.foo.append(Obj2)

b = Obj1()
len(b.foo) == 1 # True

This commit handles the empty list case. Note that, it invoke
the value's constructor because the member could be a derived
class of a list (e.g. VectorParamValue).