### PR TITLE
tests: fix failing FIFO RP daily tests

### DIFF
--- a/src/mem/cache/replacement_policies/fifo_rp.test.cc
+++ b/src/mem/cache/replacement_policies/fifo_rp.test.cc
@@ -218,6 +218,10 @@ TEST_F(FIFORPFDeathTest, ResetNull)
 
 TEST_F(FIFORPFDeathTest, TouchNull)
 {
+#ifdef NDEBUG
+    GTEST_SKIP() << "Skipping as assertions are "
+                    "stripped out of fast builds";
+#endif
     ASSERT_DEATH(rp->touch(nullptr), "");
 }
 


### PR DESCRIPTION
The unittests-fast-debug (fast) tests in the daily tests are failing due to the FIFO replacement policy TouchNull death test. The assert that is supposed to be thrown in the test doesn't occur, as the gem5.fast build optimizes out assertions. This commit makes it so that the test is skipped on fast builds.