### PR TITLE
mem-ruby: Expose ARM::CHI::Payload to python

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -90,6 +90,8 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
         .def("inject", &tlm::chi::TlmGenerator::Transaction::inject)
         .def_property("phase", &tlm::chi::TlmGenerator::Transaction::phase,
                       &tlm::chi::TlmGenerator::Transaction::phase)
+        .def_property_readonly("payload",
+                               &tlm::chi::TlmGenerator::Transaction::payload)
         .def_property_readonly("start",
                                &tlm::chi::TlmGenerator::Transaction::start);
 }


### PR DESCRIPTION
This can be useful to extract the attributes of a transaction stored in the payload (like the transaction address)

Change-Id: I86ea0402ef734ae6c13aaf8364541e84664fe435