### PR TITLE
arch-arm: Ensure Stage2Walk port pointer is used

### DIFF
--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -2721,8 +2721,7 @@ WalkUnit::Stage2Walk::finish(const Fault &_fault, const RequestPtr &req,
     }
 
     if (_fault == NoFault && !req->getFlags().isSet(Request::NO_ACCESS)) {
-        parent.getTableWalkerPort().sendTimingReq(req, data,
-            tc->getCpuPtr()->clockPeriod(), event);
+        port->sendTimingReq(req, data, tc->getCpuPtr()->clockPeriod(), event);
     } else {
         // We can't do the DMA access as there's been a problem, so tell the
         // event we're done


### PR DESCRIPTION
Clang’s -Wunused-private-field is trigged when building because
`WalkUnit::Stage2Walk::port`, a private member declared in
src/arch/arm/table_walker.hh,  is written in the constructor at
src/arch/arm/table_walker.cc but never read anywhere else.
`fetchDescriptor()` still constructs `Stage2Walk` objects, but
subsequent access goes through `parent.getTableWalkerPort()`.

This patch ensures this port pointer is used by replacing the access
via `parent.getTableWalkerPort()` with the port.