### PR TITLE
base: reduce write syscalls in stats output

### DIFF
--- a/src/base/stats/text.cc
+++ b/src/base/stats/text.cc
@@ -313,7 +313,7 @@ ScalarPrint::operator()(std::ostream &stream, bool oneLine) const
                 ccprintf(stream, " # %s", desc);
         }
         printUnits(stream);
-        stream << std::endl;
+        stream << "\n";
     }
 }
 
@@ -397,7 +397,7 @@ VectorPrint::operator()(std::ostream &stream) const
                     ccprintf(stream, " # %s", desc);
             }
             printUnits(stream);
-            stream << std::endl;
+            stream << "\n";
         }
     }
 
@@ -564,7 +564,7 @@ DistPrint::operator()(std::ostream &stream) const
                 ccprintf(stream, " # %s", desc);
         }
         printUnits(stream);
-        stream << std::endl;
+        stream << "\n";
     }
 
     if (data.type == Dist && data.overflow != Nan) {


### PR DESCRIPTION
`std::endl` flushes the output stream which invokes the `write` syscall. Replacing this with `"\n"` causes the writes to be buffered until they fill the entire memory page or buffer, and then they get flushed automatically. So this patch switches the behavior from "many small writes" to "a few large writes". This can help when many invocations of gem5 are finishing at the same time and dumping gobs and gobs of statistics.

You can check the output of `strace` to see what is happening. Each of the 1000s of statistics is writing ~100 bytes at a time to disk serially. This patch turns that into writes of 8192 byte chunks for my run. The perf benefit would be seen at the end of a run where your system is loaded with simulations (e.g. in a refrate style run).

@powerjg 