### PR TITLE
arch-arm, cpu, config: Implement Bfloat16 for Arm CPUs

### DIFF
--- a/configs/common/cores/arm/HPI.py
+++ b/configs/common/cores/arm/HPI.py
@@ -1413,6 +1413,7 @@ class HPI_FloatSimdFU(MinorFU):
             "FloatSqrt",
             "FloatMisc",
             "FloatMultAcc",
+            "Bf16Cvt",
             "SimdAdd",
             "SimdAddAcc",
             "SimdAlu",
@@ -1435,6 +1436,10 @@ class HPI_FloatSimdFU(MinorFU):
             "SimdFloatMultAcc",
             "SimdFloatMatMultAcc",
             "SimdFloatSqrt",
+            "SimdBf16Cvt",
+            "SimdBf16DotProd",
+            "SimdBf16MatMultAcc",
+            "SimdBf16MultAcc",
         ]
     )
 

--- a/configs/common/cores/arm/O3_ARM_v7a.py
+++ b/configs/common/cores/arm/O3_ARM_v7a.py
@@ -68,6 +68,10 @@ class O3_ARM_v7a_FP(FUDesc):
         OpDesc(opClass="SimdFloatMultAcc", opLat=5),
         OpDesc(opClass="SimdFloatMatMultAcc", opLat=5),
         OpDesc(opClass="SimdFloatSqrt", opLat=9),
+        OpDesc(opClass="SimdBf16Cvt", opLat=3),
+        OpDesc(opClass="SimdBf16DotProd", opLat=4),
+        OpDesc(opClass="SimdBf16MatMultAcc", opLat=5),
+        OpDesc(opClass="SimdBf16MultAcc", opLat=4),
         OpDesc(opClass="FloatAdd", opLat=5),
         OpDesc(opClass="FloatCmp", opLat=5),
         OpDesc(opClass="FloatCvt", opLat=5),
@@ -76,6 +80,7 @@ class O3_ARM_v7a_FP(FUDesc):
         OpDesc(opClass="FloatMult", opLat=4),
         OpDesc(opClass="FloatMultAcc", opLat=5),
         OpDesc(opClass="FloatMisc", opLat=3),
+        OpDesc(opClass="Bf16Cvt", opLat=3),
     ]
     count = 2
 

--- a/src/arch/arm/ArmSystem.py
+++ b/src/arch/arm/ArmSystem.py
@@ -88,6 +88,9 @@ class ArmExtension(ScopedEnum):
         "FEAT_I8MM",  # Optional in Armv8.2
         "FEAT_DOTPROD",  # Optional in Armv8.2
         "FEAT_FP16",
+        "FEAT_BF16",  # Optional in Armv8.2
+        "FEAT_AA32BF16",  # Optional in Armv8.2
+        "FEAT_EBF16",  # Optional in Armv8.2
         # Armv8.3
         "FEAT_FCMA",
         "FEAT_JSCVT",
@@ -248,6 +251,9 @@ class Armv82(Armv81):
         "FEAT_I8MM",
         "FEAT_DOTPROD",
         "FEAT_FP16",
+        "FEAT_BF16",
+        "FEAT_AA32BF16",
+        "FEAT_EBF16",
     ]
 
 

--- a/src/arch/arm/insts/fplib.hh
+++ b/src/arch/arm/insts/fplib.hh
@@ -456,11 +456,32 @@ uint32_t fplibDefaultNaN(FPCR fpcr);
 template <>
 uint64_t fplibDefaultNaN(FPCR fpcr);
 
+// Function for AArch32
 template <>
 uint16_t fplib32RSqrtStep(uint16_t op1, uint16_t op2, FPSCR &fpscr);
 template <>
 uint16_t fplib32RecipStep(uint16_t op1, uint16_t op2, FPSCR &fpscr);
 
+// Function for BF16
+uint16_t fplibBfAdd(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint16_t fplibBfMax(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint16_t fplibBfMaxNum(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint16_t fplibBfMin(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint16_t fplibBfMinNum(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint16_t fplibBfMul(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint32_t fplibBfMulH(uint16_t op1, uint16_t op2, FPSCR &fpscr);
+uint16_t fplibBfMulAdd(uint16_t addend, uint16_t op1, uint16_t op2,
+                       FPSCR &fpscr, FPCR fpcr);
+uint32_t fplibBfMulAddH(uint32_t addend, uint16_t op1, uint16_t op2,
+                        FPSCR &fpscr, FPCR fpcr);
+uint16_t fplibBfNeg(uint16_t op, FPCR fpcr);
+uint16_t fplibBfSub(uint16_t op1, uint16_t op2, FPSCR &fpscr, FPCR fpcr);
+uint32_t fplibAdd_Bf16(uint32_t op1, uint32_t op2, FPSCR &fpscr);
+uint16_t fplibConvertBF(uint32_t op, FPRounding rounding, FPSCR &fpscr,
+                        FPCR fpcr = 0);
+uint32_t fplibBfdotAdd(uint32_t addend, uint16_t op1_a, uint16_t op1_b,
+                       uint16_t op2_a, uint16_t op2_b,
+                       FPSCR &fpscr, FPCR fpcr);
 } // namespace ArmISA
 } // namespace gem5
 

--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -516,6 +516,9 @@ ISA::readMiscReg(RegIndex idx)
               fpcr.ah = 0;
               fpcr.fiz = 0;
           }
+          if (!release->has(ArmExtension::FEAT_EBF16)) {
+              fpcr.ebf = 0;
+          }
           return fpcr;
         }
       case MISCREG_FPSCR:
@@ -875,6 +878,9 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                     fpcr_val.nep = 0;
                     fpcr_val.ah = 0;
                     fpcr_val.fiz = 0;
+                }
+                if (!release->has(ArmExtension::FEAT_EBF16)) {
+                    fpcr_val.ebf = 0;
                 }
                 setMiscRegNoEffect(MISCREG_FPCR, fpcr_val);
             }

