### PR TITLE
dev,arch-riscv: Improve `rdtime` instruction

### DIFF
--- a/configs/deprecated/example/riscv/fs_linux.py
+++ b/configs/deprecated/example/riscv/fs_linux.py
@@ -182,7 +182,7 @@ np = args.num_cpus
 
 # ---------------------------- Setup System ---------------------------- #
 # Default Setup
-system = System()
+system = RiscvSystem()
 mdesc = SysConfig(
     disks=args.disk_image,
     rootdev=args.root_device,

--- a/src/arch/riscv/RiscvSystem.py
+++ b/src/arch/riscv/RiscvSystem.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2009, 2012-2013, 2015-2024 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects.System import System
+from m5.params import *
+
+
+class RiscvSystem(System):
+    type = "RiscvSystem"
+    cxx_header = "arch/riscv/system.hh"
+    cxx_class = "gem5::RiscvSystem"

--- a/src/arch/riscv/SConscript
+++ b/src/arch/riscv/SConscript
@@ -63,6 +63,7 @@ Source('pmp.cc', tags=['riscv isa'])
 Source('reg_abi.cc', tags=['riscv isa'])
 Source('remote_gdb.cc', tags=['riscv isa'])
 Source('semihosting.cc', tags=['riscv isa'])
+Source('system.cc', tags=['riscv isa'])
 Source('tlb.cc', tags=['riscv isa'])
 
 Source('linux/se_workload.cc', tags=['riscv isa'])
@@ -120,6 +121,7 @@ SimObject(
 )
 
 SimObject('RiscvCPU.py', sim_objects=[], tags=['riscv isa'])
+SimObject('RiscvSystem.py', sim_objects=['RiscvSystem'], tags=['riscv isa'])
 
 DebugFlag('RiscvMisc', tags=['riscv isa'])
 DebugFlag('PMP', tags=['riscv isa'])

--- a/src/arch/riscv/system.cc
+++ b/src/arch/riscv/system.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Google LLC
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "arch/riscv/system.hh"
+
+#include "dev/riscv/clint.hh"
+
+namespace gem5
+{
+
+uint64_t
+RiscvSystem::tryReadMtime() const
+{
+    panic_if(!_clint, "Can't get CLINT device in RiscvSystem");
+    return _clint->registers.mtime.get();
+}
+
+} // namespace gem5

--- a/src/arch/riscv/system.hh
+++ b/src/arch/riscv/system.hh
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Google LLC
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Copyright (c) 2002-2005 The Regents of The University of Michigan
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_RISCV_SYSTEM_HH__
+#define __ARCH_RISCV_SYSTEM_HH__
+
+#include "params/RiscvSystem.hh"
+#include "sim/full_system.hh"
+#include "sim/system.hh"
+
+namespace gem5
+{
+
+class Clint;
+
+class RiscvSystem : public System
+{
+  protected:
+    /**
+     * Pointer to the CLINT wrapper.
+     */
+    Clint *_clint;
+
+  public:
+    PARAMS(RiscvSystem);
+
+    RiscvSystem(const Params &p) : System(p), _clint(nullptr) {}
+
+    /** Sets the pointer to the CLINT. */
+    void
+    setClint(Clint *clint)
+    {
+        _clint = clint;
+    }
+
+    /** Get a pointer to the system's CLINT model */
+    Clint *
+    getClint() const
+    {
+        return _clint;
+    }
+
+    uint64_t tryReadMtime() const;
+};
+
+} // namespace gem5
+
+#endif

--- a/src/dev/riscv/clint.cc
+++ b/src/dev/riscv/clint.cc
@@ -37,6 +37,7 @@
 
 #include "dev/riscv/clint.hh"
 
+#include "arch/riscv/system.hh"
 #include "cpu/base.hh"
 #include "debug/Clint.hh"
 #include "mem/packet.hh"
@@ -78,15 +79,6 @@ Clint::raiseInterruptPin(int id)
     for (int context_id = 0; context_id < nThread; context_id++) {
 
         auto tc = system->threads[context_id];
-
-        // Update misc reg file
-        ISA* isa = dynamic_cast<ISA*>(tc->getIsaPtr());
-        if (isa->rvType() == RV32) {
-            isa->setMiscRegNoEffect(MISCREG_TIME, bits(mtime, 31, 0));
-            isa->setMiscRegNoEffect(MISCREG_TIMEH, bits(mtime, 63, 32));
-        } else {
-            isa->setMiscRegNoEffect(MISCREG_TIME, mtime);
-        }
 
         // Post timer interrupt
         uint64_t mtimecmp = registers.mtimecmp[context_id].get();
@@ -198,6 +190,13 @@ Clint::init()
 {
     registers.init();
     BasicPioDevice::init();
+
+    RiscvSystem *rv_sys = dynamic_cast<RiscvSystem *>(system);
+    if (rv_sys != nullptr) {
+        rv_sys->setClint(this);
+    } else {
+        warn("Set Clint to RiscvSystem failed.");
+    }
 }
 
 Port &


### PR DESCRIPTION
From RISC-V privilege spec `mcounteren` section:

```
The time CSR is a read-only shadow of the memory-mapped mtime register. When XLEN=32, the timeh CSR is a read-only shadow of the upper 32 bits of the memory-mapped mtime register, while time shadows only the lower 32 bits of mtime.
```
 
Instead of update MISCREG_TIME when the memory-mapped mtime register updated (CLINT => Time CSR). Changing `rdtime` instruction to read mtime register from CLINT helps decouple CLINT and RiscvISA dependency.

If we still using System for RISC-V. Reading `time`/`timeh` CSR will generate trap. However, OpenSBI supports handling `time` CSR trap, so the kernel still works for the case.