### PR TITLE
sim,cpu: Make SimObject imports consistent in SimObject files

### DIFF
--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -43,13 +43,13 @@ import sys
 from m5.defines import buildEnv
 from m5.objects.ClockDomain import *
 from m5.objects.ClockedObject import ClockedObject
-from m5.objects.CPUTracers import ExeTracer
+from m5.objects.ExeTracer import ExeTracer
 from m5.objects.InstTracer import InstTracer
 from m5.objects.IntPin import VectorIntSourcePin
+from m5.objects.L2XBar import L2XBar
 from m5.objects.Platform import Platform
 from m5.objects.ResetPort import ResetResponsePort
 from m5.objects.SubSystem import SubSystem
-from m5.objects.XBar import L2XBar
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import *

--- a/src/cpu/probes/PcCountTracker.py
+++ b/src/cpu/probes/PcCountTracker.py
@@ -24,9 +24,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects import SimObject
-from m5.objects.Probe import ProbeListenerObject
+from m5.objects.ProbeListenerObject import ProbeListenerObject
 from m5.params import *
+from m5.SimObject import SimObject
 from m5.util.pybind import *
 
 

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -39,7 +39,7 @@
 
 from m5.objects.DVFSHandler import *
 from m5.objects.SimpleMemory import *
-from m5.objects.Workload import StubWorkload
+from m5.objects.StubWorkload import StubWorkload
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import *


### PR DESCRIPTION
In SimObject description files, you often need to import other SimObjects to use as parameter values. Note that these are only used as parameters, so we don't need the C++ backend at this point.
The problem is that when there is a SimObject description file with multiple SimObjects declared, it's hard to know what file you should import *from*. This change begins to make a consistent decision to import from m5.objects.<SimObjectName> instead of from the file that it was declared in. This works because all SimObjects end up in m5.objects.<SimObjectName> modules.