### PR TITLE
mem: refactor Bridge to allow derived class

### DIFF
--- a/src/mem/Bridge.py
+++ b/src/mem/Bridge.py
@@ -40,10 +40,11 @@ from m5.objects.ClockedObject import ClockedObject
 from m5.params import *
 
 
-class Bridge(ClockedObject):
-    type = "Bridge"
+class BridgeBase(ClockedObject):
+    type = "BridgeBase"
     cxx_header = "mem/bridge.hh"
-    cxx_class = "gem5::Bridge"
+    cxx_class = "gem5::BridgeBase"
+    abstract = True
 
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
@@ -61,6 +62,13 @@ class Bridge(ClockedObject):
     req_size = Param.Unsigned(16, "The number of requests to buffer")
     resp_size = Param.Unsigned(16, "The number of responses to buffer")
     delay = Param.Latency("0ns", "The latency of this bridge")
+
+
+class Bridge(BridgeBase):
+    type = "Bridge"
+    cxx_header = "mem/bridge.hh"
+    cxx_class = "gem5::Bridge"
+
     ranges = VectorParam.AddrRange(
         [AllMemory], "Address ranges to pass through the bridge"
     )

--- a/src/mem/SConscript
+++ b/src/mem/SConscript
@@ -45,7 +45,7 @@ Source('comm_monitor.cc')
 
 SimObject('AbstractMemory.py', sim_objects=['AbstractMemory'])
 SimObject('AddrMapper.py', sim_objects=['AddrMapper', 'RangeAddrMapper'])
-SimObject('Bridge.py', sim_objects=['Bridge'])
+SimObject('Bridge.py', sim_objects=['BridgeBase', 'Bridge'])
 SimObject('SysBridge.py', sim_objects=['SysBridge'])
 DebugFlag('SysBridge')
 SimObject('MemCtrl.py', sim_objects=['MemCtrl'],


### PR DESCRIPTION
This commit splits Bridge into BridgeBase and Bridge. BridgeBase contains the implementation to handle packets passing through a bridge, like Bridge before. But instead of relying on a fixed set of address ranges, it allows other class to derived from it to implement the functions getAddrRanges() and recvRangeChange() and so the set of address ranges can be either fixed or dynamic depending on the derived class implementation.

The functions canPassThrough() and setRejectedData() can also be implemented by derived classes, allowing to block some ranges and directly respond to them from the bridge. This is usefull to let a bridge respond with an error code when no device is responsible for a given range behind the bridge.

The *new* Bridge class is a simple class derived from BridgeBase with a fixed address ranges and, in the end, work like the current one.

This PR is the result of modification made base on this thread https://github.com/gem5/gem5/pull/2298#discussion_r2190569552 as bridge with dynamic ranges is needed for PCI implementation.

Made in collaboration with @marinazapater