### PR TITLE
dev: Temporary fix for X86 board hanging forever

### DIFF
--- a/src/dev/pci/PciUpstream.py
+++ b/src/dev/pci/PciUpstream.py
@@ -51,11 +51,13 @@ class PciBus(NoncoherentXBar):
 
     config_error_port = RequestPort("Port to send config errors to")
 
-    # Set some default values bases on IOXBar
+    # FIXME: There should have some latency added to transfert packets within
+    # the PCI bus/hierarchy, but adding them breaks X86 Board which will hang
+    # forever.
     width = 16
-    frontend_latency = 2
-    forward_latency = 1
-    response_latency = 2
+    frontend_latency = 0
+    forward_latency = 0
+    response_latency = 0
 
 
 class PciConfigError(IsaFake):


### PR DESCRIPTION
The example x86-ubuntu-run.py is currently hanging out due to the new PCI host bridge architecture (#2298). It's seems to be related to some timing added by the PCI bus. This cause the daily tests to fail due to a timeout.

This fix removes the timing added by the PCI bus, which means that all timing are back to (nearly) the same as before when there was no real PCI hierarchy.

As PCI hierarchy should add some delay at some point, this is a temporary fix and a futur PR will be made with a better fix.