### PR TITLE
cpu: Branch predictor latency and overriding model for the decoupled frontend

### DIFF
--- a/src/cpu/minor/fetch2.cc
+++ b/src/cpu/minor/fetch2.cc
@@ -204,8 +204,10 @@ Fetch2::predictBranch(MinorDynInstPtr inst, BranchData &branch)
         DPRINTF(Branch, "Trying to predict for inst: %s\n", *inst);
 
         cpu.fetchStats[inst->id.threadId]->numBranches++;
-        if (branchPredictor.predict(inst->staticInst,
-                    inst->id.fetchSeqNum, *inst_pc, inst->id.threadId)) {
+        if (branchPredictor
+                .predict(inst->staticInst, inst->id.fetchSeqNum, *inst_pc,
+                         inst->id.threadId)
+                .taken) {
             set(branch.target, *inst_pc);
             inst->predictedTaken = true;
             set(inst->predictedTarget, inst_pc);

--- a/src/cpu/o3/bac.cc
+++ b/src/cpu/o3/bac.cc
@@ -113,6 +113,7 @@ BAC::BAC(CPU *_cpu, const BaseO3CPUParams &params)
     for (int i = 0; i < MaxThreads; i++) {
         bacPC[i].reset(params.isa[0]->newPCState());
         stalls[i] = {false, false, false};
+        branchPredictRemaining[i] = Cycles(0);
     }
 }
 
@@ -227,6 +228,9 @@ BAC::drainStall(ThreadID tid)
     assert(cpu->isDraining());
     assert(!stalls[tid].drain);
     DPRINTF(Drain, "%i: Thread drained.\n", tid);
+    DPRINTF(BAC, "%i: Clearing remaining %i cycles of predictor latency.\n",
+            tid, branchPredictRemaining[tid]);
+    branchPredictRemaining[tid] = Cycles(0);
     stalls[tid].drain = true;
 }
 
@@ -403,6 +407,16 @@ BAC::checkSignalsAndUpdate(ThreadID tid)
         return true;
     }
 
+    if (branchPredictRemaining[tid] > Cycles(0)) {
+        DPRINTF(BAC,
+                "[tid:%i] Stalling for Branch Predictor for %i more cycles.\n",
+                tid, branchPredictRemaining[tid]);
+        --branchPredictRemaining[tid];
+        stalls[tid].bpu = true;
+    } else {
+        stalls[tid].bpu = false;
+    }
+
     if (checkStall(tid)) {
         bacStatus[tid] = Blocked;
         return true;
@@ -572,7 +586,7 @@ BAC::newFetchTarget(ThreadID tid, const PCStateBase &start_pc)
     return ft;
 }
 
