### PR TITLE
sim, cpu: use hypercalls for Simulator.schedule_max_insts

### DIFF
--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -139,6 +139,10 @@ class BaseCPU(ClockedObject):
     max_insts_any_thread = Param.Counter(
         0, "terminate when any thread reaches this inst count"
     )
+    hypercall_num_max_inst_any_thread = Param.Counter(
+        0,
+        "Hypercall number of the hypercall to call upon exiting with `max_insts_any_thread` param",
+    )
     simpoint_start_insts = VectorParam.Counter(
         [], "starting instruction counts of simpoints"
     )

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -332,10 +332,8 @@ BaseCPU::init()
     // Set up instruction-count-based termination events, if any. This needs
     // to happen after threadContexts has been constructed.
     if (params().max_insts_any_thread != 0) {
-        scheduleInstStopAnyThread(
-            params().max_insts_any_thread,
-            params().hypercall_num_max_inst_any_thread
-        );
+        scheduleInstStopAnyThread(params().max_insts_any_thread,
+                                  params().hypercall_num_max_inst_any_thread);
     }
 
     // Set up instruction-count-based termination events for SimPoints
@@ -775,10 +773,10 @@ BaseCPU::unserialize(CheckpointIn &cp)
 
 void
 BaseCPU::scheduleInstStop(ThreadID tid, Counter insts, std::string cause,
-                        uint64_t hypercall_num)
+                          uint64_t hypercall_num)
 {
     const Tick now(getCurrentInstCount(tid));
-    Event* event(new LocalSimLoopExitEvent(cause, 0, 0, hypercall_num));
+    Event *event(new LocalSimLoopExitEvent(cause, 0, 0, hypercall_num));
 
     threadContexts[tid]->scheduleInstCountEvent(event, now + insts);
 }

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -774,7 +774,7 @@ void
 BaseCPU::scheduleInstStop(ThreadID tid, Counter insts, std::string cause)
 {
     const Tick now(getCurrentInstCount(tid));
-    Event *event(new LocalSimLoopExitEvent(cause, 0));
+    Event* event(new LocalSimLoopExitEvent(cause, 0, 0, 8));
 
     threadContexts[tid]->scheduleInstCountEvent(event, now + insts);
 }

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -332,7 +332,10 @@ BaseCPU::init()
     // Set up instruction-count-based termination events, if any. This needs
     // to happen after threadContexts has been constructed.
     if (params().max_insts_any_thread != 0) {
-        scheduleInstStopAnyThread(params().max_insts_any_thread);
+        scheduleInstStopAnyThread(
+            params().max_insts_any_thread,
+            params().hypercall_num_max_inst_any_thread
+        );
     }
 
     // Set up instruction-count-based termination events for SimPoints
@@ -771,10 +774,11 @@ BaseCPU::unserialize(CheckpointIn &cp)
 }
 
 void
-BaseCPU::scheduleInstStop(ThreadID tid, Counter insts, std::string cause)
+BaseCPU::scheduleInstStop(ThreadID tid, Counter insts, std::string cause,
+                        uint64_t hypercall_num)
 {
     const Tick now(getCurrentInstCount(tid));
-    Event* event(new LocalSimLoopExitEvent(cause, 0, 0, 8));
+    Event* event(new LocalSimLoopExitEvent(cause, 0, 0, hypercall_num));
 
     threadContexts[tid]->scheduleInstCountEvent(event, now + insts);
 }
@@ -847,11 +851,11 @@ BaseCPU::scheduleSimpointsInstStop(std::vector<Counter> inst_starts)
 }
 
 void
-BaseCPU::scheduleInstStopAnyThread(Counter max_insts)
+BaseCPU::scheduleInstStopAnyThread(Counter max_insts, uint64_t hypercall_num)
 {
     std::string cause = "a thread reached the max instruction count";
     for (ThreadID tid = 0; tid < numThreads; ++tid) {
-        scheduleInstStop(tid, max_insts, cause);
+        scheduleInstStop(tid, max_insts, cause, hypercall_num);
     }
 }
 

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -473,11 +473,16 @@ class BaseCPU : public ClockedObject
      * when the script wants to simulate for a specific number of
      * instructions rather than ticks.
      *
