### PR TITLE
util: Bump GPU build docker to ROCm 7.0

### DIFF
--- a/util/dockerfiles/gpu-fs/Dockerfile
+++ b/util/dockerfiles/gpu-fs/Dockerfile
@@ -53,9 +53,9 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings
 RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
     gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/6.4/ubuntu noble main" \
+RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/7.0/ubuntu noble main" \
     | tee /etc/apt/sources.list.d/amdgpu.list
-RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.4 noble main" \
+RUN echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.0 noble main" \
     | tee --append /etc/apt/sources.list.d/rocm.list
 # Note: Need to remove 'echo -e' in docker.
 RUN echo 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \

--- a/util/dockerfiles/gpu-fs/README.md
+++ b/util/dockerfiles/gpu-fs/README.md
@@ -1,7 +1,7 @@
 ## rocm-build Dockerfile
 The Dockerfile in this directory is used to build applications to be run with GPU full system.
 Applications targeting AMD's ROCm GPU framework can be built using this docker (e.g., HIP, HSA, OpenCL, etc.).
-The current major ROCm version targeted is 6.4.
+The current major ROCm version targeted is 7.0.
 This version matches the disk image provided in gem5-resources.
 
 The purpose of this docker image is to allow building applications without requiring ROCm to be installed on the host machine.


### PR DESCRIPTION
This docker image is used to build applications to be run within gem5. It is not a disk image.