-bool
+Prediction
 BAC::predict(ThreadID tid, const StaticInstPtr &inst, const FetchTargetPtr &ft,
              PCStateBase &pc)
 {
@@ -586,10 +600,11 @@ BAC::predict(ThreadID tid, const StaticInstPtr &inst, const FetchTargetPtr &ft,
      * main history of the BPU and insert these missing histories.
      */
     assert(ft->bpuHistory == nullptr);
-    bool taken = bpu->predict(inst, ft->ftNum(), pc, tid, ft->bpuHistory);
+
+    Prediction pred = bpu->predict(inst, ft->ftNum(), pc, tid, ft->bpuHistory);
 
     DPRINTF(Branch, "[tid:%i, ftn:%llu] History added.\n", tid, ft->ftNum());
-    return taken;
+    return pred;
 }
 
 void
@@ -686,7 +701,9 @@ BAC::generateFetchTargets(ThreadID tid, bool &status_change)
 
             // Now make the actual prediction. Note the BPU will advance
             // the PC to the next instruction.
-            predict_taken = predict(tid, staticInst, curFT, *next_pc);
+            Prediction pred = predict(tid, staticInst, curFT, *next_pc);
+            predict_taken = pred.taken;
+            branchPredictRemaining[tid] = Cycles(pred.latency);
 
             DPRINTF(BAC,
                     "[tid:%i, ftn:%llu] Branch found at PC %#x "
@@ -881,8 +898,7 @@ BAC::updatePreDecode(ThreadID tid, const InstSeqNum seqNum,
 
         hist =
             new BPredUnit::PredictorHistory(tid, seqNum, pc.instAddr(), inst);
-        bpu->branchPlaceholder(tid, pc.instAddr(), inst->isUncondCtrl(),
-                               hist->bpHistory);
+        bpu->branchPlaceholder(tid, pc.instAddr(), inst->isUncondCtrl(), hist);
 
         set(hist->target, std::unique_ptr<PCStateBase>(pc.clone()));
         inst->advancePC(*hist->target);
@@ -933,8 +949,11 @@ BAC::updatePC(const DynInstPtr &inst, PCStateBase &fetch_pc,
         } else {
             // With a coupled front-end we need to make the branch prediction
             // here.
-            predict_taken =
+            //
+            // Latency is ignored in coupled mode
+            Prediction pred =
                 bpu->predict(inst->staticInst, inst->seqNum, fetch_pc, tid);
+            predict_taken = pred.taken;
         }
 
         DPRINTF(BAC,

--- a/src/cpu/o3/bac.hh
+++ b/src/cpu/o3/bac.hh
@@ -52,6 +52,7 @@ namespace gem5
 {
 
 struct BaseO3CPUParams;
+using branch_prediction::Prediction;
 
 namespace o3
 {
@@ -247,10 +248,10 @@ class BAC
      * @param inst The branch instruction.
      * @param ft The fetch target that is currently processed.
      * @param PC The predicted PC is passed back through this parameter.
-     * @return Returns if the branch is taken or not.
+     * @return Returns the prediction result from the BPU.
      */
-    bool predict(ThreadID tid, const StaticInstPtr &inst,
-                 const FetchTargetPtr &ft, PCStateBase &pc);
+    Prediction predict(ThreadID tid, const StaticInstPtr &inst,
+                       const FetchTargetPtr &ft, PCStateBase &pc);
 
     /**
      * Main function that feeds the FTQ with new fetch targets.
@@ -364,6 +365,9 @@ class BAC
      * cycle. Used to tell CPU if there is activity this cycle.
      */
     bool wroteToTimeBuffer;
+
+    /** Tracks remaining cycles that the branch predictor stalls BAC */
+    Cycles branchPredictRemaining[MaxThreads];
 
     /** Source of possible stalls. */
     struct Stalls

--- a/src/cpu/pred/2bit_local.cc
+++ b/src/cpu/pred/2bit_local.cc
@@ -92,9 +92,8 @@ LocalBP::updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
 // Place holder for a function that is called to update predictor history
 }
 
-
-bool
-LocalBP::lookup(ThreadID tid, Addr branch_addr, void * &bp_history)
+Prediction
+LocalBP::lookup(ThreadID tid, Addr branch_addr, void *&bp_history)
 {
     bool taken;
     unsigned local_predictor_idx = getLocalIndex(branch_addr);
@@ -109,7 +108,7 @@ LocalBP::lookup(ThreadID tid, Addr branch_addr, void * &bp_history)
 
     taken = getPrediction(counter_val);
 
-    return taken;
+    return predictWithDefaultLatency(taken);
 }
 
 void

--- a/src/cpu/pred/2bit_local.hh
+++ b/src/cpu/pred/2bit_local.hh
@@ -46,6 +46,7 @@
 
 #include "base/sat_counter.hh"
 #include "base/types.hh"
+#include "cpu/pred/branch_type.hh"
 #include "cpu/pred/conditional.hh"
 #include "params/LocalBP.hh"
 
@@ -71,7 +72,7 @@ class LocalBP : public ConditionalPredictor
     LocalBP(const LocalBPParams &params);
 
     // Overriding interface functions
-    bool lookup(ThreadID tid, Addr pc, void * &bp_history) override;
+    Prediction lookup(ThreadID tid, Addr pc, void *&bp_history) override;
 
     void branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
                            void * &bpHistory) override;

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -145,7 +145,7 @@ class SimpleBTB(BranchTargetBuffer):
     )
 
 
-class ConditionalPredictor(SimObject):
+class ConditionalPredictor(ClockedObject):
     type = "ConditionalPredictor"
     cxx_class = "gem5::branch_prediction::ConditionalPredictor"
     cxx_header = "cpu/pred/conditional.hh"
@@ -154,6 +154,9 @@ class ConditionalPredictor(SimObject):
     numThreads = Param.Unsigned(Parent.numThreads, "Number of threads")
     instShiftAmt = Param.Unsigned(
         Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )
+    defaultLatency = Param.Cycles(
+        0, "Default latency of the predictor (in cycles)"
     )
     speculativeHistUpdate = Param.Bool(
         Parent.speculativeHistUpdate,
@@ -239,6 +242,10 @@ class BranchPredictor(SimObject):
     )
     conditionalBranchPred = Param.ConditionalPredictor(
         "Conditional branch predictor"
+    )
+    overridingBranchPred = Param.ConditionalPredictor(
+        NULL,
+        "Secondary, overriding predictor which corrects the primary predictor",
     )
     indirectBranchPred = Param.IndirectPredictor(
         SimpleIndirectPredictor(),

--- a/src/cpu/pred/bi_mode.cc
+++ b/src/cpu/pred/bi_mode.cc
@@ -128,8 +128,8 @@ BiModeBP::squash(ThreadID tid, void * &bp_history)
  * choice array's prediction is used to select between the two
  * direction predictors for the final branch prediction.
  */
-bool
-BiModeBP::lookup(ThreadID tid, Addr branchAddr, void * &bp_history)
+Prediction
+BiModeBP::lookup(ThreadID tid, Addr branchAddr, void *&bp_history)
 {
     unsigned choiceHistoryIdx = ((branchAddr >> instShiftAmt)
                                 & choiceHistoryMask);
@@ -163,7 +163,7 @@ BiModeBP::lookup(ThreadID tid, Addr branchAddr, void * &bp_history)
     history->finalPred = finalPrediction;
     bp_history = static_cast<void*>(history);
 
-    return finalPrediction;
+    return predictWithDefaultLatency(finalPrediction);
 }
 
 

--- a/src/cpu/pred/bi_mode.hh
+++ b/src/cpu/pred/bi_mode.hh
@@ -46,6 +46,7 @@
 #define __CPU_PRED_BI_MODE_PRED_HH__
 
 #include "base/sat_counter.hh"
+#include "cpu/pred/branch_type.hh"
 #include "cpu/pred/conditional.hh"
 #include "params/BiModeBP.hh"
 
@@ -73,7 +74,7 @@ class BiModeBP : public ConditionalPredictor
 {
   public:
     BiModeBP(const BiModeBPParams &params);
-    bool lookup(ThreadID tid, Addr pc, void * &bp_history) override;
+    Prediction lookup(ThreadID tid, Addr pc, void *&bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
                          Addr target, const StaticInstPtr &inst,
                          void * &bp_history) override;

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -56,12 +56,18 @@ namespace branch_prediction
 {
 
 BPredUnit::BPredUnit(const Params &params)
-    : SimObject(params), numThreads(params.numThreads),
+    : SimObject(params),
+      numThreads(params.numThreads),
       requiresBTBHit(params.requiresBTBHit),
       updateBTBAtSquash(params.updateBTBAtSquash),
-      instShiftAmt(params.instShiftAmt), predHist(numThreads), btb(params.btb),
-      ras(params.ras), cPred(params.conditionalBranchPred),
-      iPred(params.indirectBranchPred), stats(this)
+      instShiftAmt(params.instShiftAmt),
+      predHist(numThreads),
+      btb(params.btb),
+      ras(params.ras),
+      cPred(params.conditionalBranchPred),
+      overridingCPred(params.overridingBranchPred),
+      iPred(params.indirectBranchPred),
+      stats(this)
 {
 }
 
@@ -91,14 +97,13 @@ BPredUnit::drainSanityCheck() const
         assert(ph.empty());
 }
 
-
-bool
+Prediction
 BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                    PCStateBase &pc, ThreadID tid)
 {
     /** Perform the prediction. */
     PredictorHistory* bpu_history = nullptr;
-    bool taken  = predict(inst, seqNum, pc, tid, bpu_history);
+    Prediction pred = predict(inst, seqNum, pc, tid, bpu_history);
 
     assert(bpu_history!=nullptr);
 
@@ -108,7 +113,7 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
     DPRINTF(Branch, "[tid:%i] [sn:%llu] History entry added. "
             "predHist.size(): %i\n", tid, seqNum, predHist[tid].size());
 
-    return taken;
+    return pred;
 }
 
 void
@@ -117,12 +122,13 @@ BPredUnit::insertPredictorHistory(ThreadID tid, PredictorHistory *&bpu_history)
     predHist[tid].push_front(bpu_history);
 }
 
-bool
+Prediction
 BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
-                   PCStateBase &pc, ThreadID tid, PredictorHistory* &hist)
+                   PCStateBase &pc, ThreadID tid, PredictorHistory *&hist)
 {
     assert(hist == nullptr);
 
+    Cycles totalLatency = Cycles(0);
 
     // See if branch predictor predicts taken.
     // If so, get its target addr either from the BTB or the RAS.
@@ -150,7 +156,29 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
     } else {
         // Conditional branches -------
         ++stats.condPredicted;
-        hist->condPred = cPred->lookup(tid, pc.instAddr(), hist->bpHistory);
+        Prediction condPred =
+            cPred->lookup(tid, pc.instAddr(), hist->bpHistory);
+        hist->condPred = condPred.taken;
+
+        if (overridingCPred) {
+
+            Prediction secondaryPred = overridingCPred->lookup(
+                tid, pc.instAddr(), hist->overridingBpHistory);
+            if (secondaryPred.taken != hist->condPred) {
+                // If the predictors disagree,
+                // use the result of the overriding predictor
+                // and incur its latency
+                totalLatency += secondaryPred.latency;
+                hist->condPred = secondaryPred.taken;
+                hist->overridden = true;
+            } else {
+                // If the predictors agree,
+                // use the result of the primary predictor
+                totalLatency += condPred.latency;
+            }
+        } else {
+            totalLatency += condPred.latency;
+        }
 
         if (hist->condPred) {
             ++stats.condPredictedTaken;
@@ -320,6 +348,11 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                            hist->target->instAddr(), hist->inst,
                            hist->bpHistory);
 
+    if (overridingCPred) {
+        overridingCPred->updateHistories(
+            tid, hist->pc, hist->uncond, hist->predTaken,
+            hist->target->instAddr(), hist->inst, hist->overridingBpHistory);
+    }
 
     if (iPred) {
         // Update the indirect predictor with the direction prediction
@@ -327,7 +360,10 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
                       *hist->target, brType, hist->indirectHistory);
     }
 
-    return hist->predTaken;
+    return Prediction{
+        .taken = hist->predTaken,
+        .latency = totalLatency,
+    };
 }
 
 
