### PR TITLE
base: make RefCountingPtr's operator bool() explicit

### DIFF
--- a/src/base/refcnt.hh
+++ b/src/base/refcnt.hh
@@ -261,7 +261,11 @@ class RefCountingPtr
     bool operator!() const { return data == 0; }
 
     /// Check if the pointer is non-empty
-    operator bool() const { return data != 0; }
+    explicit
+    operator bool() const
+    {
+        return data != 0;
+    }
 };
 
 /// Check for equality of two reference counting pointers.

--- a/src/base/refcnt.test.cc
+++ b/src/base/refcnt.test.cc
@@ -149,7 +149,7 @@ TEST(RefcntTest, BoolAndLogicalNotOperatorOverloads)
 {
     // Test bool and ! operator overloads.
     Ptr boolTest = new TestRC();
-    EXPECT_EQ(boolTest, true);
+    EXPECT_EQ(static_cast<bool>(boolTest), true);
     EXPECT_EQ(!boolTest, false);
     boolTest = NULL;
     EXPECT_FALSE(boolTest);

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -287,7 +287,11 @@ class LSQUnit
     /** Returns if there is a memory ordering violation. Value is reset upon
      * call to getMemDepViolator().
      */
-    bool violation() { return memDepViolator; }
+    bool
+    violation() const
+    {
+        return static_cast<bool>(memDepViolator);
+    }
 
     /** Returns the memory ordering violator. */
     DynInstPtr getMemDepViolator();

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -404,7 +404,7 @@ ROB::updateHead()
 
         DynInstPtr head_inst = (*head_thread);
 
-        assert(head_inst != 0);
+        assert(head_inst);
 
         if (head_inst->seqNum < lowest_num) {
             head = head_thread;


### PR DESCRIPTION
Make RefCountingPtr's boolean conversion operator (operator bool()) explicit, to avoid masking subtle programming mistakes. For example, if the programmer meant to type `if (ptr1->seqNum < ptr2->seqNum)` but accidentally typed `if (ptr1 < ptr2->seqNum)`, that mistake will pass typechecking and will manifest as a hard-to-debug runtime error. With this fix, the typo will just result in a compile-time typechecking error.

Change-Id: Ibe0f20ad4ca192d6af9273518581868e0f027058