### PR TITLE
dev: rename PCI devices base classes

### DIFF
--- a/src/dev/pci/PciDevice.py
+++ b/src/dev/pci/PciDevice.py
@@ -216,9 +216,9 @@ class PciEndpoint(PciDevice):
     MinimumGrant = Param.UInt8(0x00, "Minimum Grant")
 
 
-class PciBridge(PciDevice):
-    type = "PciBridge"
-    cxx_class = "gem5::PciBridge"
+class PciType1Device(PciDevice):
+    type = "PciType1Device"
+    cxx_class = "gem5::PciType1Device"
     cxx_header = "dev/pci/device.hh"
     abstract = True
 

--- a/src/dev/pci/SConscript
+++ b/src/dev/pci/SConscript
@@ -42,11 +42,9 @@ Import('*')
 
 SimObject('PciDevice.py', sim_objects=[
     'PciBar', 'PciBarNone', 'PciIoBar', 'PciLegacyIoBar', 'PciMemBar',
-    'PciMemUpperBar', 'PciDevice', 'PciEndpoint', 'PciBridge'])
+    'PciMemUpperBar', 'PciDevice', 'PciEndpoint', 'PciType1Device'])
 Source('device.cc')
 DebugFlag('PciDevice')
-DebugFlag('PciEndpoint')
-DebugFlag('PciBridge')
 
 SimObject('PciUpstream.py', sim_objects=[
     'PciUpstream', 'PciUpDownBridge', 'PciBus', 'PciConfigError'

--- a/src/dev/pci/device.cc
+++ b/src/dev/pci/device.cc
@@ -54,9 +54,7 @@
 #include "base/logging.hh"
 #include "base/str.hh"
 #include "base/trace.hh"
-#include "debug/PciBridge.hh"
 #include "debug/PciDevice.hh"
-#include "debug/PciEndpoint.hh"
 #include "mem/packet.hh"
 #include "mem/packet_access.hh"
 #include "sim/byteswap.hh"
@@ -603,7 +601,7 @@ PciDevice::unserialize(CheckpointIn &cp)
 }
 
 PciEndpoint::PciEndpoint(const PciEndpointParams &p)
-    : PciDevice(p, { p.BAR0, p.BAR1, p.BAR2, p.BAR3, p.BAR4, p.BAR5 })
+    : PciDevice(p, {p.BAR0, p.BAR1, p.BAR2, p.BAR3, p.BAR4, p.BAR5})
 {
     fatal_if((_config.common.headerType & 0x7F) != 0, "HeaderType is invalid");
 
@@ -655,7 +653,7 @@ PciEndpoint::writeConfig(PacketPtr pkt)
           default:
             panic("writing to a read only register");
         }
-        DPRINTF(PciEndpoint,
+        DPRINTF(PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 1 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint8_t>());
@@ -687,9 +685,9 @@ PciEndpoint::writeConfig(PacketPtr pkt)
             break;
 
           default:
-            DPRINTF(PciEndpoint, "Writing to a read only register");
+              DPRINTF(PciDevice, "Writing to a read only register");
         }
-        DPRINTF(PciEndpoint,
+        DPRINTF(PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 4 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint32_t>());
@@ -712,8 +710,8 @@ PciEndpoint::unserialize(CheckpointIn &cp)
     pioPort.sendRangeChange();
 }
 
-PciBridge::PciBridge(const PciBridgeParams &p)
-    : PciDevice(p, { p.BAR0, p.BAR1 })
+PciType1Device::PciType1Device(const PciType1DeviceParams &p)
+    : PciDevice(p, {p.BAR0, p.BAR1})
 {
     fatal_if((_config.common.headerType & 0x7F) != 1, "HeaderType is invalid");
 
@@ -741,7 +739,7 @@ PciBridge::PciBridge(const PciBridgeParams &p)
 }
 
 Tick
-PciBridge::writeConfig(PacketPtr pkt)
+PciType1Device::writeConfig(PacketPtr pkt)
 {
     int offset = pkt->getAddr() & PCI_CONFIG_SIZE;
 
@@ -786,7 +784,7 @@ PciBridge::writeConfig(PacketPtr pkt)
           default:
               panic("writing to a read only register");
         }
-        DPRINTF(PciBridge,
+        DPRINTF(PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 1 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint8_t>());
@@ -820,7 +818,7 @@ PciBridge::writeConfig(PacketPtr pkt)
           default:
             panic("writing to a read only register");
         }
-        DPRINTF(PciBridge,
+        DPRINTF(PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 2 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint16_t>());
@@ -852,7 +850,7 @@ PciBridge::writeConfig(PacketPtr pkt)
           default:
             panic("writing to a read only register");
         }
-        DPRINTF(PciBridge,
+        DPRINTF(PciDevice,
                 "writeConfig: dev %#x func %#x reg %#x 4 bytes: data = %#x\n",
                 _devAddr.dev, _devAddr.func, offset,
                 (uint32_t)pkt->getLE<uint32_t>());
@@ -865,7 +863,7 @@ PciBridge::writeConfig(PacketPtr pkt)
 }
 
 void
-PciBridge::unserialize(CheckpointIn &cp)
+PciType1Device::unserialize(CheckpointIn &cp)
 {
     PciDevice::unserialize(cp);
 

--- a/src/dev/pci/up_down_bridge.cc
+++ b/src/dev/pci/up_down_bridge.cc
@@ -39,7 +39,7 @@
 
 #include "base/addr_range.hh"
 #include "base/logging.hh"
-#include "debug/PciBridge.hh"
+#include "debug/PciUpstream.hh"
 #include "params/PciUpDownBridge.hh"
 
 namespace gem5
@@ -78,9 +78,9 @@ PciUpDownBridge::recvRangeChange()
 
     // Avoid potential loop of range change.
     if (new_ranges != memSideRanges) {
-        DPRINTF(PciBridge, "Received range change\n");
+        DPRINTF(PciUpstream, "Received range change\n");
         for (const auto &r : new_ranges) {
-            DPRINTF(PciBridge, "-- %s\n", r.to_string());
+            DPRINTF(PciUpstream, "-- %s\n", r.to_string());
         }
 
         memSideRanges = new_ranges;


### PR DESCRIPTION
This commit rename PciEndpoint and PciBridge to PciType0Device and PciType1Device to avoid confusion with proliferation of PCI bridges names, as mentionned in https://github.com/gem5/gem5/pull/2561#issuecomment-3381337325

It also add documentation to those classes.