### PR TITLE
base: Close memory leaks in inifile

### DIFF
--- a/src/base/inifile.cc
+++ b/src/base/inifile.cc
@@ -62,6 +62,15 @@ IniFile::Entry::getValue() const
 }
 
 
+IniFile::Section::~Section()
+{
+    for (auto const& [key, entryPtr] : table) {
+        delete entryPtr;
+    }
+    table.clear();
+}
+
+
 void
 IniFile::Section::addEntry(const std::string &entryName,
                            const std::string &value,

--- a/src/base/inifile.hh
+++ b/src/base/inifile.hh
@@ -105,6 +105,7 @@ class IniFile
             : table(), referenced(false)
         {
         }
+        ~Section();
 
         /// Has this section been used?
         bool isReferenced() const { return referenced; }


### PR DESCRIPTION
This should close the largest memory leak I see.


```
==3045781==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 13476560 byte(s) in 336914 object(s) allocated from:
    #0 0x7f114afa373b in operator new(unsigned long) /spec/compilers/src/gcc-15.2.0/libsanitizer/asan/asan_new_delete.cpp:86
    #1 0x0000019cd5de in gem5::IniFile::Section::addEntry(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) gem5/base/inifile.cc:85
    #2 0x0000019d422a in gem5::IniFile::Section::add(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) gem5/base/inifile.cc:117
    #3 0x0000019e3919 in gem5::IniFile::load(std::istream&) gem5/base/inifile.cc:207
    #4 0x0000019e8336 in gem5::IniFile::load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) gem5/base/inifile.cc:64
    #5 0x000008feddde in gem5::CheckpointIn::CheckpointIn(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) gem5/sim/serialize.cc:191
```