### PR TITLE
arch-arm,cpu-o3: Fix out of bound with Ubsan

### DIFF
--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -1143,6 +1143,8 @@ TableWalker::processWalkAArch64()
     currState->longDesc.physAddrRange = _physAddrRange;
     currState->longDesc.isStage2 = isStage2;
 
+    assert(start_lookup_level < LookupLevel::Num_ArmLookupLevel);
+
     fetchDescriptor(desc_addr, currState->longDesc,
                     sizeof(uint64_t), flag, start_lookup_level,
                     LongDescEventByLevel[start_lookup_level],

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1076,6 +1076,8 @@ InstructionQueue::addReadyMemInst(const DynInstPtr &ready_inst)
 {
     OpClass op_class = ready_inst->opClass();
 
+    assert(op_class < Num_OpClasses);
+
     readyInsts[op_class].push(ready_inst);
 
     // Will need to reorder the list if either a queue is not on the list,
@@ -1446,6 +1448,8 @@ InstructionQueue::addIfReady(const DynInstPtr &inst)
         }
 
         OpClass op_class = inst->opClass();
+
+        assert(op_class < Num_OpClasses);
 
         DPRINTF(IQ, "Instruction is ready to issue, putting it onto "
                 "the ready list, PC %s opclass:%i [sn:%llu].\n",


### PR DESCRIPTION
Fix out of bound warning when building `--with-ubsan`

1.
```bash
src/arch/arm/table_walker.cc: In member function ‘gem5::Fault gem5::ArmISA::TableWalker::processWalkAArch64()’:
src/arch/arm/table_walker.cc:1146:20: error: array subscript [0, 7] is outside array bounds of ‘gem5::Event* [4]’ [-Werror=array-bounds=]
 1146 |     fetchDescriptor(desc_addr, currState->longDesc,
      |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1147 |                     sizeof(uint64_t), flag, start_lookup_level,
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1148 |                     LongDescEventByLevel[start_lookup_level],
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1149 |                     &TableWalker::doLongDescriptor);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/arch/arm/table_walker.cc:37:
src/arch/arm/table_walker.hh:1212:12: note: while referencing ‘gem5::ArmISA::TableWalker::LongDescEventByLevel’
 1212 |     Event* LongDescEventByLevel[4];
      |            ^~~~~~~~~~~~~~~~~~~~
```

2.
```bash
src/cpu/o3/inst_queue.cc: In member function ‘void gem5::o3::InstructionQueue::addReadyMemInst(const gem5::o3::DynInstPtr&)’:                                                                                                                                                             
src/cpu/o3/inst_queue.cc:1083:30: error: array subscript [0, 127] is outside array bounds of ‘bool [82]’ [-Werror=array-bounds=]                                                                                                                                                          
 1083 |     if (!queueOnList[op_class]) {                                                                                                                                                                                                                                                 
      |          ~~~~~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                                    
In file included from src/cpu/o3/inst_queue.cc:42:                                                                                                                                                                                                                                        
src/cpu/o3/inst_queue.hh:392:10: note: while referencing ‘gem5::o3::InstructionQueue::queueOnList’                                                                                                                                                                                        
  392 |     bool queueOnList[Num_OpClasses];                                                                                                                                                                                                                                              
      |          ^~~~~~~~~~~                                                                                                                                                                                                                                                              
src/cpu/o3/inst_queue.cc:1085:35: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ReadyInstQueue [82]’ {aka ‘std::priority_queue<gem5::RefCountingPtr<gem5::o3::DynInst>, std::vector<gem5::RefCountingPtr<gem5::o3::DynInst> >, gem5::o3::Instruc
tionQueue::PqCompare> [82]’} [-Werror=array-bounds=]                                                                                                                                                                                                                                      
 1085 |     } else if (readyInsts[op_class].top()->seqNum  <                                                                                                                                                                                                                              
      |                ~~~~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                               
src/cpu/o3/inst_queue.hh:360:20: note: while referencing ‘gem5::o3::InstructionQueue::readyInsts’                                                                                                                                                                                         
  360 |     ReadyInstQueue readyInsts[Num_OpClasses];                                                                                                                                                                                                                                     
      |                    ^~~~~~~~~~                                                                                                                                                                                                                                                     
src/cpu/o3/inst_queue.cc:1086:34: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ListOrderIt [82]’ {aka ‘std::__cxx11::list<gem5::o3::InstructionQueue::ListOrderEntry>::iterator [82]’} [-Werror=array-bounds=]                                 
 1086 |                (*readyIt[op_class]).oldestInst) {                                                                                                                                                                                                                                 
      |                  ~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                                
src/cpu/o3/inst_queue.hh:397:17: note: while referencing ‘gem5::o3::InstructionQueue::readyIt’                                                                                                                                                                                            
  397 |     ListOrderIt readyIt[Num_OpClasses];                                                                                                                                                                                                                                           
      |                 ^~~~~~~                                                                                                                                                                                                                                                           
src/cpu/o3/inst_queue.cc:1086:34: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ListOrderIt [82]’ {aka ‘std::__cxx11::list<gem5::o3::InstructionQueue::ListOrderEntry>::iterator [82]’} [-Werror=array-bounds=]                                 
 1086 |                (*readyIt[op_class]).oldestInst) {                                                                                                                                                                                                                                 
      |                  ~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                                
src/cpu/o3/inst_queue.hh:397:17: note: while referencing ‘gem5::o3::InstructionQueue::readyIt’                                                                                                                                                                                            
  397 |     ListOrderIt readyIt[Num_OpClasses];                                                                                                                                                                                                                                           
      |                 ^~~~~~~                                                                                                                                                                                                                                                           
src/cpu/o3/inst_queue.cc:1086:34: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ListOrderIt [82]’ {aka ‘std::__cxx11::list<gem5::o3::InstructionQueue::ListOrderEntry>::iterator [82]’} [-Werror=array-bounds=]                                 
 1086 |                (*readyIt[op_class]).oldestInst) {                                                                                                                                                                                                                                 
      |                  ~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                                
src/cpu/o3/inst_queue.hh:397:17: note: while referencing ‘gem5::o3::InstructionQueue::readyIt’                                                                                                                                                                                            
  397 |     ListOrderIt readyIt[Num_OpClasses];                                                                                                                                                                                                                                           
      |                 ^~~~~~~                                                                                                                                                                                                                                                           
src/cpu/o3/inst_queue.cc: In member function ‘void gem5::o3::InstructionQueue::addIfReady(const gem5::o3::DynInstPtr&)’:                                                                                                                                                                  
src/cpu/o3/inst_queue.cc:1458:34: error: array subscript [0, 127] is outside array bounds of ‘bool [82]’ [-Werror=array-bounds=]                                                                                                                                                          
 1458 |         if (!queueOnList[op_class]) {                                                                                                                                                                                                                                             
      |              ~~~~~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                                
src/cpu/o3/inst_queue.hh:392:10: note: while referencing ‘gem5::o3::InstructionQueue::queueOnList’                                                                                                                                                                                        
  392 |     bool queueOnList[Num_OpClasses];                                                                                                                                                                                                                                              
      |          ^~~~~~~~~~~                                                                                                                                                                                                                                                              
src/cpu/o3/inst_queue.cc:1460:39: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ReadyInstQueue [82]’ {aka ‘std::priority_queue<gem5::RefCountingPtr<gem5::o3::DynInst>, std::vector<gem5::RefCountingPtr<gem5::o3::DynInst> >, gem5::o3::Instruc
tionQueue::PqCompare> [82]’} [-Werror=array-bounds=]                                                                                                                                                                                                                                      
 1460 |         } else if (readyInsts[op_class].top()->seqNum  <                                                                                                                                                                                                                          
      |                    ~~~~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                           
src/cpu/o3/inst_queue.hh:360:20: note: while referencing ‘gem5::o3::InstructionQueue::readyInsts’                                                                                                                                                                                         
  360 |     ReadyInstQueue readyInsts[Num_OpClasses];                                                                                                                                                                                                                                     
      |                    ^~~~~~~~~~                                                                                                                                                                                                                                                     
src/cpu/o3/inst_queue.cc:1461:38: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ListOrderIt [82]’ {aka ‘std::__cxx11::list<gem5::o3::InstructionQueue::ListOrderEntry>::iterator [82]’} [-Werror=array-bounds=]                                 
 1461 |                    (*readyIt[op_class]).oldestInst) {                                                                                                                                                                                                                             
      |                      ~~~~~~~~~~~~~~~~^                                                                                                                                                                                                                                            
src/cpu/o3/inst_queue.hh:397:17: note: while referencing ‘gem5::o3::InstructionQueue::readyIt’                                                                                                                                                                                            
  397 |     ListOrderIt readyIt[Num_OpClasses];                                                                                                                                                                                                                                           
      |                 ^~~~~~~
src/cpu/o3/inst_queue.cc:1461:38: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ListOrderIt [82]’ {aka ‘std::__cxx11::list<gem5::o3::InstructionQueue::ListOrderEntry>::iterator [82]’} [-Werror=array-bounds=]
 1461 |                    (*readyIt[op_class]).oldestInst) {
      |                      ~~~~~~~~~~~~~~~~^
src/cpu/o3/inst_queue.hh:397:17: note: while referencing ‘gem5::o3::InstructionQueue::readyIt’
  397 |     ListOrderIt readyIt[Num_OpClasses];
      |                 ^~~~~~~
src/cpu/o3/inst_queue.cc:1461:38: error: array subscript [0, 127] is outside array bounds of ‘gem5::o3::InstructionQueue::ListOrderIt [82]’ {aka ‘std::__cxx11::list<gem5::o3::InstructionQueue::ListOrderEntry>::iterator [82]’} [-Werror=array-bounds=]
 1461 |                    (*readyIt[op_class]).oldestInst) {
      |                      ~~~~~~~~~~~~~~~~^
src/cpu/o3/inst_queue.hh:397:17: note: while referencing ‘gem5::o3::InstructionQueue::readyIt’
  397 |     ListOrderIt readyIt[Num_OpClasses];
```