### PR TITLE
cpu-o3: remove inactive tail bytes from memory request

### DIFF
--- a/src/cpu/utils.hh
+++ b/src/cpu/utils.hh
@@ -94,6 +94,27 @@ isAnyActiveElement(const std::vector<bool>::const_iterator& it_start,
     return (it_tmp != it_end);
 }
 
+/**
+ * Get size of inactive tail in an enablement range (0 if none).
+ */
+inline unsigned
+inactiveTailSize(const std::vector<bool>::const_iterator& it_start,
+                 const std::vector<bool>::const_iterator& it_end)
+{
+    std::vector<bool>::const_reverse_iterator rit_start(it_end);
+    std::vector<bool>::const_reverse_iterator rit_end(it_start);
+
+    unsigned count = 0;
+    for (auto it = rit_start; it != rit_end; ++it) {
+        if (!(*it)) {
+            count++;
+        } else {
+            break;
+        }
+    }
+    return count;
+}
+
 } // namespace gem5
 
 #endif // __CPU_UTILS_HH__


### PR DESCRIPTION
Currently some LSQ request types in O3 like SplitDataRequest can have various block aligned (sub)requests for the full line size even though their enablement mask has an inactive (0'd) tail. This patch checks for this pattern to reduce the request size only to the first n contiguous (enabled or disabled) bytes until the last enabled one.