### PR TITLE
arch-arm: Add support for LRCPC instructions

### DIFF
--- a/src/arch/arm/ArmISA.py
+++ b/src/arch/arm/ArmISA.py
@@ -72,9 +72,11 @@ class ArmDefaultSERelease(ArmRelease):
         "FEAT_FCMA",
         "FEAT_JSCVT",
         "FEAT_PAuth",
+        "FEAT_LRCPC",
         # Armv8.4
         "FEAT_FLAGM",
         "FEAT_FRINTTS",
+        "FEAT_LRCPC2",
         # Armv8.5
         "FEAT_FLAGM2",
         # Armv9.2
@@ -155,9 +157,9 @@ class ArmISA(BaseISA):
     )
 
     # !I8MM | !BF16 | SPECRES = 0 | !SB |
-    # GPI = 0x0 | GPA = 0x1 | API=0x0 | FCMA | JSCVT | APA=0x1
+    # GPI = 0x0 | GPA = 0x1 | LRCPC=0x2 | FCMA | JSCVT | APA=0x1
     id_aa64isar1_el1 = Param.UInt64(
-        0x0000000001011010, "AArch64 Instruction Set Attribute Register 1"
+        0x0000000001211010, "AArch64 Instruction Set Attribute Register 1"
     )
 
     # 4K | 64K | !16K | !BigEndEL0 | !SNSMem | !BigEnd | 8b ASID | 40b PA

--- a/src/arch/arm/ArmSystem.py
+++ b/src/arch/arm/ArmSystem.py
@@ -95,6 +95,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_FCMA",
         "FEAT_JSCVT",
         "FEAT_PAuth",
+        "FEAT_LRCPC",
         # Armv8.4
         "FEAT_SEL2",
         "FEAT_TLBIOS",
@@ -103,6 +104,7 @@ class ArmExtension(ScopedEnum):
         "FEAT_IDST",
         "FEAT_TTST",
         "FEAT_FRINTTS",  # Optional in Armv8.4
+        "FEAT_LRCPC2",
         # Armv8.5
         "FEAT_FLAGM2",
         "FEAT_RNG",

