### PR TITLE
mem-ruby: Update SLICC to generate only shared files

### DIFF
--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -92,7 +92,8 @@ class SLICC(Grammar):
             # set all of the types parsed so far as shared
             self.decl_list.setShared()
 
-            self.decl_list += self.parse_file(protocol, **kwargs)
+            if protocol:
+                self.decl_list += self.parse_file(protocol, **kwargs)
         except ParseError as e:
             if not self.traceback:
                 sys.exit(str(e))
@@ -118,7 +119,9 @@ class SLICC(Grammar):
         self.symtab.writeHTMLFiles(html_path)
 
     def files(self):
-        f = {os.path.join(self.protocol, "Types.hh")}
+        f = set()
+        if self.protocol:
+            f |= {os.path.join(self.protocol, "Types.hh")}
 
         f |= self.decl_list.files()
 

--- a/src/mem/slicc/symbols/SymbolTable.py
+++ b/src/mem/slicc/symbols/SymbolTable.py
@@ -135,26 +135,29 @@ class SymbolTable:
 
     def writeCodeFiles(self, path, includes):
         makeDir(path)
-        makeDir(os.path.join(path, self.slicc.protocol))
 
-        code = self.codeFormatter()
+        # Note: This will be None if generated only the shared code.
+        if self.slicc.protocol:
+            makeDir(os.path.join(path, self.slicc.protocol))
 
-        for include_path in includes:
-            code('#include "${{include_path}}"')
+            code = self.codeFormatter()
 
-        for symbol in self.sym_vec:
-            if isinstance(symbol, Type) and not symbol.isPrimitive:
-                ident = symbol.c_ident
-                if not symbol.shared and not symbol.isExternal:
-                    ident = f"{self.slicc.protocol}/{ident}"
-                code('#include "mem/ruby/protocol/${{ident}}.hh"')
+            for include_path in includes:
+                code('#include "${{include_path}}"')
 
-        code(
-            f'#include "mem/ruby/protocol/{self.slicc.protocol}/{self.slicc.protocol}ProtocolInfo.hh"'
-        )
-        code.write(path, f"{self.slicc.protocol}/Types.hh")
+            for symbol in self.sym_vec:
+                if isinstance(symbol, Type) and not symbol.isPrimitive:
+                    ident = symbol.c_ident
+                    if not symbol.shared and not symbol.isExternal:
+                        ident = f"{self.slicc.protocol}/{ident}"
+                    code('#include "mem/ruby/protocol/${{ident}}.hh"')
 
-        self.writeProtocolInfo(path)
+            code(
+                f'#include "mem/ruby/protocol/{self.slicc.protocol}/{self.slicc.protocol}ProtocolInfo.hh"'
+            )
+            code.write(path, f"{self.slicc.protocol}/Types.hh")
+
+            self.writeProtocolInfo(path)
 
         for symbol in self.sym_vec:
             symbol.writeCodeFiles(path, includes)


### PR DESCRIPTION
After the "all protocols" change, there are two types of generated files
in SLICC. There are the normal protocol files and the "shared" protocol
files. The shared files are files that are generated *exactly the same*
across all protocols. Currently, we generate these files for each protocol
that is included in the gem5 binary. (The reason we have to is because
SLICC needs to process these files every time.) This change makes it
possible out output *only* these shared files by allowing no protocol
slicc file.

These "shared" files are the only files that should be referenced by
the generic Ruby files. An exception is the CHI protocol which has
some C++ files that directly reference CHI protocol generated files.

Note: this is not currently used in SCons.

Signed-off-by: Jason Lowe-Power <jlowepower@google.com>