### PR TITLE
arch-arm: Fix inverted RAO check of HCPTR.TCP10

### DIFF
--- a/src/arch/arm/insts/static_inst.cc
+++ b/src/arch/arm/insts/static_inst.cc
@@ -752,17 +752,17 @@ ArmStaticInst::checkAdvSIMDOrFPEnabled32(ThreadContext *tc,
 
     if (have_virtualization && !is_secure) {
         HCPTR hcptr = tc->readMiscReg(MISCREG_HCPTR);
-        bool hcptr_cp10 = hcptr.tcp10;
+        bool hcptr_tcp10 = hcptr.tcp10;
         bool hcptr_tase = hcptr.tase;
 
         if (have_security && !ELIs64(tc, EL3) && !is_secure) {
             if (nsacr.nsasedis)
                 hcptr_tase = true;
-            if (nsacr.cp10)
-                hcptr_cp10 = true;
+            if (!nsacr.cp10)
+                hcptr_tcp10 = true;
         }
 
-        if ((advsimd && hcptr_tase) || hcptr_cp10) {
+        if ((advsimd && hcptr_tase) || hcptr_tcp10) {
             const uint32_t iss = advsimd ? (1 << 5) : 0xA;
             if (cur_el == EL2) {
                 return std::make_shared<UndefinedInstruction>(


### PR DESCRIPTION
The documentation states this field is read-only ones if NSACR.CP10 is set to zero, not when it is set to 1. This logic error probably happened because The values of the CP10 fields in these registers are inverted: NSACR.CP10=1 means "Advanced SIMD and floating-point features can be accessed from both Security states." whereas HCPTR.TCP10=1 means "Any attempted access to Advanced SIMD and floating-point functionality from Non-secure state is trapped to Hyp mode"