### PR TITLE
misc: split single line loop

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,7 +71,7 @@ SpacesInAngles: false                        # No < T > in templates
 # Single‐line constructs
 AllowShortIfStatementsOnASingleLine: false
 AllowShortBlocksOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: InlineOnly
 
 # Require curly braces after control statements (if, else, for, do, while)


### PR DESCRIPTION
PR #2494 forced braces around control statement (if/else, for, do/while) and short if to be on multiple line.

This commit also force short loops to be on multiple line.

Before:

```c
for (auto it: vec) { it.doSomething(); }
```

After:

```c
for (auto it: vec) {
    it.doSomething();
}
```