### PR TITLE
misc: improvement to clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -51,10 +51,15 @@ AccessModifierOffset: -2                     # Outdent public/protected/private 
 # Brace placement rules
 BreakBeforeBraces: Custom
 BraceWrapping:
-    AfterFunction: true                      # Function/class braces on newline (sec. Braces)
+    AfterFunction: true                      # Function/object braces on newline (sec. Braces)
     AfterClass: true
+    AfterStruct: true
+    AfterUnion: true
+    AfterNamespace: true
     AfterControlStatement: false             # if/for braces same line (sec. Braces)
     BeforeElse: false                        # else on same line (sec. Braces)
+    SplitEmptyFunction: false                # empty function closing brace on same line
+                                             # as openning
 
 # Spacing rules
 SpaceBeforeParens: ControlStatements         # Space before if/for/while (...)
@@ -97,3 +102,7 @@ IncludeCategories:
       Priority: 4
     - Regex: ^".*\\.hh"$
       Priority: 5
+
+# Treat those macro as start and end of block so they are indented correctly.
+MacroBlockBegin: ^(BitUnion(8|16|32|64)|(Signed)?SubBitUnion)$
+MacroBlockEnd: ^(EndBitUnion|EndSubBitUnion)$


### PR DESCRIPTION
This commit makes clang-format break before open braces for struct, union and namespace, like it does for class.

Result in

```cpp
namespace gem5
{
```

instead of

```cpp
namespace gem5 {
```

It will also regroup open and close brace for empty function on a single line (meanly for constructor), which seems to be the more common way used accross the project.

Result in

```cpp
MyClass::MyClass()
{}
```

instead of

```cpp
MyClass::MyClass()
{
}
```

Finally, it defines the macros BitUnion and SubBitUnion as block begin/end so they are indented correctly.

Result in

```cpp
BitUnion8(Example)
    Bitfield<8> field1;
    Bitfield<7> field2;
    ...
EndBitUnion(Example)
```

instead of

```cpp
BitUnion8(Example) Bitfield<8> field1;
bitfield<7> field2;
...
EndBitUnion(Example)
```