### PR TITLE
configs, test: Fix Neoverse SystemOp handling & mv test to CI with ALL/gem5 com

### DIFF
--- a/configs/common/cores/arm/neoverse_v2.py
+++ b/configs/common/cores/arm/neoverse_v2.py
@@ -51,6 +51,7 @@ class NeoverseV2_Complex_Int(FUDesc):
         OpDesc(opClass="IntDiv", opLat=11, pipelined=False),
         # Treat system register (IPR) accesses as regular integer ops.
         OpDesc(opClass="IntAlu", opLat=3, pipelined=True),
+        OpDesc(opClass="System", opLat=3, pipelined=True),
     ]
 
 

--- a/tests/gem5/example_configs/neoverse/test_neoverse_v2.py
+++ b/tests/gem5/example_configs/neoverse/test_neoverse_v2.py
@@ -41,5 +41,5 @@ gem5_verify_config(
     valid_isas=(constants.all_compiled_tag,),
     valid_hosts=constants.supported_hosts,
     fixtures=(),
-    length=constants.long_tag,
+    length=constants.quick_tag,
 )

--- a/tests/gem5/example_configs/neoverse/test_neoverse_v2.py
+++ b/tests/gem5/example_configs/neoverse/test_neoverse_v2.py
@@ -38,7 +38,7 @@ gem5_verify_config(
         config.base_dir, "configs", "example", "arm", "fdp_neoverse_v2.py"
     ),
     config_args=[f"--workload=hello"],
-    valid_isas=(constants.arm_tag,),
+    valid_isas=(constants.all_compiled_tag,),
     valid_hosts=constants.supported_hosts,
     fixtures=(),
     length=constants.long_tag,


### PR DESCRIPTION
- Restore the Neoverse V2 complex integer FU’s ability to execute SystemOp instructions so MSR/MRS sequences (e.g., TLS setup) no longer deadlock SE workloads.
- Update the Neoverse example tests to run with the ALL/gem5.opt binary, matching how we teset other configs. This is more efficient at ALL/gem5.opt builds are cached. ARM/gem5.opt needs compiled from scratch each time.
- Move the test_neoverse_v2 suite into the quick CI workflow so the fixed configuration is exercised on every PR.