### PR TITLE
stdlib: Support generation of multiple directories in CHI

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
@@ -72,7 +72,7 @@ class BaseDirectory(AbstractNode):
         dir_idx: int,
         mem_ranges: List[AddrRange],
         cache_line_size,
-    ):
+    ) -> List[AddrRange]:
         block_size_bits = int(math.log(cache_line_size, 2))
         llc_bits = int(math.log(num_directories, 2))
         numa_bit = block_size_bits + llc_bits - 1

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2021-2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2021 The Regents of the University of California
 # All Rights Reserved.
 #
@@ -24,17 +36,61 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import math
+from typing import List
+
 from m5.objects import (
     NULL,
     ClockDomain,
     RubyCache,
     RubyNetwork,
 )
+from m5.params import (
+    AddrRange,
+)
 
 from .abstract_node import AbstractNode
 
 
-class SimpleDirectory(AbstractNode):
+class BaseDirectory(AbstractNode):
+    """
+    BaseDirectory. Mainly providing address range generation
+    capabilities (see create_addr_ranges method)
+    """
+
+    def __init__(
+        self,
+        network: RubyNetwork,
+        cache_line_size: int,
+    ):
+        super().__init__(network, cache_line_size)
+
+    @classmethod
+    def create_addr_ranges(
+        cls,
+        num_directories: int,
+        dir_idx: int,
+        mem_ranges: List[AddrRange],
+        cache_line_size,
+    ):
+        block_size_bits = int(math.log(cache_line_size, 2))
+        llc_bits = int(math.log(num_directories, 2))
+        numa_bit = block_size_bits + llc_bits - 1
+
+        ranges = []
+        for r in mem_ranges:
+            addr_range = AddrRange(
+                r.start,
+                size=r.size(),
+                intlvHighBit=numa_bit,
+                intlvBits=llc_bits,
+                intlvMatch=dir_idx,
+            )
+            ranges.append(addr_range)
+        return ranges
+
+
+class SimpleDirectory(BaseDirectory):
     """A directory or home node (HNF)
 
     This simple directory has no cache. It forwards all requests as directly
@@ -46,6 +102,7 @@ class SimpleDirectory(AbstractNode):
         network: RubyNetwork,
         cache_line_size: int,
         clk_domain: ClockDomain,
+        addr_ranges: List[AddrRange],
     ):
         super().__init__(network, cache_line_size)
 
@@ -54,6 +111,7 @@ class SimpleDirectory(AbstractNode):
             dataAccessLatency=0, tagAccessLatency=1, size="128", assoc=1
         )
 
+        self.addr_ranges = addr_ranges
         self.clk_domain = clk_domain
 
         # Only used for L1 controllers

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
@@ -34,6 +34,7 @@ from m5.objects import (
     RubySystem,
 )
 from m5.objects.SubSystem import SubSystem
+from m5.params import AllMemory
 
 from gem5.coherence_protocol import CoherenceProtocol
 from gem5.utils.requires import requires
@@ -102,6 +103,7 @@ class PrivateL1CacheHierarchy(AbstractRubyCacheHierarchy):
             self.ruby_system.network,
             cache_line_size=board.get_cache_line_size(),
             clk_domain=board.get_clock_domain(),
+            addr_ranges=[AllMemory],
         )
         self.directory.ruby_system = self.ruby_system
 

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_cache_hierarchy.py
@@ -46,6 +46,7 @@ from m5.objects import (
     RubySystem,
 )
 from m5.objects.SubSystem import SubSystem
+from m5.params import AllMemory
 
 from gem5.coherence_protocol import CoherenceProtocol
 from gem5.utils.requires import requires
@@ -139,6 +140,7 @@ class PrivateL1PrivateL2CacheHierarchy(
             self.ruby_system.network,
             cache_line_size=board.get_cache_line_size(),
             clk_domain=board.get_clock_domain(),
+            addr_ranges=[AllMemory],
         )
         self.directory.ruby_system = self.ruby_system
 


### PR DESCRIPTION
Up until this point stdlib was only supporting a single directory system (with no cache), therefore it didn't require to be passed a list of address ranges, relying on the default Param value (set to the AllMemory alias :from 0 to MaxAddr) [1]

If we want to support multiple directories hierarchies, we need to provide address ranges so that a request gets dispatched to the proper directory

We add a classmethod, taken from the ruby CHI_config.py example [2] and we adapt it to stdlib

[1]: https://github.com/gem5/gem5/blob/stable/\
    src/mem/ruby/slicc_interface/Controller.py#L51
[2]: https://github.com/gem5/gem5/blob/stable/\
    configs/ruby/CHI_config.py#L636


Change-Id: I24341926da3a950554c2251bc74fff001d69fd7b