### PR TITLE
systemc: Wrap `globalNameGen`, `scheduler`, `topLevelEvents` and `allEvents` inside function

### DIFF
--- a/src/systemc/channel/sc_clock.cc
+++ b/src/systemc/channel/sc_clock.cc
@@ -66,13 +66,13 @@ class ClockTick : public ScEvent
     {
         p = new Method(name.c_str(), &funcWrapper, true);
         p->dontInitialize(true);
-        scheduler.reg(p);
+        scheduler().reg(p);
     }
 
     ~ClockTick()
     {
         if (scheduled())
-            scheduler.deschedule(this);
+            scheduler().deschedule(this);
         if (p)
             p->popListNode();
     }
@@ -80,7 +80,7 @@ class ClockTick : public ScEvent
     void
     tick()
     {
-        scheduler.schedule(this, _period);
+        scheduler().schedule(this, _period);
         p->ready();
     }
 };
@@ -153,9 +153,9 @@ sc_clock::sc_clock(const char *name, double period, double duty_cycle,
 sc_clock::~sc_clock()
 {
     if (_gem5UpEdge->scheduled())
-        ::sc_gem5::scheduler.deschedule(_gem5UpEdge);
+        ::sc_gem5::scheduler().deschedule(_gem5UpEdge);
     if (_gem5DownEdge->scheduled())
-        ::sc_gem5::scheduler.deschedule(_gem5DownEdge);
+        ::sc_gem5::scheduler().deschedule(_gem5DownEdge);
     delete _gem5UpEdge;
     delete _gem5DownEdge;
 }
@@ -183,13 +183,13 @@ sc_clock::before_end_of_elaboration()
     _gem5UpEdge->createProcess();
     _gem5DownEdge->createProcess();
     if (_posedgeFirst) {
-        ::sc_gem5::scheduler.schedule(_gem5UpEdge, _startTime);
-        ::sc_gem5::scheduler.schedule(_gem5DownEdge,
-                _startTime + _period * _dutyCycle);
+        ::sc_gem5::scheduler().schedule(_gem5UpEdge, _startTime);
+        ::sc_gem5::scheduler().schedule(_gem5DownEdge,
+                                        _startTime + _period * _dutyCycle);
     } else {
-        ::sc_gem5::scheduler.schedule(_gem5DownEdge, _startTime);
-        ::sc_gem5::scheduler.schedule(_gem5UpEdge,
-                _startTime + _period * (1.0 - _dutyCycle));
+        ::sc_gem5::scheduler().schedule(_gem5DownEdge, _startTime);
+        ::sc_gem5::scheduler().schedule(
+            _gem5UpEdge, _startTime + _period * (1.0 - _dutyCycle));
     }
 }
 

