### PR TITLE
Cleanup imports in python and stdlib

### DIFF
--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -38,15 +38,17 @@ from typing import (
 )
 
 from m5.objects import (
-    AddrRange,
     ClockDomain,
     IOXBar,
     PciBus,
-    Port,
     Root,
     SrcClockDomain,
     System,
     VoltageDomain,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 
 from ...resources.resource import WorkloadResource

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -35,7 +35,6 @@ from typing import (
 
 import m5
 from m5.objects import (
-    AddrRange,
     ArmDefaultRelease,
     ArmFsLinux,
     ArmRelease,
@@ -47,7 +46,6 @@ from m5.objects import (
     IOXBar,
     PciBus,
     PciVirtIO,
-    Port,
     RawDiskImage,
     Root,
     SimObject,
@@ -59,6 +57,10 @@ from m5.objects import (
     VirtIOBlock,
     VncServer,
     VoltageDomain,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 
 from ...isas import ISA

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -29,7 +29,6 @@ from typing import List
 
 import m5
 from m5.objects import (
-    AddrRange,
     Bridge,
     Clint,
     CowDiskImage,
@@ -47,11 +46,14 @@ from m5.objects import (
     PciBus,
     Plic,
     PMAChecker,
-    Port,
     RawDiskImage,
     RiscvLinux,
     RiscvRTC,
     Terminal,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 from m5.util.fdthelper import (
     Fdt,

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -33,7 +33,6 @@ from typing import (
 
 import m5
 from m5.objects import (
-    AddrRange,
     BadAddr,
     Bridge,
     CowDiskImage,
@@ -44,7 +43,6 @@ from m5.objects import (
     IOXBar,
     PciBus,
     PMAChecker,
-    Port,
     RawDiskImage,
     RiscvBootloaderKernelWorkload,
     RiscvMmioVirtIO,
@@ -52,6 +50,10 @@ from m5.objects import (
     Root,
     VirtIOBlock,
     VirtIORng,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 from m5.util.fdthelper import (
     Fdt,

--- a/src/python/gem5/components/boards/simple_board.py
+++ b/src/python/gem5/components/boards/simple_board.py
@@ -27,9 +27,11 @@
 from typing import List
 
 from m5.objects import (
-    AddrRange,
     IOXBar,
     PciBus,
+)
+from m5.params import (
+    AddrRange,
     Port,
 )
 

--- a/src/python/gem5/components/boards/test_board.py
+++ b/src/python/gem5/components/boards/test_board.py
@@ -30,9 +30,11 @@ from typing import (
 )
 
 from m5.objects import (
-    AddrRange,
     IOXBar,
     PciBus,
+)
+from m5.params import (
+    AddrRange,
     Port,
 )
 

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -31,8 +31,6 @@ from typing import (
 )
 
 from m5.objects import (
-    Addr,
-    AddrRange,
     BaseXBar,
     Bridge,
     CowDiskImage,
@@ -40,7 +38,6 @@ from m5.objects import (
     IOXBar,
     Pc,
     PciBus,
-    Port,
     RawDiskImage,
     X86ACPIMadt,
     X86ACPIMadtIntSourceOverride,
@@ -54,6 +51,11 @@ from m5.objects import (
     X86IntelMPIOIntAssignment,
     X86IntelMPProcessor,
     X86SMBiosBiosInformation,
+)
+from m5.params import (
+    Addr,
+    AddrRange,
+    Port,
 )
 from m5.util.convert import toMemorySize
 

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/memory_controller.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/memory_controller.py
@@ -27,11 +27,13 @@
 from typing import List
 
 from m5.objects import (
-    AddrRange,
     CHI_Memory_Controller,
     MessageBuffer,
-    Port,
     RubyNetwork,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 
 from .abstract_node import TriggerMessageBuffer

--- a/src/python/gem5/components/cachehierarchies/classic/abstract_classic_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/abstract_classic_cache_hierarchy.py
@@ -26,7 +26,7 @@
 
 from abc import abstractmethod
 
-from m5.objects import Port
+from m5.params import Port
 
 from ....coherence_protocol import CoherenceProtocol
 from ....utils.override import overrides

--- a/src/python/gem5/components/cachehierarchies/classic/no_cache.py
+++ b/src/python/gem5/components/cachehierarchies/classic/no_cache.py
@@ -30,9 +30,9 @@ from m5.objects import (
     BadAddr,
     BaseXBar,
     Bridge,
-    Port,
     SystemXBar,
 )
+from m5.params import Port
 
 from ....isas import ISA
 from ....utils.override import *

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
@@ -30,9 +30,9 @@ from m5.objects import (
     BadAddr,
     BaseXBar,
     Cache,
-    Port,
     SystemXBar,
 )
+from m5.params import Port
 
 from ....isas import ISA
 from ....utils.override import *

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_cache_hierarchy.py
@@ -44,9 +44,9 @@ from m5.objects import (
     BaseXBar,
     Cache,
     L2XBar,
-    Port,
     SystemXBar,
 )
+from m5.params import Port
 
 from ....isas import ISA
 from ....utils.override import *

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
@@ -31,9 +31,9 @@ from m5.objects import (
     BaseXBar,
     Cache,
     L2XBar,
-    Port,
     SystemXBar,
 )
+from m5.params import Port
 
 from ....isas import ISA
 from ....utils.override import *

--- a/src/python/gem5/components/devices/gpus/viper_shader.py
+++ b/src/python/gem5/components/devices/gpus/viper_shader.py
@@ -30,7 +30,6 @@
 from typing import List
 
 from m5.objects import (
-    AddrRange,
     AMDGPUDevice,
     AMDGPUInterruptHandler,
     AMDGPUMemoryManager,
@@ -56,6 +55,7 @@ from m5.objects import (
     VegaTLBCoalescer,
     Wavefront,
 )
+from m5.params import AddrRange
 
 
 class ViperCU(ComputeUnit):

--- a/src/python/gem5/components/memory/abstract_memory_system.py
+++ b/src/python/gem5/components/memory/abstract_memory_system.py
@@ -36,11 +36,14 @@ from typing import (
 
 from m5.objects import (
     AbstractMemory,
-    AddrRange,
     MemCtrl,
-    Port,
+    MemInterface,
     Root,
     SubSystem,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 
 from ..boards.abstract_board import AbstractBoard

--- a/src/python/gem5/components/memory/dramsim_3.py
+++ b/src/python/gem5/components/memory/dramsim_3.py
@@ -9,9 +9,11 @@ from typing import (
 
 import m5
 from m5.objects import (
-    AddrRange,
     DRAMsim3,
     MemCtrl,
+)
+from m5.params import (
+    AddrRange,
     Port,
 )
 from m5.util.convert import toMemorySize

--- a/src/python/gem5/components/memory/dramsys.py
+++ b/src/python/gem5/components/memory/dramsys.py
@@ -33,12 +33,14 @@ from typing import (
 )
 
 from m5.objects import (
-    AddrRange,
     DRAMSys,
     Gem5ToTlmBridge32,
     MemCtrl,
-    Port,
     SystemC_Kernel,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 from m5.util.convert import toMemorySize
 

--- a/src/python/gem5/components/memory/hbm.py
+++ b/src/python/gem5/components/memory/hbm.py
@@ -38,9 +38,12 @@ from typing import (
 
 from m5.objects import (
     AbstractMemory,
-    AddrRange,
     DRAMInterface,
     HBMCtrl,
+    MemInterface,
+)
+from m5.params import (
+    AddrRange,
     Port,
 )
 

--- a/src/python/gem5/components/memory/memory.py
+++ b/src/python/gem5/components/memory/memory.py
@@ -38,9 +38,11 @@ from typing import (
 
 from m5.objects import (
     AbstractMemory,
-    AddrRange,
     DRAMInterface,
     MemCtrl,
+)
+from m5.params import (
+    AddrRange,
     Port,
 )
 from m5.util.convert import toMemorySize

--- a/src/python/gem5/components/memory/simple.py
+++ b/src/python/gem5/components/memory/simple.py
@@ -34,10 +34,12 @@ from typing import (
 
 from m5.objects import (
     AbstractMemory,
-    AddrRange,
     MemCtrl,
-    Port,
     SimpleMemory,
+)
+from m5.params import (
+    AddrRange,
+    Port,
 )
 from m5.util.convert import toMemorySize
 

--- a/src/python/gem5/components/memory/simple.py
+++ b/src/python/gem5/components/memory/simple.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 from m5.objects import (
+    AbstractMemory,
     AddrRange,
     MemCtrl,
     Port,
@@ -84,6 +85,14 @@ class SingleChannelSimpleMemory(AbstractMemorySystem):
     @overrides(AbstractMemorySystem)
     def get_size(self) -> int:
         return self._size
+
+    @overrides(AbstractMemorySystem)
+    def get_uninterleaved_range(self) -> AddrRange:
+        return self.module.range
+
+    @overrides(AbstractMemorySystem)
+    def get_mem_interfaces(self) -> List[AbstractMemory]:
+        return [self.module]
 
     @overrides(AbstractMemorySystem)
     def set_memory_range(self, ranges: List[AddrRange]) -> None:

--- a/src/python/gem5/components/processors/abstract_core.py
+++ b/src/python/gem5/components/processors/abstract_core.py
@@ -36,10 +36,12 @@ from typing import (
 from m5.objects import (
     BaseMMU,
     PcCountTrackerManager,
-    Port,
     SubSystem,
 )
-from m5.params import PcCountPair
+from m5.params import (
+    PcCountPair,
+    Port,
+)
 
 from ...isas import ISA
 

--- a/src/python/gem5/components/processors/abstract_generator_core.py
+++ b/src/python/gem5/components/processors/abstract_generator_core.py
@@ -28,10 +28,8 @@
 from abc import abstractmethod
 from typing import Optional
 
-from m5.objects import (
-    Port,
-    PortTerminator,
-)
+from m5.objects import PortTerminator
+from m5.params import Port
 
 from ...isas import ISA
 from ...utils.override import overrides

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -34,10 +34,12 @@ from m5.objects import (
     BaseMMU,
     PcCountTracker,
     PcCountTrackerManager,
-    Port,
     Process,
 )
-from m5.params import PcCountPair
+from m5.params import (
+    PcCountPair,
+    Port,
+)
 
 from ...isas import ISA
 from ...utils.override import overrides

--- a/src/python/gem5/components/processors/complex_generator_core.py
+++ b/src/python/gem5/components/processors/complex_generator_core.py
@@ -30,10 +30,8 @@ from typing import (
     Iterator,
 )
 
-from m5.objects import (
-    Port,
-    PyTrafficGen,
-)
+from m5.objects import PyTrafficGen
+from m5.params import Port
 from m5.ticks import fromSeconds
 from m5.util.convert import (
     toLatency,

--- a/src/python/gem5/components/processors/gups_generator_core.py
+++ b/src/python/gem5/components/processors/gups_generator_core.py
@@ -28,11 +28,13 @@
 from typing import Optional
 
 from m5.objects import (
-    Addr,
     GUPSGen,
-    Port,
     SrcClockDomain,
     VoltageDomain,
+)
+from m5.params import (
+    Addr,
+    Port,
 )
 
 from ...utils.override import overrides

--- a/src/python/gem5/components/processors/linear_generator_core.py
+++ b/src/python/gem5/components/processors/linear_generator_core.py
@@ -28,9 +28,9 @@ from typing import Iterator
 
 from m5.objects import (
     BaseTrafficGen,
-    Port,
     PyTrafficGen,
 )
+from m5.params import Port
 from m5.ticks import fromSeconds
 from m5.util.convert import (
     toLatency,

--- a/src/python/gem5/components/processors/random_generator_core.py
+++ b/src/python/gem5/components/processors/random_generator_core.py
@@ -28,9 +28,9 @@ from typing import Iterator
 
 from m5.objects import (
     BaseTrafficGen,
-    Port,
     PyTrafficGen,
 )
+from m5.params import Port
 from m5.ticks import fromSeconds
 from m5.util.convert import (
     toLatency,

--- a/src/python/gem5/components/processors/spatter_gen/spatter_generator_core.py
+++ b/src/python/gem5/components/processors/spatter_gen/spatter_generator_core.py
@@ -27,10 +27,10 @@
 from typing import Union
 
 from m5.objects import (
-    Port,
     SpatterGen,
     SpatterProcessingMode,
 )
+from m5.params import Port
 
 from ....utils.override import overrides
 from ..abstract_core import AbstractCore

--- a/src/python/gem5/components/processors/strided_generator_core.py
+++ b/src/python/gem5/components/processors/strided_generator_core.py
@@ -28,9 +28,9 @@ from typing import Iterator
 
 from m5.objects import (
     BaseTrafficGen,
-    Port,
     PyTrafficGen,
 )
+from m5.params import Port
 from m5.ticks import fromSeconds
 from m5.util.convert import (
     toLatency,

--- a/src/python/gem5/components/processors/traffic_generator_core.py
+++ b/src/python/gem5/components/processors/traffic_generator_core.py
@@ -25,10 +25,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from m5.objects import (
-    Port,
-    TrafficGen,
-)
+from m5.objects import TrafficGen
+from m5.params import Port
 
 from ...utils.override import overrides
 from .abstract_core import AbstractCore

--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -1421,7 +1421,7 @@ def isSimObjectOrSequence(value):
 
 
 def isRoot(obj):
-    from m5.objects import Root
+    from m5.objects.Root import Root
 
     return obj and obj is Root.getInstance()
 


### PR DESCRIPTION
Fix imports in stdlib, the SimObject file, and fix an typing error where some pure virtual functions weren't implemented.