### PR TITLE
mem-ruby: Cleanup imports and includes

### DIFF
--- a/src/cpu/testers/rubytest/RubyTester.py
+++ b/src/cpu/testers/rubytest/RubyTester.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from m5.objects.ClockedObject import ClockedObject
+from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
 

--- a/src/mem/ruby/common/Address.hh
+++ b/src/mem/ruby/common/Address.hh
@@ -29,11 +29,6 @@
 #ifndef __MEM_RUBY_COMMON_ADDRESS_HH__
 #define __MEM_RUBY_COMMON_ADDRESS_HH__
 
-#include <cassert>
-#include <iomanip>
-#include <iostream>
-
-#include "base/intmath.hh"
 #include "base/types.hh"
 
 namespace gem5

--- a/src/mem/ruby/common/Histogram.hh
+++ b/src/mem/ruby/common/Histogram.hh
@@ -33,8 +33,6 @@
 #include <iostream>
 #include <vector>
 
-#include "mem/ruby/common/TypeDefines.hh"
-
 namespace gem5
 {
 

--- a/src/mem/ruby/network/BasicLink.hh
+++ b/src/mem/ruby/network/BasicLink.hh
@@ -33,8 +33,6 @@
 #include <string>
 #include <vector>
 
-#include "mem/ruby/network/BasicRouter.hh"
-#include "mem/ruby/slicc_interface/AbstractController.hh"
 #include "params/BasicExtLink.hh"
 #include "params/BasicIntLink.hh"
 #include "params/BasicLink.hh"

--- a/src/mem/ruby/network/BasicLink.py
+++ b/src/mem/ruby/network/BasicLink.py
@@ -24,6 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from m5.objects.BasicRouter import BasicRouter
+from m5.objects.Controller import RubyController
 from m5.params import *
 from m5.SimObject import SimObject
 

--- a/src/mem/ruby/network/Network.hh
+++ b/src/mem/ruby/network/Network.hh
@@ -63,6 +63,7 @@
 #include "mem/port.hh"
 #include "mem/ruby/common/MachineID.hh"
 #include "mem/ruby/common/TypeDefines.hh"
+#include "mem/ruby/common/WriteMask.hh"
 #include "mem/ruby/network/Topology.hh"
 #include "mem/ruby/network/dummy_port.hh"
 #include "mem/ruby/protocol/LinkDirection.hh"

--- a/src/mem/ruby/network/Network.py
+++ b/src/mem/ruby/network/Network.py
@@ -24,7 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects.BasicLink import BasicLink
+from m5.objects.BasicLink import (
+    BasicExtLink,
+    BasicIntLink,
+)
+from m5.objects.BasicRouter import BasicRouter
 from m5.objects.ClockedObject import ClockedObject
 from m5.params import *
 from m5.proxy import *

--- a/src/mem/ruby/network/Topology.cc
+++ b/src/mem/ruby/network/Topology.cc
@@ -35,6 +35,7 @@
 #include "debug/RubyNetwork.hh"
 #include "mem/ruby/common/NetDest.hh"
 #include "mem/ruby/network/BasicLink.hh"
+#include "mem/ruby/network/BasicRouter.hh"
 #include "mem/ruby/network/Network.hh"
 #include "mem/ruby/slicc_interface/AbstractController.hh"
 #include "mem/ruby/system/RubySystem.hh"

--- a/src/mem/ruby/network/simple/Switch.cc
+++ b/src/mem/ruby/network/simple/Switch.cc
@@ -41,10 +41,6 @@
 
 #include "mem/ruby/network/simple/Switch.hh"
 
-#include <numeric>
-
-#include "base/cast.hh"
-#include "base/stl_helpers.hh"
 #include "mem/ruby/network/MessageBuffer.hh"
 #include "mem/ruby/network/simple/SimpleNetwork.hh"
 

--- a/src/mem/ruby/network/simple/Throttle.cc
+++ b/src/mem/ruby/network/simple/Throttle.cc
@@ -42,7 +42,6 @@
 
 #include <cassert>
 
-#include "base/cast.hh"
 #include "base/cprintf.hh"
 #include "debug/RubyNetwork.hh"
 #include "mem/ruby/network/MessageBuffer.hh"

--- a/src/mem/ruby/profiler/AddressProfiler.cc
+++ b/src/mem/ruby/profiler/AddressProfiler.cc
@@ -31,9 +31,7 @@
 #include <vector>
 
 #include "base/bitfield.hh"
-#include "base/stl_helpers.hh"
 #include "mem/ruby/profiler/Profiler.hh"
-#include "mem/ruby/protocol/RubyRequest.hh"
 #include "mem/ruby/system/RubySystem.hh"
 
 namespace gem5

--- a/src/mem/ruby/profiler/AddressProfiler.hh
+++ b/src/mem/ruby/profiler/AddressProfiler.hh
@@ -37,7 +37,7 @@
 #include "mem/ruby/profiler/AccessTraceForAddress.hh"
 #include "mem/ruby/profiler/Profiler.hh"
 #include "mem/ruby/protocol/AccessType.hh"
-#include "mem/ruby/protocol/RubyRequest.hh"
+#include "mem/ruby/slicc_interface/RubyRequest.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/profiler/Profiler.cc
+++ b/src/mem/ruby/profiler/Profiler.cc
@@ -56,7 +56,7 @@
 #include "mem/ruby/network/Network.hh"
 #include "mem/ruby/profiler/AddressProfiler.hh"
 #include "mem/ruby/protocol/MachineType.hh"
-#include "mem/ruby/protocol/RubyRequest.hh"
+#include "mem/ruby/slicc_interface/RubyRequest.hh"
 
 /**
  * the profiler uses GPUCoalescer code even

--- a/src/mem/ruby/profiler/StoreTrace.cc
+++ b/src/mem/ruby/profiler/StoreTrace.cc
@@ -28,6 +28,7 @@
 
 #include "mem/ruby/profiler/StoreTrace.hh"
 
+#include "base/types.hh"
 #include "sim/cur_tick.hh"
 
 namespace gem5

--- a/src/mem/ruby/profiler/StoreTrace.hh
+++ b/src/mem/ruby/profiler/StoreTrace.hh
@@ -34,6 +34,7 @@
 #include "base/types.hh"
 #include "mem/ruby/common/Address.hh"
 #include "mem/ruby/common/Histogram.hh"
+#include "mem/ruby/common/TypeDefines.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/slicc_interface/AbstractController.hh
+++ b/src/mem/ruby/slicc_interface/AbstractController.hh
@@ -59,12 +59,13 @@
 #include "mem/ruby/network/MessageBuffer.hh"
 #include "mem/ruby/protocol/AccessPermission.hh"
 #include "mem/ruby/system/CacheRecorder.hh"
-#include "params/RubyController.hh"
 #include "sim/clocked_object.hh"
 #include "sim/eventq.hh"
 
 namespace gem5
 {
+
+struct RubyControllerParams;
 
 namespace ruby
 {

--- a/src/mem/ruby/slicc_interface/Controller.py
+++ b/src/mem/ruby/slicc_interface/Controller.py
@@ -37,6 +37,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.ClockedObject import ClockedObject
+from m5.objects.RubySystem import RubySystem
+from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
 

--- a/src/mem/ruby/slicc_interface/RubyRequest.hh
+++ b/src/mem/ruby/slicc_interface/RubyRequest.hh
@@ -47,10 +47,10 @@
 #include "mem/ruby/common/Address.hh"
 #include "mem/ruby/common/DataBlock.hh"
 #include "mem/ruby/common/WriteMask.hh"
-#include "mem/ruby/protocol/Message.hh"
 #include "mem/ruby/protocol/PrefetchBit.hh"
 #include "mem/ruby/protocol/RubyAccessMode.hh"
 #include "mem/ruby/protocol/RubyRequestType.hh"
+#include "mem/ruby/slicc_interface/Message.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/slicc_interface/RubySlicc_ComponentMapping.hh
+++ b/src/mem/ruby/slicc_interface/RubySlicc_ComponentMapping.hh
@@ -33,7 +33,6 @@
 #include "mem/ruby/common/MachineID.hh"
 #include "mem/ruby/common/NetDest.hh"
 #include "mem/ruby/protocol/MachineType.hh"
-#include "mem/ruby/structures/DirectoryMemory.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/structures/CacheMemory.cc
+++ b/src/mem/ruby/structures/CacheMemory.cc
@@ -41,7 +41,6 @@
 
 #include "mem/ruby/structures/CacheMemory.hh"
 
-#include "base/compiler.hh"
 #include "base/intmath.hh"
 #include "base/logging.hh"
 #include "debug/HtmMem.hh"

--- a/src/mem/ruby/structures/CacheMemory.hh
+++ b/src/mem/ruby/structures/CacheMemory.hh
@@ -42,7 +42,6 @@
 #ifndef __MEM_RUBY_STRUCTURES_CACHEMEMORY_HH__
 #define __MEM_RUBY_STRUCTURES_CACHEMEMORY_HH__
 
-#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -52,11 +51,9 @@
 #include "mem/ruby/common/DataBlock.hh"
 #include "mem/ruby/protocol/CacheRequestType.hh"
 #include "mem/ruby/protocol/CacheResourceType.hh"
-#include "mem/ruby/protocol/RubyRequest.hh"
 #include "mem/ruby/slicc_interface/AbstractCacheEntry.hh"
-#include "mem/ruby/slicc_interface/RubySlicc_ComponentMapping.hh"
-#include "mem/ruby/structures/BankedArray.hh"
 #include "mem/ruby/structures/ALUFreeListArray.hh"
+#include "mem/ruby/structures/BankedArray.hh"
 #include "mem/ruby/system/CacheRecorder.hh"
 #include "params/RubyCache.hh"
 #include "sim/sim_object.hh"

--- a/src/mem/ruby/structures/DirectoryMemory.py
+++ b/src/mem/ruby/structures/DirectoryMemory.py
@@ -36,6 +36,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from m5.objects.RubySystem import RubySystem
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject

--- a/src/mem/ruby/structures/MN_TBEStorage.hh
+++ b/src/mem/ruby/structures/MN_TBEStorage.hh
@@ -39,12 +39,9 @@
 #define __MEM_RUBY_STRUCTURES_MN_TBESTORAGE_HH__
 
 #include <cassert>
-#include <unordered_map>
 #include <vector>
 
-#include <base/statistics.hh>
-
-#include "mem/ruby/common/MachineID.hh"
+#include "base/statistics.hh"
 #include "mem/ruby/structures/TBEStorage.hh"
 
 namespace gem5

--- a/src/mem/ruby/structures/PersistentTable.hh
+++ b/src/mem/ruby/structures/PersistentTable.hh
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "base/intmath.hh"
 #include "mem/ruby/common/Address.hh"
 #include "mem/ruby/common/MachineID.hh"
 #include "mem/ruby/common/NetDest.hh"

--- a/src/mem/ruby/structures/RubyPrefetcher.cc
+++ b/src/mem/ruby/structures/RubyPrefetcher.cc
@@ -45,7 +45,6 @@
 
 #include "base/bitfield.hh"
 #include "debug/RubyPrefetcher.hh"
-#include "mem/ruby/slicc_interface/RubySlicc_ComponentMapping.hh"
 #include "mem/ruby/system/RubySystem.hh"
 
 namespace gem5

--- a/src/mem/ruby/structures/RubyPrefetcher.py
+++ b/src/mem/ruby/structures/RubyPrefetcher.py
@@ -36,7 +36,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject

--- a/src/mem/ruby/structures/RubyPrefetcherProxy.cc
+++ b/src/mem/ruby/structures/RubyPrefetcherProxy.cc
@@ -39,6 +39,7 @@
 
 #include "debug/HWPrefetch.hh"
 #include "mem/ruby/system/RubySystem.hh"
+#include "params/RubyController.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/structures/TBEStorage.hh
+++ b/src/mem/ruby/structures/TBEStorage.hh
@@ -42,7 +42,7 @@
 #include <stack>
 #include <unordered_map>
 
-#include <base/statistics.hh>
+#include "base/statistics.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -41,12 +41,9 @@
 
 #include "mem/ruby/system/RubyPort.hh"
 
-#include "base/compiler.hh"
-#include "cpu/testers/rubytest/RubyTester.hh"
 #include "debug/Config.hh"
 #include "debug/Drain.hh"
-#include "debug/Ruby.hh"
-#include "mem/ruby/protocol/AccessPermission.hh"
+#include "debug/RubyPort.hh"
 #include "mem/ruby/slicc_interface/AbstractController.hh"
 #include "mem/simple_mem.hh"
 #include "sim/full_system.hh"

--- a/src/mem/ruby/system/RubySystem.py
+++ b/src/mem/ruby/system/RubySystem.py
@@ -26,6 +26,7 @@
 
 from m5.objects.ClockedObject import ClockedObject
 from m5.objects.SimpleMemory import *
+from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
 

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -41,13 +41,9 @@
 
 #include "mem/ruby/system/Sequencer.hh"
 
-#include "arch/x86/ldstflags.hh"
-#include "base/compiler.hh"
 #include "base/logging.hh"
-#include "base/str.hh"
 #include "cpu/testers/rubytest/RubyTester.hh"
 #include "debug/LLSC.hh"
-#include "debug/MemoryAccess.hh"
 #include "debug/ProtocolTrace.hh"
 #include "debug/RubyHitMiss.hh"
 #include "debug/RubySequencer.hh"
@@ -59,7 +55,6 @@
 #include "mem/ruby/slicc_interface/RubyRequest.hh"
 #include "mem/ruby/slicc_interface/RubySlicc_Util.hh"
 #include "mem/ruby/system/RubySystem.hh"
-#include "sim/system.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/system/Sequencer.py
+++ b/src/mem/ruby/system/Sequencer.py
@@ -38,6 +38,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.ClockedObject import ClockedObject
+from m5.objects.RubyCache import RubyCache
+from m5.objects.RubySystem import RubySystem
+from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
 


### PR DESCRIPTION
This PR is general cleanup of python imports and header files in Ruby.