### PR TITLE
cpu-kvm: added support for hosts with larger page size

### DIFF
--- a/src/cpu/kvm/vm.cc
+++ b/src/cpu/kvm/vm.cc
@@ -442,6 +442,7 @@ KvmVM::disableMemSlot(const KvmVM::MemSlot num)
     if (slot.active)
         setUserMemoryRegion(num.num, NULL, 0, 0, 0);
     slot.active = false;
+    _slotPad.erase(num.num);
 }
 
 void
@@ -457,23 +458,62 @@ KvmVM::setUserMemoryRegion(uint32_t slot,
                            void *host_addr, Addr guest_addr,
                            uint64_t len, uint32_t flags)
 {
-    struct kvm_userspace_memory_region m;
+    const long page_sysconf = sysconf(_SC_PAGESIZE);
 
-    memset(&m, 0, sizeof(m));
+    warn_if(page_sysconf <= 0,
+            "Defaulting to 4 KiB page size for KVM alignment");
+
+    // 4096 is the most common page size
+    const size_t page_size = (page_sysconf > 0) ? (size_t)page_sysconf : 4096;
+    const uint64_t remainder = len % page_size;
+
+    void *padded_host = nullptr;
+    uint64_t mapped_len = len;
+
+    if (remainder != 0) {
+        const uint64_t new_len = len + (page_size - remainder);
+
+        int ret_code = posix_memalign(&padded_host, page_size, new_len);
+        if (ret_code != 0 || !padded_host) {
+            panic("KVM: Failed to allocate padded buffer of size 0x%llx\n",
+                  (unsigned long long)new_len);
+        }
+
+        if (host_addr) {
+            std::memcpy(padded_host, host_addr, len);
+        }
+
+        std::memset(static_cast<char *>(padded_host) + len, 0, new_len - len);
+
+        host_addr = padded_host;
+        mapped_len = new_len;
+
+        _slotPad[slot].reset(padded_host);
+
+        DPRINTF(Kvm,
+                "Padding memslot %u from 0x%llx to 0x%llx bytes "
+                "(host page 0x%zx)\n",
+                slot, (unsigned long long)len, (unsigned long long)mapped_len,
+                page_size);
+    }
+
+    struct kvm_userspace_memory_region m;
+    std::memset(&m, 0, sizeof(m));
     m.slot = slot;
     m.flags = flags;
     m.guest_phys_addr = (uint64_t)guest_addr;
-    m.memory_size = len;
+    m.memory_size = mapped_len;
     m.userspace_addr = (__u64)host_addr;
 
     if (ioctl(KVM_SET_USER_MEMORY_REGION, (void *)&m) == -1) {
         panic("Failed to setup KVM memory region:\n"
-              "\tHost Address: 0x%p\n"
-              "\tGuest Address: 0x%llx\n",
-              "\tSize: %ll\n",
-              "\tFlags: 0x%x\n",
-              m.userspace_addr, m.guest_phys_addr,
-              m.memory_size, m.flags);
+              "\tHost Address: 0x%llx\n"
+              "\tGuest Address: 0x%llx\n"
+              "\tSize:        0x%llx\n"
+              "\tFlags:       0x%x\n",
+              (unsigned long long)m.userspace_addr,
+              (unsigned long long)m.guest_phys_addr,
+              (unsigned long long)m.memory_size, m.flags);
     }
 }
 

--- a/src/cpu/kvm/vm.hh
+++ b/src/cpu/kvm/vm.hh
@@ -39,6 +39,7 @@
 #ifndef __CPU_KVM_KVMVM_HH__
 #define __CPU_KVM_KVMVM_HH__
 
+#include <unordered_map>
 #include <vector>
 
 #include "base/addr_range.hh"
@@ -557,6 +558,16 @@ class KvmVM : public SimObject
     };
     std::vector<MemorySlot> memorySlots;
     uint32_t maxMemorySlot;
+
+    struct Deleter
+    {
+        void
+        operator()(void *ptr) const
+        {
+            free(ptr);
+        }
+    };
+    std::unordered_map<uint32_t, std::unique_ptr<void, Deleter>> _slotPad;
 };
 
 } // namespace gem5


### PR DESCRIPTION
I really managed to screw up the commit history on [The Original PR](https://github.com/gem5/gem5/pull/2668) when trying to fix the formatting issues... Sorry about that.

On systems using large base pages (e.g. my given testbench with a Neoverse V2), KVM rejects user memory regions that are not aligned to the host page size. This causes failures when loading small regions such as theDTB, which was in my case smaller than 64 KiB.

This change pads any KVM memory region to the host page size before mapping it. The padded buffer is tracked and freed when the slot is disabled. This prevents startup failures on hosts with large page sizes without affecting behavior on 4 KiB hosts.

The current ownership tracking uses an unordered_map and an ugly struct to manage temporary padded buffers. This can probably be improved.

Here is the error that occurs without the given code:

```
src/arch/arm/fs_workload.cc:121: info: Using bootloader at address 0x10 
src/arch/arm/fs_workload.cc:139: info: Using kernel entry physical address at 0x80080000 
src/arch/arm/linux/fs_workload.cc:111: info: Loading DTB file: m5out/device.dtb at address 0x88000000 
src/cpu/kvm/vm.cc:470: panic: Failed to setup KVM memory region: 
Host Address: 0x Size: %ll 
Guest Address: 0x Flags: 0x%x 

<bad format><bad format><bad format><bad format> 
```