### PR TITLE
arch-vega: Implement remaining non-MFMA CDNA4 instructions

### DIFF
--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -1000,8 +1000,8 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_OPU_VOP3__V_PRNG_B32,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OPU_VOP3__V_PERMLANE16_SWAP_B32,
+        &Decoder::decode_OPU_VOP3__V_PERMLANE32_SWAP_B32,
         &Decoder::decode_OPU_VOP3__V_CVT_F32_BF16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -3169,9 +3169,9 @@ namespace VegaISA
         &Decoder::decode_OP_VOP1__V_CVT_F32_BF8,
         &Decoder::decode_OP_VOP1__V_CVT_PK_F32_FP8,
         &Decoder::decode_OP_VOP1__V_CVT_PK_F32_BF8,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_VOP1__V_PRNG_B32,
+        &Decoder::decode_OP_VOP1__V_PERMLANE16_SWAP_B32,
+        &Decoder::decode_OP_VOP1__V_PERMLANE32_SWAP_B32,
         &Decoder::decode_OP_VOP1__V_CVT_F32_BF16,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -6656,6 +6656,18 @@ namespace VegaISA
     Decoder::decode_OPU_VOP3__V_PRNG_B32(MachInst iFmt)
     {
         return new Inst_VOP3__V_PRNG_B32(&iFmt->iFmt_VOP3A);
+    }
+
+    GPUStaticInst *
+    Decoder::decode_OPU_VOP3__V_PERMLANE16_SWAP_B32(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_PERMLANE16_SWAP_B32(&iFmt->iFmt_VOP3A);
+    }
+
+    GPUStaticInst *
+    Decoder::decode_OPU_VOP3__V_PERMLANE32_SWAP_B32(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_PERMLANE32_SWAP_B32(&iFmt->iFmt_VOP3A);
     }
 
     GPUStaticInst*
