### PR TITLE
stdlib: Wrong wiring of PTW ports with sequencers in CHI platform

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
@@ -196,8 +196,8 @@ class PrivateL1CacheHierarchy(AbstractRubyCacheHierarchy):
         core.connect_dcache(cluster.dcache.sequencer.in_ports)
 
         core.connect_walker_ports(
-            cluster.dcache.sequencer.in_ports,
             cluster.icache.sequencer.in_ports,
+            cluster.dcache.sequencer.in_ports,
         )
 
         # Connect the interrupt ports


### PR DESCRIPTION
In the existing CHI PrivateL1CacheHierarchy the order of arguments provided to the connect_walker_ports was reversed. The method binds the first port to the I-side table walker and the second to the D-side table walker.

In the aforementioned platform we are assigning the I-side sequencer port to the D-side PTW and viceversa


Change-Id: Id03dafecc83837e483f0c196a37887da35faf715