### PR TITLE
mem-ruby: Add support for CLFLUSH type instructions in MESI Three Level protocol

### DIFF
--- a/configs/example/ruby_random_test.py
+++ b/configs/example/ruby_random_test.py
@@ -94,6 +94,8 @@ args.l3_assoc = 2
 check_flush = False
 if buildEnv["PROTOCOL"] == "MOESI_hammer":
     check_flush = True
+if buildEnv["PROTOCOL"] == "MESI_Three_Level":
+    check_flush = True
 
 tester = RubyTester(
     check_flush=check_flush,

--- a/src/mem/ruby/protocol/MESI_Three_Level-L0cache.sm
+++ b/src/mem/ruby/protocol/MESI_Three_Level-L0cache.sm
@@ -109,6 +109,10 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
     // LL/SC states
     LLSC_E, AccessPermission:Read_Only, desc="a L1 cache entry Exclusive (LL/SC locked)";
     LLSC_M, AccessPermission:Read_Write, desc="a L1 cache entry Modified (LL/SC locked)";
+
+    // Flush states
+    I_F, AccessPermission:Busy, desc="Sent flush to L1, was in invalid";
+    V_F, AccessPermission:Busy, desc="Sent flush to L1, was valid";
   }
 
   // EVENTS
@@ -152,6 +156,11 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
     Load_Linked,         desc="Load-Linked request from the home processor";
     LLSC_Data_Exclusive, desc="Data for processor (start LL/SC  lock timer)";
     LLSC_Timeout,        desc="LL/SC lock timeout";
+
+    // Flush transitions
+    Flush, desc="Receive flush from processor";
+    Flush_Ack, desc="Flush ack from L1";
+    External_Flush_Data, desc="Send data to L1 during flush";
   }
 
   // TYPES
@@ -303,6 +312,8 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
     } else if ((type == RubyRequestType:ST) || (type == RubyRequestType:ATOMIC)
                || (type == RubyRequestType:Store_Conditional)) {
       return Event:Store;
+    } else if (type == RubyRequestType:FLUSH) {
+      return Event:Flush;
     } else {
       error("Invalid RubyRequestType");
     }
@@ -481,6 +492,10 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
           trigger(Event:Fwd_GETS, in_msg.addr, cache_entry, tbe);
         } else if (in_msg.Class == CoherenceClass:GET_INSTR) {
           trigger(Event:Fwd_GET_INSTR, in_msg.addr, cache_entry, tbe);
+        } else if (in_msg.Class == CoherenceClass:FLUSH_ACK) {
+          trigger(Event:Flush_Ack, in_msg.addr, cache_entry, tbe);
+        } else if (in_msg.Class == CoherenceClass:FLUSH_DATA) {
+          trigger(Event:External_Flush_Data, in_msg.addr, cache_entry, tbe);
         } else {
           error("Invalid forwarded request type");
         }
@@ -550,6 +565,9 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
             if (in_msg.Type == RubyRequestType:Store_Conditional) {
                 // if the line is not valid, it can't be locked
                 trigger(Event:Failed_SC, in_msg.LineAddress,
+                        Dcache_entry, TBEs[in_msg.LineAddress]);
+            } else if (in_msg.Type == RubyRequestType:FLUSH) {
+                trigger(Event:Flush, in_msg.LineAddress,
                         Dcache_entry, TBEs[in_msg.LineAddress]);
             } else {
               // Check to see if it is in the OTHER L0
@@ -627,6 +645,48 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
         out_msg.MessageSize := MessageSizeType:Control;
         out_msg.AccessMode := in_msg.AccessMode;
       }
+    }
+  }
+
+  action(f_sendFlushToL1, "fs", desc="Send flush request to the L1 cache") {
+    enqueue(requestNetwork_out, CoherenceMsg, response_latency) {
+      assert(is_valid(cache_entry));
+      out_msg.addr := address;
+      out_msg.Class := CoherenceClass:FLUSH;
+      out_msg.Sender := machineID;
+      out_msg.Dest := createMachineID(MachineType:L1Cache, version);
+      if (cache_entry.Dirty) {
+        out_msg.MessageSize := MessageSizeType:Data;
+        out_msg.DataBlk := cache_entry.DataBlk;
+        out_msg.Dirty := true;
+      } else {
+        out_msg.MessageSize := MessageSizeType:Control;
+        out_msg.Dirty := false;
+      }
+    }
+  }
+
+  action(f_sendFlushNPToL1, "fnp", desc="Send flush request to the L1 cache, not present in L0") {
+    enqueue(requestNetwork_out, CoherenceMsg, response_latency) {
+      out_msg.addr := address;
+      out_msg.Class := CoherenceClass:FLUSH_NP;
+      out_msg.Sender := machineID;
+      out_msg.Dest := createMachineID(MachineType:L1Cache, version);
+      out_msg.MessageSize := MessageSizeType:Control;
+      out_msg.Dirty := false;
+    }
+  }
+
+  action(f_sendFlushDatatoL1, "fsfd", desc="Send flush data to the L1 cache") {
+    enqueue(requestNetwork_out, CoherenceMsg, response_latency) {
+      assert(is_valid(cache_entry));
+      out_msg.addr := address;
+      out_msg.Class := CoherenceClass:FLUSH_DATA;
+      out_msg.DataBlk := cache_entry.DataBlk;
+      out_msg.Dirty := cache_entry.Dirty;
+      out_msg.Sender := machineID;
+      out_msg.Dest := createMachineID(MachineType:L1Cache, version);
+      out_msg.MessageSize := MessageSizeType:Data;
     }
   }
 