--- a/src/arch/arm/isa/decoder/arm.isa
+++ b/src/arch/arm/isa/decoder/arm.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2010-2013,2017-2018 ARM Limited
+// Copyright (c) 2010-2013,2017-2018,2024-2025 ARM Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -116,7 +116,7 @@ format DataOp {
     0x7: decode OPCODE_24 {
         0: decode OPCODE_4 {
             0: decode CPNUM {
-                0xa, 0xb: VfpData::vfpData();
+                0x9, 0xa, 0xb: VfpData::vfpData();
             } // CPNUM
             1: decode CPNUM { // 27-24=1110,4 ==1
                 0x1: Gem5Op::gem5op();

--- a/src/arch/arm/isa/decoder/thumb.isa
+++ b/src/arch/arm/isa/decoder/thumb.isa
@@ -78,7 +78,7 @@ decode BIGTHUMB {
             default: decode HTOPCODE_9_8 {
                 0x2: decode LTOPCODE_4 {
                     0x0: decode LTCOPROC {
-                        0xa, 0xb: VfpData::vfpData();
+                        0x9, 0xa, 0xb: VfpData::vfpData();
                         default: WarnUnimpl::cdp(); // cdp2
                     }
                     0x1: decode LTCOPROC {

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -3206,6 +3206,11 @@ namespace Aarch64
                 // FCVT Dd = convertFormat(Hn)
                 return new FcvtFpHFpD(machInst, rd, rn);
             break;
+          case 0x6:
+            if (type == 1)
+                // FCVT Hd = convertFormat(Sn)
+                return new FcvtFpSBf(machInst, rd, rn);
+            break;
           case 0x7:
             if (type == 0)
                 // FCVT Hd = convertFormat(Sn)

--- a/src/arch/arm/isa/formats/fp.isa
+++ b/src/arch/arm/isa/formats/fp.isa
@@ -405,15 +405,15 @@ let {{
                     // VCMLA
                     bool s = bits (machInst, 20);
                     if (s) {
-                      if (q)
-                          return new VcmlaQ<uint32_t>(machInst, vd, vn, vm);
-                      else
-                          return new VcmlaD<uint32_t>(machInst, vd, vn, vm);
+                        if (q)
+                            return new VcmlaQ<uint32_t>(machInst, vd, vn, vm);
+                        else
+                            return new VcmlaD<uint32_t>(machInst, vd, vn, vm);
                     } else {
-                      if (q)
-                          return new VcmlaQ<uint16_t>(machInst, vd, vn, vm);
-                      else
-                          return new VcmlaD<uint16_t>(machInst, vd, vn, vm);
+                        if (q)
+                            return new VcmlaQ<uint16_t>(machInst, vd, vn, vm);
+                        else
+                            return new VcmlaD<uint16_t>(machInst, vd, vn, vm);
                     }
                 }
               case 4: case 5:
@@ -438,6 +438,15 @@ let {{
             }
         } else if (bit_31_24 == 0xFC && bit_11_8 == 0xc) {
             switch (op1_op2) {
+              case 0:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    if (q)
+                        return new VmmlaBfQ<uint32_t>(machInst, vd, vn, vm);
+                    else
+                        return new Unknown64(machInst);
+                }
               case 2:
                 if (u) {
                     if (q)
@@ -464,6 +473,15 @@ let {{
             }
         } else if (bit_31_24 == 0xFC && bit_11_8 == 0xd) {
             switch (op1_op2) {
+              case 0:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    if (q)
+                        return new VdotBfQ<uint32_t>(machInst, vd, vn, vm);
+                    else
+                        return new VdotBfD<uint32_t>(machInst, vd, vn, vm);
+                }
               case 2:
                 if (u) {
                     if (q)
@@ -529,7 +547,6 @@ let {{
                 return new Unknown64(machInst);
             }
         } else if (bit_31_24 == 0xFE && bit_11_8 == 0x8) {
-            vm = (RegIndex)(2 * bits(machInst, 2, 0));
 
             if (u) {
                 if (op1_op2 == 0) {
@@ -603,6 +620,17 @@ let {{
             uint8_t index = bits(machInst, 5);
 
             switch (op1_op2) {
+              case 0:
+                if (u) {
+                    return new Unknown64(machInst);
+                } else {
+                    if (q)
+                        return new VdotElemBfQ<uint32_t>(
+                            machInst, vd, vn, vm, index);
+                    else
+                        return new VdotElemBfD<uint32_t>(
+                            machInst, vd, vn, vm, index);
+                }
               case 2:
                 if (u) {
                     if (q)
@@ -2524,6 +2552,10 @@ let {{
                     if (size != 1 || (vm % 2))
                         return new Unknown(machInst);
                     return new NVcvts2h<uint16_t>(machInst, vd, vm);
+                } else if (b == 0x19) {
+                    if (size != 1 || (vm % 2))
+                        return new Unknown(machInst);
+                    return new NVcvts2bf<uint16_t>(machInst, vd, vm);
                 } else if (b == 0x1c) {
                     if (size != 1 || (vd % 2))
                         return new Unknown(machInst);
@@ -3563,7 +3595,7 @@ let {{
         RegIndex vd;
         RegIndex vm;
         RegIndex vn;
-        if (single) {
+        if (size <= 2) {
             vd = (RegIndex)(bits(machInst, 22) |
                     (bits(machInst, 15, 12) << 1));
             vm = (RegIndex)(bits(machInst, 5) |
@@ -3787,15 +3819,35 @@ let {{
                     const bool top = bits(machInst, 7);
                     if (top) {
                         if (toHalf) {
-                            return new VcvtFpSFpHT(machInst, vd, vm);
+                            switch (size) {
+                              case 1:
+                                return new VcvtFpSBfT(machInst, vd, vm);
+                              default:
+                                return new VcvtFpSFpHT(machInst, vd, vm);
+                            }
                         } else {
-                            return new VcvtFpHTFpS(machInst, vd, vm);
+                            switch (size) {
+                              case 1:
+                                return new Unknown(machInst);
+                              default:
+                                return new VcvtFpHTFpS(machInst, vd, vm);
+                            }
                         }
                     } else {
                         if (toHalf) {
-                            return new VcvtFpSFpHB(machInst, vd, vm);
+                            switch (size) {
+                              case 1:
+                                return new VcvtFpSBfB(machInst, vd, vm);
+                              default:
+                                return new VcvtFpSFpHB(machInst, vd, vm);
+                            }
                         } else {
-                            return new VcvtFpHBFpS(machInst, vd, vm);
+                            switch (size) {
+                              case 1:
+                                return new Unknown(machInst);
+                              default:
+                                return new VcvtFpHBFpS(machInst, vd, vm);
+                            }
                         }
                     }
                 }

--- a/src/arch/arm/isa/formats/neon64.isa
+++ b/src/arch/arm/isa/formats/neon64.isa
@@ -767,7 +767,29 @@ namespace Aarch64
             } else
                 return decodeNeonUThreeFpReg<FcaddDX, FcaddQX>(
                                     q, size & 0x1, machInst, vd, vn, vm);
-
+          case 0x1d:
+            if (size == 0x1) {
+               if (q)
+                   return new BfmmlaQX<uint32_t>(machInst, vd, vn, vm);
+               else
+                   return new Unknown64(machInst);
+            } else {
+                return new Unknown64(machInst);
+            }
+          case 0x1f:
+            if (size == 0x1) {
+               if (q)
+                   return new BfdotQX<uint32_t>(machInst, vd, vn, vm);
+               else
+                   return new BfdotDX<uint32_t>(machInst, vd, vn, vm);
+            } else if (size == 0x3) {
+               if (q)
+                   return new BfmlaltQX<uint32_t>(machInst, vd, vn, vm);
+               else
+                   return new BfmlalbQX<uint32_t>(machInst, vd, vn, vm);
+            } else {
+                return new Unknown64(machInst);
+            }
           default:
             return new Unknown64(machInst);
         }
@@ -1048,18 +1070,28 @@ namespace Aarch64
             return decodeNeonSTwoMiscSReg<SqxtnX, Sqxtn2X>(
                 q, size, machInst, vd, vn);
           case 0x16:
-            if (size > 0x1)
-                return new Unknown64(machInst);
             if (q) {
-                if (size)
-                    return new Fcvtn2X<uint32_t>(machInst, vd, vn);
-                else
+                switch (size) {
+                  case 0:
                     return new Fcvtn2X<uint16_t>(machInst, vd, vn);
+                  case 1:
+                    return new Fcvtn2X<uint32_t>(machInst, vd, vn);
+                  case 2:
+                    return new Bfcvtn2X<uint16_t>(machInst, vd, vn);
+                  default:
+                    return new Unknown64(machInst);
+                }
             } else {
-                if (size)
-                    return new FcvtnX<uint32_t>(machInst, vd, vn);
-                else
+                switch (size) {
+                  case 0:
                     return new FcvtnX<uint16_t>(machInst, vd, vn);
+                  case 1:
+                    return new FcvtnX<uint32_t>(machInst, vd, vn);
+                  case 2:
+                    return new BfcvtnX<uint16_t>(machInst, vd, vn);
+                  default:
+                    return new Unknown64(machInst);
+                }
             }
           case 0x17:
             if (size > 0x1)
@@ -1696,6 +1728,7 @@ namespace Aarch64
                     q, size, machInst, vd, vn, vm_fp, index_fp);
             } else if (u && (size == 1 || size == 2)) {
                 // FCMLA by element
+                vm_fp = (M << 4 | vm_bf);
                 if (size == 0x2) {
                     index_fp = H;
                     if (q)
@@ -1728,6 +1761,7 @@ namespace Aarch64
           case 0x3:
             if (u && (size == 1 || size == 2)){
                 // FCMLA by element
+                vm_fp = (M << 4 | vm_bf);
                 if (size == 0x2) {
                     index_fp = H;
                     if (q)
@@ -1778,6 +1812,7 @@ namespace Aarch64
                     q, size, machInst, vd, vn, vm_fp, index_fp);
             } else if (u && (size == 1 || size == 2)) {
                 // FCMLA by element
+                vm_fp = (M << 4 | vm_bf);
                 if (size == 0x2) {
                     index_fp = H;
                     if (q)
@@ -1809,6 +1844,7 @@ namespace Aarch64
           case 0x7:
              if (u && (size == 1 || size == 2)){
                 // FCMLA by element
+                vm_fp = (M << 4 | vm_bf);
                 if (size == 0x2) {
                     index_fp = H;
                     if (q)
@@ -1946,7 +1982,13 @@ namespace Aarch64
                       }
                   case 0x1:
                        // Armv8.2-BF16 BFDOT(elem)
-                       return new Unknown64(machInst);
+                      if (q) {
+                          return new BfdotElemQX<uint32_t>(
+                                  machInst, vd, vn, vm_dp, index_dp);
+                      } else {
+                          return new BfdotElemDX<uint32_t>(
+                                  machInst, vd, vn, vm_dp, index_dp);
+                      }
                   case 0x2:
                       if (q) {
                           return new UsdotElemQX<int32_t>(
@@ -1956,6 +1998,15 @@ namespace Aarch64
                                   machInst, vd, vn, vm_dp, index_dp);
                       }
                   case 0x3:
+                      index_dp = (H << 2) | (L << 1) | M;
+                      vm_dp = (RegIndex)vm_bf;
+                      if (q) {
+                          return new BfmlaltElemQX<uint32_t>(
+                                  machInst, vd, vn, vm_dp, index_dp);
+                      } else {
+                          return new BfmlalbElemQX<uint32_t>(
+                                  machInst, vd, vn, vm_dp, index_dp);
+                      }
                   default:
                        // Armv8.2-BF16 BFMLALB(elem), BFMLALT(elem)
                        return new Unknown64(machInst);

--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -1324,6 +1324,41 @@ let {{
     decoder_output += FpRegRegOpConstructor.subst(vcvtFpSFpHBIop);
     exec_output += PredOpExecute.subst(vcvtFpSFpHBIop);
 
+    bf16_check = '''
+      RegVal isar6 = xc->tcBase()->readMiscReg(MISCREG_ID_ISAR6);
+      if (!(bits(isar6, 23, 20) >= 0x1))
+          return std::make_shared<UndefinedInstruction>(machInst, true);
+    '''
+    vcvtFpSBfTCode = vfpEnabledCheckCode + bf16_check + '''
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        uint32_t src_elem = fpToBits(FpOp1);
+        FpDest_uw = insertBits(FpDest_uw, 31, 16,
+                        fplibConvertBF(src_elem, FPCRRounding(fpscr), fpscr));
+        FpscrExc = fpscr;
+    '''
+    vcvtFpSBfTIop = ArmInstObjParams("vcvtt", "VcvtFpSBfT", "FpRegRegOp",
+                                      { "code": vcvtFpSBfTCode,
+                                        "predicate_test": predicateTest,
+                                        "op_class": "SimdBf16CvtOp" }, [])
+    header_output += FpRegRegOpDeclare.subst(vcvtFpSBfTIop);
+    decoder_output += FpRegRegOpConstructor.subst(vcvtFpSBfTIop);
+    exec_output += PredOpExecute.subst(vcvtFpSBfTIop);
+
+    vcvtFpSBfBCode = vfpEnabledCheckCode + bf16_check + '''
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        uint32_t src_elem = fpToBits(FpOp1);
+        FpDest_uw = insertBits(FpDest_uw, 15, 0,
+                        fplibConvertBF(src_elem, FPCRRounding(fpscr), fpscr));
+        FpscrExc = fpscr;
+    '''
+    vcvtFpSBfBIop = ArmInstObjParams("vcvtb", "VcvtFpSBfB", "FpRegRegOp",
+                                      { "code": vcvtFpSBfBCode,
+                                        "predicate_test": predicateTest,
+                                        "op_class": "SimdBf16CvtOp" }, [])
+    header_output += FpRegRegOpDeclare.subst(vcvtFpSBfBIop);
+    decoder_output += FpRegRegOpConstructor.subst(vcvtFpSBfBIop);
+    exec_output += PredOpExecute.subst(vcvtFpSBfBIop);
+
     vcmpSCode = vfpEnabledCheckCode + '''
         FPSCR fpscr = (FPSCR) FpscrExc;
         vfpFlushToZero(fpscr, FpDest, FpOp1);

--- a/src/arch/arm/isa/insts/fp64.isa
+++ b/src/arch/arm/isa/insts/fp64.isa
@@ -1,6 +1,6 @@
 // -*- mode:c++ -*-
 
-// Copyright (c) 2012-2013, 2016-2018, 2025 Arm Limited
+// Copyright (c) 2012-2013, 2016-2018, 2024-2025 ARM Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -853,6 +853,26 @@ let {{
         decoder_output += AA64FpRegRegOpConstructor.subst(fcvtFpFpHIop);
         exec_output    += BasicExecute.subst(fcvtFpFpHIop);
 
+    # single precision to Bf16 conversion
+    bfcvtcode = vfp64EnabledCheckCode + '''
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        uint32_t cOp1 = AA64FpOp1P0_uw;
+        AA64FpDestP0_uw = fplibConvertBF(cOp1, FPCRRounding(fpscr), fpscr);
+        AA64FpDestP1_uw = 0;
+        AA64FpDestP2_uw = 0;
+        AA64FpDestP3_uw = 0;
+        FpscrExc = fpscr;
+    '''
+
+    instName = "FcvtFpSBf"
+    bfcvtcodeIop = ArmInstObjParams("fcvt", instName, "FpRegRegOp",
+                                    { "code": bfcvtcode,
+                                        "op_class": "Bf16CvtOp" }, [])
+    bfcvtcodeIop.snippets["code"] += zeroSveVecRegUpperPartCode % \
+            "AA64FpDest"
+    header_output  += FpRegRegOpDeclare.subst(bfcvtcodeIop);
+    decoder_output += AA64FpRegRegOpConstructor.subst(bfcvtcodeIop);
+    exec_output    += BasicExecute.subst(bfcvtcodeIop);
 
     # Build the various versions of the floating point compare instructions
     def buildFCmpOp(isQuiet, bits, isImm):

--- a/src/arch/arm/isa/insts/neon.isa
+++ b/src/arch/arm/isa/insts/neon.isa
@@ -1973,9 +1973,10 @@ let {{
                           "class_name" : Name }
             exec_output += NeonExecDeclare.subst(substDict)
 
-    def twoRegNarrowMiscInst(name, Name, opClass, types, op, readDest=False):
+    def twoRegNarrowMiscInst(name, Name, opClass, types, op, readDest=False,
+                             extra_check=''):
         global header_output, exec_output
-        eWalkCode = simdEnabledCheckCode + '''
+        eWalkCode = simdEnabledCheckCode + extra_check + '''
         BigRegVect srcReg1;
         RegVect destReg;
         '''
@@ -3096,6 +3097,11 @@ let {{
     twoRegLongInst("vfmsl", "NVfmslElemQ", "SimdFloatMultAccOp", ("uint16_t",),
                      vfmslfpCode, True, extra_check=fhm_check)
 
+    bf16_check = '''
+      RegVal isar6 = xc->tcBase()->readMiscReg(MISCREG_ID_ISAR6);
+      if (!(bits(isar6, 23, 20) >= 0x1))
+          return std::make_shared<UndefinedInstruction>(machInst, true);
+    '''
     vfmabtElemBfCode = '''
         int sel = %(sel)s;
         int immsel = bits(machInst, 3);
@@ -3108,10 +3114,12 @@ let {{
 
         FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
     '''
-    twoEqualRegInst("vfmab", "VfmabElemQ", "SimdMultOp", ("uint32_t",), 4,
-        vfmabtElemBfCode % {"sel": "0"}, True)
-    twoEqualRegInst("vfmat", "VfmatElemQ", "SimdMultOp", ("uint32_t",), 4,
-        vfmabtElemBfCode % {"sel": "1"}, True)
+    twoEqualRegInst("vfmab", "VfmabElemQ", "SimdBf16MultAccOp",
+        ("uint32_t",), 4, vfmabtElemBfCode % {"sel": "0"},
+        True, extra=bf16_check)
+    twoEqualRegInst("vfmat", "VfmatElemQ", "SimdBf16MultAccOp",
+        ("uint32_t",), 4, vfmabtElemBfCode % {"sel": "1"},
+        True, extra=bf16_check)
 
     vfmabtBfCode = '''
         int sel = %(sel)s;
@@ -3124,10 +3132,10 @@ let {{
 
         FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
     '''
-    threeEqualRegInst("vfmab", "VfmabQ", "SimdMultOp", ("uint32_t",), 4,
-        vfmabtBfCode % {"sel": "0"}, True)
-    threeEqualRegInst("vfmat", "VfmatQ", "SimdMultOp", ("uint32_t",), 4,
-        vfmabtBfCode % {"sel": "1"}, True)
+    threeEqualRegInst("vfmab", "VfmabQ", "SimdBf16MultAccOp", ("uint32_t",), 4,
+        vfmabtBfCode % {"sel": "0"}, True, extra=bf16_check)
+    threeEqualRegInst("vfmat", "VfmatQ", "SimdBf16MultAccOp", ("uint32_t",), 4,
+        vfmabtBfCode % {"sel": "1"}, True, extra=bf16_check)
 
     vmlsfpCode = '''
         FPSCR fpscr = (FPSCR) FpscrExc;
@@ -3439,6 +3447,28 @@ let {{
     threeEqualRegInst("vusdot", "VusdotQ", "SimdMultOp", ("int32_t",), 4,
         vdotCode % {"src1_type": "uint8_t", "src2_type": "int8_t"}, True)
 
+    vdotBfCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+
+        uint32_t sum = 0;
+        for (int w = 0; w < 2; w ++) {
+            uint16_t src1_elem = (uint16_t)(srcElem1 >> (16 * w));
+            uint16_t src2_elem = (uint16_t)(srcElem2 >> (16 * w));
+            uint32_t product = fplibBfMulH(src1_elem, src2_elem, fpscr);
+            sum = !w ? product : fplibAdd_Bf16(sum, product, fpscr);
+        }
+        destElem = fplibAdd_Bf16(destElem, sum, fpscr);
+    '''
+    twoEqualRegInst("vdot.bf16", "VdotElemBfD", "SimdBf16DotProdOp",
+        ("uint32_t",), 2, vdotBfCode, True, extra=bf16_check)
+    twoEqualRegInst("vdot.bf16", "VdotElemBfQ", "SimdBf16DotProdOp",
+        ("uint32_t",), 4, vdotBfCode, True, extra=bf16_check)
+
+    threeEqualRegInst("vdot.bf16", "VdotBfD", "SimdBf16DotProdOp",
+        ("uint32_t",), 2, vdotBfCode, True, extra=bf16_check)
+    threeEqualRegInst("vdot.bf16", "VdotBfQ", "SimdBf16DotProdOp",
+        ("uint32_t",), 4, vdotBfCode, True, extra=bf16_check)
+
     vmmla8bCode = '''
         for (int i = 0; i < 2; i ++) {
             for (int j = 0; j < 2; j ++) {
@@ -3467,6 +3497,34 @@ let {{
     threeEqualRegInst("vusmmla", "VusmmlaQ", "SimdMultOp", ("int32_t",), 4,
         vmmla8bCode % {"src1_type": "uint8_t", "src2_type": "int8_t"},
         readDest=True, complex=True)
+
+    vmmlaBfCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+
+        for (int i = 0; i < 2; i ++) {
+            for (int j = 0; j < 2; j ++) {
+                uint32_t sum = letoh(destReg.elements[2 * i + j]);
+                for (int k = 0; k < 2; k ++) {
+                    uint32_t srcElem1 = letoh(srcReg1.elements[2 * i + k]);
+                    uint32_t srcElem2 = letoh(srcReg2.elements[2 * j + k]);
+
+                    uint16_t elt1_a = (uint16_t)(srcElem1 >> (16 * 0));
+                    uint16_t elt1_b = (uint16_t)(srcElem2 >> (16 * 0));
+                    uint16_t elt2_a = (uint16_t)(srcElem1 >> (16 * 1));
+                    uint16_t elt2_b = (uint16_t)(srcElem2 >> (16 * 1));
+
+                    uint32_t product = fplibAdd_Bf16(
+                        fplibBfMulH(elt1_a, elt1_b, fpscr),
+                        fplibBfMulH(elt2_a, elt2_b, fpscr), fpscr);
+                    sum = fplibAdd_Bf16(sum, product, fpscr);
+                }
+                destReg.elements[2 * i + j] = htole(sum);
+            }
+        }
+    '''
+    threeEqualRegInst("vmmla", "VmmlaBfQ", "SimdBf16MatMultAccOp",
+        ("uint32_t",), 4, vmmlaBfCode, readDest=True, complex=True,
+        extra=bf16_check)
 
     vshrCode = '''
         if (imm >= sizeof(srcElem1) * 8) {
@@ -3979,6 +4037,14 @@ let {{
         FpscrExc = fpscr;
     '''
     twoRegNarrowMiscInst("vcvt", "NVcvts2h", "SimdCvtOp", ("uint16_t",), vcvts2hCode)
+
+    vcvts2bfCode = '''
+        FPSCR fpscr = fpVASimdCvtFPSCRValue((FPSCR)FpscrExc);
+        destElem = fplibConvertBF(srcElem1, FPCRRounding(fpscr), fpscr);
+        FpscrExc = fpRestoreFPSCRValue(FpscrExc, fpscr);
+    '''
+    twoRegNarrowMiscInst("vcvt", "NVcvts2bf", "SimdCvtOp", ("uint16_t",),
+                         vcvts2bfCode, extra_check=bf16_check)
 
     vcvth2sCode = '''
         destElem = 0;

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -459,9 +459,10 @@ let {{
             exec_output += NeonXExecDeclare.subst(substDict)
 
     def twoRegNarrowInstX(name, Name, opClass, types, op, readDest=False,
-                          scalar=False, hi=False, hasImm=False, nepSrc=''):
+                          scalar=False, hi=False, hasImm=False,
+                          extra_check='', nepSrc=''):
         global header_output, exec_output
-        eWalkCode = simd64EnabledCheckCode + '''
+        eWalkCode = simd64EnabledCheckCode + extra_check + '''
         BigRegVect srcReg1;
         RegVect destReg;
         '''
@@ -3998,4 +3999,171 @@ let {{
             }
         header_output += '''
         };'''
+
+    bf16_check = '''
+      AA64ISAR1 isar1 = xc->tcBase()->readMiscReg(MISCREG_ID_AA64ISAR1_EL1);
+      if (!isar1.bf16)
+          return std::make_shared<UndefinedInstruction>(machInst, true);
+    '''
+    def bfDotInst(name, Name, opClass, rCount, byElem):
+        dotCode = bf16_check + '''
+        using Src1Element = uint16_t;
+        using Src2Element = uint16_t;
+
+        // Neon dot instructions always generate one output element
+        // from 4 pairs of source elements.
+        static_assert(sizeof(Element) == 2 * sizeof(Src1Element));
+        static_assert(sizeof(Element) == 2 * sizeof(Src2Element));
+
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        FPCR fpcr = (FPCR) Fpcr;
+
+        for (unsigned i = 0; i < eCount; ++i) {
+            Element src1ElemsPacked = letoh(srcReg1.elements[i]);
+            Element src2ElemsPacked = letoh(srcReg2.elements[%(src2Index)s]);
+
+            Src1Element *src1Elems =
+                reinterpret_cast<Src1Element*>(&src1ElemsPacked);
+            Src2Element *src2Elems =
+                reinterpret_cast<Src2Element*>(&src2ElemsPacked);
+
+            // Dot instructions accumulate into the dest reg
+            Element destElem = letoh(destReg.elements[i]);
+
+            destElem = fplibBfdotAdd(destElem,
+                                     src1Elems[0], src1Elems[1],
+                                     src2Elems[0], src2Elems[1], fpscr, fpcr);
+            destReg.elements[i] = htole(destElem);
+        }
+        ''' % dict(src2Index="imm" if byElem else "i")
+        threeEqualRegInstX(name, Name, opClass, ("uint32_t",), rCount,
+                           dotCode, readDest=True, byElem=byElem,
+                           complex=True)
+
+    # BFDOT (vector)
+    bfDotInst('bfdot', 'BfdotDX', 'SimdBf16DotProdOp', 2, False)
+    bfDotInst('bfdot', 'BfdotQX', 'SimdBf16DotProdOp', 4, False)
+    # BFDOT (element)
+    bfDotInst('bfdot', 'BfdotElemDX', 'SimdBf16DotProdOp', 2, True)
+    bfDotInst('bfdot', 'BfdotElemQX', 'SimdBf16DotProdOp', 4, True)
+
+    def bfMatMulInst(name, Name, opClass):
+        matMulCode = bf16_check + '''
+        using Src1Element = uint16_t;
+        using Src2Element = uint16_t;
+
+        // Neon MM instructions always generate four output elements
+        // from 16 pairs of source elements.
+        static_assert(sizeof(Element) == 2 * sizeof(Src1Element));
+        static_assert(sizeof(Element) == 2 * sizeof(Src2Element));
+
+        // Properties of the matrices
+        constexpr unsigned destMatSize = 2; // Dest Matrices are dim 2x2
+        constexpr unsigned K = 4;           // Src matrices are dim 2x4 & 4x2
+
+        constexpr unsigned eltsPerMatrix = destMatSize * destMatSize;
+
+        Element destMat[eltsPerMatrix] = {0};
+        for (unsigned j = 0; j < eltsPerMatrix; ++j) {
+            destMat[j] = letoh(destReg.elements[j]);
+        }
+
+        Element src1MatPacked[eltsPerMatrix] = {0};
+        Element src2MatPacked[eltsPerMatrix] = {0};
+        for (unsigned j = 0; j < eltsPerMatrix; ++j) {
+            src1MatPacked[j] = letoh(srcReg1.elements[j]);
+            src2MatPacked[j] = letoh(srcReg2.elements[j]);
+        }
+
+        Src1Element *src1Mat =
+            reinterpret_cast<Src1Element*>(&src1MatPacked);
+        Src2Element *src2Mat =
+            reinterpret_cast<Src2Element*>(&src2MatPacked);
+
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        FPCR fpcr = (FPCR) Fpcr;
+
+        unsigned destEltIdx = 0;
+        for (unsigned rowIdx = 0; rowIdx < destMatSize; ++rowIdx) {
+            for (unsigned colIdx = 0; colIdx < destMatSize; ++colIdx) {
+                Element destElem = destMat[destEltIdx];
+                for (unsigned k = 0; k < K / 2; ++k) {
+                    uint16_t elt1_a = src1Mat[4 * rowIdx + 2 * k + 0];
+                    uint16_t elt1_b = src1Mat[4 * rowIdx + 2 * k + 1];
+                    uint16_t elt2_a = src2Mat[4 * colIdx + 2 * k + 0];
+                    uint16_t elt2_b = src2Mat[4 * colIdx + 2 * k + 1];
+                    destElem = fplibBfdotAdd(destElem, elt1_a, elt1_b,
+                                             elt2_a, elt2_b, fpscr, fpcr);
+                }
+                destMat[destEltIdx++] = destElem;
+            }
+        }
+
+        for (unsigned j = 0; j < eltsPerMatrix; ++j) {
+            destReg.elements[j] = htole(destMat[j]);
+        }
+        '''
+        threeEqualRegInstX(name, Name, opClass, ("uint32_t",), 4,
+                           matMulCode, readDest=True, byElem=False,
+                           complex=True)
+
+    # BFMMLA
+    bfMatMulInst('bfmmla', 'BfmmlaQX', 'SimdBf16MatMultAccOp')
+
+    def bfmlalInst(name, Name, opClass, rCount, byElem, top):
+        mlalCode = bf16_check + '''
+        using Src1Element = uint16_t;
+        using Src2Element = uint16_t;
+
+        FPSCR fpscr = (FPSCR) FpscrExc;
+        FPCR fpcr = (FPCR)Fpcr;
+
+        for (unsigned i = 0; i < eCount; ++i) {
+            Element src1ElemsPacked = letoh(srcReg1.elements[i]);
+            Element src2ElemsPacked = letoh(srcReg2.elements[%(src2Index)s]);
+
+            Src1Element *src1Elems =
+                reinterpret_cast<Src1Element*>(&src1ElemsPacked);
+            Src2Element *src2Elems =
+                reinterpret_cast<Src2Element*>(&src2ElemsPacked);
+
+            // Mla instructions accumulate into the dest reg
+            Element destElem = letoh(destReg.elements[i]);
+
+            destElem = fplibBfMulAddH(
+                destElem, src1Elems[%(src1ElemIndex)s],
+                src2Elems[%(src2ElemIndex)s], fpscr, fpcr);
+            destReg.elements[i] = htole(destElem);
+        }
+
+        FpscrExc = fpscr;
+        ''' % dict(src2Index="imm / 2" if byElem else "i",
+            src1ElemIndex="1" if top else "0",
+            src2ElemIndex="imm % 2" if byElem else ("1" if top else "0"))
+        threeEqualRegInstX(name, Name, opClass, ("uint32_t",), 4,
+                           mlalCode, readDest=True, byElem=byElem,
+                           complex=True)
+
+    # BFMLALB (by element)
+    bfmlalInst("bfmlalb", "BfmlalbElemQX", "SimdBf16MultAccOp",
+                ("uint32_t",), True, False)
+    # BFMLALB (vector)
+    bfmlalInst("bfmlalb", "BfmlalbQX", "SimdBf16MultAccOp",
+                ("uint32_t",), False, False)
+    # BFMLALT (by element)
+    bfmlalInst("bfmlalt", "BfmlaltElemQX", "SimdBf16MultAccOp",
+                ("uint32_t",), True, True)
+    # BFMLALT (vector)
+    bfmlalInst("bfmlalt", "BfmlaltQX", "SimdBf16MultAccOp",
+                ("uint32_t",), False, True)
+
+    # BFCVTN, BFCVTN2
+    bfcvtnCode = fpOp % ("fplibConvertBF"
+                         "(srcElem1, FPCRRounding(fpscr), fpscr, fpcr)")
+    twoRegNarrowInstX("bfcvtn", "BfcvtnX", "SimdBf16CvtOp",
+                      ("uint16_t",), bfcvtnCode, extra_check=bf16_check)
+    twoRegNarrowInstX("bfcvtn", "Bfcvtn2X", "SimdBf16CvtOp",
+                      ("uint16_t",), bfcvtnCode, hi=True,
+                      extra_check=bf16_check)
+
 }};

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -3579,6 +3579,7 @@ ISA::initializeMiscRegMetadata()
         isar6.jscvt = release->has(ArmExtension::FEAT_JSCVT) ? 0x1 : 0x0;
         isar6.fhm = release->has(ArmExtension::FEAT_FP16) ? 0x1 :
                     (release->has(ArmExtension::FEAT_FHM) ? 0x1 : 0x0);
+        isar6.bf16 = release->has(ArmExtension::FEAT_AA32BF16) ? 0x1 : 0x0;
         return isar6;
       }())
       .allPrivileges().exceptUserMode().writes(0);
@@ -4989,6 +4990,8 @@ ISA::initializeMiscRegMetadata()
           isar1_el1.gpa = release->has(ArmExtension::FEAT_PAuth) ? 0x1 : 0x0;
           isar1_el1.frintts =
               release->has(ArmExtension::FEAT_FRINTTS) ? 0x1 : 0x0;
+          isar1_el1.bf16 = release->has(ArmExtension::FEAT_EBF16) ? 0x2 :
+                           (release->has(ArmExtension::FEAT_BF16) ? 0x1 : 0x0);
           return isar1_el1;
       }())
       .faultRead(EL0, faultIdst)
@@ -6724,6 +6727,8 @@ ISA::initializeMiscRegMetadata()
             zfr0_el1.f32mm = release->has(ArmExtension::FEAT_F32MM) ? 1 : 0;
             zfr0_el1.f64mm = release->has(ArmExtension::FEAT_F64MM) ? 1 : 0;
             zfr0_el1.i8mm = release->has(ArmExtension::FEAT_I8MM) ? 1 : 0;
+            zfr0_el1.bf16 = release->has(ArmExtension::FEAT_EBF16) ? 0x2 :
+                          (release->has(ArmExtension::FEAT_BF16) ? 0x1 : 0x0);
             return zfr0_el1;
         }())
         .faultRead(EL0, faultIdst)

--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -135,6 +135,7 @@ namespace ArmISA
     BitUnion64(AA64ISAR1)
         Bitfield<59, 56> xs;
         Bitfield<55, 52> i8mm;
+        Bitfield<47, 44> bf16;
         Bitfield<43, 40> specres;
         Bitfield<39, 36> sb;
         Bitfield<35, 32> frintts;

--- a/src/cpu/FuncUnit.py
+++ b/src/cpu/FuncUnit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010, 2017-2018, 2020, 2022 ARM Limited
+# Copyright (c) 2010, 2017-2018, 2020, 2022, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -119,6 +119,11 @@ class OpClass(Enum):
         "SimdExt",
         "SimdFloatExt",
         "SimdConfig",
+        "SimdBf16Cvt",
+        "SimdBf16DotProd",
+        "SimdBf16MatMultAcc",
+        "SimdBf16MultAcc",
+        "Bf16Cvt",
     ]
 
 

--- a/src/cpu/minor/BaseMinorCPU.py
+++ b/src/cpu/minor/BaseMinorCPU.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2014, 2017-2018 ARM Limited
+# Copyright (c) 2012-2014, 2017-2018, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -180,6 +180,7 @@ class MinorDefaultFloatSimdFU(MinorFU):
             "FloatMultAcc",
             "FloatDiv",
             "FloatSqrt",
+            "Bf16Cvt",
             "SimdAdd",
             "SimdAddAcc",
             "SimdAlu",
@@ -223,6 +224,10 @@ class MinorDefaultFloatSimdFU(MinorFU):
             "SimdFloatExt",
             "SimdFloatCvt",
             "SimdConfig",
+            "SimdBf16Cvt",
+            "SimdBf16DotProd",
+            "SimdBf16MatMultAcc",
+            "SimdBf16MultAcc",
         ]
     )
 

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010, 2017, 2020, 2024 Arm Limited
+# Copyright (c) 2010, 2017, 2020, 2024-2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -61,6 +61,7 @@ class FP_ALU(FUDesc):
         OpDesc(opClass="FloatAdd", opLat=2),
         OpDesc(opClass="FloatCmp", opLat=2),
         OpDesc(opClass="FloatCvt", opLat=2),
+        OpDesc(opClass="Bf16Cvt", opLat=2),
     ]
     count = 4
 
@@ -117,6 +118,10 @@ class SIMD_Unit(FUDesc):
         OpDesc(opClass="SimdSha256Hash2"),
         OpDesc(opClass="SimdShaSigma2"),
         OpDesc(opClass="SimdShaSigma3"),
+        OpDesc(opClass="SimdBf16Cvt"),
+        OpDesc(opClass="SimdBf16DotProd"),
+        OpDesc(opClass="SimdBf16MatMultAcc"),
+        OpDesc(opClass="SimdBf16MultAcc"),
     ]
     count = 4
 

--- a/src/cpu/op_class.hh
+++ b/src/cpu/op_class.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017-2018, 2020, 2022 ARM Limited
+ * Copyright (c) 2010, 2017-2018, 2020, 2022, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -138,6 +138,11 @@ static const OpClass SimdStrideSegmentedStoreOp
 static const OpClass SimdExtOp = enums::SimdExt;
 static const OpClass SimdFloatExtOp = enums::SimdFloatExt;
 static const OpClass SimdConfigOp = enums::SimdConfig;
+static const OpClass SimdBf16CvtOp = enums::SimdBf16Cvt;
+static const OpClass SimdBf16DotProdOp = enums::SimdBf16DotProd;
+static const OpClass SimdBf16MatMultAccOp = enums::SimdBf16MatMultAcc;
+static const OpClass SimdBf16MultAccOp = enums::SimdBf16MultAcc;
+static const OpClass Bf16CvtOp = enums::Bf16Cvt;
 static const OpClass Num_OpClasses = enums::Num_OpClass;
 
 } // namespace gem5


### PR DESCRIPTION
This PR addds BFloat16 support to the Arm ISA by implementing the following Arm features:

- FEAT_BF16
- FEAT_EBF16
- FEAT_AA32BF16

Additionally it defines some generic Bfloat16 OpClasses to be used in our cores.