### PR TITLE
dev: Fix PCI host bridge with no range from up

### DIFF
--- a/src/dev/arm/RealView.py
+++ b/src/dev/arm/RealView.py
@@ -1129,7 +1129,8 @@ class VExpress_EMM(RealView):
 
     def _attach_pci(self, devices, bus, dma_ports=None):
         self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
-        self.pci_bus.mem_side_ports = self.pci_host.down_response_port()
+        self.pci_bus.default = self.pci_host.down_response_port()
+        self.pci_bus.config_error_port = self.pci_host.config_error.pio
 
         bus.mem_side_ports = self.pci_host.up_response_port()
         if dma_ports is None:
@@ -1526,7 +1527,8 @@ class VExpress_GEM5_Base(RealView):
 
     def _attach_pci(self, devices, bus, dma_ports=None):
         self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
-        self.pci_bus.mem_side_ports = self.pci_host.down_response_port()
+        self.pci_bus.default = self.pci_host.down_response_port()
+        self.pci_bus.config_error_port = self.pci_host.config_error.pio
 
         bus.mem_side_ports = self.pci_host.up_response_port()
         if dma_ports is None:

--- a/src/dev/pci/SConscript
+++ b/src/dev/pci/SConscript
@@ -48,9 +48,12 @@ DebugFlag('PciDevice')
 DebugFlag('PciEndpoint')
 DebugFlag('PciBridge')
 
-SimObject('PciUpstream.py', sim_objects=['PciUpstream', 'PciOneWayBridge'])
+SimObject('PciUpstream.py', sim_objects=[
+    'PciUpstream', 'PciUpDownBridge', 'PciBus', 'PciConfigError'
+])
 Source('upstream.cc')
-Source('one_way_bridge.cc')
+Source('up_down_bridge.cc')
+Source('bus.cc')
 DebugFlag('PciUpstream')
 
 SimObject('PciHost.py', sim_objects=['PciHost', 'GenericPciHost'])

--- a/src/dev/pci/bus.hh
+++ b/src/dev/pci/bus.hh
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 REDS institute of the HEIG-VD
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_PCI_BUS_HH__
+#define __DEV_PCI_BUS_HH__
+
+#include "mem/noncoherent_xbar.hh"
+
+namespace gem5
+{
+
+class PciBusParams;
+
+/**
+ * A PCI bus is a non-coherent crossbar with a special port that is used to
+ * catch configuration accesses that do not map to any device. Such accesses
+ * are forwarded to a PciConfigError device that will respond with an error
+ * code.
+ *
+ * The default port must be connected to the bridge going from downstream to
+ * upstream.
+ */
+class PciBus : public NoncoherentXBar
+{
+  public:
+    PARAMS(PciBus);
+    PciBus(const Params &p);
+
+    Port &getPort(const std::string &if_name,
+                  PortID idx = InvalidPortID) override;
+
+  protected:
+    void recvRangeChange(PortID mem_side_port_id) override;
+
+    PortID findPort(AddrRange addr_range, PacketPtr pkt = nullptr) override;
+
+    PortID configErrorPortID;
+    AddrRange configRange;
+};
+
+} // namespace gem5
+
+#endif // __DEV_PCI_BUS_HH__

--- a/src/dev/pci/up_down_bridge.cc
+++ b/src/dev/pci/up_down_bridge.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 REDS institute of the HEIG-VD
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dev/pci/up_down_bridge.hh"
+
+#include "base/addr_range.hh"
+#include "base/logging.hh"
+#include "debug/PciBridge.hh"
+#include "params/PciUpDownBridge.hh"
+
+namespace gem5
+{
+
+PciUpDownBridge::PciUpDownBridge(const Params &p)
+    : BridgeBase(p), memSideRanges(), configRange()
+{}
+
+void
+PciUpDownBridge::setConfigRange(AddrRange config_range)
+{
+    this->configRange = config_range;
+    cpuSidePort.sendRangeChange();
+}
+
+AddrRangeList
+PciUpDownBridge::getAddrRanges() const
+{
+    AddrRangeList ranges = memSideRanges;
+
+    if (configRange.valid()) {
+        // Add whole configuration range, but avoid range duplication for
+        // existing PCI devices.
+        ranges -= configRange;
+        ranges.push_back(configRange);
+    }
+
+    return ranges;
+}
+
+void
+PciUpDownBridge::recvRangeChange()
+{
+    AddrRangeList new_ranges = memSidePort.getAddrRanges();
+
+    // Avoid potential loop of range change.
+    if (new_ranges != memSideRanges) {
+        DPRINTF(PciBridge, "Received range change\n");
+        for (const auto &r : new_ranges) {
+            DPRINTF(PciBridge, "-- %s\n", r.to_string());
+        }
+
+        memSideRanges = new_ranges;
+        cpuSidePort.sendRangeChange();
+    }
+}
+
+} // namespace gem5

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -44,15 +44,27 @@
 #include <map>
 
 #include "base/addr_range.hh"
-#include "dev/pci/one_way_bridge.hh"
+#include "dev/isa_fake.hh"
 #include "dev/pci/types.hh"
