### PR TITLE
Improve SystemC stability

### DIFF
--- a/src/systemc/core/event.hh
+++ b/src/systemc/core/event.hh
@@ -161,7 +161,7 @@ class Event
 extern Events topLevelEvents;
 extern Events allEvents;
 
-EventsIt findEvent(const std::string &name);
+sc_core::sc_event *findEvent(const char *name);
 
 } // namespace sc_gem5
 

--- a/src/systemc/core/object.cc
+++ b/src/systemc/core/object.cc
@@ -81,7 +81,12 @@ nameIsUnique(Objects *objects, Events *events, const std::string &name)
     return true;
 }
 
+std::stack<sc_core::sc_object *> objParentStack;
+
 } // anonymous namespace
+
+Objects topLevelObjects;
+Objects allObjects;
 
 Object::Object(sc_core::sc_object *_sc_obj) : Object(_sc_obj, nullptr) {}
 
@@ -282,10 +287,6 @@ pickUniqueName(::sc_core::sc_object *parent, std::string base)
     return base;
 }
 
-
-Objects topLevelObjects;
-Objects allObjects;
-
 const std::vector<sc_core::sc_object *> &
 getTopLevelScObjects()
 {
@@ -293,18 +294,11 @@ getTopLevelScObjects()
 }
 
 sc_core::sc_object *
-findObject(const char *name, const Objects &objects)
+findObject(const char *name)
 {
     ObjectsIt it = findObjectIn(allObjects, name);
     return it == allObjects.end() ? nullptr : *it;
 }
-
-namespace
-{
-
-std::stack<sc_core::sc_object *> objParentStack;
-
-} // anonymous namespace
 
 sc_core::sc_object *
 pickParentObj()

--- a/src/systemc/core/object.hh
+++ b/src/systemc/core/object.hh
@@ -28,6 +28,7 @@
 #ifndef __SYSTEMC_CORE_OBJECT_HH__
 #define __SYSTEMC_CORE_OBJECT_HH__
 
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -98,6 +99,7 @@ class Object
 
     Objects children;
     Events events;
+    std::shared_mutex _lock;
     sc_core::sc_object *parent;
 
     sc_core::sc_attr_cltn cltn;

--- a/src/systemc/core/object.hh
+++ b/src/systemc/core/object.hh
@@ -108,8 +108,7 @@ std::string pickUniqueName(::sc_core::sc_object *parent, std::string name);
 extern Objects topLevelObjects;
 extern Objects allObjects;
 
-sc_core::sc_object *findObject(
-        const char *name, const Objects &objects=topLevelObjects);
+sc_core::sc_object *findObject(const char *name);
 
 sc_core::sc_object *pickParentObj();
 void pushParentObj(sc_core::sc_object *obj);

--- a/src/systemc/core/sc_event.cc
+++ b/src/systemc/core/sc_event.cc
@@ -408,9 +408,7 @@ sc_get_top_level_events()
 sc_event *
 sc_find_event(const char *name)
 {
-    std::string str(name);
-    ::sc_gem5::EventsIt it = ::sc_gem5::findEvent(str);
-    return it == ::sc_gem5::allEvents.end() ? nullptr : *it;
+    return ::sc_gem5::findEvent(name);
 }
 
 } // namespace sc_core

--- a/src/systemc/core/sc_module.cc
+++ b/src/systemc/core/sc_module.cc
@@ -838,8 +838,7 @@ sc_gen_unique_name(const char *seed)
 bool
 sc_hierarchical_name_exists(const char *name)
 {
-    return sc_gem5::findEvent(name) != sc_gem5::allEvents.end() ||
-        ::sc_gem5::findObject(name, sc_gem5::allObjects);
+    return sc_gem5::findEvent(name) || ::sc_gem5::findObject(name);
 }
 
 bool

--- a/src/systemc/core/sc_object.cc
+++ b/src/systemc/core/sc_object.cc
@@ -123,19 +123,18 @@ sc_object::simcontext() const
     return _gem5_object->simcontext();
 }
 
-sc_object::sc_object()
+sc_object::sc_object() : _gem5_object(new sc_gem5::Object(this))
 {
-    _gem5_object = new sc_gem5::Object(this);
 }
 
 sc_object::sc_object(const char *name)
+  : _gem5_object(new sc_gem5::Object(this, name))
 {
-    _gem5_object = new sc_gem5::Object(this, name);
 }
 
 sc_object::sc_object(const sc_object &other)
+  : _gem5_object(new sc_gem5::Object(this, *other._gem5_object))
 {
-    _gem5_object = new sc_gem5::Object(this, *other._gem5_object);
 }
 
 sc_object &

--- a/src/systemc/core/sc_object.cc
+++ b/src/systemc/core/sc_object.cc
@@ -33,13 +33,6 @@
 namespace sc_core
 {
 
-namespace
-{
-
-std::vector<sc_object *> top_level_objects;
-
-} // anonymous namespace
-
 const char *
 sc_object::name() const
 {

--- a/src/systemc/tests/SConscript
+++ b/src/systemc/tests/SConscript
@@ -60,7 +60,7 @@ if env['CONF']['USE_SYSTEMC'] and GetOption('with_systemc_tests'):
                 'deps' : self.deps
             }
 
-    test_dir = Dir('.')
+    test_dir = Dir('#/src/systemc/tests')
     class SystemCTestBin(Executable):
         def __init__(self, test):
             all_sources = test.sources + [with_tag('main')]


### PR DESCRIPTION
This PR includes several fixes for SystemC stability and small clean ups.
1. Fix potential sc_object initialization issue
2. Make the sc_object and sc_event thread-safe