### PR TITLE
Toward removing main.py as a dependence

### DIFF
--- a/configs/example/gem5_library/exit_handling/user-exit-handler.py
+++ b/configs/example/gem5_library/exit_handling/user-exit-handler.py
@@ -104,12 +104,13 @@ class MyExitHandler(ScheduledExitEventHandler):
 
         # Take the checkpoint.
         print("Taking checkpoint via scheduled exit event...")
-        simulator.save_checkpoint(
-            (
+        checkpoint_dir = simulator.get_checkpoint_dir()
+        if not checkpoint_dir:
+            checkpoint_dir = (
                 Path(args.checkpoint_path)
                 / f"cpt.{str(simulator.get_current_tick())}"
-            ).as_posix()
-        )
+            )
+        simulator.save_checkpoint(checkpoint_dir)
         print(f"Checkpoint taken!")
 
         # Finally we always schedule another exit 10 billion ticks from now.

--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -29,6 +29,7 @@ from abc import (
     ABCMeta,
     abstractmethod,
 )
+from pathlib import Path
 from typing import (
     List,
     Optional,
@@ -362,6 +363,9 @@ class AbstractBoard:
         CPU-side port for which coherent I/O (DMA) is issued.
         """
         raise NotImplementedError
+
+    def get_checkpoint_dir(self) -> Optional[Path]:
+        return self._checkpoint
 
     @abstractmethod
     def _setup_memory_ranges(self) -> None:

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -49,6 +49,7 @@ from m5.objects import (
     PciVirtIO,
     Port,
     RawDiskImage,
+    Root,
     SimObject,
     SrcClockDomain,
     Terminal,
@@ -341,8 +342,8 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         self.system_port = port
 
     @overrides(AbstractBoard)
-    def _pre_instantiate(self, full_system: Optional[bool] = None) -> None:
-        super()._pre_instantiate(full_system=full_system)
+    def _pre_instantiate(self, full_system: Optional[bool] = None) -> Root:
+        root = super()._pre_instantiate(full_system=full_system)
 
         # Add the PCI devices.
         self.pci_devices = self._pci_devices
@@ -360,6 +361,8 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         # Calling generateDtb from class ArmSystem to add memory information to
         # the dtb file.
         self.generateDtb(self._get_dtb_filename())
+
+        return root
 
     def _get_dtb_filename(self) -> str:
         """Returns the ``dtb`` file location.

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -49,6 +49,7 @@ from m5.objects import (
     RiscvBootloaderKernelWorkload,
     RiscvMmioVirtIO,
     RiscvRTC,
+    Root,
     VirtIOBlock,
     VirtIORng,
 )
@@ -544,7 +545,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         return "/dev/vda"
 
     @overrides(AbstractSystemBoard)
-    def _pre_instantiate(self, full_system: Optional[bool] = None):
+    def _pre_instantiate(self, full_system: Optional[bool] = None) -> Root:
         # This is a bit of a hack necessary to get the RiscDemoBoard working
         # At the time of writing the RiscvBoard does not support SE mode so
         # this branch looks pointless. However, the RiscvDemoBoard does and
@@ -574,7 +575,7 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
                 m5.options.outdir, "device.dtb"
             )
 
-        super()._pre_instantiate(full_system=full_system)
+        return super()._pre_instantiate(full_system=full_system)
 
     @overrides(KernelDiskWorkload)
     def _add_disk_to_board(self, disk_image: AbstractResource):

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -49,6 +49,7 @@ from m5.objects import (
     RiscvBootloaderKernelWorkload,
     RiscvMmioVirtIO,
     RiscvRTC,
+    Root,
     VirtIOBlock,
     VirtIORng,
 )
