### PR TITLE
arch-x86: Fix assertion due to clflush in DataTranslation::finish

### DIFF
--- a/src/arch/x86/tlb.cc
+++ b/src/arch/x86/tlb.cc
@@ -578,12 +578,13 @@ TLB::translateTiming(const RequestPtr &req, ThreadContext *tc,
     bool delayedResponse;
     assert(translation);
     // CLFLUSHOPT/WB/FLUSH should be treated as read for protection checks
+    BaseMMU::Mode orig_mode = mode;
     if (req->isCacheClean())
         mode = BaseMMU::Read;
     Fault fault =
         TLB::translate(req, tc, translation, mode, delayedResponse, true);
     if (!delayedResponse)
-        translation->finish(fault, req, tc, mode);
+        translation->finish(fault, req, tc, orig_mode);
     else
         translation->markDelayed();
 }


### PR DESCRIPTION
CLFLUSHOPT/WB/FLUSH are treated as reads to avoid page faults when done on write-protected pages. This results in an assertion when `translateTiming `calls `translation->finish` as it expects the `mode `to be consistent with `state->mode`. To fix this keep original mode and pass that to finish function

related PR: [#1080](https://github.com/gem5/gem5/pull/1080)