### PR TITLE
configs: Fix ruby_fs.py platform after PCI change

### DIFF
--- a/configs/example/arm/devices.py
+++ b/configs/example/arm/devices.py
@@ -521,11 +521,5 @@ class ArmRubySystem(BaseSimpleSystem):
 
         self.realview.attachIO(self.iobus, dma_ports=self._dma_ports)
 
-        for cluster in self._clusters:
-            for i, cpu in enumerate(cluster.cpus):
-                self.ruby._cpu_ports[i].connectCpuPorts(cpu)
-
     def attach_pci(self, dev):
-        self.realview.attachPciDevice(
-            dev, self.iobus, dma_ports=self._dma_ports
-        )
+        self.realview.attachPciDevice(dev)

--- a/configs/example/arm/ruby_fs.py
+++ b/configs/example/arm/ruby_fs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2017, 2020-2022 Arm Limited
+# Copyright (c) 2016-2017, 2020-2022, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -99,6 +99,11 @@ def config_ruby(system, args):
         clock=args.ruby_clock, voltage_domain=system.voltage_domain
     )
 
+    # Connect the sequencer ports to the CPU
+    for cluster in system.cpu_cluster:
+        for i, cpu in enumerate(cluster.cpus):
+            system.ruby._cpu_ports[i].connectCpuPorts(cpu)
+
 
 def create(args):
     """Create and configure the system object."""
@@ -148,10 +153,12 @@ def create(args):
     for dev in system.pci_devices:
         system.attach_pci(dev)
 
-    config_ruby(system, args)
-
     # Wire up the system's memory system
     system.connect()
+
+    # Generate a ruby system. This has to happen after connection
+    # so that we have extracted the dma ports
+    config_ruby(system, args)
 
     # Setup gem5's minimal Linux boot loader.
     system.realview.setupBootLoader(system, SysPaths.binary)


### PR DESCRIPTION
A recent PR changed they way PCI DMA devices are connected with ruby. As their DMA port is now connected to the PCI bridge, there is no reason for saving their DMA port when connecting things. In fact the only DMA device interfacing with ruby will be the PCI-HOST bridge.


Change-Id: I9e62172e79c94683020ce3194e07929000867e47