--- a/src/systemc/channel/sc_mutex.cc
+++ b/src/systemc/channel/sc_mutex.cc
@@ -53,15 +53,16 @@ sc_mutex::trylock()
 {
     if (holder.valid())
         return -1;
-    holder = ::sc_gem5::scheduler.current();
+    holder = ::sc_gem5::scheduler().current();
     return 0;
 }
 
 int
 sc_mutex::unlock()
 {
-    if (holder != ::sc_gem5::scheduler.current())
+    if (holder != ::sc_gem5::scheduler().current()) {
         return -1;
+    }
 
     holder = nullptr;
     unlockEvent.notify();

--- a/src/systemc/channel/sc_signal.cc
+++ b/src/systemc/channel/sc_signal.cc
@@ -122,7 +122,7 @@ WriteChecker<sc_core::SC_ONE_WRITER>::checkPort(sc_core::sc_port_base &port,
 void
 WriteChecker<sc_core::SC_ONE_WRITER>::checkWriter()
 {
-    Process *p = scheduler.current();
+    Process *p = scheduler().current();
     if (!p)
         return;
     uint64_t stamp = getChangeStamp();
@@ -146,7 +146,7 @@ WriteChecker<sc_core::SC_MANY_WRITERS>::checkPort(sc_core::sc_port_base &port,
 void
 WriteChecker<sc_core::SC_MANY_WRITERS>::checkWriter()
 {
-    Process *p = scheduler.current();
+    Process *p = scheduler().current();
     if (!p)
         return;
     uint64_t stamp = getChangeStamp();

--- a/src/systemc/channel/sc_signal_resolved.cc
+++ b/src/systemc/channel/sc_signal_resolved.cc
@@ -48,7 +48,7 @@ void sc_signal_resolved::register_port(sc_port_base &, const char *) {}
 void
 sc_signal_resolved::write(const sc_dt::sc_logic &l)
 {
-    ::sc_gem5::Process *p = ::sc_gem5::scheduler.current();
+    ::sc_gem5::Process *p = ::sc_gem5::scheduler().current();
 
     auto it = inputs.find(p);
     if (it == inputs.end()) {

--- a/src/systemc/core/channel.cc
+++ b/src/systemc/core/channel.cc
@@ -46,13 +46,13 @@ Channel::~Channel()
 void
 Channel::requestUpdate()
 {
-    scheduler.requestUpdate(this);
+    scheduler().requestUpdate(this);
 }
 
 void
 Channel::asyncRequestUpdate()
 {
-    scheduler.asyncRequestUpdate(this);
+    scheduler().asyncRequestUpdate(this);
 }
 
 std::set<Channel *> allChannels;

--- a/src/systemc/core/event.cc
+++ b/src/systemc/core/event.cc
@@ -96,7 +96,7 @@ Event::Event(sc_core::sc_event *_sc_event, const char *_basename_cstr,
     parent = internal ? nullptr : pickParentObj();
 
     if (internal) {
-        _basename = globalNameGen.gen(_basename);
+        _basename = globalNameGen().gen(_basename);
         _name = _basename;
     } else {
         std::string original_name = _basename;

--- a/src/systemc/core/event.cc
+++ b/src/systemc/core/event.cc
@@ -75,8 +75,19 @@ std::shared_mutex globalEventLock;
 
 } // anonymous namespace
 
-Events topLevelEvents;
-Events allEvents;
+Events &
+topLevelEvents()
+{
+    static Events topLevelEvents;
+    return topLevelEvents;
+}
+
+Events &
+allEvents()
+{
+    static Events allEvents;
+    return allEvents;
+}
 
 Event::Event(sc_core::sc_event *_sc_event, bool internal) :
     Event(_sc_event, nullptr, internal)
@@ -106,7 +117,7 @@ Event::Event(sc_core::sc_event *_sc_event, const char *_basename_cstr,
             Object *obj = Object::getFromScObject(parent);
             obj->addChildEvent(_sc_event);
         } else {
-            addEvent(&topLevelEvents, _sc_event);
+            addEvent(&topLevelEvents(), _sc_event);
         }
 
         std::string path = parent ? (std::string(parent->name()) + ".") : "";
@@ -122,7 +133,7 @@ Event::Event(sc_core::sc_event *_sc_event, const char *_basename_cstr,
         _name = path + _basename;
     }
 
-    addEvent(&allEvents, _sc_event);
+    addEvent(&allEvents(), _sc_event);
 
     // Determine if we're in the hierarchy (created once initialization starts
     // means no).
@@ -136,10 +147,10 @@ Event::~Event()
         Object *obj = Object::getFromScObject(parent);
         obj->delChildEvent(_sc_event);
     } else if (inHierarchy()) {
-        popEvent(&topLevelEvents, _name);
+        popEvent(&topLevelEvents(), _name);
     }
 
-    popEvent(&allEvents, _name);
+    popEvent(&allEvents(), _name);
 
     if (delayedNotify.scheduled())
         scheduler().deschedule(&delayedNotify);
@@ -251,7 +262,7 @@ Event::clearParent()
         return;
     Object::getFromScObject(parent)->delChildEvent(_sc_event);
     parent = nullptr;
-    addEvent(&topLevelEvents, _sc_event);
+    addEvent(&topLevelEvents(), _sc_event);
 }
 
 sc_core::sc_event *
@@ -259,8 +270,8 @@ findEvent(const char *name)
 {
     [[maybe_unused]] std::shared_lock lock(globalEventLock);
 
-    EventsIt it = findEventIn(allEvents, name);
-    return it == allEvents.end() ? nullptr : *it;
+    EventsIt it = findEventIn(allEvents(), name);
+    return it == allEvents().end() ? nullptr : *it;
 }
 
 } // namespace sc_gem5

--- a/src/systemc/core/event.cc
+++ b/src/systemc/core/event.cc
@@ -142,7 +142,7 @@ Event::~Event()
     popEvent(&allEvents, _name);
 
     if (delayedNotify.scheduled())
-        scheduler.deschedule(&delayedNotify);
+        scheduler().deschedule(&delayedNotify);
 }
 
 const std::string &
@@ -193,14 +193,15 @@ Event::notify(DynamicSensitivities &senses)
 void
 Event::notify()
 {
-    if (scheduler.inUpdate())
+    if (scheduler().inUpdate()) {
         SC_REPORT_ERROR(sc_core::SC_ID_IMMEDIATE_NOTIFICATION_, "");
+    }
 
     // An immediate notification overrides any pending delayed notification.
     if (delayedNotify.scheduled())
-        scheduler.deschedule(&delayedNotify);
+        scheduler().deschedule(&delayedNotify);
 
-    _triggeredStamp = scheduler.changeStamp();
+    _triggeredStamp = scheduler().changeStamp();
     notify(staticSenseMethod);
     notify(dynamicSenseMethod);
     notify(staticSenseThread);
@@ -211,12 +212,13 @@ void
 Event::notify(const sc_core::sc_time &t)
 {
     if (delayedNotify.scheduled()) {
-        if (scheduler.delayed(t) >= delayedNotify.when())
+        if (scheduler().delayed(t) >= delayedNotify.when()) {
             return;
+        }
 
-        scheduler.deschedule(&delayedNotify);
+        scheduler().deschedule(&delayedNotify);
     }
-    scheduler.schedule(&delayedNotify, t);
+    scheduler().schedule(&delayedNotify, t);
 }
 
 void
@@ -231,13 +233,13 @@ void
 Event::cancel()
 {
     if (delayedNotify.scheduled())
-        scheduler.deschedule(&delayedNotify);
+        scheduler().deschedule(&delayedNotify);
 }
 
 bool
 Event::triggered() const
 {
-    return _triggeredStamp == scheduler.changeStamp();
+    return _triggeredStamp == scheduler().changeStamp();
 }
 
 void

--- a/src/systemc/core/event.hh
+++ b/src/systemc/core/event.hh
@@ -158,8 +158,8 @@ class Event
     mutable DynamicSensitivities dynamicSenseThread;
 };
 
-extern Events topLevelEvents;
-extern Events allEvents;
+Events &topLevelEvents();
+Events &allEvents();
 
 sc_core::sc_event *findEvent(const char *name);
 

--- a/src/systemc/core/kernel.cc
+++ b/src/systemc/core/kernel.cc
@@ -59,7 +59,7 @@ Kernel::Kernel(const Params &params, int) :
     t0Event(*this, false, gem5::EventBase::Default_Pri - 1)
 {
     // Install ourselves as the scheduler's event manager.
-    ::sc_gem5::scheduler.setEventQueue(eventQueue());
+    ::sc_gem5::scheduler().setEventQueue(eventQueue());
 }
 
 void
@@ -79,7 +79,7 @@ Kernel::init()
     for (auto c: sc_gem5::allChannels)
         c->sc_chan()->before_end_of_elaboration();
 
-    ::sc_gem5::scheduler.elaborationDone(true);
+    ::sc_gem5::scheduler().elaborationDone(true);
 }
 
 void
@@ -104,7 +104,7 @@ Kernel::regStats()
         for (auto c: sc_gem5::allChannels)
             c->sc_chan()->end_of_elaboration();
     } catch (...) {
-        ::sc_gem5::scheduler.throwUp();
+        ::sc_gem5::scheduler().throwUp();
     }
 }
 
@@ -128,7 +128,7 @@ Kernel::startup()
         for (auto c: sc_gem5::allChannels)
             c->sc_chan()->start_of_simulation();
     } catch (...) {
-        ::sc_gem5::scheduler.throwUp();
+        ::sc_gem5::scheduler().throwUp();
     }
 
     startComplete = true;
