### PR TITLE
misc: Use Right PointerAlignment in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -74,7 +74,7 @@ AlwaysBreakAfterDefinitionReturnType: All    # Unless it is a definition
 
 # Pointer/reference alignment
 DerivePointerAlignment: false
-PointerAlignment: Left                       # Foo* p (sec. Pointers)
+PointerAlignment: Right                      # Foo *p (sec. Pointers)
 
 # Decoration
 AlignConsecutiveDeclarations: false          # No aligned declarations


### PR DESCRIPTION
Initial revision of clang-format was using Left PointerAlignment which basically enforces the following:

void* ptr;

As can be seen in some core gem5 files [1][2][3] we do usually tend to use Right PointerAlignment which will transform the code above into

void *ptr;

[1]: https://github.com/gem5/gem5/blob/stable/src/sim/sim_object.hh
[2]: https://github.com/gem5/gem5/blob/stable/src/sim/syscall_emul.hh
[3]: https://github.com/gem5/gem5/blob/stable/src/sim/serialize.hh

Change-Id: I930fefa0f56a1544ebacc544a8e6b6899eaaa885