@@ -734,6 +794,10 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
     cache_entry.Dirty := true;
   }
 
+  action(f_flush_complete, "fcm", desc="Notify sequencer that flush completed") {
+    sequencer.writeCallback(address, cache_entry.DataBlk);
+  }
+
   action(i_allocateTBE, "i", desc="Allocate TBE (number of invalidates=0)") {
     check_allocate(TBEs);
     assert(is_valid(cache_entry));
@@ -741,6 +805,12 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
     set_tbe(TBEs[address]);
     tbe.Dirty := cache_entry.Dirty;
     tbe.DataBlk := cache_entry.DataBlk;
+  }
+
+  action(i_allocateTBE_flush, "if", desc="Allocate TBE for flush (block not present, will not be present)") {
+    check_allocate(TBEs);
+    TBEs.allocate(address);
+    set_tbe(TBEs[address]);
   }
 
   action(k_popMandatoryQueue, "k", desc="Pop mandatory queue") {
@@ -929,7 +999,7 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
   //*****************************************************
 
   // Transitions for Load/Store/Replacement/WriteBack from transient states
-  transition({Inst_IS, IS, IM, SM}, {Load, Ifetch, Store, L0_Replacement, Load_Linked}) {
+  transition({Inst_IS, IS, IM, SM, I_F, V_F}, {Load, Ifetch, Store, L0_Replacement, Load_Linked}) {
     z_stallAndWaitMandatoryQueue;
   }
 
@@ -937,7 +1007,7 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
     z_stallAndWaitMandatoryQueue;
   }
 
-  transition({LLSC_E, LLSC_M}, {Fwd_GETS, Fwd_GETX, Fwd_GET_INSTR, InvOwn, InvElse}) {
+  transition({LLSC_E, LLSC_M, I_F, V_F}, {Fwd_GETS, Fwd_GETX, Fwd_GET_INSTR, InvOwn, InvElse}) {
     z_stallAndWaitMessageBufferQueue;
   }
 
@@ -1326,6 +1396,44 @@ machine(MachineType:L0Cache, "MESI Directory L0 Cache")
 
   transition(LLSC_M, LLSC_Timeout, M) {
     ll_unsetLoadLinkedLockTimer;
+    kd_wakeUpDependents;
+  }
+
+  // Flush transitions
+  transition(I, Flush, I_F) {
+    i_allocateTBE_flush;
+    f_sendFlushNPToL1;
+    k_popMandatoryQueue;
+  }
+
+  transition({S, E, M}, Flush, V_F) {
+    i_allocateTBE;
+    f_sendFlushToL1;
+    k_popMandatoryQueue;
+  }
+
+  transition(V_F, Flush_Ack, I) {
+    forward_eviction_to_cpu;
+    f_flush_complete;
+    s_deallocateTBE;
+    ff_deallocateCacheBlock;
+    o_popIncomingResponseQueue;
+    kd_wakeUpDependents;
+  }
+
+  transition(I_F, Flush_Ack, I) {
+    forward_eviction_to_cpu;
+    f_flush_complete;
+    s_deallocateTBE;
+    o_popIncomingResponseQueue;
+    kd_wakeUpDependents;
+  }
+
+  transition({E, M}, External_Flush_Data, I) {
+    forward_eviction_to_cpu;
+    f_sendFlushDatatoL1;
+    ff_deallocateCacheBlock;
+    o_popIncomingResponseQueue;
     kd_wakeUpDependents;
   }
 }

--- a/src/mem/ruby/protocol/MESI_Three_Level-L1cache.sm
+++ b/src/mem/ruby/protocol/MESI_Three_Level-L1cache.sm
@@ -95,6 +95,11 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
     M_IL0, AccessPermission:Maybe_Stale, desc="Modified in L1, invalidation sent to L0, have not seen response yet";
     MM_IL0, AccessPermission:Read_Write, desc="Invalidation sent to L0, have not seen response yet";
     SM_IL0, AccessPermission:Busy, desc="Invalidation sent to L0, have not seen response yet";
+
+    // Flush states
+    I_F, AccessPermission:Busy, desc="Send flush to L2, entry is invalid";
+    V_F, AccessPermission:Busy, desc="Send flush to L2, entry is valid";
+    D_F, AccessPermission:Busy, desc="Sending data to L2 during flush";
   }
 
   // EVENTS
