### PR TITLE
mem-ruby, tests: Make the TlmGenerator a ClockedObject

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -61,7 +61,7 @@ class TlmGenerator(SimObject):
     def injectAt(self, when, payload, phase):
         from m5.tlm_chi.utils import Transaction
 
-        transaction = Transaction(payload, phase, when)
+        transaction = Transaction(payload, phase)
         self._transactions.append((when, transaction))
         return transaction
 

--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -84,5 +84,8 @@ class TlmGenerator(ClockedObject):
         "be injected at a specific tick overriding any clock "
         "based timing)",
     )
+    max_pending_tran = OptionalParam.Unsigned(
+        "Max number of pending transactions issued via the inject API"
+    )
     in_port = TlmSinkPort("CHI TLM input/response port")
     out_port = TlmSourcePort("CHI TLM output/request port")

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -68,8 +68,8 @@ TlmGenerator::Transaction::Assertion::run(Transaction *tran)
 }
 
 TlmGenerator::Transaction::Transaction(ARM::CHI::Payload *pa,
-                                       ARM::CHI::Phase &ph, Tick when)
-    : passed(true), parent(nullptr), _payload(pa), _phase(ph), _start(when)
+                                       ARM::CHI::Phase &ph)
+    : passed(true), parent(nullptr), _payload(pa), _phase(ph), _start(0)
 {
     _payload->ref();
 }
@@ -160,6 +160,7 @@ void
 TlmGenerator::scheduleTransaction(Tick when, Transaction *transaction)
 {
     transaction->setGenerator(this);
+    transaction->setStart(when);
 
     auto event = new TransactionEvent(transaction, when);
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -213,7 +213,18 @@ class TlmGenerator : public ClockedObject
 
         std::string str() const;
 
+        /**
+         * Inject a transaction by registering it the TlmGenerator
+         * and by sending it downstream.
+         */
         void inject();
+
+        /**
+         * Send a transaction. It assumes the transaction is already
+         * registered in the TlmGenerator. This is the case for a
+         * completion acknowledgement as an example
+         */
+        void send();
 
         /**
          * Returns true if the transaction has failed, false
@@ -301,6 +312,8 @@ class TlmGenerator : public ClockedObject
     };
 
     void inject(Transaction *transaction);
+    void send(Transaction *transaction);
+    void terminate(Transaction *transaction);
     void recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
     void passFailCheck();
 
@@ -310,6 +323,9 @@ class TlmGenerator : public ClockedObject
 
     /** Max number of transactions to be issued every cycle */
     const unsigned transPerCycle;
+
+    /** Max number of pending transactions allowed */
+    const uint16_t maxPendingTrans;
 
     /** tick event used to schedule unscheduled transactions */
     EventFunctionWrapper tickEvent;
@@ -332,6 +348,9 @@ class TlmGenerator : public ClockedObject
 
     /** response input port */
     SinkPort<TlmGenerator> inPort;
+
+    /** Has any transaction of the suite failed? */
+    bool suiteFailure;
 };
 
 } // namespace tlm::chi

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -193,7 +193,7 @@ class TlmGenerator : public SimObject
         using Actions = std::list<ActionPtr>;
 
         Transaction(const Transaction &rhs) = delete;
-        Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph, Tick when);
+        Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph);
         ~Transaction();
 
         /**
@@ -237,6 +237,11 @@ class TlmGenerator : public SimObject
         start() const
         {
             return _start;
+        }
+        void
+        setStart(Tick when)
+        {
+            _start = when;
         }
 
       private:

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -61,7 +61,7 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
     using Assertion = tlm::chi::TlmGenerator::Transaction::Assertion;
     using Callback = Action::Callback;
     py::class_<tlm::chi::TlmGenerator::Transaction>(tlm_chi_gen, "Transaction")
-        .def(py::init<Payload *, Phase &, Tick>())
+        .def(py::init<Payload *, Phase &>())
         .def("EXPECT_STR",
              [](tlm::chi::TlmGenerator::Transaction &self, std::string name,
                 Callback cb) {

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -87,7 +87,7 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
              [](tlm::chi::TlmGenerator::Transaction &self, Callback cb) {
                  self.addCallback(std::make_unique<Action>(cb, true));
              })
-        .def("inject", &tlm::chi::TlmGenerator::Transaction::inject)
+        .def("send", &tlm::chi::TlmGenerator::Transaction::send)
         .def_property("phase", &tlm::chi::TlmGenerator::Transaction::phase,
                       &tlm::chi::TlmGenerator::Transaction::phase)
         .def_property_readonly("payload",

--- a/tests/gem5/chi_tlm_tests/configs/suites/read_shared_unit.py
+++ b/tests/gem5/chi_tlm_tests/configs/suites/read_shared_unit.py
@@ -82,7 +82,7 @@ def wait_data(transaction):
 def do_comp_ack(transaction):
     transaction.phase.channel = Channel.RSP
     transaction.phase.opcode = RspOpcode.COMP_ACK
-    transaction.inject()
+    transaction.send()
     return False
 
 

--- a/tests/gem5/chi_tlm_tests/configs/suites/read_shared_unit.py
+++ b/tests/gem5/chi_tlm_tests/configs/suites/read_shared_unit.py
@@ -1,5 +1,5 @@
 # -*- mode:python -*-
-# Copyright (c) 2024 Arm Limited
+# Copyright (c) 2024-2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -90,7 +90,7 @@ def test_all(generator):
     payload = payload_gen()
     phase = phase_gen()
 
-    tran = generator.injectAt(10, payload, phase)
+    tran = generator.inject(payload, phase, when=10)
     tran.EXPECT(channel_check)
     tran.EXPECT(opcode_check)
     tran.EXPECT(cacheline_check)


### PR DESCRIPTION
Prior to this PR the TlmGenerator was only capable
of scheduling a batch of transactions at a specific point in time
as can bee seen from its main python API:

`tran = injectAt(payload, phase, when) [1]`

While dealing with absolute numbers allows for great flexibility, it is
not very practical if a user wants to sweep the frequency of the
TlmGenerator and/or only issue a selected number of transactions
per time (they will have to manually handle this behaviour
in the python config by providing a matching tick time
to the third injectAt parameter)

To automatically provide this behaviour to the TlmGenerator, we make it
a ClockedObject.

We also rework the injectAt API by making the time parameter optional.
If it is not specified, the generator does not try to schedule the
transaction at a specific point in time. Instead it simply adds it to an
unscheduled queue of transactions.

The TlmGenerator will now be ticked according to its clock domain.
It will check every tick if there are unscheduled transactions
and will try to schedule a configurable number of those.

Adding the tick method will allow us in the future to implement some
backpressure if we deem it necessary