### PR TITLE
cpu: Remove unused parameter from FTQ to enable MacOS build

### DIFF
--- a/src/cpu/o3/ftq.cc
+++ b/src/cpu/o3/ftq.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -84,7 +85,6 @@ FetchTarget::toString()
 
 FTQ::FTQ(CPU *_cpu, const BaseO3CPUParams &params)
     : cpu(_cpu),
-      numThreads(params.numThreads),
       numEntries(params.numFTQEntries),
       stats(_cpu, params.numFTQEntries)
 {

--- a/src/cpu/o3/ftq.hh
+++ b/src/cpu/o3/ftq.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -248,9 +249,6 @@ class FTQ
 
     /** Pointer to the CPU. */
     CPU *cpu;
-
-    /** Max number of threads */
-    const unsigned numThreads;
 
     /** Number of fetch targets in the FTQ. (per thread) */
     const unsigned numEntries;


### PR DESCRIPTION
This commit removes the `numThreads` member from `class FTQ`. This member is currently unused and causes the MacOS build to fail due to a warning-as-error.
