### PR TITLE
Fix trace data overwrite

### DIFF
--- a/src/arch/isa_parser/operand_types.py
+++ b/src/arch/isa_parser/operand_types.py
@@ -238,7 +238,7 @@ class RegValOperand(RegOperand):
         {{
             RegVal final_val = {reg_val};
             xc->setRegOperand(this, {self.dest_reg_idx}, final_val);
-            if (traceData) {{
+            if (traceData && !traceData->getDataStatus()) {{
                 traceData->setData({self.reg_class}, final_val);
             }}
         }}"""
@@ -371,7 +371,7 @@ class VecRegOperand(RegOperand):
 
     def makeWrite(self):
         return f"""
-        if (traceData) {{
+        if (traceData && !traceData->getDataStatus()) {{
             traceData->setData({self.reg_class}, &tmp_d{self.dest_reg_idx});
         }}
         """
@@ -425,7 +425,7 @@ class VecPredRegOperand(RegOperand):
 
     def makeWrite(self):
         return f"""
-        if (traceData) {{
+        if (traceData && !traceData->getDataStatus()) {{
             traceData->setData({self.reg_class}, &tmp_d{self.dest_reg_idx});
         }}
         """
@@ -531,7 +531,7 @@ class ControlRegOperand(RegOperand):
             f"{self.dest_reg_idx}, {self.base_name});\n"
         )
         wb += f"""
-        if (traceData) {{
+        if (traceData && !traceData->getDataStatus()) {{
             traceData->setData({self.reg_class}, {self.base_name});
         }}
         """


### PR DESCRIPTION
This fixes an issue in the exec trace whereby the printed instruction result (data) value would be incorrect.

For example, the `and` instruction in the X86 architecture should print the result value after `D=` like this:
```
6466462000: system.cpu: T0 : 0x4235d4 @bn_mod_exp_mont_fixed_top+1743    : and edx
6466462000: system.cpu: T0 : 0x4235d4 @bn_mod_exp_mont_fixed_top+1743. 0 :   AND_R_R : and   eax, eax, edx : IntAlu :  D=0x0000000000000007
```
However, (without this patch), the trace was reporting erroneous result values for X86 ALU instructions. I found upon further inspection that the trace was actually reporting the result of one of the CC flags instead of the primary result value that is written to the destination register.

This PR addresses the issue by checking whether the InstRecord already has a data (result) value stored before assigning a new value -- this avoids the "correct" value from being subsequently overwritten when CC flags are handled.

I am not certain this is the correct way to solve this issue, but it seems to work for me. In particular, this could break instructions (potentially in other architectures) that write to the destination register after (rather than before) writing CC flags.