### PR TITLE
cpu-o3: incorrect `vtype` and `vl` generates `assert` fail in  `O3 IQ`

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1329,8 +1329,9 @@ InstructionQueue::doSquash(ThreadID tid)
             if (dest_reg->isFixedMapping()){
                 continue;
             }
-            assert(dependGraph.empty(dest_reg->flatIndex()));
-            dependGraph.clearInst(dest_reg->flatIndex());
+            if (!dependGraph.empty(dest_reg->flatIndex())) {
+                dependGraph.clearInst(dest_reg->flatIndex());
+            }
         }
         instList[tid].erase(squash_it--);
         ++iqStats.squashedInstsExamined;
@@ -1412,7 +1413,8 @@ InstructionQueue::addToProducers(const DynInstPtr &new_inst)
             continue;
         }
 
-        if (!dependGraph.empty(dest_reg->flatIndex())) {
+        if (!dependGraph.empty(dest_reg->flatIndex()) &&
+            new_inst->isNonSpeculative()) {
             dependGraph.dump();
             panic("Dependency graph %i (%s) (flat: %i) not empty!",
                   dest_reg->index(), dest_reg->className(),


### PR DESCRIPTION
As discussed here: [#2575](https://github.com/gem5/gem5/issues/2575), I got some unexpected exception in my code with the `IQ` dependency graph.

The bug happens because in the same tick the `IQ` have a `vsetvli` instruction, which will reduce the current `LMUL`, and another instruction (in this case a `vnsrl`), which depends on the new `vsetvli` configuration. However, depending on the `vs1/vs2` and the previous `LMUL` it is possible to have one of the source registers of the micro-instructions depending on a register which has never been written, causing an exception in the dependency graph, which terminates the program.  

The `O3` considers `vsetvl` instructions as control instructions, in which the result can only be inferred in the `Execute` Stage, since some variants of this instruction requires a source register. In special, `O3` always supposes that the new `vsetvl` instruction will not change the current configuration and when the prediction is wrong, the following instructions are flushed, which makes sense.

So in this case, I believe that the correct behavior is allowing speculative instructions to depend in any register, since for this situation they'll be flushed and then after executed with the correct vector configuration.

I know that removing this `assert` can allow some incorrect programs assembly-made programs to execute without problems (and maybe hide some new `gem5` bugs), but I don't know another feasible solution for this problem.

What do you think about it?
