### PR TITLE
mem-ruby: Break dependence in CHI protocol

### DIFF
--- a/src/mem/ruby/structures/MN_TBETable.cc
+++ b/src/mem/ruby/structures/MN_TBETable.cc
@@ -35,7 +35,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <mem/ruby/structures/MN_TBETable.hh>
+#include "mem/ruby/structures/MN_TBETable.hh"
+
+#include <algorithm>
+#include <vector>
+
+#include "mem/ruby/protocol/CHI/MiscNode_TBE.hh"
+#include "mem/ruby/structures/TBETable.hh"
 
 namespace gem5
 {
@@ -45,6 +51,9 @@ namespace ruby
 
 namespace CHI
 {
+
+MN_TBETable::MN_TBETable(int number_of_TBEs) : TBETable(number_of_TBEs)
+{}
 
 // Based on the current set of TBEs, choose a new "distributor"
 // Can return null -> no distributor

--- a/src/mem/ruby/structures/MN_TBETable.hh
+++ b/src/mem/ruby/structures/MN_TBETable.hh
@@ -38,10 +38,6 @@
 #ifndef __MEM_RUBY_STRUCTURES_MN_TBETABLE_HH__
 #define __MEM_RUBY_STRUCTURES_MN_TBETABLE_HH__
 
-#include <algorithm>
-#include <vector>
-
-#include "mem/ruby/protocol/CHI/MiscNode_TBE.hh"
 #include "mem/ruby/structures/TBETable.hh"
 
 namespace gem5
@@ -53,15 +49,15 @@ namespace ruby
 namespace CHI
 {
 
+class MiscNode_TBE;
+
 // Custom class only used for the CHI protocol Misc Node
 // Includes the definition of the MiscNode_TBE, because it
 // includes functions that rely on fields in the structure
 class MN_TBETable : public TBETable<MiscNode_TBE>
 {
   public:
-    MN_TBETable(int number_of_TBEs)
-      : TBETable(number_of_TBEs)
-    {}
+    MN_TBETable(int number_of_TBEs);
 
     MiscNode_TBE* chooseNewDistributor();
 };


### PR DESCRIPTION
The structure MN_TBETable table depends on the protocol which depends on the table. This change moves the implementation to the cc file to break this dependence