### PR TITLE
mem-ruby: Fix CHI TBE allocation

### DIFF
--- a/src/mem/ruby/structures/MN_TBETable.cc
+++ b/src/mem/ruby/structures/MN_TBETable.cc
@@ -49,6 +49,18 @@ namespace gem5
 namespace ruby
 {
 
+CHI::MiscNode_TBE *
+EntryFactory<CHI::MiscNode_TBE>::create(int block_size)
+{
+    return new CHI::MiscNode_TBE(block_size);
+}
+
+void
+EntryFactory<CHI::MiscNode_TBE>::destroy(CHI::MiscNode_TBE *entry)
+{
+    delete entry;
+}
+
 namespace CHI
 {
 
@@ -67,7 +79,7 @@ MN_TBETable::chooseNewDistributor()
     bool has_waiting_sync = false;
     int waiting_count = 0;
     for (auto& keyValuePair : m_map) {
-        MiscNode_TBE& tbe = keyValuePair.second;
+        MiscNode_TBE &tbe = *keyValuePair.second;
 
         switch (tbe.getstate()) {
             case MiscNode_State_DvmSync_Distributing:

--- a/src/mem/ruby/structures/MN_TBETable.hh
+++ b/src/mem/ruby/structures/MN_TBETable.hh
@@ -51,9 +51,8 @@ namespace CHI
 
 class MiscNode_TBE;
 
-// Custom class only used for the CHI protocol Misc Node
-// Includes the definition of the MiscNode_TBE, because it
-// includes functions that rely on fields in the structure
+// Custom class only used for the CHI protocol Misc Node.
+// Implementation relies on MiscNode_TBE fields defined in the protocol.
 class MN_TBETable : public TBETable<MiscNode_TBE>
 {
   public:

--- a/src/mem/ruby/structures/TBETable.hh
+++ b/src/mem/ruby/structures/TBETable.hh
@@ -42,6 +42,7 @@
 #define __MEM_RUBY_STRUCTURES_TBETABLE_HH__
 
 #include <iostream>
+#include <memory>
 #include <unordered_map>
 
 #include "mem/ruby/common/Address.hh"
@@ -52,6 +53,41 @@ namespace gem5
 
 namespace ruby
 {
+
+template <class ENTRY> struct EntryFactory
+{
+    static ENTRY *
+    create(int block_size)
+    {
+        return new ENTRY(block_size);
+    }
+
+    static void
+    destroy(ENTRY *entry)
+    {
+        delete entry;
+    }
+};
+
+template <class ENTRY> struct EntryDeleter
+{
+    void
+    operator()(ENTRY *entry) const
+    {
+        EntryFactory<ENTRY>::destroy(entry);
+    }
+};
+
+namespace CHI
+{
+class MiscNode_TBE;
+}
+
+template <> struct EntryFactory<CHI::MiscNode_TBE>
+{
+    static CHI::MiscNode_TBE *create(int block_size);
+    static void destroy(CHI::MiscNode_TBE *entry);
+};
 
 template<class ENTRY>
 class TBETable
@@ -84,8 +120,11 @@ class TBETable
     TBETable(const TBETable& obj);
     TBETable& operator=(const TBETable& obj);
 
+    using EntryPtr = std::unique_ptr<ENTRY, EntryDeleter<ENTRY>>;
+    using MapType = std::unordered_map<Addr, EntryPtr>;
+
     // Data Members (m_prefix)
-    std::unordered_map<Addr, ENTRY> m_map;
+    MapType m_map;
 
   private:
     int m_number_of_TBEs = 0;
@@ -129,9 +168,9 @@ TBETable<ENTRY>::allocate(Addr address)
     assert(!isPresent(address));
     assert(m_map.size() < m_number_of_TBEs);
     assert(m_block_size > 0);
-    ENTRY new_entry = ENTRY(m_block_size);
-    new_entry.setRubySystem(m_ruby_system);
-    m_map.emplace(address, new_entry);
+    EntryPtr new_entry(EntryFactory<ENTRY>::create(m_block_size));
+    new_entry->setRubySystem(m_ruby_system);
+    m_map.emplace(address, std::move(new_entry));
 }
 
 template<class ENTRY>
@@ -155,8 +194,11 @@ template<class ENTRY>
 inline ENTRY*
 TBETable<ENTRY>::lookup(Addr address)
 {
-  if (m_map.find(address) != m_map.end()) return &(m_map.find(address)->second);
-  return NULL;
+    auto it = m_map.find(address);
+    if (it != m_map.end()) {
+        return it->second.get();
+    }
+    return nullptr;
 }
 
 


### PR DESCRIPTION
A bug was introduced in 0f476aabf3 (PR #2706) and observed when building VEGA_X86 in a ghcr.io/gem5/gcn-gpu:latest container. It causes incomplete-type errors for `MiscNode_TBE`. It fails because the container still uses GCC 10, which instantiates `TBETable<MiscNode_TBE>` while the type is incomplete. As per-standard, this is ill-formed. GCC 11+ (and Clang) happen to instantiate the template later, after the full definition is visble, so the issue still exists even if newer compilers don't flag it.

To preserve the dependency break introduced in 0f476aabf3, this fix stores entries in `TBETable` via unique_ptr and specializes the factory in "MN_TBETable.cc" so the full `MiscNode_TBE` definition is only needed in the "MN_TBETABLE.cc" file