### PR TITLE
arch-arm: Do some OpClass retagging for some SIMD instructions

### DIFF
--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -244,22 +244,22 @@ let {{
     );
     '''
     buildDataXRegInst("crc32b", 2,
-        crcCode % {"sz": 1, "polynom": "0x04C11DB7"})
+        crcCode % {"sz": 1, "polynom": "0x04C11DB7"}, overrideOpClass="SimdCrcOp")
     buildDataXRegInst("crc32h", 2,
-        crcCode % {"sz": 2, "polynom": "0x04C11DB7"})
+        crcCode % {"sz": 2, "polynom": "0x04C11DB7"}, overrideOpClass="SimdCrcOp")
     buildDataXRegInst("crc32w", 2,
-        crcCode % {"sz": 4, "polynom": "0x04C11DB7"})
+        crcCode % {"sz": 4, "polynom": "0x04C11DB7"}, overrideOpClass="SimdCrcOp")
     buildDataXRegInst("crc32x", 2,
-        crcCode % {"sz": 8, "polynom": "0x04C11DB7"})
+        crcCode % {"sz": 8, "polynom": "0x04C11DB7"}, overrideOpClass="SimdCrcOp")
 
     buildDataXRegInst("crc32cb", 2,
-        crcCode % {"sz": 1, "polynom": "0x1EDC6F41"})
+        crcCode % {"sz": 1, "polynom": "0x1EDC6F41"}, overrideOpClass="SimdCrcOp")
     buildDataXRegInst("crc32ch", 2,
-        crcCode % {"sz": 2, "polynom": "0x1EDC6F41"})
+        crcCode % {"sz": 2, "polynom": "0x1EDC6F41"}, overrideOpClass="SimdCrcOp")
     buildDataXRegInst("crc32cw", 2,
-        crcCode % {"sz": 4, "polynom": "0x1EDC6F41"})
+        crcCode % {"sz": 4, "polynom": "0x1EDC6F41"}, overrideOpClass="SimdCrcOp")
     buildDataXRegInst("crc32cx", 2,
-        crcCode % {"sz": 8, "polynom": "0x1EDC6F41"})
+        crcCode % {"sz": 8, "polynom": "0x1EDC6F41"}, overrideOpClass="SimdCrcOp")
 
     buildDataXRegInst("sdiv", 2, '''
         int64_t op1 = Op164;

--- a/src/arch/arm/isa/insts/fp.isa
+++ b/src/arch/arm/isa/insts/fp.isa
@@ -724,25 +724,25 @@ let {{
     buildSimpleUnaryFpOp("vabs", "Vabs", "FpRegRegOp", "SimdFloatMiscOp",
                          "fplibAbs(half_src1)", "fplibAbs(half_src2)",
                          "fplibAbs(FpOp1_uw)", "fplibAbs(cOp1)")
-    buildSimpleUnaryFpOp("vrintp", "VRIntP", "FpRegRegOp", "SimdFloatMiscOp",
+    buildSimpleUnaryFpOp("vrintp", "VRIntP", "FpRegRegOp", "SimdCvtOp",
         "fplibRoundInt<uint16_t>(half_src1, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint16_t>(half_src2, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_POSINF, false, fpscr)"
         )
-    buildSimpleUnaryFpOp("vrintm", "VRIntM", "FpRegRegOp", "SimdFloatMiscOp",
+    buildSimpleUnaryFpOp("vrintm", "VRIntM", "FpRegRegOp", "SimdCvtOp",
         "fplibRoundInt<uint16_t>(half_src1, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint16_t>(half_src2, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_NEGINF, false, fpscr)"
         )
-    buildSimpleUnaryFpOp("vrinta", "VRIntA", "FpRegRegOp", "SimdFloatMiscOp",
+    buildSimpleUnaryFpOp("vrinta", "VRIntA", "FpRegRegOp", "SimdCvtOp",
         "fplibRoundInt<uint16_t>(half_src1, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint16_t>(half_src2, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_TIEAWAY, false, fpscr)"
         )
-    buildSimpleUnaryFpOp("vrintn", "VRIntN", "FpRegRegOp", "SimdFloatMiscOp",
+    buildSimpleUnaryFpOp("vrintn", "VRIntN", "FpRegRegOp", "SimdCvtOp",
         "fplibRoundInt<uint16_t>(half_src1, FPRounding_TIEEVEN, false, fpscr)",
         "fplibRoundInt<uint16_t>(half_src2, FPRounding_TIEEVEN, false, fpscr)",
         "fplibRoundInt<uint32_t>(FpOp1_uw, FPRounding_TIEEVEN, false, fpscr)",

--- a/src/arch/arm/isa/insts/fp64.isa
+++ b/src/arch/arm/isa/insts/fp64.isa
@@ -1129,7 +1129,7 @@ let {{
 
         iop = ArmInstObjParams("fcsel", "FCSel%s" % (bitsToSuffix(bits)),
                                "FpCondSelOp", { "code":     code,
-                                                "op_class": "FloatCvtOp" })
+                                                "op_class": "FloatMiscOp" })
         iop.snippets["code"] += zeroSveVecRegUpperPartCode % "AA64FpDest"
         header_output  += DataXCondSelDeclare.subst(iop)
         decoder_output += DataXCondSelConstructor.subst(iop)

--- a/src/arch/arm/isa/insts/fp64.isa
+++ b/src/arch/arm/isa/insts/fp64.isa
@@ -559,31 +559,31 @@ let {{
                          "fplibAbs<uint16_t>(cOp1)",
                          "fplibAbs<uint32_t>(cOp1)",
                          "fplibAbs<uint64_t>(cOp1)")
-    buildSimpleUnaryFpOp("frintn", "FRIntN", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frintn", "FRIntN", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPRounding_TIEEVEN, false, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPRounding_TIEEVEN, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_TIEEVEN, false, fpscr)")
-    buildSimpleUnaryFpOp("frintp", "FRIntP", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frintp", "FRIntP", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPRounding_POSINF, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_POSINF, false, fpscr)")
-    buildSimpleUnaryFpOp("frintm", "FRIntM", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frintm", "FRIntM", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPRounding_NEGINF, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_NEGINF, false, fpscr)")
-    buildSimpleUnaryFpOp("frintz", "FRIntZ", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frintz", "FRIntZ", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPRounding_ZERO, false, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPRounding_ZERO, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_ZERO, false, fpscr)")
-    buildSimpleUnaryFpOp("frinta", "FRIntA", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frinta", "FRIntA", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPRounding_TIEAWAY, false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPRounding_TIEAWAY, false, fpscr)")
-    buildSimpleUnaryFpOp("frinti", "FRIntI", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frinti", "FRIntI", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPCRRounding(fpscr), false, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPCRRounding(fpscr), false, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPCRRounding(fpscr), false, fpscr)")
-    buildSimpleUnaryFpOp("frintx", "FRIntX", "FpRegRegOp", "FloatMiscOp",
+    buildSimpleUnaryFpOp("frintx", "FRIntX", "FpRegRegOp", "FloatCvtOp",
         "fplibRoundInt<uint16_t>(cOp1, FPCRRounding(fpscr), true, fpscr)",
         "fplibRoundInt<uint32_t>(cOp1, FPCRRounding(fpscr), true, fpscr)",
         "fplibRoundInt<uint64_t>(cOp1, FPCRRounding(fpscr), true, fpscr)")
@@ -621,20 +621,20 @@ let {{
             exec_output    += BasicExecute.subst(iop)
 
     buildSimpleUnaryFpOpFrintts("frint32z", "FRInt32Z", "FpRegRegOp",
-        "FloatMiscOp",
+        "FloatCvtOp",
         "fplibRoundIntN<uint32_t>(cOp1, FPRounding_ZERO, true, 32, fpscr)",
         "fplibRoundIntN<uint64_t>(cOp1, FPRounding_ZERO, true, 32, fpscr)")
     buildSimpleUnaryFpOpFrintts("frint32x", "FRInt32X", "FpRegRegOp",
-        "FloatMiscOp",
+        "FloatCvtOp",
         "fplibRoundIntN<uint32_t>(cOp1, FPCRRounding(fpscr), true, 32, fpscr)",
         "fplibRoundIntN<uint64_t>(cOp1, FPCRRounding(fpscr), true, 32, fpscr)")
 
     buildSimpleUnaryFpOpFrintts("frint64z", "FRInt64Z", "FpRegRegOp",
-        "FloatMiscOp",
+        "FloatCvtOp",
         "fplibRoundIntN<uint32_t>(cOp1, FPRounding_ZERO, true, 64, fpscr)",
         "fplibRoundIntN<uint64_t>(cOp1, FPRounding_ZERO, true, 64, fpscr)")
     buildSimpleUnaryFpOpFrintts("frint64x", "FRInt64X", "FpRegRegOp",
-        "FloatMiscOp",
+        "FloatCvtOp",
         "fplibRoundIntN<uint32_t>(cOp1, FPCRRounding(fpscr), true, 64, fpscr)",
         "fplibRoundIntN<uint64_t>(cOp1, FPCRRounding(fpscr), true, 64, fpscr)")
 }};

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -1255,26 +1255,40 @@ let {{
                            complex=True)
 
     # SDOT (vector)
-    intDotInst('sdot', 'SdotDX', 'SimdAluOp', True, True, True, 2, False)
-    intDotInst('sdot', 'SdotQX', 'SimdAluOp', True, True, True, 4, False)
+    intDotInst('sdot', 'SdotDX', 'SimdDotProdOp',
+               True, True, True, 2, False)
+    intDotInst('sdot', 'SdotQX', 'SimdDotProdOp',
+               True, True, True, 4, False)
     # SDOT (element)
-    intDotInst('sdot', 'SdotElemDX', 'SimdAluOp', True, True, True, 2, True)
-    intDotInst('sdot', 'SdotElemQX', 'SimdAluOp', True, True, True, 4, True)
+    intDotInst('sdot', 'SdotElemDX', 'SimdDotProdOp',
+               True, True, True, 2, True)
+    intDotInst('sdot', 'SdotElemQX', 'SimdDotProdOp',
+               True, True, True, 4, True)
     # UDOT (vector)
-    intDotInst('udot', 'UdotDX', 'SimdAluOp', False, False, False, 2, False)
-    intDotInst('udot', 'UdotQX', 'SimdAluOp', False, False, False, 4, False)
+    intDotInst('udot', 'UdotDX', 'SimdDotProdOp',
+               False, False, False, 2, False)
+    intDotInst('udot', 'UdotQX', 'SimdDotProdOp',
+               False, False, False, 4, False)
     # UDOT (element)
-    intDotInst('udot', 'UdotElemDX', 'SimdAluOp', False, False, False, 2, True)
-    intDotInst('udot', 'UdotElemQX', 'SimdAluOp', False, False, False, 4, True)
+    intDotInst('udot', 'UdotElemDX', 'SimdDotProdOp',
+               False, False, False, 2, True)
+    intDotInst('udot', 'UdotElemQX', 'SimdDotProdOp',
+               False, False, False, 4, True)
     # SUDOT (element)
-    intDotInst('sudot', 'SudotElemDX', 'SimdAluOp', True, True, False, 2, True)
-    intDotInst('sudot', 'SudotElemQX', 'SimdAluOp', True, True, False, 4, True)
+    intDotInst('sudot', 'SudotElemDX', 'SimdDotProdOp',
+               True, True, False, 2, True)
+    intDotInst('sudot', 'SudotElemQX', 'SimdDotProdOp',
+               True, True, False, 4, True)
     # USDOT (vector)
-    intDotInst('usdot', 'UsdotDX', 'SimdAluOp', True, False, True, 2, False)
-    intDotInst('usdot', 'UsdotQX', 'SimdAluOp', True, False, True, 4, False)
+    intDotInst('usdot', 'UsdotDX', 'SimdDotProdOp',
+               True, False, True, 2, False)
+    intDotInst('usdot', 'UsdotQX', 'SimdDotProdOp',
+               True, False, True, 4, False)
     # USDOT (element)
-    intDotInst('usdot', 'UsdotElemDX', 'SimdAluOp', True, False, True, 2, True)
-    intDotInst('usdot', 'UsdotElemQX', 'SimdAluOp', True, False, True, 4, True)
+    intDotInst('usdot', 'UsdotElemDX', 'SimdDotProdOp',
+               True, False, True, 2, True)
+    intDotInst('usdot', 'UsdotElemQX', 'SimdDotProdOp',
+               True, False, True, 4, True)
 
     def intMatMulInst(name, Name, opClass,
                       destIsSigned, src1IsSigned, src2IsSigned):

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -3013,11 +3013,11 @@ let {{
             }
             FpscrQc = fpscr;
     '''
-    twoEqualRegInstX("sqshl", "SqshlImmDX", "SimdAluOp", smallSignedTypes, 2,
+    twoEqualRegInstX("sqshl", "SqshlImmDX", "SimdShiftOp", smallSignedTypes, 2,
                      sqshlImmCode, hasImm=True)
-    twoEqualRegInstX("sqshl", "SqshlImmQX", "SimdAluOp", signedTypes, 4,
+    twoEqualRegInstX("sqshl", "SqshlImmQX", "SimdShiftOp", signedTypes, 4,
                      sqshlImmCode, hasImm=True)
-    twoEqualRegInstX("sqshl", "SqshlImmScX", "SimdAluOp", signedTypes, 4,
+    twoEqualRegInstX("sqshl", "SqshlImmScX", "SimdShiftOp", signedTypes, 4,
                      sqshlImmCode, hasImm=True, scalar=True)
     # SQSHL (register)
     sqshlCode = '''

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -2340,9 +2340,9 @@ let {{
                       abdlCode, True, hi=True)
     # SADALP
     adalpCode = "destElem += (BigElement)srcElem1 + (BigElement)srcElem2;"
-    twoRegCondenseInstX("sadalp", "SadalpDX", "SimdAddOp", smallSignedTypes, 2,
+    twoRegCondenseInstX("sadalp", "SadalpDX", "SimdAddAccOp", smallSignedTypes, 2,
                         adalpCode, True)
-    twoRegCondenseInstX("sadalp", "SadalpQX", "SimdAddOp", smallSignedTypes, 4,
+    twoRegCondenseInstX("sadalp", "SadalpQX", "SimdAddAccOp", smallSignedTypes, 4,
                         adalpCode, True)
     # SADDL, SADDL2
     addlwCode = "destElem = (BigElement)srcElem1 + (BigElement)srcElem2;"
@@ -3514,9 +3514,9 @@ let {{
     threeRegLongInstX("uabdl2", "Uabdl2X", "SimdAddAccOp", smallUnsignedTypes,
                       abdlCode, True, hi=True)
     # UADALP
-    twoRegCondenseInstX("uadalp", "UadalpDX", "SimdAddOp", smallUnsignedTypes,
+    twoRegCondenseInstX("uadalp", "UadalpDX", "SimdAddAccOp", smallUnsignedTypes,
                         2, adalpCode, True)
-    twoRegCondenseInstX("uadalp", "UadalpQX", "SimdAddOp", smallUnsignedTypes,
+    twoRegCondenseInstX("uadalp", "UadalpQX", "SimdAddAccOp", smallUnsignedTypes,
                         4, adalpCode, True)
     # UADDL, UADDL2
     threeRegLongInstX("uaddl", "UaddlX", "SimdAddAccOp", smallUnsignedTypes,

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -2093,19 +2093,21 @@ let {{
                      frint64zCode, extra_check=frintts_check)
     # FRSQRTE
     frsqrteCode = fpOp % "fplibRSqrtEstimate<Element>(srcElem1, fpscr, fpcr)"
-    twoEqualRegInstX("frsqrte", "FrsqrteDX", "SimdFloatSqrtOp",
+    twoEqualRegInstX("frsqrte", "FrsqrteDX", "SimdCvtOp",
                      smallFloatTypes, 2, frsqrteCode)
-    twoEqualRegInstX("frsqrte", "FrsqrteQX", "SimdFloatSqrtOp", floatTypes, 4,
+    twoEqualRegInstX("frsqrte", "FrsqrteQX", "SimdCvtOp", floatTypes, 4,
                      frsqrteCode)
-    twoEqualRegInstX("frsqrte", "FrsqrteScX", "SimdFloatSqrtOp", floatTypes, 4,
+    twoEqualRegInstX("frsqrte", "FrsqrteScX", "SimdCvtOp", floatTypes, 4,
                      frsqrteCode, scalar=True, nepSrc="vd")
     # FRSQRTS
     frsqrtsCode = fpBinOp % "RSqrtStepFused"
-    threeEqualRegInstX("frsqrts", "FrsqrtsDX", "SimdFloatMiscOp",
+    threeEqualRegInstX("frsqrts", "FrsqrtsDX", "SimdFloatMultAccOp",
                        smallFloatTypes, 2, frsqrtsCode)
-    threeEqualRegInstX("frsqrts", "FrsqrtsQX", "SimdFloatMiscOp", floatTypes,
+    threeEqualRegInstX("frsqrts", "FrsqrtsQX", "SimdFloatMultAccOp",
+                       floatTypes,
                        4, frsqrtsCode)
-    threeEqualRegInstX("frsqrts", "FrsqrtsScX", "SimdFloatMiscOp", floatTypes,
+    threeEqualRegInstX("frsqrts", "FrsqrtsScX", "SimdFloatMultAccOp",
+                       floatTypes,
                        4, frsqrtsCode, scalar=True, nepSrc="vn")
     # FSQRT
     fsqrtCode = fpOp % "fplibSqrt<Element>(srcElem1, fpscr, fpcr)"
@@ -3878,9 +3880,9 @@ let {{
                      rshrCode, hasImm=True)
     # URSQRTE
     ursqrteCode = "destElem = unsignedRSqrtEstimate(srcElem1);"
-    twoEqualRegInstX("ursqrte", "UrsqrteDX", "SimdSqrtOp", ("uint32_t",), 2,
+    twoEqualRegInstX("ursqrte", "UrsqrteDX", "SimdCvtOp", ("uint32_t",), 2,
                      ursqrteCode)
-    twoEqualRegInstX("ursqrte", "UrsqrteQX", "SimdSqrtOp", ("uint32_t",), 4,
+    twoEqualRegInstX("ursqrte", "UrsqrteQX", "SimdCvtOp", ("uint32_t",), 4,
                      ursqrteCode)
     # URSRA
     twoEqualRegInstX("ursra", "UrsraDX", "SimdShiftOp", unsignedTypes, 2,

--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -6726,19 +6726,19 @@ let {{
     sveBinInst('sdivr', 'Sdivr', 'SimdDivOp', signedTypes, sdivrCode,
                PredType.MERGE, True)
     # SDOT (2-way, indexed)
-    sveDotInst('sdot', 'Sdot2wayi', 'SimdMultAccOp',
+    sveDotInst('sdot', 'Sdot2wayi', 'SimdDotProdOp',
                ['int16_t, int16_t, int32_t'],
                isIndexed = True)
     # SDOT (2-way, vectors)
-    sveDotInst('sdot', 'Sdot2wayv', 'SimdMultAccOp',
+    sveDotInst('sdot', 'Sdot2wayv', 'SimdDotProdOp',
                ['int16_t, int16_t, int32_t'],
                isIndexed = False)
     # SDOT (4-way, indexed)
-    sveDotInst('sdot', 'Sdoti', 'SimdMultAccOp',
+    sveDotInst('sdot', 'Sdoti', 'SimdDotProdOp',
                ['int8_t, int8_t, int32_t', 'int16_t, int16_t, int64_t'],
                isIndexed = True)
     # SDOT (4-way, vectors)
-    sveDotInst('sdot', 'Sdotv', 'SimdMultAccOp',
+    sveDotInst('sdot', 'Sdotv', 'SimdDotProdOp',
                ['int8_t, int8_t, int32_t', 'int16_t, int16_t, int64_t'],
                isIndexed = False)
     # SEL (predicates)
@@ -8176,17 +8176,17 @@ let {{
     sveBinInst('udivr', 'Udivr', 'SimdDivOp', unsignedTypes, udivrCode,
                PredType.MERGE, True)
     # UDOT (2-way, indexed)
-    sveDotInst('udot', 'Udot2wayi', 'SimdMultAccOp',
+    sveDotInst('udot', 'Udot2wayi', 'SimdDotProdOp',
                ['uint16_t, uint16_t, uint32_t'], isIndexed = True)
     # UDOT (2-way, vectors)
-    sveDotInst('udot', 'Udot2wayv', 'SimdMultAccOp',
+    sveDotInst('udot', 'Udot2wayv', 'SimdDotProdOp',
                ['uint16_t, uint16_t, uint32_t'], isIndexed = False)
     # UDOT (4-way, indexed)
-    sveDotInst('udot', 'Udoti', 'SimdMultAccOp',
+    sveDotInst('udot', 'Udoti', 'SimdDotProdOp',
                ['uint8_t, uint8_t, uint32_t', 'uint16_t, uint16_t, uint64_t'],
                isIndexed = True)
     # UDOT (4-way, vectors)
-    sveDotInst('udot', 'Udotv', 'SimdMultAccOp',
+    sveDotInst('udot', 'Udotv', 'SimdDotProdOp',
                ['uint8_t, uint8_t, uint32_t', 'uint16_t, uint16_t, uint64_t'],
                isIndexed = False)
     # UHADD

--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -6485,14 +6485,14 @@ let {{
             __uint128_t res = poly_mul(srcElem1, srcElem2);
             destElem = res;
     '''
-    sveBinLongInst('pmullb', 'Pmullb', 'SimdAluOp', ('uint8_t','uint32_t'),
+    sveBinLongInst('pmullb', 'Pmullb', 'SimdMultOp', ('uint8_t','uint32_t'),
                    pmullCode)
-    sveBinLongInst('pmullb', 'Pmullb128', 'SimdAluOp', ('uint64_t',),
+    sveBinLongInst('pmullb', 'Pmullb128', 'SimdMultOp', ('uint64_t',),
                    pmullCode)
     # PMULLT
-    sveBinLongInst('pmullt', 'Pmullt', 'SimdAluOp', ('uint8_t','uint32_t'),
+    sveBinLongInst('pmullt', 'Pmullt', 'SimdMultOp', ('uint8_t','uint32_t'),
                     pmullCode, uptTop = True)
-    sveBinLongInst('pmullt', 'Pmullt128', 'SimdAluOp', ('uint64_t',),
+    sveBinLongInst('pmullt', 'Pmullt128', 'SimdMultOp', ('uint64_t',),
                     pmullCode, uptTop = True)
     # PNEXT
     svePNextInst('pnext', 'Pnext', 'SimdPredAluOp', unsignedTypes)

--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -5188,7 +5188,7 @@ let {{
                PredType.MERGE, True)
     # BCAX
     bcaxCode = 'destElem ^= srcElem1 & (~srcElem2);'
-    sveBinInst('bcax', 'Bcax', 'SimdShiftOp', ('uint64_t',), bcaxCode,
+    sveBinInst('bcax', 'Bcax', 'SimdSha3Op', ('uint64_t',), bcaxCode,
                 isDestructive=True)
     # BDEP
     bdepCode = '''
@@ -5676,7 +5676,7 @@ let {{
     svePredLogicalInst('eors', 'PredEors', 'SimdPredAluOp', ('uint8_t',),
                        eorCode, isFlagSetting=True)
     # EORTB
-    sveBinInterInst('eortb', 'Eortb', 'SimdAluOp', unsignedTypes, eorCode,
+    sveBinInterInst('eortb', 'Eortb', 'SimdSha3Op', unsignedTypes, eorCode,
                     tb = True)
     # EORV
     sveAssocReducInst('eorv', 'Eorv', 'SimdReduceAluOp', unsignedTypes,
@@ -6528,7 +6528,7 @@ let {{
                      smallUnsignedTypes, raddhnCode, uptTop = True)
     # RAX1
     rax1Code = 'destElem = srcElem1 ^ ((srcElem2 << 1) | (srcElem2 >> 63));'
-    sveBinInst('rax', 'Rax1', 'SimdAluOp', ('uint64_t',), rax1Code)
+    sveBinInst('rax', 'Rax1', 'SimdSha3Op', ('uint64_t',), rax1Code)
     # RBIT
     rbitCode = '''
         destElem = reverseBits(srcElem1);'''
@@ -9008,7 +9008,7 @@ let {{
             destElem = ((destElem >> srcElem2) |
                     (destElem << (sizeof(Element) * 8 - srcElem2)));
     '''
-    sveBinImmInst('xar', 'Xar', 'SimdAluOp', unsignedTypes, xarCode)
+    sveBinImmInst('xar', 'Xar', 'SimdSha3Op', unsignedTypes, xarCode)
     # ZIP1, ZIP2 (predicates)
     zipPredIterCode = '''
         constexpr unsigned sz = sizeof(Element);

--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -6149,11 +6149,13 @@ let {{
                  PredType.MERGE)
     # FRSQRTE
     frsqrteCode = fpOp % 'fplibRSqrtEstimate<Element>(srcElem1, fpscr, fpcr)'
-    sveUnaryInst('frsqrte', 'Frsqrte', 'SimdFloatSqrtOp', floatTypes,
+    sveUnaryInst('frsqrte', 'Frsqrte', 'SimdCvtOp', floatTypes,
                  frsqrteCode)
     # FRSQRTS
+    # Floating-point reciprocal square root step is really a multiply
+    # and add(sub)
     frsqrtsCode = fpBinOp % 'RSqrtStepFused'
-    sveBinInst('frsqrts', 'Frsqrts', 'SimdFloatAluOp', floatTypes,
+    sveBinInst('frsqrts', 'Frsqrts', 'SimdFloatMultAccOp', floatTypes,
                frsqrtsCode)
     # FSCALE
     fscaleCode = fpBinOp % 'Scale'

--- a/src/cpu/FuncUnit.py
+++ b/src/cpu/FuncUnit.py
@@ -92,6 +92,7 @@ class OpClass(Enum):
         "SimdShaSigma3",
         "SimdSha3",
         "SimdSm4e",
+        "SimdCrc",
         "SimdPredAlu",
         "SimdDotProd",
         "Matrix",

--- a/src/cpu/FuncUnit.py
+++ b/src/cpu/FuncUnit.py
@@ -90,6 +90,7 @@ class OpClass(Enum):
         "SimdSha256Hash2",
         "SimdShaSigma2",
         "SimdShaSigma3",
+        "SimdSha3",
         "SimdSm4e",
         "SimdPredAlu",
         "SimdDotProd",

--- a/src/cpu/FuncUnit.py
+++ b/src/cpu/FuncUnit.py
@@ -92,6 +92,7 @@ class OpClass(Enum):
         "SimdShaSigma3",
         "SimdSm4e",
         "SimdPredAlu",
+        "SimdDotProd",
         "Matrix",
         "MatrixMov",
         "MatrixOP",

--- a/src/cpu/minor/BaseMinorCPU.py
+++ b/src/cpu/minor/BaseMinorCPU.py
@@ -219,6 +219,7 @@ class MinorDefaultFloatSimdFU(MinorFU):
             "SimdShaSigma3",
             "SimdSha3",
             "SimdSm4e",
+            "SimdCrc",
             "Matrix",
             "MatrixMov",
             "MatrixOP",

--- a/src/cpu/minor/BaseMinorCPU.py
+++ b/src/cpu/minor/BaseMinorCPU.py
@@ -217,6 +217,7 @@ class MinorDefaultFloatSimdFU(MinorFU):
             "SimdSha256Hash2",
             "SimdShaSigma2",
             "SimdShaSigma3",
+            "SimdSha3",
             "SimdSm4e",
             "Matrix",
             "MatrixMov",

--- a/src/cpu/minor/BaseMinorCPU.py
+++ b/src/cpu/minor/BaseMinorCPU.py
@@ -225,6 +225,7 @@ class MinorDefaultFloatSimdFU(MinorFU):
             "SimdFloatExt",
             "SimdFloatCvt",
             "SimdConfig",
+            "SimdDotProd",
             "SimdBf16Add",
             "SimdBf16Cmp",
             "SimdBf16Cvt",

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -121,6 +121,7 @@ class SIMD_Unit(FUDesc):
         OpDesc(opClass="SimdShaSigma3"),
         OpDesc(opClass="SimdSha3"),
         OpDesc(opClass="SimdSm4e"),
+        OpDesc(opClass="SimdCrc"),
         OpDesc(opClass="SimdBf16Add"),
         OpDesc(opClass="SimdBf16Cmp"),
         OpDesc(opClass="SimdBf16Cvt"),

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -119,6 +119,7 @@ class SIMD_Unit(FUDesc):
         OpDesc(opClass="SimdSha256Hash2"),
         OpDesc(opClass="SimdShaSigma2"),
         OpDesc(opClass="SimdShaSigma3"),
+        OpDesc(opClass="SimdSha3"),
         OpDesc(opClass="SimdSm4e"),
         OpDesc(opClass="SimdBf16Add"),
         OpDesc(opClass="SimdBf16Cmp"),

--- a/src/cpu/o3/FuncUnitConfig.py
+++ b/src/cpu/o3/FuncUnitConfig.py
@@ -110,6 +110,7 @@ class SIMD_Unit(FUDesc):
         OpDesc(opClass="SimdExt"),
         OpDesc(opClass="SimdFloatExt"),
         OpDesc(opClass="SimdConfig"),
+        OpDesc(opClass="SimdDotProd"),
         OpDesc(opClass="SimdAes"),
         OpDesc(opClass="SimdAesMix"),
         OpDesc(opClass="SimdSha1Hash"),

--- a/src/cpu/op_class.hh
+++ b/src/cpu/op_class.hh
@@ -100,6 +100,7 @@ static const OpClass SimdSha256HashOp = enums::SimdSha256Hash;
 static const OpClass SimdSha256Hash2Op = enums::SimdSha256Hash2;
 static const OpClass SimdShaSigma2Op = enums::SimdShaSigma2;
 static const OpClass SimdShaSigma3Op = enums::SimdShaSigma3;
+static const OpClass SimdSha3Op = enums::SimdSha3;
 static const OpClass SimdSm4eOp = enums::SimdSm4e;
 static const OpClass SimdPredAluOp = enums::SimdPredAlu;
 static const OpClass MatrixOp = enums::Matrix;

--- a/src/cpu/op_class.hh
+++ b/src/cpu/op_class.hh
@@ -102,6 +102,7 @@ static const OpClass SimdShaSigma2Op = enums::SimdShaSigma2;
 static const OpClass SimdShaSigma3Op = enums::SimdShaSigma3;
 static const OpClass SimdSha3Op = enums::SimdSha3;
 static const OpClass SimdSm4eOp = enums::SimdSm4e;
+static const OpClass SimdCrcOp = enums::SimdCrc;
 static const OpClass SimdPredAluOp = enums::SimdPredAlu;
 static const OpClass MatrixOp = enums::Matrix;
 static const OpClass MatrixMovOp = enums::MatrixMov;

--- a/src/cpu/op_class.hh
+++ b/src/cpu/op_class.hh
@@ -145,6 +145,7 @@ static const OpClass SimdBf16MatMultAccOp = enums::SimdBf16MatMultAcc;
 static const OpClass SimdBf16MultOp = enums::SimdBf16Mult;
 static const OpClass SimdBf16MultAccOp = enums::SimdBf16MultAcc;
 static const OpClass Bf16CvtOp = enums::Bf16Cvt;
+static const OpClass SimdDotProdOp = enums::SimdDotProd;
 static const OpClass SystemOp = enums::System;
 static const OpClass Num_OpClasses = enums::Num_OpClass;
 


### PR DESCRIPTION
With this PR we are

1. Retagging some existing instructions
2. Defining new OpClasses ("SimdSha3", "SimdCrc", "SimdDotProd")

The aim is to ensure some SIMD instructions get a more accurate depiction of the operation being performed.