### PR TITLE
cpu: Enable PcCountTracker in NULL builds

### DIFF
--- a/src/cpu/probes/SConscript
+++ b/src/cpu/probes/SConscript
@@ -26,21 +26,19 @@
 
 Import("*")
 
-if env['CONF']['BUILD_ISA']:
+SimObject(
+    "PcCountTracker.py",
+    sim_objects=["PcCountTracker", "PcCountTrackerManager"],
+)
+Source("pc_count_tracker.cc")
+Source("pc_count_tracker_manager.cc")
 
-    SimObject(
-        "PcCountTracker.py",
-        sim_objects=["PcCountTracker", "PcCountTrackerManager"],
-    )
-    Source("pc_count_tracker.cc")
-    Source("pc_count_tracker_manager.cc")
+DebugFlag("PcCountTracker")
 
-    DebugFlag("PcCountTracker")
+SimObject(
+    "InstTracker.py",
+    sim_objects=["GlobalInstTracker", "LocalInstTracker"],
+)
+Source("inst_tracker.cc")
 
-    SimObject(
-        "InstTracker.py",
-        sim_objects=["GlobalInstTracker", "LocalInstTracker"],
-    )
-    Source("inst_tracker.cc")
-
-    DebugFlag("InstTracker")
+DebugFlag("InstTracker")


### PR DESCRIPTION
The `AbstractBoard` (which is needed for tests) depends on this object
So, include this object even in NULL builds

Signed-off-by: Jason Lowe-Power <jlowepower@google.com>