### PR TITLE
mem-cache: fix segmentation fault caused by MSHR debug flag

### DIFF
--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -723,6 +723,7 @@ Cache::serviceMSHRTargets(MSHR *mshr, const PacketPtr pkt, CacheBlk *blk)
         // below from generating another response.
         assert(initial_tgt->pkt->cmd == MemCmd::LockedRMWReadReq);
         delete initial_tgt->pkt;
+        initial_tgt->pkt = nullptr;
         mshr->popTarget();
         initial_tgt = nullptr;
     }

--- a/src/mem/cache/mshr.hh
+++ b/src/mem/cache/mshr.hh
@@ -481,8 +481,10 @@ class MSHR : public QueueEntry, public Printable
      */
     void popTarget()
     {
-        DPRINTF(MSHR, "Force deallocating MSHR targets: %s\n",
-                targets.front().pkt->print());
+        if (targets.front().pkt) {
+            DPRINTF(MSHR, "Force deallocating MSHR targets: %s\n",
+                    targets.front().pkt->print());
+        }
         targets.pop_front();
     }
 


### PR DESCRIPTION
This commit fixes a segmentation fault that sometimes occurs when the MSHR debug flag is passed. Previously, in Cache::serviceMSHRTargets, the call to popTarget() would attempt to use a pointer that had already been deleted in a DPRINTF for the MSHR debug flag. Now, popTarget() checks if the pointer is null before attempting to use it.

Fixes https://github.com/gem5/gem5/issues/2693.