### PR TITLE
arch-arm, stdlib: Rework the PTW to support a configurable number of outstanding TW

### DIFF
--- a/src/arch/arm/ArmMMU.py
+++ b/src/arch/arm/ArmMMU.py
@@ -1,6 +1,6 @@
 # -*- mode:python -*-
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2021, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -41,30 +41,55 @@ from m5.objects.ArmTLB import (
     ArmTLB,
 )
 from m5.objects.BaseMMU import BaseMMU
+from m5.objects.BaseTLB import TypeTLB
 from m5.objects.ClockedObject import ClockedObject
 from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
 
 
-# Basic stage 1 translation objects
+class ArmWalkUnit(ClockedObject):
+    type = "ArmWalkUnit"
+    cxx_class = "gem5::ArmISA::WalkUnit"
+    cxx_header = "arch/arm/table_walker.hh"
+    walk_type = Param.TypeTLB("instruction/data/unified walk")
+    functional = Param.Bool(
+        False, "Is this object for functional translation?"
+    )
+    is_stage2 = Param.Bool(False, "Is this object for stage 2 translation?")
+
+    sys = Param.System(Parent.any, "system object parameter")
+
+
 class ArmTableWalker(ClockedObject):
     type = "ArmTableWalker"
     cxx_class = "gem5::ArmISA::TableWalker"
     cxx_header = "arch/arm/table_walker.hh"
-    is_stage2 = Param.Bool(False, "Is this object for stage 2 translation?")
-    num_squash_per_cycle = Param.Unsigned(
-        2, "Number of outstanding walks that can be squashed per cycle"
-    )
 
     port = RequestPort("Table Walker port")
 
     sys = Param.System(Parent.any, "system object parameter")
 
-
-# Stage 2 translation objects, only used when virtualisation is being used
-class ArmStage2TableWalker(ArmTableWalker):
-    is_stage2 = True
+    itb_walker = Param.ArmWalkUnit(
+        ArmWalkUnit(walk_type="instruction"), "HW Table walker"
+    )
+    dtb_walker = Param.ArmWalkUnit(
+        ArmWalkUnit(walk_type="data"), "HW Table walker"
+    )
+    stage2_itb_walker = Param.ArmWalkUnit(
+        ArmWalkUnit(walk_type="instruction", is_stage2=True), "HW Table walker"
+    )
+    stage2_dtb_walker = Param.ArmWalkUnit(
+        ArmWalkUnit(walk_type="data", is_stage2=True), "HW Table walker"
+    )
+    walk_unit_func_s1 = Param.ArmWalkUnit(
+        ArmWalkUnit(walk_type="unified", functional=True),
+        "Walk Unit to be used for S1 functional walks",
+    )
+    walk_unit_func_s2 = Param.ArmWalkUnit(
+        ArmWalkUnit(walk_type="unified", functional=True, is_stage2=True),
+        "Walk Unit to be used for S2 functional walks",
+    )
 
 
 class ArmMMU(BaseMMU):
@@ -88,15 +113,7 @@ class ArmMMU(BaseMMU):
         ArmStage2TLB(entry_type="data"), "Stage 2 Data TLB"
     )
 
-    itb_walker = Param.ArmTableWalker(ArmTableWalker(), "HW Table walker")
-    dtb_walker = Param.ArmTableWalker(ArmTableWalker(), "HW Table walker")
-
-    stage2_itb_walker = Param.ArmTableWalker(
-        ArmStage2TableWalker(), "HW Table walker"
-    )
-    stage2_dtb_walker = Param.ArmTableWalker(
-        ArmStage2TableWalker(), "HW Table walker"
-    )
+    walker = Param.ArmTableWalker(ArmTableWalker(), "HW Table walker")
 
     sys = Param.System(Parent.any, "system object parameter")
 
@@ -107,15 +124,7 @@ class ArmMMU(BaseMMU):
 
     @classmethod
     def walkerPorts(cls):
-        return [
-            "mmu.itb_walker.port",
-            "mmu.dtb_walker.port",
-            "mmu.stage2_itb_walker.port",
-            "mmu.stage2_dtb_walker.port",
-        ]
+        return ["mmu.walker.port"]
 
     def connectWalkerPorts(self, iport, dport):
-        self.itb_walker.port = iport
-        self.dtb_walker.port = dport
-        self.stage2_itb_walker.port = iport
-        self.stage2_dtb_walker.port = dport
+        self.walker.port = dport

--- a/src/arch/arm/ArmMMU.py
+++ b/src/arch/arm/ArmMMU.py
@@ -70,17 +70,14 @@ class ArmTableWalker(ClockedObject):
 
     sys = Param.System(Parent.any, "system object parameter")
 
-    itb_walker = Param.ArmWalkUnit(
-        ArmWalkUnit(walk_type="instruction"), "HW Table walker"
-    )
-    dtb_walker = Param.ArmWalkUnit(
-        ArmWalkUnit(walk_type="data"), "HW Table walker"
-    )
-    stage2_itb_walker = Param.ArmWalkUnit(
-        ArmWalkUnit(walk_type="instruction", is_stage2=True), "HW Table walker"
-    )
-    stage2_dtb_walker = Param.ArmWalkUnit(
-        ArmWalkUnit(walk_type="data", is_stage2=True), "HW Table walker"
+    walk_units = VectorParam.ArmWalkUnit(
+        [
+            ArmWalkUnit(walk_type="instruction"),
+            ArmWalkUnit(walk_type="data"),
+            ArmWalkUnit(walk_type="instruction", is_stage2=True),
+            ArmWalkUnit(walk_type="data", is_stage2=True),
+        ],
+        "Walk Units",
     )
     walk_unit_func_s1 = Param.ArmWalkUnit(
         ArmWalkUnit(walk_type="unified", functional=True),

--- a/src/arch/arm/ArmMMU.py
+++ b/src/arch/arm/ArmMMU.py
@@ -74,8 +74,12 @@ class ArmTableWalker(ClockedObject):
         [
             ArmWalkUnit(walk_type="instruction"),
             ArmWalkUnit(walk_type="data"),
+            ArmWalkUnit(walk_type="unified"),
+            ArmWalkUnit(walk_type="unified"),
             ArmWalkUnit(walk_type="instruction", is_stage2=True),
             ArmWalkUnit(walk_type="data", is_stage2=True),
+            ArmWalkUnit(walk_type="unified", is_stage2=True),
+            ArmWalkUnit(walk_type="unified", is_stage2=True),
         ],
         "Walk Units",
     )

--- a/src/arch/arm/SConscript
+++ b/src/arch/arm/SConscript
@@ -1,6 +1,6 @@
 # -*- mode:python -*-
 
-# Copyright (c) 2009, 2012-2013, 2017-2018, 2020, 2024 Arm Limited
+# Copyright (c) 2009, 2012-2013, 2017-2018, 2020, 2024-2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -143,10 +143,9 @@ SimObject(
     tags=['arm isa'],
 )
 SimObject(
-    "ArmMMU.py",
-    sim_objects=["ArmTableWalker", "ArmMMU"],
-    tags=['arm isa']
-)
+    'ArmMMU.py',
+    sim_objects=['ArmTableWalker', 'ArmWalkUnit', 'ArmMMU'],
+    tags='arm isa')
 SimObject(
     "ArmNativeTrace.py",
     sim_objects=["ArmNativeTrace"],

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -161,8 +161,8 @@ MMU::getTlb(BaseMMU::Mode mode, bool stage2) const
     }
 }
 
-bool
-MMU::translateFunctional(ThreadContext *tc, Addr va, Addr &pa)
+TlbEntry *
+MMU::translateFunctional(ThreadContext *tc, Addr va)
 {
     CachedState& state = updateMiscReg(tc, NormalTran, false);
 
@@ -179,12 +179,18 @@ MMU::translateFunctional(ThreadContext *tc, Addr va, Addr &pa)
     lookup_data.targetRegime = state.currRegime;
     lookup_data.mode = BaseMMU::Read;
 
-    TlbEntry *e = tlb->multiLookup(lookup_data);
+    return tlb->multiLookup(lookup_data);
+}
 
-    if (!e)
+bool
+MMU::translateFunctional(ThreadContext *tc, Addr va, Addr &pa)
+{
+    if (TlbEntry *e = translateFunctional(tc, va); !e) {
         return false;
-    pa = e->pAddr(va);
-    return true;
+    } else {
+        pa = e->pAddr(va);
+        return true;
+    }
 }
 
 void

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -59,18 +59,18 @@ namespace gem5
 using namespace ArmISA;
 
 MMU::MMU(const ArmMMUParams &p)
-  : BaseMMU(p),
-    itbStage2(p.stage2_itb), dtbStage2(p.stage2_dtb),
-    itbWalker(p.itb_walker), dtbWalker(p.dtb_walker),
-    itbStage2Walker(p.stage2_itb_walker),
-    dtbStage2Walker(p.stage2_dtb_walker),
-    test(nullptr),
-    miscRegContext(0),
-    s1State(this, false), s2State(this, true),
-    _attr(0),
-    _release(nullptr),
-    _hasWalkCache(false),
-    stats(this)
+    : BaseMMU(p),
+      itbStage2(p.stage2_itb),
+      dtbStage2(p.stage2_dtb),
+      walker(p.walker),
+      test(nullptr),
+      miscRegContext(0),
+      s1State(this, false),
+      s2State(this, true),
+      _attr(0),
+      _release(nullptr),
+      _hasWalkCache(false),
+      stats(this)
 {
     // Cache system-level properties
     if (FullSystem) {
@@ -93,16 +93,14 @@ MMU::MMU(const ArmMMUParams &p)
 void
 MMU::init()
 {
-    itbWalker->setMmu(this);
-    dtbWalker->setMmu(this);
-    itbStage2Walker->setMmu(this);
-    dtbStage2Walker->setMmu(this);
+    walker->setMmu(this);
 
-    itbStage2->setTableWalker(itbStage2Walker);
-    dtbStage2->setTableWalker(dtbStage2Walker);
+    itbStage2->setTableWalker(walker);
+    dtbStage2->setTableWalker(walker);
+    getITBPtr()->setTableWalker(walker);
+    getDTBPtr()->setTableWalker(walker);
 
-    getITBPtr()->setTableWalker(itbWalker);
-    getDTBPtr()->setTableWalker(dtbWalker);
+    getDTBPtr()->setTableWalker(walker, true);
 
     BaseMMU::init();
 
@@ -160,22 +158,6 @@ MMU::getTlb(BaseMMU::Mode mode, bool stage2) const
             return dtbStage2;
         else
             return getDTBPtr();
-    }
-}
-
-TableWalker *
-MMU::getTableWalker(BaseMMU::Mode mode, bool stage2) const
-{
-    if (mode == BaseMMU::Execute) {
-        if (stage2)
-            return itbStage2Walker;
-        else
-            return itbWalker;
-    } else {
-        if (stage2)
-            return dtbStage2Walker;
-        else
-            return dtbWalker;
     }
 }
 
@@ -1691,10 +1673,10 @@ MMU::getTE(TlbEntry **te, const RequestPtr &req, ThreadContext *tc, Mode mode,
                 vaddr_tainted, state.asid, state.vmid);
 
         Fault fault;
-        fault = getTableWalker(mode, state.isStage2)->walk(
-            req, tc, state.asid, state.vmid, mode,
-            translation, timing, functional, ss,
-            ipaspace, tran_type, state.stage2DescReq, *te);
+        fault =
+            walker->walk(req, tc, state.asid, state.vmid, mode, translation,
+                         timing, functional, ss, ipaspace, tran_type,
+                         state.stage2DescReq, state.isStage2, *te);
 
         // for timing mode, return and wait for table walk,
         if (timing || fault != NoFault) {
@@ -1796,15 +1778,24 @@ MMU::isCompleteTranslation(TlbEntry *entry) const
 void
 MMU::takeOverFrom(BaseMMU *old_mmu)
 {
-    BaseMMU::takeOverFrom(old_mmu);
-
     auto *ommu = dynamic_cast<MMU*>(old_mmu);
     assert(ommu);
+
+    Port *old_tbw_port = ommu->getTableWalkerPort();
+    Port *new_tbw_port = getTableWalkerPort();
+
+    new_tbw_port->takeOverFrom(old_tbw_port);
 
     _attr = ommu->_attr;
 
     s1State = ommu->s1State;
     s2State = ommu->s2State;
+}
+
+Port *
+MMU::getTableWalkerPort()
+{
+    return &walker->getTableWalkerPort();
 }
 
 void
@@ -1816,10 +1807,7 @@ MMU::setTestInterface(SimObject *_ti)
         TlbTestInterface *ti(dynamic_cast<TlbTestInterface *>(_ti));
         fatal_if(!ti, "%s is not a valid ARM TLB tester\n", _ti->name());
         test = ti;
-        itbWalker->setTestInterface(test);
-        dtbWalker->setTestInterface(test);
-        itbStage2Walker->setTestInterface(test);
-        dtbStage2Walker->setTestInterface(test);
+        walker->setTestInterface(ti);
     }
 }
 

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2016-2024 Arm Limited
+ * Copyright (c) 2010-2013, 2016-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1639,6 +1639,13 @@ MMU::lookup(Addr va, uint16_t asid, vmid_t vmid, SecurityState ss,
     lookup_data.mode = mode;
 
     return tlb->multiLookup(lookup_data);
+}
+
+void
+MMU::insert(TlbEntry &entry, BaseMMU::Mode mode, bool stage2)
+{
+    TLB *tlb = getTlb(mode, stage2);
+    tlb->multiInsert(TlbEntry::KeyType(entry), entry);
 }
 
 Fault

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -228,6 +228,8 @@ class MMU : public BaseMMU
      */
     bool translateFunctional(ThreadContext *tc, Addr vaddr, Addr &paddr);
 
+    TlbEntry *translateFunctional(ThreadContext *tc, Addr vaddr);
+
     Fault translateFunctional(const RequestPtr &req, ThreadContext *tc,
         BaseMMU::Mode mode) override;
 

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -70,17 +70,13 @@ class MMU : public BaseMMU
     ArmISA::TLB * getDTBPtr() const;
     ArmISA::TLB * getITBPtr() const;
 
-    TLB * getTlb(BaseMMU::Mode mode, bool stage2) const;
-    TableWalker * getTableWalker(BaseMMU::Mode mode, bool stage2) const;
+    TLB *getTlb(BaseMMU::Mode mode, bool stage2) const;
 
   protected:
     TLB *itbStage2;
     TLB *dtbStage2;
 
-    TableWalker *itbWalker;
-    TableWalker *dtbWalker;
-    TableWalker *itbStage2Walker;
-    TableWalker *dtbStage2Walker;
+    TableWalker *walker;
 
   public:
     TranslationGenPtr
@@ -301,6 +297,8 @@ class MMU : public BaseMMU
 
     void takeOverFrom(BaseMMU *old_mmu) override;
 
+    Port *getTableWalkerPort();
+
     void invalidateMiscReg();
 
     void flush(const TLBIOp &tlbi_op);
@@ -376,6 +374,8 @@ class MMU : public BaseMMU
                       bool functional, TlbEntry *mergeTe,
                       CachedState &state);
 
+    bool isCompleteTranslation(TlbEntry *te) const;
+
     Fault checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
                            bool stage2);
     Fault checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
@@ -415,8 +415,6 @@ class MMU : public BaseMMU
 
   protected:
     bool checkWalkCache() const;
-
-    bool isCompleteTranslation(TlbEntry *te) const;
 
     CachedState& updateMiscReg(
         ThreadContext *tc, ArmTranslationType tran_type,

--- a/src/arch/arm/mmu.hh
+++ b/src/arch/arm/mmu.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2016, 2019-2024 Arm Limited
+ * Copyright (c) 2010-2013, 2016, 2019-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -354,6 +354,8 @@ class MMU : public BaseMMU
                      SecurityState ss, bool functional,
                      bool ignore_asn, TranslationRegime target_regime,
                      bool stage2, BaseMMU::Mode mode);
