### PR TITLE
configs, cpu-o3: Implement a distributed InstructionQueue

### DIFF
--- a/configs/common/cores/arm/O3_ARM_v7a.py
+++ b/configs/common/cores/arm/O3_ARM_v7a.py
@@ -155,6 +155,11 @@ class O3_ARM_v7a_BP(BranchPredictor):
     instShiftAmt = 2
 
 
+class O3_ARM_v7a_IQ(IQUnit):
+    fuPool = O3_ARM_v7a_FUP()
+    numEntries = 32
+
+
 class O3_ARM_v7a_3(ArmO3CPU):
     LQEntries = 16
     SQEntries = 16
@@ -182,7 +187,6 @@ class O3_ARM_v7a_3(ArmO3CPU):
     dispatchWidth = 6
     issueWidth = 8
     wbWidth = 8
-    fuPool = O3_ARM_v7a_FUP()
     iewToCommitDelay = 1
     renameToROBDelay = 1
     commitWidth = 8
@@ -193,11 +197,11 @@ class O3_ARM_v7a_3(ArmO3CPU):
     numPhysIntRegs = 128
     numPhysFloatRegs = 192
     numPhysVecRegs = 48
-    numIQEntries = 32
     numROBEntries = 40
 
     switched_out = False
     branchPred = O3_ARM_v7a_BP()
+    instQueues = O3_ARM_v7a_IQ()
 
 
 # Instruction Cache

--- a/configs/common/cores/arm/ex5_big.py
+++ b/configs/common/cores/arm/ex5_big.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2012 The Regents of The University of Michigan
 # Copyright (c) 2016 Centre National de la Recherche Scientifique
 # All rights reserved.
@@ -132,6 +144,12 @@ class ex5_big_BP(BranchPredictor):
     instShiftAmt = 2
 
 
+# Instruction Queue
+class ex5_big_IQ(IQUnit):
+    fuPool = ex5_big_FUP()
+    numEntries = 48
+
+
 class ex5_big(ArmO3CPU):
     LQEntries = 16
     SQEntries = 16
@@ -159,7 +177,6 @@ class ex5_big(ArmO3CPU):
     dispatchWidth = 6
     issueWidth = 8
     wbWidth = 8
-    fuPool = ex5_big_FUP()
     iewToCommitDelay = 1
     renameToROBDelay = 1
     commitWidth = 8
@@ -169,11 +186,11 @@ class ex5_big(ArmO3CPU):
     forwardComSize = 5
     numPhysIntRegs = 90
     numPhysFloatRegs = 256
-    numIQEntries = 48
     numROBEntries = 60
 
     switched_out = False
     branchPred = ex5_big_BP()
+    instQueues = ex5_big_IQ()
 
 
 class L1Cache(Cache):

--- a/src/arch/x86/X86CPU.py
+++ b/src/arch/x86/X86CPU.py
@@ -30,6 +30,7 @@ from m5.objects.BaseO3CPU import BaseO3CPU
 from m5.objects.BaseTimingSimpleCPU import BaseTimingSimpleCPU
 from m5.objects.FuncUnit import *
 from m5.objects.FUPool import *
+from m5.objects.IQUnit import IQUnit
 from m5.objects.X86Decoder import X86Decoder
 from m5.objects.X86ISA import X86ISA
 from m5.objects.X86LocalApic import X86LocalApic
@@ -100,7 +101,7 @@ class X86O3CPU(BaseO3CPU, X86CPU):
     # issues division microops.  The latency of these microops should really be
     # one (or a small number) cycle each since each of these computes one bit
     # of the quotient.
-    fuPool = DefaultX86FUPool()
+    instQueues = IQUnit(fuPool=DefaultX86FUPool())
 
 
 class X86MinorCPU(BaseMinorCPU, X86CPU):

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2019 ARM Limited
+# Copyright (c) 2016, 2019, 2025 Arm Limited
 # Copyright (c) 2022-2023 The University of Edinburgh
 # All rights reserved.
 #
@@ -45,22 +45,12 @@ from m5.objects.BaseCPU import BaseCPU
 from m5.objects.BranchPredictor import *
 from m5.objects.FUPool import *
 from m5.objects.IndexingPolicies import *
+from m5.objects.IQUnit import *
 from m5.objects.ReplacementPolicies import *
