### PR TITLE
mem-ruby: Update Ruby Network to use new-style stats

### DIFF
--- a/src/mem/ruby/network/simple/PerfectSwitch.cc
+++ b/src/mem/ruby/network/simple/PerfectSwitch.cc
@@ -306,16 +306,6 @@ PerfectSwitch::storeEventInfo(int info)
 }
 
 void
-PerfectSwitch::clearStats()
-{
-}
-void
-PerfectSwitch::collateStats()
-{
-}
-
-
-void
 PerfectSwitch::print(std::ostream& out) const
 {
     out << "[PerfectSwitch " << m_switch_id << "]";

--- a/src/mem/ruby/network/simple/PerfectSwitch.hh
+++ b/src/mem/ruby/network/simple/PerfectSwitch.hh
@@ -89,8 +89,6 @@ class PerfectSwitch : public Consumer
     void wakeup();
     void storeEventInfo(int info);
 
-    void clearStats();
-    void collateStats();
     void print(std::ostream& out) const;
 
   private:

--- a/src/mem/ruby/network/simple/SimpleNetwork.hh
+++ b/src/mem/ruby/network/simple/SimpleNetwork.hh
@@ -12,6 +12,7 @@
  * modified or unmodified, in source code or in binary form.
  *
  * Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
+ * Copyright (c) 2025 Google
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -71,8 +72,9 @@ class SimpleNetwork : public Network
     int getBufferSize() { return m_buffer_size; }
     int getEndpointBandwidth() { return m_endpoint_bandwidth; }
 
-    void collateStats();
-    void regStats();
+    void
+    collateStats()
+    {} // SimpleNetwork uses new-style stats
 
     bool isVNetOrdered(int vnet) const { return m_ordered[vnet]; }
 
@@ -110,11 +112,16 @@ class SimpleNetwork : public Network
 
     struct NetworkStats : public statistics::Group
     {
-        NetworkStats(statistics::Group *parent);
+      private:
+        SimpleNetwork *parent;
+
+      public:
+        void regStats() override; // Need to override as switches created late
+        NetworkStats(SimpleNetwork *parent);
 
         //Statistical variables
-        statistics::Formula* m_msg_counts[MessageSizeType_NUM];
-        statistics::Formula* m_msg_bytes[MessageSizeType_NUM];
+        std::vector<statistics::Formula *> m_msg_counts;
+        std::vector<statistics::Formula *> m_msg_bytes;
     } networkStats;
 };
 

--- a/src/mem/ruby/network/simple/Switch.hh
+++ b/src/mem/ruby/network/simple/Switch.hh
@@ -13,6 +13,7 @@
  *
  * Copyright (c) 2020 Inria
  * Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
+ * Copyright (c) 2025 Google
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -97,9 +98,6 @@ class Switch : public BasicRouter
                     bool is_external,
                     PortDirection dst_inport = "");
 
-    void resetStats();
-    void collateStats();
-    void regStats();
     const statistics::Formula & getMsgCount(unsigned int type) const
     { return *(switchStats.m_msg_counts[type]); }
 
@@ -134,12 +132,17 @@ class Switch : public BasicRouter
   public:
     struct SwitchStats : public statistics::Group
     {
-        SwitchStats(statistics::Group *parent);
+      private:
+        Switch *parent;
+
+      public:
+        SwitchStats(Switch *parent);
+        void regStats() override; // Need to override as throttles creates late
 
         // Statistical variables
-        statistics::Formula m_avg_utilization;
-        statistics::Formula* m_msg_counts[MessageSizeType_NUM];
-        statistics::Formula* m_msg_bytes[MessageSizeType_NUM];
+        statistics::Formula percent_links_utilized;
+        std::vector<statistics::Formula *> m_msg_counts;
+        std::vector<statistics::Formula *> m_msg_bytes;
     } switchStats;
 };
 


### PR DESCRIPTION
Ruby is one of the last places in the codebase that are still using the old way of initializing stats. This change updates the network and simple network with the new style stats.

This change also fixes a bug where the Switch stats were not reset.

There's one wrinkle. The stats can't be initialized until after ports are connected and all of the internal/external links have been created. To get around this, we override the regStats functions in the stats objects.

*User-facing changes*
- All of the modified stats now have descriptions and units