### PR TITLE
stdlib: Fix multiprocessing stat file name

### DIFF
--- a/src/python/gem5/utils/multiprocessing/_command_line.py
+++ b/src/python/gem5/utils/multiprocessing/_command_line.py
@@ -74,9 +74,10 @@ def _gem5_args_for_multiprocessing(name):
         # overridden by multisim
         f"--stdout-file={name}_{options.stdout_file}",
         f"--stderr-file={name}_{options.stderr_file}",
-        # Keep the stats file name. It will be in the new outdir
-        f"--stats-file={options.stats_file}",
     ]
+    # Keep the stats files names. They will be in the new outdir
+    for filepath in options.stats_file:
+        arguments.append(f"--stats-file={filepath}")
     if options.redirect_stdout:
         arguments.append("--redirect-stdout")
     if options.redirect_stderr:


### PR DESCRIPTION
Since #2764 we can have multiple stat file outputs. This fixes a problem handling multiple stats files in multisim.

Fixes #2835