+from m5.objects.SMT import *
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import *
-
-
-class SMTFetchPolicy(ScopedEnum):
-    vals = ["RoundRobin", "Branch", "IQCount", "LSQCount"]
-
-
-class SMTQueuePolicy(ScopedEnum):
-    vals = ["Dynamic", "Partitioned", "Threshold"]
-
-
-class CommitPolicy(ScopedEnum):
-    vals = ["RoundRobin", "OldestReady"]
 
 
 class BaseO3CPU(BaseCPU):
@@ -129,7 +119,6 @@ class BaseO3CPU(BaseCPU):
     dispatchWidth = Param.Unsigned(8, "Dispatch width")
     issueWidth = Param.Unsigned(8, "Issue width")
     wbWidth = Param.Unsigned(8, "Writeback width")
-    fuPool = Param.FUPool(DefaultFUPool(), "Functional Unit pool")
 
     iewToCommitDelay = Param.Cycles(
         1, "Issue/Execute/Writeback to commit delay"
@@ -195,7 +184,7 @@ class BaseO3CPU(BaseCPU):
     numPhysMatRegs = Param.Unsigned(2, "Number of physical matrix registers")
     # most ISAs don't use condition-code regs, so default is 0
     numPhysCCRegs = Param.Unsigned(0, "Number of physical cc registers")
-    numIQEntries = Param.Unsigned(64, "Number of instruction queue entries")
+    instQueues = VectorParam.IQUnit(IQUnit(), "Vector of IQs")
     numROBEntries = Param.Unsigned(192, "Number of reorder buffer entries")
 
     smtNumFetchingThreads = Param.Unsigned(1, "SMT Number of Fetching Threads")
@@ -204,8 +193,6 @@ class BaseO3CPU(BaseCPU):
         "Partitioned", "SMT LSQ Sharing Policy"
     )
     smtLSQThreshold = Param.Int(100, "SMT LSQ Threshold Sharing Parameter")
-    smtIQPolicy = Param.SMTQueuePolicy("Partitioned", "SMT IQ Sharing Policy")
-    smtIQThreshold = Param.Int(100, "SMT IQ Threshold Sharing Parameter")
     smtROBPolicy = Param.SMTQueuePolicy(
         "Partitioned", "SMT ROB Sharing Policy"
     )

--- a/src/cpu/o3/IQUnit.py
+++ b/src/cpu/o3/IQUnit.py
@@ -1,5 +1,3 @@
-# -*- mode:python -*-
-
 # Copyright (c) 2025 Arm Limited
 # All rights reserved.
 #
@@ -11,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2006 The Regents of The University of Michigan
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -38,64 +33,28 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys
+from m5.objects.FUPool import (
+    DefaultFUPool,
+    FUPool,
+)
+from m5.objects.SMT import SMTQueuePolicy
+from m5.params import *
+from m5.proxy import Parent
+from m5.SimObject import SimObject
 
-Import('*')
 