@@ -378,6 +414,20 @@ BPredUnit::commitBranch(ThreadID tid, PredictorHistory* &hist)
     // Update the branch predictor with the correct results.
     cPred->update(tid, hist->pc, hist->actuallyTaken, hist->bpHistory, false,
                   hist->inst, hist->target->instAddr());
+
+    if (hist->inst->isCondCtrl()) {
+        updateStatsOverriding(hist->condPred, hist->actuallyTaken,
+                              hist->overridden);
+    }
+
+    // If the overriding predictor was used,
+    // also update it with the correct result
+    if (overridingCPred) {
+
+        overridingCPred->update(tid, hist->pc, hist->actuallyTaken,
+                                hist->overridingBpHistory, false, hist->inst,
+                                hist->target->instAddr());
+    }
 
     // Commit also Indirect predictor and RAS
     if (iPred) {
@@ -451,6 +501,13 @@ BPredUnit::squashHistory(ThreadID tid, PredictorHistory* &history)
     // This call will  delete the bpHistory.
     cPred->squash(tid, history->bpHistory);
 
+    // If the overriding predictor was used, also squash it
+    // This call will delete the overridingBpHistory.
+    if (overridingCPred) {
+        overridingCPred->squash(tid, history->overridingBpHistory);
+        assert(history->overridingBpHistory == nullptr);
+    }
+
     delete history;
     history = nullptr;
 }
@@ -522,9 +579,15 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
         set(hist->target,  corr_target);
 
         // Correct Direction predictor ------------------
-        cPred->update(tid, hist->pc, actually_taken, hist->bpHistory,
-                      true, hist->inst, corr_target.instAddr());
+        cPred->update(tid, hist->pc, actually_taken, hist->bpHistory, true,
+                      hist->inst, corr_target.instAddr());
 
+        // If the overriding predictor was used, also update it
+        if (overridingCPred) {
+            overridingCPred->update(tid, hist->pc, actually_taken,
+                                    hist->overridingBpHistory, true,
+                                    hist->inst, corr_target.instAddr());
+        }
 
         // Correct Indirect predictor -------------------
         if (iPred) {
@@ -608,17 +671,23 @@ BPredUnit::updateBTB(ThreadID tid, PredictorHistory *&hist)
         if (hist->condPred) ++stats.predTakenBTBMiss;
     }
 
+    stats.uniqueBranches.insert(hist->pc);
     stats.BTBUpdates++;
     btb->update(tid, hist->pc, *hist->target, hist->type, hist->inst);
     btb->incorrectTarget(hist->pc, hist->type);
 }
 
 void
