### PR TITLE
cpu-o3: Update O3 CPU modules to reduce coupling.

### DIFF
--- a/src/cpu/checker/cpu_impl.hh
+++ b/src/cpu/checker/cpu_impl.hh
@@ -43,20 +43,17 @@
 #define __CPU_CHECKER_CPU_IMPL_HH__
 
 #include <list>
-#include <string>
 
+#include "arch/generic/decoder.hh"
 #include "base/refcnt.hh"
-#include "cpu/exetrace.hh"
+#include "cpu/checker/cpu.hh"
 #include "cpu/null_static_inst.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/simple_thread.hh"
 #include "cpu/static_inst.hh"
 #include "cpu/thread_context.hh"
-#include "cpu/checker/cpu.hh"
 #include "debug/Checker.hh"
 #include "sim/full_system.hh"
-#include "sim/sim_object.hh"
-#include "sim/stats.hh"
 
 namespace gem5
 {

--- a/src/cpu/exetrace.cc
+++ b/src/cpu/exetrace.cc
@@ -44,18 +44,50 @@
 #include <sstream>
 
 #include "arch/generic/mmu.hh"
+#include "arch/generic/pcstate.hh"
+#include "base/cprintf.hh"
 #include "base/loader/symtab.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
 #include "cpu/base.hh"
 #include "cpu/static_inst.hh"
+#include "cpu/static_inst_fwd.hh"
 #include "cpu/thread_context.hh"
-#include "debug/ExecAll.hh"
-#include "debug/FmtTicksOff.hh"
+#include "debug/ExecAsid.hh"
+#include "debug/ExecCPSeq.hh"
+#include "debug/ExecEffAddr.hh"
+#include "debug/ExecEnable.hh"
+#include "debug/ExecFetchSeq.hh"
+#include "debug/ExecFlags.hh"
+#include "debug/ExecKernel.hh"
+#include "debug/ExecMacro.hh"
+#include "debug/ExecMicro.hh"
+#include "debug/ExecOpClass.hh"
+#include "debug/ExecResult.hh"
+#include "debug/ExecSymbol.hh"
+#include "debug/ExecThread.hh"
+#include "debug/ExecUser.hh"
 #include "enums/OpClass.hh"
+#include "sim/full_system.hh"
+#include "sim/insttracer.hh"
 
 namespace gem5
 {
 
 namespace trace {
+
+InstRecord *
+ExeTracer::getInstRecord(Tick when, ThreadContext *tc,
+                         const StaticInstPtr staticInst, const PCStateBase &pc,
+                         const StaticInstPtr macroStaticInst)
+{
+    if (!debug::ExecEnable) {
+        return NULL;
+    }
+
+    return new ExeTracerRecord(when, tc, staticInst, pc, *this,
+                               macroStaticInst);
+}
 
 void
 ExeTracerRecord::traceInst(const StaticInstPtr &inst, bool ran)

--- a/src/cpu/exetrace.hh
+++ b/src/cpu/exetrace.hh
@@ -86,16 +86,9 @@ class ExeTracer : public InstTracer
     {}
 
     InstRecord *
-    getInstRecord(Tick when, ThreadContext *tc,
-            const StaticInstPtr staticInst, const PCStateBase &pc,
-            const StaticInstPtr macroStaticInst=nullptr) override
-    {
-        if (!debug::ExecEnable)
-            return NULL;
-
-        return new ExeTracerRecord(when, tc,
-                staticInst, pc, *this, macroStaticInst);
-    }
+    getInstRecord(Tick when, ThreadContext *tc, const StaticInstPtr staticInst,
+                  const PCStateBase &pc,
+                  const StaticInstPtr macroStaticInst = nullptr) override;
 };
 
 } // namespace trace

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -56,7 +56,7 @@ from m5.SimObject import *
 class BaseO3CPU(BaseCPU):
     type = "BaseO3CPU"
     cxx_class = "gem5::o3::CPU"
-    cxx_header = "cpu/o3/dyn_inst.hh"
+    cxx_header = "cpu/o3/cpu.hh"
 
     @classmethod
     def memory_mode(cls):

--- a/src/cpu/o3/bac.cc
+++ b/src/cpu/o3/bac.cc
@@ -40,20 +40,31 @@
 #include <algorithm>
 
 #include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/info.hh"
+#include "base/stats/units.hh"
 #include "base/trace.hh"
+#include "base/types.hh"
 #include "cpu/inst_seq.hh"
+#include "cpu/o3/comm.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/ftq.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/branch_type.hh"
+#include "cpu/static_inst_fwd.hh"
+#include "cpu/timebuf.hh"
 #include "debug/Activity.hh"
 #include "debug/BAC.hh"
 #include "debug/Branch.hh"
 #include "debug/Drain.hh"
 #include "debug/FTQ.hh"
 #include "debug/Fetch.hh"
-#include "debug/O3PipeView.hh"
+#include "enums/BranchType.hh"
 #include "params/BaseO3CPU.hh"
-#include "sim/full_system.hh"
 
 using namespace gem5::branch_prediction;
 

--- a/src/cpu/o3/checker.cc
+++ b/src/cpu/o3/checker.cc
@@ -40,7 +40,10 @@
 
 #include "cpu/o3/checker.hh"
 
+#include "cpu/checker/cpu.hh"
 #include "cpu/checker/cpu_impl.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
+#include "cpu/o3/thread_state.hh"
 
 namespace gem5
 {

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -44,10 +44,8 @@
 #ifndef __CPU_O3_CPU_HH__
 #define __CPU_O3_CPU_HH__
 
-#include <iostream>
 #include <list>
 #include <queue>
-#include <set>
 #include <vector>
 
 #include "arch/generic/pcstate.hh"
@@ -63,7 +61,6 @@
 #include "cpu/o3/free_list.hh"
 #include "cpu/o3/ftq.hh"
 #include "cpu/o3/iew.hh"
-#include "cpu/o3/limits.hh"
 #include "cpu/o3/rename.hh"
 #include "cpu/o3/rob.hh"
 #include "cpu/o3/scoreboard.hh"
@@ -111,7 +108,7 @@ class CPU : public BaseCPU
     };
 
     BaseMMU *mmu;
-    using LSQRequest = LSQ::LSQRequest;
+    using LSQRequest = gem5::o3::LSQRequest;
 
     using PerThreadUnifiedRenameMap =
         UnifiedRenameMap::PerThreadUnifiedRenameMap;

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -42,13 +42,23 @@
 #include "cpu/o3/decode.hh"
 
 #include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/info.hh"
+#include "base/stats/units.hh"
 #include "base/trace.hh"
+#include "base/types.hh"
 #include "cpu/inst_seq.hh"
+#include "cpu/o3/comm.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/timebuf.hh"
 #include "debug/Activity.hh"
 #include "debug/Decode.hh"
 #include "params/BaseO3CPU.hh"
+#include "sim/cur_tick.hh"
 #include "sim/full_system.hh"
 
 // clang complains about std::set being overloaded with Packet::set if

--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -41,11 +41,31 @@
 #include "cpu/o3/dyn_inst.hh"
 
 #include <algorithm>
+#include <cstdint>
+#include <memory>
 
+#include "arch/generic/pcstate.hh"
+#include "base/amo.hh"
+#include "base/cprintf.hh"
 #include "base/intmath.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
+#include "cpu/base.hh"
+#include "cpu/checker/cpu.hh"
+#include "cpu/exetrace.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/cpu.hh"
+#include "cpu/o3/inst_queue.hh"
+#include "cpu/o3/lsq_unit.hh"
+#include "cpu/o3/thread_state.hh"
+#include "cpu/reg_class.hh"
+#include "cpu/static_inst.hh"
+#include "cpu/static_inst_fwd.hh"
+#include "cpu/thread_context.hh"
 #include "debug/DynInst.hh"
 #include "debug/IQ.hh"
 #include "debug/O3PipeView.hh"
+#include "mem/request.hh"
 
 namespace gem5
 {
@@ -454,6 +474,202 @@ DynInst::initiateMemAMO(Addr addr, unsigned size, Request::Flags flags,
             /* atomic */ false, nullptr, size, addr, flags, nullptr,
             std::move(amo_op), std::vector<bool>(size, true));
 }
+
+void
+DynInst::demapPage(Addr vaddr, uint64_t asn)
+{ cpu->demapPage(vaddr, asn); }
+
+int
+DynInst::cpuId() const
+{ return cpu->cpuId(); }
+
+uint32_t
+DynInst::socketId() const
+{ return cpu->socketId(); }
+
+RequestorID
+DynInst::requestorId() const
+{ return cpu->dataRequestorId(); }
+
+void
+DynInst::armMonitor(Addr address)
+{ cpu->armMonitor(threadNumber, address); }
+
+bool
+DynInst::mwait(PacketPtr pkt)
+{ return cpu->mwait(threadNumber, pkt); }
+
+void
+DynInst::mwaitAtomic(gem5::ThreadContext *tc)
+{ cpu->mwaitAtomic(threadNumber, tc, cpu->mmu); }
+
+AddressMonitor *
+DynInst::getAddrMonitor()
+{ return cpu->getCpuAddrMonitor(threadNumber); }
+
+RegVal
+DynInst::readMiscReg(int misc_reg)
+{ return cpu->readMiscReg(misc_reg, threadNumber); }
+
+void
+DynInst::setMiscReg(int misc_reg, RegVal val)
+{
+    /** Writes to misc. registers are recorded and deferred until the
+     * commit stage, when updateMiscRegs() is called. First, check if
+     * the misc reg has been written before and update its value to be
+     * committed instead of making a new entry. If not, make a new
+     * entry and record the write.
+     */
+    for (auto &idx : _destMiscRegIdx) {
+        if (idx == misc_reg) {
+            return;
+        }
+    }
+
+    _destMiscRegIdx.push_back(misc_reg);
+    _destMiscRegVal.push_back(val);
+}
+
+RegVal
+DynInst::readMiscRegOperand(const StaticInst *si, int idx)
+{
+    const RegId &reg = si->srcRegIdx(idx);
+    assert(reg.is(MiscRegClass));
+    return cpu->readMiscReg(reg.index(), threadNumber);
+}
+
+void
+DynInst::setMiscRegOperand(const StaticInst *si, int idx, RegVal val)
+{
+    const RegId &reg = si->destRegIdx(idx);
+    assert(reg.is(MiscRegClass));
+    setMiscReg(reg.index(), val);
+}
+
+void
+DynInst::updateMiscRegs()
+{
+    // @todo: Pretty convoluted way to avoid squashing from happening when
+    // using the TC during an instruction's execution (specifically for
+    // instructions that have side-effects that use the TC).  Fix this.
+    // See cpu/o3/dyn_inst_impl.hh.
+    bool no_squash_from_TC = thread->noSquashFromTC;
+    thread->noSquashFromTC = true;
+
+    for (int i = 0; i < _destMiscRegIdx.size(); i++) {
+        cpu->setMiscReg(_destMiscRegIdx[i], _destMiscRegVal[i], threadNumber);
+    }
+
+    thread->noSquashFromTC = no_squash_from_TC;
+}
+
+void
+DynInst::forwardOldRegs()
+{
+    for (int idx = 0; idx < numDestRegs(); idx++) {
+        PhysRegIdPtr prev_phys_reg = prevDestIdx(idx);
+        const RegId &original_dest_reg = staticInst->destRegIdx(idx);
+        const auto bytes = original_dest_reg.regClass().regBytes();
+
+        // Registers which aren't renamed don't need to be forwarded.
+        if (!original_dest_reg.isRenameable()) {
+            continue;
+        }
+
+        if (bytes == sizeof(RegVal)) {
+            setRegOperand(staticInst.get(), idx,
+                          cpu->getReg(prev_phys_reg, threadNumber));
+        } else {
+            const size_t size = original_dest_reg.regClass().regBytes();
+            auto val = std::make_unique<uint8_t[]>(size);
+            cpu->getReg(prev_phys_reg, val.get(), threadNumber);
+            setRegOperand(staticInst.get(), idx, val.get());
+        }
+    }
+}
+
+RegVal
+DynInst::getRegOperand(const StaticInst *si, int idx)
+{
+    const PhysRegIdPtr reg = renamedSrcIdx(idx);
+    if (reg->is(InvalidRegClass)) {
+        return 0;
+    }
+    return cpu->getReg(reg, threadNumber);
+}
+
+void
+DynInst::getRegOperand(const StaticInst *si, int idx, void *val)
+{
+    const PhysRegIdPtr reg = renamedSrcIdx(idx);
+    if (reg->is(InvalidRegClass)) {
+        return;
+    }
+    cpu->getReg(reg, val, threadNumber);
+}
+
+void *
+DynInst::getWritableRegOperand(const StaticInst *si, int idx)
+{ return cpu->getWritableReg(renamedDestIdx(idx), threadNumber); }
+
+void
+DynInst::setRegOperand(const StaticInst *si, int idx, RegVal val)
+{
+    const PhysRegIdPtr reg = renamedDestIdx(idx);
+    if (reg->is(InvalidRegClass)) {
+        return;
+    }
+    cpu->setReg(reg, val, threadNumber);
+    setResult(reg->regClass(), val);
+}
+
+void
+DynInst::setRegOperand(const StaticInst *si, int idx, const void *val)
+{
+    const PhysRegIdPtr reg = renamedDestIdx(idx);
+    if (reg->is(InvalidRegClass)) {
+        return;
+    }
+    cpu->setReg(reg, val, threadNumber);
+    setResult(reg->regClass(), val);
+}
+
+BaseCPU *
+DynInst::getCpuPtr()
+{ return cpu; }
+
+ContextID
+DynInst::contextId() const
+{ return thread->contextId(); }
+
+gem5::ThreadContext *
+DynInst::tcBase() const
+{ return thread->getTC(); }
+
+void
+DynInst::setInIQ(IQUnit *_iq)
+{
+    assert(!iq);
+    status.set(IqEntry);
+    iq = _iq;
+}
+
+void
+DynInst::clearInIQ()
+{
+    assert(iq);
+    status.reset(IqEntry);
+    iq->remove(this);
+    iq = nullptr;
+}
+
+unsigned int
+DynInst::readStCondFailures() const
+{ return thread->storeCondFailures; }
+
+void
+DynInst::setStCondFailures(unsigned int sc_failures)
+{ thread->storeCondFailures = sc_failures; }
 
 } // namespace o3
 } // namespace gem5

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -42,26 +42,22 @@
 #ifndef __CPU_O3_DYN_INST_HH__
 #define __CPU_O3_DYN_INST_HH__
 
