### PR TITLE
base: Add CTAD deduction guide for Memoizer

### DIFF
--- a/src/base/memoizer.hh
+++ b/src/base/memoizer.hh
@@ -159,6 +159,10 @@ class Memoizer
 
 };
 
+// Deduction guide
+template <typename Ret, typename... Args>
+Memoizer(Ret (*)(Args...)) -> Memoizer<Ret, Args...>;
+
 } // namespace gem5
 
 #endif // __BASE_MEMOIZER_HH__


### PR DESCRIPTION
The deduction guide is needed in the memoizer.hh file itself, not
just for the test, to enable Class Template Argument Deduction (CTAD)
for all usages of the Memoizer class.

Here's why this is important:

-   **Enables CTAD:** The guide provides a rule for the compiler on how
    to deduce template arguments (Ret, Args...) when a Memoizer object
    is created without them being explicitly specified (e.g.,
    `Memoizer(fibonacci)`).

-   **General Usage:** Placing the guide in the header makes it available
    wherever the Memoizer class is used, rather than being limited to
    a specific test file.

-   **Resolves Warning:** It fixes the `-Wctad-maybe-unsupported`
    compiler warning by clarifying that CTAD is an intended and
    supported feature for the Memoizer class.

Signed-off-by: Jason Lowe-Power <jlowepower@google.com>