-BPredUnit::branchPlaceholder(ThreadID tid, Addr pc,
-                             bool uncond, void * &bp_history)
+BPredUnit::branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
+                             PredictorHistory *&hist)
 {
     // Delegate to conditional predictor
-    cPred->branchPlaceholder(tid, pc, uncond, bp_history);
+    cPred->branchPlaceholder(tid, pc, uncond, hist->bpHistory);
+    // If the overriding predictor is used, also call it
+    if (overridingCPred) {
+        overridingCPred->branchPlaceholder(tid, pc, uncond,
+                                           hist->overridingBpHistory);
+    }
 }
 
 void
@@ -645,37 +714,57 @@ BPredUnit::dump()
     }
 }
 
+void
+BPredUnit::updateStatsOverriding(bool prediction, bool actuallyTaken,
+                                 bool overridden)
+{
+    if (prediction != actuallyTaken) {
+        if (overridden) {
+            ++stats.condWrongOverridden;
+        } else {
+            ++stats.condWrongBasePred;
+        }
+    } else {
+        if (overridden) {
+            ++stats.condCorrectOverridden;
+        } else {
+            ++stats.condCorrectBasePred;
+        }
+    }
+}
 
 BPredUnit::BPredUnitStats::BPredUnitStats(BPredUnit *bp)
     : statistics::Group(bp),
+      uniqueBranches(),
       ADD_STAT(lookups, statistics::units::Count::get(),
-              "Number of BP lookups"),
+               "Number of BP lookups"),
       ADD_STAT(squashes, statistics::units::Count::get(),
-              "Number of branches that got squashed (completely removed) as "
-              "an earlier branch was mispredicted."),
+               "Number of branches that got squashed (completely removed) as "
+               "an earlier branch was mispredicted."),
       ADD_STAT(corrected, statistics::units::Count::get(),
-              "Number of branches that got corrected but not yet commited. "
-              "Branches get corrected by decode or after execute. Also a "
-              "branch misprediction can be detected out-of-order. Therefore, "
-              "a corrected branch might not end up beeing committed in case "
-              "an even earlier branch was mispredicted"),
+               "Number of branches that got corrected but not yet commited. "
+               "Branches get corrected by decode or after execute. Also a "
+               "branch misprediction can be detected out-of-order. Therefore, "
+               "a corrected branch might not end up beeing committed in case "
+               "an even earlier branch was mispredicted"),
       ADD_STAT(earlyResteers, statistics::units::Count::get(),
-              "Number of branches that got redirected after decode."),
+               "Number of branches that got redirected after decode."),
       ADD_STAT(committed, statistics::units::Count::get(),
-              "Number of branches finally committed "),
+               "Number of branches finally committed "),
       ADD_STAT(mispredicted, statistics::units::Count::get(),
-              "Number of committed branches that were mispredicted."),
+               "Number of committed branches that were mispredicted."),
       ADD_STAT(mispredictDueToPredictor, statistics::units::Count::get(),
-              "Number of committed branches that were mispredicted by the "
-              "predictor."),
-      ADD_STAT(mispredictDueToBTBMiss, statistics::units::Count::get(),
-              "Number of committed branches that were mispredicted because of "
-              "a BTB miss."),
+               "Number of committed branches that were mispredicted by the "
+               "predictor."),
+      ADD_STAT(
+          mispredictDueToBTBMiss, statistics::units::Count::get(),
+          "Number of committed branches that were mispredicted because of "
+          "a BTB miss."),
       ADD_STAT(targetProvider, statistics::units::Count::get(),
-              "The component providing the target for taken branches"),
+               "The component providing the target for taken branches"),
       ADD_STAT(targetWrong, statistics::units::Count::get(),
-              "Number of branches where the target was incorrect or not "
-              "available at prediction time."),
+               "Number of branches where the target was incorrect or not "
+               "available at prediction time."),
       ADD_STAT(condPredicted, statistics::units::Count::get(),
                "Number of conditional branches predicted"),
       ADD_STAT(condPredictedTaken, statistics::units::Count::get(),
@@ -684,12 +773,24 @@ BPredUnit::BPredUnitStats::BPredUnitStats(BPredUnit *bp)
                "Number of conditional branches incorrect"),
       ADD_STAT(predTakenBTBMiss, statistics::units::Count::get(),
                "Number of branches predicted taken but missed in BTB"),
+      ADD_STAT(condWrongBasePred, statistics::units::Count::get(),
+               "Number of branches predicted wrong with the "
+               "base predictor (not overridden)"),
+      ADD_STAT(condWrongOverridden, statistics::units::Count::get(),
+               "Number of branches predicted wrong after being overridden"),
+      ADD_STAT(condCorrectBasePred, statistics::units::Count::get(),
+               "Number of branches predicted correctly only by the "
+               "base predictor (not overridden)"),
+      ADD_STAT(condCorrectOverridden, statistics::units::Count::get(),
+               "Number of branches predicted correctly "
+               "after being overridden"),
+      ADD_STAT(BTBUniqueBranches, statistics::units::Count::get(),
+               "Number of unique branches encountered by the BTB"),
       ADD_STAT(BTBLookups, statistics::units::Count::get(),
                "Number of BTB lookups"),
       ADD_STAT(BTBUpdates, statistics::units::Count::get(),
                "Number of BTB updates"),
