### PR TITLE
misc: Re-enable Address Sanitizer for GCC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -759,26 +759,20 @@ for variant_path in variant_paths:
     if GetOption('with_ubsan'):
         sanitizers.append('undefined')
     if GetOption('with_asan'):
-        if env['GCC']:
-            # Address sanitizer is not supported with GCC. Please see Github
-            # Issue https://github.com/gem5/gem5/issues/916 for more details.
-            warning("Address Sanitizer is not supported with GCC. "
-                    "This option will be ignored.")
-        else:
-            # Available for llvm >= 3.1. A requirement by the build system.
-            sanitizers.append('address')
-            suppressions_file = Dir('util').File('lsan-suppressions')\
-                                .get_abspath()
-            suppressions_opt = 'suppressions=%s' % suppressions_file
-            suppressions_opts = ':'.join([suppressions_opt,
-                                        'print_suppressions=0'])
-            env['ENV']['LSAN_OPTIONS'] = suppressions_opts
-            print()
-            warning('To suppress false positive leaks, set the LSAN_OPTIONS '
-                    'environment variable to "%s" when running gem5' %
-                    suppressions_opts)
-            warning('LSAN_OPTIONS=%s' % suppressions_opts)
-            print()
+        # Available for gcc >= 5 or llvm >= 3.1 both a requirement
+        # by the build system
+        sanitizers.append('address')
+        suppressions_file = Dir('util').File('lsan-suppressions').get_abspath()
+        suppressions_opt = 'suppressions=%s' % suppressions_file
+        suppressions_opts = ':'.join([suppressions_opt,
+                                      'print_suppressions=0'])
+        env['ENV']['LSAN_OPTIONS'] = suppressions_opts
+        print()
+        warning('To suppress false positive leaks, set the LSAN_OPTIONS '
+                'environment variable to "%s" when running gem5' %
+                suppressions_opts)
+        warning('LSAN_OPTIONS=%s' % suppressions_opts)
+        print()
     if sanitizers:
         sanitizers = ','.join(sanitizers)
         if env['GCC'] or env['CLANG']:

--- a/src/arch/arm/regs/cc.hh
+++ b/src/arch/arm/regs/cc.hh
@@ -82,7 +82,7 @@ class CCRegClassOps : public RegClassOps
     }
 };
 
-static inline CCRegClassOps ccRegClassOps;
+inline CCRegClassOps ccRegClassOps;
 
 inline constexpr RegClass ccRegClass = RegClass(CCRegClass, CCRegClassName,
         cc_reg::NumRegs, debug::CCRegs).ops(ccRegClassOps);

--- a/src/arch/arm/regs/mat.hh
+++ b/src/arch/arm/regs/mat.hh
@@ -87,7 +87,7 @@ using MatCol = gem5::VerticalSlice<ElemType,
 // SME ZA tile, i.e. matrix
 const int NumMatrixRegs = 1;
 
-static inline TypedRegClassOps<ArmISA::MatRegContainer> matRegClassOps;
+inline TypedRegClassOps<ArmISA::MatRegContainer> matRegClassOps;
 
 inline constexpr RegClass matRegClass =
     RegClass(MatRegClass, MatRegClassName, NumMatrixRegs, debug::MatRegs).

--- a/src/arch/arm/regs/misc.hh
+++ b/src/arch/arm/regs/misc.hh
@@ -2987,7 +2987,7 @@ namespace ArmISA
         }
     };
 
