### PR TITLE
cpu-o3: Increase MaxWidth to 16

### DIFF
--- a/src/cpu/o3/limits.hh
+++ b/src/cpu/o3/limits.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2025 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright 2021 Google Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,7 +46,7 @@ namespace gem5
 namespace o3
 {
 
-static constexpr int MaxWidth = 12;
+static constexpr int MaxWidth = 16;
 static constexpr int MaxThreads = 4;
 
 } // namespace o3


### PR DESCRIPTION
The MaxWidth controls the maximum width of the pipeline. With cores getting bigger and bigger, there's really no harm in increasing it other than midly expanding some arrays. At the moment affected data structures are in src/cpu/o3/comm.hh and this patch increases their size by 4 * sizeof(pointer) so around 32bytes in 64bit machines


Change-Id: I90fbcf15d79658d02e708c213a93a65de89a8c65