### PR TITLE
configs,stdlib: Ensure Resource ID arg passed to RISCV Demo Script

### DIFF
--- a/configs/example/gem5_library/riscv-demo-board-run.py
+++ b/configs/example/gem5_library/riscv-demo-board-run.py
@@ -55,6 +55,8 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument(
     "--workload",
+    type=str,
+    required=True,
     help="Enter the name of the workload you would like to run. You can browse"
     " through the available workloads and resources at "
     "https://resources.gem5.org",
@@ -62,6 +64,8 @@ parser.add_argument(
 
 parser.add_argument(
     "--version",
+    type=str,
+    default=None,
     help="Enter the workload version you would like to use. The latest version"
     " will be used if this is left blank.",
 )

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -955,6 +955,17 @@ def obtain_resource(
     :param quiet: If ``True``, suppress output. ``False`` by default.
     """
 
+    # Some basic validation. Resource_id must be of type string and not empty.
+    if not isinstance(resource_id, str):
+        raise TypeError(
+            f"Resource ID must be a string, got {type(resource_id).__name__}."
+        )
+
+    if not resource_id.strip():
+        raise ValueError(
+            "Resource ID cannot be an empty or whitespace-only string."
+        )
+
     # Obtain the resource object entry for this resource
     resource_json = get_resource_json_obj(
         resource_id,


### PR DESCRIPTION
In addition to fixing the script by making the argument mandatory, some validation code has been added to the `obtain_resource` function to check the type and state of `resources-id` prior to resource retrieval; throwing helpful errors if appropriate. 