### PR TITLE
arch-riscv: Fix `vslideup`

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -893,8 +893,8 @@ VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                                  uint32_t _numVdPins, uint32_t _elen,
                                  uint32_t _vlen, bool _hasVdOffset)
     : VectorArithMicroInst("vpinvd_v_micro", _machInst, SimdMiscOp, 0,
-                           _microIdx, _elen, _vlen)
-    , hasVdOffset(_hasVdOffset)
+                           _microIdx, _elen, _vlen),
+      hasVdOffset(_hasVdOffset)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(

--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -891,12 +891,10 @@ VCpyVsMicroInst::generateDisassembly(Addr pc,
 
 VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                                  uint32_t _numVdPins, uint32_t _elen,
-                                 uint32_t _vlen, bool _hasVdOffset,
-                                 bool _copyVs, uint32_t _vsIdx)
+                                 uint32_t _vlen, bool _hasVdOffset)
     : VectorArithMicroInst("vpinvd_v_micro", _machInst, SimdMiscOp, 0,
                            _microIdx, _elen, _vlen)
     , hasVdOffset(_hasVdOffset)
-    , copyVs(_copyVs)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -915,10 +913,6 @@ VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
     RegId Vd = destRegIdx(0);
     Vd.setNumPinnedWrites(_numVdPins);
     setDestRegIdx(0, Vd);
-
-    if (copyVs) {
-        setSrcRegIdx(_numSrcRegs++, vecRegClass[_vsIdx]);
-    }
 }
 
 Fault
@@ -941,14 +935,7 @@ VPinVdMicroInst::execute(ExecContext* xc, trace::InstRecord* traceData) const
     }
 
     if (traceData) {
-        traceData->setData(vecRegClass, xc->getWritableRegOperand(this, 0));
-    }
-
-    if (copyVs) {
-        vreg_t& vs = *(vreg_t *)xc->getWritableRegOperand(this, 1);
-        vreg_t old_vs;
-        xc->getRegOperand(this, 1, &old_vs);
-        vs = old_vs;
+        traceData->setData(vecRegClass, &vd);
     }
 
     return NoFault;

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -812,10 +812,10 @@ class VPinVdMicroInst : public VectorArithMicroInst
         RegId destRegIdxArr[1];
         const bool hasVdOffset;
 
-    public:
+      public:
         VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                         uint32_t _numVdPins, uint32_t _elen, uint32_t _vlen,
-                        bool _hasVdOffset=false);
+                        bool _hasVdOffset = false);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -809,15 +809,13 @@ class VPinVdMicroInst : public VectorArithMicroInst
 {
     private:
         RegId srcRegIdxArr[1];
-        RegId destRegIdxArr[2];
+        RegId destRegIdxArr[1];
         const bool hasVdOffset;
-        const bool copyVs;
 
     public:
         VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                         uint32_t _numVdPins, uint32_t _elen, uint32_t _vlen,
-                        bool _hasVdOffset=false, bool _copyVs = false,
-                        uint32_t _vsIdx = 0);
+                        bool _hasVdOffset=false);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4680,13 +4680,13 @@ decode QUADRANT default Unknown::unknown() {
                         int frontLen = microVlmax - backLen;
                         int vdOffset = 0;
                         for (int i = 0; vdOffset < frontLen
-                            && vdOffset < microVl; vdOffset++) {
+                            && vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs3_vu[i];
@@ -4973,13 +4973,13 @@ decode QUADRANT default Unknown::unknown() {
                         int frontLen = microVlmax - backLen;
                         int vdOffset = 0;
                         for (int i = 0; vdOffset < frontLen
-                            && vdOffset < microVl; vdOffset++) {
+                            && vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs3_vu[i];
@@ -5631,13 +5631,13 @@ decode QUADRANT default Unknown::unknown() {
                         int frontLen = microVlmax - backLen;
                         int vdOffset = 0;
                         for (int i = 0; vdOffset < frontLen
-                            && vdOffset < microVl; vdOffset++) {
+                            && vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs3_vu[i];

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2283,15 +2283,11 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
 
-    uint32_t vs2_end = machInst.vs2 + num_microops - 1;
-    uint32_t vd_end = machInst.vd + num_microops - 1;
-    bool overlap = (machInst.vs2 >= machInst.vd && machInst.vs2 <= vd_end)
-        || (vs2_end >= machInst.vd && vs2_end <= vd_end);
-    bool need_pin = overlap || num_microops > 2;
+    bool need_pin = num_microops > 2;
 
     for (int i = 0; need_pin && i < ceil((float) this->vl/micro_vlmax); i++) {
         microop = new VPinVdMicroInst(machInst, i, std::max(i, 1), elen, vlen,
-                                      true, overlap, machInst.vs2 + i);
+                                      true);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
@@ -2307,7 +2303,7 @@ template<typename ElemType>
 
             microop = new %(class_name)sMicro<ElemType>(
                 _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
-                _vlen, true, j == (std::max(i - 1, 0) - 1), false, overlap);
+                _vlen, true, j == (std::max(i - 1, 0) - 1), false, false);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
         }
@@ -2404,15 +2400,21 @@ template<typename ElemType>
     uint32_t vd_end = machInst.vd + num_microops - 1;
     bool overlap = (machInst.vs2 >= machInst.vd && machInst.vs2 <= vd_end)
         || (vs2_end >= machInst.vd && vs2_end <= vd_end);
-    bool need_pin = overlap || num_microops > 2;
+    bool need_pin = num_microops > 2;
 
-    for (int i = 0; need_pin && i < ceil((float) this->vl / micro_vlmax);
-        i++) {
-        microop = new VPinVdMicroInst(machInst, i,
-            std::max(num_microops-i-1, 1), elen, vlen, false, overlap,
-            machInst.vs2 + i);
-        microop->setFlag(IsDelayedCommit);
-        this->microops.push_back(microop);
+    for (int i = 0; i < ceil((float) this->vl / micro_vlmax); i++) {
+        if (overlap) {
+            microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen,
+                                          vlen);
+            microop->setFlag(IsDelayedCommit);
+            this->microops.push_back(microop);
+        }
+        if (need_pin) {
+            microop = new VPinVdMicroInst(machInst, i,
+                std::max(num_microops-i-1, 1), elen, vlen, false);
+            microop->setFlag(IsDelayedCommit);
+            this->microops.push_back(microop);
+        }
     }
 
     int micro_idx = 0;
@@ -2573,10 +2575,6 @@ Fault
         if (overlap && slideUp) {
             return std::make_shared<IllegalInstFault>(
                 "Regs overlap is not allowed for vslideup", machInst);
-        } else if (overlap && !slideUp) {
-            return std::make_shared<IllegalInstFault>(
-                "Regs overlap is not allowed for vslidedown when lmul > 1",
-                machInst);
         }
     }
 


### PR DESCRIPTION
Using the previous work from #2604 .

I fixed the `vslideup` instruction, because it doesn't increment properly the `i` variable in some loops, then when `microIdx > 0`, all the `vd` elements of a vector register are equal to the first element of this register, since we don't increment `i` in `vs[i + offset]`.