### PR TITLE
arch-arm: Fix compile errors

### DIFF
--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -1679,7 +1679,7 @@ let {{
             code += '''
         unsigned length = 1 * eCount;'''
         code += '''
-        bool mask[length];'''
+        std::vector<bool> mask(length);'''
         if toDown:
             code += '''
         for (signed i = length - 1; i >= 0; i--) {'''

--- a/src/arch/arm/isa/templates/sve_mem.isa
+++ b/src/arch/arm/isa/templates/sve_mem.isa
@@ -989,11 +989,6 @@ def template SveGatherLoadQuadMicroopInitiateAcc {{
         %(op_rd)s;
         %(ea_code)s;
 
-        union MemData {
-            MemElemType memData = 0;
-            uint8_t memDataArray[sizeof(MemElemType)];
-        } memData;
-
         int index = elemIndex;
         if (%(pred_check_code)s) {
             fault = initiateMemRead(xc, EA, sizeof(MemElemType),


### PR DESCRIPTION
There was a use of a dynamic array (not allowed in some compilers)
and an unused variable

Signed-off-by: Jason Lowe-Power <jlowepower@google.com>