### PR TITLE
stdlib: Fix binding of table walker port

### DIFF
--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_cache_hierarchy.py
@@ -167,7 +167,8 @@ class PrivateL1PrivateL2CacheHierarchy(
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
         cpu.connect_walker_ports(
-            self.membus.cpu_side_ports, self.membus.cpu_side_ports
+            self.l2buses[cpu_id].cpu_side_ports,
+            self.l2buses[cpu_id].cpu_side_ports,
         )
 
     def _setup_io_cache(self, board: AbstractBoard) -> None:


### PR DESCRIPTION
The table walker is incorrectly connected to the membus, completely skipping the L2 cache. It should really be connected to the l2bus instead.

This is not a problem arising in PTW cache capable hierarchies, as the PTW cache is connected downstream to the l2bus


Change-Id: Ibedbc4f4e1c2486d71cad91ebb3963582a5c64cb