### PR TITLE
cpu-o3: Mark some DynInst methods as const

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -518,7 +518,11 @@ class DynInst : public ExecContext, public RefCounted
     const PCStateBase &readPredTarg() { return *predPC; }
 
     /** Returns whether the instruction was predicted taken or not. */
-    bool readPredTaken() { return instFlags[PredTaken]; }
+    bool
+    readPredTaken() const
+    {
+        return instFlags[PredTaken];
+    }
 
     void
     setPredTaken(bool predicted_taken)
@@ -528,7 +532,7 @@ class DynInst : public ExecContext, public RefCounted
 
     /** Returns whether the instruction mispredicted. */
     bool
-    mispredicted()
+    mispredicted() const
     {
         std::unique_ptr<PCStateBase> next_pc(pc->clone());
         staticInst->advancePC(*next_pc);


### PR DESCRIPTION
This applies to readPredTaken and mispredicted who are not supposed to change the internal state of the object and should be marked as const accordingly

Change-Id: I1b4b3abe104ddbbbadd6cb4e23e1d971e3b774e3