@@ -138,6 +143,12 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
     // sent a NAK (because of htm abort) saying that the data
     // in L1 is the latest value.
     L0_DataNak,      desc="L0 received INV message, specifies its data is also stale";
+
+    Flush,     desc="Flush request from L0, valid in L0";
+    Flush_NP,   desc="Flush request from L0, not present in L0";
+    Flush_Ack,  desc="Flush ack from L1";
+    External_Flush_Data, desc="Send flush data to L2";
+    External_Flush_Data_Ack, desc="Flush data received from L1";
   }
 
   // TYPES
@@ -264,6 +275,12 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
       return Event:Store;
     } else if (type == CoherenceClass:PUTX) {
       return Event:WriteBack;
+    } else if (type == CoherenceClass:FLUSH) {
+      return Event:Flush;
+    } else if (type == CoherenceClass:FLUSH_NP) {
+      return Event:Flush_NP;
+    } else if (type == CoherenceClass:FLUSH_DATA) {
+      return Event:External_Flush_Data_Ack;
     } else {
       error("Invalid RequestType");
     }
@@ -320,6 +337,8 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
           }
         } else if (in_msg.Type == CoherenceResponseType:WB_ACK) {
           trigger(Event:WB_Ack, in_msg.addr, cache_entry, tbe);
+        } else if (in_msg.Type == CoherenceResponseType:FLUSH_ACK) {
+          trigger(Event:Flush_Ack, in_msg.addr, cache_entry, tbe);
         } else {
           error("Invalid L1 response type");
         }
@@ -357,6 +376,8 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
             } else {
                 trigger(Event:Fwd_GETS, in_msg.addr, cache_entry, tbe);
             }
+        } else if (in_msg.Type == CoherenceRequestType:FLUSH_DATA) {
+            trigger(Event:External_Flush_Data, in_msg.addr, cache_entry, tbe);
         } else {
           error("Invalid forwarded request type");
         }
