### PR TITLE
dev-amdgpu,stdlib: Allow for multiple GPUs in stdlib

### DIFF
--- a/configs/example/gpufs/mi300.py
+++ b/configs/example/gpufs/mi300.py
@@ -60,6 +60,11 @@ dmesg -n8
 cat /proc/cpuinfo
 dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128
 
+# Check if exists (backwards compat with ROCm <7.0)
+if [ -e /usr/lib/firmware/amdgpu/mi300_discovery ]; then
+    ln -s /usr/lib/firmware/amdgpu/mi300_discovery /usr/lib/firmware/amdgpu/ip_discovery.bin
+fi
+
 if [ -f /home/gem5/load_amdgpu.sh ]; then
     sh /home/gem5/load_amdgpu.sh
 elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then

--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -84,7 +84,8 @@ def addRunFSOptions(parser):
     parser.add_argument("--kernel", default=None, help="Linux kernel to boot")
     parser.add_argument(
         "--gpu-ipt",
-        default=None,
+        type=str,
+        default="",
         help="Intended only for gem5 developers. IP discovery table to load",
     )
     parser.add_argument(
@@ -134,10 +135,10 @@ def addRunFSOptions(parser):
     # other gfx versions there is some support in syscall emulation mode.
     parser.add_argument(
         "--gpu-device",
-        default="Vega10",
-        choices=["Vega10", "MI100", "MI200", "MI300X"],
+        default="MI300X",
+        choices=["Vega10", "MI100", "MI200", "MI300X", "MI355X"],
         help="GPU model to run: Vega10 (gfx900), MI100 (gfx908), MI200 "
-        "(gfx90a), or MI300X (gfx942).",
+        "(gfx90a), MI300X (gfx942), or MI355X (gfx950).",
     )
 
     parser.add_argument(

--- a/configs/example/gpufs/system/amdgpu.py
+++ b/configs/example/gpufs/system/amdgpu.py
@@ -204,6 +204,11 @@ def connectGPU(system, args):
         system.pc.south_bridge.gpu.SubsystemVendorID = 0x1002
         system.pc.south_bridge.gpu.SubsystemID = 0x0C34
         system.pc.south_bridge.gpu.BAR5 = PciMemBar(size="2MiB")
+    elif args.gpu_device == "MI355X":
+        system.pc.south_bridge.gpu.DeviceID = 0x75A0
+        system.pc.south_bridge.gpu.SubsystemVendorID = 0x1002
+        system.pc.south_bridge.gpu.SubsystemID = 0x0C34
+        system.pc.south_bridge.gpu.BAR5 = PciMemBar(size="2MiB")
     elif args.gpu_device == "Vega10":
         system.pc.south_bridge.gpu.DeviceID = 0x6863
     else:

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -171,10 +171,12 @@ def makeGpuFSSystem(args):
             0x7A000,
         ]
         sdma_sizes = [0x1000] * 5
-    elif args.gpu_device == "MI300X":
+    elif args.gpu_device == "MI300X" or args.gpu_device == "MI355X":
         # These MMIO addresses are based on the IP discovery file associated
         # with the disk image. Changes to these values require changes to the
         # discovery file base addresses.
+        #
+        # These are the same for MI300X and MI355X.
         num_sdmas = 16
         sdma_bases = [
             0x4980,
@@ -214,7 +216,7 @@ def makeGpuFSSystem(args):
 
     # Setup PM4 packet processors
     pm4_procs = []
-    if args.gpu_device == "MI300X":
+    if args.gpu_device == "MI300X" or args.gpu_device == "MI355X":
         # These MMIO addresses are based on the IP discovery file associated
         # with the disk image. Changes to these values require changes to the
         # discovery file base addresses.

--- a/src/dev/amdgpu/AMDGPU.py
+++ b/src/dev/amdgpu/AMDGPU.py
@@ -69,6 +69,8 @@ class AMDGPUDevice(PciEndpoint):
     SubClassCode = 0x00
     ProgIF = 0x00
 
+    gpu_id = Param.Int(0, "ID of GPU, if multiple GPUs are instantiated")
+
     # Use max possible BAR size for Vega 10. We can override with driver param
     BAR0 = PciMemBar(size="16GiB")
     BAR1 = PciMemUpperBar()

--- a/src/dev/amdgpu/SConscript
+++ b/src/dev/amdgpu/SConscript
@@ -44,6 +44,7 @@ SimObject('AMDGPU.py', sim_objects=['AMDGPUDevice', 'AMDGPUInterruptHandler',
 Source('amdgpu_device.cc', tags=['x86 isa'])
 Source('amdgpu_gfx.cc', tags=['x86 isa'])
 Source('amdgpu_nbio.cc', tags=['x86 isa'])
+Source('amdgpu_smu.cc', tags=['x86 isa'])
 Source('amdgpu_vm.cc', tags=['x86 isa'])
 Source('interrupt_handler.cc', tags=['x86 isa'])
 Source('memory_manager.cc', tags=['x86 isa'])

--- a/src/dev/amdgpu/amdgpu_device.cc
+++ b/src/dev/amdgpu/amdgpu_device.cc
@@ -53,11 +53,16 @@ namespace gem5
 {
 
 AMDGPUDevice::AMDGPUDevice(const AMDGPUDeviceParams &p)
-    : PciEndpoint(p), gpuMemMgr(p.memory_manager), deviceIH(p.device_ih),
-      cp(p.cp), checkpoint_before_mmios(p.checkpoint_before_mmios),
-      init_interrupt_count(0), _lastVMID(0),
+    : PciEndpoint(p),
+      gpuMemMgr(p.memory_manager),
+      deviceIH(p.device_ih),
+      cp(p.cp),
+      checkpoint_before_mmios(p.checkpoint_before_mmios),
+      init_interrupt_count(0),
+      _lastVMID(0),
       deviceMem(name() + ".deviceMem", p.memories, false, "", false),
-      system(p.system), gpuId(p.gpu_id)
+      system(p.system),
+      gpuId(p.gpu_id)
 {
     uint64_t vram_size = 0;
 
@@ -194,7 +199,7 @@ AMDGPUDevice::AMDGPUDevice(const AMDGPUDeviceParams &p)
     } else {
         gpuvm.setMMIOAperture(MMHUB_MMIO_RANGE,  AddrRange(0x68000, 0x6A120));
     }
-    gpuvm.setMMIOAperture(SMU_MMIO_RANGE,  AddrRange(0x5A000, 0x5ACE4));
+    gpuvm.setMMIOAperture(SMU_MMIO_RANGE, AddrRange(0x5A000, 0x5ACE4));
 
     // These are hardcoded register values to return what the driver expects
     setRegVal(AMDGPU_MP0_SMN_C2PMSG_33, 0x80000000);
@@ -426,7 +431,6 @@ AMDGPUDevice::writeConfig(PacketPtr pkt)
             return PciEndpoint::writeConfig(pkt);
         }
     }
-
 
     if (offset >= PXCAP_BASE && offset < (PXCAP_BASE + sizeof(PXCAP))) {
         uint8_t *pxcap_data = &(pxcap.data[0]);

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -51,6 +51,7 @@ namespace gem5
 
 class AMDGPUInterruptHandler;
 class SDMAEngine;
+class System;
 
 /**
  * Device model for an AMD GPU. This models the interface between the PCI bus
@@ -97,8 +98,6 @@ class AMDGPUDevice : public PciEndpoint
     bool isROM(Addr addr) const { return romRange.contains(addr); }
     void readROM(PacketPtr pkt);
     void writeROM(PacketPtr pkt);
-
-    std::array<uint8_t, ROM_SIZE> rom;
 
     /**
      * MMIO reader to populate device registers map.
@@ -156,6 +155,11 @@ class AMDGPUDevice : public PciEndpoint
      * Backing store for GPU memory / framebuffer / VRAM
      */
     memory::PhysicalMemory deviceMem;
+
+    /*
+     * For multiple GPUs, use system memory to read ROM.
+     */
+    System *system;
 
     /* Device information */
     GfxVersion gfx_version = GfxVersion::gfx900;

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -159,6 +159,7 @@ class AMDGPUDevice : public PciEndpoint
 
     /* Device information */
     GfxVersion gfx_version = GfxVersion::gfx900;
+    Addr vramSize;
 
   protected:
     /**
@@ -229,6 +230,7 @@ class AMDGPUDevice : public PciEndpoint
 
     /* Device information */
     GfxVersion getGfxVersion() const { return gfx_version; }
+    Addr getVRAMSize() const { return vramSize; }
 };
 
 } // namespace gem5

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -38,6 +38,7 @@
 #include "dev/amdgpu/amdgpu_defines.hh"
 #include "dev/amdgpu/amdgpu_gfx.hh"
 #include "dev/amdgpu/amdgpu_nbio.hh"
+#include "dev/amdgpu/amdgpu_smu.hh"
 #include "dev/amdgpu/amdgpu_vm.hh"
 #include "dev/amdgpu/memory_manager.hh"
 #include "dev/amdgpu/mmio_reader.hh"
@@ -112,6 +113,7 @@ class AMDGPUDevice : public PciEndpoint
     AMDGPUMemoryManager *gpuMemMgr;
     AMDGPUInterruptHandler *deviceIH;
     AMDGPUVM gpuvm;
+    AMDGPUSmu smu;
     GPUCommandProcessor *cp;
 
     struct AddrRangeHasher
@@ -163,6 +165,7 @@ class AMDGPUDevice : public PciEndpoint
 
     /* Device information */
     GfxVersion gfx_version = GfxVersion::gfx900;
+    const int gpuId;
     Addr vramSize;
 
   protected:
@@ -234,6 +237,7 @@ class AMDGPUDevice : public PciEndpoint
 
     /* Device information */
     GfxVersion getGfxVersion() const { return gfx_version; }
+    int getGpuId() const { return gpuId; }
     Addr getVRAMSize() const { return vramSize; }
 };
 

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -237,8 +237,16 @@ class AMDGPUDevice : public PciEndpoint
 
     /* Device information */
     GfxVersion getGfxVersion() const { return gfx_version; }
-    int getGpuId() const { return gpuId; }
-    Addr getVRAMSize() const { return vramSize; }
+    int
+    getGpuId() const
+    {
+        return gpuId;
+    }
+    Addr
+    getVRAMSize() const
+    {
+        return vramSize;
+    }
 };
 
 } // namespace gem5