-#include <algorithm>
-#include <array>
-#include <deque>
+#include <cstdint>
 #include <list>
+#include <queue>
 #include <string>
 
 #include "base/refcnt.hh"
 #include "base/trace.hh"
-#include "cpu/checker/cpu.hh"
+#include "cpu/base.hh"
 #include "cpu/exec_context.hh"
-#include "cpu/exetrace.hh"
 #include "cpu/inst_res.hh"
 #include "cpu/inst_seq.hh"
-#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/lsq_unit.hh"
 #include "cpu/op_class.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/static_inst.hh"
-#include "cpu/translation.hh"
 #include "debug/HtmCpu.hh"
 
 namespace gem5
@@ -69,8 +65,21 @@ namespace gem5
 
 class Packet;
 
+namespace trace
+{
+class InstRecord;
+}
+
 namespace o3
 {
+
+class CPU;
+class IQUnit;
+class LSQUnit;
+class LSQRequest;
+class ThreadState;
+class LSQEntry;
+class SQEntry;
 
 class DynInst : public ExecContext, public RefCounted
 {
@@ -129,7 +138,7 @@ class DynInst : public ExecContext, public RefCounted
     /** Pointer to the Impl's CPU object. */
     CPU *cpu = nullptr;
 
-    BaseCPU *getCpuPtr() { return cpu; }
+    BaseCPU *getCpuPtr();
 
     /** Pointer to the thread state. */
     ThreadState *thread = nullptr;
@@ -350,19 +359,18 @@ class DynInst : public ExecContext, public RefCounted
 
     /** Load queue index. */
     ssize_t lqIdx = -1;
-    typename LSQUnit::LQIterator lqIt;
+    LQIterator lqIt;
 
     /** Store queue index. */
     ssize_t sqIdx = -1;
-    typename LSQUnit::SQIterator sqIt;
-
+    SQIterator sqIt;
 
     /////////////////////// TLB Miss //////////////////////
     /**
      * Saved memory request (needed when the DTB address translation is
      * delayed due to a hw page table walk).
      */
-    LSQ::LSQRequest *savedRequest;
+    LSQRequest *savedRequest;
 
     /////////////////////// Checker //////////////////////
     // Need a copy of main request pointer to verify on writes.
@@ -390,11 +398,7 @@ class DynInst : public ExecContext, public RefCounted
     //
     ////////////////////////////////////////////
 
-    void
-    demapPage(Addr vaddr, uint64_t asn) override
-    {
-        cpu->demapPage(vaddr, asn);
-    }
+    void demapPage(Addr vaddr, uint64_t asn) override;
 
     Fault initiateMemRead(Addr addr, unsigned size, Request::Flags flags,
             const std::vector<bool> &byte_enable) override;
@@ -488,16 +492,16 @@ class DynInst : public ExecContext, public RefCounted
     void dump(std::string &outstring);
 
     /** Read this CPU's ID. */
-    int cpuId() const { return cpu->cpuId(); }
+    int cpuId() const;
 
     /** Read this CPU's Socket ID. */
-    uint32_t socketId() const { return cpu->socketId(); }
+    uint32_t socketId() const;
 
     /** Read this CPU's data requestor ID */
-    RequestorID requestorId() const { return cpu->dataRequestorId(); }
+    RequestorID requestorId() const;
 
     /** Read this context's system-wide ID **/
-    ContextID contextId() const { return thread->contextId(); }
+    ContextID contextId() const;
 
     /** Returns the fault type. */
     Fault getFault() const { return fault; }
@@ -797,23 +801,10 @@ class DynInst : public ExecContext, public RefCounted
     //Instruction Queue Entry
     //-----------------------
     /** Sets this instruction as a entry the IQ. */
-    void
-    setInIQ(IQUnit *_iq)
-    {
-        assert(!iq);
-        status.set(IqEntry);
-        iq = _iq;
-    }
+    void setInIQ(IQUnit *_iq);
 
     /** Clears this instruction as a entry the IQ. */
-    void
-    clearInIQ()
-    {
-        assert(iq);
-        status.reset(IqEntry);
-        iq->remove(this);
-        iq = nullptr;
-    }
+    void clearInIQ();
 
     /** Returns whether or not this instruction has issued. */
     bool isInIQ() const { return status[IqEntry]; }
@@ -952,7 +943,7 @@ class DynInst : public ExecContext, public RefCounted
     void setThreadState(ThreadState *state) { thread = state; }
 
     /** Returns the thread context. */
-    gem5::ThreadContext *tcBase() const override { return thread->getTC(); }
+    gem5::ThreadContext *tcBase() const override;
 
   public:
     /** Is this instruction's memory access strictly ordered? */
@@ -972,41 +963,17 @@ class DynInst : public ExecContext, public RefCounted
 
   public:
     /** Returns the number of consecutive store conditional failures. */
-    unsigned int
-    readStCondFailures() const override
-    {
-        return thread->storeCondFailures;
-    }
+    unsigned int readStCondFailures() const override;
 
     /** Sets the number of consecutive store conditional failures. */
-    void
-    setStCondFailures(unsigned int sc_failures) override
-    {
-        thread->storeCondFailures = sc_failures;
-    }
+    void setStCondFailures(unsigned int sc_failures) override;
 
   public:
     // monitor/mwait funtions
-    void
-    armMonitor(Addr address) override
-    {
-        cpu->armMonitor(threadNumber, address);
-    }
-    bool
-    mwait(PacketPtr pkt) override
-    {
-        return cpu->mwait(threadNumber, pkt);
-    }
-    void
-    mwaitAtomic(gem5::ThreadContext *tc) override
-    {
-        return cpu->mwaitAtomic(threadNumber, tc, cpu->mmu);
-    }
-    AddressMonitor *
-    getAddrMonitor() override
-    {
-        return cpu->getCpuAddrMonitor(threadNumber);
-    }
+    void armMonitor(Addr address) override;
+    bool mwait(PacketPtr pkt) override;
+    void mwaitAtomic(gem5::ThreadContext *tc) override;
+    AddressMonitor *getAddrMonitor() override;
 
   private:
     // hardware transactional memory
@@ -1034,114 +1001,27 @@ class DynInst : public ExecContext, public RefCounted
     /** Reads a misc. register, including any side-effects the read
      * might have as defined by the architecture.
      */
-    RegVal
-    readMiscReg(int misc_reg) override
-    {
-        return cpu->readMiscReg(misc_reg, threadNumber);
-    }
+    RegVal readMiscReg(int misc_reg) override;
 
     /** Sets a misc. register, including any side-effects the write
      * might have as defined by the architecture.
      */
-    void
-    setMiscReg(int misc_reg, RegVal val) override
-    {
-        /** Writes to misc. registers are recorded and deferred until the
-         * commit stage, when updateMiscRegs() is called. First, check if
-         * the misc reg has been written before and update its value to be
-         * committed instead of making a new entry. If not, make a new
-         * entry and record the write.
-         */
-        for (auto &idx: _destMiscRegIdx) {
-            if (idx == misc_reg)
-                return;
-        }
-
-        _destMiscRegIdx.push_back(misc_reg);
-        _destMiscRegVal.push_back(val);
-    }
+    void setMiscReg(int misc_reg, RegVal val) override;
 
     /** Reads a misc. register, including any side-effects the read
      * might have as defined by the architecture.
      */
-    RegVal
-    readMiscRegOperand(const StaticInst *si, int idx) override
-    {
-        const RegId& reg = si->srcRegIdx(idx);
-        assert(reg.is(MiscRegClass));
-        return cpu->readMiscReg(reg.index(), threadNumber);
-    }
+    RegVal readMiscRegOperand(const StaticInst *si, int idx) override;
 
     /** Sets a misc. register, including any side-effects the write
      * might have as defined by the architecture.
      */
-    void
-    setMiscRegOperand(const StaticInst *si, int idx, RegVal val) override
-    {
-        const RegId& reg = si->destRegIdx(idx);
-        assert(reg.is(MiscRegClass));
-        setMiscReg(reg.index(), val);
-
-        /** If the MiscReg allows non-serializing updates, we
-         * can update the value immediately without waiting
-         * for commit, but only if the instruction is non
-         * speculative
-         */
-        if (!reg.regClass().isSerializing(reg)) {
-            assert(isNonSpeculative());
-
-            bool no_squash_from_TC = thread->noSquashFromTC;
-            thread->noSquashFromTC = true;
-
-            /** Update the architectural state with the new value */
-            cpu->setMiscReg(reg.index(), val, threadNumber);
-
-            thread->noSquashFromTC = no_squash_from_TC;
-        }
-    }
+    void setMiscRegOperand(const StaticInst *si, int idx, RegVal val) override;
 
     /** Called at the commit stage to update the misc. registers. */
-    void
-    updateMiscRegs()
-    {
-        // @todo: Pretty convoluted way to avoid squashing from happening when
-        // using the TC during an instruction's execution (specifically for
-        // instructions that have side-effects that use the TC).  Fix this.
-        // See cpu/o3/dyn_inst_impl.hh.
-        bool no_squash_from_TC = thread->noSquashFromTC;
-        thread->noSquashFromTC = true;
+    void updateMiscRegs();
 
-        for (int i = 0; i < _destMiscRegIdx.size(); i++)
-            cpu->setMiscReg(
-                _destMiscRegIdx[i], _destMiscRegVal[i], threadNumber);
-
-        thread->noSquashFromTC = no_squash_from_TC;
-    }
-
-    void
-    forwardOldRegs()
-    {
-
-        for (int idx = 0; idx < numDestRegs(); idx++) {
-            PhysRegIdPtr prev_phys_reg = prevDestIdx(idx);
-            const RegId& original_dest_reg = staticInst->destRegIdx(idx);
-            const auto bytes = original_dest_reg.regClass().regBytes();
-
-            // Registers which aren't renamed don't need to be forwarded.
-            if (!original_dest_reg.isRenameable())
-                continue;
-
-            if (bytes == sizeof(RegVal)) {
-                setRegOperand(staticInst.get(), idx,
-                        cpu->getReg(prev_phys_reg, threadNumber));
-            } else {
-                const size_t size = original_dest_reg.regClass().regBytes();
-                auto val = std::make_unique<uint8_t[]>(size);
-                cpu->getReg(prev_phys_reg, val.get(), threadNumber);
-                setRegOperand(staticInst.get(), idx, val.get());
-            }
-        }
-    }
+    void forwardOldRegs();
     /** Traps to handle specified fault. */
     void trap(const Fault &fault);
 
@@ -1158,52 +1038,19 @@ class DynInst : public ExecContext, public RefCounted
     // storage (which is pretty hard to imagine they would have reason
     // to do).
 
-    RegVal
-    getRegOperand(const StaticInst *si, int idx) override
-    {
-        const PhysRegIdPtr reg = renamedSrcIdx(idx);
-        if (reg->is(InvalidRegClass))
-            return 0;
-        return cpu->getReg(reg, threadNumber);
-    }
+    RegVal getRegOperand(const StaticInst *si, int idx) override;
 
-    void
-    getRegOperand(const StaticInst *si, int idx, void *val) override
-    {
-        const PhysRegIdPtr reg = renamedSrcIdx(idx);
-        if (reg->is(InvalidRegClass))
-            return;
-        cpu->getReg(reg, val, threadNumber);
-    }
+    void getRegOperand(const StaticInst *si, int idx, void *val) override;
 
-    void *
-    getWritableRegOperand(const StaticInst *si, int idx) override
-    {
-        return cpu->getWritableReg(renamedDestIdx(idx), threadNumber);
-    }
+    void *getWritableRegOperand(const StaticInst *si, int idx) override;
 
     /** @todo: Make results into arrays so they can handle multiple dest
      *  registers.
      */
-    void
-    setRegOperand(const StaticInst *si, int idx, RegVal val) override
-    {
-        const PhysRegIdPtr reg = renamedDestIdx(idx);
-        if (reg->is(InvalidRegClass))
-            return;
-        cpu->setReg(reg, val, threadNumber);
-        setResult(reg->regClass(), val);
-    }
+    void setRegOperand(const StaticInst *si, int idx, RegVal val) override;
 
-    void
-    setRegOperand(const StaticInst *si, int idx, const void *val) override
-    {
-        const PhysRegIdPtr reg = renamedDestIdx(idx);
-        if (reg->is(InvalidRegClass))
-            return;
-        cpu->setReg(reg, val, threadNumber);
-        setResult(reg->regClass(), val);
-    }
+    void setRegOperand(const StaticInst *si, int idx,
+                       const void *val) override;
 };
 
 } // namespace o3

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -46,16 +46,31 @@
 #include "cpu/o3/iew.hh"
 
 #include <queue>