@@ -379,6 +400,12 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
               trigger(Event:L0_DataCopy, in_msg.addr, cache_entry, tbe);
         }  else if (in_msg.Class == CoherenceClass:INV_ACK) {
             trigger(Event:L0_Ack, in_msg.addr, cache_entry, tbe);
+        }  else if (in_msg.Class == CoherenceClass:FLUSH) {
+            trigger(Event:Flush, in_msg.addr, cache_entry, tbe);
+        }  else if (in_msg.Class == CoherenceClass:FLUSH_NP) {
+            trigger(Event:Flush_NP, in_msg.addr, cache_entry, tbe);
+        }  else if (in_msg.Class == CoherenceClass:FLUSH_DATA) {
+            trigger(Event:External_Flush_Data_Ack, in_msg.addr, cache_entry, tbe);
         }  else {
             if (is_valid(cache_entry)) {
                 trigger(mandatory_request_type_to_event(in_msg.Class),
@@ -636,6 +663,90 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
     }
   }
 
+  action(f_sendFlushToL2, "fsf", desc="send flush to L2") {
+    peek(messageBufferFromL0_in, CoherenceMsg) {
+      enqueue(requestNetwork_out, RequestMsg, l1_request_latency) {
+        out_msg.addr := address;
+        out_msg.Type := CoherenceRequestType:FLUSH;
+        out_msg.Requestor := machineID;
+        out_msg.Destination.add(mapAddressToRange(address, MachineType:L2Cache,
+                            l2_select_low_bit, l2_select_num_bits, clusterID));
+        if (in_msg.Dirty) {
+          out_msg.MessageSize := MessageSizeType:Data;
+          out_msg.DataBlk := in_msg.DataBlk;
+          out_msg.Dirty := true;
+        } else if (is_valid(cache_entry) && cache_entry.Dirty) {
+          out_msg.MessageSize := MessageSizeType:Data;
+          out_msg.DataBlk := cache_entry.DataBlk;
+          out_msg.Dirty := true;
+        } else {
+          out_msg.MessageSize := in_msg.MessageSize;
+          out_msg.Dirty := false;
+        }
+      }
+    }
+  }
+
+  action(f_sendFlushNPToL2, "fsfnp", desc="send flush to L2") {
+    peek(messageBufferFromL0_in, CoherenceMsg) {
+      enqueue(requestNetwork_out, RequestMsg, l1_request_latency) {
+        out_msg.addr := address;
+        out_msg.Type := CoherenceRequestType:FLUSH_NP;
+        out_msg.Requestor := machineID;
+        out_msg.Destination.add(mapAddressToRange(address, MachineType:L2Cache,
+                            l2_select_low_bit, l2_select_num_bits, clusterID));
+        out_msg.MessageSize := in_msg.MessageSize;
+        out_msg.Dirty := false;
+      }
+    }
+  }
+
+  action(f_sendFlushAckToL0, "fa", desc="send flush ack to L0") {
+    enqueue(bufferToL0_out, CoherenceMsg, l1_response_latency) {
+      out_msg.addr := address;
+      out_msg.Class := CoherenceClass:FLUSH_ACK;
+      out_msg.Dest := createMachineID(MachineType:L0Cache, version);
+    }
+  }
+
+  action(f_sendFlushDataToL2, "fsfd", desc="send flush data to L2") {
+    enqueue(requestNetwork_out, RequestMsg, l1_request_latency) {
+      assert(is_valid(cache_entry));
+      out_msg.addr := address;
+      out_msg.Type := CoherenceRequestType:FLUSH_DATA;
+      out_msg.Requestor := machineID;
+      out_msg.Destination.add(mapAddressToRange(address, MachineType:L2Cache,
+                          l2_select_low_bit, l2_select_num_bits, clusterID));
+      out_msg.MessageSize := MessageSizeType:Data;
+      out_msg.DataBlk := cache_entry.DataBlk;
+      out_msg.Dirty := cache_entry.Dirty;
+    }
+  }
+
+  action(f_fwdFlushDataToL2, "ffd2", desc="forward flush data to L2") {
+    peek(messageBufferFromL0_in, CoherenceMsg) {
+      enqueue(requestNetwork_out, RequestMsg, l1_request_latency) {
+        assert(is_valid(cache_entry));
+        out_msg.addr := address;
+        out_msg.Type := CoherenceRequestType:FLUSH_DATA;
+        out_msg.Requestor := machineID;
+        out_msg.Destination.add(mapAddressToRange(address, MachineType:L2Cache,
+                            l2_select_low_bit, l2_select_num_bits, clusterID));
+        out_msg.MessageSize := MessageSizeType:Data;
+        out_msg.DataBlk := in_msg.DataBlk;
+        out_msg.Dirty := in_msg.Dirty;
+      }
+    }
+  }
+
+  action(f_fwdFlushDataReqToL0, "ffd", desc="forward flush data request to L0") {
+    enqueue(bufferToL0_out, CoherenceMsg, l1_request_latency) {
+      out_msg.addr := address;
+      out_msg.Class := CoherenceClass:FLUSH_DATA;
+      out_msg.Dest := createMachineID(MachineType:L0Cache, version);
+    }
+  }
+
   action(h_data_to_l0, "h", desc="If not prefetch, send data to the L0 cache.") {
       enqueue(bufferToL0_out, CoherenceMsg, l1_response_latency) {
           assert(is_valid(cache_entry));
@@ -690,6 +801,12 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
     set_tbe(TBEs[address]);
     tbe.Dirty := cache_entry.Dirty;
     tbe.DataBlk := cache_entry.DataBlk;
+  }
+
+  action(i_allocateTBE_flush, "if", desc="Allocate TBE for flush (block not present, will not be present)") {
+    check_allocate(TBEs);
+    TBEs.allocate(address);
+    set_tbe(TBEs[address]);
   }
 
   action(k_popL0RequestQueue, "k", desc="Pop mandatory queue.") {
@@ -791,8 +908,8 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
   //*****************************************************
 
   // Transitions for Load/Store/Replacement/WriteBack from transient states
-  transition({IS, IM, IS_I, M_I, SM, SINK_WB_ACK, S_IL0, M_IL0, E_IL0, MM_IL0},
-             {Load, Store, L1_Replacement}) {
+  transition({IS, IM, IS_I, M_I, SM, SINK_WB_ACK, S_IL0, M_IL0, E_IL0, MM_IL0, I_F, V_F, D_F},
+             {Load, Store, L1_Replacement, Flush, External_Flush_Data, Flush_NP}) {
     z0_stallAndWaitL0Queue;
   }
 
@@ -1147,5 +1264,51 @@ machine(MachineType:L1Cache, "MESI Directory L1 Cache CMP")
 
   transition(I, L1_Replacement) {
     ff_deallocateCacheBlock;
+  }
+
+  // flush transitions
+  transition(I, Flush_NP, I_F) {
+    i_allocateTBE_flush;
+    f_sendFlushNPToL2;
+    k_popL0RequestQueue;
+  }
+
+  transition({S, SS, E, EE, M, MM}, {Flush, Flush_NP}, V_F) {
+    i_allocateTBE;
+    f_sendFlushToL2;
+    k_popL0RequestQueue;
+  }
+
+  transition(V_F, Flush_Ack, I) {
+    f_sendFlushAckToL0;
+    s_deallocateTBE;
+    o_popL2ResponseQueue;
+    ff_deallocateCacheBlock;
+    kd_wakeUpDependents;
+  }
+
+  transition(I_F, Flush_Ack, I) {
+    f_sendFlushAckToL0;
+    s_deallocateTBE;
+    o_popL2ResponseQueue;
+    kd_wakeUpDependents;
+  }
+
+  transition({EE, MM}, External_Flush_Data, I) {
+    f_sendFlushDataToL2;
+    ff_deallocateCacheBlock;
+    l_popL2RequestQueue;
+  }
+
+  transition({E,M}, External_Flush_Data, D_F) {
+    i_allocateTBE;
+    f_fwdFlushDataReqToL0;
+    l_popL2RequestQueue;
+  }
+
+  transition(D_F, External_Flush_Data_Ack, I) {
+    f_fwdFlushDataToL2;
+    ff_deallocateCacheBlock;
+    k_popL0RequestQueue;
   }
 }

--- a/src/mem/ruby/protocol/MESI_Three_Level-msg.sm
+++ b/src/mem/ruby/protocol/MESI_Three_Level-msg.sm
@@ -66,6 +66,12 @@ enumeration(CoherenceClass, desc="...") {
   // shared block before it got the data. So the L0 cache can use the data
   // but not store it.
   STALE_DATA;
+
+  // Flush messages
+  FLUSH, desc="Flush request from L0";
+  FLUSH_NP, desc="Flush request from L0, not present in L0";
+  FLUSH_ACK, desc="Flush ack from L1";
+  FLUSH_DATA, desc="Send flush data to L2";
 }
 
 // Class for messages sent between the L0 and the L1 controllers.

--- a/src/mem/ruby/protocol/MESI_Three_Level.slicc
+++ b/src/mem/ruby/protocol/MESI_Three_Level.slicc
@@ -1,4 +1,4 @@
-protocol "MESI_Three_Level" use_secondary_load_linked, use_secondary_store_conditional;
+protocol "MESI_Three_Level" use_secondary_load_linked, use_secondary_store_conditional, supports_flushes;
 include "MESI_Two_Level-msg.sm";
 include "MESI_Three_Level-msg.sm";
 include "MESI_Three_Level-L0cache.sm";

--- a/src/mem/ruby/protocol/MESI_Two_Level-L2cache.sm
+++ b/src/mem/ruby/protocol/MESI_Two_Level-L2cache.sm
@@ -93,6 +93,9 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     MT_IB, AccessPermission:Busy, desc="Blocked for L1_GETS from MT, got unblock, waiting for data";
     MT_SB, AccessPermission:Busy, desc="Blocked for L1_GETS from MT, got data,  waiting for unblock";
 
+    I_F, AccessPermission:Busy, desc="Flushing from NP,SS,M state, waiting for memory ack/sharers ack";
+    I_FF, AccessPermission:Busy, desc="Flushing from SS state, waiting for sharers acks and memory ack";
+    MT_F, AccessPermission:Busy, desc="Flushing from MT state, waiting for data from owner";
   }
 
   // EVENTS
@@ -126,6 +129,13 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     Exclusive_Unblock, desc="Unblock from L1 requestor";
 
     MEM_Inv, desc="Invalidation from directory";
+
+    Flush, desc="Flush request, write to mem";
+    Flush_NP, desc="Flush request not present in requestor L1 and L0, write to mem";
+    Flush_Clean, desc="Flush request, clean data, no write to mem";
+    Flush_NP_Clean, desc="Flush request not present in requestor L1 and L0, clean data, no write to mem";
+    Flush_Data, desc="Data from L1 for flush, need to write to mem";
+    Flush_Data_Clean, desc="Data from L1 for flush, no write to mem";
   }
 
   // TYPES
@@ -145,6 +155,7 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     State TBEState,             desc="Transient state";
     DataBlock DataBlk,          desc="Buffer for the data block";
     bool Dirty, default="false", desc="Data is Dirty";
+    MachineID Requestor,        desc="Who allocated this TBE";
 
     NetDest L1_GetS_IDs,            desc="Set of the internal processors that want the block in shared state";
     MachineID L1_GetX_ID,          desc="ID of the L1 cache to forward the block to once we get a response";
@@ -283,6 +294,12 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
       } else {
         return Event:L1_PUTX_old;
       }
