### PR TITLE
stdlib,python: Improve consistency of python imports

### DIFF
--- a/src/python/gem5/resources/looppoint.py
+++ b/src/python/gem5/resources/looppoint.py
@@ -35,7 +35,7 @@ from typing import (
     Union,
 )
 
-import m5
+from m5 import options
 from m5.objects import PcCountTrackerManager
 from m5.params import PcCountPair
 
@@ -376,7 +376,7 @@ class Looppoint:
     def output_json_file(
         self,
         input_indent: int = 4,
-        filepath: str = os.path.join(m5.options.outdir, "looppoint.json"),
+        filepath: Optional[str] = None,
     ) -> Dict[int, Dict]:
         """
         This function is used to output the ``_json_file`` into a json file.
@@ -384,6 +384,8 @@ class Looppoint:
         :param input_indent: The indent value of the json file.
         :param filepath: The path of the output json file.
         """
+        if filepath is None:
+            filepath = os.path.join(options.outdir, "looppoint.json")
         with open(filepath, "w") as file:
             json.dump(self.to_json(), file, indent=input_indent)
 

--- a/src/python/gem5/simulate/exit_event_generators.py
+++ b/src/python/gem5/simulate/exit_event_generators.py
@@ -30,14 +30,14 @@ from typing import (
     Optional,
 )
 
-import m5.stats
+import m5
+from m5 import stats as m5_stats
 from m5.util import warn
-
-from gem5.resources.looppoint import Looppoint
 
 from ..components.processors.abstract_processor import AbstractProcessor
 from ..components.processors.spatter_gen import SpatterGenerator
 from ..components.processors.switchable_processor import SwitchableProcessor
+from ..resources.looppoint import Looppoint
 from ..resources.resource import SimpointResource
 
 """
@@ -92,8 +92,8 @@ def dump_reset_generator():
     generator.
     """
     while True:
-        m5.stats.dump()
-        m5.stats.reset()
+        m5_stats.dump()
+        m5_stats.reset()
         yield False
 
 
@@ -120,7 +120,7 @@ def reset_stats_generator():
     the stats before resetting them.
     """
     while True:
-        m5.stats.reset()
+        m5_stats.reset()
         yield False
 
 
@@ -129,7 +129,7 @@ def dump_stats_generator():
     This generator dumps the stats every time it is called.
     """
     while True:
-        m5.stats.dump()
+        m5_stats.dump()
         yield False
 
 

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -46,9 +46,8 @@ import m5
 from m5 import options
 from m5.util import warn
 