+     * The hypercall number is used to identify the exit event in
+     * the gem5 standard library.
+     *
      * @param tid Thread monitor.
      * @param insts Number of instructions into the future.
      * @param cause Cause to signal in the exit event.
+     * @param hypercall_num The hypercall number of the exit event.
      */
-    void scheduleInstStop(ThreadID tid, Counter insts, std::string cause);
+    void scheduleInstStop(ThreadID tid, Counter insts, std::string cause,
+                          uint64_t hypercall_num = 0);
 
     /**
      * Schedule simpoint events using the scheduleInstStop function.
@@ -491,14 +496,18 @@ class BaseCPU : public ClockedObject
     void scheduleSimpointsInstStop(std::vector<Counter> inst_starts);
 
     /**
-     * Schedule an exit event when any threads in the core reach the max_insts
+     * Schedule an exit event with the given hypercall number
+     * when any threads in the core reach the max_insts
      * instructions using the scheduleInstStop function.
      *
-     * This is used to raise a MAX_INSTS exit event in thegem5 standard library
+     * This is used to raise a MAX_INSTS exit event in
+     * the gem5 standard library
      *
      * @param max_insts Number of instructions into the future.
+     * @param hypercall_num The hypercall number of the exit event.
      */
-    void scheduleInstStopAnyThread(Counter max_insts);
+    void scheduleInstStopAnyThread(Counter max_insts,
+                                  uint64_t hypercall_num = 0);
 
     /**
      * Get the number of instructions executed by the specified thread

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -507,7 +507,7 @@ class BaseCPU : public ClockedObject
      * @param hypercall_num The hypercall number of the exit event.
      */
     void scheduleInstStopAnyThread(Counter max_insts,
-                                  uint64_t hypercall_num = 0);
+                                   uint64_t hypercall_num = 0);
 
     /**
      * Get the number of instructions executed by the specified thread

--- a/src/python/gem5/components/processors/abstract_core.py
+++ b/src/python/gem5/components/processors/abstract_core.py
@@ -167,7 +167,7 @@ class AbstractCore(SubSystem):
 
     @abstractmethod
     def _set_inst_stop_any_thread(
-        self, inst: int, board_initialized: bool
+        self, inst: int, board_initialized: bool, hypercall_num: int = 0
     ) -> None:
         """Schedule an exit event when any thread in this core reaches the
         given number of instructions. This is called through the simulator
@@ -180,6 +180,7 @@ class AbstractCore(SubSystem):
                                   initialized, otherwise ``False``. This parameter is
                                   necessary as the instruction stop is setup
                                   differently dependent on this.
+        :param hypercall_num: The hypercall number of the exit event.
         """
         raise NotImplementedError("This core type does not support MAX_INSTS")
 

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -175,12 +175,13 @@ class BaseCPUCore(AbstractCore):
 
     @overrides(AbstractCore)
     def _set_inst_stop_any_thread(
-        self, inst: int, board_initialized: bool
+        self, inst: int, board_initialized: bool, hypercall_num: int = 0
     ) -> None:
         if board_initialized:
-            self.core.scheduleInstStopAnyThread(inst)
+            self.core.scheduleInstStopAnyThread(inst, hypercall_num)
         else:
             self.core.max_insts_any_thread = inst
+            self.core.hypercall_num_max_inst_any_thread = hypercall_num
 
     @overrides(AbstractCore)
     def add_pc_tracker_probe(

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -318,6 +318,21 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
         return False
 
 
+class MaxInstsExitHandler(ExitHandler, hypercall_num=8):
+    @overrides(ExitHandler)
+    def get_handler_description(self):
+        return "Reached a maximum number of instructions, set through "
+        "Simulator.schedule_max_insts()."
+
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        pass
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return True
+
+
 class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
 
     def _get_status(self, simulator: "Simulator") -> Dict[str, str]:

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -355,8 +355,11 @@ class Simulator:
 
         :param insts: A number of instructions to run to.
         """
+        hypercall_num = 8  # MAX_INSTS
         for core in self._board.get_processor().get_cores():
-            core._set_inst_stop_any_thread(inst, self._instantiated)
+            core._set_inst_stop_any_thread(
+                inst, self._instantiated, hypercall_num
+            )
 
     def get_instruction_count(self) -> int:
         """

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -179,7 +179,8 @@ LocalSimLoopExitEvent::process()
     } else {
         std::map<std::string, std::string> payload = {
             {"justification", cause}};
-        exitSimLoopWithHypercall(cause, 0, curTick(), 0, payload, hypercall_id, false);
+        exitSimLoopWithHypercall(cause, 0, curTick(), 0, payload, hypercall_id,
+                                 false);
     }
 }
 

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -179,7 +179,7 @@ LocalSimLoopExitEvent::process()
     } else {
         std::map<std::string, std::string> payload = {
             {"justification", cause}};
-        exitSimLoopWithHypercall(cause, 0, curTick(), 0, payload, 8, false);
+        exitSimLoopWithHypercall(cause, 0, curTick(), 0, payload, hypercall_id, false);
     }
 }
 

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -158,13 +158,27 @@ LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
 {
 }
 
+LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string& _cause, int c,
+                                             Tick repeat,
+                                             uint64_t hypercall_id)
+    : Event(Sim_Exit_Pri, IsExitEvent), cause(_cause), code(c), repeat(repeat),
+      hypercall_id(hypercall_id)
+{
+}
+
 //
 // handle termination event
 //
 void
 LocalSimLoopExitEvent::process()
 {
-    exitSimLoop(cause, 0);
+    if (hypercall_id == 0) {
+        exitSimLoop(cause, 0);
+    } else {
+        std::map<std::string, std::string> payload = {
+            {"justification", cause}};
+        exitSimLoopWithHypercall(cause, 0, curTick(), 0, payload, 8, false);
+    }
 }
 
 

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -158,13 +158,15 @@ LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
 {
 }
 
-LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string& _cause, int c,
+LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
                                              Tick repeat,
                                              uint64_t hypercall_id)
-    : Event(Sim_Exit_Pri, IsExitEvent), cause(_cause), code(c), repeat(repeat),
+    : Event(Sim_Exit_Pri, IsExitEvent),
+      cause(_cause),
+      code(c),
+      repeat(repeat),
       hypercall_id(hypercall_id)
-{
-}
+{}
 
 //
 // handle termination event

--- a/src/sim/sim_events.hh
+++ b/src/sim/sim_events.hh
@@ -127,7 +127,7 @@ class LocalSimLoopExitEvent : public Event
     LocalSimLoopExitEvent(const std::string &_cause, int c, Tick repeat = 0);
 
     // The "new style" constructor for LocalSimLoopExitEvent, with hypercalls
-    LocalSimLoopExitEvent(const std::string& _cause, int c, Tick repeat = 0,
+    LocalSimLoopExitEvent(const std::string &_cause, int c, Tick repeat = 0,
                           uint64_t hypercall_id = 0);
 
     const std::string getCause() const { return cause; }

--- a/src/sim/sim_events.hh
+++ b/src/sim/sim_events.hh
@@ -119,10 +119,16 @@ class LocalSimLoopExitEvent : public Event
     std::string cause;
     int code;
     Tick repeat;
+    uint64_t hypercall_id = 0;
 
   public:
+    // The "old style" constructors for LocalSimLoopExitEvent
     LocalSimLoopExitEvent();
     LocalSimLoopExitEvent(const std::string &_cause, int c, Tick repeat = 0);
+
+    // The "new style" constructor for LocalSimLoopExitEvent, with hypercalls
+    LocalSimLoopExitEvent(const std::string& _cause, int c, Tick repeat = 0,
+                          uint64_t hypercall_id = 0);
 
     const std::string getCause() const { return cause; }
     int getCode() const { return code; }


### PR DESCRIPTION
This PR modifies Simulator.schedule_max_insts() to use hypercalls instead of classic exit events. The simulation will now handle reaching a maximum number of instructions using the hypercall 8 handler. Other types of exit events that use the same underlying C++ functions that schedule_max_insts() uses will continue to use classic exit events.