### PR TITLE
python: Fix RISC-V FDT stdout-path

### DIFF
--- a/configs/deprecated/example/riscv/fs_linux.py
+++ b/configs/deprecated/example/riscv/fs_linux.py
@@ -136,7 +136,7 @@ def generateDtb(system):
 
     node = FdtNode("chosen")
     node.append(FdtPropertyStrings("bootargs", [system.workload.command_line]))
-    node.append(FdtPropertyStrings("stdout-path", ["/uart@10000000"]))
+    node.append(FdtPropertyStrings("stdout-path", ["/soc/uart@10000000"]))
     root.append(node)
 
     fdt = Fdt()

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -284,7 +284,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         node = FdtNode(f"chosen")
         bootargs = self.workload.command_line
         node.append(FdtPropertyStrings("bootargs", [bootargs]))
-        node.append(FdtPropertyStrings("stdout-path", ["/uart@10000000"]))
+        node.append(FdtPropertyStrings("stdout-path", ["/soc/uart@10000000"]))
         root.append(node)
 
         # See Documentation/devicetree/bindings/riscv/cpus.txt for details.

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -357,7 +357,7 @@ class RISCVMatchedBoard(
         node = FdtNode(f"chosen")
         bootargs = self.workload.command_line
         node.append(FdtPropertyStrings("bootargs", [bootargs]))
-        node.append(FdtPropertyStrings("stdout-path", ["/uart@10000000"]))
+        node.append(FdtPropertyStrings("stdout-path", ["/soc/uart@10000000"]))
         root.append(node)
 
         # See Documentation/devicetree/bindings/riscv/cpus.txt for details.


### PR DESCRIPTION
UART is appended on SoC node, not root node

Change-Id: I5cc29dd7f29afa5aacd07c589a896e03a2e3b3c3