### PR TITLE
cpu-o3: properly index time buffer when clearing states

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -297,9 +297,10 @@ Commit::clearStates(ThreadID tid)
     squashAfterInst[tid] = NULL;
 
     // Clear out any of this thread's instructions being sent to prior stages.
-    for (int i = -cpu->timeBuffer.getPast();
-         i <= cpu->timeBuffer.getFuture(); ++i)
-        cpu->timeBuffer[i].commitInfo[i] = {};
+    for (int i = -cpu->timeBuffer.getPast(); i <= cpu->timeBuffer.getFuture();
+         ++i) {
+        cpu->timeBuffer[i].commitInfo[tid] = {};
+    }
 }
 
 void Commit::drain() { drainPending = true; }


### PR DESCRIPTION
Fix #2402.

Change-Id: I3b61919547fae21a9ed69d4a46e5a3903e41505c