--- a/src/dev/amdgpu/amdgpu_nbio.cc
+++ b/src/dev/amdgpu/amdgpu_nbio.cc
@@ -134,6 +134,9 @@ AMDGPUNbio::readMMIO(PacketPtr pkt, Addr offset)
           pkt->setLE<uint32_t>(0);
         }
         break;
+      case MI200_BIOS_SCRATCH_7:
+        pkt->setLE<uint32_t>(0x200); // ATOM_S7_ASIC_INIT_COMPLETE_MASK
+        break;
       default:
         if (triggered_reads.count(offset)) {
             DPRINTF(AMDGPUDevice, "Found triggered read for %#x\n", offset);

--- a/src/dev/amdgpu/amdgpu_nbio.cc
+++ b/src/dev/amdgpu/amdgpu_nbio.cc
@@ -135,8 +135,8 @@ AMDGPUNbio::readMMIO(PacketPtr pkt, Addr offset)
         }
         break;
       case MI200_BIOS_SCRATCH_7:
-        pkt->setLE<uint32_t>(0x200); // ATOM_S7_ASIC_INIT_COMPLETE_MASK
-        break;
+          pkt->setLE<uint32_t>(0x200); // ATOM_S7_ASIC_INIT_COMPLETE_MASK
+          break;
       default:
         if (triggered_reads.count(offset)) {
             DPRINTF(AMDGPUDevice, "Found triggered read for %#x\n", offset);

--- a/src/dev/amdgpu/amdgpu_nbio.hh
+++ b/src/dev/amdgpu/amdgpu_nbio.hh
@@ -62,6 +62,8 @@ class AMDGPUDevice;
 #define AMDGPU_PCIE_DATA                                  0x00034
 #define AMDGPU_PCIE_DATA2                                 0x0003c
 
+#define MI200_BIOS_SCRATCH_7                               0x014c
+
 // Message bus related to psp
 #define AMDGPU_MP0_SMN_C2PMSG_33                          0x58184
 #define AMDGPU_MP0_SMN_C2PMSG_35                          0x5818c

--- a/src/dev/amdgpu/amdgpu_nbio.hh
+++ b/src/dev/amdgpu/amdgpu_nbio.hh
@@ -62,7 +62,7 @@ class AMDGPUDevice;
 #define AMDGPU_PCIE_DATA                                  0x00034
 #define AMDGPU_PCIE_DATA2                                 0x0003c
 
-#define MI200_BIOS_SCRATCH_7                               0x014c
+#define MI200_BIOS_SCRATCH_7 0x014c
 
 // Message bus related to psp
 #define AMDGPU_MP0_SMN_C2PMSG_33                          0x58184

--- a/src/dev/amdgpu/amdgpu_smu.cc
+++ b/src/dev/amdgpu/amdgpu_smu.cc
@@ -44,13 +44,13 @@ AMDGPUSmu::readMMIO(PacketPtr pkt, Addr offset)
     uint32_t regval = 0;
 
     switch (offset) {
-      case MI200_SMUIO_MCM_CONFIG:
-        regval = (gpuDevice->getGpuId() << 4);
-        break;
-      default:
-        DPRINTF(AMDGPUDevice, "SMU read of unknown MMIO offset %x (%x)\n",
-                offset, pkt->getAddr());
-        break;
+        case MI200_SMUIO_MCM_CONFIG:
+            regval = (gpuDevice->getGpuId() << 4);
+            break;
+        default:
+            DPRINTF(AMDGPUDevice, "SMU read of unknown MMIO offset %x (%x)\n",
+                    offset, pkt->getAddr());
+            break;
     }
 
     pkt->setLE<uint32_t>(regval);
@@ -63,9 +63,9 @@ void
 AMDGPUSmu::writeMMIO(PacketPtr pkt, Addr offset)
 {
     switch (offset) {
-      default:
-        DPRINTF(AMDGPUDevice, "SMU write of unknown MMIO offset %x (%x)\n",
-                offset, pkt->getAddr());
+        default:
+            DPRINTF(AMDGPUDevice, "SMU write of unknown MMIO offset %x (%x)\n",
+                    offset, pkt->getAddr());
     }
 }
 

--- a/src/dev/amdgpu/amdgpu_smu.hh
+++ b/src/dev/amdgpu/amdgpu_smu.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,54 +29,35 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __DEV_AMDGPU_AMDGPU_DEFINES_HH__
-#define __DEV_AMDGPU_AMDGPU_DEFINES_HH__
+#ifndef __DEV_AMDGPU_AMDGPU_SMU__
+#define __DEV_AMDGPU_AMDGPU_SMU__
 
-#include "base/types.hh"
+#include "mem/packet.hh"
 
 namespace gem5
 {
 
-/* Types of queues supported by device */
-enum QueueType
-{
-    Compute,
-    Gfx,
-    SDMAGfx,
-    SDMAPage,
-    ComputeAQL,
-    InterruptHandler,
-    RLC
-};
+class AMDGPUDevice;
 
-/*
- * Hold information about doorbells including queue type and the IP
- * block ID if the IP can have multiple instances.
+#define MI200_SMUIO_MCM_CONFIG                                         0x0024
+
+/**
+ * Handle MMIO reads/writes to register with "SMU" prefix.
  */
-typedef struct
+class AMDGPUSmu
 {
-    QueueType qtype;
-    int ip_id;
-} DoorbellInfo;
+  public:
+    AMDGPUSmu() = default;
 
-// AMD GPUs support 16 different virtual address spaces
-static constexpr int AMDGPU_VM_COUNT = 16;
+    void readMMIO(PacketPtr pkt, Addr offset);
+    void writeMMIO(PacketPtr pkt, Addr offset);
 
-/* Names of BARs used by the device. */
-constexpr int FRAMEBUFFER_BAR = 0;
-constexpr int DOORBELL_BAR = 2;
-constexpr int MMIO_BAR = 5;
+    void setGPUDevice(AMDGPUDevice *gpu_device);
 
-/* By default the X86 kernel expects the vga ROM at 0xc0000. */
-constexpr uint32_t VGA_ROM_DEFAULT = 0xc0000;
-constexpr uint32_t ROM_SIZE = 0x20000;        // 128kB
-
-/* Most MMIOs use DWORD addresses and thus need to be shifted. */
-static constexpr uint32_t IH_OFFSET_SHIFT = 2;
-static constexpr uint32_t GRBM_OFFSET_SHIFT  = 2;
-static constexpr uint32_t MMHUB_OFFSET_SHIFT = 2;
-static constexpr uint32_t SMU_OFFSET_SHIFT = 2;
+  private:
+    AMDGPUDevice *gpuDevice;
+};
 
 } // namespace gem5
 
