### PR TITLE
stdlib: Update types in AbstractMemorySystem

### DIFF
--- a/src/python/gem5/components/memory/abstract_memory_system.py
+++ b/src/python/gem5/components/memory/abstract_memory_system.py
@@ -35,9 +35,9 @@ from typing import (
 )
 
 from m5.objects import (
+    AbstractMemory,
     AddrRange,
     MemCtrl,
-    MemInterface,
     Port,
     Root,
     SubSystem,
@@ -77,13 +77,19 @@ class AbstractMemorySystem(SubSystem):
 
     @abstractmethod
     def get_memory_controllers(self) -> List[MemCtrl]:
-        """Get all of the memory controllers in this memory system."""
+        """Get all of the memory controllers in this memory system.
+
+        The "memory controller" is the object that has a port named "port"
+        that is the CPU-side port for the memory."""
         raise NotImplementedError
 
     @abstractmethod
-    def get_mem_interfaces(self) -> List[MemInterface]:
+    def get_mem_interfaces(self) -> List[AbstractMemory]:
         """Get all memory interfaces in this memory system.
-        Useful when creating physical memory objects."""
+        Useful when creating physical memory objects.
+
+        The "mem interface" is the object that is an AbstractMemory and
+        is used to create the backing store."""
         raise NotImplementedError
 
     @abstractmethod

--- a/src/python/gem5/components/memory/hbm.py
+++ b/src/python/gem5/components/memory/hbm.py
@@ -37,10 +37,10 @@ from typing import (
 )
 
 from m5.objects import (
+    AbstractMemory,
     AddrRange,
     DRAMInterface,
     HBMCtrl,
-    MemInterface,
     Port,
 )
 
@@ -174,7 +174,7 @@ class HighBandwidthMemory(ChanneledMemory):
         ]
 
     @overrides(ChanneledMemory)
-    def get_mem_interfaces(self) -> List[MemInterface]:
+    def get_mem_interfaces(self) -> List[AbstractMemory]:
         return [ctrl.dram for ctrl in self.get_memory_controllers()] + [
             ctrl.dram_2 for ctrl in self.get_memory_controllers()
         ]

--- a/src/python/gem5/components/memory/memory.py
+++ b/src/python/gem5/components/memory/memory.py
@@ -37,6 +37,7 @@ from typing import (
 )
 
 from m5.objects import (
+    AbstractMemory,
     AddrRange,
     DRAMInterface,
     MemCtrl,
@@ -185,7 +186,7 @@ class ChanneledMemory(AbstractMemorySystem):
         return [ctrl for ctrl in self.mem_ctrl]
 
     @overrides(AbstractMemorySystem)
-    def get_mem_interfaces(self) -> List[DRAMInterface]:
+    def get_mem_interfaces(self) -> List[AbstractMemory]:
         return self._dram
 
     @overrides(AbstractMemorySystem)


### PR DESCRIPTION
Where we're getting the memory interfaces, we *really* are getting an AbstractMemory. What we need from this object is that it can be used in the System.memories parameter. While the type before wasn't wrong, this is more generic.