### PR TITLE
base: Fix free-nonheap-object warning with Ubsan

### DIFF
--- a/src/base/refcnt.hh
+++ b/src/base/refcnt.hh
@@ -97,13 +97,12 @@ class RefCounted
     /// Increment the reference count
     void incref() const { ++count; }
 
-    /// Decrement the reference count and destroy the object if all
-    /// references are gone.
-    void
+    /// Decrement the reference count and return true if all references
+    /// are gone.
+    bool
     decref() const
     {
-        if (--count <= 0)
-            delete this;
+        return --count <= 0;
     }
 };
 
@@ -167,8 +166,9 @@ class RefCountingPtr
     void
     del()
     {
-        if (data)
-            data->decref();
+        if (data && data->decref()) {
+            delete data;
+        }
     }
 
     /**


### PR DESCRIPTION
Fix warning when building `--with-ubsan`

1.
```bash
In file included from src/cpu/static_inst.hh:54,                                                                                                                                                                                                                                          
                 from src/sim/insttracer.hh:50,
                 from src/cpu/base.hh:58,
                 from src/cpu/checker/cpu.hh:51,
                 from src/cpu/o3/checker.hh:44,
                 from build/ALL/python/_m5/param_BaseO3Checker.cc:17:
In destructor ‘virtual gem5::RefCounted::~RefCounted()’,
    inlined from ‘void gem5::RefCounted::decref() const’ at src/base/refcnt.hh:106:20,
    inlined from ‘void gem5::RefCountingPtr<T>::del() [with T = gem5::o3::DynInst]’ at src/base/refcnt.hh:171:25,
    inlined from ‘gem5::RefCountingPtr<T>::~RefCountingPtr() [with T = gem5::o3::DynInst]’ at src/base/refcnt.hh:214:28,
    inlined from ‘void std::__new_allocator<_Tp>::destroy(_Up*) [with _Up = gem5::RefCountingPtr<gem5::o3::DynInst>; _Tp = std::_List_node<gem5::RefCountingPtr<gem5::o3::DynInst> >]’ at /usr/include/c++/14/bits/new_allocator.h:198:13,
    inlined from ‘static void std::allocator_traits<std::allocator<_Tp1> >::destroy(allocator_type&, _Up*) [with _Up = gem5::RefCountingPtr<gem5::o3::DynInst>; _Tp = std::_List_node<gem5::RefCountingPtr<gem5::o3::DynInst> >]’ at /usr/include/c++/14/bits/alloc_traits.h:597:15,
    inlined from ‘void std::__cxx11::_List_base<_Tp, _Alloc>::_M_clear() [with _Tp = gem5::RefCountingPtr<gem5::o3::DynInst>; _Alloc = std::allocator<gem5::RefCountingPtr<gem5::o3::DynInst> >]’ at /usr/include/c++/14/bits/list.tcc:77:31,
    inlined from ‘std::__cxx11::_List_base<_Tp, _Alloc>::~_List_base() [with _Tp = gem5::RefCountingPtr<gem5::o3::DynInst>; _Alloc = std::allocator<gem5::RefCountingPtr<gem5::o3::DynInst> >]’ at /usr/include/c++/14/bits/stl_list.h:576:17,
    inlined from ‘std::__cxx11::list<_Tp, _Alloc>::~list() [with _Tp = gem5::RefCountingPtr<gem5::o3::DynInst>; _Alloc = std::allocator<gem5::RefCountingPtr<gem5::o3::DynInst> >]’ at /usr/include/c++/14/bits/stl_list.h:904:7,
    inlined from ‘gem5::Checker<gem5::RefCountingPtr<gem5::o3::DynInst> >::~Checker()’ at src/cpu/checker/cpu.hh:447:7:
src/base/refcnt.hh:95:28: error: ‘void operator delete(void*, std::size_t)’ called on pointer ‘((gem5::RefCountingPtr<gem5::o3::DynInst>*)__cur)[2].gem5::RefCountingPtr<gem5::o3::DynInst>::data’ with nonzero offset 8 [-Werror=free-nonheap-object]
   95 |     virtual ~RefCounted() {}
      |                            ^
In destructor ‘virtual gem5::RefCounted::~RefCounted()’,
    inlined from ‘void gem5::RefCounted::decref() const’ at src/base/refcnt.hh:106:20,
    inlined from ‘void gem5::RefCountingPtr<T>::del() [with T = gem5::o3::DynInst]’ at src/base/refcnt.hh:171:25,
    inlined from ‘gem5::RefCountingPtr<T>::~RefCountingPtr() [with T = gem5::o3::DynInst]’ at src/base/refcnt.hh:214:28,
    inlined from ‘gem5::Checker<gem5::RefCountingPtr<gem5::o3::DynInst> >::~Checker()’ at src/cpu/checker/cpu.hh:447:7:
src/base/refcnt.hh:95:28: error: ‘void operator delete(void*, std::size_t)’ called on pointer ‘((gem5::RefCountingPtr<gem5::o3::DynInst>*)this)[184].gem5::RefCountingPtr<gem5::o3::DynInst>::data’ with nonzero offset 8 [-Werror=free-nonheap-object]
   95 |     virtual ~RefCounted() {}
      |  
```

Change-Id: I6e02322fb875936f72980e2feb195a33a25eedf0