### PR TITLE
arch-riscv: Fix an issue in generateDisassembly

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -734,9 +734,8 @@ std::string VsSegMacroInst::generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const
 {
     std::stringstream ss;
-    ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", " <<
-        '(' << registerName(srcRegIdx(0)) << ')' <<
-        ", " << registerName(srcRegIdx(1));
+    ss << mnemonic << ' ' << registerName(srcRegIdx(1)) << ", " << '('
+       << registerName(srcRegIdx(0)) << ')';
     if (!machInst.vm)
         ss << ", v0.t";
     return ss.str();


### PR DESCRIPTION
When we try to disassemble the instruction `vsseg2e64` in gem5, the gem5 will try to dereference a null pointer. This patch fixed the null pointer dereference issue in `VsSegMacroInst::generateDisassembly`. Ensure that the disassembled output matches the output of objdump.

The output of objdump : `vsseg2e64.v     v2,(a2)`
The output of gem5 : `vsseg2e64_v v2, (a2)`

related issue : #2758  
