### PR TITLE
arch-x86: implement FSGSBASE

### DIFF
--- a/src/arch/x86/X86ISA.py
+++ b/src/arch/x86/X86ISA.py
@@ -83,7 +83,7 @@ class X86ISA(BaseISA):
     )
     # 0000_0007h
     ExtendedFeatures = VectorParam.UInt32(
-        [0x00000000, 0x01800000, 0x00000000, 0x00000000], "feature flags"
+        [0x00000000, 0x01800001, 0x00000000, 0x00000000], "feature flags"
     )
     # 0000_000Dh - This uses ECX index, so the last entry must be all zeros
     ExtendedState = VectorParam.UInt32(

--- a/src/arch/x86/isa/decoder/two_byte_opcodes.isa
+++ b/src/arch/x86/isa/decoder/two_byte_opcodes.isa
@@ -728,14 +728,31 @@
             0x5: Inst::SHRD(Ev,Gv);
             //0x6: group15();
             0x6: decode MODRM_MOD {
-                0x3: decode MODRM_REG {
-                    0x5: BasicOperate::LFENCE({{/*Nothing*/}},
-                                              IsReadBarrier, IsSerializeAfter);
-                    0x6: BasicOperate::MFENCE({{/*Nothing*/}},
-                                              IsReadBarrier, IsWriteBarrier);
-                    0x7: BasicOperate::SFENCE({{/*Nothing*/}},
-                                              IsWriteBarrier);
-                    default: Inst::UD2();
+                0x3: decode LEGACY_REP {
+                    0x0: decode MODRM_REG {
+                        0x5: BasicOperate::LFENCE({{/*Nothing*/}},
+                                                  IsReadBarrier,
+                                                  IsSerializeAfter);
+                        0x6: BasicOperate::MFENCE({{/*Nothing*/}},
+                                                  IsReadBarrier,
+                                                  IsWriteBarrier);
+                        0x7: BasicOperate::SFENCE({{/*Nothing*/}},
+                                                  IsWriteBarrier);
+                        default: Inst::UD2();
+                    }
+                    0x1: decode MODE_MODE {
+                        0x0: decode MODE_SUBMODE {
+                            0x0: decode MODRM_REG {
+                                0x0: Inst::RDFSBASE(Rv);
+                                0x1: Inst::RDGSBASE(Rv);
+                                0x2: Inst::WRFSBASE(Rv);
+                                0x3: Inst::WRGSBASE(Rv);
+                                default: Inst::UD2();
+                            }
+                            default: Inst::UD2();
+                        }
+                        default: Inst::UD2();
+                    }
                 }
                 default: decode MODRM_REG {
                     0x0: decode OPSIZE {

--- a/src/arch/x86/isa/insts/system/segmentation.py
+++ b/src/arch/x86/isa/insts/system/segmentation.py
@@ -340,4 +340,55 @@ def macroop SWAPGS
     wrbase gs, t1, dataSize=8
     wrval kernel_gs_base, t2, dataSize=8
 };
+
+def macroop RDFSBASE_R
+{
+    # if (CR4.FSGSBASE == 0)
+    #     raise #UD;
+    limm t2, 0x10000, dataSize=8
+    rdcr t1, cr4, dataSize=8
+    and t0, t1, t2, flags=(EZF,), dataSize=8
+    fault "std::make_shared<InvalidOpcode>()", flags=(CEZF,)
+
+    rdbase reg, fs
+};
+
+def macroop RDGSBASE_R
+{
+    # if (CR4.FSGSBASE == 0)
+    #     raise #UD;
+    limm t2, 0x10000, dataSize=8
+    rdcr t1, cr4, dataSize=8
+    and t0, t1, t2, flags=(EZF,), dataSize=8
+    fault "std::make_shared<InvalidOpcode>()", flags=(CEZF,)
+
+    rdbase reg, gs
+};
+
+def macroop WRFSBASE_R
+{
+    # if (CR4.FSGSBASE == 0)
+    #     raise #UD;
+    limm t2, 0x10000, dataSize=8
+    rdcr t1, cr4, dataSize=8
+    and t0, t1, t2, flags=(EZF,), dataSize=8
+    fault "std::make_shared<InvalidOpcode>()", flags=(CEZF,)
+
+    wrbase fs, reg
+    wrval fs_eff_base, reg
+};
+
+def macroop WRGSBASE_R
+{
+    # if (CR4.FSGSBASE == 0)
+    #     raise #UD;
+    limm t2, 0x10000, dataSize=8
+    rdcr t1, cr4, dataSize=8
+    and t0, t1, t2, flags=(EZF,), dataSize=8
+    fault "std::make_shared<InvalidOpcode>()", flags=(CEZF,)
+
+    wrbase gs, reg
+    wrval gs_eff_base, reg
+};
+
 """

--- a/src/arch/x86/isa/microasm.isa
+++ b/src/arch/x86/isa/microasm.isa
@@ -180,7 +180,8 @@ let {{
 
     for reg in (('sysenter_cs', 'SysenterCs'), ('sysenter_esp', 'SysenterEsp'),
                 ('sysenter_eip', 'SysenterEip'), 'star', 'lstar', 'cstar',
-                ('sf_mask', 'SfMask'), ('kernel_gs_base', 'KernelGsBase')):
+                ('sf_mask', 'SfMask'), ('kernel_gs_base', 'KernelGsBase'),
+                ('fs_eff_base', 'FsEffBase'), ('gs_eff_base', 'GsEffBase')):
         if isinstance(reg, tuple):
             assembler.symbols[reg[0]] = ctrlRegIdx(f"misc_reg::{reg[1]}")
         else:

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -390,6 +390,7 @@ X86_64Process::initState()
             cr4.tsd = 0; // Time Stamp Disable
             cr4.pvi = 0; // Protected-Mode Virtual Interrupts
             cr4.vme = 0; // Virtual-8086 Mode Extensions
+            cr4.fsgsbase = 1; // Enable FSGSBASE instructions
 
             tc->setMiscReg(misc_reg::Cr4, cr4);
 
@@ -629,6 +630,7 @@ X86_64Process::initState()
             // Setting pcide bit in CR4
             CR4 cr4 = tc->readMiscRegNoEffect(misc_reg::Cr4);
             cr4.pcide = 1;
+            cr4.fsgsbase = 1; // Enable FSGSBASE instructions
             tc->setMiscReg(misc_reg::Cr4, cr4);
         }
     }


### PR DESCRIPTION
This patch series implements the FSGSBASE x86-64 extension. This extension allows userspace to directly read/write the bases of the `FS` and `GS` segment registers via `rdfsbase`, `rdgsbase`, `wrfsbase`, and `wrgsbase`.

The first commit implements the decode logic and microcode for the new instructions. The second commit enables the extension in syscall emulation mode. The third commit exposes the CPUID feature flag for FSGSBASE, so that full system kernels can detect presence of the feature and automatically enable it.