### PR TITLE
configs,gpu-compute,dev: MI355X and ROCm 7 support

### DIFF
--- a/configs/example/gpufs/mi300.py
+++ b/configs/example/gpufs/mi300.py
@@ -60,6 +60,11 @@ dmesg -n8
 cat /proc/cpuinfo
 dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128
 
+# Check if exists (backwards compat with ROCm <7.0)
+if [ -e /usr/lib/firmware/amdgpu/mi300_discovery ]; then
+    ln -s /usr/lib/firmware/amdgpu/mi300_discovery /usr/lib/firmware/amdgpu/ip_discovery.bin
+fi
+
 if [ -f /home/gem5/load_amdgpu.sh ]; then
     sh /home/gem5/load_amdgpu.sh
 elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then

--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -84,7 +84,8 @@ def addRunFSOptions(parser):
     parser.add_argument("--kernel", default=None, help="Linux kernel to boot")
     parser.add_argument(
         "--gpu-ipt",
-        default=None,
+        type=str,
+        default="",
         help="Intended only for gem5 developers. IP discovery table to load",
     )
     parser.add_argument(
@@ -134,10 +135,10 @@ def addRunFSOptions(parser):
     # other gfx versions there is some support in syscall emulation mode.
     parser.add_argument(
         "--gpu-device",
-        default="Vega10",
-        choices=["Vega10", "MI100", "MI200", "MI300X"],
+        default="MI300X",
+        choices=["Vega10", "MI100", "MI200", "MI300X", "MI355X"],
         help="GPU model to run: Vega10 (gfx900), MI100 (gfx908), MI200 "
-        "(gfx90a), or MI300X (gfx942).",
+        "(gfx90a), MI300X (gfx942), or MI355X (gfx950).",
     )
 
     parser.add_argument(

--- a/configs/example/gpufs/system/amdgpu.py
+++ b/configs/example/gpufs/system/amdgpu.py
@@ -204,6 +204,11 @@ def connectGPU(system, args):
         system.pc.south_bridge.gpu.SubsystemVendorID = 0x1002
         system.pc.south_bridge.gpu.SubsystemID = 0x0C34
         system.pc.south_bridge.gpu.BAR5 = PciMemBar(size="2MiB")
+    elif args.gpu_device == "MI355X":
+        system.pc.south_bridge.gpu.DeviceID = 0x75A0
+        system.pc.south_bridge.gpu.SubsystemVendorID = 0x1002
+        system.pc.south_bridge.gpu.SubsystemID = 0x0C34
+        system.pc.south_bridge.gpu.BAR5 = PciMemBar(size="2MiB")
     elif args.gpu_device == "Vega10":
         system.pc.south_bridge.gpu.DeviceID = 0x6863
     else:

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -171,10 +171,12 @@ def makeGpuFSSystem(args):
             0x7A000,
         ]
         sdma_sizes = [0x1000] * 5
-    elif args.gpu_device == "MI300X":
+    elif args.gpu_device == "MI300X" or args.gpu_device == "MI355X":
         # These MMIO addresses are based on the IP discovery file associated
         # with the disk image. Changes to these values require changes to the
         # discovery file base addresses.
+        #
+        # These are the same for MI300X and MI355X.
         num_sdmas = 16
         sdma_bases = [
             0x4980,
@@ -214,7 +216,7 @@ def makeGpuFSSystem(args):
 
     # Setup PM4 packet processors
     pm4_procs = []
-    if args.gpu_device == "MI300X":
+    if args.gpu_device == "MI300X" or args.gpu_device == "MI355X":
         # These MMIO addresses are based on the IP discovery file associated
         # with the disk image. Changes to these values require changes to the
         # discovery file base addresses.

--- a/src/dev/amdgpu/amdgpu_vm.cc
+++ b/src/dev/amdgpu/amdgpu_vm.cc
@@ -261,8 +261,10 @@ AMDGPUVM::writeMMIO(PacketPtr pkt, Addr offset)
 {
     // There are multiple functions due to MMIO addresses being aliased to
     // something different from a previous GFX version. So far this has not
-    // been the case for supported MMIO reads.
-    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
+    // been the case for supported MMIO reads but requires special handling
+    // for newer gfx942 and gfx950 devices.
+    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
+        gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
         writeMMIOGfx940(pkt, offset);
     } else {
         writeMMIOGfx900(pkt, offset);

--- a/src/dev/amdgpu/pm4_packet_processor.cc
+++ b/src/dev/amdgpu/pm4_packet_processor.cc
@@ -290,22 +290,23 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
                     dmaBuffer);
         } break;
       case IT_MAP_PROCESS: {
-        if (gpuDevice->getGfxVersion() == GfxVersion::gfx90a ||
-            gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
-            dmaBuffer = new PM4MapProcessV2();
-            cb = new DmaVirtCallback<uint64_t>(
-                [ = ] (const uint64_t &)
-                    { mapProcessV2(q, (PM4MapProcessV2 *)dmaBuffer); });
-            dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcessV2),
-                        cb, dmaBuffer);
-        } else {
-            dmaBuffer = new PM4MapProcess();
-            cb = new DmaVirtCallback<uint64_t>(
-                [ = ] (const uint64_t &)
-                    { mapProcessV1(q, (PM4MapProcess *)dmaBuffer); });
-            dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcess), cb,
-                        dmaBuffer);
-        }
+          if (gpuDevice->getGfxVersion() == GfxVersion::gfx90a ||
+              gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
+              gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
+              dmaBuffer = new PM4MapProcessV2();
+              cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+                  mapProcessV2(q, (PM4MapProcessV2 *)dmaBuffer);
+              });
+              dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcessV2), cb,
+                          dmaBuffer);
+          } else {
+              dmaBuffer = new PM4MapProcess();
+              cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+                  mapProcessV1(q, (PM4MapProcess *)dmaBuffer);
+              });
+              dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcess), cb,
+                          dmaBuffer);
+          }
         } break;
 
       case IT_UNMAP_QUEUES: {

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -904,7 +904,8 @@ SDMAEngine::trap(SDMAQueue *q, sdmaTrap *pkt)
     int node_id = 0;
     int local_id = getId();
 
-    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
+    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
+        gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
         node_id = getId() >> 2;
 
         // For most SDMAs the "node_id" for the interrupt handler is the SDMA

--- a/src/gpu-compute/GPU.py
+++ b/src/gpu-compute/GPU.py
@@ -45,7 +45,7 @@ class PrefetchType(Enum):
 
 
 class GfxVersion(ScopedEnum):
-    vals = ["gfx900", "gfx902", "gfx908", "gfx90a", "gfx942"]
+    vals = ["gfx900", "gfx902", "gfx908", "gfx90a", "gfx942", "gfx950"]
 
 
 class PoolManager(SimObject):

--- a/src/gpu-compute/gpu_dyn_inst.cc
+++ b/src/gpu-compute/gpu_dyn_inst.cc
@@ -931,7 +931,8 @@ GPUDynInst::resolveFlatSegment(const VectorMask &mask)
 
         ComputeUnit *cu = wavefront()->computeUnit;
 
-        if (wavefront()->gfxVersion == GfxVersion::gfx942) {
+        if (wavefront()->gfxVersion == GfxVersion::gfx942 ||
+            wavefront()->gfxVersion == GfxVersion::gfx950) {
             // Architected flat scratch base address is in a dedicated hardware
             // register.
             for (int lane = 0; lane < cu->wfSize(); ++lane) {

--- a/src/gpu-compute/hsa_queue_entry.hh
+++ b/src/gpu-compute/hsa_queue_entry.hh
@@ -94,10 +94,11 @@ class HSAQueueEntry
         // LLVM docs: https://www.llvm.org/docs/AMDGPUUsage.html
         //     #code-object-v3-kernel-descriptor
         //
-        // Currently, the only supported gfx versions in gem5 that compute
-        // VGPR count differently are gfx90a and gfx942.
+        // Currently, gem5 supported gfx version use a multiplier of 8. The
+        // only exception is gfx900 (Vega10).
         if (gfx_version == GfxVersion::gfx90a ||
-            gfx_version == GfxVersion::gfx942) {
+            gfx_version == GfxVersion::gfx942 ||
+            gfx_version == GfxVersion::gfx950) {
             numVgprs = (akc->granulated_workitem_vgpr_count + 1) * 8;
         } else {
             numVgprs = (akc->granulated_workitem_vgpr_count + 1) * 4;
@@ -106,10 +107,11 @@ class HSAQueueEntry
         // SGPR allocation granulary is 16 in GFX9
         // Source: https://llvm.org/docs/AMDGPUUsage.html
         if (gfx_version == GfxVersion::gfx900 ||
-                gfx_version == GfxVersion::gfx902 ||
-                gfx_version == GfxVersion::gfx908 ||
-                gfx_version == GfxVersion::gfx90a ||
-                gfx_version == GfxVersion::gfx942) {
+            gfx_version == GfxVersion::gfx902 ||
+            gfx_version == GfxVersion::gfx908 ||
+            gfx_version == GfxVersion::gfx90a ||
+            gfx_version == GfxVersion::gfx942 ||
+            gfx_version == GfxVersion::gfx950) {
             numSgprs = ((akc->granulated_wavefront_sgpr_count + 1) * 16)/2;
         } else {
             panic("Saw unknown gfx version setting up GPR counts\n");

--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -405,7 +405,8 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
                 // For architected flat scratch, this enable is reused to set
                 // the FLAT_SCRATCH register pair to the scratch backing
                 // memory: https://llvm.org/docs/AMDGPUUsage.html#flat-scratch
-                if (task->gfxVersion() == GfxVersion::gfx942) {
+                if (task->gfxVersion() == GfxVersion::gfx942 ||
+                    task->gfxVersion() == GfxVersion::gfx950) {
                     uint32_t scratchPerWI =
                         task->amdQueue.scratch_workitem_byte_size;
 
@@ -490,7 +491,8 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
     bool packed_work_item_id = false;
 
     if (task->gfxVersion() == GfxVersion::gfx90a ||
-        task->gfxVersion() == GfxVersion::gfx942) {
+        task->gfxVersion() == GfxVersion::gfx942 ||
+        task->gfxVersion() == GfxVersion::gfx950) {
         packed_work_item_id = true;
     }
 

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -295,6 +295,60 @@ class MI300X(BaseViperGPU):
             "export HCC_AMDGPU_TARGET=gfx942\n"
             f"{debug_commands}\n"
             "dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128\n"
+            # Check if exists (backwards compat with ROCm <7.0)
+            "if [ -e /usr/lib/firmware/amdgpu/mi300_discovery ]; then\n"
+            "    ln -s /usr/lib/firmware/amdgpu/mi300_discovery /usr/lib/firmware/amdgpu/ip_discovery.bin\n"
+            "fi\n"
+            "if [ -f /home/gem5/load_amdgpu.sh ]; then\n"
+            "    sh /home/gem5/load_amdgpu.sh\n"
+            "elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then\n"
+            '    echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."\n'
+            "    /sbin/m5 exit\n"
+            "else\n"
+            "    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2\n"
+            "fi\n"
+        )
+
+        return driver_load_command
+
+
+# Defaults to a single "XCD" (i.e., 1/8th of a full MI355X).
+class MI355X(MI300X):
+    def __init__(
+        self,
+        gpu_memory: AbstractMemorySystem,
+        num_cus: int = 40,
+        cu_per_sqc: int = 4,
+        tcp_size: str = "16KiB",
+        tcp_assoc: int = 16,
+        sqc_size: str = "32KiB",
+        sqc_assoc: int = 8,
+        scalar_size: str = "32KiB",
+        scalar_assoc: int = 8,
+        tcc_size: str = "256KiB",
+        tcc_assoc: int = 16,
+        tcc_count: int = 16,
+        cache_line_size: int = 64,
+    ):
+        super().__init__(gpu_memory=gpu_memory)
+
+        self.device.DeviceID = 0x75A0
+
+    def get_driver_command(self, debug: bool = False):
+        debug_commands = "dmesg -n8\nuname -r\nlspci -v\n" if debug else ""
+
+        driver_load_command = (
+            "export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH\n"
+            "export HSA_ENABLE_INTERRUPT=0\n"
+            "export HCC_AMDGPU_TARGET=gfx950\n"
+            f"{debug_commands}\n"
+            "dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128\n"
+            "if [ -e /usr/lib/firmware/amdgpu/mi350_discovery ]; then\n"
+            "    ln -s /usr/lib/firmware/amdgpu/mi350_discovery /usr/lib/firmware/amdgpu/ip_discovery.bin\n"
+            "else\n"
+            '    echo "ERROR: ROCm 7.0+ disk image required for MI355X. Exiting gem5."\n'
+            "    /sbin/m5 exit\n"
+            "fi\n"
             "if [ -f /home/gem5/load_amdgpu.sh ]; then\n"
             "    sh /home/gem5/load_amdgpu.sh\n"
             "elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then\n"


### PR DESCRIPTION
This adds the CDNA4 ISA to the GfxVersion enum and handles conditionals in configs, gpu-compute, and dev-amdgpu which enable certain features for specific GFX versions. This is mostly the same as gfx942.

A new disk image with ROCm 7.0+ installed is required to use the MI355X model. A preview disk image can be found at:

https://github.com/abmerop/gem5-resources/tree/rocm70

To use the model you can start with
configs/example/gem5_library/x86-mi300x-gpu.py and replace MI300X with MI355X.

Note that most new instructions/features are available with the exception of the new MFMA instructions.