### PR TITLE
sim-se: handle more signals in tgkill

### DIFF
--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -2565,17 +2565,24 @@ tgkillFunc(SyscallDesc *desc, ThreadContext *tc, int tgid, int tid, int sig)
         }
     }
 
-    if (sig != 0 && sig != OS::TGT_SIGABRT)
-        return -EINVAL;
-
     if (tgt_proc == nullptr)
         return -ESRCH;
 
     if (tgid != -1 && tgt_proc->tgid() != tgid)
         return -ESRCH;
 
-    if (sig == OS::TGT_SIGABRT)
-        exitGroupFunc(desc, tc, 0);
+    switch (sig) {
+        case 0:
+            break;
+        case OS::TGT_SIGABRT:
+        case OS::TGT_SIGINT:
+        case OS::TGT_SIGTERM:
+        case OS::TGT_SIGKILL:
+            exitGroupFunc(desc, tc, 128 + sig);
+            break;
+        default:
+            return -EINVAL;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Handle SIGINT, SIGKILL, and SIGTERM in tgkill.
Also, exit with the same non-zero exit code
as signal-terminated programs on Linux hosts.

Change-Id: Ia72dc97dbe084900a52dff58ec164647c60aed94