### PR TITLE
tests,scons,arch-arm: Fix Address sanitizer compilation test failures

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -56,5 +56,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.sanitizer }} in ${{ matrix.image }}
-              run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j$(nproc) --with-${{ matrix.sanitizer }}
+              # The address sanitizer is quite memory intensive; triggering OOM errors on smaller runners.
+              # To mitigate this, we limit scons to a single thread (`-j1`)
+              run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j1 --with-${{ matrix.sanitizer }}
               timeout-minutes: 600 # 10 hours

--- a/src/arch/generic/vec_pred_reg.hh
+++ b/src/arch/generic/vec_pred_reg.hh
@@ -243,7 +243,7 @@ class VecPredRegContainer
     using MyClass = VecPredRegContainer<NumBits, Packed>;
 
   public:
-    VecPredRegContainer() {}
+    VecPredRegContainer() { reset(); }
     VecPredRegContainer(const VecPredRegContainer &) = default;
 
     MyClass&


### PR DESCRIPTION
The "ASAN" and "UBSAN" compilation tests were failing (https://github.com/gem5/gem5/actions/runs/18889849741). This PR fixes via two commits which:

1. Avoid OOM issues by reducing the number of compilation threads from 4 to 1.
2. Fix a "may be initialized error" in ARM generated code when compiling with Asan -- the address sanitizer rewrites the generated code so GCC no longer sees the full dataflow thereby triggering this error.