-if env['CONF']['BUILD_ISA']:
-    SimObject('FUPool.py', sim_objects=['FUPool'])
-    SimObject('FuncUnitConfig.py', sim_objects=[])
-    SimObject('BaseO3CPU.py', sim_objects=['BaseO3CPU'])
-    SimObject('IQUnit.py', sim_objects=['IQUnit'])
-    SimObject('SMT.py',
-        enums=['SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
+class IQUnit(SimObject):
+    type = "IQUnit"
+    cxx_class = "gem5::o3::IQUnit"
+    cxx_header = "cpu/o3/inst_queue.hh"
 
-    Source('bac.cc')
-    Source('commit.cc')
-    Source('cpu.cc')
-    Source('decode.cc')
-    Source('dyn_inst.cc')
-    Source('fetch.cc')
-    Source('free_list.cc')
-    Source('ftq.cc')
-    Source('fu_pool.cc')
-    Source('iew.cc')
-    Source('inst_queue.cc')
-    Source('lsq.cc')
-    Source('lsq_unit.cc')
-    Source('mem_dep_unit.cc')
-    Source('regfile.cc')
-    Source('rename.cc')
-    Source('rename_map.cc')
-    Source('rob.cc')
-    Source('scoreboard.cc')
-    Source('store_set.cc')
-    Source('thread_context.cc')
-    Source('thread_state.cc')
+    numEntries = Param.Unsigned(64, "Number of instruction queue entries")
 
-    DebugFlag('BAC')
-    DebugFlag('CommitRate')
-    DebugFlag('FTQ')
-    DebugFlag('IEW')
-    DebugFlag('IQ')
-    DebugFlag('LSQ')
-    DebugFlag('LSQUnit')
-    DebugFlag('MemDepUnit')
-    DebugFlag('O3CPU')
-    DebugFlag('ROB')
-    DebugFlag('Rename')
-    DebugFlag('Scoreboard')
-    DebugFlag('StoreSet')
-    DebugFlag('Writeback')
+    fuPool = Param.FUPool(DefaultFUPool(), "Functional Unit pool")
 
-    CompoundFlag('O3CPUAll', [ 'BAC', 'FTQ', 'Fetch', 'Decode', 'Rename',
-        'IEW', 'Commit',
-        'IQ', 'ROB', 'FreeList', 'LSQ', 'LSQUnit', 'StoreSet', 'MemDepUnit',
-        'DynInst', 'O3CPU', 'Activity', 'Scoreboard', 'Writeback' ])
+    numThreads = Param.Unsigned(
+        Parent.numThreads, "number of HW thread contexts"
+    )
 
-    SimObject('BaseO3Checker.py', sim_objects=['BaseO3Checker'])
-    Source('checker.cc')
-
-    # For backwards compatibility
-    SimObject('O3CPU.py', sim_objects=[], tags=['isa'])
-    SimObject('O3Checker.py', sim_objects=[], tags=['isa'])
+    smtIQPolicy = Param.SMTQueuePolicy("Partitioned", "SMT IQ Sharing Policy")
+    smtIQThreshold = Param.Int(100, "SMT IQ Threshold Sharing Parameter")

--- a/src/cpu/o3/SMT.py
+++ b/src/cpu/o3/SMT.py
@@ -1,6 +1,4 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2025 Arm Limited
+# Copyright (c) 2016, 2019 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -12,7 +10,7 @@
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
 #
-# Copyright (c) 2006 The Regents of The University of Michigan
+# Copyright (c) 2005-2007 The Regents of The University of Michigan
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -38,64 +36,16 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys
+from m5.params import ScopedEnum
 
-Import('*')
 
-if env['CONF']['BUILD_ISA']:
-    SimObject('FUPool.py', sim_objects=['FUPool'])
-    SimObject('FuncUnitConfig.py', sim_objects=[])
-    SimObject('BaseO3CPU.py', sim_objects=['BaseO3CPU'])
-    SimObject('IQUnit.py', sim_objects=['IQUnit'])
-    SimObject('SMT.py',
-        enums=['SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
+class SMTFetchPolicy(ScopedEnum):
+    vals = ["RoundRobin", "Branch", "IQCount", "LSQCount"]
 
-    Source('bac.cc')
-    Source('commit.cc')
-    Source('cpu.cc')
-    Source('decode.cc')
-    Source('dyn_inst.cc')
-    Source('fetch.cc')
-    Source('free_list.cc')
-    Source('ftq.cc')
-    Source('fu_pool.cc')
-    Source('iew.cc')
-    Source('inst_queue.cc')
-    Source('lsq.cc')
-    Source('lsq_unit.cc')
-    Source('mem_dep_unit.cc')
-    Source('regfile.cc')
-    Source('rename.cc')
-    Source('rename_map.cc')
-    Source('rob.cc')
-    Source('scoreboard.cc')
-    Source('store_set.cc')
-    Source('thread_context.cc')
-    Source('thread_state.cc')
 
-    DebugFlag('BAC')
-    DebugFlag('CommitRate')
-    DebugFlag('FTQ')
-    DebugFlag('IEW')
-    DebugFlag('IQ')
-    DebugFlag('LSQ')
-    DebugFlag('LSQUnit')
-    DebugFlag('MemDepUnit')
-    DebugFlag('O3CPU')
-    DebugFlag('ROB')
-    DebugFlag('Rename')
-    DebugFlag('Scoreboard')
-    DebugFlag('StoreSet')
-    DebugFlag('Writeback')
+class SMTQueuePolicy(ScopedEnum):
+    vals = ["Dynamic", "Partitioned", "Threshold"]
 
-    CompoundFlag('O3CPUAll', [ 'BAC', 'FTQ', 'Fetch', 'Decode', 'Rename',
-        'IEW', 'Commit',
-        'IQ', 'ROB', 'FreeList', 'LSQ', 'LSQUnit', 'StoreSet', 'MemDepUnit',
-        'DynInst', 'O3CPU', 'Activity', 'Scoreboard', 'Writeback' ])
 
-    SimObject('BaseO3Checker.py', sim_objects=['BaseO3Checker'])
-    Source('checker.cc')
-
-    # For backwards compatibility
-    SimObject('O3CPU.py', sim_objects=[], tags=['isa'])
-    SimObject('O3Checker.py', sim_objects=[], tags=['isa'])
+class CommitPolicy(ScopedEnum):
+    vals = ["RoundRobin", "OldestReady"]

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -797,10 +797,23 @@ class DynInst : public ExecContext, public RefCounted
     //Instruction Queue Entry
     //-----------------------
     /** Sets this instruction as a entry the IQ. */
-    void setInIQ() { status.set(IqEntry); }
+    void
+    setInIQ(IQUnit *_iq)
+    {
+        assert(!iq);
+        status.set(IqEntry);
+        iq = _iq;
+    }
 
-    /** Sets this instruction as a entry the IQ. */
-    void clearInIQ() { status.reset(IqEntry); }
+    /** Clears this instruction as a entry the IQ. */
+    void
+    clearInIQ()
+    {
+        assert(iq);
+        status.reset(IqEntry);
+        iq->remove(this);
+        iq = nullptr;
+    }
 
     /** Returns whether or not this instruction has issued. */
     bool isInIQ() const { return status[IqEntry]; }
@@ -811,6 +824,8 @@ class DynInst : public ExecContext, public RefCounted
     /** Returns whether or not this instruction is squashed in the IQ. */
     bool isSquashedInIQ() const { return status[SquashedInIQ]; }
 
+    /** Pointer to the IQ storing the instruction */
+    IQUnit *iq = nullptr;
 
     //Load / Store Queue Functions
     //-----------------------

--- a/src/cpu/o3/fu_pool.cc
+++ b/src/cpu/o3/fu_pool.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013 ARM Limited
+ * Copyright (c) 2012-2013, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -151,6 +151,14 @@ FUPool::FUPool(const Params &p)
     for (int i = 0; i < numFU; i++) {
         unitBusy[i] = false;
     }
+}
+
+bool
+FUPool::isCapable(OpClass capability)
+{
+    //  If this pool doesn't have the specified capability,
+    //  return this information to the caller
+    return capabilityList[capability];
 }
 
 int

--- a/src/cpu/o3/fu_pool.hh
+++ b/src/cpu/o3/fu_pool.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013 ARM Limited
+ * Copyright (c) 2012-2013, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -161,6 +161,9 @@ class FUPool : public SimObject
      * other instructions this cycle
      */
     static constexpr auto NoFreeFU = -1;
+
+    /** Returns true if the FU has the required capability */
+    bool isCapable(OpClass capability);
 
     /**
      * Gets a FU providing the requested capability. Will mark the

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2012, 2014, 2019 ARM Limited
+ * Copyright (c) 2010-2012, 2014, 2019, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -360,8 +360,8 @@ class IEW
     /** Load / store queue. */
     LSQ ldstQueue;
 
-    /** Pointer to the functional unit pool. */
-    FUPool *fuPool;
+    /** Vector of pointers to the functional unit pools. */
+    std::vector<FUPool *> fuPools;
     /** Records if the LSQ needs to be updated on the next cycle, so that
      * IEW knows if there will be activity on the next cycle.
      */


### PR DESCRIPTION
This commit is implementing a distributed InstructionQueue.

Prior to this patch it was only possible to have a unified instruction queue for the O3 CPU: every renamed/dispatched instruction was allocated in a single queue.

With this patch we define a IQUnit SimObject (which is basically a single IQ) and we allow the O3CPU to have a vector of IQs to reflect the presence of multiple instruction queues.

A IQUnit is tighlty coupled with its own FUPool: it can only store instructions executable by one of the FU in the pool. This also means we don't have a single fuPool anymore, but a collection of pools (fuPool is a IQUnit Param)

By default, the unified design is in place. To adopt the multi-IQs design, one simply has to provide a different vector to the O3CPU


Change-Id: Ic3923ab779bdb2e957fc5e7a4c5881f9e685aa81