### PR TITLE
base: Fix use-after-free warning

### DIFF
--- a/src/base/refcnt.hh
+++ b/src/base/refcnt.hh
@@ -43,6 +43,8 @@
 
 #include <type_traits>
 
+#include "base/compiler.hh"
+
 /**
  * @file base/refcnt.hh
  *
@@ -163,7 +165,7 @@ class RefCountingPtr
      * @attention this doesn't clear the pointer value, so a double
      * decref could happen if not careful.
      */
-    void
+    GEM5_NO_INLINE void
     del()
     {
         if (data && data->decref()) {


### PR DESCRIPTION
Got warning when compiling gem5 unittests with mold linker

```
In member function 'bool gem5::RefCounted::decref() const',
    inlined from 'void gem5::RefCountingPtr<T>::del() [with T = {anonymous}::TestRC]' at src/base/refcnt.hh:169:33,
    inlined from 'gem5::RefCountingPtr<T>::~RefCountingPtr() [with T = {anonymous}::TestRC]' at src/base/refcnt.hh:214:28,
    inlined from 'virtual void RefcntTest_ConstructionFromExistingPointer_Test::TestBody()' at src/base/refcnt.test.cc:97:1:
src/base/refcnt.hh:105:18: error: pointer used after 'void operator delete(void*, std::size_t)' [-Werror=use-after-free]
  105 |         return --count <= 0;
      |                  ^~~~~
In destructor 'virtual {anonymous}::TestRC::~TestRC()',
    inlined from 'void gem5::RefCountingPtr<T>::del() [with T = {anonymous}::TestRC]' at src/base/refcnt.hh:170:13,
    inlined from 'void gem5::RefCountingPtr<T>::del() [with T = {anonymous}::TestRC]' at src/base/refcnt.hh:167:5,
    inlined from 'gem5::RefCountingPtr<T>::~RefCountingPtr() [with T = {anonymous}::TestRC]' at src/base/refcnt.hh:214:28,
    inlined from 'virtual void RefcntTest_ConstructionFromExistingPointer_Test::TestBody()' at src/base/refcnt.test.cc:97:1:
src/base/refcnt.test.cc:67:5: note: call to 'void operator delete(void*, std::size_t)' here
   67 |     }
      |     ^
```