### PR TITLE
arch-x86: fix STI/CLI CR4.PVI and CPL check

### DIFF
--- a/src/arch/x86/isa/insts/general_purpose/flags/set_and_clear.py
+++ b/src/arch/x86/isa/insts/general_purpose/flags/set_and_clear.py
@@ -87,12 +87,12 @@ def macroop STI {
 
     # Check CR4.PVI
     rdcr t4, cr4, dataSize=8
-    andi t0, t4, 0x1, flags=(CEZF,)
+    andi t0, t4, 0x1, flags=(EZF,)
     fault "std::make_shared<GeneralProtection>(0)", flags=(CEZF,)
 
     # Check CPL.
     andi t4, t3, 0x3, dataSize=8
-    xori t4, t4, 0x3, dataSize=8, flags=(CEZF,)
+    xori t4, t4, 0x3, dataSize=8, flags=(EZF,)
     fault "std::make_shared<GeneralProtection>(0)", flags=(nCEZF,)
 
     #     if (RFLAGS.VIP == 1)
@@ -145,12 +145,12 @@ def macroop CLI {
 
     # Check CR4.PVI
     rdcr t4, cr4, dataSize=8
-    andi t0, t4, 0x1, flags=(CEZF,)
+    andi t0, t4, 0x1, flags=(EZF,)
     fault "std::make_shared<GeneralProtection>(0)", flags=(CEZF,)
 
     # Check CPL.
     andi t4, t3, 0x3, dataSize=8
-    xori t4, t4, 0x3, dataSize=8, flags=(CEZF,)
+    xori t4, t4, 0x3, dataSize=8, flags=(EZF,)
     fault "std::make_shared<GeneralProtection>(0)", flags=(nCEZF,)
 
     # RFLAGS.VIF = 0


### PR DESCRIPTION
The microcode implementing STI and CLI contains a typo in the flag operands of micro-ops implementing the check `CRV.PVI == 1 && CPL == 3` (`flags=(CEZF,)` instead of `flags=(EZF,)`), causing the comparison micro-ops (andi/xori) to *read* the EZF flag, rather than *write* it. This patch corrects the typo.

Change-Id: I98b44601aebe01b1f3f9791358702622f30e8d3a