### PR TITLE
systemc: fix systemc daily test failure

### DIFF
--- a/util/systemc/gem5_within_systemc/stats.cc
+++ b/util/systemc/gem5_within_systemc/stats.cc
@@ -87,7 +87,7 @@ void statsDump()
     statsEnable();
     statsPrepare();
 
-    output->begin();
+    output->begin("");
     /* gather_stats -> convert_value */
     for (auto i = stats.begin(); i != stats.end(); ++i) {
         gem5::statistics::Info *stat = *i;


### PR DESCRIPTION
The daily tests are failing due to the addition of https://github.com/gem5/gem5/pull/2484, which modified the arguments of the `begin()` function. A call to the `begin()` function in `util/systemc` was not updated for this, causing a build failure. This commit fixes this issue.