### PR TITLE
 arch-riscv: Fix RISC-V `Decoder::reset()` not calling base class reset

### DIFF
--- a/src/arch/riscv/decoder.cc
+++ b/src/arch/riscv/decoder.cc
@@ -51,6 +51,7 @@ Decoder::Decoder(const RiscvDecoderParams &p) : InstDecoder(p, &machInst)
 
 void Decoder::reset()
 {
+    InstDecoder::reset();
     aligned = true;
     mid = false;
     machInst = 0;


### PR DESCRIPTION
**Description:**
This patch adds a call to the base class `InstDecoder::reset()` inside `Decoder::reset()` in `src/arch/riscv/decoder.cc`.

While this change does not affect existing RISC-V CPU models in gem5, it ensures consistency across ISA decoders and correct behavior of functions such as `instReady()` and `needMoreBytes()` after a reset.

This also prevents potential issues when developing custom RISC-V CPU models that rely on decoder reset semantics consistent with other ISAs.

**Files changed:**

* `src/arch/riscv/decoder.cc`

**Related issue:**
Fixes discussion in https://github.com/gem5/gem5/issues/2681)

