### PR TITLE
stdlib, resources: Fix `list_resources` by calling a new endpoint

### DIFF
--- a/src/python/gem5/resources/client.py
+++ b/src/python/gem5/resources/client.py
@@ -238,7 +238,9 @@ def _list_all_resources(
             raise Exception(f"Client: {client} does not exist")
         try:
             resources.extend(
-                clientwrapper[client].get_resources(gem5_version=gem5_version)
+                clientwrapper[client].get_all_resources(
+                    gem5_version=gem5_version
+                )
             )
         except Exception as e:
             warn(f"Error getting resources from client {client}: {str(e)}")

--- a/src/python/gem5/resources/client_api/abstract_client.py
+++ b/src/python/gem5/resources/client_api/abstract_client.py
@@ -188,3 +188,14 @@ class AbstractClient(ABC):
         :return: A list of all the Resources with the given ID.
         """
         return self.get_resources(client_queries=client_queries)
+
+    @abstractmethod
+    def get_all_resources(
+        self,
+        gem5_version: str,
+    ) -> List[Dict[str, Any]]:
+        """
+        :param gem5_version: The version of gem5.
+        :return: A list of all the Resources compatible with the given gem5 version.
+        """
+        raise NotImplementedError

--- a/src/python/gem5/resources/client_api/azure_functions_client.py
+++ b/src/python/gem5/resources/client_api/azure_functions_client.py
@@ -206,3 +206,20 @@ class AzureFunctionsAPIClient(AbstractClient):
                         f"Resource {resource.get_resource_id()} is not compatible with gem5 version {resource.get_gem5_version()}."
                     )
         return resources_by_id
+
+    def get_all_resources(self, gem5_version: str) -> List[Dict[str, Any]]:
+        url = self.url
+        url += "/list-all-resources"
+
+        # If the gem5_version is not DEVELOP, add it to the url
+        if gem5_version.startswith("DEVELOP"):
+            raise ValueError(
+                "All resources are compatible with DEVELOP version. Please pass a specific gem5 version from gem5 releases."
+            )
+
+        resources = self._functions_http_json_req(
+            url,
+            data_json=[{"gem5-version": gem5_version}],
+            purpose_of_request="Get All Resources",
+        )
+        return resources

--- a/src/python/gem5/resources/client_api/jsonclient.py
+++ b/src/python/gem5/resources/client_api/jsonclient.py
@@ -179,3 +179,41 @@ class JSONClient(AbstractClient):
             resources_by_id[id] = self.sort_resources(resource_list)[0]
 
         return copy.deepcopy(resources_by_id)
+
+    def get_all_resources(self, gem5_version: str) -> List[Dict[str, Any]]:
+        """
+        Get all resources compatible with the specified gem5 version.
+
+        :param gem5_version: The gem5 version to match against.
+        :returns: A list of resources compatible with the given gem5 version.
+        """
+        if gem5_version.startswith("DEVELOP"):
+            raise ValueError(
+                "All resources are compatible with DEVELOP version. "
+                "Please pass a specific gem5 version from gem5 releases."
+            )
+
+        # Build a list of all possible prefixes from the version
+        # e.g., "25.0.0.1" -> ["25.0", "25.0.0", "25.0.0.1"]
+        version_parts = gem5_version.split(".")
+        prefixes = []
+        for i in range(2, len(version_parts) + 1):
+            prefixes.append(".".join(version_parts[:i]))
+
+        if not prefixes:
+            raise ValueError(
+                "Invalid 'gem5_version' parameter: must have at least "
+                "major.minor format (e.g., '25.0')"
+            )
+
+        # Filter resources where any gem5_version matches one of the prefixes
+        filtered_resources = [
+            resource
+            for resource in self.resources
+            if any(
+                gem5_ver in prefixes
+                for gem5_ver in resource.get("gem5_versions", [])
+            )
+        ]
+
+        return copy.deepcopy(filtered_resources)


### PR DESCRIPTION
This PR fixes the `list_resources` function in `client.py` by adding a function that points to a new endpoint on azure functions.

This PR is dependant on https://github.com/gem5/resources-azure-api/pull/7 as this PR adds the endpoint that is called by the updated `list_resources` function.