@@ -12279,6 +12291,18 @@ namespace VegaISA
     Decoder::decode_OP_VOP1__V_PRNG_B32(MachInst iFmt)
     {
         return new Inst_VOP1__V_PRNG_B32(&iFmt->iFmt_VOP1);
+    }
+
+    GPUStaticInst *
+    Decoder::decode_OP_VOP1__V_PERMLANE16_SWAP_B32(MachInst iFmt)
+    {
+        return new Inst_VOP1__V_PERMLANE16_SWAP_B32(&iFmt->iFmt_VOP1);
+    }
+
+    GPUStaticInst *
+    Decoder::decode_OP_VOP1__V_PERMLANE32_SWAP_B32(MachInst iFmt)
+    {
+        return new Inst_VOP1__V_PERMLANE32_SWAP_B32(&iFmt->iFmt_VOP1);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -999,7 +999,7 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OPU_VOP3__V_PRNG_B32,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_OPU_VOP3__V_CVT_F32_BF16,
@@ -1358,8 +1358,7 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid
-    };
+        &Decoder::decode_invalid};
 
     IsaDecodeMethod Decoder::tableSubDecode_OP_DS[] = {
         &Decoder::decode_OP_DS__DS_ADD_U32,
@@ -3337,8 +3336,7 @@ namespace VegaISA
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
-        &Decoder::decode_invalid
-    };
+        &Decoder::decode_invalid};
 
     IsaDecodeMethod Decoder::tableSubDecode_OP_VOPC[] = {
         &Decoder::decode_invalid,
@@ -6653,6 +6651,12 @@ namespace VegaISA
     {
         return new Inst_VOP3__V_LOG_LEGACY_F32(&iFmt->iFmt_VOP3A);
     } // decode_OPU_VOP3__V_LOG_LEGACY_F32
+
+    GPUStaticInst *
+    Decoder::decode_OPU_VOP3__V_PRNG_B32(MachInst iFmt)
+    {
+        return new Inst_VOP3__V_PRNG_B32(&iFmt->iFmt_VOP3A);
+    }
 
     GPUStaticInst*
     Decoder::decode_OPU_VOP3__V_CVT_F32_BF16(MachInst iFmt)
@@ -12269,6 +12273,12 @@ namespace VegaISA
     {
         fatal("Trying to decode instruction without a class\n");
         return nullptr;
+    }
+
+    GPUStaticInst *
+    Decoder::decode_OP_VOP1__V_PRNG_B32(MachInst iFmt)
+    {
+        return new Inst_VOP1__V_PRNG_B32(&iFmt->iFmt_VOP1);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -3642,7 +3642,7 @@ namespace VegaISA
         &Decoder::decode_OP_VOP3P__V_DOT4_U32_U8,
         &Decoder::decode_OP_VOP3P__V_DOT8_I32_I4,
         &Decoder::decode_OP_VOP3P__V_DOT8_U32_U4,
-        &Decoder::decode_invalid,
+        &Decoder::decode_OP_VOP3P__V_MFMA_LOAD_SCALE,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
         &Decoder::decode_invalid,
@@ -13734,6 +13734,12 @@ namespace VegaISA
     Decoder::decode_OP_VOP3P__V_DOT8_U32_U4(MachInst iFmt)
     {
         return new Inst_VOP3P__V_DOT8_U32_U4(&iFmt->iFmt_VOP3P);
+    }
+
+    GPUStaticInst *
+    Decoder::decode_OP_VOP3P__V_MFMA_LOAD_SCALE(MachInst iFmt)
+    {
+        return new Inst_VOP3P__V_MFMA_LOAD_SCALE(&iFmt->iFmt_VOP3P);
     }
 
     GPUStaticInst*

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -406,6 +406,8 @@ namespace VegaISA
         GPUStaticInst* decode_OPU_VOP3__V_EXP_LEGACY_F32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_LOG_LEGACY_F32(MachInst);
         GPUStaticInst *decode_OPU_VOP3__V_PRNG_B32(MachInst);
+        GPUStaticInst *decode_OPU_VOP3__V_PERMLANE16_SWAP_B32(MachInst);
+        GPUStaticInst *decode_OPU_VOP3__V_PERMLANE32_SWAP_B32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_CVT_F32_BF16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_MAD_LEGACY_F32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_MAD_F32(MachInst);
@@ -1400,6 +1402,8 @@ namespace VegaISA
         GPUStaticInst* decode_OP_VOP1__V_SAT_PK_U8_I16(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_SWAP_B32(MachInst);
         GPUStaticInst *decode_OP_VOP1__V_PRNG_B32(MachInst);
+        GPUStaticInst *decode_OP_VOP1__V_PERMLANE16_SWAP_B32(MachInst);
+        GPUStaticInst *decode_OP_VOP1__V_PERMLANE32_SWAP_B32(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_CVT_F32_BF16(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_ACCVGPR_MOV_B32(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_CVT_F32_FP8(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -405,6 +405,7 @@ namespace VegaISA
         GPUStaticInst* decode_OPU_VOP3__V_COS_F16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_EXP_LEGACY_F32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_LOG_LEGACY_F32(MachInst);
+        GPUStaticInst *decode_OPU_VOP3__V_PRNG_B32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_CVT_F32_BF16(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_MAD_LEGACY_F32(MachInst);
         GPUStaticInst* decode_OPU_VOP3__V_MAD_F32(MachInst);
@@ -1398,6 +1399,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_VOP1__V_CVT_NORM_U16_F16(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_SAT_PK_U8_I16(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_SWAP_B32(MachInst);
+        GPUStaticInst *decode_OP_VOP1__V_PRNG_B32(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_CVT_F32_BF16(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_ACCVGPR_MOV_B32(MachInst);
         GPUStaticInst* decode_OP_VOP1__V_CVT_F32_FP8(MachInst);

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -1706,6 +1706,7 @@ namespace VegaISA
         GPUStaticInst* decode_OP_VOP3P__V_DOT4_U32_U8(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_DOT8_I32_I4(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_DOT8_U32_U4(MachInst);
+        GPUStaticInst *decode_OP_VOP3P__V_MFMA_LOAD_SCALE(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_MFMA_F32_32X32X1_2B_F32(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_MFMA_F32_16X16X1_4B_F32(MachInst);
         GPUStaticInst* decode_OP_VOP3P__V_MFMA_F32_4X4X1_16B_F32(MachInst);

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -10865,6 +10865,86 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP1__V_CVT_PK_F32_BF8
 
+    class Inst_VOP1__V_PERMLANE16_SWAP_B32 : public Inst_VOP1
+    {
+      public:
+        Inst_VOP1__V_PERMLANE16_SWAP_B32(InFmt_VOP1 *);
+        ~Inst_VOP1__V_PERMLANE16_SWAP_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 1;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 1;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src
+                    return 4;
+                case 1: // vdst
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP1__V_PERMLANE16_SWAP_B32
+
+    class Inst_VOP1__V_PERMLANE32_SWAP_B32 : public Inst_VOP1
+    {
+      public:
+        Inst_VOP1__V_PERMLANE32_SWAP_B32(InFmt_VOP1 *);
+        ~Inst_VOP1__V_PERMLANE32_SWAP_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 1;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 1;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src
+                    return 4;
+                case 1: // vdst
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP1__V_PERMLANE32_SWAP_B32
+
     class Inst_VOPC__V_CMP_CLASS_F32 : public Inst_VOPC
     {
       public:
@@ -32112,6 +32192,86 @@ namespace VegaISA
 
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP3__V_CVT_SR_F16_F32
+
+    class Inst_VOP3__V_PERMLANE16_SWAP_B32 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_PERMLANE16_SWAP_B32(InFmt_VOP3A *);
+        ~Inst_VOP3__V_PERMLANE16_SWAP_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 1;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 1;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src_0
+                    return 4;
+                case 1: // vdst
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_PERMLANE16_SWAP_B32
+
+    class Inst_VOP3__V_PERMLANE32_SWAP_B32 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_PERMLANE32_SWAP_B32(InFmt_VOP3A *);
+        ~Inst_VOP3__V_PERMLANE32_SWAP_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 1;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 1;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src_0
+                    return 4;
+                case 1: // vdst
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_PERMLANE32_SWAP_B32
 
     class Inst_DS__DS_ADD_U32 : public Inst_DS
     {

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -10697,6 +10697,46 @@ namespace VegaISA
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP1__V_ACCVGPR_MOV_B32
 
+    class Inst_VOP1__V_PRNG_B32 : public Inst_VOP1
+    {
+      public:
+        Inst_VOP1__V_PRNG_B32(InFmt_VOP1 *);
+        ~Inst_VOP1__V_PRNG_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 1;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 1;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src
+                    return 4;
+                case 1: // vdst
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP1__V_PRNG_B32
+
     class Inst_VOP1__V_CVT_F32_FP8 : public Inst_VOP1
     {
       public:
@@ -28576,6 +28616,46 @@ namespace VegaISA
 
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP3__V_LOG_LEGACY_F32
+
+    class Inst_VOP3__V_PRNG_B32 : public Inst_VOP3A
+    {
+      public:
+        Inst_VOP3__V_PRNG_B32(InFmt_VOP3A *);
+        ~Inst_VOP3__V_PRNG_B32();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 1;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 1;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src
+                    return 4;
+                case 1: // vdst
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    }; // Inst_VOP3__V_PRNG_B32
 
     class Inst_VOP3__V_CVT_F32_BF16 : public Inst_VOP3A
     {

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -46264,6 +46264,46 @@ namespace VegaISA
 
         void execute(GPUDynInstPtr) override;
     }; // Inst_VOP3__V_CVT_PK_BF8_F32
+
+    class Inst_VOP3P__V_MFMA_LOAD_SCALE : public Inst_VOP3P
+    {
+      public:
+        Inst_VOP3P__V_MFMA_LOAD_SCALE(InFmt_VOP3P *);
+        ~Inst_VOP3P__V_MFMA_LOAD_SCALE();
+
+        int
+        getNumOperands() override
+        {
+            return numDstRegOperands() + numSrcRegOperands();
+        } // getNumOperands
+
+        int
+        numDstRegOperands() override
+        {
+            return 0;
+        }
+        int
+        numSrcRegOperands() override
+        {
+            return 2;
+        }
+
+        int
+        getOperandSize(int opIdx) override
+        {
+            switch (opIdx) {
+                case 0: // src0
+                    return 4;
+                case 1: // src1
+                    return 4;
+                default:
+                    fatal("op idx %i out of bounds\n", opIdx);
+                    return -1;
+            }
+        } // getOperandSize
+
+        void execute(GPUDynInstPtr) override;
+    };
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/vop1.cc
+++ b/src/arch/amdgpu/vega/insts/vop1.cc
@@ -2930,5 +2930,83 @@ namespace VegaISA
 
         vdst.write();
     } // execute
+    // --- Inst_VOP1__V_PERMLANE16_SWAP_B32 class methods ---
+
+    Inst_VOP1__V_PERMLANE16_SWAP_B32::Inst_VOP1__V_PERMLANE16_SWAP_B32(
+        InFmt_VOP1 *iFmt)
+        : Inst_VOP1(iFmt, "v_permlane16_swap_b32")
+    {
+        setFlag(ALU);
+    } // Inst_VOP1__V_PERMLANE16_SWAP_B32
+
+    Inst_VOP1__V_PERMLANE16_SWAP_B32::~Inst_VOP1__V_PERMLANE16_SWAP_B32()
+    {} // ~Inst_VOP1__V_PERMLANE16_SWAP_B32
+
+    // Swap data between two vector registers. Odd rows of the first operand
+    // are swapped with even rows of the second operand (one row is 16 lanes).
+    //
+    // Notes: ABS, NEG and OMOD modifiers should all be zeroed for this
+    // instruction. This instruction is useful for BFP data conversions.
+    void
+    Inst_VOP1__V_PERMLANE16_SWAP_B32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        VecOperandU32 src(gpuDynInst, instData.SRC0);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src.read();
+        vdst.read();
+
+        // Ignores EXEC MASK
+        for (int pass = 0; pass < 2; ++pass) {
+            for (int lane = 0; lane < 16; ++lane) {
+                int dlane = pass * 32 + lane + 16;
+                int slane = pass * 32 + lane;
+
+                VecElemU32 tmp = src[slane];
+                src[slane] = vdst[dlane];
+                vdst[dlane] = tmp;
+            }
+        }
+
+        src.write();
+        vdst.write();
+    } // execute
+    // --- Inst_VOP1__V_PERMLANE32_SWAP_B32 class methods ---
+
+    Inst_VOP1__V_PERMLANE32_SWAP_B32::Inst_VOP1__V_PERMLANE32_SWAP_B32(
+        InFmt_VOP1 *iFmt)
+        : Inst_VOP1(iFmt, "v_permlane32_swap_b32")
+    {
+        setFlag(ALU);
+    } // Inst_VOP1__V_PERMLANE32_SWAP_B32
+
+    Inst_VOP1__V_PERMLANE32_SWAP_B32::~Inst_VOP1__V_PERMLANE32_SWAP_B32()
+    {} // ~Inst_VOP1__V_PERMLANE32_SWAP_B32
+
+    // Swap data between two vector registers. Rows 2 and 3 of the first
+    // operand are swapped with rows 0 and 1 of the second operand (one row
+    // is 16 lanes).
+    //
+    // Notes: ABS, NEG and OMOD modifiers should all be zeroed for this
+    // instruction. This instruction is useful for BFP data conversions.
+    void
+    Inst_VOP1__V_PERMLANE32_SWAP_B32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        VecOperandU32 src(gpuDynInst, instData.SRC0);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src.read();
+        vdst.read();
+
+        // Ignores EXEC MASK
+        for (int lane = 0; lane < 32; ++lane) {
+            VecElemU32 tmp = src[lane];
+            src[lane] = vdst[lane + 32];
+            vdst[lane + 32] = tmp;
+        }
+
+        src.write();
+        vdst.write();
+    } // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop1.cc
+++ b/src/arch/amdgpu/vega/insts/vop1.cc
@@ -2885,5 +2885,50 @@ namespace VegaISA
 
         vdst.write();
     } // execute
+    // --- Inst_VOP1__V_PRNG_B32 class methods ---
+
+    Inst_VOP1__V_PRNG_B32::Inst_VOP1__V_PRNG_B32(InFmt_VOP1 *iFmt)
+        : Inst_VOP1(iFmt, "v_prng_b32")
+    {
+        setFlag(ALU);
+    } // Inst_VOP1__V_PRNG_B32
+
+    Inst_VOP1__V_PRNG_B32::~Inst_VOP1__V_PRNG_B32()
+    {} // ~Inst_VOP1__V_PRNG_B32
+
+    // Generate a pseudorandom number using an LFSR (linear feedback shift
+    // register) seeded with the vector input, then store the result into a
+    // vector register.
+    //
+    // in = S0.u32;
+    // D0.u32 = ((in << 1U) ^ (in[31] ? 197U : 0U))
+    //
+    // Notes: This function produces a sequence of pseudorandom numbers with
+    // period 2**32 - 1 unless the input is zero, in which case the period is
+    // 1.
+    void
+    Inst_VOP1__V_PRNG_B32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        Wavefront *wf = gpuDynInst->wavefront();
+        ConstVecOperandU32 src(gpuDynInst, instData.SRC0);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src.readSrc();
+
+        panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
+        panic_if(isDPPInst(), "DPP not implemented for %s", _opcode);
+
+        auto randFunc = [](VecElemU32 in) {
+            return ((in << 1) ^ (((in >> 31) & 1) ? 0xc5 : 0x00));
+        };
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                vdst[lane] = randFunc(src[lane]);
+            }
+        }
+
+        vdst.write();
+    } // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -9917,5 +9917,91 @@ namespace VegaISA
 
         vdst.write();
     } // execute
+    // --- Inst_VOP3__V_PERMLANE16_SWAP_B32 class methods ---
+
+    Inst_VOP3__V_PERMLANE16_SWAP_B32::Inst_VOP3__V_PERMLANE16_SWAP_B32(
+        InFmt_VOP3A *iFmt)
+        : Inst_VOP3A(iFmt, "v_permlane16_swap_b32", false)
+    {
+        setFlag(ALU);
+    } // Inst_VOP3__V_PERMLANE16_SWAP_B32
+
+    Inst_VOP3__V_PERMLANE16_SWAP_B32::~Inst_VOP3__V_PERMLANE16_SWAP_B32()
+    {} // ~Inst_VOP3__V_PERMLANE16_SWAP_B32
+
+    // Swap data between two vector registers. Odd rows of the first operand
+    // are swapped with even rows of the second operand (one row is 16 lanes).
+    //
+    // Notes: ABS, NEG and OMOD modifiers should all be zeroed for this
+    // instruction. This instruction is useful for BFP data conversions.
+    void
+    Inst_VOP3__V_PERMLANE16_SWAP_B32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        VecOperandU32 src0(gpuDynInst, extData.SRC0);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src0.read();
+        vdst.read();
+
+        panic_if(isSDWAInst(), "SDWA not supported for %s", _opcode);
+        panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+        panic_if(instData.CLAMP, "CLAMP not supported for %s", _opcode);
+        panic_if(extData.OMOD, "OMOD not supported for %s", _opcode);
+        panic_if(instData.ABS, "ABS not supported for %s", _opcode);
+        panic_if(extData.NEG, "NEG not supported for %s", _opcode);
+
+        // Ignores EXEC MASK
+        for (int pass = 0; pass < 2; ++pass) {
+            for (int lane = 0; lane < 16; ++lane) {
+                int dlane = pass * 32 + lane + 16;
+                int slane = pass * 32 + lane;
+
+                VecElemU32 tmp = src0[slane];
+                src0[slane] = vdst[dlane];
+                vdst[dlane] = tmp;
+            }
+        }
+
+        src0.write();
+        vdst.write();
+    } // execute
+    // --- Inst_VOP3__V_PERMLANE32_SWAP_B32 class methods ---
+
+    Inst_VOP3__V_PERMLANE32_SWAP_B32::Inst_VOP3__V_PERMLANE32_SWAP_B32(
+        InFmt_VOP3A *iFmt)
+        : Inst_VOP3A(iFmt, "v_permlane32_swap_b32", false)
+    {
+        setFlag(ALU);
+    } // Inst_VOP3__V_PERMLANE32_SWAP_B32
+
+    Inst_VOP3__V_PERMLANE32_SWAP_B32::~Inst_VOP3__V_PERMLANE32_SWAP_B32()
+    {} // ~Inst_VOP3__V_PERMLANE32_SWAP_B32
+
+    void
+    Inst_VOP3__V_PERMLANE32_SWAP_B32::execute(GPUDynInstPtr gpuDynInst)
+    {
+        VecOperandU32 src0(gpuDynInst, extData.SRC0);
+        VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+        src0.read();
+        vdst.read();
+
+        panic_if(isSDWAInst(), "SDWA not supported for %s", _opcode);
+        panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+        panic_if(instData.CLAMP, "CLAMP not supported for %s", _opcode);
+        panic_if(extData.OMOD, "OMOD not supported for %s", _opcode);
+        panic_if(instData.ABS, "ABS not supported for %s", _opcode);
+        panic_if(extData.NEG, "NEG not supported for %s", _opcode);
+
+        // Ignores EXEC MASK
+        for (int lane = 0; lane < 32; ++lane) {
+            VecElemU32 tmp = src0[lane];
+            src0[lane] = vdst[lane + 32];
+            vdst[lane + 32] = tmp;
+        }
+
+        src0.write();
+        vdst.write();
+    } // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3p.cc
+++ b/src/arch/amdgpu/vega/insts/vop3p.cc
@@ -946,6 +946,62 @@ Inst_VOP3P__V_PK_MOV_B32::execute(GPUDynInstPtr gpuDynInst)
 
     vdst.write();
 } // execute
+// --- Inst_VOP3P__V_MFMA_LOAD_SCALE class methods ---
+
+Inst_VOP3P__V_MFMA_LOAD_SCALE::Inst_VOP3P__V_MFMA_LOAD_SCALE(InFmt_VOP3P *iFmt)
+    : Inst_VOP3P(iFmt, "v_mfma_load_scale")
+{
+    setFlag(ALU);
+} // Inst_VOP3P__V_MFMA_LOAD_SCALE
+
+Inst_VOP3P__V_MFMA_LOAD_SCALE::~Inst_VOP3P__V_MFMA_LOAD_SCALE()
+{} // ~Inst_VOP3P__V_MFMA_LOAD_SCALE
+
+void
+Inst_VOP3P__V_MFMA_LOAD_SCALE::execute(GPUDynInstPtr gpuDynInst)
+{
+    // This is implemented differently in gem5 to avoid needing to change a
+    // large amount of code to handle a 4-dword instruction. Instead, we
+    // implement a fake VOP3P instruction which is assumed to come before an
+    // MFMA instruction.
+    //
+    // See https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/
+    //              instruction-set-architectures/
+    //              amd-instinct-cdna4-instruction-set-architecture.pdf
+    // section 7.2.1 for details.
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandU32 src1(gpuDynInst, extData.SRC1);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    if (isVectorReg(extData.SRC0)) {
+        int opsel = ((extData.OPSEL_HI & 1) << 1) | (instData.OPSEL & 1);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            wf->setMfmaAScale(lane,
+                              bits(src0[lane], opsel * 8 + 7, opsel * 8));
+        }
+    } else {
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            wf->setMfmaAScale(lane, bits(src0[lane], 30, 23));
+        }
+    }
+
+    if (isVectorReg(extData.SRC1)) {
+        int opsel = ((extData.OPSEL_HI & 2) << 1) | (instData.OPSEL & 2);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            wf->setMfmaBScale(lane,
+                              bits(src1[lane], opsel * 8 + 7, opsel * 8));
+        }
+    } else {
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            wf->setMfmaBScale(lane, bits(src1[lane], 30, 23));
+        }
+    }
+}
 
 } // namespace VegaISA
 } // namespace gem5

--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -1693,6 +1693,40 @@ Wavefront::printProgress()
     }
 }
 
+void
+Wavefront::setMfmaAScale(int idx, uint8_t value)
+{
+    assert(idx < VegaISA::NumVecElemPerVecReg);
+    mfmaAScale[idx] = value;
+}
+
+void
+Wavefront::setMfmaBScale(int idx, uint8_t value)
+{
+    assert(idx < VegaISA::NumVecElemPerVecReg);
+    mfmaBScale[idx] = value;
+}
+
+uint8_t
+Wavefront::getMfmaAScale(int idx)
+{
+    assert(idx < VegaISA::NumVecElemPerVecReg);
+    uint8_t rv = mfmaAScale[idx];
+    mfmaAScale[idx] = 0;
+
+    return rv;
+}
+
+uint8_t
+Wavefront::getMfmaBScale(int idx)
+{
+    assert(idx < VegaISA::NumVecElemPerVecReg);
+    uint8_t rv = mfmaBScale[idx];
+    mfmaBScale[idx] = 0;
+
+    return rv;
+}
+
 Wavefront::WavefrontStats::WavefrontStats(statistics::Group *parent)
     : statistics::Group(parent),
       ADD_STAT(numInstrExecuted,

--- a/src/gpu-compute/wavefront.hh
+++ b/src/gpu-compute/wavefront.hh
@@ -329,6 +329,14 @@ class Wavefront : public SimObject
     std::string lastInstRdyStatus;
     bool lastVrfStatus, lastSrfStatus;
 
+    // For MI355X MFMA instructions using scale the value must be reprogrammed
+    // before each scaling MFMA instruction. To enforce this, use getters /
+    // setters and clear the value when the MFMA instruction gets the value.
+    void setMfmaAScale(int idx, uint8_t value);
+    void setMfmaBScale(int idx, uint8_t value);
+    uint8_t getMfmaAScale(int idx);
+    uint8_t getMfmaBScale(int idx);
+
   private:
     TheGpuISA::GPUISA _gpuISA;
 
@@ -362,6 +370,12 @@ class Wavefront : public SimObject
     Addr _pc;
     VectorMask _execMask;
     int barId;
+
+    // For MI355X MFMAs, some instructions take a scale value set by a
+    // previous instruction. Store these in the wavefront since that is
+    // accessible from the instruction execute method.
+    std::array<uint8_t, VegaISA::NumVecElemPerVecReg> mfmaAScale;
+    std::array<uint8_t, VegaISA::NumVecElemPerVecReg> mfmaBScale;
 
   public:
     struct WavefrontStats : public statistics::Group


### PR DESCRIPTION
Implement V_PRNG_B32, V_PERMLANE16_SWAP_B32, V_PERMLANE32_SWAP_B32, and "V_MFMA_LD_SCALE_B32." The last is a workaround for the 4x dword MFMA instructions as gem5 support only up to 2 dwords.