+
+    void insert(TlbEntry &pte, BaseMMU::Mode mode, bool stage2);
 
     Fault getTE(TlbEntry **te, const RequestPtr &req,
                 ThreadContext *tc, Mode mode,

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -83,8 +83,6 @@ TableWalker::TableWalker(const Params &p)
       doProcessEvent([this]{ processWalkWrapper(); }, name()),
       test(nullptr)
 {
-    sctlr = 0;
-
     // Cache system-level properties
     if (FullSystem) {
         ArmSystem *arm_sys = dynamic_cast<ArmSystem *>(p.sys);
@@ -424,8 +422,6 @@ TableWalker::walk(const RequestPtr &_req, ThreadContext *_tc, uint16_t _asid,
         currState->hcr   = currState->tc->readMiscReg(MISCREG_HCR);
         currState->vtcr  = currState->tc->readMiscReg(MISCREG_VTCR);
     }
-    sctlr = currState->sctlr;
-
     currState->isFetch = (currState->mode == BaseMMU::Execute);
     currState->isWrite = (currState->mode == BaseMMU::Write);
 

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -54,6 +54,7 @@
 #include "debug/TLB.hh"
 #include "debug/TLBVerbose.hh"
 #include "params/ArmTableWalker.hh"
+#include "params/ArmWalkUnit.hh"
 #include "sim/system.hh"
 
 namespace gem5
@@ -63,26 +64,31 @@ using namespace ArmISA;
 
 TableWalker::TableWalker(const Params &p)
     : ClockedObject(p),
+      mmu(nullptr),
+      itbWalker(p.itb_walker),
+      dtbWalker(p.dtb_walker),
+      itbStage2Walker(p.stage2_itb_walker),
+      dtbStage2Walker(p.stage2_dtb_walker),
+      walkUnitFunctionalS1(p.walk_unit_func_s1),
+      walkUnitFunctionalS2(p.walk_unit_func_s2),
       requestorId(p.sys->getRequestorId(this)),
-      port(new Port(*this)),
-      isStage2(p.is_stage2), tlb(NULL),
-      currState(NULL), pending(false),
-      numSquashable(p.num_squash_per_cycle),
-      release(nullptr),
-      stats(this),
-      pendingReqs(0),
-      pendingChangeTick(curTick()),
-      doL1DescEvent([this]{ doL1DescriptorWrapper(); }, name()),
-      doL2DescEvent([this]{ doL2DescriptorWrapper(); }, name()),
-      doL0LongDescEvent([this]{ doL0LongDescriptorWrapper(); }, name()),
-      doL1LongDescEvent([this]{ doL1LongDescriptorWrapper(); }, name()),
-      doL2LongDescEvent([this]{ doL2LongDescriptorWrapper(); }, name()),
-      doL3LongDescEvent([this]{ doL3LongDescriptorWrapper(); }, name()),
-      LongDescEventByLevel { &doL0LongDescEvent, &doL1LongDescEvent,
-                             &doL2LongDescEvent, &doL3LongDescEvent },
-      doProcessEvent([this]{ processWalkWrapper(); }, name()),
-      test(nullptr)
+      port(new Port(*this, requestorId)),
+      stats(this)
 {
+    itbWalker->setPort(port);
+    dtbWalker->setPort(port);
+    itbStage2Walker->setPort(port);
+    dtbStage2Walker->setPort(port);
+    walkUnitFunctionalS1->setPort(port);
+    walkUnitFunctionalS2->setPort(port);
+
+    itbWalker->setTableWalker(this);
+    dtbWalker->setTableWalker(this);
+    itbStage2Walker->setTableWalker(this);
+    dtbStage2Walker->setTableWalker(this);
+    walkUnitFunctionalS1->setTableWalker(this);
+    walkUnitFunctionalS2->setTableWalker(this);
+
     // Cache system-level properties
     if (FullSystem) {
         ArmSystem *arm_sys = dynamic_cast<ArmSystem *>(p.sys);
@@ -93,12 +99,386 @@ TableWalker::TableWalker(const Params &p)
         _haveLargeAsid64 = false;
         _physAddrRange = 48;
     }
-
 }
 
-TableWalker::~TableWalker()
+void
+TableWalker::setMmu(MMU *_mmu)
 {
-    ;
+    mmu = _mmu;
+    itbWalker->setMmu(mmu);
+    dtbWalker->setMmu(mmu);
+    itbStage2Walker->setMmu(mmu);
+    dtbStage2Walker->setMmu(mmu);
+    walkUnitFunctionalS1->setMmu(mmu);
+    walkUnitFunctionalS2->setMmu(mmu);
+}
+
+WalkUnit *
+TableWalker::getWalkUnit(BaseMMU::Mode mode, bool stage2) const
+{
+    if (mode == BaseMMU::Execute) {
+        if (stage2) {
+            return itbStage2Walker;
+        } else {
+            return itbWalker;
+        }
+    } else {
+        if (stage2) {
+            return dtbStage2Walker;
+        } else {
+            return dtbWalker;
+        }
+    }
+}
+
+TypeTLB
+TableWalker::modeToType(BaseMMU::Mode mode) const
+{
+    return mode == BaseMMU::Execute ? TypeTLB::instruction : TypeTLB::data;
+}
+
+WalkUnit *
+TableWalker::getAvailableWalk(BaseMMU::Mode mode, bool stage2,
+                              bool functional) const
+{
+    if (functional) {
+        return stage2 ? walkUnitFunctionalS2 : walkUnitFunctionalS1;
+    }
+
+    if (auto walk_unit = getWalkUnit(mode, stage2); walk_unit->isAvailable()) {
+        return walk_unit;
+    } else {
+        return nullptr;
+    }
+}
+
+Fault
+TableWalker::walk(const RequestPtr &req, ThreadContext *tc, uint16_t asid,
+                  vmid_t vmid, BaseMMU::Mode mode, BaseMMU::Translation *trans,
+                  bool timing, bool functional, SecurityState ss,
+                  PASpace ipaspace, MMU::ArmTranslationType tran_type,
+                  bool stage2_req, bool stage2, const TlbEntry *walk_entry)
+{
+    assert(!(functional && timing));
+
+    for (auto it = inCompletionWalks.rbegin(); it != inCompletionWalks.rend();
+         ++it) {
+
+        if ((*it)->vaddr_tainted == req->getVaddr() &&
+            (*it)->isStage2 == stage2) {
+            ++stats.squashedBefore;
+            return std::make_shared<ReExec>();
+        }
+    }
+
+    if (mode == BaseMMU::Execute) {
+        if (!stage2) {
+            ++stats.instructionWalksS1;
+        } else {
+            ++stats.instructionWalksS2;
+        }
+    } else {
+        if (!stage2) {
+            ++stats.dataWalksS1;
+        } else {
+            ++stats.dataWalksS2;
+        }
+    }
+
+    DPRINTF(PageTableWalker, "creating new instance of WalkerState\n");
+    WalkerState *curr_state = new WalkerState();
+    curr_state->tableWalker = this;
+    curr_state->startTime = curTick();
+    curr_state->tc = tc;
+    curr_state->isStage2 = stage2;
+    curr_state->el =
+        MMU::tranTypeEL(tc->readMiscReg(MISCREG_CPSR),
+                        tc->readMiscReg(MISCREG_SCR_EL3), tran_type);
+
+    if (stage2) {
+        curr_state->regime = TranslationRegime::EL10;
+        curr_state->aarch64 = ELIs64(tc, EL2);
+        curr_state->ipaSpace = ipaspace;
+    } else {
+        curr_state->regime = translationRegime(tc, curr_state->el);
+        curr_state->aarch64 = ELIs64(tc, translationEl(curr_state->regime));
+    }
+    curr_state->transState = trans;
+    curr_state->req = req;
+    if (walk_entry) {
+        curr_state->walkEntry = *walk_entry;
+    } else {
+        curr_state->walkEntry = TlbEntry();
+    }
+    curr_state->fault = NoFault;
+    curr_state->asid = asid;
+    curr_state->vmid = vmid;
+    curr_state->timing = timing;
+    curr_state->functional = functional;
+    curr_state->mode = mode;
+    curr_state->tranType = tran_type;
+    curr_state->ss = ss;
+    curr_state->secureLookup = curr_state->ss == SecurityState::Secure;
+    curr_state->physAddrRange = _physAddrRange;
+
+    /** @todo These should be cached or grabbed from cached copies in
+     the TLB, all these miscreg reads are expensive */
+    curr_state->vaddr_tainted = curr_state->req->getVaddr();
+    if (curr_state->aarch64) {
+        curr_state->vaddr = purifyTaggedAddr(
+            curr_state->vaddr_tainted, curr_state->tc, curr_state->el,
+            curr_state->mode == BaseMMU::Execute);
+    } else {
+        curr_state->vaddr = curr_state->vaddr_tainted;
+    }
+
+    if (curr_state->aarch64) {
+        curr_state->hcr = curr_state->tc->readMiscReg(MISCREG_HCR_EL2);
+        if (stage2) {
+            curr_state->sctlr = curr_state->tc->readMiscReg(MISCREG_SCTLR_EL1);
+            if (curr_state->ss == SecurityState::Secure &&
+                curr_state->ipaSpace == PASpace::Secure) {
+                curr_state->vtcr =
+                    curr_state->tc->readMiscReg(MISCREG_VSTCR_EL2);
+            } else {
+                curr_state->vtcr =
+                    curr_state->tc->readMiscReg(MISCREG_VTCR_EL2);
+            }
+        } else {
+            switch (curr_state->regime) {
+                case TranslationRegime::EL10:
+                    curr_state->sctlr =
+                        curr_state->tc->readMiscReg(MISCREG_SCTLR_EL1);
+                    curr_state->tcr =
+                        curr_state->tc->readMiscReg(MISCREG_TCR_EL1);
+                    break;
+                case TranslationRegime::EL20:
+                case TranslationRegime::EL2:
+                    assert(mmu->release()->has(ArmExtension::VIRTUALIZATION));
+                    curr_state->sctlr =
+                        curr_state->tc->readMiscReg(MISCREG_SCTLR_EL2);
+                    curr_state->tcr =
+                        curr_state->tc->readMiscReg(MISCREG_TCR_EL2);
+                    break;
+                case TranslationRegime::EL3:
+                    assert(mmu->release()->has(ArmExtension::SECURITY));
+                    curr_state->sctlr =
+                        curr_state->tc->readMiscReg(MISCREG_SCTLR_EL3);
+                    curr_state->tcr =
+                        curr_state->tc->readMiscReg(MISCREG_TCR_EL3);
+                    break;
+                default:
+                    panic("Invalid translation regime");
+                    break;
+            }
+        }
+    } else {
+        curr_state->sctlr = curr_state->tc->readMiscReg(
+            snsBankedIndex(MISCREG_SCTLR, curr_state->tc,
+                           curr_state->ss == SecurityState::NonSecure));
+        curr_state->ttbcr = curr_state->tc->readMiscReg(
+            snsBankedIndex(MISCREG_TTBCR, curr_state->tc,
+                           curr_state->ss == SecurityState::NonSecure));
+        curr_state->htcr = curr_state->tc->readMiscReg(MISCREG_HTCR);
+        curr_state->hcr = curr_state->tc->readMiscReg(MISCREG_HCR);
+        curr_state->vtcr = curr_state->tc->readMiscReg(MISCREG_VTCR);
+    }
+    curr_state->isFetch = (curr_state->mode == BaseMMU::Execute);
+    curr_state->isWrite = (curr_state->mode == BaseMMU::Write);
+
+    stats.requestOrigin[REQUESTED][curr_state->isFetch]++;
+
+    curr_state->stage2Req = stage2_req && !stage2;
+
+    bool hyp = curr_state->el == EL2;
+    bool long_desc_format = curr_state->aarch64 || hyp ||
+                            curr_state->isStage2 ||
+                            longDescFormatInUse(curr_state->tc);
+
+    if (long_desc_format) {
+        // Helper variables used for hierarchical permissions
+        curr_state->longDescData = WalkerState::LongDescData();
+        curr_state->longDescData->rwTable = true;
+        curr_state->longDescData->userTable = true;
+        curr_state->longDescData->xnTable = false;
+        curr_state->longDescData->pxnTable = false;
+        ++stats.walksLongDescriptor;
+    } else {
+        curr_state->longDescData = std::nullopt;
+        ++stats.walksShortDescriptor;
+    }
+
+    if (auto walk_unit = getAvailableWalk(mode, stage2, functional);
+        !walk_unit) {
+        // No available walk unit at the moment. Stall the table walker
+        // This can only happen in timing mode
+        assert(curr_state->timing);
+        pendingQueue.push_back(curr_state);
+
+        pendingChange();
+
+        return NoFault;
+    } else {
+        // The walk unit is now busy servicing this walk request
+        assert(walk_unit->isAvailable());
+        walk_unit->isAvailable(false);
+
+        Fault fault = walk_unit->walk(curr_state);
+
+        // The translation walk has finished in two cases:
+        // a) If a fault has been generated
+        // b) If we are in atomic/functional mode (not timing)
+        if (fault || !curr_state->timing) {
+            // Mark the walk unit as available
+            nextWalk(walk_unit);
+
+            // Delete the walker state
+            delete curr_state;
+        } else {
+            // Either we are using the long descriptor, which means we
+            // need to extract the queue index from longDesc, or we are
+            // using the short. In the latter we always start at L1
+            LookupLevel curr_lookup_level =
+                long_desc_format ? curr_state->longDesc.lookupLevel
+                                 : LookupLevel::L1;
+
+            walk_unit->stashCurrState(curr_state, curr_lookup_level);
+        }
+
+        return fault;
+    }
+}
+
+void
+WalkUnit::processWalkWrapper(WalkerState *curr_state)
+{
+    // Check if a previous walk filled this request already
+    // @TODO Should this always be the TLB or should we look in the stage2 TLB?
+    TlbEntry *te =
+        mmu->lookup(curr_state->vaddr, curr_state->asid, curr_state->vmid,
+                    curr_state->ss, true, false, curr_state->regime,
+                    curr_state->isStage2, curr_state->mode);
+
+    // Check if we still need to have a walk for this request. If the
+    // requesting instruction has been squashed, or a previous walk has
+    // filled the TLB with a match, we just want to get rid of the walk.
+    // The latter could happen when there are multiple outstanding misses
+    // to a single page and a previous request has been successfully
+    // translated.
+    if (!curr_state->transState->squashed() &&
+        !mmu->isCompleteTranslation(te)) {
+
+        Fault fault = walk(curr_state);
+        if (fault != NoFault) {
+            curr_state->transState->finish(fault, curr_state->req,
+                                           curr_state->tc, curr_state->mode);
+
+            // Mark the walk unit as available
+            parent->nextWalk(this);
+
+            delete curr_state;
+        } else {
+            bool long_desc_format =
+                curr_state->aarch64 || curr_state->el == EL2 ||
+                curr_state->isStage2 || longDescFormatInUse(curr_state->tc);
+
+            // Either we are using the long descriptor, which means we
+            // need to extract the queue index from longDesc, or we are
+            // using the short. In the latter we always start at L1
+            LookupLevel curr_lookup_level =
+                long_desc_format ? curr_state->longDesc.lookupLevel
+                                 : LookupLevel::L1;
+
+            stashCurrState(curr_state, curr_lookup_level);
+        }
+    } else {
+        parent->squashWalk(curr_state);
+        parent->nextWalk(this);
+    }
+}
+
+void
+TableWalker::squashWalk(WalkerState *curr_state)
+{
+    DPRINTF(PageTableWalker, "Squashing table walk for address %#x\n",
+            curr_state->vaddr_tainted);
+
+    if (curr_state->transState->squashed()) {
+        // finish the translation which will delete the translation object
+        curr_state->transState->finish(
+            std::make_shared<UnimpFault>("Squashed Inst"), curr_state->req,
+            curr_state->tc, curr_state->mode);
+    } else {
+        // translate the request now that we know it will work
+        stats.walkServiceTime.sample(curTick() - curr_state->startTime);
+        mmu->translateTiming(curr_state->req, curr_state->tc,
+                             curr_state->transState, curr_state->mode,
+                             curr_state->tranType, curr_state->isStage2);
+    }
+
+    // delete the current request
+    delete curr_state;
+    stats.squashedBefore++;
+}
+
+void
+TableWalker::nextWalk(WalkUnit *walk_unit)
+{
+    WalkerState *next_walk = nullptr;
+    // With functional walk units we just mark the walker
+    // as available without trying to schedule pending
+    // walks (which are non functional by definition)
+    if (!walk_unit->functional()) {
+        for (auto candidate : pendingQueue) {
+            // Check if the walk unit is able to service the current
+            // pending walk request
+            if (walk_unit->type() & modeToType(candidate->mode) &&
+                walk_unit->stage2() == candidate->isStage2) {
+
+                next_walk = candidate;
+                walk_unit->scheduleWalk(next_walk, clockEdge(Cycles(1)));
+                break;
+            }
+        }
+    }
+
+    if (!next_walk) {
+        // Add the walk unit to the pool of available walks
+        walk_unit->isAvailable(true);
+
+        completeDrain();
+    } else {
+        // We found a match between the walk unit and a pending walk
+        // let's remove the walk from the list so that it does not
+        // get executed by a different walk unit
+        pendingQueue.remove(next_walk);
+
+        pendingChange();
+    }
+}
+
+void
+TableWalker::completeDrain()
+{
+    if (drainState() == DrainState::Draining && itbWalker->completeDrain() &&
+        dtbWalker->completeDrain() && itbStage2Walker->completeDrain() &&
+        dtbStage2Walker->completeDrain() && pendingQueue.empty()) {
+
+        DPRINTF(Drain, "TableWalker done draining, processing drain event\n");
+        signalDrainDone();
+    }
+}
+
+DrainState
+TableWalker::drain()
+{
+    if (pendingQueue.size()) {
+        DPRINTF(Drain, "TableWalker not drained\n");
+        return DrainState::Draining;
+    } else {
+        DPRINTF(Drain, "TableWalker free, no need to drain\n");
+        return DrainState::Drained;
+    }
 }
 
 TableWalker::Port &
@@ -116,34 +496,12 @@ TableWalker::getPort(const std::string &if_name, PortID idx)
     return ClockedObject::getPort(if_name, idx);
 }
 
-void
-TableWalker::setMmu(MMU *_mmu)
-{
-    mmu = _mmu;
-    release = mmu->release();
-}
-
-TableWalker::WalkerState::WalkerState() :
-    tc(nullptr), aarch64(false), regime(TranslationRegime::EL10),
-    physAddrRange(0), req(nullptr),
-    asid(0), vmid(0), transState(nullptr),
-    vaddr(0), vaddr_tainted(0),
-    sctlr(0), scr(0), cpsr(0), tcr(0),
-    htcr(0), hcr(0), vtcr(0),
-    isWrite(false), isFetch(false), ss(SecurityState::NonSecure),
-    isUncacheable(false), longDescData(std::nullopt),
-    hpd(false), sh(0), irgn(0), orgn(0), stage2Req(false),
-    stage2Tran(nullptr), timing(false), functional(false),
-    mode(BaseMMU::Read), tranType(MMU::NormalTran), l2Desc(l1Desc),
-    delayed(false), tableWalker(nullptr)
-{
-}
-
-TableWalker::Port::Port(TableWalker& _walker)
-  : QueuedRequestPort(_walker.name() + ".port", reqQueue, snoopRespQueue),
-    owner{_walker},
-    reqQueue(_walker, *this),
-    snoopRespQueue(_walker, *this)
+TableWalker::Port::Port(TableWalker &_walker, RequestorID id)
+    : QueuedRequestPort(_walker.name() + ".port", reqQueue, snoopRespQueue),
+      owner(_walker),
+      reqQueue(_walker, *this),
+      snoopRespQueue(_walker, *this),
+      _requestorId(id)
 {
 }
 
@@ -236,22 +594,112 @@ TableWalker::Port::handleResp(TableWalkerState *state, Addr addr,
 }
 
 void
-TableWalker::completeDrain()
+TableWalker::setTestInterface(TlbTestInterface *test)
 {
-    if (drainState() == DrainState::Draining &&
-        stateQueues[LookupLevel::L0].empty() &&
-        stateQueues[LookupLevel::L1].empty() &&
-        stateQueues[LookupLevel::L2].empty() &&
-        stateQueues[LookupLevel::L3].empty() &&
-        pendingQueue.empty()) {
+    itbWalker->setTestInterface(test);
+    dtbWalker->setTestInterface(test);
+    itbStage2Walker->setTestInterface(test);
+    dtbStage2Walker->setTestInterface(test);
 
-        DPRINTF(Drain, "TableWalker done draining, processing drain event\n");
+    walkUnitFunctionalS1->setTestInterface(test);
+    walkUnitFunctionalS2->setTestInterface(test);
+}
+
+/* this method keeps track of the table walker queue's residency, so
+ * needs to be called whenever requests start and complete. */
+void
+TableWalker::pendingChange()
+{
+    if (auto num_pending = pendingQueue.size(); num_pending != pendingReqs) {
+        Tick now = curTick();
+        stats.pendingWalks.sample(pendingReqs, now - pendingChangeTick);
+        pendingReqs = num_pending;
+        pendingChangeTick = now;
+    }
+}
+
+WalkUnit::WalkUnit(const Params &p)
+    : ClockedObject(p),
+      isStage2(p.is_stage2),
+      tlb(NULL),
+      walkType(p.walk_type),
+      isFunctional(p.functional),
+      available(true),
+      doProcessEvent(this, name()),
+      doL1DescEvent([this] { doL1DescriptorWrapper(); }, name()),
+      doL2DescEvent([this] { doL2DescriptorWrapper(); }, name()),
+      doL0LongDescEvent([this] { doL0LongDescriptorWrapper(); }, name()),
+      doL1LongDescEvent([this] { doL1LongDescriptorWrapper(); }, name()),
+      doL2LongDescEvent([this] { doL2LongDescriptorWrapper(); }, name()),
+      doL3LongDescEvent([this] { doL3LongDescriptorWrapper(); }, name()),
+      LongDescEventByLevel{&doL0LongDescEvent, &doL1LongDescEvent,
+                           &doL2LongDescEvent, &doL3LongDescEvent},
+      test(nullptr)
+{}
+
+WalkUnit::~WalkUnit()
+{
+    ;
+}
+
+TableWalker::WalkerState::WalkerState()
+    : tc(nullptr),
+      aarch64(false),
+      regime(TranslationRegime::EL10),
+      physAddrRange(0),
+      req(nullptr),
+      asid(0),
+      vmid(0),
+      transState(nullptr),
+      vaddr(0),
+      vaddr_tainted(0),
+      sctlr(0),
+      scr(0),
+      cpsr(0),
+      tcr(0),
+      htcr(0),
+      hcr(0),
+      vtcr(0),
+      isWrite(false),
+      isFetch(false),
+      ss(SecurityState::NonSecure),
+      isUncacheable(false),
+      longDescData(std::nullopt),
+      hpd(false),
+      sh(0),
+      irgn(0),
+      orgn(0),
+      stage2Req(false),
+      stage2Tran(nullptr),
+      timing(false),
+      functional(false),
+      mode(BaseMMU::Read),
+      tranType(MMU::NormalTran),
+      l2Desc(l1Desc),
+      delayed(false),
+      tableWalker(nullptr)
+{}
+
+bool
+WalkUnit::completeDrain()
+{
+    if (!(drainState() == DrainState::Draining)) {
+        return true;
+    } else if (stateQueues[LookupLevel::L0].empty() &&
+               stateQueues[LookupLevel::L1].empty() &&
+               stateQueues[LookupLevel::L2].empty() &&
+               stateQueues[LookupLevel::L3].empty()) {
+
+        DPRINTF(Drain, "WalkUnit done draining, processing drain event\n");
         signalDrainDone();
+        return true;
+    } else {
+        return false;
     }
 }
 
 DrainState
-TableWalker::drain()
+WalkUnit::drain()
 {
     bool state_queues_not_empty = false;
 
@@ -262,620 +710,303 @@ TableWalker::drain()
         }
     }
 
-    if (state_queues_not_empty || pendingQueue.size()) {
-        DPRINTF(Drain, "TableWalker not drained\n");
+    if (state_queues_not_empty) {
+        DPRINTF(Drain, "WalkUnit not drained\n");
         return DrainState::Draining;
     } else {
-        DPRINTF(Drain, "TableWalker free, no need to drain\n");
+        DPRINTF(Drain, "WalkUnit free, no need to drain\n");
         return DrainState::Drained;
     }
 }
 
-void
-TableWalker::drainResume()
-{
-    if (params().sys->isTimingMode() && currState) {
-        delete currState;
-        currState = NULL;
-        pendingChange();
-    }
-}
-
 bool
-TableWalker::uncacheableWalk() const
+WalkUnit::uncacheableWalk(WalkerState *curr_state) const
 {
-    bool disable_cacheability = isStage2 ?
-        currState->hcr.cd :
-        currState->sctlr.c == 0;
-    return disable_cacheability || currState->isUncacheable;
-}
-
-Fault
-TableWalker::walk(const RequestPtr &_req, ThreadContext *_tc, uint16_t _asid,
-                  vmid_t _vmid, MMU::Mode _mode,
-                  MMU::Translation *_trans, bool _timing, bool _functional,
-                  SecurityState ss, PASpace ipaspace,
-                  MMU::ArmTranslationType tranType,
-                  bool _stage2Req, const TlbEntry *walk_entry)
-{
-    assert(!(_functional && _timing));
-
-    if (_mode == BaseMMU::Execute) {
-        if (!isStage2) {
-            ++stats.instructionWalksS1;
-        } else {
-            ++stats.instructionWalksS2;
-        }
-    } else {
-        if (!isStage2) {
-            ++stats.dataWalksS1;
-        } else {
-            ++stats.dataWalksS2;
-        }
-    }
-
-    WalkerState *savedCurrState = NULL;
-
-    if (!currState && !_functional) {
-        // For atomic mode, a new WalkerState instance should be only created
-        // once per TLB. For timing mode, a new instance is generated for every
-        // TLB miss.
-        DPRINTF(PageTableWalker, "creating new instance of WalkerState\n");
-
-        currState = new WalkerState();
-        currState->tableWalker = this;
-    } else if (_functional) {
-        // If we are mixing functional mode with timing (or even
-        // atomic), we need to to be careful and clean up after
-        // ourselves to not risk getting into an inconsistent state.
-        DPRINTF(PageTableWalker,
-                "creating functional instance of WalkerState\n");
-        savedCurrState = currState;
-        currState = new WalkerState();
-        currState->tableWalker = this;
-    } else if (_timing) {
-        // This is a translation that was completed and then faulted again
-        // because some underlying parameters that affect the translation
-        // changed out from under us (e.g. asid). It will either be a
-        // misprediction, in which case nothing will happen or we'll use
-        // this fault to re-execute the faulting instruction which should clean
-        // up everything.
-        if (currState->vaddr_tainted == _req->getVaddr()) {
-            ++stats.squashedBefore;
-            return std::make_shared<ReExec>();
-        }
-    }
-    pendingChange();
-
-    currState->startTime = curTick();
-    currState->tc = _tc;
-    currState->el =
-        MMU::tranTypeEL(_tc->readMiscReg(MISCREG_CPSR),
-            _tc->readMiscReg(MISCREG_SCR_EL3),
-            tranType);
-
-    if (isStage2) {
-        currState->regime = TranslationRegime::EL10;
-        currState->aarch64 = ELIs64(_tc, EL2);
-        currState->ipaSpace = ipaspace;
-    } else {
-        currState->regime =
-            translationRegime(_tc, currState->el);
-        currState->aarch64 =
-            ELIs64(_tc, translationEl(currState->regime));
-    }
-    currState->transState = _trans;
-    currState->req = _req;
-    if (walk_entry) {
-        currState->walkEntry = *walk_entry;
-    } else {
-        currState->walkEntry = TlbEntry();
-    }
-    currState->fault = NoFault;
-    currState->asid = _asid;
-    currState->vmid = _vmid;
-    currState->timing = _timing;
-    currState->functional = _functional;
-    currState->mode = _mode;
-    currState->tranType = tranType;
-    currState->ss = ss;
-    currState->secureLookup = currState->ss == SecurityState::Secure;
-    currState->physAddrRange = _physAddrRange;
-
-    /** @todo These should be cached or grabbed from cached copies in
-     the TLB, all these miscreg reads are expensive */
-    currState->vaddr_tainted = currState->req->getVaddr();
-    if (currState->aarch64)
-        currState->vaddr = purifyTaggedAddr(currState->vaddr_tainted,
-                                            currState->tc, currState->el,
-                                            currState->mode==BaseMMU::Execute);
-    else
-        currState->vaddr = currState->vaddr_tainted;
-
-    if (currState->aarch64) {
-        currState->hcr = currState->tc->readMiscReg(MISCREG_HCR_EL2);
-        if (isStage2) {
-            currState->sctlr = currState->tc->readMiscReg(MISCREG_SCTLR_EL1);
-            if (currState->ss == SecurityState::Secure &&
-                currState->ipaSpace == PASpace::Secure) {
-                currState->vtcr =
-                    currState->tc->readMiscReg(MISCREG_VSTCR_EL2);
-            } else {
-                currState->vtcr =
-                    currState->tc->readMiscReg(MISCREG_VTCR_EL2);
-            }
-        } else switch (currState->regime) {
-          case TranslationRegime::EL10:
-            currState->sctlr = currState->tc->readMiscReg(MISCREG_SCTLR_EL1);
-            currState->tcr = currState->tc->readMiscReg(MISCREG_TCR_EL1);
-            break;
-          case TranslationRegime::EL20:
-          case TranslationRegime::EL2:
-            assert(release->has(ArmExtension::VIRTUALIZATION));
-            currState->sctlr = currState->tc->readMiscReg(MISCREG_SCTLR_EL2);
-            currState->tcr = currState->tc->readMiscReg(MISCREG_TCR_EL2);
-            break;
-          case TranslationRegime::EL3:
-            assert(release->has(ArmExtension::SECURITY));
-            currState->sctlr = currState->tc->readMiscReg(MISCREG_SCTLR_EL3);
-            currState->tcr = currState->tc->readMiscReg(MISCREG_TCR_EL3);
-            break;
-          default:
-            panic("Invalid translation regime");
-            break;
-        }
-    } else {
-        currState->sctlr = currState->tc->readMiscReg(snsBankedIndex(
-            MISCREG_SCTLR, currState->tc,
-            currState->ss == SecurityState::NonSecure));
-        currState->ttbcr = currState->tc->readMiscReg(snsBankedIndex(
-            MISCREG_TTBCR, currState->tc,
-            currState->ss == SecurityState::NonSecure));
-        currState->htcr  = currState->tc->readMiscReg(MISCREG_HTCR);
-        currState->hcr   = currState->tc->readMiscReg(MISCREG_HCR);
-        currState->vtcr  = currState->tc->readMiscReg(MISCREG_VTCR);
-    }
-    currState->isFetch = (currState->mode == BaseMMU::Execute);
-    currState->isWrite = (currState->mode == BaseMMU::Write);
-
-    stats.requestOrigin[REQUESTED][currState->isFetch]++;
-
-    currState->stage2Req = _stage2Req && !isStage2;
-
-    bool hyp = currState->el == EL2;
-    bool long_desc_format = currState->aarch64 || hyp || isStage2 ||
-                            longDescFormatInUse(currState->tc);
-
-    if (long_desc_format) {
-        // Helper variables used for hierarchical permissions
-        currState->longDescData = WalkerState::LongDescData();
-        currState->longDescData->rwTable = true;
-        currState->longDescData->userTable = true;
-        currState->longDescData->xnTable = false;
-        currState->longDescData->pxnTable = false;
-        ++stats.walksLongDescriptor;
-    } else {
-        currState->longDescData = std::nullopt;
-        ++stats.walksShortDescriptor;
-    }
-
-    if (currState->timing && (pending || pendingQueue.size())) {
-        pendingQueue.push_back(currState);
-        currState = NULL;
-        pendingChange();
-        return NoFault;
-    } else {
-        if (currState->timing) {
-            pending = true;
-            pendingChange();
-        }
-
-        Fault fault = NoFault;
-        if (currState->aarch64) {
-            fault = processWalkAArch64();
-        } else if (long_desc_format) {
-            fault = processWalkLPAE();
-        } else {
-            fault = processWalk();
-        }
-
-        // If this was a functional non-timing access restore state to
-        // how we found it.
-        if (currState->functional) {
-            delete currState;
-            currState = savedCurrState;
-        } else if (currState->timing) {
-            if (fault) {
-                pending = false;
-                nextWalk(currState->tc);
-                delete currState;
-                currState = NULL;
-            } else {
-                // Either we are using the long descriptor, which means we
-                // need to extract the queue index from longDesc, or we are
-                // using the short. In the latter we always start at L1
-                LookupLevel curr_lookup_level = long_desc_format ?
-                    currState->longDesc.lookupLevel : LookupLevel::L1;
-
-                stashCurrState(curr_lookup_level);
-            }
-        } else if (fault) {
-            currState->tc = NULL;
-            currState->req = NULL;
-        }
-
-        return fault;
-    }
+    bool disable_cacheability =
+        isStage2 ? curr_state->hcr.cd : curr_state->sctlr.c == 0;
+    return disable_cacheability || curr_state->isUncacheable;
 }
 
 void
-TableWalker::processWalkWrapper()
+WalkUnit::setMmu(MMU *_mmu)
 {
-    assert(!currState);
-    assert(pendingQueue.size());
-    pendingChange();
-    currState = pendingQueue.front();
-
-    // Check if a previous walk filled this request already
-    // @TODO Should this always be the TLB or should we look in the stage2 TLB?
-    TlbEntry* te = mmu->lookup(currState->vaddr, currState->asid,
-        currState->vmid, currState->ss, true, false,
-        currState->regime, isStage2, currState->mode);
-
-    // Check if we still need to have a walk for this request. If the requesting
-    // instruction has been squashed, or a previous walk has filled the TLB with
-    // a match, we just want to get rid of the walk. The latter could happen
-    // when there are multiple outstanding misses to a single page and a
-    // previous request has been successfully translated.
-    if (!currState->transState->squashed() && (!te || te->partial)) {
-        // We've got a valid request, lets process it
-        pending = true;
-        pendingQueue.pop_front();
-
-        bool long_desc_format = currState->aarch64 || currState->el == EL2 ||
-            isStage2 || longDescFormatInUse(currState->tc);
-
-        if (te && te->partial) {
-            currState->walkEntry = *te;
-        }
-        Fault fault;
-        if (currState->aarch64) {
-            fault = processWalkAArch64();
-        } else if (long_desc_format) {
-            fault = processWalkLPAE();
-        } else {
-            fault = processWalk();
-        }
-
-        if (fault != NoFault) {
-            pending = false;
-            nextWalk(currState->tc);
-
-            currState->transState->finish(fault, currState->req,
-                    currState->tc, currState->mode);
-
-            delete currState;
-            currState = NULL;
-        } else {
-            LookupLevel curr_lookup_level = long_desc_format ?
-                currState->longDesc.lookupLevel : LookupLevel::L1;
-
-            stashCurrState(curr_lookup_level);
-        }
-        return;
-    }
-
-
-    // If the instruction that we were translating for has been
-    // squashed we shouldn't bother.
-    unsigned num_squashed = 0;
-    ThreadContext *tc = currState->tc;
-    while ((num_squashed < numSquashable) && currState &&
-           (currState->transState->squashed() ||
-            (te && !te->partial))) {
-        pendingQueue.pop_front();
-        num_squashed++;
-        stats.squashedBefore++;
-
-        DPRINTF(TLB, "Squashing table walk for address %#x\n",
-                      currState->vaddr_tainted);
-
-        if (currState->transState->squashed()) {
-            // finish the translation which will delete the translation object
-            currState->transState->finish(
-                std::make_shared<UnimpFault>("Squashed Inst"),
-                currState->req, currState->tc, currState->mode);
-        } else {
-            // translate the request now that we know it will work
-            stats.walkServiceTime.sample(curTick() - currState->startTime);
-            mmu->translateTiming(currState->req, currState->tc,
-                currState->transState, currState->mode,
-                currState->tranType, isStage2);
-        }
-
-        // delete the current request
-        delete currState;
-
-        // peak at the next one
-        if (pendingQueue.size()) {
-            currState = pendingQueue.front();
-            te = mmu->lookup(currState->vaddr, currState->asid,
-                currState->vmid, currState->ss, true,
-                false, currState->regime, isStage2, currState->mode);
-        } else {
-            // Terminate the loop, nothing more to do
-            currState = NULL;
-        }
-    }
-    pendingChange();
-
-    // if we still have pending translations, schedule more work
-    nextWalk(tc);
-    currState = NULL;
+    mmu = _mmu;
 }
 
 Fault
-TableWalker::processWalk()
+WalkUnit::walk(WalkerState *state)
+{
+    Fault fault = NoFault;
+
+    if (state->aarch64) {
+        fault = processWalkAArch64(state);
+    } else if (longDescFormatInUse(state->tc) || state->el == EL2 ||
+               isStage2) {
+        fault = processWalkLPAE(state);
+    } else {
+        fault = processWalk(state);
+    }
+
+    return fault;
+}
+
+Fault
+WalkUnit::processWalk(WalkerState *curr_state)
 {
     Addr ttbr = 0;
 
     // For short descriptors, translation configs are held in
     // TTBR1.
-    RegVal ttbr1 = currState->tc->readMiscReg(snsBankedIndex(
-        MISCREG_TTBR1, currState->tc,
-        currState->ss == SecurityState::NonSecure));
+    RegVal ttbr1 = curr_state->tc->readMiscReg(
+        snsBankedIndex(MISCREG_TTBR1, curr_state->tc,
+                       curr_state->ss == SecurityState::NonSecure));
 
     const auto irgn0_mask = 0x1;
     const auto irgn1_mask = 0x40;
-    currState->isUncacheable = (ttbr1 & (irgn0_mask | irgn1_mask)) == 0;
+    curr_state->isUncacheable = (ttbr1 & (irgn0_mask | irgn1_mask)) == 0;
 
     // If translation isn't enabled, we shouldn't be here
-    assert(currState->sctlr.m || isStage2);
-    const bool is_atomic = currState->req->isAtomic();
-    const bool have_security = release->has(ArmExtension::SECURITY);
+    assert(curr_state->sctlr.m || isStage2);
+    const bool is_atomic = curr_state->req->isAtomic();
+    const bool have_security = mmu->release()->has(ArmExtension::SECURITY);
 
-    DPRINTF(TLB, "Beginning table walk for address %#x, TTBCR: %#x, bits:%#x\n",
-            currState->vaddr_tainted, currState->ttbcr, mbits(currState->vaddr, 31,
-                                                      32 - currState->ttbcr.n));
+    DPRINTF(PageTableWalker,
+            "Beginning table walk for address %#x, TTBCR: %#x, bits:%#x\n",
+            curr_state->vaddr_tainted, curr_state->ttbcr,
+            mbits(curr_state->vaddr, 31, 32 - curr_state->ttbcr.n));
 
-    stats.walkWaitTime.sample(curTick() - currState->startTime);
+    parent->stats.walkWaitTime.sample(curTick() - curr_state->startTime);
 
-    if (currState->ttbcr.n == 0 || !mbits(currState->vaddr, 31,
-                                          32 - currState->ttbcr.n)) {
-        DPRINTF(TLB, " - Selecting TTBR0\n");
+    if (curr_state->ttbcr.n == 0 ||
+        !mbits(curr_state->vaddr, 31, 32 - curr_state->ttbcr.n)) {
+        DPRINTF(PageTableWalker, " - Selecting TTBR0\n");
         // Check if table walk is allowed when Security Extensions are enabled
-        if (have_security && currState->ttbcr.pd0) {
-            if (currState->isFetch)
+        if (have_security && curr_state->ttbcr.pd0) {
+            if (curr_state->isFetch) {
                 return std::make_shared<PrefetchAbort>(
-                    currState->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1,
-                    isStage2,
-                    TranMethod::VmsaTran);
-            else
-                return std::make_shared<DataAbort>(
-                    currState->vaddr_tainted,
-                    DomainType::NoAccess,
-                    is_atomic ? false : currState->isWrite,
+                    curr_state->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::VmsaTran);
+            } else {
+                return std::make_shared<DataAbort>(
+                    curr_state->vaddr_tainted, DomainType::NoAccess,
+                    is_atomic ? false : curr_state->isWrite,
+                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
+                    TranMethod::VmsaTran);
+            }
         }
-        ttbr = currState->tc->readMiscReg(snsBankedIndex(
-            MISCREG_TTBR0, currState->tc,
-            currState->ss == SecurityState::NonSecure));
+        ttbr = curr_state->tc->readMiscReg(
+            snsBankedIndex(MISCREG_TTBR0, curr_state->tc,
+                           curr_state->ss == SecurityState::NonSecure));
     } else {
-        DPRINTF(TLB, " - Selecting TTBR1\n");
+        DPRINTF(PageTableWalker, " - Selecting TTBR1\n");
         // Check if table walk is allowed when Security Extensions are enabled
-        if (have_security && currState->ttbcr.pd1) {
-            if (currState->isFetch)
+        if (have_security && curr_state->ttbcr.pd1) {
+            if (curr_state->isFetch) {
                 return std::make_shared<PrefetchAbort>(
-                    currState->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1,
-                    isStage2,
-                    TranMethod::VmsaTran);
-            else
-                return std::make_shared<DataAbort>(
-                    currState->vaddr_tainted,
-                    DomainType::NoAccess,
-                    is_atomic ? false : currState->isWrite,
+                    curr_state->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::VmsaTran);
+            } else {
+                return std::make_shared<DataAbort>(
+                    curr_state->vaddr_tainted, DomainType::NoAccess,
+                    is_atomic ? false : curr_state->isWrite,
+                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
+                    TranMethod::VmsaTran);
+            }
         }
         ttbr = ttbr1;
-        currState->ttbcr.n = 0;
+        curr_state->ttbcr.n = 0;
     }
 
-    Addr l1desc_addr = mbits(ttbr, 31, 14 - currState->ttbcr.n) |
-        (bits(currState->vaddr, 31 - currState->ttbcr.n, 20) << 2);
-    DPRINTF(TLB, " - Descriptor at address %#x (%s)\n", l1desc_addr,
-            currState->ss == SecurityState::Secure ? "s" : "ns");
+    Addr l1desc_addr =
+        mbits(ttbr, 31, 14 - curr_state->ttbcr.n) |
+        (bits(curr_state->vaddr, 31 - curr_state->ttbcr.n, 20) << 2);
+    DPRINTF(PageTableWalker, " - Descriptor at address %#x (%s)\n",
+            l1desc_addr, curr_state->ss == SecurityState::Secure ? "s" : "ns");
 
     Request::Flags flag = Request::PT_WALK;
-    if (uncacheableWalk()) {
+    if (uncacheableWalk(curr_state)) {
         flag.set(Request::UNCACHEABLE);
     }
 
-    if (currState->secureLookup) {
+    if (curr_state->secureLookup) {
         flag.set(Request::SECURE);
     }
 
-    fetchDescriptor(
-        l1desc_addr, currState->l1Desc,
-        sizeof(uint32_t), flag, LookupLevel::L1,
-        &doL1DescEvent,
-        &TableWalker::doL1Descriptor);
+    fetchDescriptor(l1desc_addr, curr_state->l1Desc, sizeof(uint32_t), flag,
+                    LookupLevel::L1, &doL1DescEvent, &WalkUnit::doL1Descriptor,
+                    curr_state);
 
-    return currState->fault;
+    return curr_state->fault;
 }
 
 Fault
-TableWalker::processWalkLPAE()
+WalkUnit::processWalkLPAE(WalkerState *curr_state)
 {
     Addr ttbr, ttbr0_max, ttbr1_min, desc_addr;
     int tsz, n;
     LookupLevel start_lookup_level = LookupLevel::L1;
 
-    DPRINTF(TLB, "Beginning table walk for address %#x, TTBCR: %#x\n",
-            currState->vaddr_tainted, currState->ttbcr);
+    DPRINTF(PageTableWalker,
+            "Beginning table walk for address %#x, TTBCR: %#x\n",
+            curr_state->vaddr_tainted, curr_state->ttbcr);
 
-    stats.walkWaitTime.sample(curTick() - currState->startTime);
+    parent->stats.walkWaitTime.sample(curTick() - curr_state->startTime);
 
     Request::Flags flag = Request::PT_WALK;
-    if (currState->secureLookup)
+    if (curr_state->secureLookup) {
         flag.set(Request::SECURE);
+    }
 
     // work out which base address register to use, if in hyp mode we always
     // use HTTBR
     if (isStage2) {
-        DPRINTF(TLB, " - Selecting VTTBR (long-desc.)\n");
-        ttbr = currState->tc->readMiscReg(MISCREG_VTTBR);
-        tsz  = sext<4>(currState->vtcr.t0sz);
-        start_lookup_level = currState->vtcr.sl0 ?
-            LookupLevel::L1 : LookupLevel::L2;
-        currState->isUncacheable = currState->vtcr.irgn0 == 0;
-    } else if (currState->el == EL2) {
-        DPRINTF(TLB, " - Selecting HTTBR (long-desc.)\n");
-        ttbr = currState->tc->readMiscReg(MISCREG_HTTBR);
-        tsz  = currState->htcr.t0sz;
-        currState->isUncacheable = currState->htcr.irgn0 == 0;
+        DPRINTF(PageTableWalker, " - Selecting VTTBR (long-desc.)\n");
+        ttbr = curr_state->tc->readMiscReg(MISCREG_VTTBR);
+        tsz = sext<4>(curr_state->vtcr.t0sz);
+        start_lookup_level =
+            curr_state->vtcr.sl0 ? LookupLevel::L1 : LookupLevel::L2;
+        curr_state->isUncacheable = curr_state->vtcr.irgn0 == 0;
+    } else if (curr_state->el == EL2) {
+        DPRINTF(PageTableWalker, " - Selecting HTTBR (long-desc.)\n");
+        ttbr = curr_state->tc->readMiscReg(MISCREG_HTTBR);
+        tsz = curr_state->htcr.t0sz;
+        curr_state->isUncacheable = curr_state->htcr.irgn0 == 0;
     } else {
-        assert(longDescFormatInUse(currState->tc));
+        assert(longDescFormatInUse(curr_state->tc));
 
         // Determine boundaries of TTBR0/1 regions
-        if (currState->ttbcr.t0sz)
-            ttbr0_max = (1ULL << (32 - currState->ttbcr.t0sz)) - 1;
-        else if (currState->ttbcr.t1sz)
-            ttbr0_max = (1ULL << 32) -
-                (1ULL << (32 - currState->ttbcr.t1sz)) - 1;
-        else
+        if (curr_state->ttbcr.t0sz) {
+            ttbr0_max = (1ULL << (32 - curr_state->ttbcr.t0sz)) - 1;
+        } else if (curr_state->ttbcr.t1sz) {
+            ttbr0_max =
+                (1ULL << 32) - (1ULL << (32 - curr_state->ttbcr.t1sz)) - 1;
+        } else {
             ttbr0_max = (1ULL << 32) - 1;
-        if (currState->ttbcr.t1sz)
-            ttbr1_min = (1ULL << 32) - (1ULL << (32 - currState->ttbcr.t1sz));
-        else
-            ttbr1_min = (1ULL << (32 - currState->ttbcr.t0sz));
+        }
+        if (curr_state->ttbcr.t1sz) {
+            ttbr1_min = (1ULL << 32) - (1ULL << (32 - curr_state->ttbcr.t1sz));
+        } else {
+            ttbr1_min = (1ULL << (32 - curr_state->ttbcr.t0sz));
+        }
 
-        const bool is_atomic = currState->req->isAtomic();
+        const bool is_atomic = curr_state->req->isAtomic();
 
         // The following code snippet selects the appropriate translation table base
         // address (TTBR0 or TTBR1) and the appropriate starting lookup level
         // depending on the address range supported by the translation table (ARM
         // ARM issue C B3.6.4)
-        if (currState->vaddr <= ttbr0_max) {
-            DPRINTF(TLB, " - Selecting TTBR0 (long-desc.)\n");
+        if (curr_state->vaddr <= ttbr0_max) {
+            DPRINTF(PageTableWalker, " - Selecting TTBR0 (long-desc.)\n");
             // Check if table walk is allowed
-            if (currState->ttbcr.epd0) {
-                if (currState->isFetch)
+            if (curr_state->ttbcr.epd0) {
+                if (curr_state->isFetch) {
                     return std::make_shared<PrefetchAbort>(
-                        currState->vaddr_tainted,
-                        ArmFault::TranslationLL + LookupLevel::L1,
-                        isStage2,
+                        curr_state->vaddr_tainted,
+                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                         TranMethod::LpaeTran);
-                else
+                } else {
                     return std::make_shared<DataAbort>(
-                        currState->vaddr_tainted,
-                        DomainType::NoAccess,
-                        is_atomic ? false : currState->isWrite,
-                        ArmFault::TranslationLL + LookupLevel::L1,
-                        isStage2,
+                        curr_state->vaddr_tainted, DomainType::NoAccess,
+                        is_atomic ? false : curr_state->isWrite,
+                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                         TranMethod::LpaeTran);
+                }
             }
-            ttbr = currState->tc->readMiscReg(snsBankedIndex(
-                MISCREG_TTBR0, currState->tc,
-                currState->ss == SecurityState::NonSecure));
-            tsz = currState->ttbcr.t0sz;
-            currState->isUncacheable = currState->ttbcr.irgn0 == 0;
+            ttbr = curr_state->tc->readMiscReg(
+                snsBankedIndex(MISCREG_TTBR0, curr_state->tc,
+                               curr_state->ss == SecurityState::NonSecure));
+            tsz = curr_state->ttbcr.t0sz;
+            curr_state->isUncacheable = curr_state->ttbcr.irgn0 == 0;
             if (ttbr0_max < (1ULL << 30))  // Upper limit < 1 GiB
                 start_lookup_level = LookupLevel::L2;
-        } else if (currState->vaddr >= ttbr1_min) {
-            DPRINTF(TLB, " - Selecting TTBR1 (long-desc.)\n");
+        } else if (curr_state->vaddr >= ttbr1_min) {
+            DPRINTF(PageTableWalker, " - Selecting TTBR1 (long-desc.)\n");
             // Check if table walk is allowed
-            if (currState->ttbcr.epd1) {
-                if (currState->isFetch)
+            if (curr_state->ttbcr.epd1) {
+                if (curr_state->isFetch) {
                     return std::make_shared<PrefetchAbort>(
-                        currState->vaddr_tainted,
-                        ArmFault::TranslationLL + LookupLevel::L1,
-                        isStage2,
+                        curr_state->vaddr_tainted,
+                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                         TranMethod::LpaeTran);
-                else
+                } else {
                     return std::make_shared<DataAbort>(
-                        currState->vaddr_tainted,
-                        DomainType::NoAccess,
-                        is_atomic ? false : currState->isWrite,
-                        ArmFault::TranslationLL + LookupLevel::L1,
-                        isStage2,
+                        curr_state->vaddr_tainted, DomainType::NoAccess,
+                        is_atomic ? false : curr_state->isWrite,
+                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                         TranMethod::LpaeTran);
+                }
             }
-            ttbr = currState->tc->readMiscReg(snsBankedIndex(
-                MISCREG_TTBR1, currState->tc,
-                currState->ss == SecurityState::NonSecure));
-            tsz = currState->ttbcr.t1sz;
-            currState->isUncacheable = currState->ttbcr.irgn1 == 0;
+            ttbr = curr_state->tc->readMiscReg(
+                snsBankedIndex(MISCREG_TTBR1, curr_state->tc,
+                               curr_state->ss == SecurityState::NonSecure));
+            tsz = curr_state->ttbcr.t1sz;
+            curr_state->isUncacheable = curr_state->ttbcr.irgn1 == 0;
             // Lower limit >= 3 GiB
             if (ttbr1_min >= (1ULL << 31) + (1ULL << 30))
                 start_lookup_level = LookupLevel::L2;
         } else {
             // Out of boundaries -> translation fault
-            if (currState->isFetch)
+            if (curr_state->isFetch) {
                 return std::make_shared<PrefetchAbort>(
-                    currState->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1,
-                    isStage2,
+                    curr_state->vaddr_tainted,
+                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::LpaeTran);
-            else
+            } else {
                 return std::make_shared<DataAbort>(
-                    currState->vaddr_tainted,
-                    DomainType::NoAccess,
-                    is_atomic ? false : currState->isWrite,
-                    ArmFault::TranslationLL + LookupLevel::L1,
-                    isStage2, TranMethod::LpaeTran);
+                    curr_state->vaddr_tainted, DomainType::NoAccess,
+                    is_atomic ? false : curr_state->isWrite,
+                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
+                    TranMethod::LpaeTran);
+            }
         }
-
     }
 
     // Perform lookup (ARM ARM issue C B3.6.6)
     if (start_lookup_level == LookupLevel::L1) {
         n = 5 - tsz;
-        desc_addr = mbits(ttbr, 39, n) |
-            (bits(currState->vaddr, n + 26, 30) << 3);
-        DPRINTF(TLB, " - Descriptor at address %#x (%s) (long-desc.)\n",
-                desc_addr, currState->ss == SecurityState::Secure ?
-                "s" : "ns");
+        desc_addr =
+            mbits(ttbr, 39, n) | (bits(curr_state->vaddr, n + 26, 30) << 3);
+        DPRINTF(PageTableWalker,
+                " - Descriptor at address %#x (%s) (long-desc.)\n", desc_addr,
+                curr_state->ss == SecurityState::Secure ? "s" : "ns");
     } else {
         // Skip first-level lookup
         n = (tsz >= 2 ? 14 - tsz : 12);
-        desc_addr = mbits(ttbr, 39, n) |
-            (bits(currState->vaddr, n + 17, 21) << 3);
-        DPRINTF(TLB, " - Descriptor at address %#x (%s) (long-desc.)\n",
-                desc_addr, currState->ss == SecurityState::Secure ?
-                "s" : "ns");
+        desc_addr =
+            mbits(ttbr, 39, n) | (bits(curr_state->vaddr, n + 17, 21) << 3);
+        DPRINTF(PageTableWalker,
+                " - Descriptor at address %#x (%s) (long-desc.)\n", desc_addr,
+                curr_state->ss == SecurityState::Secure ? "s" : "ns");
     }
 
-    if (uncacheableWalk()) {
+    if (uncacheableWalk(curr_state)) {
         flag.set(Request::UNCACHEABLE);
     }
 
-    currState->longDesc.lookupLevel = start_lookup_level;
-    currState->longDesc.aarch64 = false;
-    currState->longDesc.grainSize = Grain4KB;
-    currState->longDesc.isStage2 = isStage2;
+    curr_state->longDesc.lookupLevel = start_lookup_level;
+    curr_state->longDesc.aarch64 = false;
+    curr_state->longDesc.grainSize = Grain4KB;
+    curr_state->longDesc.isStage2 = isStage2;
 
-    fetchDescriptor(
-        desc_addr, currState->longDesc,
-        sizeof(uint64_t), flag, start_lookup_level,
-        LongDescEventByLevel[start_lookup_level],
-        &TableWalker::doLongDescriptor);
+    fetchDescriptor(desc_addr, curr_state->longDesc, sizeof(uint64_t), flag,
+                    start_lookup_level,
+                    LongDescEventByLevel[start_lookup_level],
+                    &WalkUnit::doLongDescriptor, curr_state);
 
-    return currState->fault;
+    return curr_state->fault;
 }
 
 Addr
-TableWalker::s1MinTxSz(GrainSize tg) const
+WalkUnit::s1MinTxSz(WalkerState *curr_state, GrainSize tg) const
 {
     // The effective maximum input size is 48 if ARMv8.2-LVA is not
     // supported or if the translation granule that is in use is 4KB or
     // 16KB in size. When ARMv8.2-LVA is supported, for the 64KB
     // translation granule size only, the effective minimum value of
     // 52.
-    if (HaveExt(currState->tc, ArmExtension::FEAT_LVA) && tg == Grain64KB) {
+    if (HaveExt(curr_state->tc, ArmExtension::FEAT_LVA) && tg == Grain64KB) {
         return 12;
     } else {
         return 16;
@@ -883,9 +1014,9 @@ TableWalker::s1MinTxSz(GrainSize tg) const
 }
 
 Addr
-TableWalker::maxTxSz(GrainSize tg) const
+WalkUnit::maxTxSz(WalkerState *curr_state, GrainSize tg) const
 {
-    if (HaveExt(currState->tc, ArmExtension::FEAT_TTST)) {
+    if (HaveExt(curr_state->tc, ArmExtension::FEAT_TTST)) {
         switch (tg) {
           case Grain4KB: return 48;
           case Grain16KB: return 48;
@@ -903,38 +1034,40 @@ TableWalker::maxTxSz(GrainSize tg) const
 }
 
 bool
-TableWalker::s1TxSzFault(GrainSize tg, int tsz) const
+WalkUnit::s1TxSzFault(WalkerState *curr_state, GrainSize tg, int tsz) const
 {
-    Addr min_txsz = s1MinTxSz(tg);
-    Addr max_txsz = maxTxSz(tg);
+    Addr min_txsz = s1MinTxSz(curr_state, tg);
+    Addr max_txsz = maxTxSz(curr_state, tg);
 
     return tsz > max_txsz || tsz < min_txsz;
 }
 
 bool
-TableWalker::checkVAOutOfRange(Addr vaddr, int top_bit, int tsz, bool low_range)
+WalkUnit::checkVAOutOfRange(WalkerState *curr_state, int top_bit, int tsz,
+                            bool low_range)
 {
-    return low_range ?
-        bits(currState->vaddr, top_bit, tsz) != 0x0 :
-        bits(currState->vaddr, top_bit, tsz) != mask(top_bit - tsz + 1);
+    return low_range ? bits(curr_state->vaddr, top_bit, tsz) != 0x0
+                     : bits(curr_state->vaddr, top_bit, tsz) !=
+                           mask(top_bit - tsz + 1);
 }
 
 bool
-TableWalker::checkAddrSizeFaultAArch64(Addr addr, int pa_range)
+WalkUnit::checkAddrSizeFaultAArch64(Addr addr, int pa_range)
 {
-    return (pa_range != _physAddrRange &&
-            bits(addr, _physAddrRange - 1, pa_range));
+    return (pa_range != parent->physAddrRange() &&
+            bits(addr, parent->physAddrRange() - 1, pa_range));
 }
 
 Fault
-TableWalker::processWalkAArch64()
+WalkUnit::processWalkAArch64(WalkerState *curr_state)
 {
-    assert(currState->aarch64);
+    assert(curr_state->aarch64);
 
-    DPRINTF(TLB, "Beginning table walk for address %#llx, TCR: %#llx\n",
-            currState->vaddr_tainted, currState->tcr);
+    DPRINTF(PageTableWalker,
+            "Beginning table walk for address %#llx, TCR: %#llx\n",
+            curr_state->vaddr_tainted, curr_state->tcr);
 
-    stats.walkWaitTime.sample(curTick() - currState->startTime);
+    parent->stats.walkWaitTime.sample(curTick() - curr_state->startTime);
 
     // Determine TTBR, table size, granule size and phys. address range
     Addr ttbr = 0;
@@ -942,161 +1075,183 @@ TableWalker::processWalkAArch64()
     GrainSize tg = Grain4KB; // grain size computed from tg* field
     bool fault = false;
 
-    int top_bit = computeAddrTop(currState->tc,
-        bits(currState->vaddr, 55),
-        currState->mode==BaseMMU::Execute,
-        currState->tcr,
-        currState->el);
+    int top_bit = computeAddrTop(curr_state->tc, bits(curr_state->vaddr, 55),
+                                 curr_state->mode == BaseMMU::Execute,
+                                 curr_state->tcr, curr_state->el);
 
     bool vaddr_fault = false;
-    switch (currState->regime) {
-      case TranslationRegime::EL10:
-        if (isStage2) {
-            if (currState->ss == SecurityState::Secure &&
-                currState->ipaSpace == PASpace::Secure) {
-                // Secure EL1&0 Secure IPA
-                DPRINTF(TLB, " - Selecting VSTTBR_EL2 (AArch64 stage 2)\n");
-                ttbr = currState->tc->readMiscReg(MISCREG_VSTTBR_EL2);
-                currState->secureLookup = !currState->vtcr.sw;
+    switch (curr_state->regime) {
+        case TranslationRegime::EL10:
+            if (isStage2) {
+                if (curr_state->ss == SecurityState::Secure &&
+                    curr_state->ipaSpace == PASpace::Secure) {
+                    // Secure EL1&0 Secure IPA
+                    DPRINTF(PageTableWalker,
+                            " - Selecting VSTTBR_EL2 (AArch64 stage 2)\n");
+                    ttbr = curr_state->tc->readMiscReg(MISCREG_VSTTBR_EL2);
+                    curr_state->secureLookup = !curr_state->vtcr.sw;
+                } else {
+                    // Secure EL1&0 NonSecure IPA or NonSecure EL1&0
+                    DPRINTF(PageTableWalker,
+                            " - Selecting VTTBR_EL2 (AArch64 stage 2)\n");
+                    ttbr = curr_state->tc->readMiscReg(MISCREG_VTTBR_EL2);
+                    curr_state->secureLookup =
+                        curr_state->ss == SecurityState::Secure
+                            ? !curr_state->vtcr.nsw
+                            :      // Secure EL1&0 NonSecure IPA
+                            false; // NonSecure EL1&0
+                }
+                tsz = 64 - curr_state->vtcr.t0sz64;
+                tg = GrainMap_tg0[curr_state->vtcr.tg0];
+
+                ps = curr_state->vtcr.ps;
+                curr_state->sh = curr_state->vtcr.sh0;
+                curr_state->irgn = curr_state->vtcr.irgn0;
+                curr_state->orgn = curr_state->vtcr.orgn0;
             } else {
-                // Secure EL1&0 NonSecure IPA or NonSecure EL1&0
-                DPRINTF(TLB, " - Selecting VTTBR_EL2 (AArch64 stage 2)\n");
-                ttbr = currState->tc->readMiscReg(MISCREG_VTTBR_EL2);
-                currState->secureLookup = currState->ss == SecurityState::Secure ?
-                    !currState->vtcr.nsw : // Secure EL1&0 NonSecure IPA
-                    false;                 // NonSecure EL1&0
+                switch (bits(curr_state->vaddr, top_bit)) {
+                    case 0:
+                        DPRINTF(PageTableWalker,
+                                " - Selecting TTBR0_EL1 (AArch64)\n");
+                        ttbr = curr_state->tc->readMiscReg(MISCREG_TTBR0_EL1);
+                        tsz = 64 - curr_state->tcr.t0sz;
+                        tg = GrainMap_tg0[curr_state->tcr.tg0];
+                        curr_state->hpd = curr_state->tcr.hpd0;
+                        curr_state->sh = curr_state->tcr.sh0;
+                        curr_state->irgn = curr_state->tcr.irgn0;
+                        curr_state->orgn = curr_state->tcr.orgn0;
+                        vaddr_fault =
+                            s1TxSzFault(curr_state, tg,
+                                        curr_state->tcr.t0sz) ||
+                            checkVAOutOfRange(curr_state, top_bit, tsz, true);
+
+                        if (vaddr_fault || curr_state->tcr.epd0) {
+                            fault = true;
+                        }
+                        break;
+                    case 0x1:
+                        DPRINTF(PageTableWalker,
+                                " - Selecting TTBR1_EL1 (AArch64)\n");
+                        ttbr = curr_state->tc->readMiscReg(MISCREG_TTBR1_EL1);
+                        tsz = 64 - curr_state->tcr.t1sz;
+                        tg = GrainMap_tg1[curr_state->tcr.tg1];
+                        curr_state->hpd = curr_state->tcr.hpd1;
+                        curr_state->sh = curr_state->tcr.sh1;
+                        curr_state->irgn = curr_state->tcr.irgn1;
+                        curr_state->orgn = curr_state->tcr.orgn1;
+                        vaddr_fault =
+                            s1TxSzFault(curr_state, tg,
+                                        curr_state->tcr.t1sz) ||
+                            checkVAOutOfRange(curr_state, top_bit, tsz, false);
+
+                        if (vaddr_fault || curr_state->tcr.epd1) {
+                            fault = true;
+                        }
+                        break;
+                    default:
+                        // top two bytes must be all 0s or all 1s, else invalid
+                        // addr
+                        fault = true;
+                }
+                ps = curr_state->tcr.ips;
             }
-            tsz = 64 - currState->vtcr.t0sz64;
-            tg = GrainMap_tg0[currState->vtcr.tg0];
+            break;
+        case TranslationRegime::EL2:
+        case TranslationRegime::EL20:
+            switch (bits(curr_state->vaddr, top_bit)) {
+                case 0:
+                    DPRINTF(PageTableWalker,
+                            " - Selecting TTBR0_EL2 (AArch64)\n");
+                    ttbr = curr_state->tc->readMiscReg(MISCREG_TTBR0_EL2);
+                    tsz = 64 - curr_state->tcr.t0sz;
+                    tg = GrainMap_tg0[curr_state->tcr.tg0];
+                    curr_state->hpd = curr_state->hcr.e2h
+                                          ? curr_state->tcr.hpd0
+                                          : curr_state->tcr.hpd;
+                    curr_state->sh = curr_state->tcr.sh0;
+                    curr_state->irgn = curr_state->tcr.irgn0;
+                    curr_state->orgn = curr_state->tcr.orgn0;
+                    vaddr_fault =
+                        s1TxSzFault(curr_state, tg, curr_state->tcr.t0sz) ||
+                        checkVAOutOfRange(curr_state, top_bit, tsz, true);
 
-            ps = currState->vtcr.ps;
-            currState->sh = currState->vtcr.sh0;
-            currState->irgn = currState->vtcr.irgn0;
-            currState->orgn = currState->vtcr.orgn0;
-        } else {
-            switch (bits(currState->vaddr, top_bit)) {
-              case 0:
-                DPRINTF(TLB, " - Selecting TTBR0_EL1 (AArch64)\n");
-                ttbr = currState->tc->readMiscReg(MISCREG_TTBR0_EL1);
-                tsz = 64 - currState->tcr.t0sz;
-                tg = GrainMap_tg0[currState->tcr.tg0];
-                currState->hpd = currState->tcr.hpd0;
-                currState->sh = currState->tcr.sh0;
-                currState->irgn = currState->tcr.irgn0;
-                currState->orgn = currState->tcr.orgn0;
-                vaddr_fault = s1TxSzFault(tg, currState->tcr.t0sz) ||
-                    checkVAOutOfRange(currState->vaddr, top_bit, tsz, true);
+                    if (vaddr_fault ||
+                        (curr_state->hcr.e2h && curr_state->tcr.epd0)) {
+                        fault = true;
+                    }
+                    break;
 
-                if (vaddr_fault || currState->tcr.epd0)
+                case 0x1:
+                    DPRINTF(PageTableWalker,
+                            " - Selecting TTBR1_EL2 (AArch64)\n");
+                    ttbr = curr_state->tc->readMiscReg(MISCREG_TTBR1_EL2);
+                    tsz = 64 - curr_state->tcr.t1sz;
+                    tg = GrainMap_tg1[curr_state->tcr.tg1];
+                    curr_state->hpd = curr_state->tcr.hpd1;
+                    curr_state->sh = curr_state->tcr.sh1;
+                    curr_state->irgn = curr_state->tcr.irgn1;
+                    curr_state->orgn = curr_state->tcr.orgn1;
+                    vaddr_fault =
+                        s1TxSzFault(curr_state, tg, curr_state->tcr.t1sz) ||
+                        checkVAOutOfRange(curr_state, top_bit, tsz, false);
+
+                    if (vaddr_fault || !curr_state->hcr.e2h ||
+                        curr_state->tcr.epd1) {
+                        fault = true;
+                    }
+                    break;
+
+                default:
+                    // invalid addr if top two bytes are not all 0s
                     fault = true;
-                break;
-              case 0x1:
-                DPRINTF(TLB, " - Selecting TTBR1_EL1 (AArch64)\n");
-                ttbr = currState->tc->readMiscReg(MISCREG_TTBR1_EL1);
-                tsz = 64 - currState->tcr.t1sz;
-                tg = GrainMap_tg1[currState->tcr.tg1];
-                currState->hpd = currState->tcr.hpd1;
-                currState->sh = currState->tcr.sh1;
-                currState->irgn = currState->tcr.irgn1;
-                currState->orgn = currState->tcr.orgn1;
-                vaddr_fault = s1TxSzFault(tg, currState->tcr.t1sz) ||
-                    checkVAOutOfRange(currState->vaddr, top_bit, tsz, false);
-
-                if (vaddr_fault || currState->tcr.epd1)
-                    fault = true;
-                break;
-              default:
-                // top two bytes must be all 0s or all 1s, else invalid addr
-                fault = true;
             }
-            ps = currState->tcr.ips;
-        }
-        break;
-      case TranslationRegime::EL2:
-      case TranslationRegime::EL20:
-        switch(bits(currState->vaddr, top_bit)) {
-          case 0:
-            DPRINTF(TLB, " - Selecting TTBR0_EL2 (AArch64)\n");
-            ttbr = currState->tc->readMiscReg(MISCREG_TTBR0_EL2);
-            tsz = 64 - currState->tcr.t0sz;
-            tg = GrainMap_tg0[currState->tcr.tg0];
-            currState->hpd = currState->hcr.e2h ?
-                currState->tcr.hpd0 : currState->tcr.hpd;
-            currState->sh = currState->tcr.sh0;
-            currState->irgn = currState->tcr.irgn0;
-            currState->orgn = currState->tcr.orgn0;
-            vaddr_fault = s1TxSzFault(tg, currState->tcr.t0sz) ||
-                checkVAOutOfRange(currState->vaddr, top_bit, tsz, true);
-
-            if (vaddr_fault || (currState->hcr.e2h && currState->tcr.epd0))
-                fault = true;
+            ps =
+                curr_state->hcr.e2h ? curr_state->tcr.ips : curr_state->tcr.ps;
             break;
+        case TranslationRegime::EL3:
+            switch (bits(curr_state->vaddr, top_bit)) {
+                case 0:
+                    DPRINTF(PageTableWalker,
+                            " - Selecting TTBR0_EL3 (AArch64)\n");
+                    ttbr = curr_state->tc->readMiscReg(MISCREG_TTBR0_EL3);
+                    tsz = 64 - curr_state->tcr.t0sz;
+                    tg = GrainMap_tg0[curr_state->tcr.tg0];
+                    curr_state->hpd = curr_state->tcr.hpd;
+                    curr_state->sh = curr_state->tcr.sh0;
+                    curr_state->irgn = curr_state->tcr.irgn0;
+                    curr_state->orgn = curr_state->tcr.orgn0;
+                    vaddr_fault =
+                        s1TxSzFault(curr_state, tg, curr_state->tcr.t0sz) ||
+                        checkVAOutOfRange(curr_state, top_bit, tsz, true);
 
-          case 0x1:
-            DPRINTF(TLB, " - Selecting TTBR1_EL2 (AArch64)\n");
-            ttbr = currState->tc->readMiscReg(MISCREG_TTBR1_EL2);
-            tsz = 64 - currState->tcr.t1sz;
-            tg = GrainMap_tg1[currState->tcr.tg1];
-            currState->hpd = currState->tcr.hpd1;
-            currState->sh = currState->tcr.sh1;
-            currState->irgn = currState->tcr.irgn1;
-            currState->orgn = currState->tcr.orgn1;
-            vaddr_fault = s1TxSzFault(tg, currState->tcr.t1sz) ||
-                checkVAOutOfRange(currState->vaddr, top_bit, tsz, false);
-
-            if (vaddr_fault || !currState->hcr.e2h || currState->tcr.epd1)
-                fault = true;
+                    if (vaddr_fault) {
+                        fault = true;
+                    }
+                    break;
+                default:
+                    // invalid addr if top two bytes are not all 0s
+                    fault = true;
+            }
+            ps = curr_state->tcr.ps;
             break;
-
-           default:
-              // invalid addr if top two bytes are not all 0s
-              fault = true;
-        }
-        ps = currState->hcr.e2h ? currState->tcr.ips: currState->tcr.ps;
-        break;
-      case TranslationRegime::EL3:
-        switch(bits(currState->vaddr, top_bit)) {
-          case 0:
-            DPRINTF(TLB, " - Selecting TTBR0_EL3 (AArch64)\n");
-            ttbr = currState->tc->readMiscReg(MISCREG_TTBR0_EL3);
-            tsz = 64 - currState->tcr.t0sz;
-            tg = GrainMap_tg0[currState->tcr.tg0];
-            currState->hpd = currState->tcr.hpd;
-            currState->sh = currState->tcr.sh0;
-            currState->irgn = currState->tcr.irgn0;
-            currState->orgn = currState->tcr.orgn0;
-            vaddr_fault = s1TxSzFault(tg, currState->tcr.t0sz) ||
-                checkVAOutOfRange(currState->vaddr, top_bit, tsz, true);
-
-            if (vaddr_fault)
-                fault = true;
-            break;
-          default:
-            // invalid addr if top two bytes are not all 0s
-            fault = true;
-        }
-        ps = currState->tcr.ps;
-        break;
     }
 
-    currState->isUncacheable = currState->irgn == 0 ||
-                               currState->orgn == 0;
+    curr_state->isUncacheable = curr_state->irgn == 0 || curr_state->orgn == 0;
 
-    const bool is_atomic = currState->req->isAtomic();
+    const bool is_atomic = curr_state->req->isAtomic();
 
     if (fault) {
-        if (currState->isFetch) {
+        if (curr_state->isFetch) {
             return std::make_shared<PrefetchAbort>(
-                currState->vaddr_tainted,
+                curr_state->vaddr_tainted,
                 ArmFault::TranslationLL + LookupLevel::L0, isStage2,
                 TranMethod::LpaeTran);
         } else {
             return std::make_shared<DataAbort>(
-                currState->vaddr_tainted,
-                DomainType::NoAccess,
-                is_atomic ? false : currState->isWrite,
-                ArmFault::TranslationLL + LookupLevel::L0,
-                isStage2, TranMethod::LpaeTran);
+                curr_state->vaddr_tainted, DomainType::NoAccess,
+                is_atomic ? false : curr_state->isWrite,
+                ArmFault::TranslationLL + LookupLevel::L0, isStage2,
+                TranMethod::LpaeTran);
         }
     }
 
@@ -1108,62 +1263,61 @@ TableWalker::processWalkAArch64()
 
     // Clamp to lower limit
     int pa_range = decodePhysAddrRange64(ps);
-    if (pa_range > _physAddrRange) {
-        currState->physAddrRange = _physAddrRange;
+    if (pa_range > parent->physAddrRange()) {
+        curr_state->physAddrRange = parent->physAddrRange();
     } else {
-        currState->physAddrRange = pa_range;
+        curr_state->physAddrRange = pa_range;
     }
 
-    auto [table_addr, desc_addr, start_lookup_level] = walkAddresses(
-        ttbr, tg, tsz, pa_range);
+    auto [table_addr, desc_addr, start_lookup_level] =
+        walkAddresses(curr_state, ttbr, tg, tsz, pa_range);
 
     // Determine physical address size and raise an Address Size Fault if
     // necessary
-    if (checkAddrSizeFaultAArch64(table_addr, currState->physAddrRange)) {
-        DPRINTF(TLB, "Address size fault before any lookup\n");
-        if (currState->isFetch)
+    if (checkAddrSizeFaultAArch64(table_addr, curr_state->physAddrRange)) {
+        DPRINTF(PageTableWalker, "Address size fault before any lookup\n");
+        if (curr_state->isFetch) {
             return std::make_shared<PrefetchAbort>(
-                currState->vaddr_tainted,
-                ArmFault::AddressSizeLL + start_lookup_level,
-                isStage2,
+                curr_state->vaddr_tainted,
+                ArmFault::AddressSizeLL + start_lookup_level, isStage2,
                 TranMethod::LpaeTran);
-        else
+        } else {
             return std::make_shared<DataAbort>(
-                currState->vaddr_tainted,
-                DomainType::NoAccess,
-                is_atomic ? false : currState->isWrite,
-                ArmFault::AddressSizeLL + start_lookup_level,
-                isStage2,
+                curr_state->vaddr_tainted, DomainType::NoAccess,
+                is_atomic ? false : curr_state->isWrite,
+                ArmFault::AddressSizeLL + start_lookup_level, isStage2,
                 TranMethod::LpaeTran);
+        }
     }
 
     Request::Flags flag = Request::PT_WALK;
-    if (uncacheableWalk()) {
+    if (uncacheableWalk(curr_state)) {
         flag.set(Request::UNCACHEABLE);
     }
 
-    if (currState->secureLookup) {
+    if (curr_state->secureLookup) {
         flag.set(Request::SECURE);
     }
 
-    currState->longDesc.lookupLevel = start_lookup_level;
-    currState->longDesc.aarch64 = true;
-    currState->longDesc.grainSize = tg;
-    currState->longDesc.physAddrRange = _physAddrRange;
-    currState->longDesc.isStage2 = isStage2;
+    curr_state->longDesc.lookupLevel = start_lookup_level;
+    curr_state->longDesc.aarch64 = true;
+    curr_state->longDesc.grainSize = tg;
+    curr_state->longDesc.physAddrRange = parent->physAddrRange();
+    curr_state->longDesc.isStage2 = isStage2;
 
     assert(start_lookup_level < LookupLevel::Num_ArmLookupLevel);
 
-    fetchDescriptor(desc_addr, currState->longDesc,
-                    sizeof(uint64_t), flag, start_lookup_level,
+    fetchDescriptor(desc_addr, curr_state->longDesc, sizeof(uint64_t), flag,
+                    start_lookup_level,
                     LongDescEventByLevel[start_lookup_level],
-                    &TableWalker::doLongDescriptor);
+                    &WalkUnit::doLongDescriptor, curr_state);
 
-    return currState->fault;
+    return curr_state->fault;
 }
 
-std::tuple<Addr, Addr, TableWalker::LookupLevel>
-TableWalker::walkAddresses(Addr ttbr, GrainSize tg, int tsz, int pa_range)
+std::tuple<Addr, Addr, WalkUnit::LookupLevel>
+WalkUnit::walkAddresses(WalkerState *curr_state, Addr ttbr, GrainSize tg,
+                        int tsz, int pa_range)
 {
     const auto* ptops = getPageTableOps(tg);
 
@@ -1171,27 +1325,26 @@ TableWalker::walkAddresses(Addr ttbr, GrainSize tg, int tsz, int pa_range)
     Addr table_addr = 0;
     Addr desc_addr = 0;
 
-    if (currState->walkEntry.valid) {
+    if (curr_state->walkEntry.valid) {
         // WalkCache hit
-        TlbEntry* entry = &currState->walkEntry;
+        TlbEntry *entry = &curr_state->walkEntry;
         DPRINTF(PageTableWalker,
                 "Walk Cache hit: va=%#x, level=%d, table address=%#x\n",
-                currState->vaddr, entry->lookupLevel, entry->pfn);
+                curr_state->vaddr, entry->lookupLevel, entry->pfn);
 
-        if (currState->longDescData.has_value()) {
-            currState->longDescData->xnTable = entry->xn;
-            currState->longDescData->pxnTable = entry->pxn;
-            currState->longDescData->rwTable = bits(entry->ap, 1);
-            currState->longDescData->userTable = bits(entry->ap, 0);
+        if (curr_state->longDescData.has_value()) {
+            curr_state->longDescData->xnTable = entry->xn;
+            curr_state->longDescData->pxnTable = entry->pxn;
+            curr_state->longDescData->rwTable = bits(entry->ap, 1);
+            curr_state->longDescData->userTable = bits(entry->ap, 0);
         }
 
         table_addr = entry->pfn;
         first_level = (LookupLevel)(entry->lookupLevel + 1);
     } else {
         // WalkCache miss
-        first_level = isStage2 ?
-            ptops->firstS2Level(currState->vtcr.sl0) :
-            ptops->firstLevel(64 - tsz);
+        first_level = isStage2 ? ptops->firstS2Level(curr_state->vtcr.sl0)
+                               : ptops->firstLevel(64 - tsz);
         panic_if(first_level == LookupLevel::Num_ArmLookupLevel,
                  "Table walker couldn't find lookup level\n");
 
@@ -1207,17 +1360,20 @@ TableWalker::walkAddresses(Addr ttbr, GrainSize tg, int tsz, int pa_range)
         }
     }
 
-    desc_addr = table_addr + ptops->index(currState->vaddr, first_level, tsz);
+    desc_addr = table_addr + ptops->index(curr_state->vaddr, first_level, tsz);
 
     return std::make_tuple(table_addr, desc_addr, first_level);
 }
 
 void
-TableWalker::memAttrs(ThreadContext *tc, TlbEntry &te, SCTLR sctlr,
-                      uint8_t texcb, bool s)
+WalkUnit::memAttrs(WalkerState *curr_state, TlbEntry &te, uint8_t texcb,
+                   bool s)
 {
     // Note: tc and sctlr local variables are hiding tc and sctrl class
     // variables
+    auto &sctlr = curr_state->sctlr;
+    auto &tc = curr_state->tc;
+
     DPRINTF(TLBVerbose, "memAttrs texcb:%d s:%d\n", texcb, s);
     te.shareable = false; // default value
     te.nonCacheable = false;
@@ -1292,10 +1448,12 @@ TableWalker::memAttrs(ThreadContext *tc, TlbEntry &te, SCTLR sctlr,
         }
     } else {
         assert(tc);
-        PRRR prrr = tc->readMiscReg(snsBankedIndex(MISCREG_PRRR,
-            currState->tc, currState->ss == SecurityState::NonSecure));
-        NMRR nmrr = tc->readMiscReg(snsBankedIndex(MISCREG_NMRR,
-            currState->tc, currState->ss == SecurityState::NonSecure));
+        PRRR prrr = tc->readMiscReg(
+            snsBankedIndex(MISCREG_PRRR, curr_state->tc,
+                           curr_state->ss == SecurityState::NonSecure));
+        NMRR nmrr = tc->readMiscReg(
+            snsBankedIndex(MISCREG_NMRR, curr_state->tc,
+                           curr_state->ss == SecurityState::NonSecure));
         DPRINTF(TLBVerbose, "memAttrs PRRR:%08x NMRR:%08x\n", prrr, nmrr);
         uint8_t curr_tr = 0, curr_ir = 0, curr_or = 0;
         switch(bits(texcb, 2,0)) {
@@ -1420,10 +1578,10 @@ TableWalker::memAttrs(ThreadContext *tc, TlbEntry &te, SCTLR sctlr,
 }
 
 void
-TableWalker::memAttrsLPAE(ThreadContext *tc, TlbEntry &te,
-    LongDescriptor &l_descriptor)
+WalkUnit::memAttrsLPAE(WalkerState *curr_state, TlbEntry &te,
+                       LongDescriptor &l_descriptor)
 {
-    assert(release->has(ArmExtension::LPAE));
+    assert(mmu->release()->has(ArmExtension::LPAE));
 
     uint8_t attr;
     uint8_t sh = l_descriptor.sh();
@@ -1456,9 +1614,9 @@ TableWalker::memAttrsLPAE(ThreadContext *tc, TlbEntry &te,
         // LPAE always uses remapping of memory attributes, irrespective of the
         // value of SCTLR.TRE
         MiscRegIndex reg = attrIndx & 0x4 ? MISCREG_MAIR1 : MISCREG_MAIR0;
-        int reg_as_int = snsBankedIndex(reg, currState->tc,
-            currState->ss == SecurityState::NonSecure);
-        uint32_t mair = currState->tc->readMiscReg(reg_as_int);
+        int reg_as_int = snsBankedIndex(
+            reg, curr_state->tc, curr_state->ss == SecurityState::NonSecure);
+        uint32_t mair = curr_state->tc->readMiscReg(reg_as_int);
         attr = (mair >> (8 * (attrIndx % 4))) & 0xff;
         uint8_t attr_7_4 = bits(attr, 7, 4);
         uint8_t attr_3_0 = bits(attr, 3, 0);
@@ -1546,15 +1704,15 @@ TableWalker::memAttrsLPAE(ThreadContext *tc, TlbEntry &te,
 }
 
 bool
-TableWalker::uncacheableFromAttrs(uint8_t attrs)
+WalkUnit::uncacheableFromAttrs(uint8_t attrs)
 {
     return !bits(attrs, 2) || // Write-through
         attrs == 0b0100;      // NonCacheable
 }
 
 void
-TableWalker::memAttrsAArch64(ThreadContext *tc, TlbEntry &te,
-                             LongDescriptor &l_descriptor)
+WalkUnit::memAttrsAArch64(WalkerState *curr_state, TlbEntry &te,
+                          LongDescriptor &l_descriptor)
 {
     uint8_t attr;
     uint8_t attr_hi;
@@ -1595,20 +1753,20 @@ TableWalker::memAttrsAArch64(ThreadContext *tc, TlbEntry &te,
 
         // Select MAIR
         uint64_t mair;
-        switch (currState->regime) {
-          case TranslationRegime::EL10:
-            mair = tc->readMiscReg(MISCREG_MAIR_EL1);
-            break;
-          case TranslationRegime::EL20:
-          case TranslationRegime::EL2:
-            mair = tc->readMiscReg(MISCREG_MAIR_EL2);
-            break;
-          case TranslationRegime::EL3:
-            mair = tc->readMiscReg(MISCREG_MAIR_EL3);
-            break;
-          default:
-            panic("Invalid exception level");
-            break;
+        switch (curr_state->regime) {
+            case TranslationRegime::EL10:
+                mair = curr_state->tc->readMiscReg(MISCREG_MAIR_EL1);
+                break;
+            case TranslationRegime::EL20:
+            case TranslationRegime::EL2:
+                mair = curr_state->tc->readMiscReg(MISCREG_MAIR_EL2);
+                break;
+            case TranslationRegime::EL3:
+                mair = curr_state->tc->readMiscReg(MISCREG_MAIR_EL3);
+                break;
+            default:
+                panic("Invalid exception level");
+                break;
         }
 
         // Select attributes
@@ -1654,18 +1812,18 @@ TableWalker::memAttrsAArch64(ThreadContext *tc, TlbEntry &te,
 }
 
 void
-TableWalker::memAttrsWalkAArch64(TlbEntry &te)
+WalkUnit::memAttrsWalkAArch64(WalkerState *curr_state, TlbEntry &te)
 {
     te.mtype = TlbEntry::MemoryType::Normal;
-    if (uncacheableWalk()) {
+    if (uncacheableWalk(curr_state)) {
         te.shareable = 3;
         te.outerAttrs = 0;
         te.innerAttrs = 0;
         te.nonCacheable = true;
     } else {
-        te.shareable = currState->sh;
-        te.outerAttrs = currState->orgn;
-        te.innerAttrs = currState->irgn;
+        te.shareable = curr_state->sh;
+        te.outerAttrs = curr_state->orgn;
+        te.innerAttrs = curr_state->irgn;
         te.nonCacheable = (te.outerAttrs == 0 || te.outerAttrs == 2) &&
             (te.innerAttrs == 0 || te.innerAttrs == 2);
     }
@@ -1675,90 +1833,82 @@ TableWalker::memAttrsWalkAArch64(TlbEntry &te)
 }
 
 void
-TableWalker::doL1Descriptor()
+WalkUnit::doL1Descriptor(WalkerState *curr_state)
 {
-    if (currState->fault != NoFault) {
+    if (curr_state->fault != NoFault) {
         return;
     }
 
-    currState->l1Desc.data = htog(currState->l1Desc.data,
-                                  byteOrder(currState->tc));
+    curr_state->l1Desc.data =
+        htog(curr_state->l1Desc.data, byteOrder(curr_state->tc));
 
-    DPRINTF(TLB, "L1 descriptor for %#x is %#x\n",
-            currState->vaddr_tainted, currState->l1Desc.data);
+    DPRINTF(PageTableWalker, "L1 descriptor for %#x is %#x\n",
+            curr_state->vaddr_tainted, curr_state->l1Desc.data);
     TlbEntry te;
 
-    const bool is_atomic = currState->req->isAtomic();
+    const bool is_atomic = curr_state->req->isAtomic();
 
-    switch (currState->l1Desc.type()) {
-      case L1Descriptor::Ignore:
-      case L1Descriptor::Reserved:
-        if (!currState->timing) {
-            currState->tc = NULL;
-            currState->req = NULL;
-        }
-        DPRINTF(TLB, "L1 Descriptor Reserved/Ignore, causing fault\n");
-        if (currState->isFetch)
-            currState->fault =
-                std::make_shared<PrefetchAbort>(
-                    currState->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1,
-                    isStage2,
-                    TranMethod::VmsaTran);
-        else
-            currState->fault =
-                std::make_shared<DataAbort>(
-                    currState->vaddr_tainted,
-                    DomainType::NoAccess,
-                    is_atomic ? false : currState->isWrite,
+    switch (curr_state->l1Desc.type()) {
+        case L1Descriptor::Ignore:
+        case L1Descriptor::Reserved:
+            DPRINTF(PageTableWalker,
+                    "L1 Descriptor Reserved/Ignore, causing fault\n");
+            if (curr_state->isFetch) {
+                curr_state->fault = std::make_shared<PrefetchAbort>(
+                    curr_state->vaddr_tainted,
                     ArmFault::TranslationLL + LookupLevel::L1, isStage2,
                     TranMethod::VmsaTran);
-        return;
-      case L1Descriptor::Section:
-        if (currState->sctlr.afe && bits(currState->l1Desc.ap(), 0) == 0) {
-            /** @todo: check sctlr.ha (bit[17]) if Hardware Access Flag is
-              * enabled if set, do l1.Desc.setAp0() instead of generating
-              * AccessFlag0
-              */
+            } else {
+                curr_state->fault = std::make_shared<DataAbort>(
+                    curr_state->vaddr_tainted, DomainType::NoAccess,
+                    is_atomic ? false : curr_state->isWrite,
+                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
+                    TranMethod::VmsaTran);
+            }
+            return;
+        case L1Descriptor::Section:
+            if (curr_state->sctlr.afe &&
+                bits(curr_state->l1Desc.ap(), 0) == 0) {
+                /** @todo: check sctlr.ha (bit[17]) if Hardware Access Flag is
+                 * enabled if set, do l1.Desc.setAp0() instead of generating
+                 * AccessFlag0
+                 */
 
-            currState->fault = std::make_shared<DataAbort>(
-                currState->vaddr_tainted,
-                currState->l1Desc.domain(),
-                is_atomic ? false : currState->isWrite,
-                ArmFault::AccessFlagLL + LookupLevel::L1,
-                isStage2,
-                TranMethod::VmsaTran);
-        }
-        if (currState->l1Desc.supersection()) {
-            panic("Haven't implemented supersections\n");
-        }
-        insertTableEntry(currState->l1Desc, false);
-        return;
-      case L1Descriptor::PageTable:
-        {
+                curr_state->fault = std::make_shared<DataAbort>(
+                    curr_state->vaddr_tainted, curr_state->l1Desc.domain(),
+                    is_atomic ? false : curr_state->isWrite,
+                    ArmFault::AccessFlagLL + LookupLevel::L1, isStage2,
+                    TranMethod::VmsaTran);
+            }
+            if (curr_state->l1Desc.supersection()) {
+                panic("Haven't implemented supersections\n");
+            }
+            insertTableEntry(curr_state, curr_state->l1Desc, false);
+            return;
+        case L1Descriptor::PageTable: {
             Addr l2desc_addr;
-            l2desc_addr = currState->l1Desc.l2Addr() |
-                (bits(currState->vaddr, 19, 12) << 2);
-            DPRINTF(TLB, "L1 descriptor points to page table at: %#x (%s)\n",
-                    l2desc_addr, currState->ss == SecurityState::Secure ?
-                    "s" : "ns");
+            l2desc_addr = curr_state->l1Desc.l2Addr() |
+                          (bits(curr_state->vaddr, 19, 12) << 2);
+            DPRINTF(PageTableWalker,
+                    "L1 descriptor points to page table at: %#x (%s)\n",
+                    l2desc_addr,
+                    curr_state->ss == SecurityState::Secure ? "s" : "ns");
 
             Request::Flags flag = Request::PT_WALK;
 
-            if (currState->sctlr.c == 0 || currState->isUncacheable) {
+            if (curr_state->sctlr.c == 0 || curr_state->isUncacheable) {
                 flag.set(Request::UNCACHEABLE);
             }
 
-            if (currState->secureLookup)
+            if (curr_state->secureLookup) {
                 flag.set(Request::SECURE);
+            }
 
-            fetchDescriptor(
-                l2desc_addr, currState->l2Desc,
-                sizeof(uint32_t), flag, LookupLevel::L2,
-                &doL2DescEvent,
-                &TableWalker::doL2Descriptor);
+            fetchDescriptor(l2desc_addr, curr_state->l2Desc, sizeof(uint32_t),
+                            flag, LookupLevel::L2, &doL2DescEvent,
+                            &WalkUnit::doL2Descriptor, curr_state);
 
-            currState->delayed = currState->timing;
+            curr_state->delayed = curr_state->timing;
 
             return;
         }
@@ -1768,161 +1918,164 @@ TableWalker::doL1Descriptor()
 }
 
 Fault
-TableWalker::generateLongDescFault(ArmFault::FaultSource src)
+WalkUnit::generateLongDescFault(WalkerState *curr_state,
+                                ArmFault::FaultSource src)
 {
-    if (currState->isFetch) {
+    if (curr_state->isFetch) {
         return std::make_shared<PrefetchAbort>(
-            currState->vaddr_tainted,
-            src + currState->longDesc.lookupLevel,
-            isStage2,
-            TranMethod::LpaeTran);
+            curr_state->vaddr_tainted, src + curr_state->longDesc.lookupLevel,
+            isStage2, TranMethod::LpaeTran);
     } else {
         return std::make_shared<DataAbort>(
-            currState->vaddr_tainted,
-            DomainType::NoAccess,
-            currState->req->isAtomic() ? false : currState->isWrite,
-            src + currState->longDesc.lookupLevel,
-            isStage2,
+            curr_state->vaddr_tainted, DomainType::NoAccess,
+            curr_state->req->isAtomic() ? false : curr_state->isWrite,
+            src + curr_state->longDesc.lookupLevel, isStage2,
             TranMethod::LpaeTran);
     }
 }
 
 void
-TableWalker::doLongDescriptor()
+WalkUnit::scheduleWalk(WalkerState *next_walk, Tick when)
 {
-    if (currState->fault != NoFault) {
+    doProcessEvent.setState(next_walk);
+    schedule(doProcessEvent, when);
+}
+
+void
+WalkUnit::doLongDescriptor(WalkerState *curr_state)
+{
+    if (curr_state->fault != NoFault) {
         return;
     }
 
-    currState->longDesc.data = htog(currState->longDesc.data,
-                                    byteOrder(currState->tc));
+    curr_state->longDesc.data =
+        htog(curr_state->longDesc.data, byteOrder(curr_state->tc));
 
-    DPRINTF(TLB, "L%d descriptor for %#llx is %#llx (%s)\n",
-            currState->longDesc.lookupLevel, currState->vaddr_tainted,
-            currState->longDesc.data,
-            currState->aarch64 ? "AArch64" : "long-desc.");
+    DPRINTF(PageTableWalker, "L%d descriptor for %#llx is %#llx (%s)\n",
+            curr_state->longDesc.lookupLevel, curr_state->vaddr_tainted,
+            curr_state->longDesc.data,
+            curr_state->aarch64 ? "AArch64" : "long-desc.");
 
-    if ((currState->longDesc.type() == LongDescriptor::Block) ||
-        (currState->longDesc.type() == LongDescriptor::Page)) {
-        DPRINTF(PageTableWalker, "Analyzing L%d descriptor: %#llx, pxn: %d, "
+    if ((curr_state->longDesc.type() == LongDescriptor::Block) ||
+        (curr_state->longDesc.type() == LongDescriptor::Page)) {
+        DPRINTF(PageTableWalker,
+                "Analyzing L%d descriptor: %#llx, pxn: %d, "
                 "xn: %d, ap: %d, piindex: %d, af: %d, type: %d\n",
-                currState->longDesc.lookupLevel,
-                currState->longDesc.data,
-                currState->longDesc.pxn(),
-                currState->longDesc.xn(),
-                currState->longDesc.ap(),
-                currState->longDesc.piindex(),
-                currState->longDesc.af(),
-                currState->longDesc.type());
+                curr_state->longDesc.lookupLevel, curr_state->longDesc.data,
+                curr_state->longDesc.pxn(), curr_state->longDesc.xn(),
+                curr_state->longDesc.ap(), curr_state->longDesc.piindex(),
+                curr_state->longDesc.af(), curr_state->longDesc.type());
     } else {
         DPRINTF(PageTableWalker, "Analyzing L%d descriptor: %#llx, type: %d\n",
-                currState->longDesc.lookupLevel,
-                currState->longDesc.data,
-                currState->longDesc.type());
+                curr_state->longDesc.lookupLevel, curr_state->longDesc.data,
+                curr_state->longDesc.type());
     }
 
     TlbEntry te;
 
-    switch (currState->longDesc.type()) {
-      case LongDescriptor::Invalid:
-        DPRINTF(TLB, "L%d descriptor Invalid, causing fault type %d\n",
-                currState->longDesc.lookupLevel,
-                ArmFault::TranslationLL + currState->longDesc.lookupLevel);
+    switch (curr_state->longDesc.type()) {
+        case LongDescriptor::Invalid:
+            DPRINTF(PageTableWalker,
+                    "L%d descriptor Invalid, causing fault type %d\n",
+                    curr_state->longDesc.lookupLevel,
+                    ArmFault::TranslationLL +
+                        curr_state->longDesc.lookupLevel);
 
-        currState->fault = generateLongDescFault(ArmFault::TranslationLL);
-        if (!currState->timing) {
-            currState->tc = NULL;
-            currState->req = NULL;
-        }
-        return;
+            curr_state->fault =
+                generateLongDescFault(curr_state, ArmFault::TranslationLL);
+            return;
 
-      case LongDescriptor::Block:
-      case LongDescriptor::Page:
-        {
+        case LongDescriptor::Block:
+        case LongDescriptor::Page: {
             auto fault_source = ArmFault::FaultSourceInvalid;
             // Check for address size fault
-            if (checkAddrSizeFaultAArch64(currState->longDesc.paddr(),
-                currState->physAddrRange)) {
+            if (checkAddrSizeFaultAArch64(curr_state->longDesc.paddr(),
+                                          curr_state->physAddrRange)) {
 
-                DPRINTF(TLB, "L%d descriptor causing Address Size Fault\n",
-                        currState->longDesc.lookupLevel);
+                DPRINTF(PageTableWalker,
+                        "L%d descriptor causing Address Size Fault\n",
+                        curr_state->longDesc.lookupLevel);
                 fault_source = ArmFault::AddressSizeLL;
 
             // Check for access fault
-            } else if (currState->longDesc.af() == 0) {
+            } else if (curr_state->longDesc.af() == 0) {
 
-                DPRINTF(TLB, "L%d descriptor causing Access Fault\n",
-                        currState->longDesc.lookupLevel);
+                DPRINTF(PageTableWalker,
+                        "L%d descriptor causing Access Fault\n",
+                        curr_state->longDesc.lookupLevel);
                 fault_source = ArmFault::AccessFlagLL;
             }
 
             if (fault_source != ArmFault::FaultSourceInvalid) {
-                currState->fault = generateLongDescFault(fault_source);
+                curr_state->fault =
+                    generateLongDescFault(curr_state, fault_source);
             } else {
-                insertTableEntry(currState->longDesc, true);
+                insertTableEntry(curr_state, curr_state->longDesc, true);
             }
         }
-        return;
-      case LongDescriptor::Table:
-        {
+            return;
+        case LongDescriptor::Table: {
             // Set hierarchical permission flags
             if (!isStage2) {
-                currState->secureLookup = currState->secureLookup &&
-                    currState->longDesc.secureTable();
+                curr_state->secureLookup = curr_state->secureLookup &&
+                                           curr_state->longDesc.secureTable();
             }
-            currState->longDescData->rwTable =
-                currState->longDescData->rwTable &&
-                (currState->longDesc.rwTable() || currState->hpd);
-            currState->longDescData->userTable =
-                currState->longDescData->userTable &&
-                (currState->longDesc.userTable() || currState->hpd);
-            currState->longDescData->xnTable =
-                currState->longDescData->xnTable ||
-                (currState->longDesc.xnTable() && !currState->hpd);
-            currState->longDescData->pxnTable =
-                currState->longDescData->pxnTable ||
-                (currState->longDesc.pxnTable() && !currState->hpd);
+            curr_state->longDescData->rwTable =
+                curr_state->longDescData->rwTable &&
+                (curr_state->longDesc.rwTable() || curr_state->hpd);
+            curr_state->longDescData->userTable =
+                curr_state->longDescData->userTable &&
+                (curr_state->longDesc.userTable() || curr_state->hpd);
+            curr_state->longDescData->xnTable =
+                curr_state->longDescData->xnTable ||
+                (curr_state->longDesc.xnTable() && !curr_state->hpd);
+            curr_state->longDescData->pxnTable =
+                curr_state->longDescData->pxnTable ||
+                (curr_state->longDesc.pxnTable() && !curr_state->hpd);
 
             // Set up next level lookup
-            Addr next_desc_addr = currState->longDesc.nextDescAddr(
-                currState->vaddr);
+            Addr next_desc_addr =
+                curr_state->longDesc.nextDescAddr(curr_state->vaddr);
 
-            DPRINTF(TLB, "L%d descriptor points to L%d descriptor at: %#x (%s)\n",
-                    currState->longDesc.lookupLevel,
-                    currState->longDesc.lookupLevel + 1,
-                    next_desc_addr,
-                    currState->secureLookup ? "s" : "ns");
+            DPRINTF(PageTableWalker,
+                    "L%d descriptor points to L%d descriptor at: %#x (%s)\n",
+                    curr_state->longDesc.lookupLevel,
+                    curr_state->longDesc.lookupLevel + 1, next_desc_addr,
+                    curr_state->secureLookup ? "s" : "ns");
 
             // Check for address size fault
-            if (currState->aarch64 && checkAddrSizeFaultAArch64(
-                    next_desc_addr, currState->physAddrRange)) {
-                DPRINTF(TLB, "L%d descriptor causing Address Size Fault\n",
-                        currState->longDesc.lookupLevel);
+            if (curr_state->aarch64 &&
+                checkAddrSizeFaultAArch64(next_desc_addr,
+                                          curr_state->physAddrRange)) {
+                DPRINTF(PageTableWalker,
+                        "L%d descriptor causing Address Size Fault\n",
+                        curr_state->longDesc.lookupLevel);
 
-                currState->fault = generateLongDescFault(
-                    ArmFault::AddressSizeLL);
+                curr_state->fault =
+                    generateLongDescFault(curr_state, ArmFault::AddressSizeLL);
                 return;
             }
 
             if (mmu->hasWalkCache()) {
-                insertPartialTableEntry(currState->longDesc);
+                insertPartialTableEntry(curr_state);
             }
 
             Request::Flags flag = Request::PT_WALK;
-            if (currState->secureLookup)
+            if (curr_state->secureLookup) {
                 flag.set(Request::SECURE);
+            }
 
-            if (currState->sctlr.c == 0 || currState->isUncacheable) {
+            if (curr_state->sctlr.c == 0 || curr_state->isUncacheable) {
                 flag.set(Request::UNCACHEABLE);
             }
 
-            LookupLevel L = currState->longDesc.lookupLevel =
-                (LookupLevel) (currState->longDesc.lookupLevel + 1);
+            LookupLevel L = curr_state->longDesc.lookupLevel =
+                (LookupLevel)(curr_state->longDesc.lookupLevel + 1);
             Event *event = NULL;
             switch (L) {
               case LookupLevel::L1:
-                assert(currState->aarch64);
-                [[fallthrough]];
+                  assert(curr_state->aarch64);
+                  [[fallthrough]];
               case LookupLevel::L2:
               case LookupLevel::L3:
                 event = LongDescEventByLevel[L];
@@ -1932,360 +2085,352 @@ TableWalker::doLongDescriptor()
                 break;
             }
 
-            fetchDescriptor(
-                next_desc_addr, currState->longDesc,
-                sizeof(uint64_t), flag, L, event,
-                &TableWalker::doLongDescriptor);
+            fetchDescriptor(next_desc_addr, curr_state->longDesc,
+                            sizeof(uint64_t), flag, L, event,
+                            &WalkUnit::doLongDescriptor, curr_state);
 
-            currState->delayed = currState->timing;
+            curr_state->delayed = curr_state->timing;
         }
-        return;
-      default:
-        panic("A new type in a 2 bit field?\n");
+            return;
+        default:
+            panic("A new type in a 2 bit field?\n");
     }
 }
 
 void
-TableWalker::doL2Descriptor()
+WalkUnit::doL2Descriptor(WalkerState *curr_state)
 {
-    if (currState->fault != NoFault) {
+    if (curr_state->fault != NoFault) {
         return;
     }
 
-    currState->l2Desc.data = htog(currState->l2Desc.data,
-                                  byteOrder(currState->tc));
+    curr_state->l2Desc.data =
+        htog(curr_state->l2Desc.data, byteOrder(curr_state->tc));
 
-    DPRINTF(TLB, "L2 descriptor for %#x is %#x\n",
-            currState->vaddr_tainted, currState->l2Desc.data);
+    DPRINTF(PageTableWalker, "L2 descriptor for %#x is %#x\n",
+            curr_state->vaddr_tainted, curr_state->l2Desc.data);
     TlbEntry te;
 
-    const bool is_atomic = currState->req->isAtomic();
+    const bool is_atomic = curr_state->req->isAtomic();
 
-    if (currState->l2Desc.invalid()) {
-        DPRINTF(TLB, "L2 descriptor invalid, causing fault\n");
-        if (!currState->timing) {
-            currState->tc = NULL;
-            currState->req = NULL;
-        }
-        if (currState->isFetch)
-            currState->fault = std::make_shared<PrefetchAbort>(
-                    currState->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L2,
-                    isStage2,
-                    TranMethod::VmsaTran);
-        else
-            currState->fault = std::make_shared<DataAbort>(
-                currState->vaddr_tainted, currState->l1Desc.domain(),
-                is_atomic ? false : currState->isWrite,
-                ArmFault::TranslationLL + LookupLevel::L2,
-                isStage2,
+    if (curr_state->l2Desc.invalid()) {
+        DPRINTF(PageTableWalker, "L2 descriptor invalid, causing fault\n");
+        if (curr_state->isFetch) {
+            curr_state->fault = std::make_shared<PrefetchAbort>(
+                curr_state->vaddr_tainted,
+                ArmFault::TranslationLL + LookupLevel::L2, isStage2,
                 TranMethod::VmsaTran);
+        } else {
+            curr_state->fault = std::make_shared<DataAbort>(
+                curr_state->vaddr_tainted, curr_state->l1Desc.domain(),
+                is_atomic ? false : curr_state->isWrite,
+                ArmFault::TranslationLL + LookupLevel::L2, isStage2,
+                TranMethod::VmsaTran);
+        }
         return;
     }
 
-    if (currState->sctlr.afe && bits(currState->l2Desc.ap(), 0) == 0) {
+    if (curr_state->sctlr.afe && bits(curr_state->l2Desc.ap(), 0) == 0) {
         /** @todo: check sctlr.ha (bit[17]) if Hardware Access Flag is enabled
           * if set, do l2.Desc.setAp0() instead of generating AccessFlag0
           */
-         DPRINTF(TLB, "Generating access fault at L2, afe: %d, ap: %d\n",
-                 currState->sctlr.afe, currState->l2Desc.ap());
+        DPRINTF(PageTableWalker,
+                "Generating access fault at L2, afe: %d, ap: %d\n",
+                curr_state->sctlr.afe, curr_state->l2Desc.ap());
 
-        currState->fault = std::make_shared<DataAbort>(
-            currState->vaddr_tainted,
-            DomainType::NoAccess,
-            is_atomic ? false : currState->isWrite,
+        curr_state->fault = std::make_shared<DataAbort>(
+            curr_state->vaddr_tainted, DomainType::NoAccess,
+            is_atomic ? false : curr_state->isWrite,
             ArmFault::AccessFlagLL + LookupLevel::L2, isStage2,
             TranMethod::VmsaTran);
     }
 
-    insertTableEntry(currState->l2Desc, false);
+    insertTableEntry(curr_state, curr_state->l2Desc, false);
 }
 
 void
-TableWalker::doL1DescriptorWrapper()
+WalkUnit::doL1DescriptorWrapper()
 {
-    currState = stateQueues[LookupLevel::L1].front();
-    currState->delayed = false;
+    WalkerState *curr_state = stateQueues[LookupLevel::L1].front();
+    curr_state->delayed = false;
     // if there's a stage2 translation object we don't need it any more
-    if (currState->stage2Tran) {
-        delete currState->stage2Tran;
-        currState->stage2Tran = NULL;
+    if (curr_state->stage2Tran) {
+        delete curr_state->stage2Tran;
+        curr_state->stage2Tran = NULL;
     }
 
-
     DPRINTF(PageTableWalker, "L1 Desc object host addr: %p\n",
-            &currState->l1Desc.data);
+            &curr_state->l1Desc.data);
     DPRINTF(PageTableWalker, "L1 Desc object      data: %08x\n",
-            currState->l1Desc.data);
+            curr_state->l1Desc.data);
 
     DPRINTF(PageTableWalker, "calling doL1Descriptor for vaddr:%#x\n",
-            currState->vaddr_tainted);
-    doL1Descriptor();
+            curr_state->vaddr_tainted);
+    doL1Descriptor(curr_state);
 
     stateQueues[LookupLevel::L1].pop_front();
     // Check if fault was generated
-    if (currState->fault != NoFault) {
-        currState->transState->finish(currState->fault, currState->req,
-                                      currState->tc, currState->mode);
-        stats.walksShortTerminatedAtLevel[0]++;
+    if (curr_state->fault != NoFault) {
+        curr_state->transState->finish(curr_state->fault, curr_state->req,
+                                       curr_state->tc, curr_state->mode);
+        parent->stats.walksShortTerminatedAtLevel[0]++;
 
-        pending = false;
-        nextWalk(currState->tc);
+        parent->nextWalk(this);
 
-        currState->req = NULL;
-        currState->tc = NULL;
-        currState->delayed = false;
-        delete currState;
-    }
-    else if (!currState->delayed) {
+        curr_state->req = NULL;
+        curr_state->tc = NULL;
+        curr_state->delayed = false;
+        delete curr_state;
+    } else if (!curr_state->delayed) {
         // delay is not set so there is no L2 to do
         // Don't finish the translation if a stage 2 look up is underway
-        stats.walkServiceTime.sample(curTick() - currState->startTime);
+        parent->stats.walkServiceTime.sample(curTick() -
+                                             curr_state->startTime);
+
         DPRINTF(PageTableWalker, "calling translateTiming again\n");
 
-        mmu->translateTiming(currState->req, currState->tc,
-            currState->transState, currState->mode,
-            currState->tranType, isStage2);
+        parent->inCompletionWalks.push_back(curr_state);
 
-        stats.walksShortTerminatedAtLevel[0]++;
+        mmu->translateTiming(curr_state->req, curr_state->tc,
+                             curr_state->transState, curr_state->mode,
+                             curr_state->tranType, isStage2);
 
-        pending = false;
-        nextWalk(currState->tc);
+        parent->inCompletionWalks.pop_back();
 
-        currState->req = NULL;
-        currState->tc = NULL;
-        currState->delayed = false;
-        delete currState;
+        parent->stats.walksShortTerminatedAtLevel[0]++;
+
+        parent->nextWalk(this);
+
+        curr_state->req = NULL;
+        curr_state->tc = NULL;
+        curr_state->delayed = false;
+        delete curr_state;
     } else {
         // need to do L2 descriptor
-        stashCurrState(LookupLevel::L2);
+        stashCurrState(curr_state, LookupLevel::L2);
     }
-    currState = NULL;
 }
 
 void
-TableWalker::doL2DescriptorWrapper()
+WalkUnit::doL2DescriptorWrapper()
 {
-    currState = stateQueues[LookupLevel::L2].front();
-    assert(currState->delayed);
+    WalkerState *curr_state = stateQueues[LookupLevel::L2].front();
+    assert(curr_state->delayed);
+
     // if there's a stage2 translation object we don't need it any more
-    if (currState->stage2Tran) {
-        delete currState->stage2Tran;
-        currState->stage2Tran = NULL;
+    if (curr_state->stage2Tran) {
+        delete curr_state->stage2Tran;
+        curr_state->stage2Tran = NULL;
     }
 
     DPRINTF(PageTableWalker, "calling doL2Descriptor for vaddr:%#x\n",
-            currState->vaddr_tainted);
-    doL2Descriptor();
+            curr_state->vaddr_tainted);
+    doL2Descriptor(curr_state);
 
     // Check if fault was generated
-    if (currState->fault != NoFault) {
-        currState->transState->finish(currState->fault, currState->req,
-                                      currState->tc, currState->mode);
-        stats.walksShortTerminatedAtLevel[1]++;
+    if (curr_state->fault != NoFault) {
+        curr_state->transState->finish(curr_state->fault, curr_state->req,
+                                       curr_state->tc, curr_state->mode);
+        parent->stats.walksShortTerminatedAtLevel[1]++;
     } else {
-        stats.walkServiceTime.sample(curTick() - currState->startTime);
+        parent->stats.walkServiceTime.sample(curTick() -
+                                             curr_state->startTime);
+
         DPRINTF(PageTableWalker, "calling translateTiming again\n");
 
-        mmu->translateTiming(currState->req, currState->tc,
-            currState->transState, currState->mode,
-            currState->tranType, isStage2);
+        parent->inCompletionWalks.push_back(curr_state);
 
-        stats.walksShortTerminatedAtLevel[1]++;
+        mmu->translateTiming(curr_state->req, curr_state->tc,
+                             curr_state->transState, curr_state->mode,
+                             curr_state->tranType, isStage2);
+
+        parent->inCompletionWalks.pop_back();
+
+        parent->stats.walksShortTerminatedAtLevel[1]++;
     }
 
-
     stateQueues[LookupLevel::L2].pop_front();
-    pending = false;
-    nextWalk(currState->tc);
+    parent->nextWalk(this);
 
-    currState->req = NULL;
-    currState->tc = NULL;
-    currState->delayed = false;
+    curr_state->req = NULL;
+    curr_state->tc = NULL;
+    curr_state->delayed = false;
 
-    delete currState;
-    currState = NULL;
+    delete curr_state;
 }
 
 void
-TableWalker::doL0LongDescriptorWrapper()
+WalkUnit::doL0LongDescriptorWrapper()
 {
     doLongDescriptorWrapper(LookupLevel::L0);
 }
 
 void
-TableWalker::doL1LongDescriptorWrapper()
+WalkUnit::doL1LongDescriptorWrapper()
 {
     doLongDescriptorWrapper(LookupLevel::L1);
 }
 
 void
-TableWalker::doL2LongDescriptorWrapper()
+WalkUnit::doL2LongDescriptorWrapper()
 {
     doLongDescriptorWrapper(LookupLevel::L2);
 }
 
 void
-TableWalker::doL3LongDescriptorWrapper()
+WalkUnit::doL3LongDescriptorWrapper()
 {
     doLongDescriptorWrapper(LookupLevel::L3);
 }
 
 void
-TableWalker::doLongDescriptorWrapper(LookupLevel curr_lookup_level)
+WalkUnit::doLongDescriptorWrapper(LookupLevel curr_lookup_level)
 {
-    currState = stateQueues[curr_lookup_level].front();
-    assert(curr_lookup_level == currState->longDesc.lookupLevel);
-    currState->delayed = false;
+    WalkerState *curr_state = stateQueues[curr_lookup_level].front();
+    assert(curr_lookup_level == curr_state->longDesc.lookupLevel);
+    curr_state->delayed = false;
 
     // if there's a stage2 translation object we don't need it any more
-    if (currState->stage2Tran) {
-        delete currState->stage2Tran;
-        currState->stage2Tran = NULL;
+    if (curr_state->stage2Tran) {
+        delete curr_state->stage2Tran;
+        curr_state->stage2Tran = NULL;
     }
 
     DPRINTF(PageTableWalker, "calling doLongDescriptor for vaddr:%#x\n",
-            currState->vaddr_tainted);
-    doLongDescriptor();
+            curr_state->vaddr_tainted);
+    doLongDescriptor(curr_state);
 
     stateQueues[curr_lookup_level].pop_front();
 
-    if (currState->fault != NoFault) {
+    if (curr_state->fault != NoFault) {
         // A fault was generated
-        currState->transState->finish(currState->fault, currState->req,
-                                      currState->tc, currState->mode);
+        curr_state->transState->finish(curr_state->fault, curr_state->req,
+                                       curr_state->tc, curr_state->mode);
 
-        pending = false;
-        nextWalk(currState->tc);
+        parent->nextWalk(this);
 
-        currState->req = NULL;
-        currState->tc = NULL;
-        currState->delayed = false;
-        delete currState;
-    } else if (!currState->delayed) {
+        curr_state->req = NULL;
+        curr_state->tc = NULL;
+        curr_state->delayed = false;
+        delete curr_state;
+    } else if (!curr_state->delayed) {
         // No additional lookups required
+        parent->stats.walkServiceTime.sample(curTick() -
+                                             curr_state->startTime);
+
         DPRINTF(PageTableWalker, "calling translateTiming again\n");
-        stats.walkServiceTime.sample(curTick() - currState->startTime);
 
-        mmu->translateTiming(currState->req, currState->tc,
-            currState->transState, currState->mode,
-            currState->tranType, isStage2);
+        parent->inCompletionWalks.push_back(curr_state);
 
-        stats.walksLongTerminatedAtLevel[(unsigned) curr_lookup_level]++;
+        mmu->translateTiming(curr_state->req, curr_state->tc,
+                             curr_state->transState, curr_state->mode,
+                             curr_state->tranType, isStage2);
 
-        pending = false;
-        nextWalk(currState->tc);
+        parent->inCompletionWalks.pop_back();
 
-        currState->req = NULL;
-        currState->tc = NULL;
-        currState->delayed = false;
-        delete currState;
+        parent->stats.walksLongTerminatedAtLevel[curr_lookup_level]++;
+
+        parent->nextWalk(this);
+
+        curr_state->req = NULL;
+        curr_state->tc = NULL;
+        curr_state->delayed = false;
+        delete curr_state;
     } else {
         if (curr_lookup_level >= LookupLevel::Num_ArmLookupLevel - 1)
             panic("Max. number of lookups already reached in table walk\n");
         // Need to perform additional lookups
-        stashCurrState(currState->longDesc.lookupLevel);
+        stashCurrState(curr_state, curr_state->longDesc.lookupLevel);
     }
-    currState = NULL;
-}
-
-
-void
-TableWalker::nextWalk(ThreadContext *tc)
-{
-    if (pendingQueue.size())
-        schedule(doProcessEvent, clockEdge(Cycles(1)));
-    else
-        completeDrain();
 }
 
 void
-TableWalker::fetchDescriptor(Addr desc_addr,
-    DescriptorBase &descriptor, int num_bytes,
+WalkUnit::fetchDescriptor(
+    Addr desc_addr, DescriptorBase &descriptor, int num_bytes,
     Request::Flags flags, LookupLevel lookup_level, Event *event,
-    void (TableWalker::*doDescriptor)())
+    void (WalkUnit::*doDescriptor)(WalkerState *curr_state),
+    WalkerState *curr_state)
 {
     uint8_t *data = descriptor.getRawPtr();
 
     DPRINTF(PageTableWalker,
-            "Fetching descriptor at address: 0x%x stage2Req: %d\n",
-            desc_addr, currState->stage2Req);
+            "Fetching descriptor at address: 0x%x stage2Req: %d\n", desc_addr,
+            curr_state->stage2Req);
 
     // If this translation has a stage 2 then we know desc_addr is an IPA and
     // needs to be translated before we can access the page table. Do that
     // check here.
-    if (currState->stage2Req) {
+    if (curr_state->stage2Req) {
         Fault fault;
 
-        if (currState->timing) {
-            auto *tran = new
-                Stage2Walk(*this, data, event, currState->vaddr,
-                    currState->mode, currState->tranType);
-            currState->stage2Tran = tran;
-            readDataTimed(currState->tc, desc_addr, tran, num_bytes, flags);
+        if (curr_state->timing) {
+            auto *tran =
+                new Stage2Walk(*this, data, event, curr_state->vaddr,
+                               curr_state->mode, curr_state->tranType, port);
+            curr_state->stage2Tran = tran;
+            readDataTimed(curr_state->tc, desc_addr, tran, num_bytes, flags);
             fault = tran->fault;
 
             if (fault != NoFault) {
-                currState->fault = fault;
+                curr_state->fault = fault;
             }
         } else {
-            fault = readDataUntimed(currState->tc,
-                currState->vaddr, desc_addr, data, num_bytes, flags,
-                currState->mode,
-                currState->tranType,
-                currState->functional);
+            fault =
+                readDataUntimed(curr_state->tc, curr_state->vaddr, desc_addr,
+                                data, num_bytes, flags, curr_state->mode,
+                                curr_state->tranType, curr_state->functional);
 
             if (fault != NoFault) {
-                currState->fault = fault;
+                curr_state->fault = fault;
             }
 
-            (this->*doDescriptor)();
+            (this->*doDescriptor)(curr_state);
         }
     } else {
-        RequestPtr req = std::make_shared<Request>(
-            desc_addr, num_bytes, flags, requestorId);
+        RequestPtr req = std::make_shared<Request>(desc_addr, num_bytes, flags,
+                                                   port->requestorId());
         req->taskId(context_switch_task_id::DMA);
 
-        mpamTagTableWalk(req);
+        mpamTagTableWalk(curr_state, req);
 
-        Fault fault = testWalk(req, descriptor.domain(),
-            lookup_level);
+        Fault fault =
+            testWalk(curr_state, req, descriptor.domain(), lookup_level);
 
         if (fault != NoFault) {
-            currState->fault = fault;
+            curr_state->fault = fault;
             return;
         }
 
-        if (currState->timing) {
-            port->sendTimingReq(req, data,
-                currState->tc->getCpuPtr()->clockPeriod(), event);
+        if (curr_state->timing) {
+            port->sendTimingReq(
+                req, data, curr_state->tc->getCpuPtr()->clockPeriod(), event);
 
-        } else if (!currState->functional) {
+        } else if (!curr_state->functional) {
             port->sendAtomicReq(req, data,
-                currState->tc->getCpuPtr()->clockPeriod());
+                                curr_state->tc->getCpuPtr()->clockPeriod());
 
-            (this->*doDescriptor)();
+            (this->*doDescriptor)(curr_state);
         } else {
             port->sendFunctionalReq(req, data);
-            (this->*doDescriptor)();
+            (this->*doDescriptor)(curr_state);
         }
     }
 }
 
 void
-TableWalker::stashCurrState(int queue_idx)
+WalkUnit::stashCurrState(WalkerState *curr_state, int queue_idx)
 {
     DPRINTF(PageTableWalker, "Adding to walker fifo: "
             "queue size before adding: %d\n",
             stateQueues[queue_idx].size());
-    stateQueues[queue_idx].push_back(currState);
-    currState = NULL;
+    stateQueues[queue_idx].push_back(curr_state);
 }
 
 void
-TableWalker::insertPartialTableEntry(LongDescriptor &descriptor)
+WalkUnit::insertPartialTableEntry(WalkerState *curr_state)
 {
-    const bool have_security = release->has(ArmExtension::SECURITY);
+    LongDescriptor &descriptor = curr_state->longDesc;
+    const bool have_security = mmu->release()->has(ArmExtension::SECURITY);
     TlbEntry te;
 
     // Create and fill a new page table entry
@@ -2294,29 +2439,31 @@ TableWalker::insertPartialTableEntry(LongDescriptor &descriptor)
     te.partial        = true;
     // The entry is global if there is no address space identifier
     // to differentiate translation contexts
-    te.global         = !mmu->hasUnprivRegime(currState->regime);
-    te.asid           = currState->asid;
-    te.vmid           = currState->vmid;
+    // clang-format off
+    te.global         = !mmu->hasUnprivRegime(curr_state->regime);
+    te.asid           = curr_state->asid;
+    te.vmid           = curr_state->vmid;
     te.N              = descriptor.offsetBits();
     te.tg             = descriptor.grainSize;
-    te.vpn            = currState->vaddr >> te.N;
+    te.vpn            = curr_state->vaddr >> te.N;
     te.size           = (1ULL << te.N) - 1;
     te.pfn            = descriptor.nextTableAddr();
     te.domain         = descriptor.domain();
     te.lookupLevel    = descriptor.lookupLevel;
-    te.ns             = !descriptor.secure(have_security, currState);
-    te.ss             = currState->ss;
-    te.ipaSpace       = currState->ipaSpace; // Used by stage2 entries only
+    te.ns             = !descriptor.secure(have_security, curr_state);
+    te.ss             = curr_state->ss;
+    te.ipaSpace       = curr_state->ipaSpace; // Used by stage2 entries only
     te.type           = TypeTLB::unified;
 
-    te.regime = currState->regime;
+    te.regime         = curr_state->regime;
+    // clang-format on
 
-    te.xn = currState->longDescData->xnTable;
-    te.pxn = currState->longDescData->pxnTable;
-    te.ap = (currState->longDescData->rwTable << 1) |
-            (currState->longDescData->userTable);
+    te.xn = curr_state->longDescData->xnTable;
+    te.pxn = curr_state->longDescData->pxnTable;
+    te.ap = (curr_state->longDescData->rwTable << 1) |
+            (curr_state->longDescData->userTable);
 
-    memAttrsWalkAArch64(te);
+    memAttrsWalkAArch64(curr_state, te);
 
     // Debug output
     DPRINTF(TLB, descriptor.dbgHeader().c_str());
@@ -2331,67 +2478,72 @@ TableWalker::insertPartialTableEntry(LongDescriptor &descriptor)
             descriptor.getRawData());
 
     // Insert the entry into the TLBs
-    mmu->insert(te, currState->mode, isStage2);
+    mmu->insert(te, curr_state->mode, isStage2);
 }
 
 void
-TableWalker::insertTableEntry(DescriptorBase &descriptor, bool long_descriptor)
+WalkUnit::insertTableEntry(WalkerState *curr_state, DescriptorBase &descriptor,
+                           bool long_descriptor)
 {
-    const bool have_security = release->has(ArmExtension::SECURITY);
+    const bool have_security = mmu->release()->has(ArmExtension::SECURITY);
     TlbEntry te;
 
     // Create and fill a new page table entry
+    // clang-format off
     te.valid          = true;
     te.longDescFormat = long_descriptor;
-    te.asid           = currState->asid;
-    te.vmid           = currState->vmid;
+    te.asid           = curr_state->asid;
+    te.vmid           = curr_state->vmid;
     te.N              = descriptor.offsetBits();
-    te.vpn            = currState->vaddr >> te.N;
+    te.vpn            = curr_state->vaddr >> te.N;
     te.size           = (1<<te.N) - 1;
     te.pfn            = descriptor.pfn();
     te.domain         = descriptor.domain();
     te.lookupLevel    = descriptor.lookupLevel;
-    te.ns             = !descriptor.secure(have_security, currState);
-    te.ss             = currState->ss;
-    te.ipaSpace       = currState->ipaSpace; // Used by stage2 entries only
+    te.ns             = !descriptor.secure(have_security, curr_state);
+    te.ss             = curr_state->ss;
+    te.ipaSpace       = curr_state->ipaSpace; // Used by stage2 entries only
     te.xn             = descriptor.xn();
-    te.type           = currState->mode == BaseMMU::Execute ?
-        TypeTLB::instruction : TypeTLB::data;
+    te.type = curr_state->mode == BaseMMU::Execute ? TypeTLB::instruction
+                                                   : TypeTLB::data;
+    // clang-format on
 
-    te.regime = currState->regime;
+    te.regime = curr_state->regime;
 
-    stats.pageSizes[pageSizeNtoStatBin(te.N)]++;
-    stats.requestOrigin[COMPLETED][currState->isFetch]++;
+    parent->stats.pageSizes[pageSizeNtoStatBin(te.N)]++;
+    parent->stats.requestOrigin[TableWalker::COMPLETED][curr_state->isFetch]++;
 
     // ASID has no meaning for stage 2 TLB entries, so mark all stage 2 entries
     // as global
-    te.global         = descriptor.global(currState) || isStage2;
+    te.global = descriptor.global(curr_state) || curr_state->isStage2;
     if (long_descriptor) {
         LongDescriptor l_descriptor =
             dynamic_cast<LongDescriptor &>(descriptor);
 
         te.tg = l_descriptor.grainSize;
-        te.xn |= currState->longDescData->xnTable;
-        te.pxn = currState->longDescData->pxnTable || l_descriptor.pxn();
+        te.xn |= curr_state->longDescData->xnTable;
+        te.pxn = curr_state->longDescData->pxnTable || l_descriptor.pxn();
         if (isStage2) {
             // this is actually the HAP field, but its stored in the same bit
             // possitions as the AP field in a stage 1 translation.
             te.hap = l_descriptor.ap();
         } else {
-           te.ap = ((!currState->longDescData->rwTable ||
-                     descriptor.ap() >> 1) << 1) |
-               (currState->longDescData->userTable && (descriptor.ap() & 0x1));
+            te.ap =
+                ((!curr_state->longDescData->rwTable || descriptor.ap() >> 1)
+                 << 1) |
+                (curr_state->longDescData->userTable &&
+                 (descriptor.ap() & 0x1));
             // Add index of Indirect Permission.
             te.piindex = l_descriptor.piindex();
         }
-        if (currState->aarch64)
-            memAttrsAArch64(currState->tc, te, l_descriptor);
-        else
-            memAttrsLPAE(currState->tc, te, l_descriptor);
+        if (curr_state->aarch64) {
+            memAttrsAArch64(curr_state, te, l_descriptor);
+        } else {
+            memAttrsLPAE(curr_state, te, l_descriptor);
+        }
     } else {
         te.ap = descriptor.ap();
-        memAttrs(currState->tc, te, currState->sctlr, descriptor.texcb(),
-                 descriptor.shareable());
+        memAttrs(curr_state, te, descriptor.texcb(), descriptor.shareable());
     }
 
     // Debug output
@@ -2408,11 +2560,11 @@ TableWalker::insertTableEntry(DescriptorBase &descriptor, bool long_descriptor)
             descriptor.getRawData());
 
     // Insert the entry into the TLBs
-    mmu->insert(te, currState->mode, isStage2);
+    mmu->insert(te, curr_state->mode, isStage2);
 }
 
-TableWalker::LookupLevel
-TableWalker::toLookupLevel(uint8_t lookup_level_as_int)
+WalkUnit::LookupLevel
+WalkUnit::toLookupLevel(uint8_t lookup_level_as_int)
 {
     switch (lookup_level_as_int) {
       case LookupLevel::L1:
@@ -2426,46 +2578,28 @@ TableWalker::toLookupLevel(uint8_t lookup_level_as_int)
     }
 }
 
-/* this method keeps track of the table walker queue's residency, so
- * needs to be called whenever requests start and complete. */
-void
-TableWalker::pendingChange()
-{
-    unsigned n = pendingQueue.size();
-    if ((currState != NULL) && (currState != pendingQueue.front())) {
-        ++n;
-    }
-
-    if (n != pendingReqs) {
-        Tick now = curTick();
-        stats.pendingWalks.sample(pendingReqs, now - pendingChangeTick);
-        pendingReqs = n;
-        pendingChangeTick = now;
-    }
-}
-
 Fault
-TableWalker::testWalk(const RequestPtr &walk_req, DomainType domain,
-                      LookupLevel lookup_level)
+WalkUnit::testWalk(WalkerState *curr_state, const RequestPtr &walk_req,
+                   DomainType domain, LookupLevel lookup_level)
 {
     if (!test) {
         return NoFault;
     } else {
-        return test->walkCheck(walk_req, currState->vaddr,
-                               currState->ss == SecurityState::Secure,
-                               currState->el != EL0,
-                               currState->mode, domain, lookup_level);
+        return test->walkCheck(walk_req, curr_state->vaddr,
+                               curr_state->ss == SecurityState::Secure,
+                               curr_state->el != EL0, curr_state->mode, domain,
+                               lookup_level);
     }
 }
 
 void
-TableWalker::setTestInterface(TlbTestInterface *ti)
+WalkUnit::setTestInterface(TlbTestInterface *ti)
 {
     test = ti;
 }
 
 uint8_t
-TableWalker::pageSizeNtoStatBin(uint8_t N)
+WalkUnit::pageSizeNtoStatBin(uint8_t N)
 {
     /* for stats.pageSizes */
     switch(N) {
@@ -2486,16 +2620,17 @@ TableWalker::pageSizeNtoStatBin(uint8_t N)
 }
 
 Fault
-TableWalker::readDataUntimed(ThreadContext *tc, Addr vaddr, Addr desc_addr,
-    uint8_t *data, int num_bytes, Request::Flags flags, BaseMMU::Mode mode,
-    MMU::ArmTranslationType tran_type, bool functional)
+WalkUnit::readDataUntimed(ThreadContext *tc, Addr vaddr, Addr desc_addr,
+                          uint8_t *data, int num_bytes, Request::Flags flags,
+                          BaseMMU::Mode mode,
+                          MMU::ArmTranslationType tran_type, bool functional)
 {
     Fault fault;
 
     // translate to physical address using the second stage MMU
     auto req = std::make_shared<Request>();
     req->setVirt(desc_addr, num_bytes, flags | Request::PT_WALK,
-                requestorId, 0);
+                 port->requestorId(), 0);
 
     if (functional) {
         fault = mmu->translateFunctional(req, tc, BaseMMU::Read,
@@ -2528,35 +2663,43 @@ TableWalker::readDataUntimed(ThreadContext *tc, Addr vaddr, Addr desc_addr,
 }
 
 void
-TableWalker::mpamTagTableWalk(RequestPtr &req) const
+WalkUnit::mpamTagTableWalk(WalkerState *curr_state, RequestPtr &req) const
 {
-    mpam::tagRequest(currState->tc, req, currState->isFetch);
+    mpam::tagRequest(curr_state->tc, req, curr_state->isFetch);
 }
 
 void
-TableWalker::readDataTimed(ThreadContext *tc, Addr desc_addr,
-                           Stage2Walk *translation, int num_bytes,
-                           Request::Flags flags)
+WalkUnit::readDataTimed(ThreadContext *tc, Addr desc_addr,
+                        Stage2Walk *translation, int num_bytes,
+                        Request::Flags flags)
 {
     // translate to physical address using the second stage MMU
-    translation->setVirt(
-            desc_addr, num_bytes, flags | Request::PT_WALK, requestorId);
+    translation->setVirt(desc_addr, num_bytes, flags | Request::PT_WALK,
+                         port->requestorId());
     translation->translateTiming(tc);
 }
 
-TableWalker::Stage2Walk::Stage2Walk(TableWalker &_parent,
-        uint8_t *_data, Event *_event, Addr vaddr, BaseMMU::Mode _mode,
-        MMU::ArmTranslationType tran_type)
-    : data(_data), numBytes(0), event(_event), parent(_parent),
-      oVAddr(vaddr), mode(_mode), tranType(tran_type), fault(NoFault)
+WalkUnit::Stage2Walk::Stage2Walk(WalkUnit &_parent, uint8_t *_data,
+                                 Event *_event, Addr vaddr,
+                                 BaseMMU::Mode _mode,
+                                 MMU::ArmTranslationType tran_type,
+                                 TableWalker::Port *_port)
+    : data(_data),
+      numBytes(0),
+      event(_event),
+      parent(_parent),
+      oVAddr(vaddr),
+      mode(_mode),
+      tranType(tran_type),
+      port(_port),
+      fault(NoFault)
 {
     req = std::make_shared<Request>();
 }
 
 void
-TableWalker::Stage2Walk::finish(const Fault &_fault,
-                                const RequestPtr &req,
-                                ThreadContext *tc, BaseMMU::Mode mode)
+WalkUnit::Stage2Walk::finish(const Fault &_fault, const RequestPtr &req,
+                             ThreadContext *tc, BaseMMU::Mode mode)
 {
     fault = _fault;
 
@@ -2579,7 +2722,7 @@ TableWalker::Stage2Walk::finish(const Fault &_fault,
 }
 
 void
-TableWalker::Stage2Walk::translateTiming(ThreadContext *tc)
+WalkUnit::Stage2Walk::translateTiming(ThreadContext *tc)
 {
     parent.mmu->translateTiming(req, tc, this, mode, tranType, true);
 }

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -2331,7 +2331,7 @@ TableWalker::insertPartialTableEntry(LongDescriptor &descriptor)
             descriptor.getRawData());
 
     // Insert the entry into the TLBs
-    tlb->multiInsert(TlbEntry::KeyType(te), te);
+    mmu->insert(te, currState->mode, isStage2);
 }
 
 void
@@ -2408,11 +2408,7 @@ TableWalker::insertTableEntry(DescriptorBase &descriptor, bool long_descriptor)
             descriptor.getRawData());
 
     // Insert the entry into the TLBs
-    tlb->multiInsert(TlbEntry::KeyType(te), te);
-    if (!currState->timing) {
-        currState->tc  = NULL;
-        currState->req = NULL;
-    }
+    mmu->insert(te, currState->mode, isStage2);
 }
 
 TableWalker::LookupLevel

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1157,6 +1157,12 @@ class TableWalker : public ClockedObject
 
     bool haveLargeAsid64() const { return _haveLargeAsid64; }
     uint8_t physAddrRange() const { return _physAddrRange; }
+    bool
+    stage2() const
+    {
+        return isStage2;
+    }
+
     /** Checks if all state is cleared and if so, completes drain */
     void completeDrain();
     DrainState drain() override;

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1106,9 +1106,6 @@ class TableWalker : public ClockedObject
     /** TLB that is initiating these table walks */
     TLB *tlb;
 
-    /** Cached copy of the sctlr as it existed when translation began */
-    SCTLR sctlr;
-
     WalkerState *currState;
 
     /** If a timing translation is currently in progress */

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016, 2019, 2021-2024 Arm Limited
+ * Copyright (c) 2010-2016, 2019, 2021-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1124,7 +1124,10 @@ class TableWalker : public ClockedObject
     struct TableWalkerStats : public statistics::Group
     {
         TableWalkerStats(statistics::Group *parent);
-        statistics::Scalar walks;
+        statistics::Scalar instructionWalksS1;
+        statistics::Scalar instructionWalksS2;
+        statistics::Scalar dataWalksS1;
+        statistics::Scalar dataWalksS2;
         statistics::Scalar walksShortDescriptor;
         statistics::Scalar walksLongDescriptor;
         statistics::Vector walksShortTerminatedAtLevel;
@@ -1137,6 +1140,8 @@ class TableWalker : public ClockedObject
         statistics::Histogram pendingWalks;
         statistics::Vector pageSizes;
         statistics::Vector2d requestOrigin;
+
+        statistics::Formula walks;
     } stats;
 
     mutable unsigned pendingReqs;

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1063,6 +1063,9 @@ class TableWalker : public ClockedObject
     WalkUnit *getAvailableWalk(BaseMMU::Mode mode, bool stage2,
                                bool functional) const;
 
+    WalkUnit *busyOnSamePage(Addr iaddr, BaseMMU::Mode mode,
+                             bool stage2) const;
+
     Port &getTableWalkerPort();
 
     Fault walk(const RequestPtr &req, ThreadContext *tc, uint16_t asid,
@@ -1229,6 +1232,7 @@ class WalkUnit : public ClockedObject
 
     /** Timing mode: saves the currState into the stateQueues */
     void stashCurrState(WalkerState *state, int queue_idx);
+    bool busyOnSamePage(Addr iaddr) const;
 
   protected:
 

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -47,6 +47,7 @@
 #include "arch/arm/tlb.hh"
 #include "arch/arm/types.hh"
 #include "arch/generic/mmu.hh"
+#include "enums/ArmLookupLevel.hh"
 #include "mem/packet_queue.hh"
 #include "mem/qport.hh"
 #include "mem/request.hh"
@@ -57,20 +58,21 @@ namespace gem5
 {
 
 struct ArmTableWalkerParams;
+struct ArmWalkUnitParams;
 
 class ThreadContext;
 
 namespace ArmISA {
+class WalkUnit;
 class Translation;
 class TLB;
 
 class TableWalker : public ClockedObject
 {
+  public:
     using LookupLevel = enums::ArmLookupLevel;
 
-  public:
     class WalkerState;
-
     class DescriptorBase
     {
       public:
@@ -849,6 +851,13 @@ class TableWalker : public ClockedObject
         }
     };
 
+    class TableWalkerState : public Packet::SenderState
+    {
+      public:
+        Tick delay = 0;
+        Event *event = nullptr;
+    };
+
     class WalkerState
     {
       public:
@@ -956,6 +965,9 @@ class TableWalker : public ClockedObject
         /** Flag indicating if a second stage of lookup is required */
         bool stage2Req;
 
+        /** Is the access is a stage2 access */
+        bool isStage2;
+
         /** A pointer to the stage 2 translation that's in progress */
         BaseMMU::Translation *stage2Tran;
 
@@ -1000,17 +1012,10 @@ class TableWalker : public ClockedObject
         std::string name() const { return tableWalker->name(); }
     };
 
-    class TableWalkerState : public Packet::SenderState
-    {
-      public:
-        Tick delay = 0;
-        Event *event = nullptr;
-    };
-
     class Port : public QueuedRequestPort
     {
       public:
-        Port(TableWalker& _walker);
+        Port(TableWalker &_walker, RequestorID id);
 
         void sendFunctionalReq(const RequestPtr &req, uint8_t *data);
         void sendAtomicReq(const RequestPtr &req, uint8_t *data, Tick delay);
@@ -1018,6 +1023,12 @@ class TableWalker : public ClockedObject
             Event *event);
 
         bool recvTimingResp(PacketPtr pkt) override;
+
+        RequestorID
+        requestorId() const
+        {
+            return _requestorId;
+        }
 
       private:
         void handleRespPacket(PacketPtr pkt, Tick delay=0);
@@ -1028,14 +1039,149 @@ class TableWalker : public ClockedObject
                                Tick delay, Event *event);
 
       private:
-        TableWalker& owner;
+        TableWalker &owner;
 
         /** Packet queue used to store outgoing requests. */
         ReqPacketQueue reqQueue;
 
         /** Packet queue used to store outgoing snoop responses. */
         SnoopRespPacketQueue snoopRespQueue;
+
+        /** Cached requestorId of the table walker */
+        RequestorID _requestorId;
     };
+
+    PARAMS(ArmTableWalker);
+    TableWalker(const Params &p);
+
+    gem5::Port &getPort(const std::string &if_name,
+                        PortID idx = InvalidPortID) override;
+
+    void setMmu(MMU *_mmu);
+    void setTestInterface(TlbTestInterface *ti);
+
+    WalkUnit *getAvailableWalk(BaseMMU::Mode mode, bool stage2,
+                               bool functional) const;
+    WalkUnit *getWalkUnit(BaseMMU::Mode mode, bool stage2) const;
+
+    Port &getTableWalkerPort();
+
+    Fault walk(const RequestPtr &req, ThreadContext *tc, uint16_t asid,
+               vmid_t vmid, MMU::Mode mode, MMU::Translation *trans,
+               bool timing, bool functional, SecurityState ss,
+               PASpace ipaspace, MMU::ArmTranslationType tran_type,
+               bool stage2_req, bool stage2, const TlbEntry *walk_entry);
+
+    /**
+     * A walk has finished. Schedule a look in
+     * the pending queue to see if there is a pending walk awaiting
+     * to be executed next
+     *
+     * @param wu WalkUnit calling the method. With this param the walk unit
+     *           signals the Table Walker it is ready to accept a new walk
+     *           request
+     */
+    void nextWalk(WalkUnit *wu);
+
+    /**
+     * Squash the walk passed as first argument. This would happen
+     * in two cases
+     * 1) The instruction generating the memory ref has been squashed
+     * 2) No need to walk as the translation is now available in the TLB
+     */
+    void squashWalk(WalkerState *curr_state);
+
+    void completeDrain();
+    DrainState drain() override;
+
+  public:
+    TypeTLB modeToType(BaseMMU::Mode mode) const;
+
+    bool
+    haveLargeAsid64() const
+    {
+        return _haveLargeAsid64;
+    }
+    uint8_t
+    physAddrRange() const
+    {
+        return _physAddrRange;
+    }
+
+  private:
+    MMU *mmu;
+
+    /** Pool of walking units */
+    WalkUnit *itbWalker;
+    WalkUnit *dtbWalker;
+    WalkUnit *itbStage2Walker;
+    WalkUnit *dtbStage2Walker;
+
+    /** walking unit for functional walks*/
+    WalkUnit *walkUnitFunctionalS1;
+    WalkUnit *walkUnitFunctionalS2;
+
+    /** Requestor id assigned by the MMU. */
+    RequestorID requestorId;
+
+    /** Table Walker port */
+    Port *port;
+
+    /** Cached copies of system-level properties */
+    const ArmRelease *release;
+    uint8_t _physAddrRange;
+    bool _haveLargeAsid64;
+
+  private:
+    /** Statistics */
+    void pendingChange();
+
+  public:
+    /** Statistics */
+    static const unsigned REQUESTED = 0;
+    static const unsigned COMPLETED = 1;
+
+    mutable unsigned pendingReqs;
+    mutable Tick pendingChangeTick;
+
+    struct TableWalkerStats : public statistics::Group
+    {
+        TableWalkerStats(statistics::Group *parent);
+        statistics::Scalar instructionWalksS1;
+        statistics::Scalar instructionWalksS2;
+        statistics::Scalar dataWalksS1;
+        statistics::Scalar dataWalksS2;
+        statistics::Scalar walksShortDescriptor;
+        statistics::Scalar walksLongDescriptor;
+        statistics::Vector walksShortTerminatedAtLevel;
+        statistics::Vector walksLongTerminatedAtLevel;
+        statistics::Scalar squashedBefore;
+        statistics::Scalar squashedAfter;
+        statistics::Histogram walkWaitTime;
+        statistics::Histogram walkServiceTime;
+        // Essentially "L" of queueing theory
+        statistics::Histogram pendingWalks;
+        statistics::Vector pageSizes;
+        statistics::Vector2d requestOrigin;
+
+        statistics::Formula walks;
+    } stats;
+
+    /** Queue of requests that have passed are waiting because the walker is
+     * currently busy. */
+    std::list<WalkerState *> pendingQueue;
+    std::vector<WalkerState *> inCompletionWalks;
+};
+
+class WalkUnit : public ClockedObject
+{
+  public:
+    using LookupLevel = enums::ArmLookupLevel;
+    using WalkerState = TableWalker::WalkerState;
+    using DescriptorBase = TableWalker::DescriptorBase;
+    using L1Descriptor = TableWalker::L1Descriptor;
+    using L2Descriptor = TableWalker::L2Descriptor;
+    using LongDescriptor = TableWalker::LongDescriptor;
 
     /** This translation class is used to trigger the data fetch once a timing
         translation returns the translated physical address */
@@ -1046,17 +1192,20 @@ class TableWalker : public ClockedObject
         int          numBytes;
         RequestPtr   req;
         Event        *event;
-        TableWalker  &parent;
+        WalkUnit &parent;
         Addr         oVAddr;
         BaseMMU::Mode mode;
         MMU::ArmTranslationType tranType;
 
+        TableWalker::Port *port;
+
       public:
         Fault fault;
 
-        Stage2Walk(TableWalker &_parent, uint8_t *_data, Event *_event,
+        Stage2Walk(WalkUnit &_parent, uint8_t *_data, Event *_event,
                    Addr vaddr, BaseMMU::Mode mode,
-                   MMU::ArmTranslationType tran_type);
+                   MMU::ArmTranslationType tran_type,
+                   TableWalker::Port *_port);
 
         void markDelayed() {}
 
@@ -1082,23 +1231,21 @@ class TableWalker : public ClockedObject
                        Stage2Walk *translation, int num_bytes,
                        Request::Flags flags);
 
+    /** Timing mode: saves the currState into the stateQueues */
+    void stashCurrState(WalkerState *state, int queue_idx);
+
   protected:
 
     /** Queues of requests for all the different lookup levels */
     std::list<WalkerState *> stateQueues[LookupLevel::Num_ArmLookupLevel];
 
-    /** Queue of requests that have passed are waiting because the walker is
-     * currently busy. */
-    std::list<WalkerState *> pendingQueue;
-
     /** The MMU to forward second stage look upts to */
     MMU *mmu;
 
-    /** Requestor id assigned by the MMU. */
-    RequestorID requestorId;
+    /** Pointer to the parent table walker */
+    TableWalker *parent;
 
-    /** Port shared by the two table walkers. */
-    Port* port;
+    TableWalker::Port *port;
 
     /** Indicates whether this table walker is part of the stage 2 mmu */
     const bool isStage2;
@@ -1106,104 +1253,119 @@ class TableWalker : public ClockedObject
     /** TLB that is initiating these table walks */
     TLB *tlb;
 
-    WalkerState *currState;
+    /** Walk type */
+    const TypeTLB walkType;
 
-    /** If a timing translation is currently in progress */
-    bool pending;
+    /** Functional */
+    const bool isFunctional;
 
-    /** The number of walks belonging to squashed instructions that can be
-     * removed from the pendingQueue per cycle. */
-    unsigned numSquashable;
-
-    /** Cached copies of system-level properties */
-    const ArmRelease *release;
-    uint8_t _physAddrRange;
-    bool _haveLargeAsid64;
-
-    /** Statistics */
-    struct TableWalkerStats : public statistics::Group
-    {
-        TableWalkerStats(statistics::Group *parent);
-        statistics::Scalar instructionWalksS1;
-        statistics::Scalar instructionWalksS2;
-        statistics::Scalar dataWalksS1;
-        statistics::Scalar dataWalksS2;
-        statistics::Scalar walksShortDescriptor;
-        statistics::Scalar walksLongDescriptor;
-        statistics::Vector walksShortTerminatedAtLevel;
-        statistics::Vector walksLongTerminatedAtLevel;
-        statistics::Scalar squashedBefore;
-        statistics::Scalar squashedAfter;
-        statistics::Histogram walkWaitTime;
-        statistics::Histogram walkServiceTime;
-        // Essentially "L" of queueing theory
-        statistics::Histogram pendingWalks;
-        statistics::Vector pageSizes;
-        statistics::Vector2d requestOrigin;
-
-        statistics::Formula walks;
-    } stats;
-
-    mutable unsigned pendingReqs;
-    mutable Tick pendingChangeTick;
-
-    static const unsigned REQUESTED = 0;
-    static const unsigned COMPLETED = 1;
+    /** Is the walk unit free? */
+    bool available;
 
   public:
-    PARAMS(ArmTableWalker);
-    TableWalker(const Params &p);
-    virtual ~TableWalker();
+    PARAMS(ArmWalkUnit);
+    WalkUnit(const Params &p);
+    virtual ~WalkUnit();
 
-    bool haveLargeAsid64() const { return _haveLargeAsid64; }
-    uint8_t physAddrRange() const { return _physAddrRange; }
+    TypeTLB
+    type() const
+    {
+        return walkType;
+    }
+
     bool
     stage2() const
     {
         return isStage2;
     }
 
+    bool
+    functional() const
+    {
+        return isFunctional;
+    }
+
+    bool
+    isAvailable() const
+    {
+        return available;
+    }
+    void
+    isAvailable(bool _available)
+    {
+        available = _available;
+    }
+
     /** Checks if all state is cleared and if so, completes drain */
-    void completeDrain();
+    bool completeDrain();
     DrainState drain() override;
-    void drainResume() override;
 
-    gem5::Port &getPort(const std::string &if_name,
-                    PortID idx=InvalidPortID) override;
+    Fault walk(WalkerState *state);
 
-    Port &getTableWalkerPort();
-
-    Fault walk(const RequestPtr &req, ThreadContext *tc,
-               uint16_t asid, vmid_t _vmid,
-               BaseMMU::Mode mode, BaseMMU::Translation *_trans,
-               bool timing, bool functional, SecurityState ss,
-               PASpace ipaspace,
-               MMU::ArmTranslationType tran_type, bool stage2,
-               const TlbEntry *walk_entry);
+    void scheduleWalk(WalkerState *next_walk, Tick when);
 
     void setMmu(MMU *_mmu);
-    void memAttrs(ThreadContext *tc, TlbEntry &te, SCTLR sctlr,
-                  uint8_t texcb, bool s);
-    void memAttrsLPAE(ThreadContext *tc, TlbEntry &te,
+    void
+    setPort(TableWalker::Port *_port)
+    {
+        port = _port;
+    }
+    TableWalker::Port &
+    getTableWalkerPort() const
+    {
+        return *port;
+    }
+    void
+    setTableWalker(TableWalker *_parent)
+    {
+        parent = _parent;
+    }
+
+    void memAttrs(WalkerState *state, TlbEntry &te, uint8_t texcb, bool s);
+    void memAttrsLPAE(WalkerState *state, TlbEntry &te,
                       LongDescriptor &lDescriptor);
-    void memAttrsAArch64(ThreadContext *tc, TlbEntry &te,
+    void memAttrsAArch64(WalkerState *state, TlbEntry &te,
                          LongDescriptor &lDescriptor);
-    void memAttrsWalkAArch64(TlbEntry &te);
+    void memAttrsWalkAArch64(WalkerState *state, TlbEntry &te);
     bool uncacheableFromAttrs(uint8_t attrs);
 
     static LookupLevel toLookupLevel(uint8_t lookup_level_as_int);
 
   private:
+    class WalkEvent : public Event, public Named
+    {
+      public:
+        WalkEvent(WalkUnit *_parent, const std::string &_name)
+            : Event(), Named(_name), parent(_parent)
+        {}
 
-    void doL1Descriptor();
+        void
+        process() override
+        {
+            parent->processWalkWrapper(state);
+        }
+
+        void
+        setState(WalkerState *next_state)
+        {
+            state = next_state;
+        }
+
+      private:
+        WalkUnit *parent;
+        WalkerState *state;
+    } doProcessEvent;
+    void processWalkWrapper(WalkerState *state);
+
+    void doL1Descriptor(WalkerState *state);
     void doL1DescriptorWrapper();
     EventFunctionWrapper doL1DescEvent;
 
-    void doL2Descriptor();
+    void doL2Descriptor(WalkerState *state);
     void doL2DescriptorWrapper();
     EventFunctionWrapper doL2DescEvent;
 
-    void doLongDescriptor();
+    void doLongDescriptor(WalkerState *state);
 
     void doL0LongDescriptorWrapper();
     EventFunctionWrapper doL0LongDescEvent;
@@ -1217,62 +1379,55 @@ class TableWalker : public ClockedObject
     void doLongDescriptorWrapper(LookupLevel curr_lookup_level);
     Event* LongDescEventByLevel[4];
 
-    void fetchDescriptor(Addr desc_addr,
-        DescriptorBase &descriptor, int num_bytes,
-        Request::Flags flags, LookupLevel lookup_lvl, Event *event,
-        void (TableWalker::*doDescriptor)());
+    void fetchDescriptor(Addr desc_addr, DescriptorBase &descriptor,
+                         int num_bytes, Request::Flags flags,
+                         LookupLevel lookup_lvl, Event *event,
+                         void (WalkUnit::*doDescriptor)(WalkerState *state),
+                         WalkerState *state);
 
-    Fault generateLongDescFault(ArmFault::FaultSource src);
+    Fault generateLongDescFault(WalkerState *state, ArmFault::FaultSource src);
 
-    void insertTableEntry(DescriptorBase &descriptor, bool longDescriptor);
-    void insertPartialTableEntry(LongDescriptor &descriptor);
+    void insertTableEntry(WalkerState *state, DescriptorBase &descriptor,
+                          bool long_descriptor);
+    void insertPartialTableEntry(WalkerState *state);
 
     /** Returns a tuple made of:
      * 1) The address of the first page table
      * 2) The address of the first descriptor within the table
      * 3) The page table level
      */
-    std::tuple<Addr, Addr, LookupLevel> walkAddresses(
-        Addr ttbr, GrainSize tg, int tsz, int pa_range);
+    std::tuple<Addr, Addr, LookupLevel> walkAddresses(WalkerState *state,
+                                                      Addr ttbr, GrainSize tg,
+                                                      int tsz, int pa_range);
 
-    Fault processWalk();
-    Fault processWalkLPAE();
+    Fault processWalk(WalkerState *state);
+    Fault processWalkLPAE(WalkerState *state);
+    Fault processWalkAArch64(WalkerState *state);
 
-    Addr maxTxSz(GrainSize tg) const;
-    Addr s1MinTxSz(GrainSize tg) const;
-    bool s1TxSzFault(GrainSize tg, int tsz) const;
-    bool checkVAOutOfRange(Addr addr, int top_bit,
-        int tsz, bool low_range);
+    Addr maxTxSz(WalkerState *state, GrainSize tg) const;
+    Addr s1MinTxSz(WalkerState *state, GrainSize tg) const;
+    bool s1TxSzFault(WalkerState *state, GrainSize tg, int tsz) const;
+    bool checkVAOutOfRange(WalkerState *state, int top_bit, int tsz,
+                           bool low_range);
 
     /// Returns true if the address exceeds the range permitted by the
     /// system-wide setting or by the TCR_ELx IPS/PS setting
     bool checkAddrSizeFaultAArch64(Addr addr, int pa_range);
 
     /// Returns true if the table walk should be uncacheable
-    bool uncacheableWalk() const;
-
-    Fault processWalkAArch64();
-    void processWalkWrapper();
-    EventFunctionWrapper doProcessEvent;
-
-    void nextWalk(ThreadContext *tc);
-
-    void pendingChange();
-
-    /** Timing mode: saves the currState into the stateQueues */
-    void stashCurrState(int queue_idx);
+    bool uncacheableWalk(WalkerState *state) const;
 
     static uint8_t pageSizeNtoStatBin(uint8_t N);
 
-    void mpamTagTableWalk(RequestPtr &req) const;
+    void mpamTagTableWalk(WalkerState *state, RequestPtr &req) const;
 
   public: /* Testing */
     TlbTestInterface *test;
 
     void setTestInterface(TlbTestInterface *ti);
 
-    Fault testWalk(const RequestPtr &walk_req, DomainType domain,
-                   LookupLevel lookup_level);
+    Fault testWalk(WalkerState *state, const RequestPtr &walk_req,
+                   DomainType domain, LookupLevel lookup_level);
 };
 
 } // namespace ArmISA

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1062,7 +1062,6 @@ class TableWalker : public ClockedObject
 
     WalkUnit *getAvailableWalk(BaseMMU::Mode mode, bool stage2,
                                bool functional) const;
-    WalkUnit *getWalkUnit(BaseMMU::Mode mode, bool stage2) const;
 
     Port &getTableWalkerPort();
 
@@ -1112,10 +1111,7 @@ class TableWalker : public ClockedObject
     MMU *mmu;
 
     /** Pool of walking units */
-    WalkUnit *itbWalker;
-    WalkUnit *dtbWalker;
-    WalkUnit *itbStage2Walker;
-    WalkUnit *dtbStage2Walker;
+    std::vector<WalkUnit *> walkUnits;
 
     /** walking unit for functional walks*/
     WalkUnit *walkUnitFunctionalS1;

--- a/src/arch/arm/table_walker.hh
+++ b/src/arch/arm/table_walker.hh
@@ -1182,8 +1182,6 @@ class TableWalker : public ClockedObject
                const TlbEntry *walk_entry);
 
     void setMmu(MMU *_mmu);
-    void setTlb(TLB *_tlb) { tlb = _tlb; }
-    TLB* getTlb() { return tlb; }
     void memAttrs(ThreadContext *tc, TlbEntry &te, SCTLR sctlr,
                   uint8_t texcb, bool s);
     void memAttrsLPAE(ThreadContext *tc, TlbEntry &te,

--- a/src/arch/arm/tlb.cc
+++ b/src/arch/arm/tlb.cc
@@ -140,7 +140,7 @@ TLB::~TLB()
 }
 
 void
-TLB::setTableWalker(TableWalker *table_walker)
+TLB::setTableWalker(TableWalker *table_walker, bool functional)
 {
     tableWalker = table_walker;
 }

--- a/src/arch/arm/tlb.cc
+++ b/src/arch/arm/tlb.cc
@@ -143,7 +143,6 @@ void
 TLB::setTableWalker(TableWalker *table_walker)
 {
     tableWalker = table_walker;
-    tableWalker->setTlb(this);
 }
 
 TlbEntry*

--- a/src/arch/arm/tlb.hh
+++ b/src/arch/arm/tlb.hh
@@ -216,9 +216,7 @@ class TLB : public BaseTLB
 
     void takeOverFrom(BaseTLB *otlb) override;
 
-    void setTableWalker(TableWalker *table_walker);
-
-    TableWalker *getTableWalker() { return tableWalker; }
+    void setTableWalker(TableWalker *table_walker, bool functional = false);
 
     int getsize() const { return size; }
 

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2022 The Regents of the University of California
 # All rights reserved.
 #
@@ -121,17 +133,7 @@ class BaseCPUCore(AbstractCore):
 
     @overrides(AbstractCore)
     def connect_walker_ports(self, port1: Port, port2: Port) -> None:
-        if self.get_isa() == ISA.ARM:
-            # Unlike X86 and RISCV MMU, the ARM MMU has two L1 TLB walker ports
-            # named `walker` and `stage2_walker` for both data and instruction.
-            # The gem5 standard library currently supports one TLB walker port
-            # per cache level. Therefore, we are explicitly setting the walker
-            # ports and not setting the stage2_walker ports for ARM systems.
-
-            self.core.mmu.itb_walker.port = port1
-            self.core.mmu.dtb_walker.port = port2
-        else:
-            self.core.mmu.connectWalkerPorts(port1, port2)
+        self.core.mmu.connectWalkerPorts(port1, port2)
 
     @overrides(AbstractCore)
     def set_workload(self, process: Process) -> None:


### PR DESCRIPTION
One of the existing limitation of the Arm PTW is that it only supports one outstanding table walk per table walker.
We currently have 4 different table walkers:

1. Data, stage1
2. Data, stage2
3. Instruction, stage2
4. Instruction, stage2

So effectively the PTW can only sustain one I-side and one D-side translation at a time. Other requests missing in the TLB
and reaching the PTW will be marked as pending and will be added to the pending queue. They will wait until the previous
walk finishes.
When it does, the PTW tries to re-translate requests from the pendingQueue (if they are targeting the same
page, then there will be a matching TLB entry and walk can be squashed, otherwise, a new series of
walks will have to start)

With this PT, we start supporting a configurable number of outstanding table walks.

We are renaming the 4 available Arm table walkers (dtb_walker, itb_walker, dtb_stage2, itb_stage2)
into WalkUnits, and we are defining a single TableWalker parent, with a single port connected to the memory
subsystem.

Every table walker flavour will go through the same port so we are effectively shifting from a multiple table walker
design into a single table walker design (with partitioned resources)

This patch is abandoning the rigid structure of prior design and it is allowing the pooling of walk unit resources.
Once a walk unit finishes its jobs, it signals it to the TableWalker by adding itself into the availableWalks set
and by awakening the TableWalker.
Once awakened, the latter will go through the list of pending walk requests and dispatch them to available walk
units