### PR TITLE
stdlib: Clean up stdlib imports in CHI

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/nodes/abstract_node.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/abstract_node.py
@@ -33,9 +33,9 @@ from m5.objects import (
     RubyNetwork,
 )
 
-from gem5.components.processors.abstract_core import AbstractCore
-from gem5.components.processors.cpu_types import CPUTypes
-from gem5.isas import ISA
+from .....isas import ISA
+from ....processors.abstract_core import AbstractCore
+from ....processors.cpu_types import CPUTypes
 
 
 class TriggerMessageBuffer(MessageBuffer):

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
@@ -40,12 +40,12 @@ import math
 from typing import List
 
 from m5.objects import (
-    NULL,
     ClockDomain,
     RubyCache,
     RubyNetwork,
 )
 from m5.params import (
+    NULL,
     AddrRange,
 )
 

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/dma_requestor.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/dma_requestor.py
@@ -25,14 +25,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects import (
-    NULL,
     ClockDomain,
     RubyCache,
 )
+from m5.params import (
+    NULL,
+)
 
-from gem5.components.processors.abstract_core import AbstractCore
-from gem5.isas import ISA
-
+from .....isas import ISA
+from ....processors.abstract_core import AbstractCore
 from .abstract_node import AbstractNode
 
 

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/l1_cache.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/l1_cache.py
@@ -37,14 +37,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects import (
-    NULL,
     ClockDomain,
     RubyCache,
     RubyNetwork,
 )
+from m5.params import (
+    NULL,
+)
 
-from gem5.isas import ISA
-
+from .....isas import ISA
 from .abstract_node import AbstractNode
 
 

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/l2_cache.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/l2_cache.py
@@ -37,15 +37,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects import (
-    NULL,
     ClockDomain,
     RubyCache,
     RubyNetwork,
 )
+from m5.params import (
+    NULL,
+)
 
-from gem5.components.processors.abstract_core import AbstractCore
-from gem5.isas import ISA
-
+from .....isas import ISA
+from ....processors.abstract_core import AbstractCore
 from .abstract_node import AbstractNode
 
 

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
@@ -28,33 +28,34 @@ from itertools import chain
 from typing import List
 
 from m5.objects import (
-    NULL,
     RubyPortProxy,
     RubySequencer,
     RubySystem,
 )
 from m5.objects.SubSystem import SubSystem
-from m5.params import AllMemory
+from m5.params import (
+    NULL,
+    AllMemory,
+)
 
-from gem5.coherence_protocol import CoherenceProtocol
-from gem5.utils.requires import requires
+from ....coherence_protocol import CoherenceProtocol
+from ....utils.requires import requires
 
 requires(coherence_protocol_required=CoherenceProtocol.CHI)
 
-from gem5.components.boards.abstract_board import AbstractBoard
-from gem5.components.cachehierarchies.abstract_cache_hierarchy import (
+from ....isas import ISA
+from ....utils.override import overrides
+from ...boards.abstract_board import AbstractBoard
+from ...processors.abstract_core import AbstractCore
+from ..abstract_cache_hierarchy import (
     AbstractCacheHierarchy,
 )
-from gem5.components.cachehierarchies.ruby.abstract_ruby_cache_hierarchy import (
+from ..ruby.abstract_ruby_cache_hierarchy import (
     AbstractRubyCacheHierarchy,
 )
-from gem5.components.cachehierarchies.ruby.topologies.simple_pt2pt import (
+from ..ruby.topologies.simple_pt2pt import (
     SimplePt2Pt,
 )
-from gem5.components.processors.abstract_core import AbstractCore
-from gem5.isas import ISA
-from gem5.utils.override import overrides
-
 from .nodes.directory import SimpleDirectory
 from .nodes.dma_requestor import DMARequestor
 from .nodes.l1_cache import L1CacheController


### PR DESCRIPTION
- NULL should come from m5.params
- Use relative paths for gem5 library imports