### PR TITLE
stats: Add lastCommitPC to ThreadStateStats

### DIFF
--- a/src/cpu/minor/execute.cc
+++ b/src/cpu/minor/execute.cc
@@ -881,6 +881,7 @@ Execute::doInstCommitAccounting(MinorDynInstPtr inst)
     {
         thread->numInst++;
         thread->threadStats.numInsts++;
+        thread->threadStats.lastCommitPC = inst->pc->instAddr();
         cpu.commitStats[tid]->numInsts++;
         cpu.executeStats[tid]->numInsts++;
         cpu.baseStats.numInsts++;

--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -1159,6 +1159,7 @@ CPU::instDone(ThreadID tid, const DynInstPtr &inst)
     if (!inst->isMicroop() || inst->isLastMicroop()) {
         thread[tid]->numInst++;
         thread[tid]->threadStats.numInsts++;
+        thread[tid]->threadStats.lastCommitPC = inst->pcState().instAddr();
         commitStats[tid]->numInstsNotNOP++;
 
         // Check for instruction-count-based events.

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -184,6 +184,7 @@ BaseSimpleCPU::countCommitInst()
         commitStats[tid]->numInsts++;
         baseStats.numInsts++;
         t_info.thread->threadStats.numInsts++;
+        t_info.thread->threadStats.lastCommitPC = t_info.pcState().instAddr();
         executeStats[tid]->numInsts++;
         if (!is_nop) {
             commitStats[tid]->numInstsNotNOP++;

--- a/src/cpu/thread_state.cc
+++ b/src/cpu/thread_state.cc
@@ -63,14 +63,16 @@ ThreadState::unserialize(CheckpointIn &cp)
 }
 
 ThreadState::ThreadStateStats::ThreadStateStats(BaseCPU *cpu,
-                                                const ThreadID& tid)
-      : statistics::Group(cpu, csprintf("thread_%i", tid).c_str()),
+                                                const ThreadID &tid)
+    : statistics::Group(cpu, csprintf("thread_%i", tid).c_str()),
       ADD_STAT(numInsts, statistics::units::Count::get(),
                "Number of Instructions committed"),
       ADD_STAT(numOps, statistics::units::Count::get(),
-        "Number of Ops committed"),
+               "Number of Ops committed"),
       ADD_STAT(numMemRefs, statistics::units::Count::get(),
-               "Number of Memory References")
+               "Number of Memory References"),
+      ADD_STAT(lastCommitPC, statistics::units::Count::get(),
+               "Program Counter of last committed instruction")
 {
 }
 

--- a/src/cpu/thread_state.hh
+++ b/src/cpu/thread_state.hh
@@ -98,6 +98,8 @@ struct ThreadState : public Serializable
         statistics::Scalar numOps;
         /** Stat for number of memory references. */
         statistics::Scalar numMemRefs;
+        /** Stat for last committed instruction's PC. */
+        statistics::Scalar lastCommitPC;
     } threadStats;
 
     /** Number of simulated loads, used for tracking events based on


### PR DESCRIPTION
This commit adds a new statistic, lastCommitPC, to the ThreadStateStats structure in thread_state.hh. This statistic tracks the program counter (PC) of the last instruction that was committed by the CPU. We have also changed simple, O3, and minor CPU models to update this statistic whenever an instruction is committed.

This addition provides valuable insight into the execution flow of the simulated CPU, allowing users to monitor the last executed instruction's address. This can be particularly useful when used with `periodicStatDump` to trace sampled execution points over time.