@@ -160,7 +160,7 @@ Kernel::stopWork()
         for (auto c: sc_gem5::allChannels)
             c->sc_chan()->end_of_simulation();
     } catch (...) {
-        ::sc_gem5::scheduler.throwUp();
+        ::sc_gem5::scheduler().throwUp();
     }
 
     endComplete = true;
@@ -172,11 +172,11 @@ void
 Kernel::t0Handler()
 {
     if (stopAfterCallbacks) {
-        scheduler.clear();
-        ::sc_gem5::scheduler.initPhase();
-        scheduler.scheduleStop(false);
+        scheduler().clear();
+        ::sc_gem5::scheduler().initPhase();
+        scheduler().scheduleStop(false);
     } else {
-        ::sc_gem5::scheduler.initPhase();
+        ::sc_gem5::scheduler().initPhase();
         status(::sc_core::SC_RUNNING);
     }
 }

--- a/src/systemc/core/module.cc
+++ b/src/systemc/core/module.cc
@@ -46,7 +46,12 @@ Module *_new_module;
 
 } // anonymous namespace
 
-UniqueNameGen globalNameGen;
+UniqueNameGen &
+globalNameGen()
+{
+    static UniqueNameGen globalNameGen;
+    return globalNameGen;
+};
 
 Module::Module(const char *name) :
     _name(name), _sc_mod(nullptr), _obj(nullptr), _ended(false),

--- a/src/systemc/core/module.hh
+++ b/src/systemc/core/module.hh
@@ -66,7 +66,7 @@ class UniqueNameGen
     }
 };
 
-extern UniqueNameGen globalNameGen;
+UniqueNameGen &globalNameGen();
 
 class Module
 {

--- a/src/systemc/core/object.cc
+++ b/src/systemc/core/object.cc
@@ -293,8 +293,9 @@ pickUniqueName(::sc_core::sc_object *parent, std::string base)
         return Object::getFromScObject(parent)->pickUniqueName(base);
 
     std::string seed = base;
-    while (!nameIsUnique(&topLevelObjects, &topLevelEvents, base))
+    while (!nameIsUnique(&topLevelObjects, &topLevelEvents(), base)) {
         base = ::sc_core::sc_gen_unique_name(seed.c_str());
+    }
 
     return base;
 }

--- a/src/systemc/core/object.cc
+++ b/src/systemc/core/object.cc
@@ -320,7 +320,7 @@ pickParentObj()
     if (!objParentStack.empty())
         return objParentStack.top();
 
-    Process *p = scheduler.current();
+    Process *p = scheduler().current();
     if (p)
         return p;
 

--- a/src/systemc/core/process.cc
+++ b/src/systemc/core/process.cc
@@ -81,15 +81,15 @@ Process::suspend(bool inc_kids)
 
     if (!_suspended && !_terminated) {
         _suspended = true;
-        _suspendedReady = scheduler.suspend(this);
+        _suspendedReady = scheduler().suspend(this);
 
         if (procKind() != ::sc_core::SC_METHOD_PROC_ &&
-                scheduler.current() == this) {
+            scheduler().current() == this) {
             // This isn't in the spec, but Accellera says that a thread that
             // self suspends should be marked ready immediately when it's
             // resumed.
             _suspendedReady = true;
-            scheduler.yield();
+            scheduler().yield();
         }
     }
 }
