### PR TITLE
arch-arm: fix writeback type for AArch32 FP16 instructions

### DIFF
--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -477,7 +477,7 @@ let {{
                       "operation triggers invalid implicit conversion");
         uint16_t half_dest1 = %(op1)s;
         uint16_t half_dest2 = %(op2)s;
-        FpDestP0 = (uint32_t)half_dest1 | ((uint32_t)half_dest2 << 16);
+        FpDestP0_uw = (uint32_t)half_dest1 | ((uint32_t)half_dest2 << 16);
         FpscrExc = fpscr;
     '''
 


### PR DESCRIPTION
Fixes warning: implicit conversion from 'uint32_t' (aka 'unsigned int') to 'float' may lose precision [-Wimplicit-int-float-conversion]

Change-Id: I605a2db2bf46e80b826a8c9e672e018109de478c