-from gem5.simulate.exit_event import ExitEvent
-from gem5.utils.override import overrides
-
+from ..utils.override import overrides
+from .exit_event import ExitEvent
 from .exit_event_generators import (
     dump_stats_generator,
     exit_generator,

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -39,14 +39,12 @@ from typing import (
 )
 
 import m5
-import m5.options
-import m5.ticks
+from m5 import options as m5_options
 from m5.ext.pystats.simstat import SimStat
 from m5.stats import addStatVisitor
 from m5.util import warn
 
-from gem5.components.boards.abstract_board import AbstractBoard
-
+from ..components.boards.abstract_board import AbstractBoard
 from ..resources.resource import WorkloadResource
 from .exit_event import ExitEvent
 from .exit_handler import (
@@ -509,7 +507,7 @@ class Simulator:
         Show exit event messages. This will print the exit event messages to
         the console.
         """
-        m5.options.show_exit_event_messages = True
+        m5_options.show_exit_event_messages = True
 
     def override_outdir(self, new_outdir: Path) -> None:
         """This function can be used to override the output directory locatiomn
@@ -642,7 +640,7 @@ class Simulator:
                 exit_event_hypercall_id
             ](self._last_exit_event.getPayload())
 
-            if m5.options.show_exit_event_messages:
+            if m5_options.show_exit_event_messages:
                 print(
                     f"Exit event: {exit_handler.get_handler_description()} called at tick {self.get_current_tick()}"
                 )

--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -40,7 +40,6 @@
 
 import importlib
 import inspect
-import sys
 from functools import wraps
 from types import (
     FunctionType,
@@ -50,10 +49,6 @@ from types import (
 
 import m5
 from m5.citations import gem5_citations
-
-# Use the pyfdt and not the helper class, because the fdthelper
-# relies on the SimObject definition
-from m5.ext.pyfdt import pyfdt
 
 # There are a few things we need that aren't in params.__all__ since
 # normal users don't need them

--- a/src/python/m5/__init__.py
+++ b/src/python/m5/__init__.py
@@ -30,10 +30,10 @@
 
 try:
     # Try to import a native module
-    import _m5.core
+    from _m5 import core
 
     # Try to grab something from it in case demandimport is being used
-    _m5.core.curTick
+    core.curTick
     in_gem5 = True
 except ImportError:
     # The import failed, we're being called from the build system

--- a/src/python/m5/citations.py
+++ b/src/python/m5/citations.py
@@ -27,8 +27,6 @@
 from pathlib import Path
 from typing import Type
 
-import m5.options
-
 
 def add_citation(sim_obj_cls: Type["SimObject"], citation: str):
     """Add a citation to a SimObject class.
@@ -51,6 +49,8 @@ def gather_citations(root: "SimObject", output_dir: str):
     of the citations together and then print them to citations.bib in the
     output directory.
     """
+    # Note: this needs to be imported after `main` is run, because we set
+    # this variable in main.
 
     citations = {}
     for obj in root.descendants():

--- a/src/python/m5/stats/__init__.py
+++ b/src/python/m5/stats/__init__.py
@@ -40,12 +40,13 @@
 import m5
 from m5.objects import Root
 from m5.params import isNullPointer
+from m5.SimObject import isSimObjectVector
 from m5.util import (
     attrdict,
     fatal,
 )
 
-import _m5.stats
+from _m5 import stats as _m5_stats
 
 # Stat exports
 from _m5.stats import periodicStatDump
@@ -150,10 +151,10 @@ def _textFactory(fn, desc=True, spaces=True):
 
     """
 
-    return _m5.stats.initText(fn, desc, spaces)
+    return _m5_stats.initText(fn, desc, spaces)
 
 
-@_url_factory(["h5"], enable=hasattr(_m5.stats, "initHDF5"))
+@_url_factory(["h5"], enable=hasattr(_m5_stats, "initHDF5"))
 def _hdf5Factory(fn, chunking=10, desc=True, formulas=True):
     """Output stats in HDF5 format.
 
@@ -187,7 +188,7 @@ def _hdf5Factory(fn, chunking=10, desc=True, formulas=True):
 
     """
 
-    return _m5.stats.initHDF5(fn, chunking, desc, formulas)
+    return _m5_stats.initHDF5(fn, chunking, desc, formulas)
 
 
 @_url_factory(["json"])
@@ -253,8 +254,8 @@ def printStatVisitorTypes():
 
 
 def initSimStats():
-    _m5.stats.initSimStats()
-    _m5.stats.registerPythonStatsHandlers()
+    _m5_stats.initSimStats()
+    _m5_stats.registerPythonStatsHandlers()
 
 
 def _visit_groups(visitor, root=None):
@@ -277,7 +278,7 @@ def _bindStatHierarchy(root):
     def _bind_obj(name, obj):
         if isNullPointer(obj):
             return
-        if m5.SimObject.isSimObjectVector(obj):
+        if isSimObjectVector(obj):
             if len(obj) == 1:
                 _bind_obj(name, obj[0])
             else:
@@ -289,7 +290,7 @@ def _bindStatHierarchy(root):
             # class of SystemC_ScModule, is not a subclass of Stat::Group. So
             # it will cause a type error if obj is a SystemC_ScModule when
             # calling addStatGroup().
-            if isinstance(obj.getCCObject(), _m5.stats.Group):
+            if isinstance(obj.getCCObject(), _m5_stats.Group):
                 parent = root
                 while parent:
                     if hasattr(parent, "addStatGroup"):
@@ -327,7 +328,7 @@ def enable():
 
     # Legacy stat
     global stats_list
-    stats_list = list(_m5.stats.statsList())
+    stats_list = list(_m5_stats.statsList())
 
     for stat in stats_list:
         check_stat(None, stat)
@@ -341,7 +342,7 @@ def enable():
     _visit_stats(check_stat)
     _visit_stats(lambda g, s: s.enable())
 
-    _m5.stats.enable()
+    _m5_stats.enable()
 
 
 def prepare():
@@ -415,7 +416,7 @@ def dump(roots=None, message=""):
 
     # Only prepare stats the first time we dump them in the same tick.
     if new_dump:
-        _m5.stats.processDumpQueue()
+        _m5_stats.processDumpQueue()
         # Notify new-style stats group that we are about to dump stats.
         sim_root = Root.getInstance()
         if sim_root:
@@ -447,7 +448,7 @@ def reset():
     for stat in stats_list:
         stat.reset()
 
-    _m5.stats.processResetQueue()
+    _m5_stats.processResetQueue()
 
 
 flags = attrdict(

--- a/src/python/m5/stats/gem5stats.py
+++ b/src/python/m5/stats/gem5stats.py
@@ -43,7 +43,7 @@ from m5.ext.pystats.storagetype import *
 from m5.objects import *
 from m5.params import SimObjectVector
 
-import _m5.stats
+from _m5 import stats as _m5_stats
 
 
 class JsonOutputVistor:
@@ -84,7 +84,7 @@ class JsonOutputVistor:
             simstat.dump(fp=fp, **self.json_args)
 
 
-def __get_statistic(statistic: _m5.stats.Info) -> Optional[Statistic]:
+def __get_statistic(statistic: _m5_stats.Info) -> Optional[Statistic]:
     """
     Translates a _m5.stats.Info object into a Statistic object, to process
     statistics at the Python level.
@@ -95,32 +95,32 @@ def __get_statistic(statistic: _m5.stats.Info) -> Optional[Statistic]:
               Info object cannot, or should not, be translated.
     """
 
-    assert isinstance(statistic, _m5.stats.Info)
+    assert isinstance(statistic, _m5_stats.Info)
     statistic.prepare()
 
-    if isinstance(statistic, _m5.stats.ScalarInfo):
+    if isinstance(statistic, _m5_stats.ScalarInfo):
         if statistic.is_nozero and statistic.value == 0.0:
             # In the case where the "nozero" flag is set, and the value is
             # zero, we don't want to include this statistic so return None.
             return None
         return __get_scaler(statistic)
-    elif isinstance(statistic, _m5.stats.DistInfo):
+    elif isinstance(statistic, _m5_stats.DistInfo):
         return __get_distribution(statistic)
-    elif isinstance(statistic, _m5.stats.FormulaInfo):
+    elif isinstance(statistic, _m5_stats.FormulaInfo):
         # We don't do anything with Formula's right now.
         # We may never do so, see https://gem5.atlassian.net/browse/GEM5-868.
         pass
-    elif isinstance(statistic, _m5.stats.VectorInfo):
+    elif isinstance(statistic, _m5_stats.VectorInfo):
         return __get_vector(statistic)
-    elif isinstance(statistic, _m5.stats.Vector2dInfo):
+    elif isinstance(statistic, _m5_stats.Vector2dInfo):
         return __get_vector2d(statistic)
-    elif isinstance(statistic, _m5.stats.SparseHistInfo):
+    elif isinstance(statistic, _m5_stats.SparseHistInfo):
         return __get_sparse_hist(statistic)
 
     return None
 
 
-def __get_scaler(statistic: _m5.stats.ScalarInfo) -> Scalar:
+def __get_scaler(statistic: _m5_stats.ScalarInfo) -> Scalar:
     value = statistic.value
     unit = statistic.unit
     description = statistic.desc
@@ -132,7 +132,7 @@ def __get_scaler(statistic: _m5.stats.ScalarInfo) -> Scalar:
     )
 
 
-def __get_distribution(statistic: _m5.stats.DistInfo) -> Distribution:
+def __get_distribution(statistic: _m5_stats.DistInfo) -> Distribution:
     description = statistic.desc
     value = statistic.values
     bin_size = statistic.bucket_size
@@ -168,7 +168,7 @@ def __get_distribution(statistic: _m5.stats.DistInfo) -> Distribution:
     )
 
 
-def __get_vector(statistic: _m5.stats.VectorInfo) -> Vector:
+def __get_vector(statistic: _m5_stats.VectorInfo) -> Vector:
     vec: Dict[Union[str, int, float], Scalar] = {}
 
     for index in range(statistic.size):
@@ -208,7 +208,7 @@ def __get_vector(statistic: _m5.stats.VectorInfo) -> Vector:
     )
 
 
-def __get_vector2d(statistic: _m5.stats.Vector2dInfo) -> Vector2d:
+def __get_vector2d(statistic: _m5_stats.Vector2dInfo) -> Vector2d:
     # All the values in a 2D Vector are Scalar values
     description = statistic.desc
     x_size = statistic.x_size
@@ -244,7 +244,7 @@ def __get_vector2d(statistic: _m5.stats.Vector2dInfo) -> Vector2d:
     return Vector2d(value=vector_rep, type="Vector2d", description=description)
 
 
-def __get_sparse_hist(statistic: _m5.stats.SparseHistInfo) -> SparseHist:
+def __get_sparse_hist(statistic: _m5_stats.SparseHistInfo) -> SparseHist:
     description = statistic.desc
     value = statistic.values
 
@@ -262,7 +262,7 @@ def __get_sparse_hist(statistic: _m5.stats.SparseHistInfo) -> SparseHist:
     )
 
 
-def _prepare_stats(group: _m5.stats.Group):
+def _prepare_stats(group: _m5_stats.Group):
     """
     Prepares the statistics for dumping.
     """
@@ -375,7 +375,7 @@ def get_simstat(
     """
 
     if prepare_stats:
-        _m5.stats.processDumpQueue()
+        _m5_stats.processDumpQueue()
 
     stats_map = {}
     for r in root:

--- a/src/python/m5/ticks.py
+++ b/src/python/m5/ticks.py
@@ -25,22 +25,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import decimal
-import sys
 
 from m5.util import warn
 
 
 # fix the global frequency
 def fixGlobalFrequency():
-    import _m5.core
+    from _m5 import core
 
-    _m5.core.fixClockFrequency()
+    core.fixClockFrequency()
 
 
 def setGlobalFrequency(ticksPerSecond):
     from m5.util import convert
 
-    import _m5.core
+    from _m5 import core
 
     if isinstance(ticksPerSecond, int):
         tps = ticksPerSecond
@@ -52,7 +51,7 @@ def setGlobalFrequency(ticksPerSecond):
         raise TypeError(
             f"wrong type '{type(ticksPerSecond)}' for ticksPerSecond"
         )
-    _m5.core.setClockFrequency(int(tps))
+    core.setClockFrequency(int(tps))
 
 
 # how big does a rounding error need to be before we warn about it?
@@ -60,14 +59,14 @@ frequency_tolerance = 0.001  # 0.1%
 
 
 def fromSeconds(value):
-    import _m5.core
+    from _m5 import core
 
     if not isinstance(value, float):
         raise TypeError(f"can't convert '{type(value)}' to type tick")
 
     # once someone needs to convert to seconds, the global frequency
     # had better be fixed
-    if not _m5.core.clockFrequencyFixed():
+    if not core.clockFrequencyFixed():
         raise AttributeError(
             "In order to do conversions, the global frequency must be fixed"
         )
@@ -76,7 +75,7 @@ def fromSeconds(value):
         return 0
 
     # convert the value from time to ticks
-    value *= _m5.core.getClockFrequency()
+    value *= core.getClockFrequency()
 
     int_value = int(
         decimal.Decimal(value).to_integral_value(decimal.ROUND_HALF_UP)


### PR DESCRIPTION
This change improves the consistency of python imports in the following ways:
- No more `import m5.<module>` so that you have to refer to the module as `m5.<module>`. Sometimes this results in using "import .. as .." to make the name more clear.
- When possible, import the submodule that is used instead of the entire m5 module.
- Fix some cases of using the complete path to import instead of relative in the stdlib.
- Remove unused imports