### PR TITLE
dev: Fix PCI build

### DIFF
--- a/src/dev/pci/bus.hh
+++ b/src/dev/pci/bus.hh
@@ -39,11 +39,10 @@
 #define __DEV_PCI_BUS_HH__
 
 #include "mem/noncoherent_xbar.hh"
+#include "params/PciBus.hh"
 
 namespace gem5
 {
-
-class PciBusParams;
 
 /**
  * A PCI bus is a non-coherent crossbar with a special port that is used to

--- a/src/dev/pci/up_down_bridge.hh
+++ b/src/dev/pci/up_down_bridge.hh
@@ -39,11 +39,10 @@
 #define __DEV_PCI_ONE_WAY_BRIDGE_HH__
 
 #include "mem/bridge.hh"
+#include "params/PciUpDownBridge.hh"
 
 namespace gem5
 {
-
-class PciUpDownBridgeParams;
 
 /**
  * This bridge lets packets pass from upstream to downstream of a PCI bridge.

--- a/src/dev/pci/upstream.cc
+++ b/src/dev/pci/upstream.cc
@@ -69,7 +69,6 @@ PciConfigError::setAddrRange(AddrRange range)
 PciUpstream::PciUpstream(const Params &p)
     : ClockedObject(p),
       upToDown(p.up_to_down),
-      downToUp(p.down_to_up),
       configErrorDevice(p.config_error)
 {}
 

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -47,14 +47,14 @@
 #include "dev/isa_fake.hh"
 #include "dev/pci/types.hh"
 #include "dev/pci/up_down_bridge.hh"
+#include "params/PciConfigError.hh"
+#include "params/PciUpstream.hh"
 #include "sim/clocked_object.hh"
 
 namespace gem5
 {
 
 class PciDevice;
-class PciConfigErrorParams;
-class PciUpstreamParams;
 
 class PciConfigError : public IsaFake
 {
@@ -321,7 +321,6 @@ class PciUpstream : public ClockedObject
 
     /** The two one way bridges to connect both side buses */
     PciUpDownBridge *upToDown;
-    BridgeBase *downToUp;
 
     PciConfigError *configErrorDevice;
 };


### PR DESCRIPTION
Clang 17.0 is very pedantic about class vs. struct. This change uses the header files instead of forward declarations. This change also removes an unused variable.