### PR TITLE
fastmodel: Fix compiler error when building fastmodels

### DIFF
--- a/src/arch/arm/fastmodel/iris/cpu.cc
+++ b/src/arch/arm/fastmodel/iris/cpu.cc
@@ -28,6 +28,7 @@
 #include "arch/arm/fastmodel/iris/cpu.hh"
 
 #include "arch/arm/fastmodel/iris/thread_context.hh"
+#include "cpu/thread_context.hh"
 #include "scx/scx.h"
 #include "sim/serialize.hh"
 
@@ -55,6 +56,15 @@ BaseCPU::~BaseCPU()
     for (auto &tc: threadContexts)
         delete tc;
     threadContexts.clear();
+}
+
+void
+BaseCPU::wakeup(ThreadID tid)
+{
+    auto *tc = threadContexts.at(tid);
+    if (tc->status() == gem5::ThreadContext::Suspended) {
+        tc->activate();
+    }
 }
 
 Counter

--- a/src/arch/arm/fastmodel/iris/cpu.hh
+++ b/src/arch/arm/fastmodel/iris/cpu.hh
@@ -75,13 +75,7 @@ class BaseCPU : public gem5::BaseCPU
         panic("%s not implemented.", __FUNCTION__);
     }
 
-    void
-    wakeup(ThreadID tid) override
-    {
-        auto *tc = threadContexts.at(tid);
-        if (tc->status() == gem5::ThreadContext::Suspended)
-            tc->activate();
-    }
+    void wakeup(ThreadID tid) override;
 
     Counter totalInsts() const override;
     Counter totalOps() const override { return totalInsts(); }


### PR DESCRIPTION
Fix following error
```
In file included from src/arch/arm/fastmodel/iris/cpu.cc:28:
src/arch/arm/fastmodel/iris/cpu.hh: In member function ‘virtual void gem5::Iris::BaseCPU::wakeup(gem5::ThreadID)’:
src/arch/arm/fastmodel/iris/cpu.hh:82:15: error: invalid use of incomplete type ‘class gem5::ThreadContext’
   82 |         if (tc->status() == gem5::ThreadContext::Suspended)
      |               ^~
In file included from src/cpu/base.hh:48,
                 from src/arch/arm/fastmodel/iris/cpu.hh:31:
src/arch/generic/interrupts.hh:38:7: note: forward declaration of ‘class gem5::ThreadContext’
   38 | class ThreadContext;
      |       ^~~~~~~~~~~~~
src/arch/arm/fastmodel/iris/cpu.hh:82:50: error: incomplete type ‘gem5::ThreadContext’ used in nested name specifier
   82 |         if (tc->status() == gem5::ThreadContext::Suspended)
      |                                                  ^~~~~~~~~
src/arch/arm/fastmodel/iris/cpu.hh:83:15: error: invalid use of incomplete type ‘class gem5::ThreadContext’
   83 |             tc->activate();
      |               ^~
src/arch/generic/interrupts.hh:38:7: note: forward declaration of ‘class gem5::ThreadContext’
   38 | class ThreadContext;
      |       ^~~~~~~~~~~~~
```

Change-Id: I16d0d42754b9eec71dc58da151852450311a2aa8