### PR TITLE
mem: Remove deprecated port names in mem

### DIFF
--- a/src/mem/AddrMapper.py
+++ b/src/mem/AddrMapper.py
@@ -53,14 +53,8 @@ class AddrMapper(SimObject):
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
     )
-    master = DeprecatedParam(
-        mem_side_port, "`master` is now called `mem_side_port`"
-    )
     cpu_side_port = ResponsePort(
         "This port receives requests and sends responses"
-    )
-    slave = DeprecatedParam(
-        cpu_side_port, "`slave` is now called `cpu_side_port`"
     )
 
 

--- a/src/mem/Bridge.py
+++ b/src/mem/Bridge.py
@@ -49,14 +49,8 @@ class BridgeBase(ClockedObject):
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
     )
-    master = DeprecatedParam(
-        mem_side_port, "`master` is now called `mem_side_port`"
-    )
     cpu_side_port = ResponsePort(
         "This port receives requests and sends responses"
-    )
-    slave = DeprecatedParam(
-        cpu_side_port, "`slave` is now called `cpu_side_port`"
     )
 
     req_size = Param.Unsigned(16, "The number of requests to buffer")

--- a/src/mem/CommMonitor.py
+++ b/src/mem/CommMonitor.py
@@ -52,14 +52,8 @@ class CommMonitor(SimObject):
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
     )
-    master = DeprecatedParam(
-        mem_side_port, "`master` is now called `mem_side_port`"
-    )
     cpu_side_port = ResponsePort(
         "This port receives requests and sends responses"
-    )
-    slave = DeprecatedParam(
-        cpu_side_port, "`slave` is now called `cpu_side_port`"
     )
 
     # control the sample period window length of this monitor

--- a/src/mem/MemChecker.py
+++ b/src/mem/MemChecker.py
@@ -53,14 +53,8 @@ class MemCheckerMonitor(SimObject):
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
     )
-    master = DeprecatedParam(
-        mem_side_port, "`master` is now called `mem_side_port`"
-    )
     cpu_side_port = ResponsePort(
         "This port receives requests and sends responses"
-    )
-    slave = DeprecatedParam(
-        cpu_side_port, "`slave` is now called `cpu_side_port`"
     )
     warn_only = Param.Bool(False, "Warn about violations only")
     memchecker = Param.MemChecker("Instance shared with other monitors")

--- a/src/mem/MemDelay.py
+++ b/src/mem/MemDelay.py
@@ -46,14 +46,8 @@ class MemDelay(ClockedObject):
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
     )
-    master = DeprecatedParam(
-        mem_side_port, "`master` is now called `mem_side_port`"
-    )
     cpu_side_port = ResponsePort(
         "This port receives requests and sends responses"
-    )
-    slave = DeprecatedParam(
-        cpu_side_port, "`slave` is now called `cpu_side_port`"
     )
 
 

--- a/src/mem/SerialLink.py
+++ b/src/mem/SerialLink.py
@@ -52,14 +52,8 @@ class SerialLink(ClockedObject):
     mem_side_port = RequestPort(
         "This port sends requests and receives responses"
     )
-    master = DeprecatedParam(
-        mem_side_port, "`master` is now called `mem_side_port`"
-    )
     cpu_side_port = ResponsePort(
         "This port receives requests and sends responses"
-    )
-    slave = DeprecatedParam(
-        cpu_side_port, "`slave` is now called `cpu_side_port`"
     )
     req_size = Param.Unsigned(16, "The number of requests to buffer")
     resp_size = Param.Unsigned(16, "The number of responses to buffer")

--- a/src/mem/XBar.py
+++ b/src/mem/XBar.py
@@ -52,14 +52,8 @@ class BaseXBar(ClockedObject):
     cpu_side_ports = VectorResponsePort(
         "Vector port for connecting mem side ports"
     )
-    slave = DeprecatedParam(
-        cpu_side_ports, "`slave` is now called `cpu_side_ports`"
-    )
     mem_side_ports = VectorRequestPort(
         "Vector port for connecting cpu side ports"
-    )
-    master = DeprecatedParam(
-        mem_side_ports, "`master` is now called `mem_side_ports`"
     )
 
     # Latencies governing the time taken for the variuos paths a

--- a/src/mem/qos/QoSMemCtrl.py
+++ b/src/mem/qos/QoSMemCtrl.py
@@ -90,6 +90,3 @@ class QoSMemCtrl(ClockedObject):
         [""] * 16,
         "Requestor Names to be mapped to service parameters in QoS scheduler",
     )
-    qos_masters = DeprecatedParam(
-        qos_requestors, "`qos_master` is now called `qos_requestors`"
-    )

--- a/src/mem/ruby/network/MessageBuffer.py
+++ b/src/mem/ruby/network/MessageBuffer.py
@@ -73,9 +73,7 @@ class MessageBuffer(SimObject):
     )
 
     out_port = RequestPort("Request port to MessageBuffer receiver")
-    master = DeprecatedParam(out_port, "`master` is now called `out_port`")
     in_port = ResponsePort("Response port from MessageBuffer sender")
-    slave = DeprecatedParam(in_port, "`slave` is now called `in_port`")
     max_dequeue_rate = Param.Unsigned(
         0,
         "Maximum number of messages that can \

--- a/src/mem/ruby/network/Network.py
+++ b/src/mem/ruby/network/Network.py
@@ -56,9 +56,7 @@ class RubyNetwork(ClockedObject):
     int_links = VectorParam.BasicIntLink("Links between internal nodes")
 
     in_port = VectorResponsePort("CPU input port")
-    slave = DeprecatedParam(in_port, "`slave` is now called `in_port`")
     out_port = VectorRequestPort("CPU output port")
-    master = DeprecatedParam(out_port, "`master` is now called `out_port`")
 
     data_msg_size = Param.Int(
         Parent.block_size_bytes,

--- a/src/mem/ruby/system/Sequencer.py
+++ b/src/mem/ruby/system/Sequencer.py
@@ -56,30 +56,17 @@ class RubyPort(ClockedObject):
         "has multiple ports (e.g., I/D ports) all of the ports for a "
         "single CPU can connect to one RubyPort."
     )
-    slave = DeprecatedParam(in_ports, "`slave` is now called `in_ports`")
 
     interrupt_out_port = VectorRequestPort(
         "Port to connect to x86 interrupt "
         "controller to send the CPU requests from outside."
     )
-    master = DeprecatedParam(
-        interrupt_out_port, "`master` is now called `interrupt_out_port`"
-    )
 
     pio_request_port = RequestPort("Ruby pio request port")
-    pio_master_port = DeprecatedParam(
-        pio_request_port, "`pio_master_port` is now called `pio_request_port`"
-    )
 
     mem_request_port = RequestPort("Ruby mem request port")
-    mem_master_port = DeprecatedParam(
-        mem_request_port, "`mem_master_port` is now called `mem_request_port`"
-    )
 
     pio_response_port = ResponsePort("Ruby pio response port")
-    pio_slave_port = DeprecatedParam(
-        pio_response_port, "`pio_slave_port` is now called `pio_response_port`"
-    )
 
     using_ruby_tester = Param.Bool(False, "")
     no_retry_on_stall = Param.Bool(False, "")


### PR DESCRIPTION
We tagged them as deprecated quite some time ago.
Pretty confident we can get rid of them


Change-Id: I6f1f6f760fd6719d09ec01d83dd449076d1af78a