-    static inline MiscRegClassOps miscRegClassOps;
+    inline MiscRegClassOps miscRegClassOps;
 
     inline constexpr RegClass miscRegClass =
         RegClass(MiscRegClass, MiscRegClassName, NUM_MISCREGS,

--- a/src/arch/arm/regs/vec.hh
+++ b/src/arch/arm/regs/vec.hh
@@ -93,10 +93,9 @@ const int VECREG_UREG0 = 32;
 const int PREDREG_FFR = 16;
 const int PREDREG_UREG0 = 17;
 
-static inline VecElemRegClassOps<RegVal>
-    vecRegElemClassOps(NumVecElemPerVecReg);
-static inline TypedRegClassOps<ArmISA::VecRegContainer> vecRegClassOps;
-static inline TypedRegClassOps<ArmISA::VecPredRegContainer> vecPredRegClassOps;
+inline VecElemRegClassOps<RegVal> vecRegElemClassOps(NumVecElemPerVecReg);
+inline TypedRegClassOps<ArmISA::VecRegContainer> vecRegClassOps;
+inline TypedRegClassOps<ArmISA::VecPredRegContainer> vecPredRegClassOps;
 
 inline constexpr RegClass vecRegClass =
     RegClass(VecRegClass, VecRegClassName, NumVecRegs, debug::VecRegs).

--- a/src/arch/mips/dsp.cc
+++ b/src/arch/mips/dsp.cc
@@ -137,7 +137,7 @@ MipsISA::dspAbs(int32_t a, int32_t fmt, uint32_t *dspctl)
     int32_t result;
     int64_t svalue;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, SIGNED);
 
