### PR TITLE
arch-riscv: Only show RVV message when we enable it

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -314,12 +314,12 @@ ISA::ISA(const Params &p) : BaseISA(p, "riscv"),
     _regClasses.push_back(&ccRegClass);
     _regClasses.push_back(&miscRegClass);
 
-    fatal_if( p.vlen < p.elen,
-    "VLEN should be greater or equal",
-        "than ELEN. Ch. 2RISC-V vector spec.");
+    if (enableRvv) {
+        fatal_if(p.vlen < p.elen, "VLEN should be greater or equal",
+                 "than ELEN. Ch. 2RISC-V vector spec.");
 
-    inform("RVV enabled, VLEN = %d bits, ELEN = %d bits",
-            p.vlen, p.elen);
+        inform("RVV enabled, VLEN = %d bits, ELEN = %d bits", p.vlen, p.elen);
+    }
 
     miscRegFile.resize(NUM_PHYS_MISCREGS);
     clear();


### PR DESCRIPTION
Onriginally, the info message "RVV enabled, VLEN = %d bits, ELEN = %d bits" is printed unconditionally even if you set enable_rvv=false. This patch try to fix this issue.

Related issue : #2712 