### PR TITLE
stdlib: Remove dependency of simulator on m5.options

### DIFF
--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -39,7 +39,6 @@ from typing import (
 )
 
 import m5
-from m5 import options as m5_options
 from m5.ext.pystats.simstat import SimStat
 from m5.stats import addStatVisitor
 from m5.util import warn
@@ -102,6 +101,7 @@ class Simulator:
         max_ticks: Optional[int] = m5.MaxTick,
         id: Optional[int] = None,
         outdir: Optional[str | Path] = None,
+        show_exit_event_messages: Optional[bool] = None,
     ) -> None:
         """
         :param board: The board to be simulated.
@@ -151,12 +151,14 @@ class Simulator:
         Simulator configuration. Note, the latter means the ID only available
         after the Simulator has been instantiated. The ID can be obtained via
         the `get_id` method.
-        :param exit_event_handler_id_map: An optional parameter specifying the
-        mapping each exit event IDs the Exit Event handler class responsible
-        for handling them. The Simulator provides sensible defaults for stdlib
-        exit events, but this parameter allows the user to override these
-        or add handlers for custom exit events. Use
-        `ExitHandler.get_handler_map` to see the mapping.
+        :param outdir: directory to put output files (stats, config, etc.). If
+                       value is None, then fall back to what is specified on the
+                       command line via `--outdir`.
+        :param show_exit_event_messages: If true, every time the simulator exits
+                                         the main simulation loop, print the
+                                         exit event reason to stdout. If none,
+                                         fall back on the gem5 command line
+                                         value.
 
         See ClassicGeneratorExitHandler for details on
         """
@@ -203,6 +205,14 @@ class Simulator:
         else:
             self._outdir = Path(outdir)
             self.override_outdir(self._outdir)
+
+        if show_exit_event_messages is None:
+            # Use the command line option from gem5 binary
+            from m5 import options
+
+            self._show_exit_event_messages = options.show_exit_event_messages
+        else:
+            self._show_exit_event_messages = show_exit_event_messages
 
     def switch_processor(self) -> None:
         """
@@ -507,14 +517,14 @@ class Simulator:
         Show exit event messages. This will print the exit event messages to
         the console.
         """
-        m5_options.show_exit_event_messages = True
+        self._show_exit_event_messages = True
 
     def override_outdir(self, new_outdir: Path) -> None:
-        """This function can be used to override the output directory locatiomn
-        Assiming the path passed is valid, the directory will be created
+        """This function can be used to override the output directory location
+        Assuming the path passed is valid, the directory will be created
         and set as the new output directory, thus overriding what was set at
-        the gem5 command line. Is there fore advised this function is used with
-        caution. Its primary use is for swaning multiple gem5 processes from
+        the gem5 command line. Is therefore advised this function is used with
+        caution. Its primary use is for spawning multiple gem5 processes from
         a gem5 process to allow the child processes their own output directory.
 
         :param new_outdir: The new output directory to be used instead of that
@@ -526,7 +536,6 @@ class Simulator:
                 "Cannot override the output directory after the simulation "
                 "has been instantiated."
             )
-        from m5 import options
 
         from _m5.core import setOutputDir
 
@@ -538,8 +547,14 @@ class Simulator:
         if not new_outdir.is_dir():
             raise Exception(f"'{new_outdir}' is not a directory")
 
-        options.outdir = str(new_outdir)  # for backwards compatibility
-        setOutputDir(options.outdir)
+        try:
+            from m5 import options
+
+            options.outdir = str(new_outdir)  # for backwards compatibility
+        except ImportError:
+            pass  # In this case, we're not using main.py
+
+        setOutputDir(new_outdir.as_posix())
         self._outdir = new_outdir
 
     def _instantiate(self) -> None:
@@ -640,7 +655,7 @@ class Simulator:
                 exit_event_hypercall_id
             ](self._last_exit_event.getPayload())
 
-            if m5_options.show_exit_event_messages:
+            if self._show_exit_event_messages:
                 print(
                     f"Exit event: {exit_handler.get_handler_description()} called at tick {self.get_current_tick()}"
                 )


### PR DESCRIPTION
Add a show_exit_event_messages parameter to the simulator to remove the last required us of m5.options. This change also improves the other uses of m5.options to give reasonable fallbacks and updates the docstrings.