@@ -103,7 +103,7 @@ Process::resume(bool inc_kids)
     if (_suspended && !_terminated) {
         _suspended = false;
         if (_suspendedReady)
-            scheduler.resume(this);
+            scheduler().resume(this);
         _suspendedReady = false;
     }
 }
@@ -187,7 +187,7 @@ Process::reset(bool inc_kids)
     _resetEvent.notify();
 
     if (_needsStart) {
-        scheduler.runNow(this);
+        scheduler().runNow(this);
     } else {
         _isUnwinding = true;
         injectException(resetException);
@@ -216,7 +216,7 @@ void
 Process::injectException(ExceptionWrapperBase &exc)
 {
     excWrapper = &exc;
-    scheduler.runNow(this);
+    scheduler().runNow(this);
 };
 
 void
@@ -248,7 +248,7 @@ Process::signalReset(bool set, bool sync)
             asyncResetCount++;
             cancelTimeout();
             clearDynamic();
-            scheduler.runNext(this);
+            scheduler().runNext(this);
         }
     } else {
         if (sync)
@@ -304,14 +304,14 @@ void
 Process::cancelTimeout()
 {
     if (timeoutEvent.scheduled())
-        scheduler.deschedule(&timeoutEvent);
+        scheduler().deschedule(&timeoutEvent);
 }
 
 void
 Process::setTimeout(::sc_core::sc_time t)
 {
     cancelTimeout();
-    scheduler.schedule(&timeoutEvent, t);
+    scheduler().schedule(&timeoutEvent, t);
 }
 
 void
@@ -359,7 +359,7 @@ Process::ready()
     if (suspended())
         _suspendedReady = true;
     else if (!scheduled())
-        scheduler.ready(this);
+        scheduler().ready(this);
 }
 
 void

--- a/src/systemc/core/process_types.hh
+++ b/src/systemc/core/process_types.hh
@@ -94,11 +94,11 @@ class Thread : public Process
                 thread->run();
             } catch (...) {
                 thread->terminate();
-                scheduler.throwUp();
+                scheduler().throwUp();
                 return;
             }
             thread->terminate();
-            scheduler.yield();
+            scheduler().yield();
         }
     };
     friend class Context;

--- a/src/systemc/core/sc_event.cc
+++ b/src/systemc/core/sc_event.cc
@@ -402,7 +402,7 @@ sc_event::sc_event(bool, const char *_name) :
 const std::vector<sc_event *> &
 sc_get_top_level_events()
 {
-    return ::sc_gem5::topLevelEvents;
+    return ::sc_gem5::topLevelEvents();
 }
 
 sc_event *

--- a/src/systemc/core/sc_export.cc
+++ b/src/systemc/core/sc_export.cc
@@ -59,8 +59,9 @@ sc_export_base::sc_export_base(const char *n) : sc_object(n)
         reportError(SC_ID_INSERT_EXPORT_, "simulation running",
                 name(), kind());
     }
-    if (::sc_gem5::scheduler.elaborationDone())
+    if (::sc_gem5::scheduler().elaborationDone()) {
         reportError(SC_ID_INSERT_EXPORT_, "elaboration done", name(), kind());
+    }
 
     auto m = sc_gem5::pickParentModule();
     if (!m)

--- a/src/systemc/core/sc_main.cc
+++ b/src/systemc/core/sc_main.cc
@@ -59,7 +59,7 @@ sc_argv()
 void
 sc_start()
 {
-    gem5::Tick now = ::sc_gem5::scheduler.getCurTick();
+    gem5::Tick now = ::sc_gem5::scheduler().getCurTick();
     sc_start(sc_time::from_value(gem5::MaxTick - now), SC_EXIT_ON_STARVATION);
 }
 
@@ -67,19 +67,19 @@ void
 sc_pause()
 {
     if (::sc_gem5::Kernel::status() == SC_RUNNING)
-        ::sc_gem5::scheduler.schedulePause();
+        ::sc_gem5::scheduler().schedulePause();
 }
 
 void
 sc_start(const sc_time &time, sc_starvation_policy p)
 {
     if (time.value() == 0) {
-        ::sc_gem5::scheduler.oneCycle();
+        ::sc_gem5::scheduler().oneCycle();
     } else {
-        gem5::Tick now = ::sc_gem5::scheduler.getCurTick();
+        gem5::Tick now = ::sc_gem5::scheduler().getCurTick();
         if (gem5::MaxTick - now < time.value())
             SC_REPORT_ERROR(SC_ID_SIMULATION_TIME_OVERFLOW_, "");
-        ::sc_gem5::scheduler.start(now + time.value(), p == SC_RUN_TO_TIME);
+        ::sc_gem5::scheduler().start(now + time.value(), p == SC_RUN_TO_TIME);
     }
 }
 
@@ -117,7 +117,7 @@ sc_stop()
 
     if ((sc_get_status() & SC_RUNNING)) {
         bool finish_delta = (_stop_mode == SC_STOP_FINISH_DELTA);
-        ::sc_gem5::scheduler.scheduleStop(finish_delta);
+        ::sc_gem5::scheduler().scheduleStop(finish_delta);
     } else {
         ::sc_gem5::Kernel::stop();
     }