-#endif // __DEV_AMDGPU_AMDGPU_DEFINES_HH__
+#endif // __DEV_AMDGPU_AMDGPU_SMU__

--- a/src/dev/amdgpu/amdgpu_smu.hh
+++ b/src/dev/amdgpu/amdgpu_smu.hh
@@ -39,7 +39,7 @@ namespace gem5
 
 class AMDGPUDevice;
 
-#define MI200_SMUIO_MCM_CONFIG                                         0x0024
+#define MI200_SMUIO_MCM_CONFIG 0x0024
 
 /**
  * Handle MMIO reads/writes to register with "SMU" prefix.

--- a/src/dev/amdgpu/amdgpu_vm.cc
+++ b/src/dev/amdgpu/amdgpu_vm.cc
@@ -261,8 +261,10 @@ AMDGPUVM::writeMMIO(PacketPtr pkt, Addr offset)
 {
     // There are multiple functions due to MMIO addresses being aliased to
     // something different from a previous GFX version. So far this has not
-    // been the case for supported MMIO reads.
-    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
+    // been the case for supported MMIO reads but requires special handling
+    // for newer gfx942 and gfx950 devices.
+    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
+        gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
         writeMMIOGfx940(pkt, offset);
     } else {
         writeMMIOGfx900(pkt, offset);

--- a/src/dev/amdgpu/amdgpu_vm.hh
+++ b/src/dev/amdgpu/amdgpu_vm.hh
@@ -127,6 +127,7 @@ typedef enum : int
     GFX_MMIO_RANGE,
     GRBM_MMIO_RANGE,
     IH_MMIO_RANGE,
+    SMU_MMIO_RANGE,
     NUM_MMIO_RANGES
 } mmio_range_t;
 

--- a/src/dev/amdgpu/pm4_packet_processor.cc
+++ b/src/dev/amdgpu/pm4_packet_processor.cc
@@ -290,22 +290,23 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
                     dmaBuffer);
         } break;
       case IT_MAP_PROCESS: {
-        if (gpuDevice->getGfxVersion() == GfxVersion::gfx90a ||
-            gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
-            dmaBuffer = new PM4MapProcessV2();
-            cb = new DmaVirtCallback<uint64_t>(
-                [ = ] (const uint64_t &)
-                    { mapProcessV2(q, (PM4MapProcessV2 *)dmaBuffer); });
-            dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcessV2),
-                        cb, dmaBuffer);
-        } else {
-            dmaBuffer = new PM4MapProcess();
-            cb = new DmaVirtCallback<uint64_t>(
-                [ = ] (const uint64_t &)
-                    { mapProcessV1(q, (PM4MapProcess *)dmaBuffer); });
-            dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcess), cb,
-                        dmaBuffer);
-        }
+          if (gpuDevice->getGfxVersion() == GfxVersion::gfx90a ||
+              gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
+              gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
+              dmaBuffer = new PM4MapProcessV2();
+              cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+                  mapProcessV2(q, (PM4MapProcessV2 *)dmaBuffer);
+              });
+              dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcessV2), cb,
+                          dmaBuffer);
+          } else {
+              dmaBuffer = new PM4MapProcess();
+              cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+                  mapProcessV1(q, (PM4MapProcess *)dmaBuffer);
+              });
+              dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcess), cb,
+                          dmaBuffer);
+          }
         } break;
 
       case IT_UNMAP_QUEUES: {

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -904,7 +904,8 @@ SDMAEngine::trap(SDMAQueue *q, sdmaTrap *pkt)
     int node_id = 0;
     int local_id = getId();
 
-    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942) {
+    if (gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
+        gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
         node_id = getId() >> 2;
 
         // For most SDMAs the "node_id" for the interrupt handler is the SDMA

--- a/src/gpu-compute/GPU.py
+++ b/src/gpu-compute/GPU.py
@@ -45,7 +45,7 @@ class PrefetchType(Enum):
 
 
 class GfxVersion(ScopedEnum):
-    vals = ["gfx900", "gfx902", "gfx908", "gfx90a", "gfx942"]
+    vals = ["gfx900", "gfx902", "gfx908", "gfx90a", "gfx942", "gfx950"]
 
 
 class PoolManager(SimObject):

--- a/src/gpu-compute/gpu_dyn_inst.cc
+++ b/src/gpu-compute/gpu_dyn_inst.cc
@@ -931,7 +931,8 @@ GPUDynInst::resolveFlatSegment(const VectorMask &mask)
 
         ComputeUnit *cu = wavefront()->computeUnit;
 
-        if (wavefront()->gfxVersion == GfxVersion::gfx942) {
+        if (wavefront()->gfxVersion == GfxVersion::gfx942 ||
+            wavefront()->gfxVersion == GfxVersion::gfx950) {
             // Architected flat scratch base address is in a dedicated hardware
             // register.
             for (int lane = 0; lane < cu->wfSize(); ++lane) {

--- a/src/gpu-compute/hsa_queue_entry.hh
+++ b/src/gpu-compute/hsa_queue_entry.hh
@@ -94,10 +94,11 @@ class HSAQueueEntry
         // LLVM docs: https://www.llvm.org/docs/AMDGPUUsage.html
         //     #code-object-v3-kernel-descriptor
         //
-        // Currently, the only supported gfx versions in gem5 that compute
-        // VGPR count differently are gfx90a and gfx942.
+        // Currently, gem5 supported gfx version use a multiplier of 8. The
+        // only exception is gfx900 (Vega10).
         if (gfx_version == GfxVersion::gfx90a ||
-            gfx_version == GfxVersion::gfx942) {
+            gfx_version == GfxVersion::gfx942 ||
+            gfx_version == GfxVersion::gfx950) {
             numVgprs = (akc->granulated_workitem_vgpr_count + 1) * 8;
         } else {
             numVgprs = (akc->granulated_workitem_vgpr_count + 1) * 4;
@@ -106,10 +107,11 @@ class HSAQueueEntry
         // SGPR allocation granulary is 16 in GFX9
         // Source: https://llvm.org/docs/AMDGPUUsage.html
         if (gfx_version == GfxVersion::gfx900 ||
-                gfx_version == GfxVersion::gfx902 ||
-                gfx_version == GfxVersion::gfx908 ||
-                gfx_version == GfxVersion::gfx90a ||
-                gfx_version == GfxVersion::gfx942) {
+            gfx_version == GfxVersion::gfx902 ||
+            gfx_version == GfxVersion::gfx908 ||
+            gfx_version == GfxVersion::gfx90a ||
+            gfx_version == GfxVersion::gfx942 ||
+            gfx_version == GfxVersion::gfx950) {
             numSgprs = ((akc->granulated_wavefront_sgpr_count + 1) * 16)/2;
         } else {
             panic("Saw unknown gfx version setting up GPR counts\n");

--- a/src/gpu-compute/wavefront.cc
+++ b/src/gpu-compute/wavefront.cc
@@ -405,7 +405,8 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
                 // For architected flat scratch, this enable is reused to set
                 // the FLAT_SCRATCH register pair to the scratch backing
                 // memory: https://llvm.org/docs/AMDGPUUsage.html#flat-scratch
-                if (task->gfxVersion() == GfxVersion::gfx942) {
+                if (task->gfxVersion() == GfxVersion::gfx942 ||
+                    task->gfxVersion() == GfxVersion::gfx950) {
                     uint32_t scratchPerWI =
                         task->amdQueue.scratch_workitem_byte_size;
 
@@ -490,7 +491,8 @@ Wavefront::initRegState(HSAQueueEntry *task, int wgSizeInWorkItems)
     bool packed_work_item_id = false;
 
     if (task->gfxVersion() == GfxVersion::gfx90a ||
-        task->gfxVersion() == GfxVersion::gfx942) {
+        task->gfxVersion() == GfxVersion::gfx942 ||
+        task->gfxVersion() == GfxVersion::gfx950) {
         packed_work_item_id = true;
     }
 

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -153,7 +153,11 @@ class MI210(BaseViperGPU):
 
         # Setup device-specific address ranges for various SoC components.
         shader = ViperShader(
-            self._my_id, num_cus, cache_line_size, self.device
+            self._my_id,
+            num_cus,
+            cache_line_size,
+            self.device,
+            gpu_memory.get_size(),
         )
         self.set_shader(shader)
 
@@ -235,7 +239,11 @@ class MI300X(BaseViperGPU):
 
         # Setup device-specific address ranges for various SoC components.
         shader = ViperShader(
-            self._my_id, num_cus, cache_line_size, self.device
+            self._my_id,
+            num_cus,
+            cache_line_size,
+            self.device,
+            gpu_memory.get_size(),
         )
         self.set_shader(shader)
 

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -295,6 +295,74 @@ class MI300X(BaseViperGPU):
             "export HCC_AMDGPU_TARGET=gfx942\n"
             f"{debug_commands}\n"
             "dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128\n"
+            # Check if exists (backwards compat with ROCm <7.0)
+            "if [ -e /usr/lib/firmware/amdgpu/mi300_discovery ]; then\n"
+            "    ln -s /usr/lib/firmware/amdgpu/mi300_discovery /usr/lib/firmware/amdgpu/ip_discovery.bin\n"
+            "fi\n"
+            "if [ -f /home/gem5/load_amdgpu.sh ]; then\n"
+            "    sh /home/gem5/load_amdgpu.sh\n"
+            "elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then\n"
+            '    echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."\n'
+            "    /sbin/m5 exit\n"
+            "else\n"
+            "    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2\n"
+            "fi\n"
+        )
+
+        return driver_load_command
+
+
+# Defaults to a single "XCD" (i.e., 1/8th of a full MI355X).
+class MI355X(MI300X):
+    def __init__(
+        self,
+        gpu_memory: AbstractMemorySystem,
+        num_cus: int = 40,
+        cu_per_sqc: int = 4,
+        tcp_size: str = "16KiB",
+        tcp_assoc: int = 16,
+        sqc_size: str = "32KiB",
+        sqc_assoc: int = 8,
+        scalar_size: str = "32KiB",
+        scalar_assoc: int = 8,
+        tcc_size: str = "256KiB",
+        tcc_assoc: int = 16,
+        tcc_count: int = 16,
+        cache_line_size: int = 64,
+    ):
+        super().__init__(
+            gpu_memory=gpu_memory,
+            num_cus=num_cus,
+            cu_per_sqc=cu_per_sqc,
+            tcp_size=tcp_size,
+            tcp_assoc=tcp_assoc,
+            sqc_size=sqc_size,
+            sqc_assoc=sqc_assoc,
+            scalar_size=scalar_size,
+            scalar_assoc=scalar_assoc,
+            tcc_size=tcc_size,
+            tcc_assoc=tcc_assoc,
+            tcc_count=tcc_count,
+            cache_line_size=cache_line_size,
+        )
+
+        self.device.DeviceID = 0x75A0
+
+    def get_driver_command(self, debug: bool = False):
+        debug_commands = "dmesg -n8\nuname -r\nlspci -v\n" if debug else ""
+
+        driver_load_command = (
+            "export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH\n"
+            "export HSA_ENABLE_INTERRUPT=0\n"
+            "export HCC_AMDGPU_TARGET=gfx950\n"
+            f"{debug_commands}\n"
+            "dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128\n"
+            "if [ -e /usr/lib/firmware/amdgpu/mi350_discovery ]; then\n"
+            "    ln -s /usr/lib/firmware/amdgpu/mi350_discovery /usr/lib/firmware/amdgpu/ip_discovery.bin\n"
+            "else\n"
+            '    echo "ERROR: ROCm 7.0+ disk image required for MI355X. Exiting gem5."\n'
+            "    /sbin/m5 exit\n"
+            "fi\n"
             "if [ -f /home/gem5/load_amdgpu.sh ]; then\n"
             "    sh /home/gem5/load_amdgpu.sh\n"
             "elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then\n"

--- a/src/python/gem5/components/devices/gpus/viper_shader.py
+++ b/src/python/gem5/components/devices/gpus/viper_shader.py
@@ -43,6 +43,7 @@ from m5.objects import (
     HSAPacketProcessor,
     LdsState,
     PciLegacyIoBar,
+    PciMemBar,
     PM4PacketProcessor,
     RegisterFileCache,
     RegisterManager,
@@ -179,6 +180,7 @@ class ViperShader(Shader):
         num_cus: int,
         cache_line_size: int,
         device: AMDGPUDevice,
+        vram_size: int,
     ):
         """
         The shader defines something the represents a single software visible
@@ -233,6 +235,8 @@ class ViperShader(Shader):
         self.system_hub = AMDGPUSystemHub()
         self._cpu_dma_ports.append(self.system_hub.dma)
 
+        self._vram_size = vram_size
+
         self._setup_device(device)
 
     def get_compute_units(self):
@@ -281,6 +285,9 @@ class ViperShader(Shader):
             device.ExpansionROM = 0xD0000000 + (0x20000 * self._shader_id)
             bar4_addr = 0xF000 + (0x100 * self._shader_id)
             device.BAR4 = PciLegacyIoBar(addr=bar4_addr, size="256B")
+
+        # To enable large BAR access, BAR0 must equal VRAM size.
+        device.BAR0 = PciMemBar(size=f"{self._vram_size}B")
 
     def _create_pm4s(self, pm4_starts: List[int], pm4_ends: List[int]):
         """Create PM4 packet processors."""

--- a/src/python/gem5/components/devices/gpus/viper_shader.py
+++ b/src/python/gem5/components/devices/gpus/viper_shader.py
@@ -215,7 +215,7 @@ class ViperShader(Shader):
         self._create_tlbs(device)
 
         # This arbitrary address is something in the X86 I/O hole
-        hsapp_gpu_map_paddr = 0xE00000000
+        hsapp_gpu_map_paddr = 0xE00000000 + 0x1000 * shader_id
         self.dispatcher = GPUDispatcher()
         self.gpu_cmd_proc = GPUCommandProcessor(
             hsapp=HSAPacketProcessor(
@@ -288,6 +288,8 @@ class ViperShader(Shader):
 
         # To enable large BAR access, BAR0 must equal VRAM size.
         device.BAR0 = PciMemBar(size=f"{self._vram_size}B")
+
+        device.gpu_id = self._shader_id
 
     def _create_pm4s(self, pm4_starts: List[int], pm4_ends: List[int]):
         """Create PM4 packet processors."""


### PR DESCRIPTION
This is based on #2603 and will have to be rebased when that is merged.

- Allows for user specified GPU memory size. Previously this was hard coded to 16GiB and the user specified size in stdlib was ignored. This is more necessary for multiple GPU simulation to reduce memory required for a single simulation.
- Add support for additional GPU's ROM region. These read from the PCI ROM address instead of legacy x86 VGA ROM region. It works by copying the VBIOS from VGA region. Implicitly this means all GPUs must be the same model (i.e., all MI300X or all MI355X).
- Support for miscellaneous MMIOs only used when multiple GPUs are detected.

Example top level config snippet:

```
...
# HBM2Stack best available
gpu0 = MI355X(gpu_memory=HBM2Stack(size="4GiB"))
gpu1 = MI355X(gpu_memory=HBM2Stack(size="4GiB"))
gpu2 = MI355X(gpu_memory=HBM2Stack(size="4GiB"))
gpu3 = MI355X(gpu_memory=HBM2Stack(size="4GiB"))

board = ViperBoard(
    ...,
    gpus=[gpu0, gpu1, gpu2, gpu3],
)
...
```

Limitation: The GPUs cannot yet communicate device-to-device. XGMI support is needed for this.