-      ADD_STAT(BTBHits, statistics::units::Count::get(),
-               "Number of BTB hits"),
+      ADD_STAT(BTBHits, statistics::units::Count::get(), "Number of BTB hits"),
       ADD_STAT(BTBHitRatio, statistics::units::Ratio::get(), "BTB Hit Ratio",
                BTBHits / BTBLookups),
       ADD_STAT(BTBMispredicted, statistics::units::Count::get(),
@@ -757,6 +858,20 @@ BPredUnit::BPredUnitStats::BPredUnitStats(BPredUnit *bp)
         .flags(total | pdf);
     targetWrong.ysubnames(enums::BranchTypeStrings);
 
+}
+
+void
+BPredUnit::BPredUnitStats::preDumpStats()
+{
+    BTBUniqueBranches = uniqueBranches.size();
+}
+
+void
+BPredUnit::BPredUnitStats::resetStats()
+{
+    statistics::Group::resetStats();
+
+    uniqueBranches.clear();
 }
 
 } // namespace branch_prediction

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -70,11 +70,11 @@ namespace branch_prediction
  */
 class BPredUnit : public SimObject
 {
+    /** Branch Predictor Unit (BPU) interface functions */
+  public:
     typedef BranchPredictorParams Params;
     typedef enums::TargetProvider TargetProvider;
 
-    /** Branch Predictor Unit (BPU) interface functions */
-  public:
     /**
      * @param params The params object, that has the size of the BP and BTB.
      */
@@ -94,8 +94,8 @@ class BPredUnit : public SimObject
      * @param tid The thread id.
      * @return Returns if the branch is taken or not.
      */
-    bool predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
-                 PCStateBase &pc, ThreadID tid);
+    Prediction predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
+                       PCStateBase &pc, ThreadID tid);
 
     /**
      * Tells the branch predictor to commit any updates until the given
@@ -127,6 +127,10 @@ class BPredUnit : public SimObject
     void squash(const InstSeqNum &squashed_sn, const PCStateBase &corr_target,
                 bool actually_taken, ThreadID tid, bool from_commit=true);
 
+    /** *******************************************************
+     * Interface functions to the conditional branch predictor
+     *
+     */
     /**
      * Looks up a given PC in the BTB to see if a matching entry exists.
      * @param tid The thread id.
@@ -180,24 +184,6 @@ class BPredUnit : public SimObject
         ++stats.BTBUpdates;
         return btb->update(tid, pc, target);
     }
-
-    /**
-     * Special function for the decoupled front-end. In it there can be
-     * branches which are not detected by the BPU in the first place as it
-     * requires a BTB hit. This function will generate a placeholder for
-     * such a branch once it is pre-decoded in the fetch stage. It will
-     * only create the branch history object but not update any internal state
-     * of the BPU.
-     * If the branch turns to be wrong then decode or commit will
-     * be able to use the normal squash functionality to correct the branch.
-     * Note that not all branch predictors implement this functionality.
-     * @param tid The thread id.
-     * @param pc The branch's PC.
-     * @param uncond Whether or not this branch is an unconditional branch.
-     * @param bp_history Pointer that will be set to an branch history object.
-     */
-    void branchPlaceholder(ThreadID tid, Addr pc,
-                            bool uncond, void * &bp_history);
 
     void dump();
 
@@ -269,6 +255,7 @@ class BPredUnit : public SimObject
      *         +-------------------------------------+
      *
      */
+
     struct PredictorHistory
     {
         /**
@@ -276,16 +263,27 @@ class BPredUnit : public SimObject
          * information needed to update the predictor, BTB, and RAS.
          */
         PredictorHistory(ThreadID _tid, InstSeqNum sn, Addr _pc,
-                         const StaticInstPtr & inst)
-            : seqNum(sn), tid(_tid), pc(_pc),
-              inst(inst), type(getBranchType(inst)),
-              call(inst->isCall()), uncond(!inst->isCondCtrl()),
-              predTaken(false), actuallyTaken(false), condPred(false),
-              btbHit(false), targetProvider(TargetProvider::NoTarget),
-              resteered(false), mispredict(false), target(nullptr),
+                         const StaticInstPtr &inst)
+            : seqNum(sn),
+              tid(_tid),
+              pc(_pc),
+              inst(inst),
+              type(getBranchType(inst)),
+              call(inst->isCall()),
+              uncond(!inst->isCondCtrl()),
+              predTaken(false),
+              actuallyTaken(false),
+              condPred(false),
+              overridden(false),
+              btbHit(false),
+              targetProvider(TargetProvider::NoTarget),
+              resteered(false),
+              mispredict(false),
+              target(nullptr),
               bpHistory(nullptr),
-              indirectHistory(nullptr), rasHistory(nullptr)
-        { }
+              indirectHistory(nullptr),
+              rasHistory(nullptr)
+        {}
 
         ~PredictorHistory()
         {
@@ -333,6 +331,9 @@ class BPredUnit : public SimObject
         /** The prediction of the conditional predictor */
         bool condPred;
 
+        /** Whether the overriding predictor was the provider */
+        bool overridden;
+
         /** Was BTB hit at prediction time */
         bool btbHit;
 
@@ -356,10 +357,11 @@ class BPredUnit : public SimObject
          */
         void *bpHistory = nullptr;
 
+        void *overridingBpHistory = nullptr;
+
         void *indirectHistory = nullptr;
 
         void *rasHistory = nullptr;
-
     };
 
     /**
@@ -374,8 +376,9 @@ class BPredUnit : public SimObject
     /**
      * Internal prediction function.
      */
-    bool predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
-               PCStateBase &pc, ThreadID tid, PredictorHistory* &bpu_history);
+    Prediction predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
+                       PCStateBase &pc, ThreadID tid,
+                       PredictorHistory *&bpu_history);
 
     /**
      * Squashes a particular branch instance. Reverts
@@ -391,7 +394,25 @@ class BPredUnit : public SimObject
      * @param tid The thread id.
      * @param bpu_history The history of the branch to be commited.
      */
-    void commitBranch(ThreadID tid, PredictorHistory* &bpu_history);
+    void commitBranch(ThreadID tid, PredictorHistory *&bpu_history);
+
+    /**
+     * Special function for the decoupled front-end. In it there can be
+     * branches which are not detected by the BPU in the first place as it
+     * requires a BTB hit. This function will generate a placeholder for
+     * such a branch once it is pre-decoded in the fetch stage. It will
+     * only create the branch history object but not update any internal state
+     * of the BPU.
+     * If the branch turns to be wrong then decode or commit will
+     * be able to use the normal squash functionality to correct the branch.
+     * Note that not all branch predictors implement this functionality.
+     * @param tid The thread id.
+     * @param pc The branch's PC.
+     * @param uncond Whether or not this branch is an unconditional branch.
+     * @param bp_history Pointer that will be set to an branch history object.
+     */
+    void branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
+                           PredictorHistory *&bpu_history);
 
     /**
      *  Update the BTB with the correct target of a branch.
@@ -399,6 +420,12 @@ class BPredUnit : public SimObject
      * @param bpu_history The history of the branch to be updated.
      */
     void updateBTB(ThreadID tid, PredictorHistory *&bpu_history);
