### PR TITLE
arch-arm: Add missing break in decoder

### DIFF
--- a/src/arch/arm/isa/formats/sve_2nd_level.isa
+++ b/src/arch/arm/isa/formats/sve_2nd_level.isa
@@ -2485,6 +2485,7 @@ namespace Aarch64
                     default:
                         break;
                 }
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
My compiler complained about this missing breakpoint in the decoder
switch/case.

Signed-off-by: Jason Lowe-Power <jlowepower@google.com>