### PR TITLE
cpu: Adapt simpoint listener to new probe structure

### DIFF
--- a/src/cpu/simple/probes/simpoint.cc
+++ b/src/cpu/simple/probes/simpoint.cc
@@ -68,13 +68,13 @@ SimPoint::init()
 void
 SimPoint::regProbeListeners()
 {
-    typedef ProbeListenerArg<SimPoint, std::pair<SimpleThread*,StaticInstPtr>>
-        SimPointListener;
+    typedef ProbeListenerArg<SimPoint, std::pair<SimpleThread*,
+                             const StaticInstPtr>> SimPointListener;
     connectListener<SimPointListener>(this, "Commit", &SimPoint::profile);
 }
 
 void
-SimPoint::profile(const std::pair<SimpleThread*, StaticInstPtr>& p)
+SimPoint::profile(const std::pair<SimpleThread*, const StaticInstPtr>& p)
 {
     SimpleThread* thread = p.first;
     const StaticInstPtr &inst = p.second;

--- a/src/cpu/simple/probes/simpoint.hh
+++ b/src/cpu/simple/probes/simpoint.hh
@@ -94,7 +94,7 @@ class SimPoint : public ProbeListenerObject
      * Called at every macro inst to increment basic block inst counts and
      * to profile block if end of block.
      */
-    void profile(const std::pair<SimpleThread*, StaticInstPtr>&);
+    void profile(const std::pair<SimpleThread*, const StaticInstPtr>&);
 
   private:
     /** SimPoint profiling interval size in instructions */


### PR DESCRIPTION
The new probe structure expects ```const StaticInstPtr``` when
listening to the ```Commit``` probe point. Simpoints still used
the ```StaticInstPtr``` which causes a casting mismatch.

The same issue was raised for looppoint analysis in #2399