### PR TITLE
arch-riscv: new vector instructions

### DIFF
--- a/src/arch/riscv/isa/bitfields.isa
+++ b/src/arch/riscv/isa/bitfields.isa
@@ -164,3 +164,6 @@ def bitfield BIT31      bit31;
 def bitfield BIT30      bit30;
 def bitfield SIMM5      uimm_vsetivli;
 def bitfield SIMM3      simm3;
+
+// Zvbb
+def bitfield BIT26      <26>;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4500,6 +4500,30 @@ decode QUADRANT default Unknown::unknown() {
                         Vd_vu[i] = ei;
                     }}, OPMVV, SimdMiscOp);
                 }
+                format VectorCompressFormat {
+                    0x17: vcompress_vm({{
+                        static uint64_t vcompress_cnt;
+                        static uint64_t vcompress_buf[65536];
+                        if(this->microIdx == 0) {
+                            vcompress_cnt = 0;
+                        }
+                        for (uint32_t i = 0; i < microVl; i++) {
+                            uint32_t num_regs = vtype_regs_per_group(vtype);
+                            uint32_t ei = i + num_elements_reg(vtype, vlen) *
+                                (this->microIdx % num_regs);
+                            if (elem_mask(Vs1_vu, ei) &&
+                                this->microIdx < num_regs) {
+                                vcompress_buf[vcompress_cnt] = Vs2_vu[i];
+                                Vd_vu[i] = vcompress_buf[vcompress_cnt];
+                                vcompress_cnt ++;
+                            }
+                            if (ei < vcompress_cnt &&
+                                this->microIdx >= num_regs) {
+                                Vd_vu[i] = vcompress_buf[ei];
+                            }
+                        }
+                    }}, OPMVV, SimdMiscOp);
+                }
                 format VectorMaskFormat {
                     0x18: vmandn_mm({{
                         Vd_ub[i/8] = ASSIGN_VD_BIT(i,

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4387,6 +4387,28 @@ decode QUADRANT default Unknown::unknown() {
                         res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
                         Vd_vi[i] = res >> 1;
                     }}, OPMVV, SimdAddOp);
+                    0x0c: vclmul_vv({{
+                        uint64_t result = 0;
+                        uint64_t src1 = Vs1_vu[i];
+                        uint64_t src2 = Vs2_vu[i];
+                        for (int j = 0; j < 64; j++) {
+                            if ((src2 >> j) & 1) {
+                                result ^= src1 << j;
+                            }
+                        }
+                        Vd_vu[i] = result;
+                    }}, OPMVV, SimdMultOp);
+                    0x0d: vclmulh_vv({{
+                        uint64_t result = 0;
+                        uint64_t src1 = Vs1_vu[i];
+                        uint64_t src2 = Vs2_vu[i];
+                        for (int j = 0; j < 64; j++) {
+                            if ((src2 >> j) & 1) {
+                                result ^= src1 >> (64-j);
+                            }
+                        }
+                        Vd_vu[i] = result;
+                    }}, OPMVV, SimdMultOp);
                 }
                 // VWXUNARY0
                 0x10: decode VS1 {
@@ -5688,6 +5710,28 @@ decode QUADRANT default Unknown::unknown() {
                         res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
                         Vd_vi[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
+                   0x0c: vclmul_vx({{
+                        uint64_t result = 0;
+                        uint64_t src1 = Rs1_vu;
+                        uint64_t src2 = Vs2_vu[i];
+                        for (int j = 0; j < 64; j++) {
+                            if ((src2 >> j) & 1) {
+                                result ^= src1 << j;
+                            }
+                        }
+                        Vd_vu[i] = result;
+                    }}, OPMVX, SimdMultOp);
+                    0x0d: vclmulh_vx({{
+                        uint64_t result = 0;
+                        uint64_t src1 = Rs1_vu;
+                        uint64_t src2 = Vs2_vu[i];
+                        for (int j = 0; j < 64; j++) {
+                            if ((src2 >> j) & 1) {
+                                result ^= src1 >> (64-j);
+                            }
+                        }
+                        Vd_vu[i] = result;
+                    }}, OPMVX, SimdMultOp);
                 }
                 0x0e: VectorSlide1UpFormat::vslide1up_vx({{
                     int offset = 1;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3701,6 +3701,9 @@ decode QUADRANT default Unknown::unknown() {
                     0x0: vadd_vv({{
                         Vd_vu[i] = Vs2_vu[i] + Vs1_vu[i];
                     }}, OPIVV, SimdAddOp);
+                    0x1: vandn_vv({{
+                        Vd_vu[i] = Vs2_vu[i] & (~Vs1_vu[i]);
+                    }}, OPIVV, SimdAluOp);
                     0x2: vsub_vv({{
                         Vd_vu[i] = Vs2_vu[i] - Vs1_vu[i];
                     }}, OPIVV, SimdAddOp);
@@ -3771,6 +3774,16 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPIVV, SimdAddOp);
                         // the unmasked versions (vm=1) are reserved
                     }
+                    0x14: vror_vv({{
+                        Vd_vu[i] =   (Vs2_vu[i] >> (Vs1_vu[i] & (sew - 1)))
+                                   | (Vs2_vu[i] <<
+                                        ((sew - Vs1_vu[i]) & (sew - 1)));
+                    }}, OPIVV, SimdShiftOp);
+                    0x15: vrol_vv({{
+                        Vd_vu[i] =   (Vs2_vu[i] << (Vs1_vu[i] & (sew - 1)))
+                                   | (Vs2_vu[i] >>
+                                        ((sew - Vs1_vu[i]) & (sew - 1)));
+                    }}, OPIVV, SimdShiftOp);
                     0x17: decode VM {
                         0x0: vmerge_vvm({{
                             Vd_vu[i] = elem_mask(v0, ei)
@@ -3949,6 +3962,12 @@ decode QUADRANT default Unknown::unknown() {
 
                         Vd_vi[i + offset] = (vi)res;
                     }}, OPIVV, SimdCvtOp);
+                }
+                format VectorIntWideningFormat {
+                    0x35: vwsll_vv({{
+                        Vd_vwu[i] = vwu(Vs2_vu[i + offset]) <<
+                            (vwu(Vs1_vu[i + offset]) & ((vwu(sew) << 1) - 1));
+                    }}, OPIVV, SimdShiftOp);
                 }
             }
             // OPFVV
@@ -4798,6 +4817,12 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPIVI, SimdAddOp);
                         // the unmasked versions (vm=1) are reserved
                     }
+                    0x14, 0x15: vror_vi({{
+                        uint64_t shamt = SIMM5 | (BIT26 << 5);
+                        Vd_vu[i] =   (Vs2_vu[i] >> (shamt & (sew - 1)))
+                                   | (Vs2_vu[i] <<
+                                        ((sew - shamt) & (sew - 1)));
+                    }}, OPIVI, SimdShiftOp);
                     0x17: decode VM {
                         0x0: vmerge_vim({{
                             Vd_vi[i] = elem_mask(v0, ei)
@@ -4948,6 +4973,12 @@ decode QUADRANT default Unknown::unknown() {
                         Vd_vi[i + offset] = (vi)res;
                     }}, OPIVI, SimdCvtOp);
                 }
+                format VectorIntWideningFormat {
+                    0x35: vwsll_vi({{
+                        Vd_vwu[i] = vwu(Vs2_vu[i + offset]) <<
+                            (vwu(SIMM5) & ((vwu(sew) << 1) - 1));
+                    }}, OPIVI, SimdShiftOp);
+                }
             }
             // OPIVX
             0x4: decode VFUNCT6 {
@@ -4955,6 +4986,9 @@ decode QUADRANT default Unknown::unknown() {
                     0x0: vadd_vx({{
                         Vd_vu[i] = Vs2_vu[i] + Rs1_vu;
                     }}, OPIVX, SimdAddOp);
+                    0x1: vandn_vx({{
+                        Vd_vu[i] = Vs2_vu[i] & (~Rs1_vu);
+                    }}, OPIVX, SimdAluOp);
                     0x2: vsub_vx({{
                         Vd_vu[i] = Vs2_vu[i] - Rs1_vu;
                     }}, OPIVX, SimdAddOp);
@@ -5107,6 +5141,16 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPIVX, SimdAddOp);
                         // the unmasked versions (vm=1) are reserved
                     }
+                    0x14: vror_vx({{
+                        Vd_vu[i] =   (Vs2_vu[i] >> (Rs1_vu & (sew - 1)))
+                                   | (Vs2_vu[i] <<
+                                        ((sew - Rs1_vu) & (sew - 1)));
+                    }}, OPIVX, SimdShiftOp);
+                    0x15: vrol_vx({{
+                        Vd_vu[i] =   (Vs2_vu[i] << (Rs1_vu & (sew - 1)))
+                                   | (Vs2_vu[i] >>
+                                        ((sew - Rs1_vu) & (sew - 1)));
+                    }}, OPIVX, SimdShiftOp);
                     0x17: decode VM {
                         0x0: vmerge_vxm({{
                             Vd_vu[i] = elem_mask(v0, ei) ? Rs1_vu : Vs2_vu[i];
@@ -5281,6 +5325,12 @@ decode QUADRANT default Unknown::unknown() {
                         Vd_ub[(i + offset)/8] = ASSIGN_VD_BIT(i + offset,
                             (Vs2_vi[i] > Rs1_vi));
                     }}, OPIVX, SimdCmpOp);
+                }
+                format VectorIntWideningFormat {
+                    0x35: vwsll_vx({{
+                        Vd_vwu[i] = vwu(Vs2_vu[i + offset]) <<
+                            (vwu(Rs1_vu) & ((vwu(sew) << 1) - 1));
+                    }}, OPIVX, SimdShiftOp);
                 }
             }
             // OPFVF

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -362,11 +362,13 @@ def format VectorIntWideningFormat(code, category, *flags) {{
         src1_is_vec = True
     elif category in ["OPIVX", "OPMVX"]:
         src1_reg_id = "intRegClass[_machInst.rs1]"
+    elif category == "OPIVI":
+        pass
     else:
         error("not supported category for VectorIntFormat: %s" % category)
     src2_reg_id = ""
     src2_sew_mul = 1
-    if inst_suffix in ["vv", "vx"]:
+    if inst_suffix in ["vv", "vx", "vi"]:
         src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx / 2]"
     elif inst_suffix in ["wv", "wx"]:
         src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
@@ -375,7 +377,8 @@ def format VectorIntWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
 
     set_src_reg_idx = ""
-    set_src_reg_idx += setSrcWrapper(src1_reg_id)
+    if category != "OPIVI":
+        set_src_reg_idx += setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
 
     dest_set_src_reg_idx = setSrcWrapper(dest_reg_id)

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1467,6 +1467,72 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     decode_block = VectorIntWideningDecodeBlock.subst(iop)
 }};
 
+def format VectorCompressFormat(code, category, *flags) {{
+    macroop_class_name = 'VectorArithMacroInst'
+    microop_class_name = 'VectorArithMicroInst'
+
+    iop = InstObjParams(
+        name,
+        Name,
+        macroop_class_name,
+        {'code': code,
+         'declare_varith_template': declareVArithTemplate(Name)},
+        flags
+    )
+    inst_name, inst_suffix = name.split("_", maxsplit=1)
+
+    dest_reg_id = "vecRegClass[_machInst.vd +
+                    (_microIdx)%vtype_regs_per_group(vtype)]"
+
+    num_src_regs = 0
+
+    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    num_src_regs += 1
+
+    src1_reg_id = "vecRegClass[_machInst.vs1]"
+    num_src_regs += 1
+
+    old_vd_idx = num_src_regs
+
+    set_dest_reg_idx = setDestWrapper(dest_reg_id)
+
+    set_src_reg_idx = ""
+    set_src_reg_idx += setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+
+    dest_set_src_reg_idx = setSrcWrapper(dest_reg_id)
+    set_src_reg_idx += dest_set_src_reg_idx
+    set_src_reg_idx += setSrcVm()
+
+    # code
+
+    vm_decl_rd = vmDeclAndReadData()
+
+    set_vlenb = setVlenb()
+
+    microiop = InstObjParams(name + "_micro",
+        Name + "Micro",
+        microop_class_name,
+        {'code': code,
+         'set_dest_reg_idx': set_dest_reg_idx,
+         'set_src_reg_idx': set_src_reg_idx,
+         'set_vlenb' : set_vlenb,
+         'vm_decl_rd': vm_decl_rd,
+         'copy_old_vd': copyOldVd(old_vd_idx),
+         'declare_varith_template': declareVArithTemplate(Name + "Micro")},
+        flags)
+
+    header_output = \
+        VectorIntMicroDeclare.subst(microiop) + \
+        VectorIntMacroDeclare.subst(iop)
+    decoder_output = \
+        VectorIntMicroConstructor.subst(microiop) + \
+        VectorCompressMacroConstructor.subst(iop)
+    exec_output = VectorIntMicroExecute.subst(microiop)
+    decode_block = VectorIntDecodeBlock.subst(iop)
+}};
+
+
 let {{
 
 def VectorSlideBase(name, Name, category, code, flags, macro_construtor,

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -279,6 +279,72 @@ def format VectorIntFormat(code, category, *flags) {{
     decode_block = VectorIntDecodeBlock.subst(iop)
 }};
 
+def format VectorCompressFormat(code, category, *flags) {{
+    macroop_class_name = 'VectorArithMacroInst'
+    microop_class_name = 'VectorArithMicroInst'
+
+    iop = InstObjParams(
+        name,
+        Name,
+        macroop_class_name,
+        {'code': code,
+         'declare_varith_template': declareVArithTemplate(Name)},
+        flags
+    )
+    inst_name, inst_suffix = name.split("_", maxsplit=1)
+
+    dest_reg_id = "vecRegClass[_machInst.vd + \
+        (_microIdx)%vtype_regs_per_group(vtype)]"
+
+    num_src_regs = 0
+
+    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    num_src_regs += 1
+
+    src1_reg_id = "vecRegClass[_machInst.vs1]"
+    num_src_regs += 1
+
+    old_vd_idx = num_src_regs
+
+    set_dest_reg_idx = setDestWrapper(dest_reg_id)
+
+    set_src_reg_idx = ""
+    set_src_reg_idx += setSrcWrapper(src1_reg_id)
+    set_src_reg_idx += setSrcWrapper(src2_reg_id)
+
+    dest_set_src_reg_idx = setSrcWrapper(dest_reg_id)
+
+    set_src_reg_idx += dest_set_src_reg_idx
+    set_src_reg_idx += setSrcVm()
+
+    # code
+
+    vm_decl_rd = vmDeclAndReadData()
+
+    set_vlenb = setVlenb()
+
+    microiop = InstObjParams(name + "_micro",
+        Name + "Micro",
+        microop_class_name,
+        {'code': code,
+         'set_dest_reg_idx': set_dest_reg_idx,
+         'set_src_reg_idx': set_src_reg_idx,
+         'set_vlenb' : set_vlenb,
+         'vm_decl_rd': vm_decl_rd,
+         'copy_old_vd': copyOldVd(old_vd_idx),
+         'declare_varith_template': declareVArithTemplate(Name + "Micro")},
+        flags)
+
+    header_output = \
+        VectorIntMicroDeclare.subst(microiop) + \
+        VectorIntMacroDeclare.subst(iop)
+    decoder_output = \
+        VectorIntMicroConstructor.subst(microiop) + \
+        VectorCompressMacroConstructor.subst(iop)
+    exec_output = VectorIntMicroExecute.subst(microiop)
+    decode_block = VectorIntDecodeBlock.subst(iop)
+}};
+
 
 def format VectorIntExtFormat(code, category, *flags) {{
     iop = InstObjParams(
@@ -1468,71 +1534,6 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
         VectorReduceMacroConstructor.subst(iop)
     exec_output = VectorReduceIntWideningMicroExecute.subst(microiop)
     decode_block = VectorIntWideningDecodeBlock.subst(iop)
-}};
-
-def format VectorCompressFormat(code, category, *flags) {{
-    macroop_class_name = 'VectorArithMacroInst'
-    microop_class_name = 'VectorArithMicroInst'
-
-    iop = InstObjParams(
-        name,
-        Name,
-        macroop_class_name,
-        {'code': code,
-         'declare_varith_template': declareVArithTemplate(Name)},
-        flags
-    )
-    inst_name, inst_suffix = name.split("_", maxsplit=1)
-
-    dest_reg_id = "vecRegClass[_machInst.vd +
-                    (_microIdx)%vtype_regs_per_group(vtype)]"
-
-    num_src_regs = 0
-
-    src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
-    num_src_regs += 1
-
-    src1_reg_id = "vecRegClass[_machInst.vs1]"
-    num_src_regs += 1
-
-    old_vd_idx = num_src_regs
-
-    set_dest_reg_idx = setDestWrapper(dest_reg_id)
-
-    set_src_reg_idx = ""
-    set_src_reg_idx += setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-
-    dest_set_src_reg_idx = setSrcWrapper(dest_reg_id)
-    set_src_reg_idx += dest_set_src_reg_idx
-    set_src_reg_idx += setSrcVm()
-
-    # code
-
-    vm_decl_rd = vmDeclAndReadData()
-
-    set_vlenb = setVlenb()
-
-    microiop = InstObjParams(name + "_micro",
-        Name + "Micro",
-        microop_class_name,
-        {'code': code,
-         'set_dest_reg_idx': set_dest_reg_idx,
-         'set_src_reg_idx': set_src_reg_idx,
-         'set_vlenb' : set_vlenb,
-         'vm_decl_rd': vm_decl_rd,
-         'copy_old_vd': copyOldVd(old_vd_idx),
-         'declare_varith_template': declareVArithTemplate(Name + "Micro")},
-        flags)
-
-    header_output = \
-        VectorIntMicroDeclare.subst(microiop) + \
-        VectorIntMacroDeclare.subst(iop)
-    decoder_output = \
-        VectorIntMicroConstructor.subst(microiop) + \
-        VectorCompressMacroConstructor.subst(iop)
-    exec_output = VectorIntMicroExecute.subst(microiop)
-    decode_block = VectorIntDecodeBlock.subst(iop)
 }};
 
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2250,6 +2250,51 @@ Fault
 
 }};
 
+
+def template VectorCompressMacroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst, uint32_t _elen,
+                                         uint32_t _vlen)
+    : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _elen, _vlen)
+{
+    %(set_reg_idx_arr)s;
+    %(constructor)s;
+    const uint32_t num_microops = vtype_regs_per_group(vtype);
+    int32_t tmp_vl = this->vl;
+    const int32_t micro_vlmax = vtype_VLMAX(_machInst.vtype8, vlen, true);
+    int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
+    StaticInstPtr microop;
+
+    if (micro_vl == 0) {
+        microop = new VectorNopMicroInst(_machInst);
+        this->microops.push_back(microop);
+    }
+    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+                                                    _elen, _vlen);
+        microop->setDelayedCommit();
+        this->microops.push_back(microop);
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+    }
+    tmp_vl = this->vl;
+    micro_vl = std::min(tmp_vl, micro_vlmax);
+    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
+        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl,
+                                        i + num_microops, _elen, _vlen);
+        microop->setDelayedCommit();
+        this->microops.push_back(microop);
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+    }
+
+    this->microops.front()->setFirstMicroop();
+    this->microops.back()->setLastMicroop();
+}
+
+%(declare_varith_template)s;
+
+}};
+
 def template VectorSlideMacroDeclare {{
 
 template<typename ElemType>

--- a/src/arch/riscv/types.hh
+++ b/src/arch/riscv/types.hh
@@ -180,6 +180,8 @@ BitUnion64(ExtMachInst)
     Bitfield<19, 15>    uimm_vsetivli;
     // vsetvl
     Bitfield<31, 25>    bit31_25;
+    // Zvbb
+    Bitfield<26>        bit26;
 
 EndBitUnion(ExtMachInst)
 

--- a/src/arch/riscv/types.hh
+++ b/src/arch/riscv/types.hh
@@ -181,7 +181,7 @@ BitUnion64(ExtMachInst)
     // vsetvl
     Bitfield<31, 25>    bit31_25;
     // Zvbb
-    Bitfield<26>        bit26;
+    Bitfield<26> bit26;
 
 EndBitUnion(ExtMachInst)
 

--- a/src/arch/riscv/utility.hh
+++ b/src/arch/riscv/utility.hh
@@ -839,6 +839,13 @@ int_rounding(T result, uint8_t xrm, unsigned gb) {
     return result;
 }
 
+inline uint64_t
+num_elements_reg(const uint64_t vtype, const uint64_t vlen)
+{
+    int64_t vsew = bits(vtype, 5, 3);
+    return vlen >> (vsew + 3);
+}
+
 } // namespace RiscvISA
 } // namespace gem5
 


### PR DESCRIPTION
As discussed here [#2566](https://github.com/gem5/gem5/issues/2566). I noted that there are some missing vector instructions, in this PR I implemented the following instructions:
- vandn
- vwsll
- vror
- vrol
- vcompress
- vclmul
- vclmulh
I tested the instructions locally and looks fine.
Can you do a special check  in my implementation of vcompress? Since I relies in a internal buffer and I spends 2*micro_vl instructions for doing it.