--- a/src/arch/arm/isa/formats/aarch64.isa
+++ b/src/arch/arm/isa/formats/aarch64.isa
@@ -1358,6 +1358,7 @@ namespace Aarch64
         // bit 27,25=10
         switch (bits(machInst, 29, 28)) {
           case 0x0:
+          {
             if (bits(machInst, 26) == 0) {
                 if (bits(machInst, 24) != 0)
                     return new Unknown64(machInst);
@@ -1562,14 +1563,50 @@ namespace Aarch64
             } else {
                 return decodeNeonMem(machInst);
             }
+          }
           case 0x1:
           {
-            if (bits(machInst, 24) != 0)
-                return new Unknown64(machInst);
-            uint8_t switchVal = (bits(machInst, 26) << 0) |
-                                (bits(machInst, 31, 30) << 1);
             int64_t imm = sext<19>(bits(machInst, 23, 5)) << 2;
             RegIndex rt = (RegIndex)(uint32_t)bits(machInst, 4, 0);
+
+            if (bits(machInst, 24) != 0) {
+               if (bits(machInst, 21) != 0) {
+                  return new Unknown64(machInst);
+               }
+
+               warn_once("LoadAcquirePC implemented with SC\n");
+
+               uint8_t switchVal = (bits(machInst, 23, 22) << 0) |
+                                   (bits(machInst, 31, 30) << 2);
+               RegIndex rn = (RegIndex)(uint32_t)bits(machInst, 9, 5);
+               RegIndex rnsp = makeSP(rn);
+               uint64_t imm = sext<9>(bits(machInst, 20, 12));
+               switch (switchVal) {
+                 case 0x1:
+                   return new LDAPURB64_IMM(machInst, rt, rnsp, imm);
+                 case 0x2:
+                   return new LDAPURSBX64_IMM(machInst, rt, rnsp, imm);
+                 case 0x3:
+                   return new LDAPURSBW64_IMM(machInst, rt, rnsp, imm);
+                 case 0x5:
+                   return new LDAPURH64_IMM(machInst, rt, rnsp, imm);
+                 case 0x6:
+                   return new LDAPURSHX64_IMM(machInst, rt, rnsp, imm);
+                 case 0x7:
+                   return new LDAPURSHW64_IMM(machInst, rt, rnsp, imm);
+                 case 0x9:
+                   return new LDAPURX64_IMM(machInst, rt, rnsp, imm);
+                 case 0xd:
+                   return new LDAPURW64_IMM(machInst, rt, rnsp, imm);
+                 case 0xa:
+                   return new LDAPURSW64_IMM(machInst, rt, rnsp, imm);
+                 default:
+                   return new Unknown64(machInst);
+               }
+            }
+            uint8_t switchVal = (bits(machInst, 26) << 0) |
+                                (bits(machInst, 31, 30) << 1);
+
             switch (switchVal) {
               case 0x0:
                 return new LDRWL64_LIT(machInst, rt, imm);

--- a/src/arch/arm/isa/insts/ldr64.isa
+++ b/src/arch/arm/isa/insts/ldr64.isa
@@ -94,6 +94,10 @@ let {{
                 self.instFlags.extend(["IsWriteBarrier", "IsReadBarrier"])
                 self.memFlags.append("Request::ACQUIRE")
 
+            if self.flavor in ("acquire_pc"):
+                self.instFlags.extend(["IsWriteBarrier", "IsReadBarrier"])
+                self.memFlags.append("Request::ACQUIRE_PC")
+
             if self.flavor in ("acex", "exclusive", "exp", "acexp"):
                 self.memFlags.append("Request::LLSC")
 
@@ -474,6 +478,25 @@ let {{
     LoadRaw64("ldar", "LDARW64", size=4, flavor="acquire").emit()
     LoadRaw64("ldarh", "LDARH64", size=2, flavor="acquire").emit()
     LoadRaw64("ldarb", "LDARB64", size=1, flavor="acquire").emit()
+
+    LoadImm64("ldapurb", "LDAPURB64_IMM", size=1,
+              sign=False, flavor="acquire_pc").emit()
+    LoadImm64("ldapursb", "LDAPURSBW64_IMM", size=1,
+              sign=True, flavor="acquire_pc").emit()
+    LoadImm64("ldapursb", "LDAPURSBX64_IMM", size=1,
+              sign=True, flavor="acquire_pc").emit()
+    LoadImm64("ldapurh", "LDAPURH64_IMM", size=2,
+              sign=False, flavor="acquire_pc").emit()
+    LoadImm64("ldapursh", "LDAPURSHW64_IMM", size=2,
+              sign=True, flavor="acquire_pc").emit()
+    LoadImm64("ldapursh", "LDAPURSHX64_IMM", size=2,
+              sign=True, flavor="acquire_pc").emit()
+    LoadImm64("ldapursw", "LDAPURSW64_IMM", size=4,
+              sign=True, flavor="acquire_pc").emit()
+    LoadImm64("ldapur", "LDAPURW64_IMM", size=4,
+              sign=False, flavor="acquire_pc").emit()
+    LoadImm64("ldapur", "LDAPURX64_IMM", size=8,
+              sign=False, flavor="acquire_pc").emit()
 
     LoadEx64("ldaxr", "LDAXRX64", size=8, flavor="acex").emit()
     LoadEx64("ldaxr", "LDAXRW64", size=4, flavor="acex").emit()

--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -5011,6 +5011,9 @@ ISA::initializeMiscRegMetadata()
           isar1_el1.apa = release->has(ArmExtension::FEAT_PAuth) ? 0x1 : 0x0;
           isar1_el1.jscvt = release->has(ArmExtension::FEAT_JSCVT) ? 0x1 : 0x0;
           isar1_el1.fcma = release->has(ArmExtension::FEAT_FCMA) ? 0x1 : 0x0;
+          isar1_el1.lrcpc = release->has(ArmExtension::FEAT_LRCPC2)  ? 0x2
+                            : release->has(ArmExtension::FEAT_LRCPC) ? 0x1
+                                                                     : 0x0;
           isar1_el1.gpa = release->has(ArmExtension::FEAT_PAuth) ? 0x1 : 0x0;
           isar1_el1.frintts =
               release->has(ArmExtension::FEAT_FRINTTS) ? 0x1 : 0x0;

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -103,6 +103,7 @@ class Request : public Extensible<Request>
 
     enum : FlagsType
     {
+        // clang-format off
         /**
          * Architecture specific flags.
          *
@@ -168,6 +169,8 @@ class Request : public Extensible<Request>
         EVICT_NEXT                  = 0x04000000,
         /** The request should be marked with ACQUIRE. */
         ACQUIRE                     = 0x00020000,
+        /** The request should be marked with ACQUIRE_PC. */
+        ACQUIRE_PC                  = 0x00002000,
         /** The request should be marked with RELEASE. */
         RELEASE                     = 0x00040000,
 
@@ -259,6 +262,7 @@ class Request : public Extensible<Request>
         /** TLBI_EXT_SYNC_COMP seems to be the largest value
             of FlagsType, so HAS_NO_ADDR's value is that << 1 */
         HAS_NO_ADDR                = 0x0001000000000000,
+        // clang-format on
     };
     static const FlagsType STORE_NO_DATA = CACHE_BLOCK_ZERO |
         CLEAN | INVALIDATE;
@@ -1086,7 +1090,11 @@ class Request : public Extensible<Request>
     Flags getDest() const { return _flags & DST_BITS; }
 
     bool isAcquire() const { return _cacheCoherenceFlags.isSet(ACQUIRE); }
-
+    bool
+    isAcquirePC() const
+    {
+        return _cacheCoherenceFlags.isSet(ACQUIRE_PC);
+    }
 
     /**
      * Accessor functions for the cache bypass flags. The cache bypass


### PR DESCRIPTION
ARMv8.4 adds LRCPC2 instructions to enable RCpc memory model.

This patch adds support for them.