### PR TITLE
misc: clang-format update

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -55,6 +55,7 @@ BraceWrapping:
     AfterClass: true
     AfterStruct: true
     AfterUnion: true
+    AfterEnum: true
     AfterNamespace: true
     AfterControlStatement: false             # if/for braces same line (sec. Braces)
     BeforeElse: false                        # else on same line (sec. Braces)
@@ -77,6 +78,11 @@ AllowShortFunctionsOnASingleLine: InlineOnly
 # unless inside macro definitions or if the braces would enclose preprocessor
 # directives
 InsertBraces: true
+
+# Each constructor initializer in separate line
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 
 # Return‐type / function‐name separation
 AlwaysBreakAfterReturnType: None             # Do not break after return type


### PR DESCRIPTION
While working on the decoupled front-end and formatting the whole files I found these clang-config updates to align with other files.

This commit makes clang-format break for each enum

Result in

```cpp
enum Status
{
    Invalid,
    Valid,
...
```

instead of

```cpp
enum Status { Invalid, Valid,...
```

It also breaks after each initializer in the constructor

Results in

```cpp
BAC::BAC(CPU *_cpu)
    : cpu(_cpu),
      bpu(params.branchPred),
```

instead of

```cpp

BAC::BAC(CPU *_cpu)
    : cpu(_cpu), bpu(params.branchPred),
```