@@ -127,14 +127,14 @@ const sc_time &
 sc_time_stamp()
 {
     static sc_time tstamp(1.0, SC_SEC);
-    tstamp = sc_time::from_value(::sc_gem5::scheduler.getCurTick());
+    tstamp = sc_time::from_value(::sc_gem5::scheduler().getCurTick());
     return tstamp;
 }
 
 sc_dt::uint64
 sc_delta_count()
 {
-    return sc_gem5::scheduler.numCycles();
+    return sc_gem5::scheduler().numCycles();
 }
 
 bool
@@ -146,13 +146,13 @@ sc_is_running()
 bool
 sc_pending_activity_at_current_time()
 {
-    return ::sc_gem5::scheduler.pendingCurr();
+    return ::sc_gem5::scheduler().pendingCurr();
 }
 
 bool
 sc_pending_activity_at_future_time()
 {
-    return ::sc_gem5::scheduler.pendingFuture();
+    return ::sc_gem5::scheduler().pendingFuture();
 }
 
 bool
@@ -165,7 +165,7 @@ sc_pending_activity()
 sc_time
 sc_time_to_pending_activity()
 {
-    return sc_time::from_value(::sc_gem5::scheduler.timeToPending());
+    return sc_time::from_value(::sc_gem5::scheduler().timeToPending());
 }
 
 sc_status

--- a/src/systemc/core/sc_main_fiber.cc
+++ b/src/systemc/core/sc_main_fiber.cc
@@ -71,7 +71,7 @@ ScMainFiber::main()
             reportHandlerProc(reportifyException(),
                     ::sc_core::sc_report_handler::get_catch_actions());
         }
-        scheduler.clear();
+        scheduler().clear();
     } else {
         // If python tries to call sc_main but no sc_main was defined...
         fatal("sc_main called but not defined.\n");

--- a/src/systemc/core/sc_module.cc
+++ b/src/systemc/core/sc_module.cc
@@ -61,7 +61,7 @@ newMethodProcess(const char *name, ProcessFuncWrapper *func)
                 name.c_str());
         return nullptr;
     }
-    scheduler.reg(p);
+    scheduler().reg(p);
     return p;
 }
 
@@ -76,7 +76,7 @@ newThreadProcess(const char *name, ProcessFuncWrapper *func)
                 name.c_str());
         return nullptr;
     }
-    scheduler.reg(p);
+    scheduler().reg(p);
     return p;
 }
 
@@ -91,7 +91,7 @@ newCThreadProcess(const char *name, ProcessFuncWrapper *func)
                 name.c_str());
         return nullptr;
     }
-    scheduler.reg(p);
+    scheduler().reg(p);
     p->dontInitialize(true);
     return p;
 }
@@ -259,8 +259,9 @@ sc_module::sc_module() :
 {
     if (sc_is_running())
         SC_REPORT_ERROR(SC_ID_INSERT_MODULE_, "simulation running");
-    if (::sc_gem5::scheduler.elaborationDone())
+    if (::sc_gem5::scheduler().elaborationDone()) {
         SC_REPORT_ERROR(SC_ID_INSERT_MODULE_, "elaboration done");
+    }
 }
 
 sc_module::sc_module(const sc_module_name &) : sc_module() {}
@@ -537,7 +538,7 @@ sc_module::at_negedge(const sc_signal_in_if<sc_dt::sc_logic> &s)
 void
 next_trigger()
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->cancelTimeout();
     p->clearDynamic();
 }
@@ -545,7 +546,7 @@ next_trigger()
 void
 next_trigger(const sc_event &e)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->cancelTimeout();
     ::sc_gem5::newDynamicSensitivityEvent(p, &e);
 }
@@ -553,7 +554,7 @@ next_trigger(const sc_event &e)
 void
 next_trigger(const sc_event_or_list &eol)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->cancelTimeout();
     ::sc_gem5::newDynamicSensitivityEventOrList(p, &eol);
 }
@@ -561,7 +562,7 @@ next_trigger(const sc_event_or_list &eol)
 void
 next_trigger(const sc_event_and_list &eal)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->cancelTimeout();
     ::sc_gem5::newDynamicSensitivityEventAndList(p, &eal);
 }
@@ -569,7 +570,7 @@ next_trigger(const sc_event_and_list &eal)
 void
 next_trigger(const sc_time &t)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->setTimeout(t);
     p->clearDynamic();
 }
@@ -583,7 +584,7 @@ next_trigger(double d, sc_time_unit u)
 void
 next_trigger(const sc_time &t, const sc_event &e)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->setTimeout(t);
     ::sc_gem5::newDynamicSensitivityEvent(p, &e);
 }
@@ -597,7 +598,7 @@ next_trigger(double d, sc_time_unit u, const sc_event &e)
 void
 next_trigger(const sc_time &t, const sc_event_or_list &eol)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->setTimeout(t);
     ::sc_gem5::newDynamicSensitivityEventOrList(p, &eol);
 }
@@ -611,7 +612,7 @@ next_trigger(double d, sc_time_unit u, const sc_event_or_list &eol)
 void
 next_trigger(const sc_time &t, const sc_event_and_list &eal)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->setTimeout(t);
     ::sc_gem5::newDynamicSensitivityEventAndList(p, &eal);
 }
