### PR TITLE
python: Match walker caches to available MMU ports

### DIFF
--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -96,6 +96,9 @@ PySource('gem5.components.cachehierarchies.classic',
     'gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py')
 PySource('gem5.components.cachehierarchies.classic',
     'gem5/components/cachehierarchies/classic/'
+    'private_l1_walk_cache_hierarchy.py')
+PySource('gem5.components.cachehierarchies.classic',
+    'gem5/components/cachehierarchies/classic/'
     'private_l1_private_l2_cache_hierarchy.py')
 PySource('gem5.components.cachehierarchies.classic',
     'gem5/components/cachehierarchies/classic/'

--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -106,6 +106,9 @@ PySource('gem5.components.cachehierarchies.classic',
 PySource('gem5.components.cachehierarchies.classic',
     'gem5/components/cachehierarchies/classic/'
     'private_l1_shared_l2_cache_hierarchy.py')
+PySource('gem5.components.cachehierarchies.classic',
+    'gem5/components/cachehierarchies/classic/'
+    'private_l1_shared_l2_walk_cache_hierarchy.py')
 PySource('gem5.components.cachehierarchies.classic.caches',
     'gem5/components/cachehierarchies/classic/caches/__init__.py')
 PySource('gem5.components.cachehierarchies.classic.caches',

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Regents of the University of California
+# Copyright (c) 2021-2025 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
@@ -122,13 +122,19 @@ class PrivateL1CacheHierarchy(AbstractClassicCacheHierarchy):
             self.l1dcaches[i].mem_side = self.membus.cpu_side_ports
 
             walker_ports = cpu.get_mmu().walkerPorts()
+            if len(walker_ports) > 2:
+                raise RuntimeError(
+                    "Unexpected number of walker ports "
+                    f"from CPU {i}: {len(walker_ports)}.\n"
+                    "Expected 0, 1, or 2"
+                )
             if len(walker_ports) == 0:
                 continue
 
             dptw_cache = MMUCache(size="8KiB")
             dptw_cache.mem_side = self.membus.cpu_side_ports
 
-            if len(walker_ports) > 1:
+            if len(walker_ports) == 2:
                 iptw_cache = MMUCache(size="8KiB")
                 iptw_cache.mem_side = self.membus.cpu_side_ports
                 cpu.connect_walker_ports(
@@ -136,6 +142,10 @@ class PrivateL1CacheHierarchy(AbstractClassicCacheHierarchy):
                 )
                 iptw_caches.append(iptw_cache)
             else:
+                assert len(walker_ports) == 1, (
+                    f"This branch expects 1 walker_port, got "
+                    f"{len(walker_ports)}."
+                )
                 cpu.connect_walker_ports(
                     dptw_cache.cpu_side, dptw_cache.cpu_side
                 )

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 The Regents of the University of California
+# Copyright (c) 2021, 2025 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_cache_hierarchy.py
@@ -130,7 +130,7 @@ class PrivateL1CacheHierarchy(AbstractClassicCacheHierarchy):
                 cpu.connect_interrupt()
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
-        walker_ports = cpu.get_mmu().walkerPorts()
+        walker_ports = cpu.get_mmu().walkerPorts() if cpu.has_mmu() else []
         if len(walker_ports) > 2:
             raise RuntimeError(
                 "Unexpected number of walker ports "

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_walk_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_walk_cache_hierarchy.py
@@ -62,23 +62,31 @@ class PrivateL1PrivateL2WalkCacheHierarchy(PrivateL1PrivateL2CacheHierarchy):
         super().incorporate_cache(board)
         self.iptw_caches = self._tmp_iptw_caches
         self.dptw_caches = self._tmp_dptw_caches
-        del self._tmp_iptw_caches
-        del self._tmp_dptw_caches
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
         walker_ports = cpu.get_mmu().walkerPorts()
+        if len(walker_ports) > 2:
+            raise RuntimeError(
+                "Unexpected number of walker ports "
+                f"from CPU {cpu_id}: {len(walker_ports)}.\n"
+                "Expected 0, 1, or 2"
+            )
+
         if len(walker_ports) == 0:
             return
 
         dptw_cache = MMUCache(size="8KiB")
         dptw_cache.mem_side = self.l2buses[cpu_id].cpu_side_ports
 
-        if len(walker_ports) > 1:
+        if len(walker_ports) == 2:
             iptw_cache = MMUCache(size="8KiB")
             iptw_cache.mem_side = self.l2buses[cpu_id].cpu_side_ports
             cpu.connect_walker_ports(iptw_cache.cpu_side, dptw_cache.cpu_side)
             self._tmp_iptw_caches.append(iptw_cache)
         else:
+            assert (
+                len(walker_ports) == 1
+            ), f"This branch expects 1 walker_port, got {len(walker_ports)}."
             cpu.connect_walker_ports(dptw_cache.cpu_side, dptw_cache.cpu_side)
 
         self._tmp_dptw_caches.append(dptw_cache)

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_walk_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_private_l2_walk_cache_hierarchy.py
@@ -65,7 +65,7 @@ class PrivateL1PrivateL2WalkCacheHierarchy(PrivateL1PrivateL2CacheHierarchy):
         self.dptw_caches = self._tmp_dptw_caches
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
-        walker_ports = cpu.get_mmu().walkerPorts()
+        walker_ports = cpu.get_mmu().walkerPorts() if cpu.has_mmu() else []
         if len(walker_ports) > 2:
             raise RuntimeError(
                 "Unexpected number of walker ports "

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 The Regents of the University of California
 # Copyright (c) 2022 The Regents of the Yonsei University
 # All rights reserved.
 #
@@ -28,6 +29,7 @@ from typing import Optional
 
 from m5.objects import (
     BadAddr,
+    BaseCPU,
     BaseXBar,
     Cache,
     L2XBar,
@@ -44,7 +46,6 @@ from .abstract_classic_cache_hierarchy import AbstractClassicCacheHierarchy
 from .caches.l1dcache import L1DCache
 from .caches.l1icache import L1ICache
 from .caches.l2cache import L2Cache
-from .caches.mmu_cache import MMUCache
 
 
 class PrivateL1SharedL2CacheHierarchy(
@@ -52,8 +53,9 @@ class PrivateL1SharedL2CacheHierarchy(
 ):
     """
     A cache setup where each core has a private L1 Data and Instruction Cache,
-    and a L2 cache is shared with all cores. The shared L2 cache is mostly
-    inclusive with respect to the split I/D L1 and MMU caches.
+    and a L2 cache is shared with all cores. Table walker ports connect
+    directly to the shared L2 bus by default, ensuring the absence of implicit
+    walk caches unless explicitly requested via a subclass.
     """
 
     def _get_default_membus(self) -> SystemXBar:
@@ -136,8 +138,6 @@ class PrivateL1SharedL2CacheHierarchy(
         ]
         self.l2bus = L2XBar()
         self.l2cache = L2Cache(size=self._l2_size, assoc=self._l2_assoc)
-        iptw_caches = []
-        dptw_caches = []
 
         if board.has_coherent_io():
             self._setup_io_cache(board)
@@ -148,36 +148,7 @@ class PrivateL1SharedL2CacheHierarchy(
 
             self.l1icaches[i].mem_side = self.l2bus.cpu_side_ports
             self.l1dcaches[i].mem_side = self.l2bus.cpu_side_ports
-            walker_ports = cpu.get_mmu().walkerPorts()
-            if len(walker_ports) > 2:
-                raise RuntimeError(
-                    "Unexpected number of walker ports "
-                    f"from CPU {i}: {len(walker_ports)}.\n"
-                    "Expected 0, 1, or 2"
-                )
-            if len(walker_ports) == 0:
-                continue
-
-            dptw_cache = MMUCache(size="8KiB", writeback_clean=False)
-            dptw_cache.mem_side = self.l2bus.cpu_side_ports
-
-            if len(walker_ports) == 2:
-                iptw_cache = MMUCache(size="8KiB", writeback_clean=False)
-                iptw_cache.mem_side = self.l2bus.cpu_side_ports
-                cpu.connect_walker_ports(
-                    iptw_cache.cpu_side, dptw_cache.cpu_side
-                )
-                iptw_caches.append(iptw_cache)
-            else:
-                assert len(walker_ports) == 1, (
-                    f"This branch expects 1 walker_port, got "
-                    f"{len(walker_ports)}."
-                )
-                cpu.connect_walker_ports(
-                    dptw_cache.cpu_side, dptw_cache.cpu_side
-                )
-
-            dptw_caches.append(dptw_cache)
+            self._connect_table_walker(i, cpu)
 
             if board.get_processor().get_isa() == ISA.X86:
                 int_req_port = self.membus.mem_side_ports
@@ -189,9 +160,22 @@ class PrivateL1SharedL2CacheHierarchy(
         self.l2bus.mem_side_ports = self.l2cache.cpu_side
         self.membus.cpu_side_ports = self.l2cache.mem_side
 
-        if iptw_caches:
-            self.iptw_caches = iptw_caches
-        self.dptw_caches = dptw_caches
+    def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
+        walker_ports = cpu.get_mmu().walkerPorts()
+        if len(walker_ports) > 2:
+            raise RuntimeError(
+                "Unexpected number of walker ports "
+                f"from CPU {cpu_id}: {len(walker_ports)}.\n"
+                "Expected 0, 1, or 2"
+            )
+
+        if len(walker_ports) == 0:
+            return
+
+        cpu.connect_walker_ports(
+            self.l2bus.cpu_side_ports,
+            self.l2bus.cpu_side_ports,
+        )
 
     def _setup_io_cache(self, board: AbstractBoard) -> None:
         """Create a cache for coherent I/O connections"""

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
@@ -149,13 +149,19 @@ class PrivateL1SharedL2CacheHierarchy(
             self.l1icaches[i].mem_side = self.l2bus.cpu_side_ports
             self.l1dcaches[i].mem_side = self.l2bus.cpu_side_ports
             walker_ports = cpu.get_mmu().walkerPorts()
+            if len(walker_ports) > 2:
+                raise RuntimeError(
+                    "Unexpected number of walker ports "
+                    f"from CPU {i}: {len(walker_ports)}.\n"
+                    "Expected 0, 1, or 2"
+                )
             if len(walker_ports) == 0:
                 continue
 
             dptw_cache = MMUCache(size="8KiB", writeback_clean=False)
             dptw_cache.mem_side = self.l2bus.cpu_side_ports
 
-            if len(walker_ports) > 1:
+            if len(walker_ports) == 2:
                 iptw_cache = MMUCache(size="8KiB", writeback_clean=False)
                 iptw_cache.mem_side = self.l2bus.cpu_side_ports
                 cpu.connect_walker_ports(
@@ -163,6 +169,10 @@ class PrivateL1SharedL2CacheHierarchy(
                 )
                 iptw_caches.append(iptw_cache)
             else:
+                assert len(walker_ports) == 1, (
+                    f"This branch expects 1 walker_port, got "
+                    f"{len(walker_ports)}."
+                )
                 cpu.connect_walker_ports(
                     dptw_cache.cpu_side, dptw_cache.cpu_side
                 )

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
@@ -161,7 +161,7 @@ class PrivateL1SharedL2CacheHierarchy(
         self.membus.cpu_side_ports = self.l2cache.mem_side
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
-        walker_ports = cpu.get_mmu().walkerPorts()
+        walker_ports = cpu.get_mmu().walkerPorts() if cpu.has_mmu() else []
         if len(walker_ports) > 2:
             raise RuntimeError(
                 "Unexpected number of walker ports "

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_cache_hierarchy.py
@@ -136,16 +136,8 @@ class PrivateL1SharedL2CacheHierarchy(
         ]
         self.l2bus = L2XBar()
         self.l2cache = L2Cache(size=self._l2_size, assoc=self._l2_assoc)
-        # ITLB Page walk caches
-        self.iptw_caches = [
-            MMUCache(size="8KiB", writeback_clean=False)
-            for _ in range(board.get_processor().get_num_cores())
-        ]
-        # DTLB Page walk caches
-        self.dptw_caches = [
-            MMUCache(size="8KiB", writeback_clean=False)
-            for _ in range(board.get_processor().get_num_cores())
-        ]
+        iptw_caches = []
+        dptw_caches = []
 
         if board.has_coherent_io():
             self._setup_io_cache(board)
@@ -156,12 +148,26 @@ class PrivateL1SharedL2CacheHierarchy(
 
             self.l1icaches[i].mem_side = self.l2bus.cpu_side_ports
             self.l1dcaches[i].mem_side = self.l2bus.cpu_side_ports
-            self.iptw_caches[i].mem_side = self.l2bus.cpu_side_ports
-            self.dptw_caches[i].mem_side = self.l2bus.cpu_side_ports
+            walker_ports = cpu.get_mmu().walkerPorts()
+            if len(walker_ports) == 0:
+                continue
 
-            cpu.connect_walker_ports(
-                self.iptw_caches[i].cpu_side, self.dptw_caches[i].cpu_side
-            )
+            dptw_cache = MMUCache(size="8KiB", writeback_clean=False)
+            dptw_cache.mem_side = self.l2bus.cpu_side_ports
+
+            if len(walker_ports) > 1:
+                iptw_cache = MMUCache(size="8KiB", writeback_clean=False)
+                iptw_cache.mem_side = self.l2bus.cpu_side_ports
+                cpu.connect_walker_ports(
+                    iptw_cache.cpu_side, dptw_cache.cpu_side
+                )
+                iptw_caches.append(iptw_cache)
+            else:
+                cpu.connect_walker_ports(
+                    dptw_cache.cpu_side, dptw_cache.cpu_side
+                )
+
+            dptw_caches.append(dptw_cache)
 
             if board.get_processor().get_isa() == ISA.X86:
                 int_req_port = self.membus.mem_side_ports
@@ -172,6 +178,10 @@ class PrivateL1SharedL2CacheHierarchy(
 
         self.l2bus.mem_side_ports = self.l2cache.cpu_side
         self.membus.cpu_side_ports = self.l2cache.mem_side
+
+        if iptw_caches:
+            self.iptw_caches = iptw_caches
+        self.dptw_caches = dptw_caches
 
     def _setup_io_cache(self, board: AbstractBoard) -> None:
         """Create a cache for coherent I/O connections"""

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_walk_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_shared_l2_walk_cache_hierarchy.py
@@ -60,7 +60,7 @@ class PrivateL1SharedL2WalkCacheHierarchy(PrivateL1SharedL2CacheHierarchy):
         self.dptw_caches = self._tmp_dptw_caches
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
-        walker_ports = cpu.get_mmu().walkerPorts()
+        walker_ports = cpu.get_mmu().walkerPorts() if cpu.has_mmu() else []
         if len(walker_ports) > 2:
             raise RuntimeError(
                 "Unexpected number of walker ports "

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_walk_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_walk_cache_hierarchy.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from m5.objects import BaseCPU
+
+from ....utils.override import *
+from ...boards.abstract_board import AbstractBoard
+from .caches.mmu_cache import MMUCache
+from .private_l1_cache_hierarchy import PrivateL1CacheHierarchy
+
+
+class PrivateL1WalkCacheHierarchy(PrivateL1CacheHierarchy):
+    """Private L1 hierarchy variant that attaches MMU caches to walker ports."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    @overrides(PrivateL1CacheHierarchy)
+    def incorporate_cache(self, board: AbstractBoard) -> None:
+        self._tmp_iptw_caches = []
+        self._tmp_dptw_caches = []
+        super().incorporate_cache(board)
+        if self._tmp_iptw_caches:
+            self.iptw_caches = self._tmp_iptw_caches
+        self.dptw_caches = self._tmp_dptw_caches
+
+    def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
+        walker_ports = cpu.get_mmu().walkerPorts()
+        if len(walker_ports) > 2:
+            raise RuntimeError(
+                "Unexpected number of walker ports "
+                f"from CPU {cpu_id}: {len(walker_ports)}.\n"
+                "Expected 0, 1, or 2"
+            )
+
+        if len(walker_ports) == 0:
+            return
+
+        dptw_cache = MMUCache(size="8KiB")
+        dptw_cache.mem_side = self.membus.cpu_side_ports
+
+        if len(walker_ports) == 2:
+            iptw_cache = MMUCache(size="8KiB")
+            iptw_cache.mem_side = self.membus.cpu_side_ports
+            cpu.connect_walker_ports(
+                iptw_cache.cpu_side,
+                dptw_cache.cpu_side,
+            )
+            self._tmp_iptw_caches.append(iptw_cache)
+        else:
+            assert (
+                len(walker_ports) == 1
+            ), f"This branch expects 1 walker_port, got {len(walker_ports)}."
+            cpu.connect_walker_ports(
+                dptw_cache.cpu_side,
+                dptw_cache.cpu_side,
+            )
+
+        self._tmp_dptw_caches.append(dptw_cache)

--- a/src/python/gem5/components/cachehierarchies/classic/private_l1_walk_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/classic/private_l1_walk_cache_hierarchy.py
@@ -48,7 +48,7 @@ class PrivateL1WalkCacheHierarchy(PrivateL1CacheHierarchy):
         self.dptw_caches = self._tmp_dptw_caches
 
     def _connect_table_walker(self, cpu_id: int, cpu: BaseCPU) -> None:
-        walker_ports = cpu.get_mmu().walkerPorts()
+        walker_ports = cpu.get_mmu().walkerPorts() if cpu.has_mmu() else []
         if len(walker_ports) > 2:
             raise RuntimeError(
                 "Unexpected number of walker ports "

--- a/src/python/gem5/components/processors/abstract_core.py
+++ b/src/python/gem5/components/processors/abstract_core.py
@@ -127,6 +127,17 @@ class AbstractCore(SubSystem):
         """
         raise NotImplementedError
 
+    def has_mmu(self) -> bool:
+        """Return True if this core has an MMU.
+
+        This is needed to check a core has a MMU before trying to get it.
+        There are cores without MMUs. E.g, some generator cores.
+        """
+        try:
+            return isinstance(self.get_mmu(), BaseMMU)
+        except NotImplementedError:
+            return False
+
     @abstractmethod
     def get_mmu(self) -> BaseMMU:
         """Return the MMU for this core.

--- a/src/python/gem5/prebuilt/demo/x86_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/x86_demo_board.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Regents of the University of California
+# Copyright (c) 2021-2025 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,8 @@
 from m5.util import warn
 
 from ...components.boards.x86_board import X86Board
-from ...components.cachehierarchies.classic.private_l1_shared_l2_cache_hierarchy import (
-    PrivateL1SharedL2CacheHierarchy,
+from ...components.cachehierarchies.classic.private_l1_shared_l2_walk_cache_hierarchy import (
+    PrivateL1SharedL2WalkCacheHierarchy,
 )
 from ...components.memory.multi_channel import DualChannelDDR4_2400
 from ...components.processors.cpu_types import CPUTypes
@@ -81,7 +81,7 @@ class X86DemoBoard(X86Board):
             cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=2
         )
 
-        cache_hierarchy = PrivateL1SharedL2CacheHierarchy(
+        cache_hierarchy = PrivateL1SharedL2WalkCacheHierarchy(
             l1d_size="64KiB", l1i_size="64KiB", l2_size="8MiB"
         )
 

--- a/src/python/gem5/prebuilt/demo/x86_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/x86_demo_board.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 The Regents of the University of California
+# Copyright (c) 2021, 2025 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Some CPUs expose zero or one MMU walker port, but the classic cache hierarchies always instantiated both ITLB and DTLB walk caches. When a CPU lacked an instruction walker, the ITLB cache was left dangling and gem5 aborted with “Cache ports on board.cache_hierarchy.iptw_caches are not connected” which was causing our Daily tests to fail (specifically, "configs/example/gem5_library/arm-hello-dramsys.py" and other DRAMSys tests).

The fix here is to only create walk caches when the CPU reports walker ports, and reuse the D-side cache when there is a single shared walker. The prebuilt RISC-V hierarchy and the private L1/L2 walk-cache setup follow the same pattern.

~~The Arm table walker’s cached port pointer is marked as `[[ maybe_unused]]` to avoid a new compiler warning when no I-side walker exists.~~