### PR TITLE
python: Re-enable config.ini output

### DIFF
--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -111,7 +111,7 @@ def _dump_configs(
     if ini_config is None:
         from m5 import options
 
-        dump_config = options.dump_config
+        ini_config = options.dump_config
     if json_config is None:
         from m5 import options
 


### PR DESCRIPTION
output. This change fixes the typo.