+#include <string>
 
+#include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/info.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
 #include "cpu/checker/cpu.hh"
+#include "cpu/o3/comm.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/fu_pool.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/o3/lsq_unit.hh"
+#include "cpu/o3/scoreboard.hh"
 #include "cpu/timebuf.hh"
 #include "debug/Activity.hh"
 #include "debug/Drain.hh"
 #include "debug/IEW.hh"
 #include "params/BaseO3CPU.hh"
+#include "sim/cur_tick.hh"
+#include "sim/probe/probe.hh"
 
 namespace gem5
 {

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -41,18 +41,35 @@
 
 #include "cpu/o3/inst_queue.hh"
 
-#include <limits>
 #include <vector>
 
+#include "arch/generic/isa.hh"
+#include "base/cprintf.hh"
 #include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/info.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/comm.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/fu_pool.hh"
+#include "cpu/o3/iew.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/op_class.hh"
+#include "cpu/reg_class.hh"
+#include "cpu/timebuf.hh"
 #include "debug/IQ.hh"
 #include "enums/OpClass.hh"
+#include "enums/SMTQueuePolicy.hh"
 #include "params/BaseO3CPU.hh"
 #include "params/IQUnit.hh"
 #include "sim/core.hh"
+#include "sim/cur_tick.hh"
+#include "sim/eventq.hh"
 
 // clang complains about std::set being overloaded with Packet::set if
 // we open up the entire namespace std

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -41,22 +41,39 @@
 
 #include "cpu/o3/lsq.hh"
 
-#include <algorithm>
+#include <cstdint>
 #include <list>
+#include <memory>
 #include <string>
+#include <utility>
 
-#include "base/compiler.hh"
+#include "arch/generic/mmu.hh"
+#include "base/amo.hh"
 #include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
+#include "cpu/inst_seq.hh"
 #include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/iew.hh"
 #include "cpu/o3/limits.hh"
+#include "cpu/o3/lsq_unit.hh"
+#include "cpu/thread_context.hh"
+#include "cpu/utils.hh"
 #include "debug/Drain.hh"
 #include "debug/Fetch.hh"
 #include "debug/HtmCpu.hh"
 #include "debug/LSQ.hh"
 #include "debug/Writeback.hh"
+#include "enums/SMTQueuePolicy.hh"
+#include "mem/packet.hh"
+#include "mem/port.hh"
+#include "mem/request.hh"
 #include "params/BaseO3CPU.hh"
+#include "sim/cur_tick.hh"
 
 namespace gem5
 {
@@ -160,12 +177,14 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
 
     thread.reserve(numThreads);
     for (ThreadID tid = 0; tid < numThreads; tid++) {
-        thread.emplace_back(maxLQEntries, maxSQEntries);
-        thread[tid].init(cpu, iew_ptr, params, this, tid);
-        thread[tid].setDcachePort(&dcachePort);
+        thread.emplace_back(
+            std::make_unique<LSQUnit>(maxLQEntries, maxSQEntries));
+        thread[tid]->init(cpu, iew_ptr, params, this, tid);
+        thread[tid]->setDcachePort(&dcachePort);
     }
 }
 
+LSQ::~LSQ() = default;
 
 std::string
 LSQ::name() const
@@ -186,7 +205,7 @@ LSQ::drainSanityCheck() const
     assert(isDrained());
 
     for (ThreadID tid = 0; tid < numThreads; tid++)
-        thread[tid].drainSanityCheck();
+        thread[tid]->drainSanityCheck();
 }
 
 bool
@@ -214,7 +233,7 @@ LSQ::takeOverFrom()
     _cacheBlocked = false;
 
     for (ThreadID tid = 0; tid < numThreads; tid++) {
-        thread[tid].takeOverFrom();
+        thread[tid]->takeOverFrom();
     }
 }
 
@@ -269,7 +288,7 @@ LSQ::insertLoad(const DynInstPtr &load_inst)
 {
     ThreadID tid = load_inst->threadNumber;
 
-    thread[tid].insertLoad(load_inst);
+    thread[tid]->insertLoad(load_inst);
 }
 
 void
@@ -277,7 +296,7 @@ LSQ::insertStore(const DynInstPtr &store_inst)
 {
     ThreadID tid = store_inst->threadNumber;
 
-    thread[tid].insertStore(store_inst);
+    thread[tid]->insertStore(store_inst);
 }
 
 Fault
@@ -285,7 +304,7 @@ LSQ::executeLoad(const DynInstPtr &inst)
 {
     ThreadID tid = inst->threadNumber;
 
-    return thread[tid].executeLoad(inst);
+    return thread[tid]->executeLoad(inst);
 }
 
 Fault
@@ -293,20 +312,16 @@ LSQ::executeStore(const DynInstPtr &inst)
 {
     ThreadID tid = inst->threadNumber;
 
-    return thread[tid].executeStore(inst);
+    return thread[tid]->executeStore(inst);
 }
 
 void
 LSQ::commitLoads(InstSeqNum &youngest_inst, ThreadID tid)
-{
-    thread.at(tid).commitLoads(youngest_inst);
-}
+{ thread.at(tid)->commitLoads(youngest_inst); }
 
 void
 LSQ::commitStores(InstSeqNum &youngest_inst, ThreadID tid)
-{
-    thread.at(tid).commitStores(youngest_inst);
-}
+{ thread.at(tid)->commitStores(youngest_inst); }
 
 void
 LSQ::writebackStores()
@@ -317,65 +332,62 @@ LSQ::writebackStores()
                 "available for Writeback.\n", tid, numStoresToWB(tid));
         }
 
-        thread[tid].writebackStores();
+        thread[tid]->writebackStores();
     }
 }
 
 void
 LSQ::squash(const InstSeqNum &squashed_num, ThreadID tid)
-{
-    thread.at(tid).squash(squashed_num);
-}
+{ thread.at(tid)->squash(squashed_num); }
 
 bool
 LSQ::violation()
 {
     /* Answers: Does Anybody Have a Violation?*/
     for (ThreadID tid : *activeThreads) {
-        if (thread[tid].violation())
+        if (thread[tid]->violation()) {
             return true;
+        }
     }
 
     return false;
 }
 
-bool LSQ::violation(ThreadID tid) { return thread.at(tid).violation(); }
+bool
+LSQ::violation(ThreadID tid)
+{ return thread.at(tid)->violation(); }
 
 DynInstPtr
 LSQ::getMemDepViolator(ThreadID tid)
-{
-    return thread.at(tid).getMemDepViolator();
-}
+{ return thread.at(tid)->getMemDepViolator(); }
 
 int
 LSQ::getLoadHead(ThreadID tid)
-{
-    return thread.at(tid).getLoadHead();
-}
+{ return thread.at(tid)->getLoadHead(); }
 
 InstSeqNum
 LSQ::getLoadHeadSeqNum(ThreadID tid)
-{
-    return thread.at(tid).getLoadHeadSeqNum();
-}
+{ return thread.at(tid)->getLoadHeadSeqNum(); }
 
 int
 LSQ::getStoreHead(ThreadID tid)
-{
-    return thread.at(tid).getStoreHead();
-}
+{ return thread.at(tid)->getStoreHead(); }
 
 InstSeqNum
 LSQ::getStoreHeadSeqNum(ThreadID tid)
-{
-    return thread.at(tid).getStoreHeadSeqNum();
-}
+{ return thread.at(tid)->getStoreHeadSeqNum(); }
 
-int LSQ::getCount(ThreadID tid) { return thread.at(tid).getCount(); }
+int
+LSQ::getCount(ThreadID tid)
+{ return thread.at(tid)->getCount(); }
 
-int LSQ::numLoads(ThreadID tid) { return thread.at(tid).numLoads(); }
+int
+LSQ::numLoads(ThreadID tid)
+{ return thread.at(tid)->numLoads(); }
 
-int LSQ::numStores(ThreadID tid) { return thread.at(tid).numStores(); }
+int
+LSQ::numStores(ThreadID tid)
+{ return thread.at(tid)->numStores(); }
 
 int
 LSQ::numHtmStarts(ThreadID tid) const
@@ -383,7 +395,7 @@ LSQ::numHtmStarts(ThreadID tid) const
     if (tid == InvalidThreadID)
         return 0;
     else
-        return thread[tid].numHtmStarts();
+        return thread[tid]->numHtmStarts();
 }
 int
 LSQ::numHtmStops(ThreadID tid) const
@@ -391,14 +403,15 @@ LSQ::numHtmStops(ThreadID tid) const
     if (tid == InvalidThreadID)
         return 0;
     else
-        return thread[tid].numHtmStops();
+        return thread[tid]->numHtmStops();
 }
 
 void
 LSQ::resetHtmStartsStops(ThreadID tid)
 {
-    if (tid != InvalidThreadID)
-        thread[tid].resetHtmStartsStops();
+    if (tid != InvalidThreadID) {
+        thread[tid]->resetHtmStartsStops();
+    }
 }
 
 uint64_t
@@ -407,14 +420,15 @@ LSQ::getLatestHtmUid(ThreadID tid) const
     if (tid == InvalidThreadID)
         return 0;
     else
-        return thread[tid].getLatestHtmUid();
+        return thread[tid]->getLatestHtmUid();
 }
 
 void
 LSQ::setLastRetiredHtmUid(ThreadID tid, uint64_t htmUid)
 {
-    if (tid != InvalidThreadID)
-        thread[tid].setLastRetiredHtmUid(htmUid);
+    if (tid != InvalidThreadID) {
+        thread[tid]->setLastRetiredHtmUid(htmUid);
+    }
 }
 
 void
@@ -424,7 +438,7 @@ LSQ::recvReqRetry()
     cacheBlocked(false);
 
     for (ThreadID tid : *activeThreads) {
-        thread[tid].recvRetry();
+        thread[tid]->recvRetry();
     }
 }
 
@@ -432,8 +446,8 @@ void
 LSQ::completeDataAccess(PacketPtr pkt)
 {
     LSQRequest *request = dynamic_cast<LSQRequest*>(pkt->senderState);
-    thread[cpu->contextToThread(request->contextId())]
-        .completeDataAccess(pkt);
+    thread[cpu->contextToThread(request->contextId())]->completeDataAccess(
+        pkt);
 }
 
 void
@@ -452,7 +466,7 @@ LSQ::recvTimingResp(PacketPtr pkt)
     LSQRequest *request = dynamic_cast<LSQRequest*>(pkt->senderState);
     panic_if(!request, "Got packet back with unknown sender state\n");
 
-    thread[cpu->contextToThread(request->contextId())].recvTimingResp(pkt);
+    thread[cpu->contextToThread(request->contextId())]->recvTimingResp(pkt);
 
     if (pkt->isInvalidate()) {
         // This response also contains an invalidate; e.g. this can be the case
@@ -470,7 +484,7 @@ LSQ::recvTimingResp(PacketPtr pkt)
                 pkt->getAddr());
 
         for (ThreadID tid = 0; tid < numThreads; tid++) {
-            thread[tid].checkSnoop(pkt);
+            thread[tid]->checkSnoop(pkt);
         }
     }
     // Update the LSQRequest state (this may delete the request)
