### PR TITLE
mem: Skip unused chunks when restoring checkpoints

### DIFF
--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -465,22 +465,21 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
     uint64_t curr_size = 0;
     uint32_t bytes_read;
     uint8_t buffer[chunk_size];
+    uint8_t zeros[chunk_size] = {0};
     while (curr_size < range.size()) {
         bytes_read = gzread(compressed_mem, buffer, chunk_size);
         if (bytes_read == 0)
             break;
 
-        bool all_zero = true;
-        for (uint32_t i = 0; i < bytes_read; i++) {
-            if (buffer[i] != 0) {
-                all_zero = false;
-                break;
-            }
-        }
+        bool all_zero = (memcmp(buffer, zeros, bytes_read) == 0);
 
         if (!all_zero) {
             memcpy(pmem, buffer, bytes_read);
         }
+
+        curr_size += bytes_read;
+        pmem += bytes_read;
+    }
 
     if (gzclose(compressed_mem))
         fatal("Close failed on physical memory checkpoint file '%s'\n",

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -464,13 +464,23 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
 
     uint64_t curr_size = 0;
     uint32_t bytes_read;
+    uint8_t buffer[chunk_size];
     while (curr_size < range.size()) {
-        bytes_read = gzread(compressed_mem, pmem, chunk_size);
+        bytes_read = gzread(compressed_mem, buffer, chunk_size);
         if (bytes_read == 0)
             break;
-        curr_size += bytes_read;
-        pmem += bytes_read;
-    }
+
+        bool all_zero = true;
+        for (uint32_t i = 0; i < bytes_read; i++) {
+            if (buffer[i] != 0) {
+                all_zero = false;
+                break;
+            }
+        }
+
+        if (!all_zero) {
+            memcpy(pmem, buffer, bytes_read);
+        }
 
     if (gzclose(compressed_mem))
         fatal("Close failed on physical memory checkpoint file '%s'\n",

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -76,14 +76,19 @@ namespace gem5
 namespace memory
 {
 
-PhysicalMemory::PhysicalMemory(const std::string& _name,
-                               const std::vector<AbstractMemory*>& _memories,
+PhysicalMemory::PhysicalMemory(const std::string &_name,
+                               const std::vector<AbstractMemory *> &_memories,
                                bool mmap_using_noreserve,
-                               const std::string& shared_backstore,
-                               bool auto_unlink_shared_backstore) :
-    _name(_name), size(0), mmapUsingNoReserve(mmap_using_noreserve),
-    sharedBackstore(shared_backstore), sharedBackstoreSize(0),
-    pageSize(sysconf(_SC_PAGE_SIZE))
+                               const std::string &shared_backstore,
+                               bool auto_unlink_shared_backstore,
+                               bool is_sparse_restore)
+    : _name(_name),
+      size(0),
+      mmapUsingNoReserve(mmap_using_noreserve),
+      sharedBackstore(shared_backstore),
+      sharedBackstoreSize(0),
+      pageSize(sysconf(_SC_PAGE_SIZE)),
+      isSparseRestore(is_sparse_restore)
 {
     // Register cleanup callback if requested.
     if (auto_unlink_shared_backstore && !sharedBackstore.empty()) {
@@ -464,21 +469,33 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
 
     uint64_t curr_size = 0;
     uint32_t bytes_read;
-    uint8_t buffer[chunk_size];
-    uint8_t zeros[chunk_size] = {0};
-    while (curr_size < range.size()) {
-        bytes_read = gzread(compressed_mem, buffer, chunk_size);
-        if (bytes_read == 0)
-            break;
+    if (isSparseRestore) {
+        uint8_t buffer[chunk_size];
+        uint8_t zeros[chunk_size] = {0};
+        while (curr_size < range.size()) {
+            bytes_read = gzread(compressed_mem, buffer, chunk_size);
+            if (bytes_read == 0) {
+                break;
+            }
 
-        bool all_zero = (memcmp(buffer, zeros, bytes_read) == 0);
+            bool all_zero = (memcmp(buffer, zeros, bytes_read) == 0);
 
-        if (!all_zero) {
-            memcpy(pmem, buffer, bytes_read);
+            if (!all_zero) {
+                memcpy(pmem, buffer, bytes_read);
+            }
+
+            curr_size += bytes_read;
+            pmem += bytes_read;
         }
-
-        curr_size += bytes_read;
-        pmem += bytes_read;
+    } else {
+        while (curr_size < range.size()) {
+            bytes_read = gzread(compressed_mem, pmem, chunk_size);
+            if (bytes_read == 0) {
+                break;
+            }
+            curr_size += bytes_read;
+            pmem += bytes_read;
+        }
     }
 
     if (gzclose(compressed_mem))

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -470,6 +470,12 @@ PhysicalMemory::unserializeStore(CheckpointIn &cp)
     uint64_t curr_size = 0;
     uint32_t bytes_read;
     if (isSparseRestore) {
+        static_assert(chunk_size >= 4096 && (chunk_size % 4096 == 0),
+                      "chunk_size must be a multiple of the 4KB page size");
+        static_assert(
+            chunk_size <= 65536,
+            "chunk_size too large, smaller chunks improve sparse efficiency");
+
         uint8_t buffer[chunk_size];
         uint8_t zeros[chunk_size] = {0};
         while (curr_size < range.size()) {

--- a/src/mem/physical.hh
+++ b/src/mem/physical.hh
@@ -193,7 +193,8 @@ class PhysicalMemory : public Serializable
                    const std::vector<AbstractMemory *> &_memories,
                    bool mmap_using_noreserve,
                    const std::string &shared_backstore,
-                   bool auto_unlink_shared_backstore, bool is_sparse_restore);
+                   bool auto_unlink_shared_backstore,
+                   bool is_sparse_restore = false);
 
     /**
      * Unmap all the backing store we have used.

--- a/src/mem/physical.hh
+++ b/src/mem/physical.hh
@@ -153,6 +153,8 @@ class PhysicalMemory : public Serializable
     // Let the user choose if we reserve swap space when calling mmap
     const bool mmapUsingNoReserve;
 
+    const bool isSparseRestore;
+
     const std::string sharedBackstore;
     uint64_t sharedBackstoreSize;
 
@@ -187,11 +189,11 @@ class PhysicalMemory : public Serializable
     /**
      * Create a physical memory object, wrapping a number of memories.
      */
-    PhysicalMemory(const std::string& _name,
-                   const std::vector<AbstractMemory*>& _memories,
+    PhysicalMemory(const std::string &_name,
+                   const std::vector<AbstractMemory *> &_memories,
                    bool mmap_using_noreserve,
-                   const std::string& shared_backstore,
-                   bool auto_unlink_shared_backstore);
+                   const std::string &shared_backstore,
+                   bool auto_unlink_shared_backstore, bool is_sparse_restore);
 
     /**
      * Unmap all the backing store we have used.

--- a/src/mem/physical.hh
+++ b/src/mem/physical.hh
@@ -153,12 +153,12 @@ class PhysicalMemory : public Serializable
     // Let the user choose if we reserve swap space when calling mmap
     const bool mmapUsingNoReserve;
 
-    const bool isSparseRestore;
-
     const std::string sharedBackstore;
     uint64_t sharedBackstoreSize;
 
     long pageSize;
+
+    const bool isSparseRestore;
 
     // The physical memory used to provide the memory in the simulated
     // system

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -114,6 +114,10 @@ class System(SimObject):
         "shared_backstore is non-empty.",
     )
 
+    is_sparse_restore = Param.Bool(
+        False, "Skip zero-filled pages during restore"
+    )
+
     cache_line_size = Param.Unsigned(64, "Cache line size in bytes")
 
     redirect_paths = VectorParam.RedirectPath([], "Path redirections")

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -115,7 +115,9 @@ class System(SimObject):
     )
 
     is_sparse_restore = Param.Bool(
-        False, "Skip zero-filled pages during restore"
+        False,
+        "Optimizes host RAM footprint by skipping zero-filled pages during restore, "
+        "preventing physical memory allocation for unused guest regions.",
     )
 
     cache_line_size = Param.Unsigned(64, "Cache line size in bytes")

--- a/src/sim/system.cc
+++ b/src/sim/system.cc
@@ -165,24 +165,25 @@ System::Threads::quiesceTick(ContextID id, Tick when)
 int System::numSystemsRunning = 0;
 
 System::System(const Params &p)
-    : SimObject(p), _systemPort("system_port"),
+    : SimObject(p),
+      _systemPort("system_port"),
       externalMemRanges(p.external_memory_ranges.begin(),
-                         p.external_memory_ranges.end()),
+                        p.external_memory_ranges.end()),
       multiThread(p.multi_thread),
       init_param(p.init_param),
       physProxy(_systemPort, p.cache_line_size),
       workload(p.workload),
       physmem(name() + ".physmem", p.memories, p.mmap_using_noreserve,
-              p.shared_backstore, p.auto_unlink_shared_backstore),
-      ShadowRomRanges(p.shadow_rom_ranges.begin(),
-                      p.shadow_rom_ranges.end()),
+              p.shared_backstore, p.auto_unlink_shared_backstore,
+              p.is_sparse_restore),
+      ShadowRomRanges(p.shadow_rom_ranges.begin(), p.shadow_rom_ranges.end()),
       memoryMode(p.mem_mode),
       _cacheLineSize(p.cache_line_size),
       numWorkIds(p.num_work_ids),
       thermalModel(p.thermal_model),
-      _m5opRange(p.m5ops_base ?
-                 RangeSize(p.m5ops_base, 0x10000) :
-                 AddrRange(1, 0)), // Create an empty range if disabled
+      _m5opRange(p.m5ops_base
+                     ? RangeSize(p.m5ops_base, 0x10000)
+                     : AddrRange(1, 0)), // Create an empty range if disabled
       redirectPaths(p.redirect_paths)
 {
     panic_if(!workload, "No workload set for system %s "


### PR DESCRIPTION
Problem:
When restoring from a checkpoint previously the loader performed gzread() directly into the destination memory (pmem) in fixed-size chunks. This meant we always allocated RAM pages, even when the compressed data represented all-zero blocks. On large memory images, this resulted in wasting physical memory on the host system.

What the changes do:
Reads each chunk into a temporary buffer instead of writing directly to the target memory.
Scans the chunk to determine whether it contains only zero bytes.
Writes the chunk to pmem only if it contains non-zero data.
Still advances pmem and curr_size to preserve the correct memory layout.