@@ -625,7 +626,7 @@ next_trigger(double d, sc_time_unit u, const sc_event_and_list &eal)
 bool
 timed_out()
 {
-    ::sc_gem5::Process *p = sc_gem5::scheduler.current();
+    ::sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (!p)
         return false;
     else
@@ -652,12 +653,12 @@ waitErrorCheck(sc_gem5::Process *p)
 void
 wait()
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->cancelTimeout();
     p->clearDynamic();
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
@@ -667,7 +668,7 @@ wait(int n)
         std::string msg = gem5::csprintf("n = %d", n);
         SC_REPORT_ERROR(SC_ID_WAIT_N_INVALID_, msg.c_str());
     }
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     p->waitCount(n - 1);
     wait();
 }
@@ -675,45 +676,45 @@ wait(int n)
 void
 wait(const sc_event &e)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->cancelTimeout();
     ::sc_gem5::newDynamicSensitivityEvent(p, &e);
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
 wait(const sc_event_or_list &eol)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->cancelTimeout();
     ::sc_gem5::newDynamicSensitivityEventOrList(p, &eol);
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
 wait(const sc_event_and_list &eal)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->cancelTimeout();
     ::sc_gem5::newDynamicSensitivityEventAndList(p, &eal);
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
 wait(const sc_time &t)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->setTimeout(t);
     p->clearDynamic();
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
@@ -725,12 +726,12 @@ wait(double d, sc_time_unit u)
 void
 wait(const sc_time &t, const sc_event &e)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->setTimeout(t);
     ::sc_gem5::newDynamicSensitivityEvent(p, &e);
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
@@ -742,12 +743,12 @@ wait(double d, sc_time_unit u, const sc_event &e)
 void
 wait(const sc_time &t, const sc_event_or_list &eol)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->setTimeout(t);
     ::sc_gem5::newDynamicSensitivityEventOrList(p, &eol);
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
@@ -759,12 +760,12 @@ wait(double d, sc_time_unit u, const sc_event_or_list &eol)
 void
 wait(const sc_time &t, const sc_event_and_list &eal)
 {
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (waitErrorCheck(p))
         return;
     p->setTimeout(t);
     ::sc_gem5::newDynamicSensitivityEventAndList(p, &eal);
-    sc_gem5::scheduler.yield();
+    sc_gem5::scheduler().yield();
 }
 
 void
@@ -828,7 +829,7 @@ sc_gen_unique_name(const char *seed)
     if (mod)
         return mod->uniqueName(seed);
 
-    sc_gem5::Process *p = sc_gem5::scheduler.current();
+    sc_gem5::Process *p = sc_gem5::scheduler().current();
     if (p)
         return p->uniqueName(seed);
 

--- a/src/systemc/core/sc_module.cc
+++ b/src/systemc/core/sc_module.cc
@@ -832,7 +832,7 @@ sc_gen_unique_name(const char *seed)
     if (p)
         return p->uniqueName(seed);
 
-    return ::sc_gem5::globalNameGen.gen(seed);
+    return ::sc_gem5::globalNameGen().gen(seed);
 }
 
 bool

--- a/src/systemc/core/sc_module_name.cc
+++ b/src/systemc/core/sc_module_name.cc
@@ -36,16 +36,18 @@
 namespace sc_core
 {
 
+// clang-format off
 sc_module_name::sc_module_name(const char *name) :
     _name(name), _gem5_module(nullptr), _on_the_stack(true)
 {
     if (sc_is_running())
         SC_REPORT_ERROR(SC_ID_INSERT_MODULE_, "simulation running");
-    else if (::sc_gem5::scheduler.elaborationDone())
+    else if (::sc_gem5::scheduler().elaborationDone())
         SC_REPORT_ERROR(SC_ID_INSERT_MODULE_, "elaboration done");
     else
         _gem5_module = new sc_gem5::Module(name);
 }
+// clang-format on
 
 sc_module_name::sc_module_name(const sc_module_name &other) :
     _name(other._name), _gem5_module(other._gem5_module), _on_the_stack(false)

--- a/src/systemc/core/sc_port.cc
+++ b/src/systemc/core/sc_port.cc
@@ -63,7 +63,7 @@ sc_port_base::sc_port_base(const char *n, int max_size, sc_port_policy p) :
         reportError(SC_ID_INSERT_PORT_, "simulation running",
                 name(), kind());
     }
