### PR TITLE
arch-x86: Fix PHMINPOSUW_XMM_M addressing bug

### DIFF
--- a/src/arch/x86/isa/insts/simd128/floating_point/compare/compare_and_write_minimum_or_maximum.py
+++ b/src/arch/x86/isa/insts/simd128/floating_point/compare/compare_and_write_minimum_or_maximum.py
@@ -180,8 +180,8 @@ def macroop PHMINPOSUW_XMM_XMM {
 };
 
 def macroop PHMINPOSUW_XMM_M {
-    ldfp ufp1, seg, riprel, "DISPLACEMENT", dataSize=8
-    ldfp ufp2, seg, riprel, "DISPLACEMENT + 8", dataSize=8
+    ldfp ufp1, seg, sib, "DISPLACEMENT", dataSize=8
+    ldfp ufp2, seg, sib, "DISPLACEMENT + 8", dataSize=8
     phminposuw xmml, ufp1, ufp2, size=2
     xorfp xmmh, xmmh, xmmh
 };


### PR DESCRIPTION
Related to commit a589d7b5697b3fbe61e1842e1831aef50aa96f32

This causes a segmentation fault when running this instruction. The address calculated for the `ldfp` micro-op is erroneous. Probably a bad copy paste because it breaks the pattern 😃 




Co-authored-by: @odxa20