@@ -494,7 +508,7 @@ LSQ::recvTimingSnoopReq(PacketPtr pkt)
         DPRINTF(LSQ, "received invalidation for addr:%#x\n",
                 pkt->getAddr());
         for (ThreadID tid = 0; tid < numThreads; tid++) {
-            thread[tid].checkSnoop(pkt);
+            thread[tid]->checkSnoop(pkt);
         }
     } else if (pkt->req && pkt->req->isTlbiExtSync()) {
         DPRINTF(LSQ, "received TLBI Ext Sync\n");
@@ -504,7 +518,7 @@ LSQ::recvTimingSnoopReq(PacketPtr pkt)
         staleTranslationWaitTxnId = pkt->req->getExtraData();
 
         for (auto& unit : thread) {
-            unit.startStaleTranslationFlush();
+            unit->startStaleTranslationFlush();
         }
 
         // In case no units have pending ops, just go ahead
@@ -542,7 +556,7 @@ LSQ::numStores()
     unsigned total = 0;
 
     for (ThreadID tid : *activeThreads) {
-        total += thread[tid].numStores();
+        total += thread[tid]->numStores();
     }
 
     return total;
@@ -554,7 +568,7 @@ LSQ::numFreeLoadEntries()
     unsigned total = 0;
 
     for (ThreadID tid : *activeThreads) {
-        total += thread[tid].numFreeLoadEntries();
+        total += thread[tid]->numFreeLoadEntries();
     }
 
     return total;
@@ -566,7 +580,7 @@ LSQ::numFreeStoreEntries()
     unsigned total = 0;
 
     for (ThreadID tid : *activeThreads) {
-        total += thread[tid].numFreeStoreEntries();
+        total += thread[tid]->numFreeStoreEntries();
     }
 
     return total;
@@ -574,22 +588,19 @@ LSQ::numFreeStoreEntries()
 
 unsigned
 LSQ::numFreeLoadEntries(ThreadID tid)
-{
-        return thread[tid].numFreeLoadEntries();
-}
+{ return thread[tid]->numFreeLoadEntries(); }
 
 unsigned
 LSQ::numFreeStoreEntries(ThreadID tid)
-{
-        return thread[tid].numFreeStoreEntries();
-}
+{ return thread[tid]->numFreeStoreEntries(); }
 
 bool
 LSQ::isFull()
 {
     for (ThreadID tid : *activeThreads) {
-        if (!(thread[tid].lqFull() || thread[tid].sqFull()))
+        if (!(thread[tid]->lqFull() || thread[tid]->sqFull())) {
             return false;
+        }
     }
 
     return true;
@@ -603,7 +614,7 @@ LSQ::isFull(ThreadID tid)
     if (lsqPolicy == SMTQueuePolicy::Dynamic)
         return isFull();
     else
-        return thread[tid].lqFull() || thread[tid].sqFull();
+        return thread[tid]->lqFull() || thread[tid]->sqFull();
 }
 
 bool
@@ -616,8 +627,9 @@ bool
 LSQ::lqEmpty() const
 {
     for (ThreadID tid : *activeThreads) {
-        if (!thread[tid].lqEmpty())
+        if (!thread[tid]->lqEmpty()) {
             return false;
+        }
     }
 
     return true;
@@ -627,8 +639,9 @@ bool
 LSQ::sqEmpty() const
 {
     for (ThreadID tid : *activeThreads) {
-        if (!thread[tid].sqEmpty())
+        if (!thread[tid]->sqEmpty()) {
             return false;
+        }
     }
 
     return true;
@@ -638,8 +651,9 @@ bool
 LSQ::lqFull()
 {
     for (ThreadID tid : *activeThreads) {
-        if (!thread[tid].lqFull())
+        if (!thread[tid]->lqFull()) {
             return false;
+        }
     }
 
     return true;
@@ -653,7 +667,7 @@ LSQ::lqFull(ThreadID tid)
     if (lsqPolicy == SMTQueuePolicy::Dynamic)
         return lqFull();
     else
-        return thread[tid].lqFull();
+        return thread[tid]->lqFull();
 }
 
 bool
@@ -675,15 +689,16 @@ LSQ::sqFull(ThreadID tid)
     if (lsqPolicy == SMTQueuePolicy::Dynamic)
         return sqFull();
     else
-        return thread[tid].sqFull();
+        return thread[tid]->sqFull();
 }
 
 bool
 LSQ::isStalled()
 {
     for (ThreadID tid : *activeThreads) {
-        if (!thread[tid].isStalled())
+        if (!thread[tid]->isStalled()) {
             return false;
+        }
     }
 
     return true;
@@ -695,7 +710,7 @@ LSQ::isStalled(ThreadID tid)
     if (lsqPolicy == SMTQueuePolicy::Dynamic)
         return isStalled();
     else
-        return thread[tid].isStalled();
+        return thread[tid]->isStalled();
 }
 
 bool
@@ -711,15 +726,11 @@ LSQ::hasStoresToWB()
 
 bool
 LSQ::hasStoresToWB(ThreadID tid)
-{
-    return thread.at(tid).hasStoresToWB();
-}
+{ return thread.at(tid)->hasStoresToWB(); }
 
 int
 LSQ::numStoresToWB(ThreadID tid)
-{
-    return thread.at(tid).numStoresToWB();
-}
+{ return thread.at(tid)->numStoresToWB(); }
 
 bool
 LSQ::willWB()
@@ -734,23 +745,19 @@ LSQ::willWB()
 
 bool
 LSQ::willWB(ThreadID tid)
-{
-    return thread.at(tid).willWB();
-}
+{ return thread.at(tid)->willWB(); }
 
 void
 LSQ::dumpInsts() const
 {
     for (ThreadID tid : *activeThreads) {
-        thread[tid].dumpInsts();
+        thread[tid]->dumpInsts();
     }
 }
 
 void
 LSQ::dumpInsts(ThreadID tid) const
-{
-    thread.at(tid).dumpInsts();
-}
+{ thread.at(tid)->dumpInsts(); }
 
 Fault
 LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
@@ -785,13 +792,15 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
         if (htm_cmd || tlbi_cmd) {
             assert(addr == 0x0lu);
             assert(size == 8);
-            request = new UnsquashableDirectRequest(&thread[tid], inst, flags);
+            request =
+                new UnsquashableDirectRequest(thread[tid].get(), inst, flags);
         } else if (needs_burst) {
-            request = new SplitDataRequest(&thread[tid], inst, isLoad, addr,
-                    size, flags, data, res);
+            request = new SplitDataRequest(thread[tid].get(), inst, isLoad,
+                                           addr, size, flags, data, res);
         } else {
-            request = new SingleDataRequest(&thread[tid], inst, isLoad, addr,
-                    size, flags, data, res, std::move(amo_op));
+            request = new SingleDataRequest(thread[tid].get(), inst, isLoad,
+                                            addr, size, flags, data, res,
+                                            std::move(amo_op));
         }
         assert(request);
         request->_byteEnable = byte_enable;
@@ -841,8 +850,8 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
 }
 
 void
-LSQ::SingleDataRequest::finish(const Fault &fault, const RequestPtr &request,
-        gem5::ThreadContext* tc, BaseMMU::Mode mode)
+SingleDataRequest::finish(const Fault &fault, const RequestPtr &request,
+                          gem5::ThreadContext *tc, BaseMMU::Mode mode)
 {
     _fault.push_back(fault);
     numInTranslationFragments = 0;
@@ -873,8 +882,8 @@ LSQ::SingleDataRequest::finish(const Fault &fault, const RequestPtr &request,
 }
 
 void
-LSQ::SplitDataRequest::finish(const Fault &fault, const RequestPtr &req,
-        gem5::ThreadContext* tc, BaseMMU::Mode mode)
+SplitDataRequest::finish(const Fault &fault, const RequestPtr &req,
+                         gem5::ThreadContext *tc, BaseMMU::Mode mode)
 {
     int i;
     for (i = 0; i < _reqs.size() && _reqs[i] != req; i++);
@@ -921,7 +930,7 @@ LSQ::SplitDataRequest::finish(const Fault &fault, const RequestPtr &req,
 }
 
 void
-LSQ::SingleDataRequest::initiateTranslation()
+SingleDataRequest::initiateTranslation()
 {
     assert(_reqs.size() == 0);
 
@@ -942,19 +951,19 @@ LSQ::SingleDataRequest::initiateTranslation()
 }
 
 PacketPtr
-LSQ::SplitDataRequest::mainPacket()
+SplitDataRequest::mainPacket()
 {
     return _mainPacket;
 }
 
 RequestPtr
-LSQ::SplitDataRequest::mainReq()
+SplitDataRequest::mainReq()
 {
     return _mainReq;
 }
 
 void
-LSQ::SplitDataRequest::initiateTranslation()
+SplitDataRequest::initiateTranslation()
 {
     auto cacheLineSize = _port.cacheLineSize();
     Addr base_addr = _addr;
@@ -1022,12 +1031,17 @@ LSQ::SplitDataRequest::initiateTranslation()
     }
 }
 
-LSQ::LSQRequest::LSQRequest(
-        LSQUnit *port, const DynInstPtr& inst, bool isLoad) :
-    _state(State::NotIssued),
-    _port(*port), _inst(inst), _data(nullptr),
-    _res(nullptr), _addr(0), _size(0), _flags(0),
-    _numOutstandingPackets(0), _amo_op(nullptr)
+LSQRequest::LSQRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad)
+    : _state(State::NotIssued),
+      _port(*port),
+      _inst(inst),
+      _data(nullptr),
+      _res(nullptr),
+      _addr(0),
+      _size(0),
+      _flags(0),
+      _numOutstandingPackets(0),
+      _amo_op(nullptr)
 {
     flags.set(Flag::IsLoad, isLoad);
     flags.set(Flag::WriteBackToRegister,
@@ -1037,20 +1051,24 @@ LSQ::LSQRequest::LSQRequest(
     install();
 }
 
-LSQ::LSQRequest::LSQRequest(
-        LSQUnit *port, const DynInstPtr& inst, bool isLoad,
-        const Addr& addr, const uint32_t& size, const Request::Flags& flags_,
-        PacketDataPtr data, uint64_t* res, AtomicOpFunctorPtr amo_op,
-        bool stale_translation)
+LSQRequest::LSQRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad,
+                       const Addr &addr, const uint32_t &size,
+                       const Request::Flags &flags_, PacketDataPtr data,
+                       uint64_t *res, AtomicOpFunctorPtr amo_op,
+                       bool stale_translation)
     : _state(State::NotIssued),
-    numTranslatedFragments(0),
-    numInTranslationFragments(0),
-    _port(*port), _inst(inst), _data(data),
-    _res(res), _addr(addr), _size(size),
-    _flags(flags_),
-    _numOutstandingPackets(0),
-    _amo_op(std::move(amo_op)),
-    _hasStaleTranslation(stale_translation)
+      numTranslatedFragments(0),
+      numInTranslationFragments(0),
+      _port(*port),
+      _inst(inst),
+      _data(data),
+      _res(res),
+      _addr(addr),
+      _size(size),
+      _flags(flags_),
+      _numOutstandingPackets(0),
+      _amo_op(std::move(amo_op)),
+      _hasStaleTranslation(stale_translation)
 {
     flags.set(Flag::IsLoad, isLoad);
     flags.set(Flag::WriteBackToRegister,
@@ -1061,7 +1079,7 @@ LSQ::LSQRequest::LSQRequest(
 }
 
 void
-LSQ::LSQRequest::install()
+LSQRequest::install()
 {
     if (isLoad()) {
         _port.loadQueue[_inst->lqIdx].setRequest(this);
@@ -1072,11 +1090,13 @@ LSQ::LSQRequest::install()
     }
 }
 
-bool LSQ::LSQRequest::squashed() const { return _inst->isSquashed(); }
+bool
+LSQRequest::squashed() const
+{ return _inst->isSquashed(); }
 
 void
-LSQ::LSQRequest::addReq(Addr addr, unsigned size,
-           const std::vector<bool>& byte_enable)
+LSQRequest::addReq(Addr addr, unsigned size,
+                   const std::vector<bool> &byte_enable)
 {
     unsigned inactive_tail_size = inactiveTailSize(byte_enable.begin(),
                                                    byte_enable.end());
@@ -1111,7 +1131,7 @@ LSQ::LSQRequest::addReq(Addr addr, unsigned size,
     }
 }
 
-LSQ::LSQRequest::~LSQRequest()
+LSQRequest::~LSQRequest()
 {
     assert(!isAnyOutstandingRequest());
     _inst->savedRequest = nullptr;
@@ -1121,13 +1141,13 @@ LSQ::LSQRequest::~LSQRequest()
 };
 
 ContextID
-LSQ::LSQRequest::contextId() const
+LSQRequest::contextId() const
 {
     return _inst->contextId();
 }
 
 void
-LSQ::LSQRequest::sendFragmentToTranslation(int i)
+LSQRequest::sendFragmentToTranslation(int i)
 {
     numInTranslationFragments++;
     _port.getMMUPtr()->translateTiming(req(i), _inst->thread->getTC(),
@@ -1135,7 +1155,7 @@ LSQ::LSQRequest::sendFragmentToTranslation(int i)
 }
 
 void
-LSQ::SingleDataRequest::markAsStaleTranslation()
+SingleDataRequest::markAsStaleTranslation()
 {
     // If this element has been translated and is currently being requested,
     // then it may be stale
@@ -1150,7 +1170,7 @@ LSQ::SingleDataRequest::markAsStaleTranslation()
 }
 
 void
-LSQ::SplitDataRequest::markAsStaleTranslation()
+SplitDataRequest::markAsStaleTranslation()
 {
     // If this element has been translated and is currently being requested,
     // then it may be stale
@@ -1165,7 +1185,7 @@ LSQ::SplitDataRequest::markAsStaleTranslation()
 }
 
 bool
-LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
+SingleDataRequest::recvTimingResp(PacketPtr pkt)
 {
     assert(_numOutstandingPackets == 1);
     flags.set(Flag::Complete);
@@ -1176,7 +1196,7 @@ LSQ::SingleDataRequest::recvTimingResp(PacketPtr pkt)
 }
 
 bool
-LSQ::SplitDataRequest::recvTimingResp(PacketPtr pkt)
+SplitDataRequest::recvTimingResp(PacketPtr pkt)
 {
     uint32_t pktIdx = 0;
     while (pktIdx < _packets.size() && pkt != _packets[pktIdx])
@@ -1202,7 +1222,7 @@ LSQ::SplitDataRequest::recvTimingResp(PacketPtr pkt)
 }
 
 void
-LSQ::SingleDataRequest::buildPackets()
+SingleDataRequest::buildPackets()
 {
     /* Retries do not create new packets. */
     if (_packets.size() == 0) {
@@ -1234,7 +1254,7 @@ LSQ::SingleDataRequest::buildPackets()
 }
 
 void
-LSQ::SplitDataRequest::buildPackets()
+SplitDataRequest::buildPackets()
 {
     /* Extra data?? */
     Addr base_address = _addr;
@@ -1299,7 +1319,7 @@ LSQ::SplitDataRequest::buildPackets()
 }
 
 void
-LSQ::SingleDataRequest::sendPacketToCache()
+SingleDataRequest::sendPacketToCache()
 {
     assert(_numOutstandingPackets == 0);
     if (lsqUnit()->trySendPacket(isLoad(), _packets.at(0)))
@@ -1307,7 +1327,7 @@ LSQ::SingleDataRequest::sendPacketToCache()
 }
 
 void
-LSQ::SplitDataRequest::sendPacketToCache()
+SplitDataRequest::sendPacketToCache()
 {
     /* Try to send the packets. */
     while (numReceivedPackets + _numOutstandingPackets < _packets.size() &&
@@ -1318,15 +1338,15 @@ LSQ::SplitDataRequest::sendPacketToCache()
 }
 
 Cycles
-LSQ::SingleDataRequest::handleLocalAccess(
-        gem5::ThreadContext *thread, PacketPtr pkt)
+SingleDataRequest::handleLocalAccess(gem5::ThreadContext *thread,
+                                     PacketPtr pkt)
 {
     return pkt->req->localAccessor(thread, pkt);
 }
 
 Cycles
-LSQ::SplitDataRequest::handleLocalAccess(
-        gem5::ThreadContext *thread, PacketPtr mainPkt)
+SplitDataRequest::handleLocalAccess(gem5::ThreadContext *thread,
+                                    PacketPtr mainPkt)
 {
     Cycles delay(0);
     unsigned offset = 0;
@@ -1345,10 +1365,8 @@ LSQ::SplitDataRequest::handleLocalAccess(
 }
 
 bool
-LSQ::SingleDataRequest::isCacheBlockHit(Addr blockAddr, Addr blockMask)
-{
-    return ( (LSQRequest::_reqs[0]->getPaddr() & blockMask) == blockAddr);
-}
+SingleDataRequest::isCacheBlockHit(Addr blockAddr, Addr blockMask)
+{ return ((LSQRequest::_reqs[0]->getPaddr() & blockMask) == blockAddr); }
 
 /**
  * Caches may probe into the load-store queue to enforce memory ordering
@@ -1366,7 +1384,7 @@ LSQ::SingleDataRequest::isCacheBlockHit(Addr blockAddr, Addr blockMask)
  * another core or the block cannot be accurately monitored by the load queue.
  */
 bool
-LSQ::SplitDataRequest::isCacheBlockHit(Addr blockAddr, Addr blockMask)
+SplitDataRequest::isCacheBlockHit(Addr blockAddr, Addr blockMask)
 {
     bool is_hit = false;
     for (auto &r: _reqs) {
@@ -1508,17 +1526,15 @@ LSQ::DcachePort::recvReqRetry()
     lsq->recvReqRetry();
 }
 
-LSQ::UnsquashableDirectRequest::UnsquashableDirectRequest(
-    LSQUnit* port,
-    const DynInstPtr& inst,
-    const Request::Flags& flags_) :
-    SingleDataRequest(port, inst, true, 0x0lu, 8, flags_,
-        nullptr, nullptr, nullptr)
+UnsquashableDirectRequest::UnsquashableDirectRequest(
+    LSQUnit *port, const DynInstPtr &inst, const Request::Flags &flags_)
+    : SingleDataRequest(port, inst, true, 0x0lu, 8, flags_, nullptr, nullptr,
+                        nullptr)
 {
 }
 
 void
-LSQ::UnsquashableDirectRequest::initiateTranslation()
+UnsquashableDirectRequest::initiateTranslation()
 {
     // Special commands are implemented as loads to avoid significant
     // changes to the cpu and memory interfaces
@@ -1554,7 +1570,7 @@ LSQ::UnsquashableDirectRequest::initiateTranslation()
 }
 
 void
-LSQ::UnsquashableDirectRequest::markAsStaleTranslation()
+UnsquashableDirectRequest::markAsStaleTranslation()
 {
     // HTM/TLBI operations do not translate,
     // so cannot have stale translations
@@ -1562,9 +1578,8 @@ LSQ::UnsquashableDirectRequest::markAsStaleTranslation()
 }
 
 void
-LSQ::UnsquashableDirectRequest::finish(const Fault &fault,
-        const RequestPtr &req, gem5::ThreadContext* tc,
-        BaseMMU::Mode mode)
+UnsquashableDirectRequest::finish(const Fault &fault, const RequestPtr &req,
+                                  gem5::ThreadContext *tc, BaseMMU::Mode mode)
 {
     panic("unexpected behaviour - finish()");
 }
@@ -1577,8 +1592,9 @@ LSQ::checkStaleTranslations()
     DPRINTF(LSQ, "Checking pending TLBI sync\n");
     // Check if all thread queues are complete
     for (const auto& unit : thread) {
-        if (unit.checkStaleTranslations())
+        if (unit->checkStaleTranslations()) {
             return;
+        }
     }
     DPRINTF(LSQ, "No threads have blocking TLBI sync\n");
 
@@ -1605,7 +1621,7 @@ LSQ::read(LSQRequest* request, ssize_t load_idx)
     assert(request->req()->contextId() == request->contextId());
     ThreadID tid = cpu->contextToThread(request->req()->contextId());
 
-    return thread.at(tid).read(request, load_idx);
+    return thread.at(tid)->read(request, load_idx);
 }
 
 Fault
@@ -1613,7 +1629,7 @@ LSQ::write(LSQRequest* request, uint8_t *data, ssize_t store_idx)
 {
     ThreadID tid = cpu->contextToThread(request->req()->contextId());
 
-    return thread.at(tid).write(request, data, store_idx);
+    return thread.at(tid)->write(request, data, store_idx);
 }
 
 } // namespace o3

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -45,8 +45,6 @@
 #include <cassert>
 #include <cstdint>
 #include <list>
-#include <map>
-#include <queue>
 #include <vector>
 
 #include "arch/generic/mmu.hh"
@@ -55,8 +53,8 @@
 #include "base/statistics.hh"
 #include "base/types.hh"
 #include "cpu/inst_seq.hh"
-#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/utils.hh"
+#include "dyn_inst_ptr.hh"
 #include "enums/SMTQueuePolicy.hh"
 #include "mem/port.hh"
 #include "sim/sim_object.hh"
@@ -73,18 +71,546 @@ class CPU;
 class IEW;
 class LSQUnit;
 
+/** Memory operation metadata.
+ * This class holds the information about a memory operation. It lives
+ * from initiateAcc to resource deallocation at commit or squash.
+ * LSQRequest objects are owned by the LQ/SQ Entry in the LSQUnit that
+ * holds the operation. In addition, the LSQRequest is a TranslationState,
+ * therefore, upon squash, there must be a defined ownership transferal
+ * in case the LSQ resources are deallocated before the TLB is done using
+ * the TranslationState.
+ * If that happens, the LSQRequest will be self-owned, and responsible to
+ * detect that its services are no longer required and self-destruct.
+ *
+ * Lifetime of a LSQRequest:
+ *                 +--------------------+
+ *                 |LSQ creates and owns|
+ *                 +--------------------+
+ *                           |
+ *                 +--------------------+
+ *                 | Initate translation|
+ *                 +--------------------+
+ *                           |
+ *                        ___^___
+ *                    ___/       \___
+ *             ______/   Squashed?   \
+ *            |      \___         ___/
+ *            |          \___ ___/
+ *            |              v
+ *            |              |
+ *            |    +--------------------+
+ *            |    |  Translation done  |
+ *            |    +--------------------+
+ *            |              |
+ *            |    +--------------------+
+ *            |    |     Send packet    |<------+
+ *            |    +--------------------+       |
+ *            |              |                  |
+ *            |           ___^___               |
+ *            |       ___/       \___           |
+ *            |  ____/   Squashed?   \          |
+ *            | |    \___         ___/          |
+ *            | |        \___ ___/              |
+ *            | |            v                  |
+ *            | |            |                  |
+ *            | |         ___^___               |
+ *            | |     ___/       \___           |
+ *            | |    /     Done?     \__________|
+ *            | |    \___         ___/
+ *            | |        \___ ___/
+ *            | |            v
+ *            | |            |
+ *            | |  +--------------------+
+ *            | |  |    Manage stuff    |
+ *            | |  |   Free resources   |
+ *            | |  +--------------------+
+ *            | |
+ *            | |  +--------------------+
+ *            | |  |    self owned      |
+ *            | +->|  on recvTimingResp |
+ *            |    |   free resources   |
+ *            |    +--------------------+
+ *            |
+ *            |   +----------------------+
+ *            |   |  self owned (Trans)  |
+ *            +-->| on TranslationFinish |
+ *                |    free resources    |
+ *                +----------------------+
+ *
+ *
+ */
+class LSQRequest : public BaseMMU::Translation, public Packet::SenderState
+{
+  protected:
+    typedef uint32_t FlagsStorage;
+    typedef Flags<FlagsStorage> FlagsType;
+
+    enum Flag : FlagsStorage
+    {
+        IsLoad = 0x00000001,
+        /** True if this request needs to writeBack to register.
+         * Will be set in case of load or a store/atomic
+         * that writes registers (SC)
+         */
+        WriteBackToRegister = 0x00000002,
+        Delayed = 0x00000004,
+        IsSplit = 0x00000008,
+        /** True if any translation has been sent to TLB. */
+        TranslationStarted = 0x00000010,
+        /** True if there are un-replied outbound translations.. */
+        TranslationFinished = 0x00000020,
+        Sent = 0x00000040,
+        Retry = 0x00000080,
+        Complete = 0x00000100,
+        /** Ownership tracking flags. */
+        /** Translation squashed. */
+        TranslationSquashed = 0x00000200,
+        /** Request discarded */
+        Discarded = 0x00000400,
+        /** LSQ resources freed. */
+        LSQEntryFreed = 0x00000800,
+        /** Store written back. */
+        WritebackScheduled = 0x00001000,
+        WritebackDone = 0x00002000,
+        /** True if this is an atomic request */
+        IsAtomic = 0x00004000
+    };
+    FlagsType flags;
+
+    enum class State
+    {
+        NotIssued,
+        Translation,
+        Request,
+        Fault,
+        PartialFault,
+    };
+    State _state;
+    void
+    setState(const State &newState)
+    { _state = newState; }
+
+    uint32_t numTranslatedFragments;
+    uint32_t numInTranslationFragments;
+
+    void
+    markDelayed() override
+    { flags.set(Flag::Delayed); }
+    bool
+    isDelayed()
+    { return flags.isSet(Flag::Delayed); }
+
+  public:
+    LSQUnit &_port;
+    const DynInstPtr _inst;
+    uint32_t _taskId;
+    PacketDataPtr _data;
+    std::vector<PacketPtr> _packets;
+    std::vector<RequestPtr> _reqs;
+    std::vector<Fault> _fault;
+    uint64_t *_res;
+    const Addr _addr;
+    const uint32_t _size;
+    const Request::Flags _flags;
+    std::vector<bool> _byteEnable;
+    uint32_t _numOutstandingPackets;
+    AtomicOpFunctorPtr _amo_op;
+    bool _hasStaleTranslation;
+
+  protected:
+    LSQUnit *
+    lsqUnit()
+    { return &_port; }
+    LSQRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad);
+    LSQRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad,
+               const Addr &addr, const uint32_t &size,
+               const Request::Flags &flags_, PacketDataPtr data = nullptr,
+               uint64_t *res = nullptr, AtomicOpFunctorPtr amo_op = nullptr,
+               bool stale_translation = false);
+
+    bool
+    isLoad() const
+    { return flags.isSet(Flag::IsLoad); }
+
+    bool
+    isAtomic() const
+    { return flags.isSet(Flag::IsAtomic); }
+
+    /** Install the request in the LQ/SQ. */
+    void install();
+
+    bool squashed() const override;
+
+    /** Release the LSQRequest.
+     * Notify the sender state that the request it points to is not valid
+     * anymore. Understand if the request is orphan (self-managed) and if
+     * so, mark it as freed, else destroy it, as this means
+     * the end of its life cycle.
+     * An LSQRequest is orphan when its resources are released
+     * but there is any in-flight translation request to the TLB or access
+     * request to the memory.
+     */
+    void
+    release(Flag reason)
+    {
+        assert(reason == Flag::LSQEntryFreed || reason == Flag::Discarded);
+        if (!isAnyOutstandingRequest()) {
+            delete this;
+        } else {
+            flags.set(reason);
+        }
+    }
+
+    /** Helper function used to add a (sub)request, given its address
+     * `addr`, size `size` and byte-enable mask `byteEnable`.
+     *
+     * The request is only added if there is at least one active
+     * element in the mask.
+     */
+    void addReq(Addr addr, unsigned size,
+                const std::vector<bool> &byte_enable);
+
+    /** Destructor.
+     * The LSQRequest owns the request. If the packet has already been
+     * sent, the sender state will be deleted upon receiving the reply.
+     */
+    virtual ~LSQRequest();
+
+  public:
+    /** Convenience getters/setters. */
+    /** @{ */
+    /** Set up Context numbers. */
+    void
+    setContext(const ContextID &context_id)
+    { req()->setContext(context_id); }
+
+    const DynInstPtr &
+    instruction()
+    { return _inst; }
+
+    bool
+    hasStaleTranslation() const
+    { return _hasStaleTranslation; }
+
+    virtual void markAsStaleTranslation() = 0;
+
+    /** Set up virtual request.
+     * For a previously allocated Request objects.
+     */
+    void
+    setVirt(Addr vaddr, unsigned size, Request::Flags flags_,
+            RequestorID requestor_id, Addr pc)
+    { req()->setVirt(vaddr, size, flags_, requestor_id, pc); }
+
+    ContextID contextId() const;
+
+    void
+    taskId(const uint32_t &v)
+    {
+        _taskId = v;
+        for (auto &r : _reqs) {
+            r->taskId(v);
+        }
+    }
+
+    uint32_t
+    taskId() const
+    { return _taskId; }
+
+    RequestPtr
+    req(int idx = 0)
+    { return _reqs.at(idx); }
+    const RequestPtr
+    req(int idx = 0) const
+    { return _reqs.at(idx); }
+
+    Addr
+    getVaddr(int idx = 0) const
+    { return req(idx)->getVaddr(); }
+    virtual void initiateTranslation() = 0;
+
+    PacketPtr
+    packet(int idx = 0)
+    { return _packets.at(idx); }
+
+    virtual PacketPtr
+    mainPacket()
+    {
+        assert(_packets.size() == 1);
+        return packet();
+    }
+
+    virtual RequestPtr
+    mainReq()
+    {
+        assert(_reqs.size() == 1);
+        return req();
+    }
+
+    /**
+     * Test if there is any in-flight translation or mem access request
+     */
+    bool
+    isAnyOutstandingRequest()
+    {
+        return numInTranslationFragments > 0 || _numOutstandingPackets > 0 ||
+               (flags.isSet(Flag::WritebackScheduled) &&
+                !flags.isSet(Flag::WritebackDone));
+    }
+
+    /**
+     * Test if the LSQRequest has been released, i.e. self-owned.
+     * An LSQRequest manages itself when the resources on the LSQ are freed
+     * but the translation is still going on and the LSQEntry was freed.
+     */
+    bool
+    isReleased()
+    {
+        return flags.isSet(Flag::LSQEntryFreed) ||
+               flags.isSet(Flag::Discarded);
+    }
+
+    bool
+    isSplit() const
+    { return flags.isSet(Flag::IsSplit); }
+
+    bool
+    needWBToRegister() const
+    { return flags.isSet(Flag::WriteBackToRegister); }
+    /** @} */
+    virtual bool recvTimingResp(PacketPtr pkt) = 0;
+    virtual void sendPacketToCache() = 0;
+    virtual void buildPackets() = 0;
+
+    /**
+     * Memory mapped IPR accesses
+     */
+    virtual Cycles handleLocalAccess(gem5::ThreadContext *thread,
+                                     PacketPtr pkt) = 0;
+
+    /**
+     * Test if the request accesses a particular cache line.
+     */
+    virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask) = 0;
+
+    /** Update the status to reflect that a packet was sent. */
+    void
+    packetSent()
+    { flags.set(Flag::Sent); }
+    /** Update the status to reflect that a packet was not sent.
+     * When a packet fails to be sent, we mark the request as needing a
+     * retry. Note that Retry flag is sticky.
+     */
+    void
+    packetNotSent()
+    {
+        flags.set(Flag::Retry);
+        flags.clear(Flag::Sent);
+    }
+
+    void sendFragmentToTranslation(int i);
+    bool
+    isComplete()
+    { return flags.isSet(Flag::Complete); }
+
+    bool
+    isInTranslation()
+    { return _state == State::Translation; }
+
+    bool
+    isTranslationComplete()
+    { return flags.isSet(Flag::TranslationStarted) && !isInTranslation(); }
+
+    bool
+    isTranslationBlocked()
+    {
+        return _state == State::Translation &&
+               flags.isSet(Flag::TranslationStarted) &&
+               !flags.isSet(Flag::TranslationFinished);
+    }
+
+    bool
+    isSent()
+    { return flags.isSet(Flag::Sent); }
+
+    bool
+    isPartialFault()
+    { return _state == State::PartialFault; }
+
+    bool
+    isMemAccessRequired()
+    { return (_state == State::Request || (isPartialFault() && isLoad())); }
+
+    void
+    setStateToFault()
+    { setState(State::Fault); }
+
+    /**
+     * The LSQ entry is cleared
+     */
+    void
+    freeLSQEntry()
+    { release(Flag::LSQEntryFreed); }
+
+    /**
+     * The request is discarded (e.g. partial store-load forwarding)
+     */
+    void
+    discard()
+    { release(Flag::Discarded); }
+
+    void
+    packetReplied()
+    {
+        assert(_numOutstandingPackets > 0);
+        _numOutstandingPackets--;
+        if (_numOutstandingPackets == 0 && isReleased()) {
+            delete this;
+        }
+    }
+
+    void
+    writebackScheduled()
+    {
+        assert(!flags.isSet(Flag::WritebackScheduled));
+        flags.set(Flag::WritebackScheduled);
+    }
+
+    void
+    writebackDone()
+    {
+        flags.set(Flag::WritebackDone);
+        /* If the lsq resources are already free */
+        if (_numOutstandingPackets == 0 && isReleased()) {
+            delete this;
+        }
+    }
+
+    void
+    squashTranslation()
+    {
+        assert(numInTranslationFragments == 0);
+        flags.set(Flag::TranslationSquashed);
+        /* If we are on our own, self-destruct. */
+        if (isReleased()) {
+            delete this;
+        }
+    }
+
+    void
+    complete()
+    { flags.set(Flag::Complete); }
+
+    virtual std::string
+    name() const
+    { return "LSQRequest"; }
+};
+
+class SingleDataRequest : public LSQRequest
+{
+  public:
+    SingleDataRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad,
+                      const Addr &addr, const uint32_t &size,
+                      const Request::Flags &flags_,
+                      PacketDataPtr data = nullptr, uint64_t *res = nullptr,
+                      AtomicOpFunctorPtr amo_op = nullptr)
+        : LSQRequest(port, inst, isLoad, addr, size, flags_, data, res,
+                     std::move(amo_op))
+    {}
+
+    virtual ~SingleDataRequest() {}
+    virtual void markAsStaleTranslation();
+    virtual void initiateTranslation();
+    virtual void finish(const Fault &fault, const RequestPtr &req,
+                        gem5::ThreadContext *tc, BaseMMU::Mode mode);
+    virtual bool recvTimingResp(PacketPtr pkt);
+    virtual void sendPacketToCache();
+    virtual void buildPackets();
+    virtual Cycles handleLocalAccess(gem5::ThreadContext *thread,
+                                     PacketPtr pkt);
+    virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask);
+    virtual std::string
+    name() const
+    { return "SingleDataRequest"; }
+};
+
+// This class extends SingleDataRequest for the purpose
+// of allowing special requests (eg Hardware transactional memory, TLB
+// shootdowns) to bypass irrelevant system elements like translation &
+// squashing.
+class UnsquashableDirectRequest : public SingleDataRequest
+{
+  public:
+    UnsquashableDirectRequest(LSQUnit *port, const DynInstPtr &inst,
+                              const Request::Flags &flags_);
+    inline virtual ~UnsquashableDirectRequest() {}
+    virtual void initiateTranslation();
+    virtual void markAsStaleTranslation();
+    virtual void finish(const Fault &fault, const RequestPtr &req,
+                        gem5::ThreadContext *tc, BaseMMU::Mode mode);
+    virtual std::string
+    name() const
+    { return "UnsquashableDirectRequest"; }
+};
+
+class SplitDataRequest : public LSQRequest
+{
+  protected:
+    uint32_t numFragments;
+    uint32_t numReceivedPackets;
+    RequestPtr _mainReq;
+    PacketPtr _mainPacket;
+
+  public:
+    SplitDataRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad,
+                     const Addr &addr, const uint32_t &size,
+                     const Request::Flags &flags_,
+                     PacketDataPtr data = nullptr, uint64_t *res = nullptr)
+        : LSQRequest(port, inst, isLoad, addr, size, flags_, data, res,
+                     nullptr),
+          numFragments(0),
+          numReceivedPackets(0),
+          _mainReq(nullptr),
+          _mainPacket(nullptr)
+    { flags.set(Flag::IsSplit); }
+    virtual ~SplitDataRequest()
+    {
+        if (_mainReq) {
+            _mainReq = nullptr;
+        }
+        if (_mainPacket) {
+            delete _mainPacket;
+            _mainPacket = nullptr;
+        }
+    }
+    virtual void markAsStaleTranslation();
+    virtual void finish(const Fault &fault, const RequestPtr &req,
+                        gem5::ThreadContext *tc, BaseMMU::Mode mode);
+    virtual bool recvTimingResp(PacketPtr pkt);
+    virtual void initiateTranslation();
+    virtual void sendPacketToCache();
+    virtual void buildPackets();
+
+    virtual Cycles handleLocalAccess(gem5::ThreadContext *thread,
+                                     PacketPtr pkt);
+    virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask);
+
+    virtual RequestPtr mainReq();
+    virtual PacketPtr mainPacket();
+    virtual std::string
+    name() const
+    { return "SplitDataRequest"; }
+};
+
 class LSQ
 {
   public:
-    class LSQRequest;
-
     /**
      * DcachePort class for the load/store queue.
      */
     class DcachePort : public RequestPort
     {
       protected:
-
         /** Pointer to LSQ. */
         LSQ *lsq;
         CPU *cpu;
@@ -95,7 +621,7 @@ class LSQ
 
         struct DcachePortStats : public statistics::Group
         {
-            DcachePortStats(CPU* cpu);
+            DcachePortStats(CPU *cpu);
 
             /* Number of recieved responses */
             statistics::Scalar numRecvResp;
@@ -120,7 +646,6 @@ class LSQ
         } dcachePortStats;
 
       protected:
-
         /** Timing version of receive.  Handles writing back and
          * completing the load or store that has returned from
          * memory. */
@@ -142,556 +667,16 @@ class LSQ
          *
          * @return true since we have to snoop
          */
-        virtual bool isSnooping() const { return true; }
+        virtual bool
+        isSnooping() const
+        { return true; }
 
         /** Applies throttling in recvTimingResp for incoming load responses */
         bool throttleReadResp(PacketPtr pkt);
     };
 
-    /** Memory operation metadata.
-     * This class holds the information about a memory operation. It lives
-     * from initiateAcc to resource deallocation at commit or squash.
-     * LSQRequest objects are owned by the LQ/SQ Entry in the LSQUnit that
-     * holds the operation. In addition, the LSQRequest is a TranslationState,
-     * therefore, upon squash, there must be a defined ownership transferal
-     * in case the LSQ resources are deallocated before the TLB is done using
-     * the TranslationState.
-     * If that happens, the LSQRequest will be self-owned, and responsible to
-     * detect that its services are no longer required and self-destruct.
-     *
-     * Lifetime of a LSQRequest:
-     *                 +--------------------+
-     *                 |LSQ creates and owns|
-     *                 +--------------------+
-     *                           |
-     *                 +--------------------+
-     *                 | Initate translation|
-     *                 +--------------------+
-     *                           |
-     *                        ___^___
-     *                    ___/       \___
-     *             ______/   Squashed?   \
-     *            |      \___         ___/
-     *            |          \___ ___/
-     *            |              v
-     *            |              |
-     *            |    +--------------------+
-     *            |    |  Translation done  |
-     *            |    +--------------------+
-     *            |              |
-     *            |    +--------------------+
-     *            |    |     Send packet    |<------+
-     *            |    +--------------------+       |
-     *            |              |                  |
-     *            |           ___^___               |
-     *            |       ___/       \___           |
-     *            |  ____/   Squashed?   \          |
-     *            | |    \___         ___/          |
-     *            | |        \___ ___/              |
-     *            | |            v                  |
-     *            | |            |                  |
-     *            | |         ___^___               |
-     *            | |     ___/       \___           |
-     *            | |    /     Done?     \__________|
-     *            | |    \___         ___/
-     *            | |        \___ ___/
-     *            | |            v
-     *            | |            |
-     *            | |  +--------------------+
-     *            | |  |    Manage stuff    |
-     *            | |  |   Free resources   |
-     *            | |  +--------------------+
-     *            | |
-     *            | |  +--------------------+
-     *            | |  |    self owned      |
-     *            | +->|  on recvTimingResp |
-     *            |    |   free resources   |
-     *            |    +--------------------+
-     *            |
-     *            |   +----------------------+
-     *            |   |  self owned (Trans)  |
-     *            +-->| on TranslationFinish |
-     *                |    free resources    |
-     *                +----------------------+
-     *
-     *
-     */
-    class LSQRequest : public BaseMMU::Translation, public Packet::SenderState
-    {
-      protected:
-        typedef uint32_t FlagsStorage;
-        typedef Flags<FlagsStorage> FlagsType;
-
-        enum Flag : FlagsStorage
-        {
-            IsLoad              = 0x00000001,
-            /** True if this request needs to writeBack to register.
-              * Will be set in case of load or a store/atomic
-              * that writes registers (SC)
-              */
-            WriteBackToRegister = 0x00000002,
-            Delayed             = 0x00000004,
-            IsSplit             = 0x00000008,
-            /** True if any translation has been sent to TLB. */
-            TranslationStarted  = 0x00000010,
-            /** True if there are un-replied outbound translations.. */
-            TranslationFinished = 0x00000020,
-            Sent                = 0x00000040,
-            Retry               = 0x00000080,
-            Complete            = 0x00000100,
-            /** Ownership tracking flags. */
-            /** Translation squashed. */
-            TranslationSquashed = 0x00000200,
-            /** Request discarded */
-            Discarded           = 0x00000400,
-            /** LSQ resources freed. */
-            LSQEntryFreed       = 0x00000800,
-            /** Store written back. */
-            WritebackScheduled  = 0x00001000,
-            WritebackDone       = 0x00002000,
-            /** True if this is an atomic request */
-            IsAtomic            = 0x00004000
-        };
-        FlagsType flags;
-
-        enum class State
-        {
-            NotIssued,
-            Translation,
-            Request,
-            Fault,
-            PartialFault,
-        };
-        State _state;
-        void setState(const State& newState) { _state = newState; }
-
-        uint32_t numTranslatedFragments;
-        uint32_t numInTranslationFragments;
-
-
-        void markDelayed() override { flags.set(Flag::Delayed); }
-        bool isDelayed() { return flags.isSet(Flag::Delayed); }
-
-      public:
-        LSQUnit& _port;
-        const DynInstPtr _inst;
-        uint32_t _taskId;
-        PacketDataPtr _data;
-        std::vector<PacketPtr> _packets;
-        std::vector<RequestPtr> _reqs;
-        std::vector<Fault> _fault;
-        uint64_t* _res;
-        const Addr _addr;
-        const uint32_t _size;
-        const Request::Flags _flags;
-        std::vector<bool> _byteEnable;
-        uint32_t _numOutstandingPackets;
-        AtomicOpFunctorPtr _amo_op;
-        bool _hasStaleTranslation;
-
-      protected:
-        LSQUnit* lsqUnit() { return &_port; }
-        LSQRequest(LSQUnit* port, const DynInstPtr& inst, bool isLoad);
-        LSQRequest(LSQUnit* port, const DynInstPtr& inst, bool isLoad,
-                const Addr& addr, const uint32_t& size,
-                const Request::Flags& flags_, PacketDataPtr data=nullptr,
-                uint64_t* res=nullptr, AtomicOpFunctorPtr amo_op=nullptr,
-                bool stale_translation=false);
-
-        bool
-        isLoad() const
-        {
-            return flags.isSet(Flag::IsLoad);
-        }
-
-        bool
-        isAtomic() const
-        {
-            return flags.isSet(Flag::IsAtomic);
-        }
-
-        /** Install the request in the LQ/SQ. */
-        void install();
-
-        bool squashed() const override;
-
-
-        /** Release the LSQRequest.
-         * Notify the sender state that the request it points to is not valid
-         * anymore. Understand if the request is orphan (self-managed) and if
-         * so, mark it as freed, else destroy it, as this means
-         * the end of its life cycle.
-         * An LSQRequest is orphan when its resources are released
-         * but there is any in-flight translation request to the TLB or access
-         * request to the memory.
-         */
-        void
-        release(Flag reason)
-        {
-            assert(reason == Flag::LSQEntryFreed || reason == Flag::Discarded);
-            if (!isAnyOutstandingRequest()) {
-                delete this;
-            } else {
-                flags.set(reason);
-            }
-        }
-
-        /** Helper function used to add a (sub)request, given its address
-         * `addr`, size `size` and byte-enable mask `byteEnable`.
-         *
-         * The request is only added if there is at least one active
-         * element in the mask.
-         */
-        void addReq(Addr addr, unsigned size,
-                const std::vector<bool>& byte_enable);
-
-        /** Destructor.
-         * The LSQRequest owns the request. If the packet has already been
-         * sent, the sender state will be deleted upon receiving the reply.
-         */
-        virtual ~LSQRequest();
-
-      public:
-        /** Convenience getters/setters. */
-        /** @{ */
-        /** Set up Context numbers. */
-        void
-        setContext(const ContextID& context_id)
-        {
-            req()->setContext(context_id);
-        }
-
-        const DynInstPtr& instruction() { return _inst; }
-
-        bool hasStaleTranslation() const { return _hasStaleTranslation; }
-
-        virtual void markAsStaleTranslation() = 0;
-
-        /** Set up virtual request.
-         * For a previously allocated Request objects.
-         */
-        void
-        setVirt(Addr vaddr, unsigned size, Request::Flags flags_,
-                RequestorID requestor_id, Addr pc)
-        {
-            req()->setVirt(vaddr, size, flags_, requestor_id, pc);
-        }
-
-        ContextID contextId() const;
-
-        void
-        taskId(const uint32_t& v)
-        {
-            _taskId = v;
-            for (auto& r: _reqs)
-                r->taskId(v);
-        }
-
-        uint32_t taskId() const { return _taskId; }
-
-        RequestPtr req(int idx = 0) { return _reqs.at(idx); }
-        const RequestPtr req(int idx = 0) const { return _reqs.at(idx); }
-
-        Addr getVaddr(int idx = 0) const { return req(idx)->getVaddr(); }
-        virtual void initiateTranslation() = 0;
-
-        PacketPtr packet(int idx = 0) { return _packets.at(idx); }
-
-        virtual PacketPtr
-        mainPacket()
-        {
-            assert (_packets.size() == 1);
-            return packet();
-        }
-
-        virtual RequestPtr
-        mainReq()
-        {
-            assert (_reqs.size() == 1);
-            return req();
-        }
-
-        /**
-         * Test if there is any in-flight translation or mem access request
-         */
-        bool
-        isAnyOutstandingRequest()
-        {
-            return numInTranslationFragments > 0 ||
-                _numOutstandingPackets > 0 ||
-                (flags.isSet(Flag::WritebackScheduled) &&
-                 !flags.isSet(Flag::WritebackDone));
-        }
-
-        /**
-         * Test if the LSQRequest has been released, i.e. self-owned.
-         * An LSQRequest manages itself when the resources on the LSQ are freed
-         * but the translation is still going on and the LSQEntry was freed.
-         */
-        bool
-        isReleased()
-        {
-            return flags.isSet(Flag::LSQEntryFreed) ||
-                flags.isSet(Flag::Discarded);
-        }
-
-        bool
-        isSplit() const
-        {
-            return flags.isSet(Flag::IsSplit);
-        }
-
-        bool
-        needWBToRegister() const
-        {
-            return flags.isSet(Flag::WriteBackToRegister);
-        }
-        /** @} */
-        virtual bool recvTimingResp(PacketPtr pkt) = 0;
-        virtual void sendPacketToCache() = 0;
-        virtual void buildPackets() = 0;
-
-        /**
-         * Memory mapped IPR accesses
-         */
-        virtual Cycles handleLocalAccess(
-                gem5::ThreadContext *thread, PacketPtr pkt) = 0;
-
-        /**
-         * Test if the request accesses a particular cache line.
-         */
-        virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask) = 0;
-
-        /** Update the status to reflect that a packet was sent. */
-        void
-        packetSent()
-        {
-            flags.set(Flag::Sent);
-        }
-        /** Update the status to reflect that a packet was not sent.
-         * When a packet fails to be sent, we mark the request as needing a
-         * retry. Note that Retry flag is sticky.
-         */
-        void
-        packetNotSent()
-        {
-            flags.set(Flag::Retry);
-            flags.clear(Flag::Sent);
-        }
-
-        void sendFragmentToTranslation(int i);
-        bool
-        isComplete()
-        {
-            return flags.isSet(Flag::Complete);
-        }
-
-        bool
-        isInTranslation()
-        {
-            return _state == State::Translation;
-        }
-
-        bool
-        isTranslationComplete()
-        {
-            return flags.isSet(Flag::TranslationStarted) &&
-                   !isInTranslation();
-        }
-
-        bool
-        isTranslationBlocked()
-        {
-            return _state == State::Translation &&
-                flags.isSet(Flag::TranslationStarted) &&
-                !flags.isSet(Flag::TranslationFinished);
-        }
-
-        bool
-        isSent()
-        {
-            return flags.isSet(Flag::Sent);
-        }
-
-        bool
-        isPartialFault()
-        {
-            return _state == State::PartialFault;
-        }
-
-        bool
-        isMemAccessRequired()
-        {
-            return (_state == State::Request ||
-                    (isPartialFault() && isLoad()));
-        }
-
-        void
-        setStateToFault()
-        {
-            setState(State::Fault);
-        }
-
-        /**
-         * The LSQ entry is cleared
-         */
-        void
-        freeLSQEntry()
-        {
-            release(Flag::LSQEntryFreed);
-        }
-
-        /**
-         * The request is discarded (e.g. partial store-load forwarding)
-         */
-        void
-        discard()
-        {
-            release(Flag::Discarded);
-        }
-
-        void
-        packetReplied()
-        {
-            assert(_numOutstandingPackets > 0);
-            _numOutstandingPackets--;
-            if (_numOutstandingPackets == 0 && isReleased())
-                delete this;
-        }
-
-        void
-        writebackScheduled()
-        {
-            assert(!flags.isSet(Flag::WritebackScheduled));
-            flags.set(Flag::WritebackScheduled);
-        }
-
-        void
-        writebackDone()
-        {
-            flags.set(Flag::WritebackDone);
-            /* If the lsq resources are already free */
-            if (_numOutstandingPackets == 0 && isReleased()) {
-                delete this;
-            }
-        }
-
-        void
-        squashTranslation()
-        {
-            assert(numInTranslationFragments == 0);
-            flags.set(Flag::TranslationSquashed);
-            /* If we are on our own, self-destruct. */
-            if (isReleased()) {
-                delete this;
-            }
-        }
-
-        void
-        complete()
-        {
-            flags.set(Flag::Complete);
-        }
-
-        virtual std::string name() const { return "LSQRequest"; }
-    };
-
-    class SingleDataRequest : public LSQRequest
-    {
-      public:
-        SingleDataRequest(LSQUnit* port, const DynInstPtr& inst,
-                bool isLoad, const Addr& addr, const uint32_t& size,
-                const Request::Flags& flags_, PacketDataPtr data=nullptr,
-                uint64_t* res=nullptr, AtomicOpFunctorPtr amo_op=nullptr) :
-            LSQRequest(port, inst, isLoad, addr, size, flags_, data, res,
-                       std::move(amo_op)) {}
-
-        virtual ~SingleDataRequest() {}
-        virtual void markAsStaleTranslation();
-        virtual void initiateTranslation();
-        virtual void finish(const Fault &fault, const RequestPtr &req,
-                gem5::ThreadContext* tc, BaseMMU::Mode mode);
-        virtual bool recvTimingResp(PacketPtr pkt);
-        virtual void sendPacketToCache();
-        virtual void buildPackets();
-        virtual Cycles handleLocalAccess(
-                gem5::ThreadContext *thread, PacketPtr pkt);
-        virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask);
-        virtual std::string name() const { return "SingleDataRequest"; }
-    };
-
-    // This class extends SingleDataRequest for the purpose
-    // of allowing special requests (eg Hardware transactional memory, TLB
-    // shootdowns) to bypass irrelevant system elements like translation &
-    // squashing.
-    class UnsquashableDirectRequest : public SingleDataRequest
-    {
-      public:
-        UnsquashableDirectRequest(LSQUnit* port, const DynInstPtr& inst,
-                const Request::Flags& flags_);
-        inline virtual ~UnsquashableDirectRequest() {}
-        virtual void initiateTranslation();
-        virtual void markAsStaleTranslation();
-        virtual void finish(const Fault &fault, const RequestPtr &req,
-                gem5::ThreadContext* tc, BaseMMU::Mode mode);
-        virtual std::string
-        name() const
-        {
-            return "UnsquashableDirectRequest";
-        }
-    };
-
-    class SplitDataRequest : public LSQRequest
-    {
-      protected:
-        uint32_t numFragments;
-        uint32_t numReceivedPackets;
-        RequestPtr _mainReq;
-        PacketPtr _mainPacket;
-
-      public:
-        SplitDataRequest(LSQUnit* port, const DynInstPtr& inst,
-                bool isLoad, const Addr& addr, const uint32_t& size,
-                const Request::Flags & flags_, PacketDataPtr data=nullptr,
-                uint64_t* res=nullptr) :
-            LSQRequest(port, inst, isLoad, addr, size, flags_, data, res,
-                       nullptr),
-            numFragments(0),
-            numReceivedPackets(0),
-            _mainReq(nullptr),
-            _mainPacket(nullptr)
-        {
-            flags.set(Flag::IsSplit);
-        }
-        virtual ~SplitDataRequest()
-        {
-            if (_mainReq) {
-                _mainReq = nullptr;
-            }
-            if (_mainPacket) {
-                delete _mainPacket;
-                _mainPacket = nullptr;
-            }
-        }
-        virtual void markAsStaleTranslation();
-        virtual void finish(const Fault &fault, const RequestPtr &req,
-                gem5::ThreadContext* tc, BaseMMU::Mode mode);
-        virtual bool recvTimingResp(PacketPtr pkt);
-        virtual void initiateTranslation();
-        virtual void sendPacketToCache();
-        virtual void buildPackets();
-
-        virtual Cycles handleLocalAccess(
-                gem5::ThreadContext *thread, PacketPtr pkt);
-        virtual bool isCacheBlockHit(Addr blockAddr, Addr cacheBlockMask);
-
-        virtual RequestPtr mainReq();
-        virtual PacketPtr mainPacket();
-        virtual std::string name() const { return "SplitDataRequest"; }
-    };
-
-    /** Constructs an LSQ with the given parameters. */
     LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params);