+    } else if (type == CoherenceRequestType:FLUSH) {
+      return Event:Flush;
+    } else if (type == CoherenceRequestType:FLUSH_NP) {
+      return Event:Flush_NP;
+    } else if (type == CoherenceRequestType:FLUSH_DATA) {
+      return Event:Flush_Data;
     } else {
       DPRINTF(RubySlicc, "address: %#x, Request Type: %s\n", addr, type);
       error("Invalid L1 forwarded request type");
@@ -381,7 +398,25 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
         assert(machineIDToMachineType(in_msg.Requestor) == MachineType:L1Cache);
         assert(in_msg.Destination.isElement(machineID));
 
-        if (is_valid(cache_entry)) {
+        if (in_msg.Type == CoherenceRequestType:FLUSH) {
+          if (in_msg.Dirty || (is_valid(cache_entry) && cache_entry.Dirty)) {
+            trigger(Event:Flush, in_msg.addr, cache_entry, tbe);
+          } else {
+            trigger(Event:Flush_Clean, in_msg.addr, cache_entry, tbe);
+          }
+        } else if (in_msg.Type == CoherenceRequestType:FLUSH_NP) {
+          if (is_valid(cache_entry) && cache_entry.Dirty) {
+            trigger(Event:Flush_NP, in_msg.addr, cache_entry, tbe);
+          } else {
+            trigger(Event:Flush_NP_Clean, in_msg.addr, cache_entry, tbe);
+          }
+        } else if (in_msg.Type == CoherenceRequestType:FLUSH_DATA) {
+          if (in_msg.Dirty || cache_entry.Dirty) {// must be valid because asked for data
+            trigger(Event:Flush_Data, in_msg.addr, cache_entry, tbe);
+          } else {
+            trigger(Event:Flush_Data_Clean, in_msg.addr, cache_entry, tbe);
+          }
+        } else if (is_valid(cache_entry)) {
           // The L2 contains the block, so proceeded with handling the request
           trigger(L1Cache_request_type_to_event(in_msg.Type, in_msg.addr,
                                                 in_msg.Requestor, cache_entry),
@@ -735,6 +770,83 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     }
   }
 
+  action(f_sendFlushAckToL1, "fsf", desc="send flush ack to L1") {
+    enqueue(responseL2Network_out, ResponseMsg, l2_response_latency) {
+      out_msg.addr := address;
+      out_msg.Type := CoherenceResponseType:FLUSH_ACK;
+      if (is_valid(tbe)) {
+        out_msg.Destination.add(tbe.Requestor);
+      } else {
+        peek(L1RequestL2Network_in, RequestMsg) {
+          out_msg.Destination.add(in_msg.Requestor);
+        }
+      }
+      out_msg.MessageSize := MessageSizeType:Control;
+    }
+  }
+
+  action(f_sendFlushNotNeededAckToL1, "fsfn", desc="send flush ack to L1 when flush not needed") {
+    peek(L1RequestL2Network_in, RequestMsg) {
+      enqueue(responseL2Network_out, ResponseMsg, l2_response_latency) {
+        out_msg.addr := address;
+        out_msg.Type := CoherenceResponseType:FLUSH_ACK;
+        out_msg.Destination.add(in_msg.Requestor);
+        out_msg.MessageSize := MessageSizeType:Control;
+      }
+    }
+  }
+
+  action(f_flushGetDataFromOwner, "fgd", desc="get data from owner before flush") {
+    enqueue(L1RequestL2Network_out, RequestMsg, to_l1_latency) {
+      assert(is_valid(cache_entry));
+      out_msg.addr := address;
+      out_msg.Type := CoherenceRequestType:FLUSH_DATA;
+      out_msg.Requestor := machineID;
+      out_msg.Destination.add(cache_entry.Exclusive);
+      out_msg.MessageSize := MessageSizeType:Control;
+    }
+  }
+
+  action(t_setTbeRequestor, "tst", desc="set TBE requestor from l1 cache") {
+    peek(L1RequestL2Network_in, RequestMsg) {
+      tbe.Requestor := in_msg.Requestor;
+    }
+  }
+
+  action(c_exclusiveFlushReplacement, "cef", desc="Send flushed data to memory") {
+    peek(L1RequestL2Network_in, RequestMsg) {
+      enqueue(responseL2Network_out, ResponseMsg, l2_response_latency) {
+        assert(is_valid(cache_entry));
+        out_msg.addr := address;
+        out_msg.Type := CoherenceResponseType:MEMORY_DATA;
+        out_msg.Sender := machineID;
+        out_msg.Destination.add(mapAddressToMachine(address, MachineType:Directory));
+        out_msg.DataBlk := cache_entry.DataBlk;
+        out_msg.Dirty := cache_entry.Dirty;
+        if (in_msg.Dirty) {
+          out_msg.DataBlk := in_msg.DataBlk;
+          out_msg.Dirty := in_msg.Dirty;
+        }
+        out_msg.MessageSize := MessageSizeType:Response_Data;
+      }
+    }
+  }
+
+  action(fwn_sendInvToSharersMinusRequestorFlush, "fwn", desc="invalidate sharers for L2 replacement, requestor is sharer") {
+    peek(L1RequestL2Network_in, RequestMsg) {
+      enqueue(L1RequestL2Network_out, RequestMsg, to_l1_latency) {
+        assert(is_valid(cache_entry));
+        out_msg.addr := address;
+        out_msg.Type := CoherenceRequestType:INV;
+        out_msg.Requestor := machineID;
+        out_msg.Destination := cache_entry.Sharers;
+        out_msg.Destination.remove(in_msg.Requestor);
+        out_msg.MessageSize := MessageSizeType:Request_Control;
+        tbe.pendingAcks := out_msg.Destination.count();
+      }
+    }
+  }
+
   action(uu_profileMiss, "\um", desc="Profile the demand miss") {
     L2cache.profileDemandMiss();
   }
@@ -821,7 +933,7 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     jj_popL1RequestQueue;
   }
 
-  transition({IM, IS, ISS, SS_MB, MT_MB, MT_IIB, MT_IB, MT_SB}, {L2_Replacement, L2_Replacement_clean}) {
+  transition({IM, IS, ISS, SS_MB, MT_MB, MT_IIB, MT_IB, MT_SB}, {L2_Replacement, L2_Replacement_clean, Flush, Flush_Data, Flush_NP, Flush_Clean, Flush_NP_Clean, Flush_Data_Clean}) {
     zz_stallAndWaitL1RequestQueue;
   }
 
@@ -838,6 +950,9 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
     zz_stallAndWaitL1RequestQueue;
   }
 
+  transition({I_F, MT_F, I_FF}, {L1_GETS, L1_GET_INSTR, L1_GETX, L1_UPGRADE, L1_PUTX, L1_PUTX_old, L2_Replacement, L2_Replacement_clean, WB_Data, WB_Data_clean, MEM_Inv, Unblock, Exclusive_Unblock}) {
+    zz_stallAndWaitL1RequestQueue;
+  }
 
   transition(NP, L1_GETS,  ISS) {
     qq_allocateL2CacheBlock;
@@ -1079,6 +1194,100 @@ machine(MachineType:L2Cache, "MESI Directory L2 Cache CMP")
 
   transition(MCT_I, {WB_Data_clean, Ack_all}, M_I) {
     c_exclusiveCleanReplacement;
+    o_popIncomingResponseQueue;
+  }
+
+  // Flush transitions
+  transition(NP, {Flush, Flush_NP, Flush_Clean, Flush_NP_Clean}) {
+    f_sendFlushNotNeededAckToL1;
+    jj_popL1RequestQueue;
+  }
+
+  transition(SS, {Flush, Flush_NP}, I_FF) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    fwn_sendInvToSharersMinusRequestorFlush;
+    c_exclusiveFlushReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(SS, {Flush_Clean, Flush_NP_Clean}, I_FF) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    fwn_sendInvToSharersMinusRequestorFlush;
+    c_exclusiveCleanReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(M, Flush_NP, I_F) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    c_exclusiveFlushReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(M, Flush_NP_Clean, I_F) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    c_exclusiveCleanReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(MT, Flush, I_F) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    c_exclusiveFlushReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(MT, Flush_Clean, I_F) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    c_exclusiveCleanReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(MT, {Flush_NP, Flush_NP_Clean}, MT_F) {
+    i_allocateTBE;
+    t_setTbeRequestor;
+    f_flushGetDataFromOwner;
+    jj_popL1RequestQueue;
+  }
+
+  transition(MT_F, Flush_Data, I_F) {
+    c_exclusiveFlushReplacement;
+    jj_popL1RequestQueue;
+  }
+
+  transition(MT_F, Flush_Data_Clean, NP) {
+    f_sendFlushAckToL1;
+    s_deallocateTBE;
+    rr_deallocateL2CacheBlock;
+    jj_popL1RequestQueue;
+  }
+
+  transition(I_FF, Mem_Ack, I_F) {
+    o_popIncomingResponseQueue;
+  }
+
+  transition(I_FF, Ack) {
+    q_updateAck;
+    o_popIncomingResponseQueue;
+  }
+
+  transition(I_F, Ack) {
+    q_updateAck;
+    o_popIncomingResponseQueue;
+  }
+
+  transition(I_FF, Ack_all, I_F) {
+    o_popIncomingResponseQueue;
+  }
+
+  transition(I_F, {Mem_Ack, Ack_all}, NP) {
+    f_sendFlushAckToL1;
+    s_deallocateTBE;
+    rr_deallocateL2CacheBlock;
     o_popIncomingResponseQueue;
   }
 

--- a/src/mem/ruby/protocol/MESI_Two_Level-msg.sm
+++ b/src/mem/ruby/protocol/MESI_Two_Level-msg.sm
@@ -41,6 +41,10 @@ enumeration(CoherenceRequestType, desc="...") {
 
   DMA_READ, desc="DMA Read";
   DMA_WRITE, desc="DMA Write";
+
+  FLUSH, desc="Flush request";
+  FLUSH_NP, desc="Flush request (not present in L1 and L0)";
+  FLUSH_DATA, desc="Get data for flush request";
 }
 
 // CoherenceResponseType
@@ -54,6 +58,8 @@ enumeration(CoherenceResponseType, desc="...") {
   UNBLOCK, desc="unblock";
   EXCLUSIVE_UNBLOCK, desc="exclusive unblock";
   INV, desc="Invalidate from directory";
+
+  FLUSH_ACK, desc="Flush ack";
 }
 
 // RequestMsg

--- a/src/mem/ruby/slicc_interface/ProtocolInfo.hh
+++ b/src/mem/ruby/slicc_interface/ProtocolInfo.hh
@@ -75,7 +75,9 @@ class ProtocolInfo
     }
     bool
     getSupportsFlushes() const
-    { return supportsFlushes; }
+    {
+        return supportsFlushes;
+    }
 };
 
 } // namespace ruby

