### PR TITLE
Fix compiler warnings arm isa

### DIFF
--- a/src/arch/arm/isa/formats/pred.isa
+++ b/src/arch/arm/isa/formats/pred.isa
@@ -167,7 +167,6 @@ def format DataOp(code, flagtype = logic) {{
 }};
 
 def format DataImmOp(code, flagtype = logic) {{
-    code += "resTemp = resTemp;"
     iop = ArmInstObjParams(name, Name, 'PredImmOp',
             { "code" : code, "predicate_test" : pickPredicate(code) })
     ccIop = ArmInstObjParams(name, Name + "Cc", 'PredImmOp',

--- a/src/arch/arm/isa/formats/sve_2nd_level.isa
+++ b/src/arch/arm/isa/formats/sve_2nd_level.isa
@@ -2485,6 +2485,7 @@ namespace Aarch64
                     default:
                         break;
                 }
+                break;
             default:
                 break;
         }

--- a/src/arch/arm/isa/insts/branch64.isa
+++ b/src/arch/arm/isa/insts/branch64.isa
@@ -149,8 +149,6 @@ let {{
         if (testPredicate(CondCodesNZ, CondCodesC, CondCodesV, condCode))
             NPC = purifyTaggedAddr(RawPC + imm, xc->tcBase(),
                                    currEL(xc->tcBase()), true);
-        else
-            NPC = NPC;
     '''
     bIop = ArmInstObjParams("b", "BCond64", "BranchImmCond64", bCode,
                             ['IsCondControl', 'IsDirectControl'])

--- a/src/arch/arm/isa/insts/fp64.isa
+++ b/src/arch/arm/isa/insts/fp64.isa
@@ -191,8 +191,6 @@ let {{
 
     fmovUCoreRegXCode = vfp64EnabledCheckCode + '''
         /* Explicitly merge with previous value */
-        AA64FpDestP0_uw = AA64FpDestP0_uw;
-        AA64FpDestP1_uw = AA64FpDestP1_uw;
         AA64FpDestP2_uw = XOp1_ud;
         AA64FpDestP3_uw = XOp1_ud >> 32;'''
     fmovUCoreRegXIop = ArmInstObjParams("fmov", "FmovUCoreRegX", "FpRegRegOp",

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -269,7 +269,8 @@ let {{
             if hi and not bigDest:  # Explicitly merge with lower half
                 for reg in range(0, destCnt):
                     eWalkCode += '''
-        AA64FpDestP%(reg)d_uw = AA64FpDestP%(reg)d_uw;''' % { "reg" : reg }
+        // THIS CODE IS DUPLICATING!
+        // AA64FpDestP%(reg)d_uw = AA64FpDestP%(reg)d_uw;''' % { "reg" : reg }
             else:  # zero upper half
                 for reg in range(destCnt, 4):
                     eWalkCode += '''
@@ -529,7 +530,8 @@ let {{
         if hi:
             for reg in range(0, 2):  # Explicitly merge with the lower half
                 eWalkCode += '''
-        AA64FpDestP%(reg)d_uw = AA64FpDestP%(reg)d_uw;''' % { "reg" : reg }
+        // THIS CODE IS TWO DUPLICATING!
+        // AA64FpDestP%(reg)d_uw = AA64FpDestP%(reg)d_uw;''' % { "reg" : reg }
         else:
             if (not readDest) and scalar and nepSrc == 'vd':
                 eWalkCode += '''

--- a/src/arch/arm/isa/templates/pred.isa
+++ b/src/arch/arm/isa/templates/pred.isa
@@ -174,8 +174,7 @@ def template PredOpExecute {{
             ExecContext *xc, trace::InstRecord *traceData) const
     {
         Fault fault = NoFault;
-        uint64_t resTemp = 0;
-        resTemp = resTemp;
+        [[maybe_unused]] uint64_t resTemp = 0;
         %(op_decl)s;
         %(op_rd)s;
 
@@ -198,8 +197,7 @@ def template QuiescePredOpExecute {{
             ExecContext *xc, trace::InstRecord *traceData) const
     {
         Fault fault = NoFault;
-        uint64_t resTemp = 0;
-        resTemp = resTemp;
+        [[maybe_unused]] int64_t resTemp = 0;
         %(op_decl)s;
         %(op_rd)s;
 
@@ -224,8 +222,7 @@ def template QuiescePredOpExecuteWithFixup {{
             ExecContext *xc, trace::InstRecord *traceData) const
     {
         Fault fault = NoFault;
-        uint64_t resTemp = 0;
-        resTemp = resTemp;
+        [[maybe_unused]] int64_t resTemp = 0;
         %(op_decl)s;
         %(op_rd)s;
 


### PR DESCRIPTION
This PR fixes some self-assignment warnings and one missing break statement. The self-assignments are replaced with `[[maybe_unused]]` when needed.