### PR TITLE
cpu: Link tagBits to tag_bits in the SimpleBTB

### DIFF
--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2022-2023 The University of Edinburgh
 # Copyright (c) 2024 Technical University of Munich
+# Copyright (c) 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -137,6 +138,7 @@ class SimpleBTB(BranchTargetBuffer):
             assoc=Parent.associativity,
             num_entries=Parent.numEntries,
             set_shift=Parent.instShiftAmt,
+            tag_bits=Parent.tagBits,
             numThreads=1,
         ),
         "BTB indexing policy",


### PR DESCRIPTION
Since the introduction of the BTBSetAssociative class the number of bits for the tag was not directly linked to the parent tagBits parameter and was therefore set to the default value of 64, unless it was explicitly linked as it was in some gem5 configs [1][2].

In the long term we should consider adding some checks as it all seems a bit brittle as of now

[1]: https://github.com/gem5/gem5/blob/stable/\
    configs/common/cores/arm/O3_ARM_v7a.py#L121
[2]: https://github.com/gem5/gem5/blob/stable/\
    configs/common/cores/arm/HPI.py#L1693


Change-Id: Ie6227388e1fe79f3c37d759eef9e8672e9d8a1ec