### PR TITLE
arch-arm,base: Fix ramdisk loading

### DIFF
--- a/src/arch/arm/linux/fs_workload.cc
+++ b/src/arch/arm/linux/fs_workload.cc
@@ -99,7 +99,7 @@ FsLinux::initState()
                     params().initrd_filename, params().initrd_addr);
 
             loader::ImageFileDataPtr initrd_file_data(
-                new loader::ImageFileData(params().initrd_filename));
+                new loader::ImageFileData(params().initrd_filename, false));
             system->physProxy.writeBlob(params().initrd_addr,
                                         initrd_file_data->data(),
                                         initrd_file_data->len());

--- a/src/base/loader/image_file_data.cc
+++ b/src/base/loader/image_file_data.cc
@@ -96,7 +96,7 @@ doGzipLoad(int fd)
     return fd; // return fd to decompressed temporary file for mmap()'ing
 }
 
-ImageFileData::ImageFileData(const std::string &fname)
+ImageFileData::ImageFileData(const std::string &fname, bool try_decompress)
 {
     _filename = fname;
 
@@ -107,7 +107,7 @@ ImageFileData::ImageFileData(const std::string &fname)
         "incorrect.\n", fname);
 
     // Decompress GZ files.
-    if (hasGzipMagic(fd)) {
+    if (try_decompress && hasGzipMagic(fd)) {
         fd = doGzipLoad(fd);
         panic_if(fd < 0, "Failed to unzip file %s.\n", fname);
     }

--- a/src/base/loader/image_file_data.hh
+++ b/src/base/loader/image_file_data.hh
@@ -53,7 +53,7 @@ class ImageFileData
     uint8_t const *data() const { return _data; }
     size_t len() const { return _len; }
 
-    ImageFileData(const std::string &f_name);
+    ImageFileData(const std::string &f_name, bool try_decompress = true);
     virtual ~ImageFileData();
 };
 


### PR DESCRIPTION
We encounter the issue when loading ramdisk in cpio.gz format. Because the data includes the gzip magic flag, the workload will try to decompress it before loading. However, it will lose some [cpio.gz](http://cpio.gz/) contents because cpio.gz might contain several files in it.
    
When loading ramdisk to memory by workload, we should disable data  decompression. The kernel can decompress then during execution.

Change-Id: Ic02add10c91ae7e3548819a870ff97e6385c7348