### PR TITLE
python: Add missing escape in param_types cxx_ini-parse func

### DIFF
--- a/src/python/m5/params/param_types.py
+++ b/src/python/m5/params/param_types.py
@@ -785,7 +785,7 @@ class Time(ParamValue):
     def cxx_ini_parse(cls, code, src, dest, ret):
         code("char *_parse_ret = strptime((${src}).c_str(),")
         code('    "%a %b %d %H:%M:%S %Y", &(${dest}));')
-        code("${ret} _parse_ret && *_parse_ret == '\0';")
+        code("${ret} _parse_ret && *_parse_ret == '\\0';")
 
 
 class MemoryBandwidth(float, ParamValue):


### PR DESCRIPTION
'\\0' became '\0' in #2574. This caused daily tests to fail: https://github.com/gem5/gem5/actions/runs/17808599651/job/50626492040