+    ~LSQ();
 
     /** Returns the name of the LSQ. */
     std::string name() const;
@@ -984,7 +969,7 @@ class LSQ
     DcachePort dcachePort;
 
     /** The LSQ units for individual threads. */
-    std::vector<LSQUnit> thread;
+    std::vector<std::unique_ptr<LSQUnit>> thread;
 
     /** Number of Threads. */
     ThreadID numThreads;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -42,17 +42,30 @@
 #include "cpu/o3/lsq_unit.hh"
 
 #include "arch/generic/debugfaults.hh"
-#include "base/str.hh"
+#include "arch/generic/mmu.hh"
+#include "base/cprintf.hh"
+#include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/info.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
 #include "cpu/checker/cpu.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/o3/lsq.hh"
-#include "debug/Activity.hh"
 #include "debug/HtmCpu.hh"
-#include "debug/IEW.hh"
 #include "debug/LSQUnit.hh"
+#include "mem/htm.hh"
 #include "mem/packet.hh"
+#include "mem/port.hh"
 #include "mem/request.hh"
+#include "sim/cur_tick.hh"
+#include "sim/eventq.hh"
+#include "sim/faults.hh"
 
 namespace gem5
 {
@@ -1617,7 +1630,7 @@ LSQUnit::read(LSQRequest *request, ssize_t load_idx)
     // if we the cache is not blocked, do cache access
     // if the request is not sent and cache is unblocked
     // then put the instruction into retry queue so we do not need
-    // an exta cycle to re-issue and execute
+    // an extra cycle to re-issue and execute
     request->buildPackets();
     request->sendPacketToCache();
     if (!request->isSent()) {
@@ -1677,6 +1690,52 @@ LSQUnit::getStoreHeadSeqNum()
     else
         return 0;
 }
+
+LSQEntry::~LSQEntry()
+{
+    if (_request != nullptr) {
+        _request->freeLSQEntry();
+        _request = nullptr;
+    }
+}
+
+void
+LSQEntry::clear()
+{
+    _inst = nullptr;
+    if (_request != nullptr) {
+        _request->freeLSQEntry();
+    }
+    _request = nullptr;
+    _valid = false;
+    _size = 0;
+}
+
+void
+LSQEntry::set(const DynInstPtr &new_inst)
+{
+    assert(!_valid);
+    _inst = new_inst;
+    _valid = true;
+    _size = 0;
+}
+
+SQEntry::SQEntry()
+{ std::memset(_data, 0, DataSize); }
+
+void
+SQEntry::set(const DynInstPtr &inst)
+{ LSQEntry::set(inst); }
+
+void
+SQEntry::clear()
+{
+    LSQEntry::clear();
+    _canWB = _completed = _committed = _isAllZeros = false;
+}
+
+LSQUnit::LSQUnit(const LSQUnit &l) : stats(nullptr)
+{ panic("LSQUnit is not copy-able"); }
 
 } // namespace o3
 } // namespace gem5

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -42,11 +42,7 @@
 #ifndef __CPU_O3_LSQ_UNIT_HH__
 #define __CPU_O3_LSQ_UNIT_HH__
 