-    if (::sc_gem5::scheduler.elaborationDone()) {
+    if (::sc_gem5::scheduler().elaborationDone()) {
         reportError(SC_ID_INSERT_PORT_, "elaboration done",
                 name(), kind());
     }

--- a/src/systemc/core/sc_prim.cc
+++ b/src/systemc/core/sc_prim.cc
@@ -34,7 +34,11 @@
 namespace sc_gem5
 {
 
-uint64_t getChangeStamp() { return scheduler.changeStamp(); }
+uint64_t
+getChangeStamp()
+{
+    return scheduler().changeStamp();
+}
 
 } // namespace sc_gem5
 
@@ -46,7 +50,7 @@ sc_prim_channel::sc_prim_channel() : _gem5_channel(nullptr)
     if (sc_is_running()) {
         SC_REPORT_ERROR(SC_ID_INSERT_PRIM_CHANNEL_, "simulation running");
     }
-    if (::sc_gem5::scheduler.elaborationDone()) {
+    if (::sc_gem5::scheduler().elaborationDone()) {
         SC_REPORT_ERROR(SC_ID_INSERT_PRIM_CHANNEL_, "elaboration done");
     }
     _gem5_channel = new sc_gem5::Channel(this);
@@ -58,7 +62,7 @@ sc_prim_channel::sc_prim_channel(const char *_name) :
     if (sc_is_running()) {
         SC_REPORT_ERROR(SC_ID_INSERT_PRIM_CHANNEL_, "simulation running");
     }
-    if (::sc_gem5::scheduler.elaborationDone()) {
+    if (::sc_gem5::scheduler().elaborationDone()) {
         SC_REPORT_ERROR(SC_ID_INSERT_PRIM_CHANNEL_, "elaboration done");
     }
     _gem5_channel = new sc_gem5::Channel(this);

--- a/src/systemc/core/sc_process_handle.cc
+++ b/src/systemc/core/sc_process_handle.cc
@@ -57,7 +57,7 @@ sc_unwind_exception::~sc_unwind_exception() throw() {}
 void
 sc_set_location(const char *file, int lineno)
 {
-    sc_process_b *current = ::sc_gem5::scheduler.current();
+    sc_process_b *current = ::sc_gem5::scheduler().current();
     if (!current)
         return;
     current->file = file;
@@ -68,9 +68,8 @@ sc_set_location(const char *file, int lineno)
 sc_process_b *
 sc_get_curr_process_handle()
 {
-    return ::sc_gem5::scheduler.current();
+    return ::sc_gem5::scheduler().current();
 }
-
 
 sc_process_handle::sc_process_handle() : _gem5_process(nullptr) {}
 
@@ -312,7 +311,7 @@ sc_process_handle
 sc_get_current_process_handle()
 {
     if (sc_is_running())
-        return sc_process_handle(::sc_gem5::scheduler.current());
+        return sc_process_handle(::sc_gem5::scheduler().current());
     else
         return sc_process_handle(::sc_gem5::Process::newest());
 }

--- a/src/systemc/core/sc_simcontext.cc
+++ b/src/systemc/core/sc_simcontext.cc
@@ -49,7 +49,7 @@ void sc_simcontext::reset() { objIndex = 0; }
 sc_curr_proc_handle
 sc_simcontext::get_curr_proc_info()
 {
-    ::sc_gem5::Process *p = ::sc_gem5::scheduler.current();
+    ::sc_gem5::Process *p = ::sc_gem5::scheduler().current();
     currProcInfo.process_handle = p;
     currProcInfo.kind = p ? p->procKind() : SC_NO_PROC_;
     return &currProcInfo;
@@ -78,7 +78,7 @@ sc_simcontext::next_object()
 bool
 sc_simcontext::elaboration_done()
 {
-    return ::sc_gem5::scheduler.elaborationDone();
+    return ::sc_gem5::scheduler().elaborationDone();
 }
 
 sc_simcontext *

--- a/src/systemc/core/sc_spawn.cc
+++ b/src/systemc/core/sc_spawn.cc
@@ -108,7 +108,7 @@ spawnWork(ProcessFuncWrapper *func, const char *name,
                 proc->name());
     }
 
-    scheduler.reg(proc);
+    scheduler().reg(proc);
 
     return proc;
 }

--- a/src/systemc/core/sched_event.cc
+++ b/src/systemc/core/sched_event.cc
@@ -35,7 +35,7 @@ namespace sc_gem5
 ScEvent::~ScEvent()
 {
     if (scheduled())
-        scheduler.deschedule(this);
+        scheduler().deschedule(this);
 }
 
 } // namespace sc_gem5

--- a/src/systemc/core/scheduler.cc
+++ b/src/systemc/core/scheduler.cc
@@ -491,8 +491,18 @@ Scheduler::trace(bool delta)
         tf->trace(delta);
 }
 
-Scheduler scheduler;
-Process *getCurrentProcess() { return scheduler.current(); }
+Scheduler &
+scheduler()
+{
+    static Scheduler s;
+    return s;
+}
+
+Process *
+getCurrentProcess()
+{
+    return scheduler().current();
+}
 
 namespace {
 

--- a/src/systemc/core/scheduler.hh
+++ b/src/systemc/core/scheduler.hh
@@ -540,7 +540,7 @@ class Scheduler
     void trace(bool delta);
 };
 
-extern Scheduler scheduler;
+Scheduler &scheduler();
 
 // A proxy function to avoid having to expose the scheduler in header files.
 Process *getCurrentProcess();
@@ -548,22 +548,22 @@ Process *getCurrentProcess();
 inline void
 Scheduler::TimeSlot::process()
 {
-    scheduler.stepChangeStamp();
-    scheduler.status(StatusTiming);
+    scheduler().stepChangeStamp();
+    scheduler().status(StatusTiming);
 
     try {
         while (!events.empty())
             events.front()->run();
     } catch (...) {
         if (events.empty())
-            scheduler.completeTimeSlot(this);
+            scheduler().completeTimeSlot(this);
         else
-            scheduler.schedule(this);
-        scheduler.throwUp();
+            scheduler().schedule(this);
+        scheduler().throwUp();
     }
 
-    scheduler.status(StatusOther);
-    scheduler.completeTimeSlot(this);
+    scheduler().status(StatusOther);
+    scheduler().completeTimeSlot(this);
 }
 
 const ::sc_core::sc_report reportifyException();

--- a/src/systemc/core/sensitivity.cc
+++ b/src/systemc/core/sensitivity.cc
@@ -62,7 +62,7 @@ Sensitivity::notifyWork(Event *e)
 bool
 Sensitivity::notify(Event *e)
 {
-    if (scheduler.current() == process) {
+    if (scheduler().current() == process) {
         static bool warned = false;
         if (!warned) {
             SC_REPORT_WARNING(sc_core::SC_ID_IMMEDIATE_SELF_NOTIFICATION_,

--- a/src/systemc/utils/sc_report_handler.cc
+++ b/src/systemc/utils/sc_report_handler.cc
@@ -88,10 +88,10 @@ sc_report_handler::report(sc_severity severity, const char *msg_type,
     msgInfo.checkLimits(severity, actions);
     sevInfo.checkLimit(actions);
 
-    ::sc_gem5::Process *current = ::sc_gem5::scheduler.current();
+    ::sc_gem5::Process *current = ::sc_gem5::scheduler().current();
     sc_report report(severity, msg_type, msg, verbosity, file, line,
-            sc_time::from_value(::sc_gem5::scheduler.getCurTick()),
-            current ? current->name() : nullptr, msgInfo.id);
+                     sc_time::from_value(::sc_gem5::scheduler().getCurTick()),
+                     current ? current->name() : nullptr, msgInfo.id);
 
     if (actions & SC_CACHE_REPORT) {
         if (current) {
@@ -298,7 +298,7 @@ sc_report_handler::default_handler(
     if (actions & SC_ABORT)
         sc_abort();
     if (actions & SC_THROW) {
-        ::sc_gem5::Process *current = ::sc_gem5::scheduler.current();
+        ::sc_gem5::Process *current = ::sc_gem5::scheduler().current();
         if (current)
             current->isUnwinding(false);
         throw report;
@@ -316,7 +316,7 @@ sc_report_handler::get_new_action_id()
 sc_report *
 sc_report_handler::get_cached_report()
 {
-    ::sc_gem5::Process *current = ::sc_gem5::scheduler.current();
+    ::sc_gem5::Process *current = ::sc_gem5::scheduler().current();
     if (current)
         return current->lastReport();
     return ::sc_gem5::globalReportCache.get();
@@ -325,7 +325,7 @@ sc_report_handler::get_cached_report()
 void
 sc_report_handler::clear_cached_report()
 {
-    ::sc_gem5::Process *current = ::sc_gem5::scheduler.current();
+    ::sc_gem5::Process *current = ::sc_gem5::scheduler().current();
     if (current) {
         current->lastReport(nullptr);
     } else {
@@ -392,7 +392,7 @@ sc_report_compose_message(const sc_report &report)
         gem5::ccprintf(str, "\nIn file: %s:%d", report.get_file_name(),
                  report.get_line_number());
 
-        ::sc_gem5::Process *current = ::sc_gem5::scheduler.current();
+        ::sc_gem5::Process *current = ::sc_gem5::scheduler().current();
         const char *name = report.get_process_name();
         if (current && sc_is_running() && name) {
             gem5::ccprintf(str, "\nIn process: %s @ %s", name,

--- a/src/systemc/utils/tracefile.cc
+++ b/src/systemc/utils/tracefile.cc
@@ -43,12 +43,12 @@ TraceFile::TraceFile(const std::string &name) :
     _os(gem5::simout.create(name, true, true)), timeUnitTicks(0),
     timeUnitValue(0.0), timeUnitUnit(::sc_core::SC_PS), _traceDeltas(false)
 {
-    ::sc_gem5::scheduler.registerTraceFile(this);
+    ::sc_gem5::scheduler().registerTraceFile(this);
 }
 
 TraceFile::~TraceFile()
 {
-    ::sc_gem5::scheduler.unregisterTraceFile(this);
+    ::sc_gem5::scheduler().unregisterTraceFile(this);
     gem5::simout.close(_os);
 }
 

--- a/src/systemc/utils/vcd.cc
+++ b/src/systemc/utils/vcd.cc
@@ -250,7 +250,7 @@ VcdTraceFile::initialize()
 
     stream() << "$enddefinitions  $end" << std::endl << std::endl;
 
-    gem5::Tick now = scheduler.getCurTick();
+    gem5::Tick now = scheduler().getCurTick();
 
     std::string timedump_comment =
         gem5::csprintf("All initial values are dumped below at time "
@@ -277,7 +277,7 @@ VcdTraceFile::~VcdTraceFile()
 
     if (timeUnitTicks) {
         gem5::ccprintf(stream(), "#%u\n",
-            scheduler.getCurTick() / timeUnitTicks);
+                       scheduler().getCurTick() / timeUnitTicks);
     }
 }
 
@@ -300,7 +300,7 @@ VcdTraceFile::trace(bool delta)
         return;
     }
 
-    gem5::Tick now = scheduler.getCurTick() / timeUnitTicks + deltaOffset;
+    gem5::Tick now = scheduler().getCurTick() / timeUnitTicks + deltaOffset;
 
     if (now <= lastPrintedTime) {
         // TODO warn about reversed time?


### PR DESCRIPTION
Wrap these global variables inside function to avoid global systemc modules initialization order issue