### PR TITLE
arch-x86: raise #DE on division overflow

### DIFF
--- a/src/arch/x86/insts/static_inst.cc
+++ b/src/arch/x86/insts/static_inst.cc
@@ -38,6 +38,7 @@
 
 #include "arch/x86/insts/static_inst.hh"
 
+#include "arch/x86/faults.hh"
 #include "arch/x86/regs/segment.hh"
 #include "cpu/reg_class.hh"
 
@@ -110,7 +111,8 @@ void X86StaticInst::printSegment(std::ostream &os, int segment)
 
 void
 X86StaticInst::divideStep(uint64_t dividend, uint64_t divisor,
-        uint64_t &quotient, uint64_t &remainder)
+                          uint64_t &quotient, uint64_t &remainder,
+                          Fault &fault)
 {
     // Check for divide by zero.
     assert(divisor != 0);
@@ -133,9 +135,20 @@ X86StaticInst::divideStep(uint64_t dividend, uint64_t divisor,
             divisor >>= 1;
         }
         // Decrement the remainder and increment the quotient.
-        quotient += quotientBit;
+        addCheckUnsignedOverflow(quotient, quotientBit, fault);
         remainder -= divisor;
     }
+}
+
+void
+X86StaticInst::addCheckUnsignedOverflow(uint64_t &value, uint64_t addend,
+                                        Fault &fault)
+{
+    const uint64_t new_value = value + addend;
+    if (new_value < value) {
+        fault = std::make_shared<DivideError>();
+    }
+    value = new_value;
 }
 
 void

--- a/src/arch/x86/insts/static_inst.hh
+++ b/src/arch/x86/insts/static_inst.hh
@@ -127,7 +127,11 @@ class X86StaticInst : public StaticInst
             Addr pc, const loader::SymbolTable *symtab) const override;
 
     static void divideStep(uint64_t divident, uint64_t divisor,
-            uint64_t &quotient, uint64_t &remainder);
+                           uint64_t &quotient, uint64_t &remainder,
+                           Fault &fault);
+
+    static void addCheckUnsignedOverflow(uint64_t &value, uint64_t addend,
+                                         Fault &fault);
 
     static inline uint64_t
     merge(uint64_t into, RegIndex index, uint64_t val, int size)

--- a/src/arch/x86/isa/microops/regop.isa
+++ b/src/arch/x86/isa/microops/regop.isa
@@ -633,7 +633,7 @@ let {{
             if (divisor == 0) {
                 fault = std::make_shared<DivideError>();
             } else {
-                divideStep(dividend, divisor, quotient, remainder);
+                divideStep(dividend, divisor, quotient, remainder, fault);
                 //Record the final results.
                 Remainder = remainder;
                 Quotient = quotient;
@@ -660,7 +660,7 @@ let {{
                     while (remaining && !(dividend & (1ULL << 63))) {
                         dividend = (dividend << 1) |
                             bits(SrcReg1, remaining - 1);
-                        quotient <<= 1;
+                        addCheckUnsignedOverflow(quotient, quotient, fault);
                         remaining--;
                     }
                     if (dividend & (1ULL << 63)) {
@@ -669,11 +669,12 @@ let {{
                             highBit = true;
                             dividend = (dividend << 1) |
                                 bits(SrcReg1, remaining - 1);
-                            quotient <<= 1;
+                            addCheckUnsignedOverflow(quotient, quotient,
+                                                     fault);
                             remaining--;
                         }
                         if (highBit || divisor <= dividend) {
-                            quotient++;
+                            addCheckUnsignedOverflow(quotient, 1, fault);
                             dividend -= divisor;
                         }
                     }
@@ -683,12 +684,12 @@ let {{
                     while (dividend < divisor && remaining) {
                         dividend = (dividend << 1) |
                             bits(SrcReg1, remaining - 1);
-                        quotient <<= 1;
+                        addCheckUnsignedOverflow(quotient, quotient, fault);
                         remaining--;
                     }
                     remainder = dividend;
                     //Do the division.
-                    divideStep(dividend, divisor, quotient, remainder);
+                    divideStep(dividend, divisor, quotient, remainder, fault);
                 }
             }
             //Keep track of how many bits there are still to pull in.
@@ -707,7 +708,13 @@ let {{
         '''
 
     class Divq(RdRegOp):
-        code = 'DestReg = merge(SrcReg1, dest, Quotient, dataSize);'
+        code = '''
+            if (Quotient != signedPick(Quotient, 0, dataSize)) {
+                fault = std::make_shared<DivideError>();
+            } else {
+                DestReg = merge(SrcReg1, dest, Quotient, dataSize);
+            }
+        '''
         big_code = 'DestReg = Quotient & mask(dataSize * 8);'
 
     class Divr(RdRegOp):


### PR DESCRIPTION
Fix #2730. Check for overflow when performing division. If the quotient does not fit in 8/16/32/64 bits for a 8-/16-/32-/64-bit div2 micro-op, then raise a divide error (#DE).

Change-Id: Ic06714ef9546c3542316ec3a3a74042fb613da64