-#include "params/PciUpstream.hh"
+#include "dev/pci/up_down_bridge.hh"
 #include "sim/clocked_object.hh"
 
 namespace gem5
 {
 
 class PciDevice;
+class PciConfigErrorParams;
+class PciUpstreamParams;
+
+class PciConfigError : public IsaFake
+{
+  public:
+    PARAMS(PciConfigError);
+
+    PciConfigError(const Params &p);
+
+    void setAddrRange(AddrRange range);
+};
 
 /**
  * The PCI upstream describes any device (PCI host bridge, PCI-PCI bridge)
@@ -308,8 +320,10 @@ class PciUpstream : public ClockedObject
     std::map<PciDevAddr, PciDevice *> devices;
 
     /** The two one way bridges to connect both side buses */
-    PciOneWayBridge *upToDown;
-    PciOneWayBridge *downToUp;
+    PciUpDownBridge *upToDown;
+    BridgeBase *downToUp;
+
+    PciConfigError *configErrorDevice;
 };
 
 } // namespace gem5

--- a/src/dev/x86/Pc.py
+++ b/src/dev/x86/Pc.py
@@ -99,8 +99,10 @@ class Pc(Platform):
         self.fake_com_4.pio = bus.mem_side_ports
         self.fake_floppy.pio = bus.mem_side_ports
 
-        self.pci_bus.mem_side_ports = self.pci_host.down_response_port()
+        self.pci_bus.default = self.pci_host.down_response_port()
         self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
+        self.pci_bus.config_error_port = self.pci_host.config_error.pio
+
         bus.mem_side_ports = self.pci_host.up_response_port()
 
         if dma_ports.count(self.pci_host.up_request_port()) == 0:

--- a/src/mem/xbar.hh
+++ b/src/mem/xbar.hh
@@ -347,7 +347,7 @@ class BaseXBar : public ClockedObject
      * @param pkt Packet that containing the address range.
      * @return id of port that the packet should be sent ou of.
      */
-    PortID findPort(AddrRange addr_range, PacketPtr pkt=nullptr);
+    virtual PortID findPort(AddrRange addr_range, PacketPtr pkt = nullptr);
 
     PortID
     findPort(PacketPtr pkt)

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -156,11 +156,14 @@ class RiscvBoard(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         # Add PCI
         self.iobus.mem_side_ports = self.platform.pci_host.up_response_port()
         self.iobus.cpu_side_ports = self.platform.pci_host.up_request_port()
-        self.platform.pci_bus.mem_side_ports = (
+        self.platform.pci_bus.default = (
             self.platform.pci_host.down_response_port()
         )
         self.platform.pci_bus.cpu_side_ports = (
             self.platform.pci_host.down_request_port()
+        )
+        self.platform.pci_bus.config_error_port = (
+            self.platform.pci_host.config_error.pio
         )
 
         # Add Ethernet card

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -130,7 +130,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         # Setup memory system specific settings.
         if self.get_cache_hierarchy().is_ruby():
             self.pc.attachIO(
-                self.get_io_bus(), [self.pc.pci_host.mem_request_port()]
+                self.get_io_bus(), [self.pc.pci_host.up_request_port()]
             )
         else:
             self.bridge = Bridge(delay="50ns")
@@ -330,7 +330,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
     def get_dma_ports(self) -> Sequence[Port]:
         if self.has_dma_ports():
             return [
-                self.pc.pci_host.mem_request_port(),
+                self.pc.pci_host.up_request_port(),
                 self.iobus.mem_side_ports,
             ]
         else:

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -201,11 +201,14 @@ class RISCVMatchedBoard(
             self.iobus.cpu_side_ports = (
                 self.platform.pci_host.up_request_port()
             )
-            self.pci_bus.mem_side_ports = (
+            self.platform.pci_bus.default = (
                 self.platform.pci_host.down_response_port()
             )
-            self.pci_bus.cpu_side_ports = (
+            self.platform.pci_bus.cpu_side_ports = (
                 self.platform.pci_host.down_request_port()
+            )
+            self.platform.pci_bus.config_error_port = (
+                self.platform.pci_host.config_error.pio
             )
 
             # Add Ethernet card
@@ -217,8 +220,8 @@ class RISCVMatchedBoard(
             )
 
             self.ethernet.upstream = self.platform.pci_host
-            self.ethernet.pio = self.pci_bus.mem_side_ports
-            self.ethernet.dma = self.pci_bus.cpu_side_ports
+            self.ethernet.pio = self.platform.pci_bus.mem_side_ports
+            self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
 
             if self.get_cache_hierarchy().is_ruby():
                 for device in self._off_chip_devices + self._on_chip_devices:


### PR DESCRIPTION
PCI host bridge was intended to be connected to ports which returns a correct set of address ranges when calling getAddrRanges(). But RubyPort::MemResponsePort does return an empty list, making use of that function when connected to it, which is the case for system using Ruby
hierarchy.

This commit change the downstream to upstream bridge to be connected to the default port of PciBus. But, as that port was connected to an IsaFake to handle configuration access error, that one requires to be moved. So PciBus now contains a new port for that which will act like a second default port but only for the configuration ranges.

Also, as down to up bridge is now connected to default, a simple Bridge class can be used. And so PciOneWayBridge can be renamed to PciUpDownBridge and simplified as it doesn't require to remove undesired ranges responded by the down to up bridge.
