### PR TITLE
tests: remove duplicate option on arm boot tests

### DIFF
--- a/tests/gem5/arm_boot_tests/test_linux_boot.py
+++ b/tests/gem5/arm_boot_tests/test_linux_boot.py
@@ -43,7 +43,6 @@ def test_boot(
     length: str,
     systemd: bool,
     to_tick: Optional[int] = None,
-    systemd: bool = False,
 ):
     name = f"{cpu}-cpu_{num_cpus}-cores_{mem_system}_{memory_class}_\
 arm_boot_test"


### PR DESCRIPTION
#2365 wanted to reduce ARM Boot tests execution time by excluding systemd from the boot of many of the tests. But the options `systemd` was added twice as argument of `test_boot` for ARM, making the following *warning* to appear when executing tests using `main.py` and so the test are silently not executed.

```
Traceback (most recent call last):
  File ".../gem5/tests/../ext/testlib/loader.py", line 230, in load_file
    exec(open(path).read(), newdict, newdict)
  File "<string>", line 46
SyntaxError: duplicate argument 'systemd' in function definition

Exception thrown while loading ".../gem5/tests/gem5/arm_boot_tests/test_linux_boot.py"
Ignoring all tests in this file.
```

This PR remove the unwanted duplicated option so the tests can be rexecuted.