### PR TITLE
cpu: BTB update at squash/commit option

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -223,6 +223,13 @@ class BranchPredictor(SimObject):
         "This info is only available from the BTB. "
         "Low-end CPUs predecoding might be used to identify branches. ",
     )
+    updateBTBAtSquash = Param.Bool(
+        True,
+        "Update the BTB at squash time instead of commit. This can be useful "
+        "to update the BTB earlier to avoid BTB misses on subsequent "
+        "branches. However, it can also lead to BTB pollution if the branch "
+        "is on the false path and will be squashed later.",
+    )
 
     btb = Param.BranchTargetBuffer(SimpleBTB(), "Branch target buffer (BTB)")
     ras = Param.ReturnAddrStack(

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -400,7 +400,12 @@ class BPredUnit : public SimObject
      */
     void commitBranch(ThreadID tid, PredictorHistory* &bpu_history);
 
-
+    /**
+     *  Update the BTB with the correct target of a branch.
+     * @param tid The thread id.
+     * @param bpu_history The history of the branch to be updated.
+     */
+    void updateBTB(ThreadID tid, PredictorHistory *&bpu_history);
 
   protected:
     /** Number of the threads for which the branch history is maintained. */
@@ -413,6 +418,12 @@ class BPredUnit : public SimObject
      * This info is only available from the BTB.
      * Low-end CPUs predecoding might be used to identify branches. */
     const bool requiresBTBHit;
+
+    /** Update the BTB at squash time instead of commit. This can be useful
+     * to update the BTB earlier to avoid BTB misses on subsequent branches.
+     * However, it can also lead to BTB pollution if the branch is on the
+     * false path and will be squashed later. */
+    const bool updateBTBAtSquash;
 
     /** Number of bits to shift instructions by for predictor addresses. */
     const unsigned instShiftAmt;


### PR DESCRIPTION
Option to update the BTB at either squash or commit time. Updating at squash can be useful to update the BTB earlier and avoid BTB misses on subsequent branches.
However, it can also lead to BTB pollution if the branch is on the false path and will be squashed later. This config lets you explore the differences
Furthermore, the statistics and probe point for conditional branches was moved to commit.