### PR TITLE
mem-cache: Add assert for extractTag function

### DIFF
--- a/src/mem/cache/tags/tagged_entry.hh
+++ b/src/mem/cache/tags/tagged_entry.hh
@@ -156,6 +156,7 @@ class TaggedEntry : public ReplaceableEntry
     bool
     match(const KeyType &key) const
     {
+        assert(extractTag);
         return isValid() && (getTag() == extractTag(key.address)) &&
             (isSecure() == key.secure);
     }
@@ -169,6 +170,7 @@ class TaggedEntry : public ReplaceableEntry
     virtual void
     insert(const KeyType &key)
     {
+        assert(extractTag);
         setValid();
         setTag(extractTag(key.address));
         if (key.secure) {


### PR DESCRIPTION
Previously, if this wasn't set, it causes a bad_function_exception that was difficult to track down