--- a/src/mem/ruby/slicc_interface/ProtocolInfo.hh
+++ b/src/mem/ruby/slicc_interface/ProtocolInfo.hh
@@ -47,15 +47,17 @@ class ProtocolInfo
     const bool partialFuncReads;
     const bool useSecondaryLoadLinked;
     const bool useSecondaryStoreConditional;
+    const bool supportsFlushes;
 
   public:
     ProtocolInfo(std::string name, bool partial_func_reads,
                  bool use_secondary_load_linked,
-                 bool use_secondary_store_conditional) :
-        name(name),
-        partialFuncReads(partial_func_reads),
-        useSecondaryLoadLinked(use_secondary_load_linked),
-        useSecondaryStoreConditional(use_secondary_store_conditional)
+                 bool use_secondary_store_conditional, bool supports_flushes)
+        : name(name),
+          partialFuncReads(partial_func_reads),
+          useSecondaryLoadLinked(use_secondary_load_linked),
+          useSecondaryStoreConditional(use_secondary_store_conditional),
+          supportsFlushes(supports_flushes)
     {
     }
 
@@ -71,7 +73,9 @@ class ProtocolInfo
     {
         return useSecondaryStoreConditional;
     }
-
+    bool
+    getSupportsFlushes() const
+    { return supportsFlushes; }
 };
 
 } // namespace ruby

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -276,7 +276,8 @@ RubyPort::MemResponsePort::recvTimingReq(PacketPtr pkt)
 
     // ruby doesn't support cache maintenance operations at the
     // moment, as a workaround, we respond right away