+
+    /**
+     * Stat collection for overriding
+     */
+    void updateStatsOverriding(bool prediction, bool actuallyTaken,
+                               bool overridden);
 
   protected:
     /** Number of the threads for which the branch history is maintained. */
@@ -437,6 +464,9 @@ class BPredUnit : public SimObject
     /** The conditional branch predictor. */
     ConditionalPredictor * cPred;
 
+    /** The overriding conditional branch predictor. */
+    ConditionalPredictor *overridingCPred;
+
     /** The indirect target predictor. */
     IndirectPredictor * iPred;
 
@@ -444,6 +474,11 @@ class BPredUnit : public SimObject
     struct BPredUnitStats : public statistics::Group
     {
         BPredUnitStats(BPredUnit *bp);
+
+        std::unordered_set<Addr> uniqueBranches;
+
+        void preDumpStats() override;
+        void resetStats() override;
 
         /** Stats per branch type */
         statistics::Vector2d lookups;
@@ -465,7 +500,14 @@ class BPredUnit : public SimObject
         statistics::Scalar condIncorrect;
         statistics::Scalar predTakenBTBMiss;
 
+        /** Additional scalar stats for the overriding predictor */
+        statistics::Scalar condWrongBasePred;
+        statistics::Scalar condWrongOverridden;
+        statistics::Scalar condCorrectBasePred;
+        statistics::Scalar condCorrectOverridden;
+
         /** BTB stats. */
+        statistics::Scalar BTBUniqueBranches;
         statistics::Scalar BTBLookups;
         statistics::Scalar BTBUpdates;
         statistics::Scalar BTBHits;

--- a/src/cpu/pred/branch_type.hh
+++ b/src/cpu/pred/branch_type.hh
@@ -84,6 +84,13 @@ inline std::string toString(BranchType type)
     return std::string(enums::BranchTypeStrings[type]);
 }
 
+struct Prediction
+{
+    /** Whether the branch is predicted taken */
+    bool taken;
+    /** The latency that this prediction would normally take */
+    Cycles latency;
+};
 
 } // namespace branch_prediction
 } // namespace gem5

--- a/src/cpu/pred/conditional.cc
+++ b/src/cpu/pred/conditional.cc
@@ -41,6 +41,8 @@
 
 #include "cpu/pred/conditional.hh"
 