@@ -168,8 +168,8 @@ MipsISA::dspAdd(int32_t a, int32_t b, int32_t fmt, int32_t saturate,
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -199,8 +199,8 @@ MipsISA::dspAddh(int32_t a, int32_t b, int32_t fmt, int32_t round,
 {
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -224,8 +224,8 @@ MipsISA::dspSub(int32_t a, int32_t b, int32_t fmt, int32_t saturate,
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -254,8 +254,8 @@ MipsISA::dspSubh(int32_t a, int32_t b, int32_t fmt, int32_t round,
 {
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -280,7 +280,7 @@ MipsISA::dspShll(int32_t a, uint32_t sa, int32_t fmt, int32_t saturate,
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
 
     sa = bits(sa, SIMD_LOG2N[fmt] - 1, 0);
     simdUnpack(a, a_values, fmt, sign);
@@ -307,7 +307,7 @@ MipsISA::dspShrl(int32_t a, uint32_t sa, int32_t fmt, int32_t sign)
 {
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
-    uint64_t a_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
 
     sa = bits(sa, SIMD_LOG2N[fmt] - 1, 0);
 
@@ -327,7 +327,7 @@ MipsISA::dspShra(int32_t a, uint32_t sa, int32_t fmt, int32_t round,
 {
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
-    uint64_t a_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
 
     sa = bits(sa, SIMD_LOG2N[fmt] - 1, 0);
 
@@ -353,8 +353,8 @@ MipsISA::dspMulq(int32_t a, int32_t b, int32_t fmt, int32_t saturate,
     int sa = SIMD_NBITS[fmt];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
     int64_t temp;
 
     simdUnpack(a, a_values, fmt, SIGNED);
@@ -393,8 +393,8 @@ MipsISA::dspMul(int32_t a, int32_t b, int32_t fmt, int32_t saturate,
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, SIGNED);
     simdUnpack(b, b_values, fmt, SIGNED);
@@ -424,8 +424,8 @@ MipsISA::dspMuleu(int32_t a, int32_t b, int32_t mode, uint32_t *dspctl)
     int nvals = SIMD_NVALS[SIMD_FMT_PH];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, SIMD_FMT_QB, UNSIGNED);
     simdUnpack(b, b_values, SIMD_FMT_PH, UNSIGNED);
@@ -458,9 +458,9 @@ MipsISA::dspMuleq(int32_t a, int32_t b, int32_t mode, uint32_t *dspctl)
     int nvals = SIMD_NVALS[SIMD_FMT_W];
     int32_t result;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
-    uint64_t c_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
+    uint64_t c_values[SIMD_MAX_VALS] = {};
 
     memset(c_values, 0, sizeof(c_values));
 
@@ -498,8 +498,8 @@ MipsISA::dspDpaq(int64_t dspac, int32_t a, int32_t b, int32_t ac,
     int64_t result = 0;
     int64_t temp = 0;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, infmt, SIGNED);
     simdUnpack(b, b_values, infmt, SIGNED);
@@ -565,8 +565,8 @@ MipsISA::dspDpsq(int64_t dspac, int32_t a, int32_t b, int32_t ac,
     int64_t result = 0;
     int64_t temp = 0;
     uint32_t ouflag = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, infmt, SIGNED);
     simdUnpack(b, b_values, infmt, SIGNED);
@@ -628,8 +628,8 @@ MipsISA::dspDpa(int64_t dspac, int32_t a, int32_t b, int32_t ac,
                 int32_t fmt, int32_t sign, int32_t mode)
 {
     int nvals = SIMD_NVALS[fmt];
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -656,8 +656,8 @@ MipsISA::dspDps(int64_t dspac, int32_t a, int32_t b, int32_t ac,
                 int32_t fmt, int32_t sign, int32_t mode)
 {
     int nvals = SIMD_NVALS[fmt];
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -684,8 +684,8 @@ MipsISA::dspMaq(int64_t dspac, int32_t a, int32_t b, int32_t ac,
                  int32_t fmt, int32_t mode, int32_t saturate, uint32_t *dspctl)
 {
     int nvals = SIMD_NVALS[fmt - 1];
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
     int64_t temp = 0;
     uint32_t ouflag = 0;
 
@@ -726,8 +726,8 @@ MipsISA::dspMaq(int64_t dspac, int32_t a, int32_t b, int32_t ac,
 int64_t
 MipsISA::dspMulsa(int64_t dspac, int32_t a, int32_t b, int32_t ac, int32_t fmt)
 {
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, SIGNED);
     simdUnpack(b, b_values, fmt, SIGNED);
@@ -742,8 +742,8 @@ MipsISA::dspMulsaq(int64_t dspac, int32_t a, int32_t b, int32_t ac,
     int32_t fmt, uint32_t *dspctl)
 {
     int nvals = SIMD_NVALS[fmt];
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
     int64_t temp[2] = {0, 0};
     uint32_t ouflag = 0;
 
@@ -772,8 +772,8 @@ MipsISA::dspCmp(int32_t a, int32_t b, int32_t fmt, int32_t sign, int32_t op,
 {
     int nvals = SIMD_NVALS[fmt];
     int ccond = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -804,8 +804,8 @@ MipsISA::dspCmpg(int32_t a, int32_t b, int32_t fmt, int32_t sign, int32_t op)
 {
     int nvals = SIMD_NVALS[fmt];
     int32_t result = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -838,8 +838,8 @@ MipsISA::dspCmpgd(int32_t a, int32_t b, int32_t fmt, int32_t sign, int32_t op,
     int nvals = SIMD_NVALS[fmt];
     int32_t result = 0;
     int ccond = 0;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, sign);
     simdUnpack(b, b_values, fmt, sign);
@@ -876,8 +876,8 @@ MipsISA::dspPrece(int32_t a, int32_t infmt, int32_t insign, int32_t outfmt,
     int ninvals = SIMD_NVALS[infmt];
     int noutvals = SIMD_NVALS[outfmt];
     int32_t result;
-    uint64_t in_values[SIMD_MAX_VALS];
-    uint64_t out_values[SIMD_MAX_VALS];
+    uint64_t in_values[SIMD_MAX_VALS] = {};
+    uint64_t out_values[SIMD_MAX_VALS] = {};
 
     if (insign == SIGNED && outsign == SIGNED)
       sa = SIMD_NBITS[infmt];
@@ -913,9 +913,9 @@ MipsISA::dspPrece(int32_t a, int32_t infmt, int32_t insign, int32_t outfmt,
 int32_t
 MipsISA::dspPrecrqu(int32_t a, int32_t b, uint32_t *dspctl)
 {
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
-    uint64_t r_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
+    uint64_t r_values[SIMD_MAX_VALS] = {};
     uint32_t ouflag = 0;
     int32_t result = 0;
 
@@ -942,9 +942,9 @@ MipsISA::dspPrecrqu(int32_t a, int32_t b, uint32_t *dspctl)
 int32_t
 MipsISA::dspPrecrq(int32_t a, int32_t b, int32_t fmt, uint32_t *dspctl)
 {
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
-    uint64_t r_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
+    uint64_t r_values[SIMD_MAX_VALS] = {};
     uint32_t ouflag = 0;
     int32_t result;
 
@@ -969,9 +969,9 @@ MipsISA::dspPrecrSra(int32_t a, int32_t b, int32_t sa, int32_t fmt,
     int32_t round)
 {
     int nvals = SIMD_NVALS[fmt];
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
-    uint64_t c_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
+    uint64_t c_values[SIMD_MAX_VALS] = {};
     int32_t result = 0;
 
     simdUnpack(a, a_values, fmt, SIGNED);
@@ -997,9 +997,9 @@ MipsISA::dspPick(int32_t a, int32_t b, int32_t fmt, uint32_t *dspctl)
 {
     int nvals = SIMD_NVALS[fmt];
     int32_t result;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
-    uint64_t c_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
+    uint64_t c_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, UNSIGNED);
     simdUnpack(b, b_values, fmt, UNSIGNED);
@@ -1021,9 +1021,9 @@ int32_t
 MipsISA::dspPack(int32_t a, int32_t b, int32_t fmt)
 {
     int32_t result;
-    uint64_t a_values[SIMD_MAX_VALS];
-    uint64_t b_values[SIMD_MAX_VALS];
-    uint64_t c_values[SIMD_MAX_VALS];
+    uint64_t a_values[SIMD_MAX_VALS] = {};
+    uint64_t b_values[SIMD_MAX_VALS] = {};
+    uint64_t c_values[SIMD_MAX_VALS] = {};
 
     simdUnpack(a, a_values, fmt, UNSIGNED);
     simdUnpack(b, b_values, fmt, UNSIGNED);

--- a/src/arch/power/insts/integer.hh
+++ b/src/arch/power/insts/integer.hh
@@ -274,11 +274,12 @@ class IntArithOp : public IntOp
      * 128-bit by 64-bit unsigned integer division based on
      * https://codereview.stackexchange.com/a/71013
      */
+    // clang-format off
     inline std::tuple<bool, uint64_t, uint64_t>
     divide(uint64_t ralo, uint64_t rahi, uint64_t rb) const
     {
         bool ov;
-        uint64_t q, r;
+        uint64_t q = 0, r = 0;
     #if defined(__SIZEOF_INT128__)
         if (rb == 0) {
             ov = true;
@@ -328,7 +329,7 @@ class IntArithOp : public IntOp
     divide(uint64_t ralo, int64_t rahi, int64_t rb) const
     {
         bool ov;
-        int64_t q, r;
+        int64_t q = 0, r = 0;
     #if defined(__SIZEOF_INT128__)
         if (rb == 0) {
             ov = true;
@@ -362,6 +363,7 @@ class IntArithOp : public IntOp
     #endif
         return std::make_tuple(ov, q, r);
     }
+    // clang-format on
 
     std::string generateDisassembly(
             Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/regs/vector.hh
+++ b/src/arch/riscv/regs/vector.hh
@@ -66,7 +66,7 @@ const std::vector<std::string> VecRegNames = {
 // vector index
 const int VecMemInternalReg0 = NumVecStandardRegs;
 
-static inline TypedRegClassOps<RiscvISA::VecRegContainer> vecRegClassOps;
+inline TypedRegClassOps<RiscvISA::VecRegContainer> vecRegClassOps;
 
 inline constexpr RegClass vecRegClass =
     RegClass(VecRegClass, VecRegClassName, NumVecRegs, debug::VecRegs).

--- a/src/kern/linux/helpers.cc
+++ b/src/kern/linux/helpers.cc
@@ -43,8 +43,9 @@
  * GCC 12.1.
  */
 
-// ignore 'maybe-uniitialized' warnings for GCC 12.1.
-#if __GNUC__ &&  __GNUC__ == 12 && __GNUC_MINOR__ == 1
+// clang-format off
+// ignore 'maybe-uniitialized' warnings for GCC >= 12.
+#if __GNUC__ && __GNUC__ >= 12
     #define SUPPRESSING_MAYBE_UNINITIALIZED_WARNING
     // save diagnostic state.
     #pragma GCC diagnostic push
@@ -55,6 +56,7 @@
     // restore the diagnostic state.
     #pragma GCC diagnostic pop
 #endif
+// clang-format on
 
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
To enable Address Sanitizer for GCC, the PR changes:

1. Change some `RegClassOps` variables definition from `static inline` to `inline` to ensure they are not discarded
2. Fix some maybe-uninitalized warning issue

The PR build successfully with
```
scons build/ALL/gem5.opt --with-asan --without-tcmalloc
```