### PR TITLE
cpu-o3: Add LQ and SQ average occupancy stat

### DIFF
--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014,2017-2018,2020-2021 ARM Limited
+ * Copyright (c) 2012-2014,2017-2018,2020-2021,2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -304,6 +304,16 @@ class LSQUnit
     /** Returns the number of stores in the SQ. */
     int numStores() { return storeQueue.size(); }
 
+    /** Returns the current occupancy of the passed
+     * queue (store queue or load queue) */
+    template <typename Queue>
+    double
+    queueOccupancy(const Queue &queue) const
+    {
+        return static_cast<double>(queue.size()) /
+               static_cast<double>(queue.capacity());
+    }
+
     // hardware transactional memory
     int numHtmStarts() const { return htmStarts; }
     int numHtmStops() const { return htmStops; }
@@ -541,6 +551,11 @@ class LSQUnit
 
         /** Total number of loads and stores written to the load store queue */
         statistics::Scalar addedLoadsAndStores;
+
+        /** LQ Occupancy */
+        statistics::Average lqAvgOccupancy;
+        /** SQ Occupancy */
+        statistics::Average sqAvgOccupancy;
     } stats;
 
   public:


### PR DESCRIPTION
Current LSQ statistics report several info, but they lack one of the key ones, which is the average
occupancy of LD/ST in the LSQ.
This helps on understanding whether your workload is memory bound and your IPC is somehow limited by your LSQ (a full LSQ will stall the entire pipeline at rename).

We therefore add a lq and sq occupancy stat which will provide the average occupancy (from 0 to 1, where a number close to zero means there is plenty of space available and a number close to 1 means we are running at full capacity and the memsys is bottlenecking your performance)


Change-Id: I38c0b93e23b4b26fddb430fb3649fcdaf022393c