+#include "base/types.hh"
+
 namespace gem5
 {
 
@@ -48,11 +50,10 @@ namespace branch_prediction
 {
 
 ConditionalPredictor::ConditionalPredictor(const Params &params)
-    : SimObject(params),
-      instShiftAmt(params.instShiftAmt)
-{
-}
-
+    : ClockedObject(params),
+      instShiftAmt(params.instShiftAmt),
+      defaultLatency(params.defaultLatency)
+{}
 
 void
 ConditionalPredictor::branchPlaceholder(ThreadID tid, Addr pc,

--- a/src/cpu/pred/conditional.hh
+++ b/src/cpu/pred/conditional.hh
@@ -46,7 +46,7 @@
 #include "cpu/inst_seq.hh"
 #include "cpu/pred/branch_type.hh"
 #include "params/ConditionalPredictor.hh"
-#include "sim/sim_object.hh"
+#include "sim/clocked_object.hh"
 
 namespace gem5
 {
@@ -54,14 +54,22 @@ namespace gem5
 namespace branch_prediction
 {
 
-class ConditionalPredictor : public SimObject
+class ConditionalPredictor : public ClockedObject
 {
   public:
-
     typedef ConditionalPredictorParams Params;
 
     ConditionalPredictor(const Params &params);
 
+    /**
+     * Returns the default prediction latency in cycles
+     * @return The prediction latency in cycles
+     */
+    Cycles
+    getDefaultLatency() const
+    {
+        return defaultLatency;
+    }
 
     /**
      * Looks up a given conditional branch PC of in the BP to see if it
@@ -72,7 +80,7 @@ class ConditionalPredictor : public SimObject
      * has the branch predictor state associated with the lookup.
      * @return Whether the branch is taken or not taken.
      */
-    virtual bool lookup(ThreadID tid, Addr pc, void * &bp_history) = 0;
+    virtual Prediction lookup(ThreadID tid, Addr pc, void *&bp_history) = 0;
 
     /**
      * Ones done with the prediction this function updates the
@@ -141,6 +149,16 @@ class ConditionalPredictor : public SimObject
 
     /** Number of bits to shift instructions by for predictor addresses. */
     const unsigned instShiftAmt;
+
+    /** Default latency of the predictor in cycles */
+    const Cycles defaultLatency;
+
+    /** Return a prediction with the default latency */
+    Prediction
+    predictWithDefaultLatency(bool taken) const
+    {
+        return Prediction{taken, defaultLatency};
+    }
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/ltage.cc
+++ b/src/cpu/pred/ltage.cc
@@ -81,9 +81,9 @@ LTAGE::branchPlaceholder(ThreadID tid, Addr pc,
     bpHistory = (void*)(bi);
 }
 
-//prediction
-bool
-LTAGE::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void* &b)
+// prediction
+Prediction
+LTAGE::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void *&b)
 {
     LTageBranchInfo *bi = new LTageBranchInfo(*tage, *loopPredictor,
                                               branch_pc, cond_branch);
@@ -110,7 +110,7 @@ LTAGE::predict(ThreadID tid, Addr branch_pc, bool cond_branch, void* &b)
     // record final prediction
     bi->lpBranchInfo->predTaken = pred_taken;
 
-    return pred_taken;
+    return predictWithDefaultLatency(pred_taken);
 }
 
 // PREDICTOR UPDATE

--- a/src/cpu/pred/ltage.hh
+++ b/src/cpu/pred/ltage.hh
@@ -89,7 +89,6 @@ class LTAGE : public TAGE
                            bool uncond, void * &bp_history) override;
     void init() override;
 
-  protected:
     /** The loop predictor object */
     LoopPredictor *loopPredictor;
 
@@ -127,8 +126,8 @@ class LTAGE : public TAGE
      * @param b Reference to wrapping pointer to allow storing
      * derived class prediction information in the base class.
      */
-    bool predict(
-        ThreadID tid, Addr branch_pc, bool cond_branch, void* &b) override;
+    Prediction predict(ThreadID tid, Addr branch_pc, bool cond_branch,
+                       void *&b) override;
 };
 
 } // namespace branch_prediction

--- a/src/cpu/pred/multiperspective_perceptron.cc
+++ b/src/cpu/pred/multiperspective_perceptron.cc
@@ -591,9 +591,9 @@ MultiperspectivePerceptron::updateHistories(ThreadID tid, Addr pc,
     threadData[tid]->path_history[0] = pc2;
 }
 
-bool
+Prediction
 MultiperspectivePerceptron::lookup(ThreadID tid, Addr instPC,
-                                   void * &bp_history)
+                                   void *&bp_history)
 {
     MPPBranchInfo *bi = new MPPBranchInfo(instPC, pcshift, true);
     bp_history = (void *)bi;
@@ -608,11 +608,11 @@ MultiperspectivePerceptron::lookup(ThreadID tid, Addr instPC,
         if (f.alwaysNotTakenSoFar()) {
             bi->filtered = true;
             bi->prediction = false;
-            return false;
+            return predictWithDefaultLatency(false);
         } else if (f.alwaysTakenSoFar()) {
             bi->filtered = true;
             bi->prediction = true;
-            return true;
+            return predictWithDefaultLatency(true);
         }
         if (f.neverSeen()) {
             use_static = true;
@@ -630,7 +630,7 @@ MultiperspectivePerceptron::lookup(ThreadID tid, Addr instPC,
         }
     }
 
-    return bi->prediction;
+    return predictWithDefaultLatency(bi->prediction);
 }
 
 void

--- a/src/cpu/pred/multiperspective_perceptron.hh
+++ b/src/cpu/pred/multiperspective_perceptron.hh
@@ -1064,7 +1064,8 @@ class MultiperspectivePerceptron : public ConditionalPredictor
     void init() override;
 
     // Base class methods.
-    bool lookup(ThreadID tid, Addr branch_addr, void* &bp_history) override;
+    Prediction lookup(ThreadID tid, Addr branch_addr,
+                      void *&bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
                          Addr target, const StaticInstPtr &inst,
                          void * &bp_history) override;

--- a/src/cpu/pred/multiperspective_perceptron_tage.cc
+++ b/src/cpu/pred/multiperspective_perceptron_tage.cc
@@ -515,9 +515,9 @@ MultiperspectivePerceptronTAGE::updateHistories(ThreadID tid,
     }
 }
 
-bool
+Prediction
 MultiperspectivePerceptronTAGE::lookup(ThreadID tid, Addr instPC,
-                                   void * &bp_history)
+                                       void *&bp_history)
 {
     MPPTAGEBranchInfo *bi =
         new MPPTAGEBranchInfo(instPC, pcshift, true, *tage, *loopPredictor,
@@ -543,7 +543,7 @@ MultiperspectivePerceptronTAGE::lookup(ThreadID tid, Addr instPC,
             0 /* altBank: unused */, init_lsum);
     bi->predictedTaken = pred_taken;
     bi->lpBranchInfo->predTaken = pred_taken;
-    return pred_taken;
+    return predictWithDefaultLatency(pred_taken);
 }
 
 

--- a/src/cpu/pred/multiperspective_perceptron_tage.hh
+++ b/src/cpu/pred/multiperspective_perceptron_tage.hh
@@ -250,7 +250,7 @@ class MultiperspectivePerceptronTAGE : public MultiperspectivePerceptron
 
     void init() override;
 
-    bool lookup(ThreadID tid, Addr instPC, void * &bp_history) override;
+    Prediction lookup(ThreadID tid, Addr instPC, void *&bp_history) override;
 
     void update(ThreadID tid, Addr pc, bool taken,
                 void * &bp_history, bool squashed,

--- a/src/cpu/pred/tage.cc
+++ b/src/cpu/pred/tage.cc
@@ -110,20 +110,21 @@ TAGE::squash(ThreadID tid, void * &bp_history)
     bp_history = nullptr;
 }
 
-bool
-TAGE::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
+Prediction
+TAGE::predict(ThreadID tid, Addr pc, bool cond_branch, void *&b)
 {
     TageBranchInfo *bi = new TageBranchInfo(*tage, pc, cond_branch);
-    b = (void*)(bi);
-    return tage->tagePredict(tid, pc, cond_branch, bi->tageBranchInfo);
+    b = (void *)(bi);
+    return predictWithDefaultLatency(
+        tage->tagePredict(tid, pc, cond_branch, bi->tageBranchInfo));
 }
 
-bool
-TAGE::lookup(ThreadID tid, Addr pc, void* &bp_history)
+Prediction
+TAGE::lookup(ThreadID tid, Addr pc, void *&bp_history)
 {
-    bool retval = predict(tid, pc, true, bp_history);
+    Prediction retval = predict(tid, pc, true, bp_history);
 
-    DPRINTF(Tage, "Lookup branch: %lx; predict:%d\n", pc, retval);
+    DPRINTF(Tage, "Lookup branch: %lx; predict:%d\n", pc, retval.taken);
 
     return retval;
 }

--- a/src/cpu/pred/tage.hh
+++ b/src/cpu/pred/tage.hh
@@ -95,15 +95,15 @@ class TAGE: public ConditionalPredictor
         }
     };
 
