### PR TITLE
cpu-o3: Bundle some RenameStats into a vector

### DIFF
--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 ARM Limited
+ * Copyright (c) 2012, 2017, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -103,7 +103,8 @@ class Rename
         Squashing,
         Blocked,
         Unblocking,
-        SerializeStall
+        SerializeStall,
+        ThreadStatusMax
     };
 
   private:
@@ -481,21 +482,13 @@ class Rename
 
     struct RenameStats : public statistics::Group
     {
+        static std::string statusStrings[ThreadStatusMax];
+        static std::string statusDefinitions[ThreadStatusMax];
+
         RenameStats(statistics::Group *parent);
 
-        /** Stat for total number of cycles spent squashing. */
-        statistics::Scalar squashCycles;
-        /** Stat for total number of cycles spent idle. */
-        statistics::Scalar idleCycles;
-        /** Stat for total number of cycles spent blocking. */
-        statistics::Scalar blockCycles;
-        /** Stat for total number of cycles spent stalling for a serializing
-         *  inst. */
-        statistics::Scalar serializeStallCycles;
-        /** Stat for total number of cycles spent running normally. */
-        statistics::Scalar runCycles;
-        /** Stat for total number of cycles spent unblocking. */
-        statistics::Scalar unblockCycles;
+        /** Stat for total number of cycles spent in each rename state */
+        statistics::Vector status;
         /** Stat for total number of renamed instructions. */
         statistics::Scalar renamedInsts;
         /** Stat for total number of squashed instructions that rename


### PR DESCRIPTION
This commit is bundling the following Scalar stats into a single vector stat:

* squashCycles = "Number of cycles rename is squashing"
* idleCycles = "Number of cycles rename is idle"
* blockCycles = "Number of cycles rename is blocking"
* serializeStallCycles = "Number of cycles rename stalled for serializing inst"
* runCycles = "Number of cycles rename is running"
* unblockCycles = "Number of cycles rename is unblocking"

There are two reasons behind this change:

1) More compact definition of the stats
2) Allowing vector level analysis:
At the moment the stats are unrelated to each other so it is not immediate to assess the cycle distribution among those. For example my stat file could end up looking like

rename.squashCycles = 235400
rename.idleCycles = 35404
rename.blockCycles = 2399
...

While I can infer from a qualitative point of view the rename stage is spending most of its time squashing, it is not immediate to extrapolate how much of the time compared to the overall number of cycles.

gem5 statistics::Vector supports this natively with the Stats::pdf flag.

So with the new Vector stat this will look like:

rename.status::Squashing = 235400, 75%
rename.status::Idle = 35404, 23%
rename.status::Blocking = 2399, 5%
...

So I know we are squashing 75% of our time.

Change-Id: I9ca58744093945966e96d18402bdb44986cf23d3