### PR TITLE
arch-riscv: fix bugs in pinned registers in `vred*` instructions

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -44,6 +44,12 @@ let {{
     def setSrcVm():
         return "if (!this->vm)\n" + \
                "    setSrcRegIdx(_numSrcRegs++, vecRegClass[0]);"
+    def setSrcVmOrTmp0():
+        return "if (!this->vm){\n" + \
+               "(_machInst.vd == 0) ? " + \
+               "setSrcRegIdx(_numSrcRegs++,vecRegClass[VecMemInternalReg0]):"+\
+               "setSrcRegIdx(_numSrcRegs++,vecRegClass[0]);\n" + \
+               "}\n"
     def vmDeclAndReadData():
         return '''
             [[maybe_unused]] RiscvISA::vreg_t tmp_v0;
@@ -1294,7 +1300,7 @@ def format VectorReduceIntFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVm()
+    set_src_reg_idx += setSrcVmOrTmp0()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
 
@@ -1343,7 +1349,7 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVm()
+    set_src_reg_idx += setSrcVmOrTmp0()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
 
@@ -1397,7 +1403,7 @@ def format VectorReduceFloatWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVm()
+    set_src_reg_idx += setSrcVmOrTmp0()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
     type_def = '''
@@ -1510,7 +1516,7 @@ def format VectorReduceIntWideningFormat(code, category, *flags) {{
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVm()
+    set_src_reg_idx += setSrcVmOrTmp0()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1714,7 +1714,14 @@ template<typename ElemType>
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
 
-    microop = new VPinVdMicroInst(machInst, 0, num_microops, elen, vlen);
+    int k;
+    tmp_vl = this->vl;
+    micro_vl = std::min(tmp_vl, micro_vlmax);
+    for (k = 0; k < num_microops && micro_vl > 0; ++k) {
+        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
+    }
+
+    microop = new VPinVdMicroInst(machInst, 0, k, elen, vlen);
     microop->setFlag(IsDelayedCommit);
     this->microops.push_back(microop);
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1704,8 +1704,15 @@ template<typename ElemType>
         this->microops.push_back(microop);
     }
 
+    if (machInst.vd != machInst.vs1 && (machInst.vd == 0 && !machInst.vm)) {
+        microop = new VCpyVsMicroInst(machInst, 0, 0, elen, vlen);
+        microop->setFlag(IsDelayedCommit);
+        this->microops.push_back(microop);
+    }
+
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        if (machInst.vd == (machInst.vs2 + i) && machInst.vd != machInst.vs1) {
+        if (machInst.vd == (machInst.vs2 + i) && machInst.vd != machInst.vs1 &&
+            !(machInst.vd == 0 && !machInst.vm)) {
             microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen,
                                           vlen);
             microop->setFlag(IsDelayedCommit);


### PR DESCRIPTION
As discussed here: [#2658](https://github.com/gem5/gem5/issues/2658), the number of pinned writes in the `vpin_micro` instruction created in the `VectorReduceMacroConstructor` is incorrect and can generate an `assert` fail in the `rename_map.cc` file.

The fix is simple, I set the number of pinned writes as exactly the value of micro-instructions that will be generated.