### PR TITLE
misc: Update stats dump to have a optional message

### DIFF
--- a/src/base/stats/hdf5.cc
+++ b/src/base/stats/hdf5.cc
@@ -79,7 +79,7 @@ Hdf5::~Hdf5()
 }
 
 void
-Hdf5::begin(const std::string& message)
+Hdf5::begin(const std::string &message)
 {
     // HDF5 format ignores the message parameter
     // as it doesn't support text messages

--- a/src/base/stats/hdf5.cc
+++ b/src/base/stats/hdf5.cc
@@ -78,7 +78,6 @@ Hdf5::~Hdf5()
 {
 }
 
-
 void
 Hdf5::begin(const std::string& message)
 {

--- a/src/base/stats/hdf5.cc
+++ b/src/base/stats/hdf5.cc
@@ -80,8 +80,10 @@ Hdf5::~Hdf5()
 
 
 void
-Hdf5::begin()
+Hdf5::begin(const std::string& message)
 {
+    // HDF5 format ignores the message parameter
+    // as it doesn't support text messages
     h5File = H5::H5File(fname,
                         // Truncate the file if this is the first dump
                         dumpCount > 0 ? H5F_ACC_RDWR : H5F_ACC_TRUNC);

--- a/src/base/stats/hdf5.hh
+++ b/src/base/stats/hdf5.hh
@@ -67,7 +67,7 @@ class Hdf5 : public Output
     Hdf5(const Hdf5 &other) = delete;
 
   public: // Output interface
-    void begin() override;
+    void begin(const std::string& message = "") override;
     void end() override;
     bool valid() const override;
 

--- a/src/base/stats/hdf5.hh
+++ b/src/base/stats/hdf5.hh
@@ -67,7 +67,7 @@ class Hdf5 : public Output
     Hdf5(const Hdf5 &other) = delete;
 
   public: // Output interface
-    void begin(const std::string& message) override;
+    void begin(const std::string &message) override;
     void end() override;
     bool valid() const override;
 

--- a/src/base/stats/hdf5.hh
+++ b/src/base/stats/hdf5.hh
@@ -67,7 +67,7 @@ class Hdf5 : public Output
     Hdf5(const Hdf5 &other) = delete;
 
   public: // Output interface
-    void begin(const std::string& message = "") override;
+    void begin(const std::string& message) override;
     void end() override;
     bool valid() const override;
 

--- a/src/base/stats/output.hh
+++ b/src/base/stats/output.hh
@@ -65,7 +65,7 @@ struct Output
 {
     virtual ~Output() {}
 
-    virtual void begin(const std::string& message) = 0;
+    virtual void begin(const std::string &message) = 0;
     virtual void end() = 0;
     virtual bool valid() const = 0;
 

--- a/src/base/stats/output.hh
+++ b/src/base/stats/output.hh
@@ -72,8 +72,6 @@ struct Output
     virtual void beginGroup(const char *name) = 0;
     virtual void endGroup() = 0;
 
-    virtual void printResetMessage(const std::string& message = "") {};
-
     virtual void visit(const ScalarInfo &info) = 0;
     virtual void visit(const VectorInfo &info) = 0;
     virtual void visit(const DistInfo &info) = 0;

--- a/src/base/stats/output.hh
+++ b/src/base/stats/output.hh
@@ -65,12 +65,14 @@ struct Output
 {
     virtual ~Output() {}
 
-    virtual void begin() = 0;
+    virtual void begin(const std::string& message = "") = 0;
     virtual void end() = 0;
     virtual bool valid() const = 0;
 
     virtual void beginGroup(const char *name) = 0;
     virtual void endGroup() = 0;
+
+    virtual void printResetMessage(const std::string& message = "") {};
 
     virtual void visit(const ScalarInfo &info) = 0;
     virtual void visit(const VectorInfo &info) = 0;

--- a/src/base/stats/output.hh
+++ b/src/base/stats/output.hh
@@ -65,7 +65,7 @@ struct Output
 {
     virtual ~Output() {}
 
-    virtual void begin(const std::string& message = "") = 0;
+    virtual void begin(const std::string& message) = 0;
     virtual void end() = 0;
     virtual bool valid() const = 0;
 

--- a/src/base/stats/text.cc
+++ b/src/base/stats/text.cc
@@ -130,16 +130,12 @@ void
 Text::begin(const std::string& message)
 {
     if (message.empty()) {
-        ccprintf(
-            *stream,
-            "\n---------- Begin Simulation Statistics ----------\n"
-        );
+        ccprintf(*stream,
+                 "\n---------- Begin Simulation Statistics ----------\n");
     } else {
-        ccprintf(
-            *stream,
-            "\n---------- Begin Simulation Statistics : %s ----------\n",
-            message
-        );
+        ccprintf(*stream,
+                 "\n---------- Begin Simulation Statistics : %s ----------\n",
+                 message);
     }
 }
 

--- a/src/base/stats/text.cc
+++ b/src/base/stats/text.cc
@@ -127,7 +127,7 @@ Text::valid() const
 }
 
 void
-Text::begin(const std::string& message)
+Text::begin(const std::string &message)
 {
     if (message.empty()) {
         ccprintf(*stream,

--- a/src/base/stats/text.cc
+++ b/src/base/stats/text.cc
@@ -150,14 +150,6 @@ Text::end()
     stream->flush();
 }
 
-void
-Text::printResetMessage(const std::string& message)
-{
-    if (!message.empty()) {
-        ccprintf(*stream, "Resetting stats: %s\n", message);
-    }
-}
-
 std::string
 Text::statName(const std::string &name) const
 {

--- a/src/base/stats/text.cc
+++ b/src/base/stats/text.cc
@@ -127,9 +127,20 @@ Text::valid() const
 }
 
 void
-Text::begin()
+Text::begin(const std::string& message)
 {
-    ccprintf(*stream, "\n---------- Begin Simulation Statistics ----------\n");
+    if (message.empty()) {
+        ccprintf(
+            *stream,
+            "\n---------- Begin Simulation Statistics ----------\n"
+        );
+    } else {
+        ccprintf(
+            *stream,
+            "\n---------- Begin Simulation Statistics : %s ----------\n",
+            message
+        );
+    }
 }
 
 void
@@ -137,6 +148,14 @@ Text::end()
 {
     ccprintf(*stream, "\n---------- End Simulation Statistics   ----------\n");
     stream->flush();
+}
+
+void
+Text::printResetMessage(const std::string& message)
+{
+    if (!message.empty()) {
+        ccprintf(*stream, "Resetting stats: %s\n", message);
+    }
 }
 
 std::string

--- a/src/base/stats/text.hh
+++ b/src/base/stats/text.hh
@@ -100,7 +100,6 @@ class Text : public Output
     bool valid() const override;
     void begin(const std::string& message) override;
     void end() override;
-    void printResetMessage(const std::string& message = "") override;
 };
 
 std::string ValueToString(Result value, int precision);

--- a/src/base/stats/text.hh
+++ b/src/base/stats/text.hh
@@ -98,8 +98,9 @@ class Text : public Output
 
     // Implement Output
     bool valid() const override;
-    void begin() override;
+    void begin(const std::string& message = "") override;
     void end() override;
+    void printResetMessage(const std::string& message = "") override;
 };
 
 std::string ValueToString(Result value, int precision);

--- a/src/base/stats/text.hh
+++ b/src/base/stats/text.hh
@@ -98,7 +98,7 @@ class Text : public Output
 
     // Implement Output
     bool valid() const override;
-    void begin(const std::string& message = "") override;
+    void begin(const std::string& message) override;
     void end() override;
     void printResetMessage(const std::string& message = "") override;
 };

--- a/src/base/stats/text.hh
+++ b/src/base/stats/text.hh
@@ -98,7 +98,7 @@ class Text : public Output
 
     // Implement Output
     bool valid() const override;
-    void begin(const std::string& message) override;
+    void begin(const std::string &message) override;
     void end() override;
 };
 

--- a/src/python/m5/stats/__init__.py
+++ b/src/python/m5/stats/__init__.py
@@ -388,8 +388,13 @@ lastDump = 0
 global_dump_roots = []
 
 
-def dump(roots=None):
-    """Dump all statistics data to the registered outputs"""
+def dump(roots=None, message=""):
+    """Dump all statistics data to the registered outputs
+
+    Args:
+        roots: Optional list of roots to dump
+        message: Optional message to include in text output headers
+    """
 
     all_roots = []
     if roots is not None:
@@ -425,13 +430,21 @@ def dump(roots=None):
                 output.dump(all_roots)
         else:
             if output.valid():
-                output.begin()
+                output.begin(message)
                 _dump_to_visitor(output, roots=all_roots)
                 output.end()
 
 
-def reset():
-    """Reset all statistics to the base state"""
+def reset(message=""):
+    """Reset all statistics to the base state
+
+    Args:
+        message: Optional message to output when resetting stats
+    """
+
+    for output in outputList:
+        if not isinstance(output, JsonOutputVistor):
+            output.printResetMessage(message)
 
     # call reset stats on all SimObjects
     root = Root.getInstance()

--- a/src/python/m5/stats/__init__.py
+++ b/src/python/m5/stats/__init__.py
@@ -435,16 +435,8 @@ def dump(roots=None, message=""):
                 output.end()
 
 
-def reset(message=""):
-    """Reset all statistics to the base state
-
-    Args:
-        message: Optional message to output when resetting stats
-    """
-
-    for output in outputList:
-        if not isinstance(output, JsonOutputVistor):
-            output.printResetMessage(message)
+def reset():
+    """Reset all statistics to the base state"""
 
     # call reset stats on all SimObjects
     root = Root.getInstance()

--- a/src/python/pybind11/stats.cc
+++ b/src/python/pybind11/stats.cc
@@ -134,8 +134,6 @@ pybind_init_stats(py::module_ &m_native)
         .def("valid", &statistics::Output::valid)
         .def("beginGroup", &statistics::Output::beginGroup)
         .def("endGroup", &statistics::Output::endGroup)
-        .def("printResetMessage",
-        &statistics::Output::printResetMessage, py::arg("message") = "")
         ;
 
     py::class_<statistics::Info,

--- a/src/python/pybind11/stats.cc
+++ b/src/python/pybind11/stats.cc
@@ -133,7 +133,8 @@ pybind_init_stats(py::module_ &m_native)
         .def("end", &statistics::Output::end)
         .def("valid", &statistics::Output::valid)
         .def("beginGroup", &statistics::Output::beginGroup)
-        .def("endGroup", &statistics::Output::endGroup);
+        .def("endGroup", &statistics::Output::endGroup)
+        ;
 
     py::class_<statistics::Info,
         std::unique_ptr<statistics::Info, py::nodelete>>(m, "Info")

--- a/src/python/pybind11/stats.cc
+++ b/src/python/pybind11/stats.cc
@@ -129,12 +129,11 @@ pybind_init_stats(py::module_ &m_native)
         ;
 
     py::class_<statistics::Output>(m, "Output")
-        .def("begin", &statistics::Output::begin, py::arg("message"))
+        .def("begin", &statistics::Output::begin)
         .def("end", &statistics::Output::end)
         .def("valid", &statistics::Output::valid)
         .def("beginGroup", &statistics::Output::beginGroup)
-        .def("endGroup", &statistics::Output::endGroup)
-        ;
+        .def("endGroup", &statistics::Output::endGroup);
 
     py::class_<statistics::Info,
         std::unique_ptr<statistics::Info, py::nodelete>>(m, "Info")

--- a/src/python/pybind11/stats.cc
+++ b/src/python/pybind11/stats.cc
@@ -129,11 +129,13 @@ pybind_init_stats(py::module_ &m_native)
         ;
 
     py::class_<statistics::Output>(m, "Output")
-        .def("begin", &statistics::Output::begin)
+        .def("begin", &statistics::Output::begin, py::arg("message") = "")
         .def("end", &statistics::Output::end)
         .def("valid", &statistics::Output::valid)
         .def("beginGroup", &statistics::Output::beginGroup)
         .def("endGroup", &statistics::Output::endGroup)
+        .def("printResetMessage",
+        &statistics::Output::printResetMessage, py::arg("message") = "")
         ;
 
     py::class_<statistics::Info,

--- a/src/python/pybind11/stats.cc
+++ b/src/python/pybind11/stats.cc
@@ -129,7 +129,7 @@ pybind_init_stats(py::module_ &m_native)
         ;
 
     py::class_<statistics::Output>(m, "Output")
-        .def("begin", &statistics::Output::begin, py::arg("message") = "")
+        .def("begin", &statistics::Output::begin, py::arg("message"))
         .def("end", &statistics::Output::end)
         .def("valid", &statistics::Output::valid)
         .def("beginGroup", &statistics::Output::beginGroup)


### PR DESCRIPTION
In the current implementation, we call `stats.dump` as `m5.stats.dump()` and this call generated a stats.txt file that starts as the following:

```
---------- Begin Simulation Statistics ----------
simSeconds                                   9.915965                       # Number of seconds simulated (Second)
simTicks                                 9915965318458                       # Number of ticks simulated (Tick)
```

With this change the function call would look like `m5.stats.dump(message = "Dumping stats at end of ROI")` and the stats.txt output would then start with

```
---------- Begin Simulation Statistics : Dumping stats at end of ROI ----------
simSeconds                                   9.915965                       # Number of seconds simulated (Second)
simTicks                                 9915965318458                       # Number of ticks simulated (Tick)
```