### PR TITLE
arch-arm, dev-arm: Replace params inclusion with forward declaration

### DIFF
--- a/src/arch/arm/decoder.cc
+++ b/src/arch/arm/decoder.cc
@@ -45,6 +45,7 @@
 #include "base/cast.hh"
 #include "base/trace.hh"
 #include "debug/Decoder.hh"
+#include "params/ArmDecoder.hh"
 #include "sim/full_system.hh"
 
 namespace gem5

--- a/src/arch/arm/decoder.hh
+++ b/src/arch/arm/decoder.hh
@@ -51,10 +51,11 @@
 #include "cpu/static_inst.hh"
 #include "debug/Decode.hh"
 #include "enums/DecoderFlavor.hh"
-#include "params/ArmDecoder.hh"
 
 namespace gem5
 {
+
+struct ArmDecoderParams;
 
 class BaseISA;
 

--- a/src/arch/arm/fs_workload.cc
+++ b/src/arch/arm/fs_workload.cc
@@ -47,6 +47,7 @@
 #include "dev/arm/gic_v2.hh"
 #include "kern/system_events.hh"
 #include "params/ArmFsWorkload.hh"
+#include "params/ArmSystem.hh"
 
 namespace gem5
 {
@@ -142,6 +143,13 @@ FsWorkload::initState()
         if (!arm_sys->highestELIs64())
             arm_sys->threads[0]->pcState(kernelObj->entryPoint());
     }
+}
+
+void
+FsWorkload::setSystem(System *sys)
+{
+    KernelWorkload::setSystem(sys);
+    gdb = BaseRemoteGDB::build<RemoteGDB>(params().remote_gdb_port, system);
 }
 
 loader::ObjectFile *

--- a/src/arch/arm/fs_workload.hh
+++ b/src/arch/arm/fs_workload.hh
@@ -48,12 +48,13 @@
 #include "arch/arm/aapcs64.hh"
 #include "arch/arm/remote_gdb.hh"
 #include "kern/linux/events.hh"