-    virtual bool predict(ThreadID tid, Addr branch_pc, bool cond_branch,
-                         void* &b);
+    virtual Prediction predict(ThreadID tid, Addr branch_pc, bool cond_branch,
+                               void *&b);
 
   public:
 
     TAGE(const TAGEParams &params);
 
     // Base class methods.
-    bool lookup(ThreadID tid, Addr pc, void* &bp_history) override;
+    Prediction lookup(ThreadID tid, Addr pc, void *&bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond,
                          bool taken, Addr target, const StaticInstPtr &inst,
                          void * &bp_history) override;

--- a/src/cpu/pred/tage_sc_l.cc
+++ b/src/cpu/pred/tage_sc_l.cc
@@ -401,8 +401,8 @@ TAGE_SC_L::branchPlaceholder(ThreadID tid, Addr pc, bool uncond,
     bp_history = (void *)(bi);
 }
 
-bool
-TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
+Prediction
+TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void *&b)
 {
     TageSCLBranchInfo *bi = new TageSCLBranchInfo(*tage,
                                                   *statisticalCorrector,
@@ -454,7 +454,7 @@ TAGE_SC_L::predict(ThreadID tid, Addr pc, bool cond_branch, void* &b)
     // record final prediction
     bi->lpBranchInfo->predTaken = pred_taken;
 
-    return pred_taken;
+    return predictWithDefaultLatency(pred_taken);
 }
 
 void

--- a/src/cpu/pred/tage_sc_l.hh
+++ b/src/cpu/pred/tage_sc_l.hh
@@ -171,8 +171,8 @@ class TAGE_SC_L: public LTAGE
   public:
     TAGE_SC_L(const TAGE_SC_LParams &params);
 
-    bool predict(
-        ThreadID tid, Addr branch_pc, bool cond_branch, void* &b) override;
+    Prediction predict(ThreadID tid, Addr branch_pc, bool cond_branch,
+                       void *&b) override;
     void squash(ThreadID tid, void * &bp_history) override;
     void update(ThreadID tid, Addr pc, bool taken, void * &bp_history,
                 bool squashed, const StaticInstPtr & inst,

--- a/src/cpu/pred/tournament.cc
+++ b/src/cpu/pred/tournament.cc
@@ -149,8 +149,8 @@ TournamentBP::updateLocalHist(unsigned local_history_idx, bool taken)
         (localHistoryTable[local_history_idx] << 1) | taken;
 }
 
-bool
-TournamentBP::lookup(ThreadID tid, Addr pc, void * &bp_history)
+Prediction
+TournamentBP::lookup(ThreadID tid, Addr pc, void *&bp_history)
 {
     bool local_prediction;
     unsigned local_history_idx;
@@ -188,9 +188,9 @@ TournamentBP::lookup(ThreadID tid, Addr pc, void * &bp_history)
     // Select and return the prediction
     // History update will be happen in the next function
     if (choice_prediction) {
-        return global_prediction;
+        return predictWithDefaultLatency(global_prediction);
     } else {
-        return local_prediction;
+        return predictWithDefaultLatency(local_prediction);
     }
 }
 

--- a/src/cpu/pred/tournament.hh
+++ b/src/cpu/pred/tournament.hh
@@ -72,7 +72,7 @@ class TournamentBP : public ConditionalPredictor
     TournamentBP(const TournamentBPParams &params);
 
     // Base class methods.
-    bool lookup(ThreadID tid, Addr pc, void* &bp_history) override;
+    Prediction lookup(ThreadID tid, Addr pc, void *&bp_history) override;
     void updateHistories(ThreadID tid, Addr pc, bool uncond, bool taken,
                          Addr target, const StaticInstPtr &inst,
                          void * &bp_history) override;

--- a/src/cpu/simple/base.cc
+++ b/src/cpu/simple/base.cc
@@ -414,8 +414,9 @@ BaseSimpleCPU::preExecute()
         const InstSeqNum cur_sn(0);
         set(t_info.predPC, thread->pcState());
         const bool predict_taken(
-            branchPred->predict(curStaticInst, cur_sn, *t_info.predPC,
-                curThread));
+            branchPred
+                ->predict(curStaticInst, cur_sn, *t_info.predPC, curThread)
+                .taken);
 
         if (predict_taken)
             ++t_info.execContextStats.numPredictedBranches;


### PR DESCRIPTION
This change enhances the realism of the branch predictor, providing a model for access latency to the conditional BP and an accompanying implementation of overriding prediction (https://www.cs.utexas.edu/~skeckler/pubs/micro00.pdf)

It builds on top of the decoupled frontend, and applies an amount of latency which can be statically configured but then also dynamically overridden by implementors of `conditional.cc` to allow more complex behaviour.

The decoupled frontend is stalled for the amount of cycles specified after each prediction.
Users can optionally specify a secondary overriding predictor, with a different latency.

By default, overriding is disabled and the latency is statically configured to 0 cycles.
To choose different settings, the following configuration can be used:

```python
from m5.objects import BranchPredictor, SimpleBTB, LocalBP, TAGE_SC_L_64KB 

class BPU(BranchPredictor):
    btb = SimpleBTB()
    conditionalBranchPred = LocalBP(
        defaultLatency = 1
    )
    overridingBranchPred = TAGE_SC_L_64KB(
        defaultLatency = 3
    )

cpu.branchPred = BPU()
```

In this case, `LocalBP` is overridden by `TAGE_SC_L_64KB`, producing the following behaviour:
- When a conditional branch is reached by the decoupled frontend, both predictors are queried simultaneously
- The results are compared:
    - If both predictors agree, 1 cycle of latency is applied to the `BAC` stage
    - On a disagreement, the result from `TAGE_SC_L_64KB` is used, and 3 cycles of latency are applied to the `BAC` stage   