### PR TITLE
arch-arm: bug fixes for generic timing registers in SE mode

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -656,8 +656,15 @@ ISA::readMiscReg(RegIndex idx)
       // Generic Timer registers
       case MISCREG_CNTFRQ ... MISCREG_CNTVOFF:
       case MISCREG_CNTFRQ_EL0 ... MISCREG_CNTVOFF_EL2:
-        return getGenericTimer().readMiscReg(idx);
-
+          if (FullSystem) {
+              return getGenericTimer().readMiscReg(idx);
+          } else {
+              warn("Call to %s attempts to access a system timer which is "
+                   "inaccessible within SE mode. Divergent behaviour is "
+                   "possible.",
+                   miscRegName[idx]);
+              return 0;
+          }
       case MISCREG_ICC_AP0R0 ... MISCREG_ICH_LRC15:
       case MISCREG_ICC_PMR_EL1 ... MISCREG_ICC_IGRPEN1_EL3:
       case MISCREG_ICH_AP0R0_EL2 ... MISCREG_ICH_LR15_EL2:

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -1438,6 +1438,9 @@ Fault
 faultFgtEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
     const bool in_host = EL2Enabled(tc) && hcr.e2h && hcr.tge;
     if (fgtEnabled(tc) && !in_host &&
@@ -1890,6 +1893,9 @@ Fault
 faultCtrEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
      const SCTLR sctlr = tc->readMiscReg(MISCREG_SCTLR_EL1);
      const SCTLR sctlr2 = tc->readMiscReg(MISCREG_SCTLR_EL2);
      const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
@@ -1917,6 +1923,9 @@ Fault
 faultMdccsrEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const DBGDS32 mdscr = tc->readMiscReg(MISCREG_MDSCR_EL1);
     const HDCR mdcr_el2 = tc->readMiscReg(MISCREG_MDCR_EL2);
     const HDCR mdcr_el3 = tc->readMiscReg(MISCREG_MDCR_EL3);
@@ -2441,6 +2450,9 @@ Fault
 faultGenericTimerEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const bool el2_enabled = EL2Enabled(tc);
     const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
     const bool in_host = el2_enabled && hcr.e2h && hcr.tge;
@@ -2462,6 +2474,9 @@ Fault
 faultCntpctEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const bool el2_enabled = EL2Enabled(tc);
     const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
     const bool in_host = el2_enabled && hcr.e2h && hcr.tge;
@@ -2508,6 +2523,9 @@ Fault
 faultCntvctEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const bool el2_enabled = EL2Enabled(tc);
     const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
     const bool in_host = el2_enabled && hcr.e2h && hcr.tge;
@@ -2544,6 +2562,9 @@ Fault
 faultCntpCtlEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const bool el2_enabled = EL2Enabled(tc);
     const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
     const bool in_host = el2_enabled && hcr.e2h && hcr.tge;
@@ -2591,6 +2612,9 @@ Fault
 faultCntvCtlEL0(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     const bool el2_enabled = EL2Enabled(tc);
     const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
     const bool in_host = el2_enabled && hcr.e2h && hcr.tge;


### PR DESCRIPTION
The pull request fixes issues leading to faults for certain timing registers. Namely:
- the timers are never initialized in SE mode
- they attempt to access higher exception levels which again causes issues in SE mode