### PR TITLE
base: Make dump stats message optional

### DIFF
--- a/src/base/stats/hdf5.hh
+++ b/src/base/stats/hdf5.hh
@@ -67,7 +67,7 @@ class Hdf5 : public Output
     Hdf5(const Hdf5 &other) = delete;
 
   public: // Output interface
-    void begin(const std::string &message) override;
+    void begin(const std::string &message = "") override;
     void end() override;
     bool valid() const override;
 

--- a/src/base/stats/output.hh
+++ b/src/base/stats/output.hh
@@ -65,7 +65,7 @@ struct Output
 {
     virtual ~Output() {}
 
-    virtual void begin(const std::string &message) = 0;
+    virtual void begin(const std::string &message = "") = 0;
     virtual void end() = 0;
     virtual bool valid() const = 0;
 

--- a/src/base/stats/text.hh
+++ b/src/base/stats/text.hh
@@ -98,7 +98,7 @@ class Text : public Output
 
     // Implement Output
     bool valid() const override;
-    void begin(const std::string &message) override;
+    void begin(const std::string &message = "") override;
     void end() override;
 };
 


### PR DESCRIPTION
https://github.com/gem5/gem5/pull/2484 Updated the stats dump to include a message. This was intended to be optional but was implemented as a mandatory argument. This commit corrects this mistake.

This fixes the failing daily test: https://github.com/gem5/gem5/actions/runs/16974822600/job/48120913459