### PR TITLE
cpu: Workaround missing IsUnconditional flag

### DIFF
--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -145,7 +145,7 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
      * the direction is always taken
      */
 
-    if (inst->isUncondCtrl()) {
+    if (hist->uncond) {
         // Unconditional branches -----
         hist->condPred = true;
     } else {

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -292,7 +292,7 @@ class BPredUnit : public SimObject
                          const StaticInstPtr & inst)
             : seqNum(sn), tid(_tid), pc(_pc),
               inst(inst), type(getBranchType(inst)),
-              call(inst->isCall()), uncond(inst->isUncondCtrl()),
+              call(inst->isCall()), uncond(!inst->isCondCtrl()),
               predTaken(false), actuallyTaken(false), condPred(false),
               btbHit(false), targetProvider(TargetProvider::NoTarget),
               resteered(false), mispredict(false), target(nullptr),


### PR DESCRIPTION
Some branch instructions do not set the `IsUnconditional` flag appropriately
when setting flags like `IsCall` or `IsReturn`. For example `sret` or `mret` in
RISC-V but also some instructions in ARM.
This causes the branch predictor to incorrectly think its an conditional branch
while still doing the RAS access. (See #2463)
We assume now all instructions are unconditional except the `IsConditional`
flag is explicity set.

Fixes #2463