-#include <algorithm>
 #include <cstring>
-#include <map>
-#include <memory>
-#include <queue>
 
 #include "arch/generic/debugfaults.hh"
 #include "arch/generic/vec_reg.hh"
@@ -54,7 +50,6 @@
 #include "cpu/base.hh"
 #include "cpu/inst_seq.hh"
 #include "cpu/o3/comm.hh"
-#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/lsq.hh"
 #include "cpu/timebuf.hh"
@@ -71,7 +66,124 @@ struct BaseO3CPUParams;
 namespace o3
 {
 
+class CPU;
+class DynInst;
 class IEW;
+
+class LSQEntry
+{
+  public:
+    static constexpr auto MaxDataBytes = MaxVecRegLenInBytes;
+
+  private:
+    /** The instruction. */
+    DynInstPtr _inst;
+    /** The request. */
+    LSQRequest *_request = nullptr;
+    /** The size of the operation. */
+    uint32_t _size = 0;
+    /** Valid entry. */
+    bool _valid = false;
+
+  public:
+    ~LSQEntry();
+
+    void clear();
+
+    void set(const DynInstPtr &new_inst);
+
+    LSQRequest *
+    request()
+    { return _request; }
+    void
+    setRequest(LSQRequest *r)
+    { _request = r; }
+    bool
+    hasRequest()
+    { return _request != nullptr; }
+    /** Member accessors. */
+    /** @{ */
+    bool
+    valid() const
+    { return _valid; }
+    uint32_t &
+    size()
+    { return _size; }
+    const uint32_t &
+    size() const
+    { return _size; }
+    const DynInstPtr &
+    instruction() const
+    { return _inst; }
+    /** @} */
+};
+
+class SQEntry : public LSQEntry
+{
+  private:
+    /** The store data. */
+    char _data[MaxDataBytes];
+    /** Whether or not the store can writeback. */
+    bool _canWB = false;
+    /** Whether or not the store is committed. */
+    bool _committed = false;
+    /** Whether or not the store is completed. */
+    bool _completed = false;
+    /** Does this request write all zeros and thus doesn't
+     * have any data attached to it. Used for cache block zero
+     * style instructs (ARM DC ZVA; ALPHA WH64)
+     */
+    bool _isAllZeros = false;
+
+  public:
+    static constexpr size_t DataSize = sizeof(_data);
+    /** Constructs an empty store queue entry. */
+    SQEntry();
+
+    void set(const DynInstPtr &inst);
+
+    void clear();
+
+    /** Member accessors. */
+    /** @{ */
+    bool &
+    canWB()
+    { return _canWB; }
+    const bool &
+    canWB() const
+    { return _canWB; }
+    bool &
+    completed()
+    { return _completed; }
+    const bool &
+    completed() const
+    { return _completed; }
+    bool &
+    committed()
+    { return _committed; }
+    const bool &
+    committed() const
+    { return _committed; }
+    bool &
+    isAllZeros()
+    { return _isAllZeros; }
+    const bool &
+    isAllZeros() const
+    { return _isAllZeros; }
+    char *
+    data()
+    { return _data; }
+    const char *
+    data() const
+    { return _data; }
+    /** @} */
+};
+
+using LQEntry = LSQEntry;
+using LoadQueue = CircularQueue<LQEntry>;
+using StoreQueue = CircularQueue<SQEntry>;
+using LQIterator = typename LoadQueue::iterator;
+using SQIterator = typename StoreQueue::iterator;
 
 /**
  * Class that implements the actual LQ and SQ for each specific
@@ -90,112 +202,7 @@ class LSQUnit
   public:
     static constexpr auto MaxDataBytes = MaxVecRegLenInBytes;
 
-    using LSQRequest = LSQ::LSQRequest;
   private:
-    class LSQEntry
-    {
-      private:
-        /** The instruction. */
-        DynInstPtr _inst;
-        /** The request. */
-        LSQRequest* _request = nullptr;
-        /** The size of the operation. */
-        uint32_t _size = 0;
-        /** Valid entry. */
-        bool _valid = false;
-
-      public:
-        ~LSQEntry()
-        {
-            if (_request != nullptr) {
-                _request->freeLSQEntry();
-                _request = nullptr;
-            }
-        }
-
-        void
-        clear()
-        {
-            _inst = nullptr;
-            if (_request != nullptr) {
-                _request->freeLSQEntry();
-            }
-            _request = nullptr;
-            _valid = false;
-            _size = 0;
-        }
-
-        void
-        set(const DynInstPtr& new_inst)
-        {
-            assert(!_valid);
-            _inst = new_inst;
-            _valid = true;
-            _size = 0;
-        }
-
-        LSQRequest* request() { return _request; }
-        void setRequest(LSQRequest* r) { _request = r; }
-        bool hasRequest() { return _request != nullptr; }
-        /** Member accessors. */
-        /** @{ */
-        bool valid() const { return _valid; }
-        uint32_t& size() { return _size; }
-        const uint32_t& size() const { return _size; }
-        const DynInstPtr& instruction() const { return _inst; }
-        /** @} */
-    };
-
-    class SQEntry : public LSQEntry
-    {
-      private:
-        /** The store data. */
-        char _data[MaxDataBytes];
-        /** Whether or not the store can writeback. */
-        bool _canWB = false;
-        /** Whether or not the store is committed. */
-        bool _committed = false;
-        /** Whether or not the store is completed. */
-        bool _completed = false;
-        /** Does this request write all zeros and thus doesn't
-         * have any data attached to it. Used for cache block zero
-         * style instructs (ARM DC ZVA; ALPHA WH64)
-         */
-        bool _isAllZeros = false;
-
-      public:
-        static constexpr size_t DataSize = sizeof(_data);
-        /** Constructs an empty store queue entry. */
-        SQEntry()
-        {
-            std::memset(_data, 0, DataSize);
-        }
-
-        void set(const DynInstPtr& inst) { LSQEntry::set(inst); }
-
-        void
-        clear()
-        {
-            LSQEntry::clear();
-            _canWB = _completed = _committed = _isAllZeros = false;
-        }
-
-        /** Member accessors. */
-        /** @{ */
-        bool& canWB() { return _canWB; }
-        const bool& canWB() const { return _canWB; }
-        bool& completed() { return _completed; }
-        const bool& completed() const { return _completed; }
-        bool& committed() { return _committed; }
-        const bool& committed() const { return _committed; }
-        bool& isAllZeros() { return _isAllZeros; }
-        const bool& isAllZeros() const { return _isAllZeros; }
-        char* data() { return _data; }
-        const char* data() const { return _data; }
-        /** @} */
-    };
-    using LQEntry = LSQEntry;
-
     /** Coverage of one address range with another */
     enum class AddrRangeCoverage
     {
@@ -205,10 +212,6 @@ class LSQUnit
     };
 
   public:
-    using LoadQueue = CircularQueue<LQEntry>;
-    using StoreQueue = CircularQueue<SQEntry>;
-
-  public:
     /** Constructs an LSQ unit. init() must be called prior to use. */
     LSQUnit(uint32_t lqEntries, uint32_t sqEntries);
 
@@ -216,10 +219,7 @@ class LSQUnit
      * contructor is deleted explicitly. However, STL vector requires
      * a valid copy constructor for the base type at compile time.
      */
-    LSQUnit(const LSQUnit &l): stats(nullptr)
-    {
-        panic("LSQUnit is not copy-able");
-    }
+    LSQUnit(const LSQUnit &l);
 
     /** Initializes the LSQ unit with the specified number of entries. */
     void init(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params,
@@ -581,10 +581,9 @@ class LSQUnit
     InstSeqNum getStoreHeadSeqNum();
 
     /** Returns whether or not the LSQ unit is stalled. */
-    bool isStalled()  { return stalled; }
-  public:
-    typedef typename CircularQueue<LQEntry>::iterator LQIterator;
-    typedef typename CircularQueue<SQEntry>::iterator SQIterator;
+    bool
+    isStalled()
+    { return stalled; }
 };
 
 } // namespace o3

--- a/src/cpu/o3/mem_dep_unit.cc
+++ b/src/cpu/o3/mem_dep_unit.cc
@@ -26,16 +26,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "cpu/o3/mem_dep_unit.hh"
+
 #include <map>
 #include <memory>
 #include <vector>
 
