### PR TITLE
cpu-minor: explicitly check if instruction in ROM during decoding

### DIFF
--- a/src/cpu/minor/decode.cc
+++ b/src/cpu/minor/decode.cc
@@ -164,9 +164,8 @@ Decode::evaluate()
                 StaticInstPtr parent_static_inst = NULL;
                 MinorDynInstPtr output_inst = inst;
 
-                auto* dec_ptr = cpu.getContext(
-                                               inst->id.threadId)
-                                               ->getDecoderPtr();
+                auto *dec_ptr =
+                    cpu.getContext(inst->id.threadId)->getDecoderPtr();
 
                 if (inst->isFault()) {
                     DPRINTF(Decode, "Fault being passed: %d\n",
@@ -185,18 +184,13 @@ Decode::evaluate()
                     }
 
                     if (isRomMicroPC(decode_info.microopPC->microPC())) {
-                      static_micro_inst =
-                        dec_ptr->fetchRomMicroop(
-                                                 decode_info.microopPC
-                                                 ->microPC(),
-                                                 static_inst);
+                        static_micro_inst = dec_ptr->fetchRomMicroop(
+                            decode_info.microopPC->microPC(), static_inst);
                     } else {
                       /* Get the micro-op static instruction from the
                        * static_inst. */
-                      static_micro_inst =
-                        static_inst->fetchMicroop(
-                                                  decode_info.microopPC
-                                                  ->microPC());
+                      static_micro_inst = static_inst->fetchMicroop(
+                          decode_info.microopPC->microPC());
                     }
 
                     output_inst =

--- a/src/cpu/minor/decode.cc
+++ b/src/cpu/minor/decode.cc
@@ -187,10 +187,10 @@ Decode::evaluate()
                         static_micro_inst = dec_ptr->fetchRomMicroop(
                             decode_info.microopPC->microPC(), static_inst);
                     } else {
-                      /* Get the micro-op static instruction from the
-                       * static_inst. */
-                      static_micro_inst = static_inst->fetchMicroop(
-                          decode_info.microopPC->microPC());
+                        /* Get the micro-op static instruction from the
+                         * static_inst. */
+                        static_micro_inst = static_inst->fetchMicroop(
+                            decode_info.microopPC->microPC());
                     }
 
                     output_inst =

--- a/src/cpu/minor/decode.cc
+++ b/src/cpu/minor/decode.cc
@@ -37,6 +37,7 @@
 
 #include "cpu/minor/decode.hh"
 
+#include "arch/generic/decoder.hh"
 #include "base/logging.hh"
 #include "base/trace.hh"
 #include "cpu/minor/pipeline.hh"
@@ -163,6 +164,10 @@ Decode::evaluate()
                 StaticInstPtr parent_static_inst = NULL;
                 MinorDynInstPtr output_inst = inst;
 
+                auto* dec_ptr = cpu.getContext(
+                                               inst->id.threadId)
+                                               ->getDecoderPtr();
+
                 if (inst->isFault()) {
                     DPRINTF(Decode, "Fault being passed: %d\n",
                         inst->fault->name());
@@ -179,11 +184,20 @@ Decode::evaluate()
                         decode_info.inMacroop = true;
                     }
 
-                    /* Get the micro-op static instruction from the
-                     * static_inst. */
-                    static_micro_inst =
+                    if (isRomMicroPC(decode_info.microopPC->microPC())) {
+                      static_micro_inst =
+                        dec_ptr->fetchRomMicroop(
+                                                 decode_info.microopPC
+                                                 ->microPC(),
+                                                 static_inst);
+                    } else {
+                      /* Get the micro-op static instruction from the
+                       * static_inst. */
+                      static_micro_inst =
                         static_inst->fetchMicroop(
-                                decode_info.microopPC->microPC());
+                                                  decode_info.microopPC
+                                                  ->microPC());
+                    }
 
                     output_inst =
                         new MinorDynInst(static_micro_inst, inst->id);


### PR DESCRIPTION
Check if current micro-op is in ROM, and, if so, fetch the instruction from ROM when decoding. This fixes the `invalid micro-op!` panic that occurs when running the SPEC2017 benchmarks with the Minor CPU and [matches the corresponding behavior in the O3 CPU](https://github.com/gem5/gem5/blob/ddd4ae35adb0a3df1f1ba11e9a973a5c2f8c2944/src/cpu/o3/fetch.cc#L1238).