### PR TITLE
sim-se,arch: Initialize max stack size from parameter (all ISAs)

### DIFF
--- a/src/arch/arm/process.cc
+++ b/src/arch/arm/process.cc
@@ -78,7 +78,7 @@ ArmProcess32::ArmProcess32(const ProcessParams &params,
 {
     Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     Addr stack_base = 0xbf000000L;
-    Addr max_stack_size = 8 * 1024 * 1024;
+    Addr max_stack_size = params.maxStackSize;
     Addr next_thread_stack_base = stack_base - max_stack_size;
     Addr mmap_end = 0x40000000L;
 
@@ -94,7 +94,7 @@ ArmProcess64::ArmProcess64(
 {
     Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     Addr stack_base = 0x7fffff0000L;
-    Addr max_stack_size = 8 * 1024 * 1024;
+    Addr max_stack_size = params.maxStackSize;
     Addr next_thread_stack_base = stack_base - max_stack_size;
     Addr mmap_end = 0x4000000000L;
 

--- a/src/arch/mips/process.cc
+++ b/src/arch/mips/process.cc
@@ -60,7 +60,7 @@ MipsProcess::MipsProcess(const ProcessParams &params,
     // user address space. MIPS stack grows down from here
     Addr stack_base = 0x7FFFFFFF;
 
-    Addr max_stack_size = 8 * 1024 * 1024;
+    Addr max_stack_size = params.maxStackSize;
 
     // Set pointer for next thread stack.  Reserve 8M for main stack.
     Addr next_thread_stack_base = stack_base - max_stack_size;

--- a/src/arch/power/process.cc
+++ b/src/arch/power/process.cc
@@ -65,7 +65,7 @@ PowerProcess::PowerProcess(
 
     Addr stack_base = 0xbf000000L;
 
-    Addr max_stack_size = 8 * 1024 * 1024;
+    Addr max_stack_size = params.maxStackSize;
 
     // Set pointer for next thread stack.  Reserve 8M for main stack.
     Addr next_thread_stack_base = stack_base - max_stack_size;

--- a/src/arch/riscv/process.cc
+++ b/src/arch/riscv/process.cc
@@ -73,7 +73,7 @@ RiscvProcess64::RiscvProcess64(const ProcessParams &params,
         RiscvProcess(params, objFile)
 {
     const Addr stack_base = 0x7FFFFFFFFFFFFFFFL;
-    const Addr max_stack_size = 8 * 1024 * 1024;
+    const Addr max_stack_size = params.maxStackSize;
     const Addr next_thread_stack_base = stack_base - max_stack_size;
     const Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     const Addr mmap_end = 0x4000000000000000L;
@@ -86,7 +86,7 @@ RiscvProcess32::RiscvProcess32(const ProcessParams &params,
         RiscvProcess(params, objFile)
 {
     const Addr stack_base = 0x7FFFFFFF;
-    const Addr max_stack_size = 8 * 1024 * 1024;
+    const Addr max_stack_size = params.maxStackSize;
     const Addr next_thread_stack_base = stack_base - max_stack_size;
     const Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     const Addr mmap_end = 0x40000000L;

--- a/src/arch/sparc/process.hh
+++ b/src/arch/sparc/process.hh
@@ -36,6 +36,7 @@
 #include "arch/sparc/page_size.hh"
 #include "base/loader/object_file.hh"
 #include "mem/page_table.hh"
+#include "params/Process.hh"
 #include "sim/process.hh"
 
 namespace gem5
@@ -79,7 +80,7 @@ class Sparc32Process : public SparcProcess
         brk_point = roundUp(brk_point, SparcISA::PageBytes);
 
         // Reserve 8M for main stack.
-        Addr max_stack_size = 8 * 1024 * 1024;
+        Addr max_stack_size = params.maxStackSize;
 
         // Set up stack. On SPARC Linux, stack goes from the top of memory
         // downward, less the hole for the kernel address space.
@@ -113,7 +114,7 @@ class Sparc64Process : public SparcProcess
         Addr brk_point = image.maxAddr();
         brk_point = roundUp(brk_point, SparcISA::PageBytes);
 
-        Addr max_stack_size = 8 * 1024 * 1024;
+        Addr max_stack_size = params.maxStackSize;
 
         // Set up stack. On SPARC Linux, stack goes from the top of memory
         // downward, less the hole for the kernel address space.

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -139,7 +139,7 @@ I386Process::I386Process(const ProcessParams &params,
 
     Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     Addr stack_base = _gdtStart;
-    Addr max_stack_size = 8 * 1024 * 1024;
+    Addr max_stack_size = params.maxStackSize;
     Addr next_thread_stack_base = stack_base - max_stack_size;
     Addr mmap_end = 0xB7FFF000ULL;
 


### PR DESCRIPTION
This pull request fixes issue https://github.com/gem5/gem5/issues/2711 by changing the hard-coded `max_stack_size` (8MiB) to `params.maxStackSize`.

Basically applies the fix in pull request https://github.com/gem5/gem5/pull/892 to all ISAs