### PR TITLE
arch-arm: Fix macOS build after FEAT_SVE2 PR

### DIFF
--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -5044,7 +5044,7 @@ let {{
     sveAdrInst('adr', 'Adr', 'SimdAddOp', ('uint32_t', 'uint64_t'), adrCode)
     # AESD (vectors)
     cryptoBinCode = '''
-        uint32_t eltspersegment = 16 / sizeof(Element);
+        constexpr uint32_t eltspersegment = 16 / sizeof(Element);
 
         Crypto crypto;
         Element tempElem1[eltspersegment];
@@ -5072,7 +5072,7 @@ let {{
             True, customIterCode=cryptoBinCode % {'op': aeseCode})
     # AESIMC
     cryptoUnaryCode = '''
-        uint32_t eltspersegment = 16 / sizeof(Element);
+        constexpr uint32_t eltspersegment = 16 / sizeof(Element);
 
         Crypto crypto;
         Element tempElem1[eltspersegment];


### PR DESCRIPTION
By tagging eltspersegment as constexpr we avoid any compilation error mentioned in [1]

[1]: https://github.com/gem5/gem5/pull/2765


Change-Id: Ia2c9679b6aacbe9b4b73477f7b6921aacdbc2c68