### PR TITLE
arch-arm: Fix switcheroo long tests for Arm

### DIFF
--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -467,7 +467,12 @@ TableWalker::completeDrain()
 DrainState
 TableWalker::drain()
 {
-    if (pendingQueue.size()) {
+    auto draining = [](WalkUnit *wu) {
+        return wu->drain() == DrainState::Draining;
+    };
+
+    if (pendingQueue.size() ||
+        std::any_of(walkUnits.begin(), walkUnits.end(), draining)) {
         DPRINTF(Drain, "TableWalker not drained\n");
         return DrainState::Draining;
     } else {


### PR DESCRIPTION
Switcheroo tests were failing after the introduction of a unified table walker design for Arm [1].

With the definition of a new SimObjecy (the WalkUnit), draining of the table walker needs some syncronization between the single TableWalker and the multiple WalkUnits

This was done with the following solution:

void
TableWalker::completeDrain()
{
    auto drain_completed = [](WalkUnit *wu) { return wu->completeDrain(); };

    if (drainState() == DrainState::Draining &&
        std::all_of(walkUnits.begin(), walkUnits.end(), drain_completed) &&
        pendingQueue.empty()) {

        DPRINTF(Drain, "TableWalker done draining, processing drain event\n");
        signalDrainDone();
    }
}

Which means the drain is marked as complete for the table walker once all WalkUnits have completed and there are no pending transactions.

However the drain_completed lambda was actually never called because the TableWalker was automatically marked as Drained even if there were pending walks. So the first check

drainState() == DrainState::Draining evaluates to false and we never mark the WalkUnit as drained

[1]: https://github.com/gem5/gem5/pull/2650
[2]: https://github.com/gem5/gem5/blob/develop/src/
    arch/arm/table_walker.cc#L454


Change-Id: Ia8612178a1e2280c9c31f88e0047a2ea86a7bba9