-    if (pkt->req->isCacheMaintenance()) {
+    if (pkt->req->isCacheMaintenance() &&
+        !owner.m_ruby_system->getProtocolInfo().getSupportsFlushes()) {
         warn_once("Cache maintenance operations are not supported in Ruby.\n");
         pkt->makeResponse();
         schedTimingResp(pkt, curTick());

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -738,7 +738,7 @@ Sequencer::hitCallback(SequencerRequest* srequest, DataBlock& data,
     // update the data unless it is a non-data-carrying flush
     if (m_ruby_system->getWarmupEnabled()) {
         data.setData(pkt);
-    } else if (!pkt->isFlush()) {
+    } else if (!pkt->isFlush() && !pkt->isCleanInvalidateRequest()) {
         if ((type == RubyRequestType_LD) ||
             (type == RubyRequestType_IFETCH) ||
             (type == RubyRequestType_RMW_Read) ||
@@ -1054,8 +1054,8 @@ Sequencer::makeRequest(PacketPtr pkt)
                     primary_type = secondary_type = RubyRequestType_LD;
                 }
             }
-        } else if (pkt->isFlush()) {
-          primary_type = secondary_type = RubyRequestType_FLUSH;
+        } else if (pkt->isFlush() || pkt->isCleanInvalidateRequest()) {
+            primary_type = secondary_type = RubyRequestType_FLUSH;
         } else if (pkt->cmd == MemCmd::MemSyncReq) {
             primary_type = secondary_type = RubyRequestType_REPLACEMENT;
             assert(!m_cache_inv_pkt);

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -79,6 +79,7 @@ class SLICC(Grammar):
             "partial_func_reads": False,
             "use_secondary_load_linked": False,
             "use_secondary_store_conditional": False,
+            "supports_flushes": False,
         }
 
         if not includes:


### PR DESCRIPTION
Aims to fix the issue referenced [here](https://github.com/gem5/gem5/issues/2642). Correctness tests done:

- Verified that cache line is actually being flushed by measuring time of access
- Tested correctness of writing dirty data. Cache lines shared among cores are also flushed correctly. Example program:
```c
#include <stdio.h>
#include <stdlib.h>
#include <sys/mman.h>
#include <stdint.h>
#include <string.h>
#include <unistd.h>
#include <sched.h>

void clflush(void *ptr) {
    asm volatile(
        "clflush (%0)"
        :
        : "r"(ptr)
        : "memory"
    );
}

void mfence() {
    asm volatile("mfence" ::: "memory");
}

int main() {
    int data = 42;
    printf("Before clflush: data = %d\n", data);
    clflush(&data);
    printf("After clflush: data = %d\n", data);

    volatile char* x = (char*) mmap(NULL, 256*sizeof(char), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
    x[255] = 1;
    int pid = fork();
    if (pid == 0) {
        for (int i = 0; i < 128; i++) {
            x[i] = 1;
        }
        mfence();
        x[255] = 0;
        mfence();
        return 0;
    }

    while (x[255] == 1);
    clflush(&x[0]);
    clflush(&x[64]);
    int sum = 0;
    for (int i = 0; i < 128; i++) sum += x[i];

    printf("sum = %d\n", sum);

    return 0;
}

```
sum is correctly printed as 128.

Note that for this to work, these lines (279-284) need to be removed from `RubyPort.cc`. I have not included this in the PR as it would break other protocols.
```cpp
if (pkt->req->isCacheMaintenance()) {
    warn_once("Cache maintenance operations are not supported in Ruby.\n");
    pkt->makeResponse();
    schedTimingResp(pkt, curTick());
    return true;
}
```