### PR TITLE
resources: make workloads work with set_se_multi_binary_workload

### DIFF
--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -1270,19 +1270,34 @@ def _get_workload(
     if "parameters" not in workload:
         workload["parameters"] = {}
 
-    for resource in workload["resources"].values():
-        db_query.append(
-            ClientQuery(
-                resource_id=resource["id"],
-                resource_version=resource["resource_version"],
-                gem5_version=gem5_version,
+    for resource_param in workload["resources"].values():
+        # Each Key in the resources dictionary represents a parameter name in the function that is called by the workload
+        # Each value in the resources dictionary can be a single resource or a list of resources that the parameter can take
+
+        if isinstance(resource_param, list):
+            for res in resource_param:
+                db_query.append(
+                    ClientQuery(
+                        resource_id=res["id"],
+                        resource_version=res["resource_version"],
+                        gem5_version=gem5_version,
+                    )
+                )
+        else:
+            db_query.append(
+                ClientQuery(
+                    resource_id=resource_param["id"],
+                    resource_version=resource_param["resource_version"],
+                    gem5_version=gem5_version,
+                )
             )
-        )
     # Fetching resources as a list of dicts
     resource_details_list = get_multiple_resource_json_obj(db_query, clients)
 
-    # Creating the resource objects for each resource
-    for param_name, param_resource in workload["resources"].items():
+    def create_resource_object(
+        param_resource: Dict[str, str],
+        resource_details_list: List[Dict[str, str]],
+    ) -> AbstractResource:
         resource_match = None
         for resource in resource_details_list:
             if (
@@ -1318,11 +1333,23 @@ def _get_workload(
             resource_match["category"]
         ]
 
-        workload["parameters"][param_name] = resource_class(
+        return resource_class(
             local_path=to_path,
             downloader=downloader,
             **resource_match,
         )
+
+    # Creating the resource objects for each resource
+    for param_name, param_resource in workload["resources"].items():
+        if isinstance(param_resource, list):
+            workload["parameters"][param_name] = [
+                create_resource_object(resource, resource_details_list)
+                for resource in param_resource
+            ]
+        else:
+            workload["parameters"][param_name] = create_resource_object(
+                param_resource, resource_details_list
+            )
 
     del workload["resources"]
 

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -1283,13 +1283,19 @@ def _get_workload(
                         gem5_version=gem5_version,
                     )
                 )
-        else:
+        elif isinstance(resource_param, dict):
             db_query.append(
                 ClientQuery(
                     resource_id=resource_param["id"],
                     resource_version=resource_param["resource_version"],
                     gem5_version=gem5_version,
                 )
+            )
+        else:
+            raise Exception(
+                f"The resources field in the workload {workload['id']} with version {workload['resource_version']} is invalid.\n"
+                f"The current value of the resources field is {workload['resources']}.\n"
+                f"Each value in the resources field must be a list or a dict containing resources information."
             )
     # Fetching resources as a list of dicts
     resource_details_list = get_multiple_resource_json_obj(db_query, clients)


### PR DESCRIPTION
The  `set_se_multi_binary_workload ` function expects parameter which accepts a list of resources. This change updates the `resources` field in workload json to work with that requiremet.

- With this change:
  - Each Key in the resources dictionary represents a parameter name in the function that is called by the workload (No change here)
  - Each value in the resources dictionary can be a single resource or a list of resources that the above mentioned parameter can take
  
 To test this change with `set_se_multi_binary_workload`, you can create a JSON file with the following test resource:
 
 ```json
 [
    {
    "category": "workload",
    "id": "x86-multi-hello",
    "description": "",
    "function": "set_se_multi_binary_workload",
    "resources": {
        "binaries": [
            {
                "id": "x86-hello64-static",
                "resource_version": "1.0.0"
            },
            {
                "id": "x86-hello64-static",
                "resource_version": "1.0.0"
            }
        ]
    },
    "additional_params": {
        "arguments": []
    },
    "architecture": "X86",
    "size": 0,
    "tags": [],
    "license": "",
    "author": [
    ],
    "source_url": "",
    "resource_version": "1.0.0",
    "gem5_versions": [
        "25.0"
    ],
    "example_usage": ""
}
]
 ```
 
 and call with workload with the following test config
 
 ```python
 from gem5.components.boards.simple_board import SimpleBoard
from gem5.components.cachehierarchies.classic.no_cache import NoCache
from gem5.components.memory import SingleChannelDDR3_1600
from gem5.components.processors.cpu_types import CPUTypes
from gem5.components.processors.simple_processor import SimpleProcessor
from gem5.isas import ISA
from gem5.resources.resource import obtain_resource
from gem5.simulate.simulator import Simulator
from gem5.utils.requires import requires

requires(isa_required=ISA.X86)

cache_hierarchy = NoCache()

memory = SingleChannelDDR3_1600(size="32MiB")

processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=2)

board = SimpleBoard(
    clk_freq="3GHz",
    processor=processor,
    memory=memory,
    cache_hierarchy=cache_hierarchy,
)

board.set_workload(
    obtain_resource("x86-multi-hello", resource_version="1.0.0")
)

simulator = Simulator(board=board)
simulator.run()
```