### PR TITLE
python: Fix imports broken by PR 2595

### DIFF
--- a/src/python/m5/debug.py
+++ b/src/python/m5/debug.py
@@ -33,6 +33,7 @@ from _m5.debug import (
     SimpleFlag,
     allFlags,
     getAllFlagsVersion,
+    schedBreak,
 )
 
 


### PR DESCRIPTION
PR #2595 made a couple of mistakes in refactoring imports. This fixes the overridden variable by naming the imported models with a private variable. This also adds back the import for debug-break