-#include "base/compiler.hh"
-#include "base/debug.hh"
+#include "base/cprintf.hh"
+#include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/inst_queue.hh"
 #include "cpu/o3/limits.hh"
-#include "cpu/o3/mem_dep_unit.hh"
 #include "debug/MemDepUnit.hh"
 #include "params/BaseO3CPU.hh"
 

--- a/src/cpu/o3/probe/elastic_trace.cc
+++ b/src/cpu/o3/probe/elastic_trace.cc
@@ -40,6 +40,7 @@
 #include "base/callback.hh"
 #include "base/output.hh"
 #include "base/trace.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
 #include "cpu/reg_class.hh"
 #include "debug/ElasticTrace.hh"

--- a/src/cpu/o3/rob.cc
+++ b/src/cpu/o3/rob.cc
@@ -42,11 +42,18 @@
 
 #include <list>
 
-#include "base/logging.hh"
+#include "base/stats/group.hh"
+#include "base/stats/units.hh"
+#include "base/trace.hh"
+#include "base/types.hh"
+#include "cpu/inst_seq.hh"
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/dyn_inst.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
 #include "cpu/o3/limits.hh"
 #include "debug/Fetch.hh"
 #include "debug/ROB.hh"
+#include "enums/SMTQueuePolicy.hh"
 #include "params/BaseO3CPU.hh"
 
 namespace gem5


### PR DESCRIPTION
Refactors the O3 CPU model and related components to resolve circular dependencies and satisfy explicit dependency requirements for the Bazel build system.

Key changes include:
*   **cpu/o3**: Moved inline method implementations (e.g., `DynInst`, `LSQUnit`, `InstructionQueue`) from header files to source files to break dependency cycles (specifically `DynInst` <-> `LSQUnit` and `DynInst` <-> `CPU`).
*   **cpu/o3**: Refactored `LSQRequest` and `LSQ` class definitions to improve header modularity.
*   **cpu/o3**: Updated `BaseO3CPU.py` to point to the correct C++ header (`cpu/o3/cpu.hh`).
*   **cpu/checker**: Cleaned up includes in `cpu_impl.hh` and `cpu.hh` to reduce dependency coupling.
*   **cpu/exetrace**: Moved `getInstRecord` implementation to `exetrace.cc`.
*   **General**: Added missing `#include` directives across various source files to fix compilation errors arising from stricter dependency sandboxing.