### PR TITLE
mem-cache: Add cache_snoop parameter to Fetch Directed Prefetcher

### DIFF
--- a/src/mem/cache/prefetch/Prefetcher.py
+++ b/src/mem/cache/prefetch/Prefetcher.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012, 2014, 2019, 2022-2024 Arm Limited
+# Copyright (c) 2012, 2014, 2019, 2022-2025 Arm Limited
 # Copyright (c) 2023 The University of Edinburgh
 # All rights reserved.
 #
@@ -766,6 +766,11 @@ class FetchDirectedPrefetcher(BasePrefetcher):
         True,
         "Squash the prefetch associated with a fetch target in case it gets "
         "removded fron the the FTQ (Fetch consumes it or a pipeline flush).",
+    )
+    cache_snoop = Param.Bool(
+        True,
+        "Snoop the icache (if present) and do not enqueue prefetches for "
+        "blocks already in the cache.",
     )
 
 

--- a/src/mem/cache/prefetch/fdp.cc
+++ b/src/mem/cache/prefetch/fdp.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -59,7 +60,7 @@ FetchDirectedPrefetcher::FetchDirectedPrefetcher(
       latency(cyclesToTicks(p.latency)),
       pfqSize(p.pfq_size),
       tqSize(p.tq_size),
-      cacheSnoop(true),
+      cacheSnoop(p.cache_snoop),
       stats(this, p.pfq_size, p.tq_size)
 {}
 


### PR DESCRIPTION
Adds a `cache_snoop` parameter to the `FetchDirectedPrefetcher` to allow the feature to be controlled from Python configuration scripts.