### PR TITLE
arch-riscv: fix old vd index for vslideup.vi

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1578,16 +1578,28 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
     src1_ireg_id = "intRegClass[_machInst.rs1]"
     src1_freg_id = "floatRegClass[_machInst.rs1]"
 
+    num_src_regs = 0
     if category == "OPIVX":
         set_src_reg_idx += setSrcWrapper(src1_ireg_id)
-    elif category in ["OPFVF"]:
+        num_src_regs += 1
+    elif category == "OPFVF":
         set_src_reg_idx += setSrcWrapper(src1_freg_id)
+        num_src_regs += 1
+
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
     set_src_reg_idx += setSrcWrapper(src3_reg_id)
+    num_src_regs += 2
 
-    if name not in ["vslideup_vx", "vslidedown_vx"]:
-        set_src_reg_idx += tailMaskCondSetSrcWrapper( \
-            setSrcWrapper(dest_reg_id))
+    dest_set_src_reg_idx = ""
+    # No dest reg pin: Bypass tail/mask policy to copy unchanged elements
+    if name == "vslideup_vi":
+        dest_set_src_reg_idx = f"oldDstIdx = {num_src_regs};\n"
+        dest_set_src_reg_idx += setSrcWrapper(dest_reg_id)
+    elif name not in ["vslideup_vx", "vslidedown_vx"]:
+        dest_set_src_reg_idx = tailMaskCondSetSrcWrapper(
+            setSrcWrapper(dest_reg_id)
+        )
+    set_src_reg_idx += dest_set_src_reg_idx
 
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_vlenb = setVlenb()


### PR DESCRIPTION
Small fix for vslideup.vi instruction. The old destination index was not correctly set.