-#include "params/ArmFsWorkload.hh"
 #include "sim/kernel_workload.hh"
 #include "sim/sim_object.hh"
 
 namespace gem5
 {
+
+struct ArmFsWorkloadParams;
 
 namespace ArmISA
 {
@@ -149,13 +150,7 @@ class FsWorkload : public KernelWorkload
 
     void initState() override;
 
-    void
-    setSystem(System *sys) override
-    {
-        KernelWorkload::setSystem(sys);
-        gdb = BaseRemoteGDB::build<RemoteGDB>(
-                params().remote_gdb_port, system);
-    }
+    void setSystem(System *sys) override;
 
     Addr
     fixFuncEventAddr(Addr addr) const override

--- a/src/arch/arm/interrupts.cc
+++ b/src/arch/arm/interrupts.cc
@@ -38,9 +38,15 @@
 #include "arch/arm/interrupts.hh"
 
 #include "arch/arm/system.hh"
+#include "params/ArmInterrupts.hh"
 
 namespace gem5
 {
+
+ArmISA::Interrupts::Interrupts(const Params &p) : BaseInterrupts(p)
+{
+    clearAll();
+}
 
 bool
 ArmISA::Interrupts::takeInt32(InterruptTypes int_type) const

--- a/src/arch/arm/interrupts.hh
+++ b/src/arch/arm/interrupts.hh
@@ -48,10 +48,11 @@
 #include "cpu/thread_context.hh"
 #include "debug/Interrupt.hh"
 #include "enums/ArmExtension.hh"
-#include "params/ArmInterrupts.hh"
 
 namespace gem5
 {
+
+struct ArmInterruptsParams;
 
 namespace ArmISA
 {
@@ -81,11 +82,7 @@ class Interrupts : public BaseInterrupts
   public:
     using Params = ArmInterruptsParams;
 
-    Interrupts(const Params &p) : BaseInterrupts(p)
-    {
-        clearAll();
-    }
-
+    Interrupts(const Params &p);
 
     void
     post(int int_num, int index) override

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -49,8 +49,9 @@
 #include "arch/arm/tlbi_op.hh"
 #include "debug/MMU.hh"
 #include "mem/packet_access.hh"
-#include "sim/pseudo_inst.hh"
+#include "params/ArmMMU.hh"
 #include "sim/process.hh"
+#include "sim/pseudo_inst.hh"
 
 namespace gem5
 {

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -48,10 +48,11 @@
 #include "base/statistics.hh"
 #include "enums/ArmLookupLevel.hh"
 
-#include "params/ArmMMU.hh"
-
 namespace gem5
 {
+
+struct ArmMMUParams;
+class ArmRelease;
 
 namespace ArmISA {
 

--- a/src/arch/arm/nativetrace.cc
+++ b/src/arch/arm/nativetrace.cc
@@ -67,6 +67,10 @@ namespace trace {
     "f31", "fpscr"
 };
 
+ArmNativeTrace::ArmNativeTrace(const Params &p)
+    : NativeTrace(p), stopOnPCError(p.stop_on_pc_error)
+{}
+
 void
 ArmNativeTrace::ThreadState::update(NativeTrace *parent)
 {

--- a/src/arch/arm/nativetrace.hh
+++ b/src/arch/arm/nativetrace.hh
@@ -31,10 +31,11 @@
 
 #include "base/types.hh"
 #include "cpu/nativetrace.hh"
-#include "params/ArmNativeTrace.hh"
 
 namespace gem5
 {
+
+struct ArmNativeTraceParams;
 
 namespace trace {
 
@@ -103,9 +104,7 @@ class ArmNativeTrace : public NativeTrace
   public:
     using Params = ArmNativeTraceParams;
 
-    ArmNativeTrace(const Params &p) :
-        NativeTrace(p), stopOnPCError(p.stop_on_pc_error)
-    {}
+    ArmNativeTrace(const Params &p);
 
     void check(NativeTraceRecord *record);
 };

--- a/src/arch/arm/system.cc
+++ b/src/arch/arm/system.cc
@@ -51,6 +51,7 @@
 #include "dev/arm/gic_v2.hh"
 #include "mem/physical.hh"
 #include "params/ArmRelease.hh"
+#include "params/ArmSystem.hh"
 
 namespace gem5
 {

--- a/src/arch/arm/system.hh
+++ b/src/arch/arm/system.hh
@@ -48,16 +48,16 @@
 
 #include "arch/arm/page_size.hh"
 #include "arch/arm/types.hh"
+#include "enums/ArmExtension.hh"
 #include "kern/linux/events.hh"
-#include "params/ArmSystem.hh"
 #include "sim/full_system.hh"
 #include "sim/sim_object.hh"
 #include "sim/system.hh"
-#include "enums/ArmExtension.hh"
-
 
 namespace gem5
 {
+
+struct ArmSystemParams;
 
 class GenericTimer;
 class BaseGic;
@@ -65,6 +65,7 @@ class FVPBasePwrCtrl;
 class ThreadContext;
 
 struct ArmReleaseParams;
+struct ArmSemihosting;
 
 class ArmRelease : public SimObject
 {

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -53,6 +53,7 @@
 #include "debug/PageTableWalker.hh"
 #include "debug/TLB.hh"
 #include "debug/TLBVerbose.hh"
+#include "params/ArmTableWalker.hh"
 #include "sim/system.hh"
 
 namespace gem5

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -50,12 +50,13 @@
 #include "mem/packet_queue.hh"
 #include "mem/qport.hh"
 #include "mem/request.hh"
-#include "params/ArmTableWalker.hh"
 #include "sim/clocked_object.hh"
 #include "sim/eventq.hh"
 
 namespace gem5
 {
+
+struct ArmTableWalkerParams;
 
 class ThreadContext;
 

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -50,11 +50,12 @@
 #include "base/statistics.hh"
 #include "enums/TypeTLB.hh"
 #include "mem/request.hh"
-#include "params/ArmTLB.hh"
 #include "sim/probe/pmu.hh"
 
 namespace gem5
 {
+
+struct ArmTLBParams;
 
 class ThreadContext;
 

--- a/src/dev/arm/a9scu.cc
+++ b/src/dev/arm/a9scu.cc
@@ -41,6 +41,7 @@
 #include "base/trace.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/A9SCU.hh"
 #include "sim/system.hh"
 
 namespace gem5

--- a/src/dev/arm/a9scu.hh
+++ b/src/dev/arm/a9scu.hh
@@ -39,7 +39,6 @@
 #define __DEV_ARM_A9SCU_HH__
 
 #include "dev/io_device.hh"
-#include "params/A9SCU.hh"
 
 /** @file
  * This defines the snoop control unit register on an A9
@@ -47,6 +46,8 @@
 
 namespace gem5
 {
+
+struct A9SCUParams;
 
 class A9SCU : public BasicPioDevice
 {
@@ -58,7 +59,7 @@ class A9SCU : public BasicPioDevice
     };
 
   public:
-    typedef A9SCUParams Params;
+    using Params = A9SCUParams;
 
     /**
       * The constructor for RealView just registers itself with the MMU.

--- a/src/dev/arm/amba_device.cc
+++ b/src/dev/arm/amba_device.cc
@@ -45,6 +45,9 @@
 #include "dev/arm/amba_fake.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/AmbaDmaDevice.hh"
+#include "params/AmbaIntDevice.hh"
+#include "params/AmbaPioDevice.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/amba_device.hh
+++ b/src/dev/arm/amba_device.hh
@@ -52,12 +52,13 @@
 #include "dev/io_device.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
-#include "params/AmbaPioDevice.hh"
-#include "params/AmbaDmaDevice.hh"
-#include "params/AmbaIntDevice.hh"
 
 namespace gem5
 {
+
+struct AmbaPioDeviceParams;
+struct AmbaDmaDeviceParams;
+struct AmbaIntDeviceParams;
 
 class AmbaDevice
 {

--- a/src/dev/arm/amba_fake.cc
+++ b/src/dev/arm/amba_fake.cc
@@ -44,6 +44,7 @@
 #include "debug/AMBA.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/AmbaFake.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/amba_fake.hh
+++ b/src/dev/arm/amba_fake.hh
@@ -50,10 +50,11 @@
 #define __DEV_ARM_AMBA_FAKE_H__
 
 #include "dev/arm/amba_device.hh"
-#include "params/AmbaFake.hh"
 
 namespace gem5
 {
+
+struct AmbaFakeParams;
 
 class AmbaFake : public AmbaPioDevice
 {

--- a/src/dev/arm/energy_ctrl.hh
+++ b/src/dev/arm/energy_ctrl.hh
@@ -54,10 +54,11 @@
 #define __DEV_ARM_ENERGY_CTRL_HH__
 
 #include "dev/io_device.hh"
-#include "params/EnergyCtrl.hh"
 
 namespace gem5
 {
+
+struct EnergyCtrlParams;
 
 class DVFSHandler;
 
@@ -116,7 +117,7 @@ class EnergyCtrl : public BasicPioDevice
         PIO_NUM_FIELDS
     };
 
-    typedef EnergyCtrlParams Params;
+    using Params = EnergyCtrlParams;
     EnergyCtrl(const Params &p);
 
     /**

--- a/src/dev/arm/flash_device.cc
+++ b/src/dev/arm/flash_device.cc
@@ -54,6 +54,7 @@
 
 #include "base/trace.hh"
 #include "debug/Drain.hh"
+#include "params/FlashDevice.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/flash_device.hh
+++ b/src/dev/arm/flash_device.hh
@@ -43,11 +43,12 @@
 #include "debug/FlashDevice.hh"
 #include "dev/arm/abstract_nvm.hh"
 #include "enums/DataDistribution.hh"
-#include "params/FlashDevice.hh"
 #include "sim/serialize.hh"
 
 namespace gem5
 {
+
+struct FlashDeviceParams;
 
 /**
  * Flash Device model

--- a/src/dev/arm/gic_v2.cc
+++ b/src/dev/arm/gic_v2.cc
@@ -49,6 +49,7 @@
 #include "debug/Interrupt.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/GicV2.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/gic_v2.hh
+++ b/src/dev/arm/gic_v2.hh
@@ -54,10 +54,11 @@
 #include "dev/arm/base_gic.hh"
 #include "dev/io_device.hh"
 #include "dev/platform.hh"
-#include "params/GicV2.hh"
 
 namespace gem5
 {
+
+struct GicV2Params;
 
 class GicV2Registers
 {

--- a/src/dev/arm/gic_v2m.cc
+++ b/src/dev/arm/gic_v2m.cc
@@ -63,9 +63,15 @@
 #include "dev/io_device.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/Gicv2m.hh"
+#include "params/Gicv2mFrame.hh"
 
 namespace gem5
 {
+
+Gicv2mFrame::Gicv2mFrame(const Params &p)
+    : SimObject(p), addr(p.addr), spi_base(p.spi_base), spi_len(p.spi_len)
+{}
 
 Gicv2m::Gicv2m(const Params &p)
     : PioDevice(p), pioDelay(p.pio_delay), frames(p.frames), gic(p.gic)

--- a/src/dev/arm/gic_v2m.hh
+++ b/src/dev/arm/gic_v2m.hh
@@ -48,11 +48,12 @@
 #include "dev/arm/base_gic.hh"
 #include "dev/io_device.hh"
 #include "dev/platform.hh"
-#include "params/Gicv2m.hh"
-#include "params/Gicv2mFrame.hh"
 
 namespace gem5
 {
+
+struct Gicv2mParams;
+struct Gicv2mFrameParams;
 
 /**
  * Ultimately this class should be embedded in the Gicv2m class, but
@@ -66,10 +67,8 @@ class Gicv2mFrame : public SimObject
     const unsigned int  spi_base;
     const unsigned int  spi_len;
 
-    typedef Gicv2mFrameParams Params;
-    Gicv2mFrame(const Params &p) :
-        SimObject(p), addr(p.addr), spi_base(p.spi_base), spi_len(p.spi_len)
-    {}
+    using Params = Gicv2mFrameParams;
+    Gicv2mFrame(const Params &p);
 };
 
 class Gicv2m : public PioDevice
@@ -94,7 +93,7 @@ class Gicv2m : public PioDevice
     unsigned int log2framenum;
 
   public:
-    typedef Gicv2mParams Params;
+    using Params = Gicv2mParams;
     Gicv2m(const Params &p);
 
     /** @{ */

--- a/src/dev/arm/gic_v3_its.cc
+++ b/src/dev/arm/gic_v3_its.cc
@@ -50,6 +50,7 @@
 #include "dev/arm/gic_v3_distributor.hh"
 #include "dev/arm/gic_v3_redistributor.hh"
 #include "mem/packet_access.hh"
+#include "params/Gicv3Its.hh"
 
 #define COMMAND(x, method) { x, DispatchEntry(#x, method) }
 

--- a/src/dev/arm/gic_v3_its.hh
+++ b/src/dev/arm/gic_v3_its.hh
@@ -48,7 +48,6 @@
 #include "base/coroutine.hh"
 #include "base/types.hh"
 #include "dev/dma_device.hh"
-#include "params/Gicv3Its.hh"
 
 namespace gem5
 {
@@ -58,6 +57,8 @@ class Gicv3Redistributor;
 class ItsProcess;
 class ItsTranslation;
 class ItsCommand;
+
+struct Gicv3ItsParams;
 
 enum class ItsActionType
 {

--- a/src/dev/arm/kmi.cc
+++ b/src/dev/arm/kmi.cc
@@ -47,6 +47,7 @@
 #include "dev/ps2/device.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/Pl050.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/kmi.hh
+++ b/src/dev/arm/kmi.hh
@@ -50,10 +50,11 @@
 
 #include "base/vnc/vncinput.hh"
 #include "dev/arm/amba_device.hh"
-#include "params/Pl050.hh"
 
 namespace gem5
 {
+
+struct Pl050Params;
 
 namespace ps2 {
 class Device;

--- a/src/dev/arm/pl111.cc
+++ b/src/dev/arm/pl111.cc
@@ -46,6 +46,7 @@
 #include "dev/arm/base_gic.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/Pl111.hh"
 #include "sim/system.hh"
 
 // clang complains about std::set being overloaded with Packet::set if

--- a/src/dev/arm/pl111.hh
+++ b/src/dev/arm/pl111.hh
@@ -50,13 +50,14 @@
 #include "base/framebuffer.hh"
 #include "base/output.hh"
 #include "dev/arm/amba_device.hh"
-#include "params/Pl111.hh"
 #include "sim/serialize.hh"
 
 namespace gem5
 {
 
 class VncInput;
+
+struct Pl111Params;
 
 class Pl111: public AmbaDmaDevice
 {

--- a/src/dev/arm/realview.cc
+++ b/src/dev/arm/realview.cc
@@ -46,6 +46,7 @@
 
 #include "base/logging.hh"
 #include "dev/arm/base_gic.hh"
+#include "params/RealView.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/realview.hh
+++ b/src/dev/arm/realview.hh
@@ -48,13 +48,14 @@
 #define __DEV_ARM_RealView_HH__
 
 #include "dev/platform.hh"
-#include "params/RealView.hh"
 
 namespace gem5
 {
 
 class BaseGic;
 class IdeController;
+
+struct RealViewParams;
 
 class RealView : public Platform
 {

--- a/src/dev/arm/rtc_pl031.cc
+++ b/src/dev/arm/rtc_pl031.cc
@@ -45,6 +45,7 @@
 #include "dev/arm/amba_device.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/PL031.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/rtc_pl031.hh
+++ b/src/dev/arm/rtc_pl031.hh
@@ -39,7 +39,6 @@
 #define __DEV_ARM_RTC_PL310_HH__
 
 #include "dev/arm/amba_device.hh"
-#include "params/PL031.hh"
 
 /** @file
  * This implements the ARM Primecell 031 RTC
@@ -47,6 +46,8 @@
 
 namespace gem5
 {
+
+struct PL031Params;
 
 class PL031 : public AmbaIntDevice
 {

--- a/src/dev/arm/rv_ctrl.cc
+++ b/src/dev/arm/rv_ctrl.cc
@@ -41,6 +41,9 @@
 #include "debug/RVCTRL.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/RealViewCtrl.hh"
+#include "params/RealViewOsc.hh"
+#include "params/RealViewTemperatureSensor.hh"
 #include "sim/power/thermal_model.hh"
 #include "sim/system.hh"
 #include "sim/voltage_domain.hh"
@@ -300,6 +303,14 @@ RealViewOsc::write(uint32_t freq)
     DPRINTF(RVCTRL, "Setting new OSC frequency: %f MHz\n", freq / 1E6);
     clockPeriod(sim_clock::as_float::s / freq);
 }
+
+RealViewTemperatureSensor::RealViewTemperatureSensor(
+    const RealViewTemperatureSensorParams &p)
+    : SimObject(p),
+      RealViewCtrl::Device(*p.parent, RealViewCtrl::FUNC_TEMP, p.site,
+                           p.position, p.dcc, p.device),
+      system(p.system)
+{}
 
 uint32_t
 RealViewTemperatureSensor::read() const

--- a/src/dev/arm/rv_ctrl.hh
+++ b/src/dev/arm/rv_ctrl.hh
@@ -40,9 +40,6 @@
 
 #include "base/bitunion.hh"
 #include "dev/io_device.hh"
-#include "params/RealViewCtrl.hh"
-#include "params/RealViewOsc.hh"
-#include "params/RealViewTemperatureSensor.hh"
 
 /** @file
  * This implements the simple real view registers on a PBXA9
@@ -50,6 +47,10 @@
 
 namespace gem5
 {
+
+struct RealViewCtrlParams;
+struct RealViewOscParams;
+struct RealViewTemperatureSensorParams;
 
 class RealViewCtrl : public BasicPioDevice
 {
@@ -229,12 +230,7 @@ class RealViewTemperatureSensor
     : public SimObject, RealViewCtrl::Device
 {
   public:
-    RealViewTemperatureSensor(const RealViewTemperatureSensorParams &p)
-    : SimObject(p),
-      RealViewCtrl::Device(*p.parent, RealViewCtrl::FUNC_TEMP,
-                           p.site, p.position, p.dcc, p.device),
-      system(p.system)
-    {}
+    RealViewTemperatureSensor(const RealViewTemperatureSensorParams &p);
     virtual ~RealViewTemperatureSensor() {};
 
   public: // RealViewCtrl::Device interface

--- a/src/dev/arm/smmu_v3.cc
+++ b/src/dev/arm/smmu_v3.cc
@@ -51,6 +51,7 @@
 #include "dev/arm/base_gic.hh"
 #include "dev/arm/smmu_v3_transl.hh"
 #include "mem/packet_access.hh"
+#include "params/SMMUv3.hh"
 #include "sim/system.hh"
 
 namespace gem5

--- a/src/dev/arm/smmu_v3.hh
+++ b/src/dev/arm/smmu_v3.hh
@@ -53,7 +53,6 @@
 #include "dev/arm/smmu_v3_ports.hh"
 #include "dev/arm/smmu_v3_proc.hh"
 #include "mem/packet.hh"
-#include "params/SMMUv3.hh"
 #include "sim/clocked_object.hh"
 #include "sim/eventq.hh"
 
@@ -80,8 +79,10 @@ namespace gem5
 {
 
 class ArmInterruptPin;
-
 class SMMUTranslationProcess;
+class System;
+
+struct SMMUv3Params;
 
 class SMMUv3 : public ClockedObject
 {

--- a/src/dev/arm/smmu_v3_deviceifc.cc
+++ b/src/dev/arm/smmu_v3_deviceifc.cc
@@ -41,6 +41,7 @@
 #include "debug/SMMUv3.hh"
 #include "dev/arm/smmu_v3.hh"
 #include "dev/arm/smmu_v3_transl.hh"
+#include "params/SMMUv3DeviceInterface.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/smmu_v3_deviceifc.hh
+++ b/src/dev/arm/smmu_v3_deviceifc.hh
@@ -45,7 +45,6 @@
 #include "dev/arm/smmu_v3_events.hh"
 #include "dev/arm/smmu_v3_ports.hh"
 #include "dev/arm/smmu_v3_proc.hh"
-#include "params/SMMUv3DeviceInterface.hh"
 #include "sim/clocked_object.hh"
 
 namespace gem5
@@ -54,6 +53,8 @@ namespace gem5
 class SMMUTranslationProcess;
 class SMMUv3;
 class SMMUDevicePort;
+
+struct SMMUv3DeviceInterfaceParams;
 
 class SMMUv3DeviceInterface : public ClockedObject
 {

--- a/src/dev/arm/ssc.cc
+++ b/src/dev/arm/ssc.cc
@@ -37,6 +37,8 @@
 
 #include "dev/arm/ssc.hh"
 
+#include "params/SysSecCtrl.hh"
+
 namespace gem5
 {
 

--- a/src/dev/arm/ssc.hh
+++ b/src/dev/arm/ssc.hh
@@ -40,10 +40,11 @@
 
 #include "dev/io_device.hh"
 #include "dev/reg_bank.hh"
-#include "params/SysSecCtrl.hh"
 
 namespace gem5
 {
+
+struct SysSecCtrlParams;
 
 /** System Security Control registers */
 class SysSecCtrl : public BasicPioDevice

--- a/src/dev/arm/timer_cpulocal.cc
+++ b/src/dev/arm/timer_cpulocal.cc
@@ -48,6 +48,7 @@
 #include "dev/arm/base_gic.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/CpuLocalTimer.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/timer_cpulocal.hh
+++ b/src/dev/arm/timer_cpulocal.hh
@@ -45,7 +45,6 @@
 #include "base/bitunion.hh"
 #include "base/types.hh"
 #include "dev/io_device.hh"
-#include "params/CpuLocalTimer.hh"
 #include "sim/serialize.hh"
 
 /** @file
@@ -58,6 +57,8 @@ namespace gem5
 
 class BaseGic;
 class ArmInterruptPin;
+
+struct CpuLocalTimerParams;
 
 class CpuLocalTimer : public BasicPioDevice
 {

--- a/src/dev/arm/timer_sp804.cc
+++ b/src/dev/arm/timer_sp804.cc
@@ -47,6 +47,7 @@
 #include "dev/arm/base_gic.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/Sp804.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/timer_sp804.hh
+++ b/src/dev/arm/timer_sp804.hh
@@ -43,7 +43,6 @@
 #include "base/bitunion.hh"
 #include "base/types.hh"
 #include "dev/arm/amba_device.hh"
-#include "params/Sp804.hh"
 #include "sim/eventq.hh"
 #include "sim/serialize.hh"
 
@@ -55,6 +54,7 @@ namespace gem5
 {
 
 class BaseGic;
+struct Sp804Params;
 
 class Sp804 : public AmbaPioDevice
 {

--- a/src/dev/arm/ufs_device.cc
+++ b/src/dev/arm/ufs_device.cc
@@ -69,6 +69,8 @@
 
 #include "dev/arm/ufs_device.hh"
 
+#include "params/UFSHostDevice.hh"
+
 namespace gem5
 {
 

--- a/src/dev/arm/ufs_device.hh
+++ b/src/dev/arm/ufs_device.hh
@@ -151,17 +151,18 @@
 #include "debug/UFSHostDevice.hh"
 #include "dev/arm/abstract_nvm.hh"
 #include "dev/arm/base_gic.hh"
-#include "dev/storage/disk_image.hh"
 #include "dev/dma_device.hh"
 #include "dev/io_device.hh"
+#include "dev/storage/disk_image.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
-#include "params/UFSHostDevice.hh"
 #include "sim/serialize.hh"
 #include "sim/stats.hh"
 
 namespace gem5
 {
+
+struct UFSHostDeviceParams;
 
 /**
  * Host controller layer: This is your Host controller

--- a/src/dev/arm/vgic.cc
+++ b/src/dev/arm/vgic.cc
@@ -45,6 +45,7 @@
 #include "dev/arm/base_gic.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
+#include "params/VGic.hh"
 
 namespace gem5
 {

--- a/src/dev/arm/vgic.hh
+++ b/src/dev/arm/vgic.hh
@@ -57,10 +57,13 @@
 #include "base/bitunion.hh"
 #include "dev/io_device.hh"
 #include "dev/platform.hh"
-#include "params/VGic.hh"
 
 namespace gem5
 {
+
+class BaseGic;
+
+struct VGicParams;
 
 class VGic : public PioDevice
 {


### PR DESCRIPTION
This PR is trying to avoid including the params header in the SimObject header file to minimize
header dependency and therefore minimize recompilation time. This is done via forward declaration.

Unless the situation requires it (e.g. in Gicv3 we have a templated method), there's no reason why
we shouldn't be moving any Param logic to the source file