### PR TITLE
dev: add PCI to PCI bridge

### DIFF
--- a/configs/example/gem5_library/x86-pcie-root-port.py
+++ b/configs/example/gem5_library/x86-pcie-root-port.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 REDS institute of the HEIG-VD
+# All rights reserved.
+#
+# Copyright (c) 2021-2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This script is copied from x86-ubuntu-run-with-kvm.py and adds an example of
+a PCI-to-PCI bridge usage. To demonstrate it, a simple PCIe Root Port is added,
+which only adds the required PCI configuration to be detected correctly.
+An ethernet port is connected behind the port.
+
+After boot, the simulation will run `lspci` and `ip link` to show that the root port
+and the ethernet card are present and detected.
+
+Usage
+-----
+
+```
+scons build/ALL/gem5.opt
+./build/ALL/gem5.opt configs/example/gem5_library/x86-pcie-root-port.py
+```
+"""
+
+from m5.objects import (
+    IGbE_e1000,
+    IPcieRootPort,
+)
+
+from gem5.coherence_protocol import CoherenceProtocol
+from gem5.components.boards.x86_board import X86Board
+from gem5.components.cachehierarchies.abstract_cache_hierarchy import (
+    AbstractCacheHierarchy,
+)
+from gem5.components.memory.abstract_memory_system import AbstractMemorySystem
+from gem5.components.memory.single_channel import SingleChannelDDR3_1600
+from gem5.components.processors.abstract_processor import AbstractProcessor
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_switchable_processor import (
+    SimpleSwitchableProcessor,
+)
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.exit_handler import ExitHandler
+from gem5.simulate.simulator import Simulator
+from gem5.utils.override import overrides
+from gem5.utils.requires import requires
+
+# This checks if the host system supports KVM. It also checks if the gem5
+# binary is compiled to include the MESI_Two_Level cache coherence protocol.
+requires(
+    coherence_protocol_required=CoherenceProtocol.MESI_TWO_LEVEL,
+    kvm_required=True,
+)
+
+from gem5.components.cachehierarchies.ruby.mesi_two_level_cache_hierarchy import (
+    MESITwoLevelCacheHierarchy,
+)
+
+# Here we set up a MESI Two Level Cache Hierarchy.
+cache_hierarchy = MESITwoLevelCacheHierarchy(
+    l1d_size="16KiB",
+    l1d_assoc=8,
+    l1i_size="16KiB",
+    l1i_assoc=8,
+    l2_size="256KiB",
+    l2_assoc=16,
+    num_l2_banks=1,
+)
+
+# Set up the system memory.
+memory = SingleChannelDDR3_1600(size="3GiB")
+
+# Here we set up the processor. This is a special switchable processor in which
+# a starting core type and a switch core type must be specified. Once a
+# configuration is instantiated a user may call `processor.switch()` or
+# `simulator.switch_processor()`, if using a hypercall exit handler, to switch
+# from the starting core types to the switch core types. In this simulation
+# we start with KVM cores to simulate the OS boot, then switch to the Timing
+# cores for the command we wish to run after boot.
+
+processor = SimpleSwitchableProcessor(
+    starting_core_type=CPUTypes.KVM,
+    switch_core_type=CPUTypes.TIMING,
+    isa=ISA.X86,
+    num_cores=2,
+)
+
+# Here we set up the board. The X86Board allows for FS mode (full system) or
+# SE mode (syscall emulation) X86 simulations.
+
+
+class PcieRootX86Board(X86Board):
+
+    # Add PCI root port (PCI-to-PCI bridge)
+    pcie_root_port = IPcieRootPort(
+        pci_dev=1,
+        pci_func=0,
+    )
+
+    # PCI device behind the bridge. pci_dev must be 0 for PCIe Root Port.
+    ethernet = IGbE_e1000(
+        pci_dev=0,
+        pci_func=0,
+    )
+
+    def __init__(
+        self,
+        clk_freq: str,
+        processor: AbstractProcessor,
+        memory: AbstractMemorySystem,
+        cache_hierarchy: AbstractCacheHierarchy,
+    ) -> None:
+        super().__init__(clk_freq, processor, memory, cache_hierarchy)
+
+        self._set_readfile_contents("lspci -v && ip link")
+
+    def _setup_io_devices(self):
+        super()._setup_io_devices()
+
+        # Connect the PCI root port with the host bridge and the downstream device.
+        self.pcie_root_port.internal_connect()
+        self.pcie_root_port.connect_upper_bridge(self.get_pci_host())
+        self.pcie_root_port.connect_device(self.ethernet)
+
+
+board = PcieRootX86Board(
+    clk_freq="3GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+)
+
+workload = obtain_resource(
+    "x86-ubuntu-24.04-boot-with-systemd", resource_version="5.0.0"
+)
+board.set_workload(workload)
+
+
+# Examples of how you can override the default exit handler behaviors.
+# Exit handlers don't have to be specified in the config script if you don't
+# want to modify/override their default behaviors. Below, we override the
+# default after-boot exit handler to switch processors.
+
+# You can inherit from either the class that handles a certain hypercall by
+# default, or inherit directly from ExitHandler and specify a hypercall number.
+# See src/python/gem5/simulate/exit_handler.py for more information on which
+# behaviors map to which hypercalls, and what the default behaviors are.
+
+
+class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        print("First exit: kernel booted")
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return False
+
+
+class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        simulator.switch_processor()
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return False
+
+
+class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+    @overrides(ExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        print(f"Third exit: {self.get_handler_description()}")
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return True
+
+
+simulator = Simulator(board=board)
+
+simulator.run()

--- a/src/dev/pci/PciToPciBridge.py
+++ b/src/dev/pci/PciToPciBridge.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 REDS institute of the HEIG-VD
+#  All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects.Bridge import (
+    Bridge,
+    BridgeBase,
+)
+from m5.objects.PciDevice import (
+    PciDevice,
+    PciType1Device,
+)
+from m5.objects.PciUpstream import (
+    PciBus,
+    PciConfigError,
+    PciUpDownBridge,
+)
+from m5.params import *
+from m5.proxy import *
+
+
+class PciToPciBridge(PciType1Device):
+    type = "PciToPciBridge"
+    cxx_class = "gem5::PciToPciBridge"
+    cxx_header = "dev/pci/p2p_bridge.hh"
+
+    up_to_down = Param.PciUpDownBridge(
+        PciUpDownBridge(), "Bridge upstream -> downstream"
+    )
+    down_to_up = Param.BridgeBase(Bridge(), "Bridge downstream -> upstream")
+
+    internal_bus = Param.PciBus(
+        PciBus(),
+        "Internal PCI bus XBar used to transmit packets between devices",
+    )
+
+    config_error = Param.PciConfigError(
+        PciConfigError(), "Device to handle config errors"
+    )
+
+    devices = VectorParam.PciDevice(
+        [], "List of all PCI device connected to this upstream"
+    )
+
+    def internal_connect(self):
+        """Helper function to connect the PCI to PCI bridge internal ports"""
+        self.up_to_down.mem_side_port = self.internal_bus.cpu_side_ports
+        self.down_to_up.cpu_side_port = self.internal_bus.default
+        self.config_error.pio = self.internal_bus.config_error_port
+
+    def connect_upper_bridge(self, bridge):
+        """
+        Connect the PCI to PCI bridge to given upstream bridge.
+
+        bridge should be either a PCI host bridge (PciHost)
+        or another PCI to PCI bridge, with connect_device() function
+        and internal_bus member of type PciBus.
+        """
+        bridge.connect_device(self)
+
+        self.up_to_down.cpu_side_port = bridge.internal_bus.mem_side_ports
+        self.down_to_up.mem_side_port = bridge.internal_bus.cpu_side_ports
+
+    def connect_device(self, device: PciDevice):
+        """Connect given PCI device to the PCI to PCI bridge"""
+        if device in self.devices:
+            raise ValueError(
+                f"Device {device} is already connected to this PCI host"
+            )
+        for existing in self.devices:
+            if (
+                existing.pci_dev == device.pci_dev
+                and existing.pci_func == device.pci_func
+            ):
+                raise ValueError(
+                    f"PCI slot (dev={existing.pci_dev}, func={existing.pci_func}) is already "
+                    f"occupied by {existing}"
+                )
+
+        self.devices.append(device)
+
+        device.pio = self.internal_bus.mem_side_ports
+        device.dma = self.internal_bus.cpu_side_ports

--- a/src/dev/pci/PciToPciBridge.py
+++ b/src/dev/pci/PciToPciBridge.py
@@ -96,7 +96,7 @@ class PciToPciBridge(PciType1Device):
         """Connect given PCI device to the PCI to PCI bridge"""
         if device in self.devices:
             raise ValueError(
-                f"Device {device} is already connected to this PCI host"
+                f"Device {device} is already connected to this PCI-to-PCI bridge"
             )
         for existing in self.devices:
             if (

--- a/src/dev/pci/PciToPciBridge.py
+++ b/src/dev/pci/PciToPciBridge.py
@@ -112,3 +112,22 @@ class PciToPciBridge(PciType1Device):
 
         device.pio = self.internal_bus.mem_side_ports
         device.dma = self.internal_bus.cpu_side_ports
+
+
+class IPcieRootPort(PciToPciBridge):
+    """
+    Based on Intel 6th-10th Gen Core Processor PCIe Controller.
+    This doesn't include PCI capabilities, but is sufficient to have a working
+    PCI-to-PCI bridge.
+
+    Root ports support only one downstream device requires the downstream
+    device device to use pci_dev = 0.
+    """
+
+    VendorID = 0x8086
+    DeviceID = 0x1901
+    HeaderType = 1
+    Revision = 0x5
+    ProgIF = 0x00
+    SubClassCode = 0x04
+    ClassCode = 0x06

--- a/src/dev/pci/SConscript
+++ b/src/dev/pci/SConscript
@@ -58,6 +58,9 @@ SimObject('PciHost.py', sim_objects=['PciHost', 'GenericPciHost'])
 Source('host.cc')
 DebugFlag('PciHost')
 
+SimObject('PciToPciBridge.py', sim_objects=['PciToPciBridge'])
+Source('p2p_bridge.cc')
+
 SimObject('CopyEngine.py', sim_objects=['CopyEngine'])
 Source('copy_engine.cc')
 DebugFlag('DMACopyEngine')

--- a/src/dev/pci/device.cc
+++ b/src/dev/pci/device.cc
@@ -301,7 +301,14 @@ PciDevice::getAddrRanges() const
             ranges.push_back(bar->range());
     }
 
-    ranges.push_back(upstreamInterface->configRange());
+    // An invalid range can be returned if the upstream PCI to PCI bridge
+    // doesn't have a bus number yet. So check that to avoid adding it to the
+    // range list.
+    auto config_range = upstreamInterface->configRange();
+
+    if (config_range.valid()) {
+        ranges.push_back(config_range);
+    }
 
     return ranges;
 }
@@ -794,102 +801,135 @@ PciType1Device::writeConfig(PacketPtr pkt)
     }
 
     switch (pkt->getSize()) {
-      case sizeof(uint8_t):
-        switch (offset) {
-          case PCI1_PRI_BUS_NUM:
-            _config.type1.primaryBusNum = pkt->getLE<uint8_t>();
-            break;
-          case PCI1_SEC_BUS_NUM:
-            _config.type1.secondaryBusNum = pkt->getLE<uint8_t>();
-            break;
-          case PCI1_SUB_BUS_NUM:
-            _config.type1.subClassCode = pkt->getLE<uint8_t>();
-            break;
-          case PCI1_SEC_LAT_TIMER:
-            _config.type1.secondaryLatencyTimer = pkt->getLE<uint8_t>();
-            break;
-          case PCI1_IO_BASE:
-            _config.type1.ioBase = pkt->getLE<uint8_t>();
-            break;
-          case PCI1_IO_LIMIT:
-            _config.type1.ioLimit = pkt->getLE<uint8_t>();
-            break;
-          default:
-              panic("writing to a read only register");
-        }
-        DPRINTF(PciDevice,
+        case sizeof(uint8_t):
+            switch (offset) {
+                case PCI1_PRI_BUS_NUM:
+                    _config.type1.primaryBusNum = pkt->getLE<uint8_t>();
+                    break;
+                case PCI1_SEC_BUS_NUM:
+                    _config.type1.secondaryBusNum = pkt->getLE<uint8_t>();
+                    break;
+                case PCI1_SUB_BUS_NUM:
+                    _config.type1.subordinateBusNum = pkt->getLE<uint8_t>();
+                    break;
+                case PCI1_SEC_LAT_TIMER:
+                    _config.type1.secondaryLatencyTimer =
+                        pkt->getLE<uint8_t>();
+                    break;
+                case PCI1_IO_BASE:
+                    _config.type1.ioBase = pkt->getLE<uint8_t>();
+                    break;
+                case PCI1_IO_LIMIT:
+                    _config.type1.ioLimit = pkt->getLE<uint8_t>();
+                    break;
+                default:
+                    panic("writing to a read only register");
+            }
+            DPRINTF(
+                PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 1 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint8_t>());
-        break;
-      case sizeof(uint16_t):
-        switch (offset) {
-          case PCI1_SECONDARY_STATUS:
-            _config.type1.secondaryStatus = pkt->getLE<uint16_t>();
             break;
-          case PCI1_MEM_BASE:
-            _config.type1.memBase = pkt->getLE<uint16_t>();
-            break;
-          case PCI1_MEM_LIMIT:
-            _config.type1.memLimit = pkt->getLE<uint16_t>();
-            break;
-          case PCI1_PRF_MEM_BASE:
-            _config.type1.prefetchMemBase = pkt->getLE<uint16_t>();
-            break;
-          case PCI1_PRF_MEM_LIMIT:
-            _config.type1.prefetchMemLimit = pkt->getLE<uint16_t>();
-            break;
-          case PCI1_IO_BASE_UPPER:
-            _config.type1.ioBaseUpper = pkt->getLE<uint16_t>();
-            break;
-          case PCI1_IO_LIMIT_UPPER:
-            _config.type1.ioLimitUpper = pkt->getLE<uint16_t>();
-            break;
-          case PCI1_BRIDGE_CTRL:
-            _config.type1.bridgeControl = pkt->getLE<uint16_t>();
-            break;
-          default:
-            panic("writing to a read only register");
-        }
-        DPRINTF(PciDevice,
+        case sizeof(uint16_t):
+            switch (offset) {
+                case PCI1_IO_BASE: {
+                    uint16_t ioConfig = pkt->getLE<uint16_t>();
+                    _config.type1.ioBase = ioConfig & mask(8);
+                    _config.type1.ioLimit = ioConfig >> 8;
+                } break;
+                case PCI1_SECONDARY_STATUS:
+                    _config.type1.secondaryStatus = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_MEM_BASE:
+                    _config.type1.memBase = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_MEM_LIMIT:
+                    _config.type1.memLimit = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_PRF_MEM_BASE:
+                    _config.type1.prefetchMemBase = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_PRF_MEM_LIMIT:
+                    _config.type1.prefetchMemLimit = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_IO_BASE_UPPER:
+                    _config.type1.ioBaseUpper = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_IO_LIMIT_UPPER:
+                    _config.type1.ioLimitUpper = pkt->getLE<uint16_t>();
+                    break;
+                case PCI1_BRIDGE_CTRL:
+                    _config.type1.bridgeControl = pkt->getLE<uint16_t>();
+                    break;
+                default:
+                    panic("writing to a read only register");
+            }
+            DPRINTF(
+                PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 2 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint16_t>());
-        break;
-      case sizeof(uint32_t):
-        switch (offset) {
-          case PCI1_BASE_ADDR0:
-          case PCI1_BASE_ADDR1:
-            {
-              int num = PCI1_BAR_NUMBER(offset);
-              auto *bar = BARs[num];
-              _config.type1.baseAddr[num] = htole(
-                  bar->write(*upstreamInterface, pkt->getLE<uint32_t>()));
-              pioPort.sendRangeChange();
+            break;
+        case sizeof(uint32_t):
+            switch (offset) {
+                case PCI1_BASE_ADDR0:
+                case PCI1_BASE_ADDR1: {
+                    int num = PCI1_BAR_NUMBER(offset);
+                    auto *bar = BARs[num];
+                    _config.type1.baseAddr[num] = htole(bar->write(
+                        *upstreamInterface, pkt->getLE<uint32_t>()));
+                    pioPort.sendRangeChange();
+                } break;
+                case PCI1_PRI_BUS_NUM: {
+                    uint32_t busConfig = pkt->getLE<uint32_t>();
+                    _config.type1.primaryBusNum = busConfig & mask(8);
+                    _config.type1.secondaryBusNum = (busConfig >> 8) & mask(8);
+                    _config.type1.subordinateBusNum =
+                        (busConfig >> 16) & mask(8);
+                    _config.type1.secondaryLatencyTimer =
+                        (busConfig >> 24) & mask(8);
+                } break;
+                case PCI1_MEM_BASE: {
+                    uint32_t memConfig = pkt->getLE<uint32_t>();
+                    _config.type1.memBase = memConfig & mask(16);
+                    _config.type1.memLimit = memConfig >> 16;
+                } break;
+                case PCI1_PRF_MEM_BASE: {
+                    uint32_t prefConfig = pkt->getLE<uint32_t>();
+                    _config.type1.prefetchMemBase = prefConfig & mask(16);
+                    _config.type1.prefetchMemLimit = prefConfig >> 16;
+                } break;
+                case PCI1_PRF_BASE_UPPER:
+                    _config.type1.prefetchBaseUpper = pkt->getLE<uint32_t>();
+                    break;
+                case PCI1_PRF_LIMIT_UPPER:
+                    _config.type1.prefetchLimitUpper = pkt->getLE<uint32_t>();
+                    break;
+                case PCI1_IO_BASE_UPPER: {
+                    uint32_t ioUpperConfig = pkt->getLE<uint32_t>();
+                    _config.type1.ioBaseUpper = ioUpperConfig & mask(16);
+                    _config.type1.ioLimitUpper = ioUpperConfig >> 16;
+                } break;
+                case PCI1_ROM_BASE_ADDR:
+                    if (letoh(pkt->getLE<uint32_t>()) == 0xfffffffe) {
+                        _config.type1.expansionROM =
+                            htole((uint32_t)0xffffffff);
+                    } else {
+                        _config.type1.expansionROM = pkt->getLE<uint32_t>();
+                    }
+                    break;
+                default:
+                    panic("writing to a read only register");
             }
-            break;
-          case PCI1_PRF_BASE_UPPER:
-            _config.type1.prefetchBaseUpper = pkt->getLE<uint32_t>();
-            break;
-          case PCI1_PRF_LIMIT_UPPER:
-            _config.type1.prefetchLimitUpper = pkt->getLE<uint32_t>();
-            break;
-          case PCI1_ROM_BASE_ADDR:
-            if (letoh(pkt->getLE<uint32_t>()) == 0xfffffffe)
-                _config.type1.expansionROM = htole((uint32_t)0xffffffff);
-            else
-                _config.type1.expansionROM = pkt->getLE<uint32_t>();
-            break;
-          default:
-            panic("writing to a read only register");
-        }
-        DPRINTF(PciDevice,
+            DPRINTF(
+                PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 4 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint32_t>());
-        break;
-      default:
-        panic("invalid access size(?) for PCI configspace!\n");
+            break;
+        default:
+            panic("invalid access size(?) for PCI configspace!\n");
     }
     pkt->makeAtomicResponse();
     return configDelay;

--- a/src/dev/pci/device.cc
+++ b/src/dev/pci/device.cc
@@ -293,13 +293,6 @@ AddrRangeList
 PciDevice::getAddrRanges() const
 {
     AddrRangeList ranges;
-    PciCommandRegister command = letoh(_config.common.command);
-    for (auto *bar: BARs) {
-        if (command.ioSpace && bar->isIo())
-            ranges.push_back(bar->range());
-        if (command.memorySpace && bar->isMem())
-            ranges.push_back(bar->range());
-    }
 
     // An invalid range can be returned if the upstream PCI to PCI bridge
     // doesn't have a bus number yet. So check that to avoid adding it to the
@@ -308,6 +301,16 @@ PciDevice::getAddrRanges() const
 
     if (config_range.valid()) {
         ranges.push_back(config_range);
+
+        PciCommandRegister command = letoh(_config.common.command);
+        for (auto *bar : BARs) {
+            if (command.ioSpace && bar->isIo()) {
+                ranges.push_back(bar->range());
+            }
+            if (command.memorySpace && bar->isMem()) {
+                ranges.push_back(bar->range());
+            }
+        }
     }
 
     return ranges;

--- a/src/dev/pci/device.hh
+++ b/src/dev/pci/device.hh
@@ -566,6 +566,12 @@ class PciType1Device : public PciDevice
         return _config.type1;
     }
 
+    const PCIConfigType1 &
+    config() const
+    {
+        return _config.type1;
+    }
+
     /**
      * Write to the PCI config space data that is stored locally. This may be
      * overridden by the device but at some point it will eventually call this

--- a/src/dev/pci/device.hh
+++ b/src/dev/pci/device.hh
@@ -507,6 +507,15 @@ class PciDevice : public DmaDevice
     }
 
     /**
+     * Get the PCI bus number to which this device is connected.
+     */
+    PciBusNum
+    getBusNum() const
+    {
+        return upstreamInterface->getBusNum();
+    }
+
+    /**
      * Called to receive a bus number change from the PCI upstream.
      * A bus number change means that all address ranges
      * (configuration, ...) can be changed, so this will send a range

--- a/src/dev/pci/host.cc
+++ b/src/dev/pci/host.cc
@@ -96,10 +96,9 @@ GenericPciHost::getConfigAddrRange() const
 }
 
 AddrRange
-GenericPciHost::interfaceConfigRange(PciBusNum bus_num,
-                                     const PciDevice &device) const
+GenericPciHost::interfaceConfigRange(const PciDevice &device) const
 {
-    Addr start = devConfigAddr(bus_num, device.devAddr());
+    Addr start = devConfigAddr(device.getBusNum(), device.devAddr());
 
     return RangeSize(start, 1 << confDeviceBits);
 }
@@ -120,13 +119,13 @@ GenericPciHost::interfaceBusConfigRange(PciBusNum start_bus,
 }
 
 void
-GenericPciHost::interfacePostInt(PciBusNum bus_num, const PciDevice &device)
+GenericPciHost::interfacePostInt(const PciDevice &device)
 {
     platform.postPciInt(mapPciInterrupt(device));
 }
 
 void
-GenericPciHost::interfaceClearInt(PciBusNum bus_num, const PciDevice &device)
+GenericPciHost::interfaceClearInt(const PciDevice &device)
 {
     platform.clearPciInt(mapPciInterrupt(device));
 }

--- a/src/dev/pci/host.cc
+++ b/src/dev/pci/host.cc
@@ -108,8 +108,13 @@ AddrRange
 GenericPciHost::interfaceBusConfigRange(PciBusNum start_bus,
                                         PciBusNum end_bus) const
 {
+    if (end_bus < start_bus) {
+        return AddrRange();
+    }
+
     Addr start = devConfigAddr(start_bus, PciDevAddr(0, 0));
-    Addr size = (end_bus - start_bus + 1) << (BUS_OFFSET + confDeviceBits);
+    Addr size = static_cast<Addr>(end_bus - start_bus + 1)
+                << (BUS_OFFSET + confDeviceBits);
 
     return RangeSize(start, size);
 }

--- a/src/dev/pci/host.cc
+++ b/src/dev/pci/host.cc
@@ -79,6 +79,16 @@ GenericPciHost::~GenericPciHost()
 {
 }
 
+Addr
+GenericPciHost::devConfigAddr(PciBusNum bus_num,
+                              const PciDevAddr &dev_addr) const
+{
+    Addr bus_addr = (bus_num << BUS_OFFSET) + (dev_addr.dev << DEVICE_OFFSET) +
+                    (dev_addr.func << FUNCTION_OFFSET);
+
+    return confBase + (bus_addr << confDeviceBits);
+}
+
 AddrRange
 GenericPciHost::getConfigAddrRange() const
 {
@@ -86,24 +96,32 @@ GenericPciHost::getConfigAddrRange() const
 }
 
 AddrRange
-GenericPciHost::interfaceConfigRange(const PciDevice &device) const
+GenericPciHost::interfaceConfigRange(PciBusNum bus_num,
+                                     const PciDevice &device) const
 {
-    PciDevAddr dev_addr = device.devAddr();
-    Addr bus_addr = (getBusNum() << 8) + (dev_addr.dev << 3) + dev_addr.func;
-
-    Addr start = confBase + (bus_addr << confDeviceBits);
+    Addr start = devConfigAddr(bus_num, device.devAddr());
 
     return RangeSize(start, 1 << confDeviceBits);
 }
 
+AddrRange
+GenericPciHost::interfaceBusConfigRange(PciBusNum start_bus,
+                                        PciBusNum end_bus) const
+{
+    Addr start = devConfigAddr(start_bus, PciDevAddr(0, 0));
+    Addr size = (end_bus - start_bus + 1) << (BUS_OFFSET + confDeviceBits);
+
+    return RangeSize(start, size);
+}
+
 void
-GenericPciHost::interfacePostInt(const PciDevice &device)
+GenericPciHost::interfacePostInt(PciBusNum bus_num, const PciDevice &device)
 {
     platform.postPciInt(mapPciInterrupt(device));
 }
 
 void
-GenericPciHost::interfaceClearInt(const PciDevice &device)
+GenericPciHost::interfaceClearInt(PciBusNum bus_num, const PciDevice &device)
 {
     platform.clearPciInt(mapPciInterrupt(device));
 }

--- a/src/dev/pci/host.hh
+++ b/src/dev/pci/host.hh
@@ -119,26 +119,22 @@ class GenericPciHost : public PciHost
     AddrRange getConfigAddrRange() const override;
 
   protected: // PciUpstream
-    AddrRange interfaceConfigRange(PciBusNum bus_num,
-                                   const PciDevice &device) const override;
+    AddrRange interfaceConfigRange(const PciDevice &device) const override;
 
     Addr
-    interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
-                     Addr pci_addr) const override
+    interfacePioAddr(const PciDevice &device, Addr pci_addr) const override
     {
         return pciPioBase + pci_addr;
     }
 
     Addr
-    interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
-                     Addr pci_addr) const override
+    interfaceMemAddr(const PciDevice &device, Addr pci_addr) const override
     {
         return pciMemBase + pci_addr;
     }
 
     Addr
-    interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
-                     Addr pci_addr) const override
+    interfaceDmaAddr(const PciDevice &device, Addr pci_addr) const override
     {
         return pciDmaBase + pci_addr;
     }
@@ -153,9 +149,8 @@ class GenericPciHost : public PciHost
     }
 
   protected: // Interrupt handling
-    void interfacePostInt(PciBusNum bus_num, const PciDevice &device) override;
-    void interfaceClearInt(PciBusNum bus_num,
-                           const PciDevice &device) override;
+    void interfacePostInt(const PciDevice &device) override;
+    void interfaceClearInt(const PciDevice &device) override;
 
     virtual uint32_t mapPciInterrupt(const PciDevice &device) const;
 

--- a/src/dev/pci/host.hh
+++ b/src/dev/pci/host.hh
@@ -119,25 +119,32 @@ class GenericPciHost : public PciHost
     AddrRange getConfigAddrRange() const override;
 
   protected: // PciUpstream
-    AddrRange interfaceConfigRange(const PciDevice &device) const override;
+    AddrRange interfaceConfigRange(PciBusNum bus_num,
+                                   const PciDevice &device) const override;
 
     Addr
-    interfacePioAddr(const PciDevice &device, Addr pci_addr) const override
+    interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
+                     Addr pci_addr) const override
     {
         return pciPioBase + pci_addr;
     }
 
     Addr
-    interfaceMemAddr(const PciDevice &device, Addr pci_addr) const override
+    interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
+                     Addr pci_addr) const override
     {
         return pciMemBase + pci_addr;
     }
 
     Addr
-    interfaceDmaAddr(const PciDevice &device, Addr pci_addr) const override
+    interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
+                     Addr pci_addr) const override
     {
         return pciDmaBase + pci_addr;
     }
+
+    AddrRange interfaceBusConfigRange(PciBusNum start_bus,
+                                      PciBusNum end_bus) const override;
 
     PciBusNum
     getBusNum() const override
@@ -146,12 +153,15 @@ class GenericPciHost : public PciHost
     }
 
   protected: // Interrupt handling
-    void interfacePostInt(const PciDevice &device) override;
-    void interfaceClearInt(const PciDevice &device) override;
+    void interfacePostInt(PciBusNum bus_num, const PciDevice &device) override;
+    void interfaceClearInt(PciBusNum bus_num,
+                           const PciDevice &device) override;
 
     virtual uint32_t mapPciInterrupt(const PciDevice &device) const;
 
   protected:
+    Addr devConfigAddr(PciBusNum bus_num, const PciDevAddr &dev_addr) const;
+
     Platform &platform;
 
     const Addr confBase;
@@ -161,6 +171,10 @@ class GenericPciHost : public PciHost
     const Addr pciPioBase;
     const Addr pciMemBase;
     const Addr pciDmaBase;
+
+    constexpr static uint64_t FUNCTION_OFFSET = 0;
+    constexpr static uint64_t DEVICE_OFFSET = 3;
+    constexpr static uint64_t BUS_OFFSET = 8;
 };
 
 } // namespace gem5

--- a/src/dev/pci/p2p_bridge.cc
+++ b/src/dev/pci/p2p_bridge.cc
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025 REDS institute of the HEIG-VD
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dev/pci/p2p_bridge.hh"
+
+#include "base/addr_range.hh"
+#include "base/types.hh"
+#include "dev/pci/types.hh"
+#include "dev/pci/upstream.hh"
+#include "params/PciToPciBridge.hh"
+
+namespace gem5
+{
+
+PciToPciBridge::PciToPciBridge(const Params &p)
+    : PciType1Device(p),
+      PciUpstream(p.up_to_down, p.config_error, p.devices, name())
+{}
+
+PciToPciBridge::~PciToPciBridge()
+{}
+
+void
+PciToPciBridge::init()
+{
+    PciType1Device::init();
+    PciUpstream::init();
+}
+
+PciBusNum
+PciToPciBridge::getBusNum() const
+{
+    return config().secondaryBusNum;
+}
+
+Tick
+PciToPciBridge::writeConfig(PacketPtr pkt)
+{
+    Tick tick = PciType1Device::writeConfig(pkt);
+
+    auto offset = pkt->getAddr() & PCI_CONFIG_SIZE;
+    auto end_offset = offset + pkt->getSize();
+
+    // All downstream devices need to update their address ranges when
+    // secondary bus number has changed.
+    if ((offset <= PCI1_SEC_BUS_NUM && PCI1_SEC_BUS_NUM < end_offset) ||
+        (offset <= PCI1_SUB_BUS_NUM && PCI1_SUB_BUS_NUM < end_offset)) {
+        sendBusChange();
+    }
+
+    return tick;
+}
+
+bool
+PciToPciBridge::isDownstreamBus(PciBusNum bus_num) const
+{
+    // If this bridge number is zero, this means that the bridge isn't
+    // configured yet, and so there is no subordinate bus.
+    if (getBusNum() == 0) {
+        return false;
+    }
+
+    return (getBusNum() <= bus_num) && (bus_num <= config().subordinateBusNum);
+}
+
+AddrRange
+PciToPciBridge::getConfigAddrRange() const
+{
+    // No bus assigned, return invalid range
+    if (getBusNum() == 0) {
+        return AddrRange();
+    }
+
+    return upstreamInterface->busConfigRange(getBusNum(),
+                                             config().subordinateBusNum);
+}
+
+AddrRange
+PciToPciBridge::interfaceConfigRange(PciBusNum bus_num,
+                                     const PciDevice &device) const
+{
+    if (!isDownstreamBus(bus_num)) {
+        return AddrRange();
+    }
+
+    return upstreamInterface->configRange(bus_num, device);
+}
+
+Addr
+PciToPciBridge::interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
+                                 Addr pci_addr) const
+{
+    if (!isDownstreamBus(bus_num)) {
+        return 0;
+    }
+
+    return upstreamInterface->pioAddr(bus_num, device, pci_addr);
+}
+
+Addr
+PciToPciBridge::interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
+                                 Addr pci_addr) const
+{
+    if (!isDownstreamBus(bus_num)) {
+        return 0;
+    }
+
+    return upstreamInterface->memAddr(bus_num, device, pci_addr);
+}
+
+Addr
+PciToPciBridge::interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
+                                 Addr pci_addr) const
+{
+    if (!isDownstreamBus(bus_num)) {
+        return 0;
+    }
+
+    return upstreamInterface->dmaAddr(bus_num, device, pci_addr);
+}
+
+void
+PciToPciBridge::interfacePostInt(PciBusNum bus_num, const PciDevice &device)
+{
+    if (!isDownstreamBus(bus_num)) {
+        warn("Posting interrupt on unmapped bus\n");
+        return;
+    }
+
+    upstreamInterface->postInt(bus_num, device);
+}
+
+void
+PciToPciBridge::interfaceClearInt(PciBusNum bus_num, const PciDevice &device)
+{
+    if (!isDownstreamBus(bus_num)) {
+        warn("Clearing interrupt on unmapped bus\n");
+        return;
+    }
+
+    upstreamInterface->clearInt(bus_num, device);
+}
+
+AddrRange
+PciToPciBridge::interfaceBusConfigRange(PciBusNum start_bus,
+                                        PciBusNum end_bus) const
+{
+    if (!isDownstreamBus(start_bus) || !isDownstreamBus(end_bus)) {
+        return AddrRange();
+    }
+
+    return upstreamInterface->busConfigRange(start_bus, end_bus);
+}
+
+} // namespace gem5

--- a/src/dev/pci/p2p_bridge.cc
+++ b/src/dev/pci/p2p_bridge.cc
@@ -111,69 +111,65 @@ PciToPciBridge::getConfigAddrRange() const
 }
 
 AddrRange
-PciToPciBridge::interfaceConfigRange(PciBusNum bus_num,
-                                     const PciDevice &device) const
+PciToPciBridge::interfaceConfigRange(const PciDevice &device) const
 {
-    if (!isDownstreamBus(bus_num)) {
+    if (!isDownstreamBus(device.getBusNum())) {
         return AddrRange();
     }
 
-    return upstreamInterface->configRange(bus_num, device);
+    return upstreamInterface->configRange(device);
 }
 
 Addr
-PciToPciBridge::interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
-                                 Addr pci_addr) const
+PciToPciBridge::interfacePioAddr(const PciDevice &device, Addr pci_addr) const
 {
-    if (!isDownstreamBus(bus_num)) {
+    if (!isDownstreamBus(device.getBusNum())) {
         return 0;
     }
 
-    return upstreamInterface->pioAddr(bus_num, device, pci_addr);
+    return upstreamInterface->pioAddr(device, pci_addr);
 }
 
 Addr
-PciToPciBridge::interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
-                                 Addr pci_addr) const
+PciToPciBridge::interfaceMemAddr(const PciDevice &device, Addr pci_addr) const
 {
-    if (!isDownstreamBus(bus_num)) {
+    if (!isDownstreamBus(device.getBusNum())) {
         return 0;
     }
 
-    return upstreamInterface->memAddr(bus_num, device, pci_addr);
+    return upstreamInterface->memAddr(device, pci_addr);
 }
 
 Addr
-PciToPciBridge::interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
-                                 Addr pci_addr) const
+PciToPciBridge::interfaceDmaAddr(const PciDevice &device, Addr pci_addr) const
 {
-    if (!isDownstreamBus(bus_num)) {
+    if (!isDownstreamBus(device.getBusNum())) {
         return 0;
     }
 
-    return upstreamInterface->dmaAddr(bus_num, device, pci_addr);
+    return upstreamInterface->dmaAddr(device, pci_addr);
 }
 
 void
-PciToPciBridge::interfacePostInt(PciBusNum bus_num, const PciDevice &device)
+PciToPciBridge::interfacePostInt(const PciDevice &device)
 {
-    if (!isDownstreamBus(bus_num)) {
+    if (!isDownstreamBus(device.getBusNum())) {
         warn("Posting interrupt on unmapped bus\n");
         return;
     }
 
-    upstreamInterface->postInt(bus_num, device);
+    upstreamInterface->postInt(device);
 }
 
 void
-PciToPciBridge::interfaceClearInt(PciBusNum bus_num, const PciDevice &device)
+PciToPciBridge::interfaceClearInt(const PciDevice &device)
 {
-    if (!isDownstreamBus(bus_num)) {
+    if (!isDownstreamBus(device.getBusNum())) {
         warn("Clearing interrupt on unmapped bus\n");
         return;
     }
 
-    upstreamInterface->clearInt(bus_num, device);
+    upstreamInterface->clearInt(device);
 }
 
 AddrRange

--- a/src/dev/pci/p2p_bridge.cc
+++ b/src/dev/pci/p2p_bridge.cc
@@ -100,13 +100,14 @@ PciToPciBridge::isDownstreamBus(PciBusNum bus_num) const
 AddrRange
 PciToPciBridge::getConfigAddrRange() const
 {
-    // No bus assigned, return invalid range
-    if (getBusNum() == 0) {
+    // No valid bus assigned, return invalid range
+    const auto bus_num = getBusNum();
+    const auto sub_num = config().subordinateBusNum;
+    if ((bus_num == 0) || sub_num < bus_num) {
         return AddrRange();
     }
 
-    return upstreamInterface->busConfigRange(getBusNum(),
-                                             config().subordinateBusNum);
+    return upstreamInterface->busConfigRange(bus_num, sub_num);
 }
 
 AddrRange

--- a/src/dev/pci/p2p_bridge.hh
+++ b/src/dev/pci/p2p_bridge.hh
@@ -97,7 +97,7 @@ class PciToPciBridge : public PciType1Device, public PciUpstream
     PciBusNum getBusNum() const override;
 
     /**
-     * Check whatever a bus number is a valid downstream bus number.
+     * Check whether a bus number is a valid downstream bus number.
      * A valid downstream bus number is contained in the range between
      * secondary and subordinate number for configuration header.
      */
@@ -109,12 +109,15 @@ class PciToPciBridge : public PciType1Device, public PciUpstream
     Tick
     writeDevice(PacketPtr pkt) override
     {
+        pkt->makeAtomicResponse();
         return 0;
     }
 
     Tick
     readDevice(PacketPtr pkt) override
     {
+        pkt->setUintX(0, ByteOrder::little);
+        pkt->makeAtomicResponse();
         return 0;
     }
 };

--- a/src/dev/pci/p2p_bridge.hh
+++ b/src/dev/pci/p2p_bridge.hh
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 REDS institute of the HEIG-VD
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_PCI_P2P_BRIDGE_HH__
+#define __DEV_PCI_P2P_BRIDGE_HH__
+
+#include "dev/pci/device.hh"
+#include "dev/pci/types.hh"
+#include "dev/pci/upstream.hh"
+
+namespace gem5
+{
+
+class Platform;
+struct PciToPciBridgeParams;
+
+/**
+ * The PCI to PCI bridge upstream implements the required interface to let
+ * PCI device connect to them. PciToPciBridge class will forward address and
+ * range request to the next upstream, which can be the PCI host or another PCI
+ * bridge. If downstream bus number is set to 0, the bridge will be considered
+ * as unconfigured and then return empty ranges or invalid addresses.
+ */
+class PciToPciBridge : public PciType1Device, public PciUpstream
+{
+  public:
+    /* Remove name() ambiguity. */
+    using PciType1Device::name;
+
+    PARAMS(PciToPciBridge);
+    PciToPciBridge(const Params &p);
+    virtual ~PciToPciBridge();
+
+    void init() override;
+
+    /**
+     * Get the range for the configuration memory space for which this PCI
+     * bridge is responsible. The range should include the full configuration
+     * space even where no bus/device are present.
+     */
+    AddrRange getConfigAddrRange() const override;
+
+  protected: // PciUpstream
+    AddrRange interfaceConfigRange(PciBusNum bus_num,
+                                   const PciDevice &device) const override;
+
+    Addr interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
+                          Addr pci_addr) const override;
+
+    Addr interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
+                          Addr pci_addr) const override;
+
+    Addr interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
+                          Addr pci_addr) const override;
+
+    AddrRange interfaceBusConfigRange(PciBusNum start_bus,
+                                      PciBusNum end_bus) const override;
+
+    void interfacePostInt(PciBusNum bus_num, const PciDevice &device) override;
+    void interfaceClearInt(PciBusNum bus_num,
+                           const PciDevice &device) override;
+
+    PciBusNum getBusNum() const override;
+
+    /**
+     * Check whatever a bus number is a valid downstream bus number.
+     * A valid downstream bus number is contained in the range between
+     * secondary and subordinate number for configuration header.
+     */
+    bool isDownstreamBus(PciBusNum bus_num) const;
+
+  protected: // PciDevice
+    Tick writeConfig(PacketPtr pkt) override;
+
+    Tick
+    writeDevice(PacketPtr pkt) override
+    {
+        return 0;
+    }
+
+    Tick
+    readDevice(PacketPtr pkt) override
+    {
+        return 0;
+    }
+};
+
+} // namespace gem5
+
+#endif // __DEV_PCI_P2P_BRIDGE_HH__

--- a/src/dev/pci/p2p_bridge.hh
+++ b/src/dev/pci/p2p_bridge.hh
@@ -75,24 +75,22 @@ class PciToPciBridge : public PciType1Device, public PciUpstream
     AddrRange getConfigAddrRange() const override;
 
   protected: // PciUpstream
-    AddrRange interfaceConfigRange(PciBusNum bus_num,
-                                   const PciDevice &device) const override;
+    AddrRange interfaceConfigRange(const PciDevice &device) const override;
 
-    Addr interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
+    Addr interfacePioAddr(const PciDevice &device,
                           Addr pci_addr) const override;
 
-    Addr interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
+    Addr interfaceMemAddr(const PciDevice &device,
                           Addr pci_addr) const override;
 
-    Addr interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
+    Addr interfaceDmaAddr(const PciDevice &device,
                           Addr pci_addr) const override;
 
     AddrRange interfaceBusConfigRange(PciBusNum start_bus,
                                       PciBusNum end_bus) const override;
 
-    void interfacePostInt(PciBusNum bus_num, const PciDevice &device) override;
-    void interfaceClearInt(PciBusNum bus_num,
-                           const PciDevice &device) override;
+    void interfacePostInt(const PciDevice &device) override;
+    void interfaceClearInt(const PciDevice &device) override;
 
     PciBusNum getBusNum() const override;
 

--- a/src/dev/pci/upstream.cc
+++ b/src/dev/pci/upstream.cc
@@ -140,21 +140,26 @@ PciUpstream::DeviceInterface::name() const
                     upstream.getBusNum(), dev_addr.dev, dev_addr.func);
 }
 
+PciBusNum
+PciUpstream::DeviceInterface::getBusNum() const
+{
+    return upstream.getBusNum();
+}
+
 void
 PciUpstream::DeviceInterface::postInt()
 {
     DPRINTF(PciUpstream, "postInt\n");
 
-    upstream.interfacePostInt(upstream.getBusNum(), device);
+    upstream.interfacePostInt(device);
 }
 
 void
-PciUpstream::DeviceInterface::postInt(PciBusNum bus_num,
-                                      const PciDevice &device)
+PciUpstream::DeviceInterface::postInt(const PciDevice &device)
 {
     DPRINTF(PciUpstream, "postInt\n");
 
-    upstream.interfacePostInt(bus_num, device);
+    upstream.interfacePostInt(device);
 }
 
 void
@@ -162,68 +167,63 @@ PciUpstream::DeviceInterface::clearInt()
 {
     DPRINTF(PciUpstream, "clearInt\n");
 
-    upstream.interfaceClearInt(upstream.getBusNum(), device);
+    upstream.interfaceClearInt(device);
 }
 
 void
-PciUpstream::DeviceInterface::clearInt(PciBusNum bus_num,
-                                       const PciDevice &device)
+PciUpstream::DeviceInterface::clearInt(const PciDevice &device)
 {
     DPRINTF(PciUpstream, "clearInt\n");
 
-    upstream.interfaceClearInt(bus_num, device);
+    upstream.interfaceClearInt(device);
 }
 
 AddrRange
 PciUpstream::DeviceInterface::configRange() const
 {
-    return upstream.interfaceConfigRange(upstream.getBusNum(), device);
+    return upstream.interfaceConfigRange(device);
 }
 
 AddrRange
-PciUpstream::DeviceInterface::configRange(PciBusNum bus_num,
-                                          const PciDevice &device) const
+PciUpstream::DeviceInterface::configRange(const PciDevice &device) const
 {
-    return upstream.interfaceConfigRange(bus_num, device);
+    return upstream.interfaceConfigRange(device);
 }
 
 Addr
 PciUpstream::DeviceInterface::pioAddr(Addr addr) const
 {
-    return upstream.interfacePioAddr(upstream.getBusNum(), device, addr);
+    return upstream.interfacePioAddr(device, addr);
 }
 
 Addr
-PciUpstream::DeviceInterface::pioAddr(PciBusNum bus_num,
-                                      const PciDevice &device, Addr addr) const
+PciUpstream::DeviceInterface::pioAddr(const PciDevice &device, Addr addr) const
 {
-    return upstream.interfacePioAddr(bus_num, device, addr);
+    return upstream.interfacePioAddr(device, addr);
 }
 
 Addr
 PciUpstream::DeviceInterface::memAddr(Addr addr) const
 {
-    return upstream.interfaceMemAddr(upstream.getBusNum(), device, addr);
+    return upstream.interfaceMemAddr(device, addr);
 }
 
 Addr
-PciUpstream::DeviceInterface::memAddr(PciBusNum bus_num,
-                                      const PciDevice &device, Addr addr) const
+PciUpstream::DeviceInterface::memAddr(const PciDevice &device, Addr addr) const
 {
-    return upstream.interfaceMemAddr(bus_num, device, addr);
+    return upstream.interfaceMemAddr(device, addr);
 }
 
 Addr
 PciUpstream::DeviceInterface::dmaAddr(Addr addr) const
 {
-    return upstream.interfaceDmaAddr(upstream.getBusNum(), device, addr);
+    return upstream.interfaceDmaAddr(device, addr);
 }
 
 Addr
-PciUpstream::DeviceInterface::dmaAddr(PciBusNum bus_num,
-                                      const PciDevice &device, Addr addr) const
+PciUpstream::DeviceInterface::dmaAddr(const PciDevice &device, Addr addr) const
 {
-    return upstream.interfaceDmaAddr(bus_num, device, addr);
+    return upstream.interfaceDmaAddr(device, addr);
 }
 
 AddrRange

--- a/src/dev/pci/upstream.cc
+++ b/src/dev/pci/upstream.cc
@@ -65,6 +65,18 @@ PciConfigError::setAddrRange(AddrRange range)
     pioPort.sendRangeChange();
 }
 
+AddrRangeList
+PciConfigError::getAddrRanges() const
+{
+    // Avoid triggering assertion error with zero size range, which is the case
+    // when the a PCI to PCI bridge isn't configured yet.
+    if (pioSize == 0) {
+        return AddrRangeList();
+    }
+
+    return IsaFake::getAddrRanges();
+}
+
 PciUpstream::PciUpstream(PciUpDownBridge *up_to_down,
                          PciConfigError *config_error_dev,
                          const std::vector<PciDevice *> &pci_devices,
@@ -92,8 +104,6 @@ PciUpstream::PciUpstream(PciUpDownBridge *up_to_down,
 void
 PciUpstream::init()
 {
-    upToDown->setConfigRange(getConfigAddrRange());
-    configErrorDevice->setAddrRange(getConfigAddrRange());
     sendBusChange();
 }
 
@@ -135,7 +145,16 @@ PciUpstream::DeviceInterface::postInt()
 {
     DPRINTF(PciUpstream, "postInt\n");
 
-    upstream.interfacePostInt(device);
+    upstream.interfacePostInt(upstream.getBusNum(), device);
+}
+
+void
+PciUpstream::DeviceInterface::postInt(PciBusNum bus_num,
+                                      const PciDevice &device)
+{
+    DPRINTF(PciUpstream, "postInt\n");
+
+    upstream.interfacePostInt(bus_num, device);
 }
 
 void
@@ -143,36 +162,84 @@ PciUpstream::DeviceInterface::clearInt()
 {
     DPRINTF(PciUpstream, "clearInt\n");
 
-    upstream.interfaceClearInt(device);
+    upstream.interfaceClearInt(upstream.getBusNum(), device);
+}
+
+void
+PciUpstream::DeviceInterface::clearInt(PciBusNum bus_num,
+                                       const PciDevice &device)
+{
+    DPRINTF(PciUpstream, "clearInt\n");
+
+    upstream.interfaceClearInt(bus_num, device);
 }
 
 AddrRange
 PciUpstream::DeviceInterface::configRange() const
 {
-    return upstream.interfaceConfigRange(device);
+    return upstream.interfaceConfigRange(upstream.getBusNum(), device);
+}
+
+AddrRange
+PciUpstream::DeviceInterface::configRange(PciBusNum bus_num,
+                                          const PciDevice &device) const
+{
+    return upstream.interfaceConfigRange(bus_num, device);
 }
 
 Addr
 PciUpstream::DeviceInterface::pioAddr(Addr addr) const
 {
-    return upstream.interfacePioAddr(device, addr);
+    return upstream.interfacePioAddr(upstream.getBusNum(), device, addr);
+}
+
+Addr
+PciUpstream::DeviceInterface::pioAddr(PciBusNum bus_num,
+                                      const PciDevice &device, Addr addr) const
+{
+    return upstream.interfacePioAddr(bus_num, device, addr);
 }
 
 Addr
 PciUpstream::DeviceInterface::memAddr(Addr addr) const
 {
-    return upstream.interfaceMemAddr(device, addr);
+    return upstream.interfaceMemAddr(upstream.getBusNum(), device, addr);
+}
+
+Addr
+PciUpstream::DeviceInterface::memAddr(PciBusNum bus_num,
+                                      const PciDevice &device, Addr addr) const
+{
+    return upstream.interfaceMemAddr(bus_num, device, addr);
 }
 
 Addr
 PciUpstream::DeviceInterface::dmaAddr(Addr addr) const
 {
-    return upstream.interfaceDmaAddr(device, addr);
+    return upstream.interfaceDmaAddr(upstream.getBusNum(), device, addr);
+}
+
+Addr
+PciUpstream::DeviceInterface::dmaAddr(PciBusNum bus_num,
+                                      const PciDevice &device, Addr addr) const
+{
+    return upstream.interfaceDmaAddr(bus_num, device, addr);
+}
+
+AddrRange
+PciUpstream::DeviceInterface::busConfigRange(PciBusNum start_bus,
+                                             PciBusNum end_bus) const
+{
+    return upstream.interfaceBusConfigRange(start_bus, end_bus);
 }
 
 void
 PciUpstream::sendBusChange()
 {
+    // Update bridge and error device configuration range
+    upToDown->setConfigRange(getConfigAddrRange());
+    configErrorDevice->setAddrRange(getConfigAddrRange());
+
     for (std::pair<PciDevAddr, PciDevice *> device : devices) {
         device.second->recvBusChange();
     }

--- a/src/dev/pci/upstream.cc
+++ b/src/dev/pci/upstream.cc
@@ -69,7 +69,7 @@ AddrRangeList
 PciConfigError::getAddrRanges() const
 {
     // Avoid triggering assertion error with zero size range, which is the case
-    // when the a PCI to PCI bridge isn't configured yet.
+    // when a PCI-to-PCI bridge isn't configured yet.
     if (pioSize == 0) {
         return AddrRangeList();
     }

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -145,6 +145,11 @@ class PciUpstream
         const std::string name() const;
 
         /**
+         * Get the PCI bus number of the upstream bridge.
+         */
+        PciBusNum getBusNum() const;
+
+        /**
          * Post a PCI interrupt to the CPU.
          */
         void postInt();
@@ -154,10 +159,9 @@ class PciUpstream
          * This function should be used by bridges to post interrupts
          * from devices downstream of them.
          *
-         * @param bus_num Bus number to which the device is connected.
          * @param device PCI device posting the interrupts.
          */
-        void postInt(PciBusNum bus_num, const PciDevice &device);
+        void postInt(const PciDevice &device);
 
         /**
          * Clear a posted PCI interrupt
@@ -169,10 +173,9 @@ class PciUpstream
          * This function should be used by bridges to clear interrupts
          * from devices downstream of them.
          *
-         * @param bus_num Bus number to which the device is connected.
          * @param device PCI device posting the interrupts.
          */
-        void clearInt(PciBusNum bus_num, const PciDevice &device);
+        void clearInt(const PciDevice &device);
 
         /**
          * Calculate the physical address range of the PCI device
@@ -187,12 +190,10 @@ class PciUpstream
          * configuration space. This function should be used by bridges to get
          * ranges from devices downstream of them.
          *
-         * @param bus_num Bus number to which the device is connected.
          * @param device PCI device requesting configuration range.
          * @return Address range in the system's physical address space.
          */
-        AddrRange configRange(PciBusNum bus_num,
-                              const PciDevice &device) const;
+        AddrRange configRange(const PciDevice &device) const;
 
         /**
          * Calculate the physical address of an IO location on the PCI
@@ -208,13 +209,11 @@ class PciUpstream
          * bus. This function should be used by bridges to get address
          * from devices downstream of them.
          *
-         * @param bus_num Bus number to which the device is connected.
          * @param device PCI device requesting PIO addr.
          * @param addr Address in the PCI IO address space
          * @return Address in the system's physical address space.
          */
-        Addr pioAddr(PciBusNum bus_num, const PciDevice &device,
-                     Addr addr) const;
+        Addr pioAddr(const PciDevice &device, Addr addr) const;
 
         /**
          * Calculate the physical address of a non-prefetchable memory
@@ -230,13 +229,11 @@ class PciUpstream
          * location in the PCI address space. This function should be used by
          * bridge to get address from devices downstream of them.
          *
-         * @param bus_num Bus number to which the device is connected.
          * @param device PCI device requesting memory address translation.
          * @param addr Address in the PCI memory address space
          * @return Address in the system's physical address space.
          */
-        Addr memAddr(PciBusNum bus_num, const PciDevice &device,
-                     Addr addr) const;
+        Addr memAddr(const PciDevice &device, Addr addr) const;
 
         /**
          * Calculate the physical address of a prefetchable memory
@@ -252,13 +249,11 @@ class PciUpstream
          * location in the PCI address space. This function should be used by
          * bridge to get address from devices downstream of them.
          *
-         * @param bus_num Bus number to which the device is connected.
          * @param device PCI device request DMA address.
          * @param addr Address in the PCI DMA memory address space
          * @return Address in the system's physical address space.
          */
-        Addr dmaAddr(PciBusNum bus_num, const PciDevice &device,
-                     Addr addr) const;
+        Addr dmaAddr(const PciDevice &device, Addr addr) const;
 
         /**
          * Calculate the physical address range of the PCI configuration space
@@ -299,67 +294,58 @@ class PciUpstream
     /**
      * Post an interrupt to the CPU.
      *
-     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      */
-    virtual void interfacePostInt(PciBusNum bus_num,
-                                  const PciDevice &device) = 0;
+    virtual void interfacePostInt(const PciDevice &device) = 0;
 
     /**
      * Clear an interrupt to the CPU.
      *
-     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      */
-    virtual void interfaceClearInt(PciBusNum bus_num,
-                                   const PciDevice &device) = 0;
+    virtual void interfaceClearInt(const PciDevice &device) = 0;
 
     /**
      * Calculate the physical address range of the PCI device
      * configuration space.
      *
-     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @return Configuration address range in the system's physical address
      *         space.
      */
-    virtual AddrRange interfaceConfigRange(PciBusNum bus_num,
-                                           const PciDevice &device) const = 0;
+    virtual AddrRange interfaceConfigRange(const PciDevice &device) const = 0;
 
     /**
      * Calculate the physical address of an IO location on the PCI
      * bus.
      *
-     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @param pci_addr Address in the PCI IO address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
+    virtual Addr interfacePioAddr(const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**
      * Calculate the physical address of a non-prefetchable memory
      * location in the PCI address space.
      *
-     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @param pci_addr Address in the PCI memory address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
+    virtual Addr interfaceMemAddr(const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**
      * Calculate the physical address of a prefetchable memory
      * location in the PCI address space.
      *
-     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @param pci_addr Address in the PCI DMA memory address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
+    virtual Addr interfaceDmaAddr(const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -62,6 +62,8 @@ class PciConfigError : public IsaFake
     PciConfigError(const Params &p);
 
     void setAddrRange(AddrRange range);
+
+    AddrRangeList getAddrRanges() const override;
 };
 
 /**
@@ -148,9 +150,29 @@ class PciUpstream
         void postInt();
 
         /**
+         * Post a PCI interrupt to the CPU.
+         * This function should be used by bridges to post interrupts
+         * from devices downstream of them.
+         *
+         * @param bus_num Bus number to which the device is connected.
+         * @param device PCI device posting the interrupts.
+         */
+        void postInt(PciBusNum bus_num, const PciDevice &device);
+
+        /**
          * Clear a posted PCI interrupt
          */
         void clearInt();
+
+        /**
+         * Clear a posted PCI interrupt.
+         * This function should be used by bridges to clear interrupts
+         * from devices downstream of them.
+         *
+         * @param bus_num Bus number to which the device is connected.
+         * @param device PCI device posting the interrupts.
+         */
+        void clearInt(PciBusNum bus_num, const PciDevice &device);
 
         /**
          * Calculate the physical address range of the PCI device
@@ -159,6 +181,18 @@ class PciUpstream
          * @return Address range in the system's physical address space.
          */
         AddrRange configRange() const;
+
+        /**
+         * Calculate the physical address range of the PCI device
+         * configuration space. This function should be used by bridges to get
+         * ranges from devices downstream of them.
+         *
+         * @param bus_num Bus number to which the device is connected.
+         * @param device PCI device requesting configuration range.
+         * @return Address range in the system's physical address space.
+         */
+        AddrRange configRange(PciBusNum bus_num,
+                              const PciDevice &device) const;
 
         /**
          * Calculate the physical address of an IO location on the PCI
@@ -170,6 +204,19 @@ class PciUpstream
         Addr pioAddr(Addr addr) const;
 
         /**
+         * Calculate the physical address of an IO location on the PCI
+         * bus. This function should be used by bridges to get address
+         * from devices downstream of them.
+         *
+         * @param bus_num Bus number to which the device is connected.
+         * @param device PCI device requesting PIO addr.
+         * @param addr Address in the PCI IO address space
+         * @return Address in the system's physical address space.
+         */
+        Addr pioAddr(PciBusNum bus_num, const PciDevice &device,
+                     Addr addr) const;
+
+        /**
          * Calculate the physical address of a non-prefetchable memory
          * location in the PCI address space.
          *
@@ -179,6 +226,19 @@ class PciUpstream
         Addr memAddr(Addr addr) const;
 
         /**
+         * Calculate the physical address of a non-prefetchable memory
+         * location in the PCI address space. This function should be used by
+         * bridge to get address from devices downstream of them.
+         *
+         * @param bus_num Bus number to which the device is connected.
+         * @param device PCI device posting the interrupts.
+         * @param addr Address in the PCI memory address space
+         * @return Address in the system's physical address space.
+         */
+        Addr memAddr(PciBusNum bus_num, const PciDevice &device,
+                     Addr addr) const;
+
+        /**
          * Calculate the physical address of a prefetchable memory
          * location in the PCI address space.
          *
@@ -186,6 +246,29 @@ class PciUpstream
          * @return Address in the system's physical address space.
          */
         Addr dmaAddr(Addr addr) const;
+
+        /**
+         * Calculate the physical address of a prefetchable memory
+         * location in the PCI address space. This function should be used by
+         * bridge to get address from devices downstream of them.
+         *
+         * @param bus_num Bus number to which the device is connected.
+         * @param device PCI device request DMA address.
+         * @param addr Address in the PCI DMA memory address space
+         * @return Address in the system's physical address space.
+         */
+        Addr dmaAddr(PciBusNum bus_num, const PciDevice &device,
+                     Addr addr) const;
+
+        /**
+         * Calculate the physical address range of the PCI configuration space
+         * for a range of buses.
+         *
+         * @param start_bus First bus of the range to get
+         * @param end_bus Last bus of the range to get, included
+         * @return Address range in the system's physical address space.
+         */
+        AddrRange busConfigRange(PciBusNum start_bus, PciBusNum end_bus) const;
 
       protected:
         PciUpstream &upstream;
@@ -216,59 +299,80 @@ class PciUpstream
     /**
      * Post an interrupt to the CPU.
      *
+     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      */
-    virtual void interfacePostInt(const PciDevice &device) = 0;
+    virtual void interfacePostInt(PciBusNum bus_num,
+                                  const PciDevice &device) = 0;
 
     /**
      * Clear an interrupt to the CPU.
      *
+     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      */
-    virtual void interfaceClearInt(const PciDevice &device) = 0;
+    virtual void interfaceClearInt(PciBusNum bus_num,
+                                   const PciDevice &device) = 0;
 
     /**
      * Calculate the physical address range of the PCI device
      * configuration space.
      *
+     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @return Configuration address range in the system's physical address
      *         space.
      */
-    virtual AddrRange interfaceConfigRange(const PciDevice &device) const = 0;
+    virtual AddrRange interfaceConfigRange(PciBusNum bus_num,
+                                           const PciDevice &device) const = 0;
 
     /**
      * Calculate the physical address of an IO location on the PCI
      * bus.
      *
+     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @param pci_addr Address in the PCI IO address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfacePioAddr(const PciDevice &device,
+    virtual Addr interfacePioAddr(PciBusNum bus_num, const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**
      * Calculate the physical address of a non-prefetchable memory
      * location in the PCI address space.
      *
+     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @param pci_addr Address in the PCI memory address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfaceMemAddr(const PciDevice &device,
+    virtual Addr interfaceMemAddr(PciBusNum bus_num, const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**
      * Calculate the physical address of a prefetchable memory
      * location in the PCI address space.
      *
+     * @param bus_num Bus number to which the device is connected.
      * @param device The requesting PCI device
      * @param pci_addr Address in the PCI DMA memory address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfaceDmaAddr(const PciDevice &device,
+    virtual Addr interfaceDmaAddr(PciBusNum bus_num, const PciDevice &device,
                                   Addr pci_addr) const = 0;
+
+    /**
+     * Get the range for the configuration memory space for which a downstream
+     * PCI bridge is responsible for.
+     *
+     * @param start_bus First bus for which the bridge is responsible
+     * (secondary bus number)
+     * @param end_bus Last bus for which the bridge is responsible, included
+     * (subordinate bus number)
+     */
+    virtual AddrRange interfaceBusConfigRange(PciBusNum start_bus,
+                                              PciBusNum end_bus) const = 0;
 
     /** @} */
 

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -231,7 +231,7 @@ class PciUpstream
          * bridge to get address from devices downstream of them.
          *
          * @param bus_num Bus number to which the device is connected.
-         * @param device PCI device posting the interrupts.
+         * @param device PCI device requesting memory address translation.
          * @param addr Address in the PCI memory address space
          * @return Address in the system's physical address space.
          */


### PR DESCRIPTION
This commit brings PCI to PCI bridge into gem5.
    
A P2P bridge acts like an upstream to one or many PCI device (or other P2P bridge), like a PCI host bridge do. But unlike those, a P2P bridge must be connected to another upstream (host bridge or P2P bridge). They also have a type 1 PCI configuration header which gives bus number and addresses behind the bridge.

In this implementation, the class PciToPciBridge is added. It inherit from both PciType1Device and PciUpstream, implementing required functions. This is a simple implementation which redirect all request from downstream device to upper bridge. For this purpose, DeviceInterface class in PciUpstream has been extended for the function to be called with the PCI device and its bus number in arguments.

The PciToPciBridge Python configuration is similar to the one of PciHost.