### PR TITLE
cpu-o3: Make space for a pipeline tracer

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -62,7 +62,6 @@
 #include "debug/Drain.hh"
 #include "debug/ExecFaulting.hh"
 #include "debug/HtmCpu.hh"
-#include "debug/O3PipeView.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/faults.hh"
 #include "sim/full_system.hh"
@@ -1251,11 +1250,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     // Finally clear the head ROB entry.
     rob->retireHead(tid);
 
-#if TRACING_ON
-    if (debug::O3PipeView) {
-        head_inst->commitTick = curTick() - head_inst->fetchTick;
-    }
-#endif
+    head_inst->commitTick = curTick() - head_inst->fetchTick;
 
     // If this was a store, record it for this cycle.
     if (head_inst->isStore() || head_inst->isAtomic())

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright 2014 Google, Inc.
- * Copyright (c) 2010-2014, 2017, 2020 ARM Limited
+ * Copyright (c) 2010-2014, 2017, 2020, 2025 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1223,13 +1223,7 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     DPRINTF(Commit,
             "[tid:%i] [sn:%llu] Committing instruction with PC %s\n",
             tid, head_inst->seqNum, head_inst->pcState());
-    if (head_inst->traceData) {
-        head_inst->traceData->setFetchSeq(head_inst->seqNum);
-        head_inst->traceData->setCPSeq(thread[tid]->numOp);
-        head_inst->traceData->dump();
-        delete head_inst->traceData;
-        head_inst->traceData = NULL;
-    }
+
     if (head_inst->isReturn()) {
         DPRINTF(Commit,
                 "[tid:%i] [sn:%llu] Return Instruction Committed PC %s \n",
@@ -1251,6 +1245,14 @@ Commit::commitHead(const DynInstPtr &head_inst, unsigned inst_num)
     rob->retireHead(tid);
 
     head_inst->commitTick = curTick() - head_inst->fetchTick;
+
+    if (head_inst->traceData) {
+        head_inst->traceData->setFetchSeq(head_inst->seqNum);
+        head_inst->traceData->setCPSeq(thread[tid]->numOp);
+        head_inst->traceData->dump();
+        delete head_inst->traceData;
+        head_inst->traceData = NULL;
+    }
 
     // If this was a store, record it for this cycle.
     if (head_inst->isStore() || head_inst->isAtomic())

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -48,7 +48,6 @@
 #include "cpu/o3/limits.hh"
 #include "debug/Activity.hh"
 #include "debug/Decode.hh"
-#include "debug/O3PipeView.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/full_system.hh"
 
@@ -701,11 +700,7 @@ Decode::decodeInsts(ThreadID tid)
         ++stats.decodedInsts;
         --insts_available;
 
-#if TRACING_ON
-        if (debug::O3PipeView) {
-            inst->decodeTick = curTick() - inst->fetchTick;
-        }
-#endif
+        inst->decodeTick = curTick() - inst->fetchTick;
 
         // Ensure that if it was predicted as a branch, it really is a
         // branch.

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -999,7 +999,6 @@ class DynInst : public ExecContext, public RefCounted
     uint64_t htmDepth = 0;
 
   public:
-#if TRACING_ON
     // Value -1 indicates that particular phase
     // hasn't happened (yet).
     /** Tick records used for the pipeline activity viewer. */
@@ -1011,7 +1010,6 @@ class DynInst : public ExecContext, public RefCounted
     int32_t completeTick = -1;
     int32_t commitTick = -1;
     int32_t storeTick = -1;
-#endif
 
     /* Values used by LoadToUse stat */
     Tick firstIssue = -1;

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, 2021 ARM Limited
+ * Copyright (c) 2010, 2016, 2021, 2025 Arm Limited
  * Copyright (c) 2013 Advanced Micro Devices, Inc.
  * All rights reserved
  *
@@ -1005,6 +1005,7 @@ class DynInst : public ExecContext, public RefCounted
     Tick fetchTick = -1;      // instruction fetch is completed.
     int32_t decodeTick = -1;  // instruction enters decode phase
     int32_t renameTick = -1;  // instruction enters rename phase
+    int32_t renameEndTick = -1; // instruction exits rename phase
     int32_t dispatchTick = -1;
     int32_t issueTick = -1;
     int32_t completeTick = -1;

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -60,7 +60,6 @@
 #include "debug/Drain.hh"
 #include "debug/Fetch.hh"
 #include "debug/O3CPU.hh"
-#include "debug/O3PipeView.hh"
 #include "mem/packet.hh"
 #include "params/BaseO3CPU.hh"
 #include "sim/byteswap.hh"
@@ -1283,11 +1282,7 @@ Fetch::fetch(bool &status_change)
             ppFetch->notify(instruction);
             numInst++;
 
-#if TRACING_ON
-            if (debug::O3PipeView) {
-                instruction->fetchTick = curTick();
-            }
-#endif
+            instruction->fetchTick = curTick();
 
             set(next_pc, this_pc);
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2014 ARM Limited
+ * Copyright (c) 2010-2014, 2025 Arm Limited
  * Copyright (c) 2012-2013 AMD
  * Copyright (c) 2022-2023 The University of Edinburgh
  * All rights reserved.
@@ -1032,9 +1032,9 @@ Fetch::buildInst(ThreadID tid, StaticInstPtr staticInst,
 
 #if TRACING_ON
     if (trace) {
-        instruction->traceData =
-            cpu->getTracer()->getInstRecord(curTick(), cpu->tcBase(tid),
-                    instruction->staticInst, this_pc, curMacroop);
+        instruction->traceData = cpu->getTracer()->getInstRecord(
+            curTick(), cpu->tcBase(tid), instruction.get(),
+            instruction->staticInst, this_pc, curMacroop);
     }
 #else
     instruction->traceData = NULL;

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -55,7 +55,6 @@
 #include "debug/Activity.hh"
 #include "debug/Drain.hh"
 #include "debug/IEW.hh"
-#include "debug/O3PipeView.hh"
 #include "params/BaseO3CPU.hh"
 
 namespace gem5
@@ -1072,9 +1071,8 @@ IEW::dispatchInsts(ThreadID tid)
 
         ++iewStats.dispatchedInsts;
 
-#if TRACING_ON
         inst->dispatchTick = curTick() - inst->fetchTick;
-#endif
+
         ppDispatch->notify(inst);
     }
 
@@ -1534,11 +1532,7 @@ IEW::updateExeInstStats(const DynInstPtr& inst)
 
     cpu->executeStats[tid]->numInsts++;
 
-#if TRACING_ON
-    if (debug::O3PipeView) {
-        inst->completeTick = curTick() - inst->fetchTick;
-    }
-#endif
+    inst->completeTick = curTick() - inst->fetchTick;
 
     //
     // ALU Operations

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -51,7 +51,6 @@
 #include "debug/HtmCpu.hh"
 #include "debug/IEW.hh"
 #include "debug/LSQUnit.hh"
-#include "debug/O3PipeView.hh"
 #include "mem/packet.hh"
 #include "mem/request.hh"
 
@@ -1171,12 +1170,7 @@ LSQUnit::completeStore(typename StoreQueue::iterator store_idx)
             "idx:%i\n",
             store_inst->seqNum, store_idx.idx() - 1, storeQueue.head() - 1);
 
-#if TRACING_ON
-    if (debug::O3PipeView) {
-        store_inst->storeTick =
-            curTick() - store_inst->fetchTick;
-    }
-#endif
+    store_inst->storeTick = curTick() - store_inst->fetchTick;
 
     if (isStalled() &&
         store_inst->seqNum == stallingStoreIsn) {

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -48,7 +48,6 @@
 #include "cpu/o3/limits.hh"
 #include "cpu/reg_class.hh"
 #include "debug/Activity.hh"
-#include "debug/O3PipeView.hh"
 #include "debug/Rename.hh"
 #include "params/BaseO3CPU.hh"
 
@@ -822,11 +821,7 @@ Rename::sortInsts()
     for (int i = 0; i < insts_from_decode; ++i) {
         const DynInstPtr &inst = fromDecode->insts[i];
         insts[inst->threadNumber].push_back(inst);
-#if TRACING_ON
-        if (debug::O3PipeView) {
-            inst->renameTick = curTick() - inst->fetchTick;
-        }
-#endif
+        inst->renameTick = curTick() - inst->fetchTick;
     }
 }
 

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -750,6 +750,8 @@ Rename::renameInsts(ThreadID tid)
         // this instruction have been renamed.
         ppRename->notify(inst);
 
+        inst->renameEndTick = curTick() - inst->fetchTick;
+
         // Put instruction in rename queue.
         toIEW->insts[toIEWIndex] = inst;
         ++(toIEW->size);

--- a/src/sim/insttracer.hh
+++ b/src/sim/insttracer.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, 2020, 2023 Arm Limited
+ * Copyright (c) 2014, 2017, 2020, 2023, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -349,6 +349,14 @@ class InstTracer : public SimObject
         getInstRecord(Tick when, ThreadContext *tc,
                 const StaticInstPtr staticInst, const PCStateBase &pc,
                 const StaticInstPtr macroStaticInst=nullptr) = 0;
+
+    virtual InstRecord *
+    getInstRecord(Tick when, ThreadContext *tc, const ExecContext *xc,
+                  const StaticInstPtr staticInst, const PCStateBase &pc,
+                  const StaticInstPtr macroStaticInst = nullptr)
+    {
+        return getInstRecord(when, tc, staticInst, pc, macroStaticInst);
+    };
 
     std::string
     disassemble(StaticInstPtr inst,


### PR DESCRIPTION
At the moment the internal O3 pipeline tracer is bolted inside the O3 CPU model and the dynamic instruction
class. Timings are annotated on every O3 instruction whenever the O3PipeViewer option is selected and all
the annotations are dumped when the instruction gets destructed.

With this PR we aim at making space for other pipeline viewers, to be implemented as CPU tracers:

1) We decouple timing annotations from the O3PipeViewer option
2) We extend the InstTracer APIs to accept a DynInst / ExecContext in general, which contains dynamic information
about the execution context.

**Caveats and limitations:**

We don't move the O3PipeViewer to use the new logic for the following reasons:

1) We will lose the capability of generating an O3PipeView while using another tracer (gem5 only supports one tracer at a time) -> Note: a multi-tracer implementation is actually possible, it was my first CR for gem5 (got rejected but I was too junior and didn't push back)

2) The O3PipeViewer dumps every instruction (even instructions squashed due to misprediction), but the tracer only dumps committed instructions. So the pipe viewer won't have an easy way of dumping speculative instructions. This solution might require an extension to the tracer APIs (which are easy but pretty restrictive)