@@ -338,7 +339,7 @@ class RISCVMatchedBoard(
             memory.set_memory_range(self.mem_ranges)
 
     @overrides(AbstractSystemBoard)
-    def _pre_instantiate(self, full_system: Optional[bool] = None) -> None:
+    def _pre_instantiate(self, full_system: Optional[bool] = None) -> Root:
         if self._fs:
             if len(self._bootloader) > 0:
                 self.workload.bootloader_addr = 0x80000000
@@ -351,7 +352,7 @@ class RISCVMatchedBoard(
                 self.workload.kernel_addr = 0x80000000
                 self.workload.entry_point = 0x80000000
 
-        super()._pre_instantiate(full_system=full_system)
+        return super()._pre_instantiate(full_system=full_system)
 
     def generate_device_tree(self, outdir: str) -> None:
         """Creates the ``dtb`` and ``dts`` files.

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -653,3 +653,6 @@ class Simulator:
                                will be saved.
         """
         m5.checkpoint(str(checkpoint_dir))
+
+    def get_checkpoint_dir(self) -> Optional[Path]:
+        return self._board.get_checkpoint_dir()

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -547,6 +547,7 @@ class Simulator:
             self._root = self._board._pre_instantiate(
                 full_system=self._full_system
             )
+            assert self._root is not None
 
             # m5.instantiate() takes a parameter specifying the path to the
             # checkpoint directory. If the parameter is None, no checkpoint

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -101,7 +101,6 @@ class Simulator:
             ]
         ] = None,
         expected_execution_order: Optional[List[ExitEvent]] = None,
-        checkpoint_path: Optional[Path] = None,
         max_ticks: Optional[int] = m5.MaxTick,
         id: Optional[int] = None,
     ) -> None:
@@ -138,12 +137,6 @@ class Simulator:
                                 executed each time the associated exit event is encountered.
 
                                 See `ClassicGeneratorExitHandler` for more details
-        :param checkpoint_path: An optional parameter specifying the directory of
-                                the checkpoint to instantiate from. When the path
-                                is ``None``, no checkpoint will be loaded. By default,
-                                the path is ``None``. **This parameter is deprecated.
-                                Please set the checkpoint when setting the board's
-                                workload**.
         :param max_ticks: The maximum number of ticks to execute  in the
                           simulation run before exiting with a ``MAX_TICK``
                           exit event. If not set this value is to `m5.MaxTick`,
@@ -191,18 +184,6 @@ class Simulator:
 
         self._last_exit_event = None
         self._exit_event_count = 0
-
-        if checkpoint_path:
-            warn(
-                "Setting the checkpoint path via the Simulator constructor is "
-                "deprecated and will be removed in future releases of gem5. "
-                "Please set this through via the appropriate workload "
-                "function (i.e., `set_se_binary_workload` or "
-                "`set_kernel_disk_workload`). If both are set the workload "
-                "function set takes precedence."
-            )
-
-        self._checkpoint_path = checkpoint_path
 
         # Set up the classic event generators.
         ClassicGeneratorExitHandler.set_exit_event_map(
@@ -572,8 +553,6 @@ class Simulator:
             # will be restored.
             if self._board._checkpoint:
                 m5.instantiate(self._board._checkpoint.as_posix())
-            else:
-                m5.instantiate(self._checkpoint_path)
             self._instantiated = True
 
             # Let the board know that instantiate has been called so it can do

--- a/src/python/m5/__init__.py
+++ b/src/python/m5/__init__.py
@@ -52,6 +52,7 @@ if in_gem5:
     if defines.buildEnv["USE_SYSTEMC"]:
         from . import systemc
         from . import tlm
+    from . import simulate as _simulate_module
     from . import util
     from .event import *
     from .main import main

--- a/src/python/m5/citations.py
+++ b/src/python/m5/citations.py
@@ -46,7 +46,7 @@ def add_citation(sim_obj_cls: Type["SimObject"], citation: str):
     sim_obj_cls._citations += citation
 
 
-def gather_citations(root: "SimObject"):
+def gather_citations(root: "SimObject", output_dir: str):
     """Based on the root SimObject, walk the object hierarchy and gather all
     of the citations together and then print them to citations.bib in the
     output directory.
@@ -60,7 +60,7 @@ def gather_citations(root: "SimObject"):
             # If a key repeats, then just overwrite it
             citations[key] = cite
 
-    with open(Path(m5.options.outdir) / "citations.bib", "w") as output:
+    with open(Path(output_dir) / "citations.bib", "w") as output:
         output.writelines(citations.values())
 
 

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -120,7 +120,7 @@ def _dump_configs(root):
         do_dot(root, options.outdir, options.dot_config)
         do_ruby_dot(root, options.outdir, options.dot_config)
 
-    gather_citations(root)
+    gather_citations(root, options.outdir)
 
 
 def _create_cpp_objects(root, ckpt_dir):


### PR DESCRIPTION
I am working toward enabling a more modular version of gem5 where we can link to python modules instead of using the gem5 binary with the marshalled python code. This is one of the many hurdles to overcome: specifically that main.py populates m5.options. This PR is the first step toward decoupling the stdlib from main.py and m5.options. Generally, this is cleaning up code and there should be no functional changes.