### PR TITLE
dev: Temporary fix for X86 board hanging forever & moved to board

### DIFF
--- a/src/dev/pci/PciUpstream.py
+++ b/src/dev/pci/PciUpstream.py
@@ -51,13 +51,11 @@ class PciBus(NoncoherentXBar):
 
     config_error_port = RequestPort("Port to send config errors to")
 
-    # FIXME: There should have some latency added to transfert packets within
-    # the PCI bus/hierarchy, but adding them breaks X86 Board which will hang
-    # forever.
+    # Set some default values bases on IOXBar
     width = 16
-    frontend_latency = 0
-    forward_latency = 0
-    response_latency = 0
+    frontend_latency = 2
+    forward_latency = 1
+    response_latency = 2
 
 
 class PciConfigError(IsaFake):

--- a/src/dev/pci/PciUpstream.py
+++ b/src/dev/pci/PciUpstream.py
@@ -51,11 +51,13 @@ class PciBus(NoncoherentXBar):
 
     config_error_port = RequestPort("Port to send config errors to")
 
-    # Set some default values bases on IOXBar
+    # FIXME: There should have some latency added to transfert packets within
+    # the PCI bus/hierarchy, but adding them breaks X86 Board which will hang
+    # forever.
     width = 16
-    frontend_latency = 2
-    forward_latency = 1
-    response_latency = 2
+    frontend_latency = 0
+    forward_latency = 0
+    response_latency = 0
 
 
 class PciConfigError(IsaFake):

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -104,6 +104,15 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         if self.is_fullsystem():
             self.pc = Pc()
 
+            # FIXME: There should have some latency added to transfer packets
+            # within the PCI bus/hierarchy, but adding them breaks X86 Board
+            # which will hang forever. The hanging can be reproduced b
+            # removing the following three lines then running gem5 with the
+            # "configs/example/gem5_library/x86-ubuntu-run.py" script.
+            self.pc.pci_bus.frontend_latency = 0
+            self.pc.pci_bus.forward_latency = 0
+            self.pc.pci_bus.response_latency = 0
+
             self.workload = X86FsLinux()
 
             # North Bridge
@@ -205,6 +214,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
         )
 
         pci_bus = X86IntelMPBus(bus_id=0, bus_type="PCI   ")
+
         base_entries.append(pci_bus)
         isa_bus = X86IntelMPBus(bus_id=1, bus_type="ISA   ")
         base_entries.append(isa_bus)


### PR DESCRIPTION
A copy of PR #2679 but with latency-to-zero temporary fix moved to the `X86Board` as suggested by [here](https://github.com/gem5/gem5/pull/2679#discussion_r2461281668).

This will fix the [failing daily tests](https://github.com/gem5/gem5/actions/runs/18822725569) which are timing out via a stall  in "configs/example/gem5_library/x86-ubuntu-run.py" script.
