### PR TITLE
arch-riscv: fix `vm*` for `VLEN/EEW < 8` and `LMUL > 1`

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -454,7 +454,7 @@ VMaskMergeMicroInst::execute(ExecContext* xc,
     auto Vd = tmp_d0.as<uint8_t>();
     uint32_t vlenb = vlen >> 3;
     const uint32_t elems_per_vreg = vlenb / elemSize;
-    size_t bit_cnt = elems_per_vreg;
+    size_t bit_cnt = 0;
 
     // mask tails are always treated as agnostic: writting 1s
     tmp_d0.set(0xff);


### PR DESCRIPTION
As reported here: [#2622](https://github.com/gem5/gem5/issues/2622), `vmseq` (and others `vm*` instructions) doesn't work properly when `VLEN/EEW < 8` and `LMUL > 1`.

The bug is in the `VMaskMergeMicroInst::execute()` function, when `VLEN/EEW < 8` the `if` is executed.
However the initial value of the variable `bit_cnt` is wrong (must be 0), so when `LMUL > 1`, the following elements are write in the wrong position of `Vd`.