### PR TITLE
misc: multiple stats outputs with --stats-file

### DIFF
--- a/src/python/m5/main.py
+++ b/src/python/m5/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016, 2019 Arm Limited
+# Copyright (c) 2016, 2019, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -224,8 +224,9 @@ def parse_options():
     option(
         "--stats-file",
         metavar="FILE",
-        default="stats.txt",
-        help="Sets the output file for statistics [Default: %default]",
+        action="append",
+        default=[],
+        help="Append additional file for statistics output (Defaults to stats.txt if unset)",
     )
     option(
         "--stats-help",
@@ -570,7 +571,11 @@ def main():
     sys.path[0:0] = options.path
 
     # set stats options
-    stats.addStatVisitor(options.stats_file)
+    if not options.stats_file:
+        options.stats_file.append("stats.txt")
+
+    for visitor in options.stats_file:
+        stats.addStatVisitor(visitor)
 
     # Disable listeners unless running interactively or explicitly
     # enabled


### PR DESCRIPTION
This commit allows multiple stats output files to be specified using --stats-file. This is useful if for exampe we want to output statistics in multiple different formats.
For example:
"./build/ALL/gem5.opt --stats-file json://stats1.json --stats-file stats.txt test.py"
Would dump stats in both text and json formats.
If the argument isn't specified we use stats.txt as the default location for stats dumps.

Change-Id: I049b237ece3e0e89a78bfad19ca071dff8940d5c
Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>