### PR TITLE
mem-ruby: Annotate CHI-TLM scheduling time in Transaction obj

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -1,5 +1,5 @@
 # -*- mode:python -*-
-# Copyright (c) 2024 Arm Limited
+# Copyright (c) 2024-2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -57,7 +57,7 @@ class TlmGenerator(SimObject):
     def injectAt(self, when, payload, phase):
         from m5.tlm_chi import Transaction
 
-        transaction = Transaction(payload, phase)
+        transaction = Transaction(payload, phase, when)
         self._transactions.append((when, transaction))
         return transaction
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -67,8 +67,9 @@ TlmGenerator::Transaction::Assertion::run(Transaction *tran)
     }
 }
 
-TlmGenerator::Transaction::Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph)
-  : passed(true), parent(nullptr), _payload(pa), _phase(ph)
+TlmGenerator::Transaction::Transaction(ARM::CHI::Payload *pa,
+                                       ARM::CHI::Phase &ph, Tick when)
+    : passed(true), parent(nullptr), _payload(pa), _phase(ph), _start(when)
 {
     _payload->ref();
 }

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -192,7 +192,7 @@ class TlmGenerator : public SimObject
         using Actions = std::list<ActionPtr>;
 
         Transaction(const Transaction &rhs) = delete;
-        Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph);
+        Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph, Tick when);
         ~Transaction();
 
         /**
@@ -232,6 +232,11 @@ class TlmGenerator : public SimObject
 
         ARM::CHI::Payload* payload() const { return _payload; }
         ARM::CHI::Phase& phase() { return _phase; }
+        Tick
+        start() const
+        {
+            return _start;
+        }
 
       private:
         Actions actions;
@@ -240,6 +245,7 @@ class TlmGenerator : public SimObject
         TlmGenerator *parent;
         ARM::CHI::Payload *_payload;
         ARM::CHI::Phase _phase;
+        Tick _start;
     };
 
     void scheduleTransaction(Tick when, Transaction *tr);

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -61,46 +61,37 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
     using Assertion = tlm::chi::TlmGenerator::Transaction::Assertion;
     using Callback = Action::Callback;
     py::class_<tlm::chi::TlmGenerator::Transaction>(tlm_chi_gen, "Transaction")
-        .def(py::init<Payload*, Phase&>())
+        .def(py::init<Payload *, Phase &, Tick>())
         .def("EXPECT_STR",
-            [] (tlm::chi::TlmGenerator::Transaction &self,
-                std::string name,
-                Callback cb)
-            {
-                self.addCallback(std::make_unique<Expectation>(name, cb));
-            })
-        .def("EXPECT",
-            [] (tlm::chi::TlmGenerator::Transaction &self,
-                py::function cb)
-            {
+             [](tlm::chi::TlmGenerator::Transaction &self, std::string name,
+                Callback cb) {
+                 self.addCallback(std::make_unique<Expectation>(name, cb));
+             })
+        .def(
+            "EXPECT",
+            [](tlm::chi::TlmGenerator::Transaction &self, py::function cb) {
                 self.addCallback(std::make_unique<Expectation>(
                     cb.attr("__name__").cast<std::string>(),
                     cb.cast<Callback>()));
             })
         .def("ASSERT",
-            [] (tlm::chi::TlmGenerator::Transaction &self,
-                std::string name,
-                Callback cb)
-            {
-                self.addCallback(std::make_unique<Assertion>(name, cb));
-            })
+             [](tlm::chi::TlmGenerator::Transaction &self, std::string name,
+                Callback cb) {
+                 self.addCallback(std::make_unique<Assertion>(name, cb));
+             })
         .def("DO",
-            [] (tlm::chi::TlmGenerator::Transaction &self,
-                Callback cb)
-            {
-                self.addCallback(std::make_unique<Action>(cb, false));
-            })
+             [](tlm::chi::TlmGenerator::Transaction &self, Callback cb) {
+                 self.addCallback(std::make_unique<Action>(cb, false));
+             })
         .def("DO_WAIT",
-            [] (tlm::chi::TlmGenerator::Transaction &self,
-                Callback cb)
-            {
-                self.addCallback(std::make_unique<Action>(cb, true));
-            })
+             [](tlm::chi::TlmGenerator::Transaction &self, Callback cb) {
+                 self.addCallback(std::make_unique<Action>(cb, true));
+             })
         .def("inject", &tlm::chi::TlmGenerator::Transaction::inject)
-        .def_property("phase",
-            &tlm::chi::TlmGenerator::Transaction::phase,
-            &tlm::chi::TlmGenerator::Transaction::phase)
-        ;
+        .def_property("phase", &tlm::chi::TlmGenerator::Transaction::phase,
+                      &tlm::chi::TlmGenerator::Transaction::phase)
+        .def_property_readonly("start",
+                               &tlm::chi::TlmGenerator::Transaction::start);
 }
 
 EmbeddedPyBind embed_("tlm_chi_gen", &tlm_chi_generator_pybind, "tlm_chi");


### PR DESCRIPTION
With this commit we annotate the transaction scheduling time in the Transaction object and we make it observable to the python scripts.

In this way testers can verify the scheduling time of a specific transaction while simulation has started

Change-Id: I6d161a019cc9df2298984978d739054104d8ccf4