### PR TITLE
misc: split single line if statements and add braces in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,10 +63,15 @@ SpaceInEmptyParentheses: false               # No f( ) -> f() (sec. Spacing)
 SpacesInAngles: false                        # No < T > in templates
 
 # Single‐line constructs
-AllowShortIfStatementsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
 AllowShortBlocksOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: InlineOnly
+
+# Require curly braces after control statements (if, else, for, do, while)
+# unless inside macro definitions or if the braces would enclose preprocessor
+# directives
+InsertBraces: true
 
 # Return‐type / function‐name separation
 AlwaysBreakAfterReturnType: All              # Return on its own line (sec. Functions)


### PR DESCRIPTION
This commit modifies .clang-format to split single line if statements across multiple lines. It also modifies .clang-format to require curly braces around control statements (if, else, for, do, while) unless inside macro definitions or if braces would enclose preprocessor directives.

Before:

```cpp
if (true) std::cout << "Hello world!" << std::endl;
```

After:

```cpp
if (true) {
    std::cout << "Hello world!" << std::endl;
}
```