### PR TITLE
sim: Allow int64_t source to bind integral sink

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -777,6 +777,9 @@ class SimObject(metaclass=MetaSimObject):
         self._hr_values = multidict(ancestor._hr_values)
         # clone SimObject-valued parameters
         for key, val in ancestor._values.items():
+            if val == []:
+                self._values[key] = type(val)()
+                continue
             val = tryAsSimObjectOrVector(val)
             if val is not None:
                 self._values[key] = val(_memo=memo_dict)

--- a/src/sim/signal.hh
+++ b/src/sim/signal.hh
@@ -28,7 +28,9 @@
 #ifndef __SIM_SIGNAL_HH__
 #define __SIM_SIGNAL_HH__
 
+#include <cstdint>
 #include <functional>
+#include <variant>
 
 #include "base/logging.hh"
 #include "sim/port.hh"
@@ -39,7 +41,7 @@ namespace gem5
 template <typename State>
 class SignalSourcePort;
 
-template <typename State>
+template <typename State, typename Enable = void>
 class SignalSinkPort : public Port
 {
   public:
@@ -95,6 +97,133 @@ class SignalSinkPort : public Port
 };
 
 template <typename State>
+class SignalSinkPort<State, std::enable_if_t<std::is_integral_v<State>>>
+    : public Port {
+  public:
+    using OnChangeFunc = std::function<void(const State &new_val)>;
+
+  private:
+    friend SignalSourcePort<State>;
+    friend SignalSourcePort<int64_t>;
+
+    SignalSourcePort<State> *_source = nullptr;
+    SignalSourcePort<int64_t> *_number_source = nullptr;
+
+    State _state = {};
+
+  protected:
+    // if bypass_on_change is specified true, it will not call the _onChange
+    // function. Only _state will be updated if needed.
+    virtual void
+    set(const State &new_state, const bool bypass_on_change = false)
+    {
+        if (new_state == _state)
+            return;
+
+        _state = new_state;
+        if (!bypass_on_change && _onChange)
+            _onChange(_state);
+    }
+
+    OnChangeFunc _onChange;
+
+  public:
+    SignalSinkPort(const std::string &_name, PortID _id=InvalidPortID) :
+        Port(_name, _id)
+    {}
+
+    const State &state() const { return _state; }
+    void onChange(OnChangeFunc func) { _onChange = std::move(func); }
+
+    void bind(Port &peer) override;
+
+    void
+    unbind() override
+    {
+        _source = nullptr;
+        Port::unbind();
+    }
+};
+
+template <>
+class SignalSourcePort<int64_t> : public Port
+{
+  private:
+    std::variant<
+        std::monostate,
+        SignalSinkPort<bool>*,
+        SignalSinkPort<uint32_t>*> numeric_sink_ptr;
+    int64_t _state;
+
+  public:
+    SignalSourcePort(const std::string &_name, PortID _id = InvalidPortID)
+        : Port(_name, _id)
+    {
+        _state = {};
+    }
+
+    // Give an initial value to the _state instead of using a default value.
+    SignalSourcePort(const std::string &_name, PortID _id,
+                     const int64_t &init_state)
+        : SignalSourcePort(_name, _id)
+    {
+        _state = init_state;
+    }
+
+    // if bypass_on_change is specified true, it will not call the _onChange
+    // function. Only _state will be updated if needed.
+    void
+    set(const int64_t &new_state, const bool bypass_on_change = false)
+    {
+        _state = new_state;
+        std::visit([this, new_state, bypass_on_change](auto &&sink_ptr){
+            using SinkPtrType = std::decay_t<decltype(sink_ptr)>;
+            if constexpr (std::is_same_v<SinkPtrType, SignalSinkPort<bool>*>) {
+                warn_if(new_state > 1 || new_state < 0,
+                    "Value %lld from %s is out of range for bool signal %s.",
+                    new_state, name().c_str(), sink_ptr->name().c_str());
+                sink_ptr->set(new_state != 0, bypass_on_change);
+            }
+            else if constexpr (std::is_same_v<SinkPtrType,
+                SignalSinkPort<uint32_t>*>) {
+                warn_if(new_state < 0 ||
+                    new_state > std::numeric_limits<uint32_t>::max(),
+                    "Value %lld from %s is out of range for uint32 signal %s.",
+                    new_state, name().c_str(), sink_ptr->name().c_str());
+                sink_ptr->set(static_cast<uint32_t>(new_state),
+                              bypass_on_change);
+            }
+        }, numeric_sink_ptr);
+    }
+
+    const int64_t &state() const { return _state; }
+
+    void
+    bind(Port &peer) override
+    {
+        numeric_sink_ptr = std::monostate{};
+
+        if (auto *bool_s = dynamic_cast<SignalSinkPort<bool> *>(&peer)) {
+            numeric_sink_ptr = bool_s;
+        }
+        if (auto *uint32_s = dynamic_cast<SignalSinkPort<uint32_t> *>(&peer)) {
+            numeric_sink_ptr = uint32_s;
+        }
+
+        fatal_if(std::holds_alternative<std::monostate>(numeric_sink_ptr),
+             "Attempt to bind numeric signal pin %s to incompatible pin %s",
+             name(), peer.name());
+        Port::bind(peer);
+    }
+    void
+    unbind() override
+    {
+        numeric_sink_ptr = std::monostate{};
+        Port::unbind();
+    }
+};
+
+template <typename State>
 class SignalSourcePort : public Port
 {
   private:
@@ -142,6 +271,23 @@ class SignalSourcePort : public Port
         Port::unbind();
     }
 };
+
+template <typename State>
+void SignalSinkPort<State, std::enable_if_t<std::is_integral_v<State>>>::bind(
+    Port &peer) {
+    if (_source = dynamic_cast<SignalSourcePort<State> *>(&peer);
+        _source != nullptr) {
+        _state = _source->state();
+    }
+    if (_number_source = dynamic_cast<SignalSourcePort<int64_t> *>(&peer);
+        _number_source != nullptr) {
+        _state = _number_source->state();
+    }
+    Port::bind(peer);
+    // The state of sink has to match the state of source.
+    fatal_if(!_source && !_number_source, "Attempt to bind signal pin %s to "
+            "incompatible pin %s", name(), peer.name());
+}
 
 }  // namespace gem5
 


### PR DESCRIPTION
This PR declares two specialization.

1. SourcePort<int64> allow it to bind integral sink. When the value change, check the type and warn if the value overflows the sink.
2. SinkPort<integral types> allow it to bind either its type or int64_t

After this change, the SignalSourcePort<int64_t> can bind to the integral types.