### PR TITLE
cpu-o3: Instant ROB squash

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -136,7 +136,10 @@ class BaseO3CPU(BaseCPU):
     )
     renameToROBDelay = Param.Cycles(1, "Rename to reorder buffer delay")
     commitWidth = Param.Unsigned(8, "Commit width")
-    squashWidth = Param.Unsigned(8, "Squash width")
+    squashWidth = OptionalParam.Unsigned(
+        "Squash width. If unspecified all instructions are "
+        "squashed instantly within one cycle.",
+    )
     trapLatency = Param.Cycles(13, "Trap latency")
     fetchTrapLatency = Param.Cycles(1, "Fetch trap latency")
 

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -64,6 +64,7 @@ ROB::ROB(CPU *_cpu, const BaseO3CPUParams &params)
       numThreads(params.numThreads),
       stats(_cpu)
 {
+    assert(!squashWidth.has_value() || (squashWidth > 0));
     //Figure out rob policy
     if (robPolicy == SMTQueuePolicy::Dynamic) {
         //Set Max Entries to Total ROB Capacity
@@ -316,7 +317,7 @@ ROB::doSquash(ThreadID tid)
 
     bool robTailUpdate = false;
 
-    unsigned int numInstsToSquash = squashWidth;
+    auto numInstsToSquash = squashWidth.has_value() ? squashWidth : numEntries;
 
     // If the CPU is exiting, squash all of the instructions
     // it is told to, even if that exceeds the squashWidth.

--- a/src/cpu/o3/rob.hh
+++ b/src/cpu/o3/rob.hh
@@ -288,8 +288,11 @@ class ROB
     /** ROB List of Instructions */
     std::list<DynInstPtr> instList[MaxThreads];
 
-    /** Number of instructions that can be squashed in a single cycle. */
-    unsigned squashWidth;
+    /** Number of instructions that can be squashed in a single cycle.
+     * A negative number means all instructions are squashed instantly
+     * within on cycle
+     */
+    const std::optional<unsigned> squashWidth;
 
   public:
     /** Iterator pointing to the instruction which is the last instruction
@@ -328,7 +331,6 @@ class ROB
 
     /** Number of active threads. */
     ThreadID numThreads;
-
 
     struct ROBStats : public statistics::Group
     {


### PR DESCRIPTION
The squashWidth limits the number of instructions squashed
within on cycle. In case of a full, large ROB this can incure tens
of cycles during which the rename stage is blocked. E.g. with
160 instructions in the ROB and squash width of 8 rename will be
blocked 20 cycles.
With this change users can set the squash width to a negative number
and then all instructions will be squashed immediatly.
In a real implementation it is more likely the case where this can
simply be done with updating a pointer.