### PR TITLE
mem-cache: Prefetch for all cache blocks in a Fetch Target

### DIFF
--- a/src/mem/cache/prefetch/fdp.hh
+++ b/src/mem/cache/prefetch/fdp.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023 The University of Edinburgh
+ * Copyright (c) 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -135,6 +136,11 @@ class FetchDirectedPrefetcher : public Base
         /** The time when the prefetch is ready to be sent to the cache. */
         Tick readyTime;
 
+        /** Marks a Prefetch Request as canceled if notifyFTQRemove was
+         * called during translation. In this case the prefetch will not
+         * proceed to the prefetch queue. */
+        bool canceled;
+
         bool
         operator==(const int &a) const
         {
@@ -153,6 +159,18 @@ class FetchDirectedPrefetcher : public Base
         void
         markDelayed() override
         {}
+
+        void
+        markCanceled()
+        {
+            canceled = true;
+        }
+
+        bool
+        isCanceled() const
+        {
+            return canceled;
+        }
     };
 
     /** The prefetch queue */


### PR DESCRIPTION
This PR updates the Fetch Directed Prefetcher to prefetch for all cache 
blocks in each Fetch Target. The previous version only prefetched the 
first cache block in the fetch target. In many cases the full Fetch 
Target resides in a single cache line. However, for some Fetch Target 
sizes and alignments, the Fetch Target may span multiple consecutive 
cache lines, resulting in under-prefetching.

This update provides a small additional performance uplift for I-cache
bound workloads (up to ~2% for the workloads tested).

This PR also adds code to squash the Fetch Target associated with an
in-flight translation when the `notifyFTQRemove` probe is triggered
in the `FetchDirectedPrefetcher`. Previously, if the translation was
in progress the FT would not be squashed.

Since the translation mechanism is asynchronous in timing mode, the
FTs are marked as canceled and then dropped before progressing to the
prefetch queue in the `translationComplete` handler. Stats accounting
is performed in `notifyFTQRemove`.