### PR TITLE
mem-cache: register TagExtractor for SectorTag

### DIFF
--- a/src/mem/cache/tags/sector_tags.cc
+++ b/src/mem/cache/tags/sector_tags.cc
@@ -120,12 +120,18 @@ SectorTags::tagsInit()
             // Set its index and sector offset
             blk->setSectorOffset(k);
 
+            // Register TagExtractor for SubBlk
+            blk->registerTagExtractor(genTagExtractor(indexingPolicy));
+
             // Update block index
             ++blk_index;
         }
 
         // Link block to indexing policy
         indexingPolicy->setEntry(sec_blk, sec_blk_index);
+
+        // Register TagExtractor for SecBlk
+        sec_blk->registerTagExtractor(genTagExtractor(indexingPolicy));
     }
 }
 


### PR DESCRIPTION
SectorTag didn’t register TagExtractor, causing errors when calling blk->match() or sec_blk->match() since match() uses the extractor internally. 
Because SectorTag has both a sector block and a sector sub-block—and both directly or indirectly inherit TaggedEntry—each must register TagExtractor.
Related issue: https://github.com/gem5/gem5/issues/2586