### PR TITLE
systemc: Fix a bug when length is 0 in get_direct_mem_ptr

### DIFF
--- a/src/systemc/tlm_bridge/tlm_to_gem5.cc
+++ b/src/systemc/tlm_bridge/tlm_to_gem5.cc
@@ -471,6 +471,15 @@ TlmToGem5Bridge<BITWIDTH>::get_direct_mem_ptr(tlm::tlm_generic_payload &trans,
     Addr start_addr = trans.get_address();
     Addr length = trans.get_data_length();
 
+    // The data_length field in trans is not a required field when doing
+    // get_direct_mem_ptr, so the size might be 0.
+    // However, if the length is 0, the created AddrRange in gem5 will have
+    // different meaning.
+    // To avoid the situation, set length to 1 if the original length is 0.
+    if (length == 0) {
+        length = 1;
+    }
+
     MemBackdoorReq req({start_addr, start_addr + length}, flags);
     MemBackdoorPtr backdoor = nullptr;
 


### PR DESCRIPTION
It's allowed to set data_length to tlm_generic_payload to 0 in get_direct_mem_ptr, since it's not a required field

However, if we use length 0 to create gem5::AddrRange, the meaning will be all address ranges (0 to 2^64 - 1).

This commit tries to fix this issue by setting the length to 1

Change-Id: I84b7088a55124d0bed3e6d28891a5c5300dc2f99