### PR TITLE
tests: Update PR CI clang-format check to use verbose mode.

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -50,7 +50,7 @@ jobs:
 
             - name: Run clang-format check
               run: |
-                  python util/run-git-clang-format.py --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }}
+                  python util/run-git-clang-format.py --verbose --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }}
                   if [ $? -ne 0 ]; then
                     echo "::error::Code formatting issues detected! Please run clang-format on your changes."
                     exit 1

--- a/util/run-git-clang-format.py
+++ b/util/run-git-clang-format.py
@@ -376,7 +376,6 @@ if __name__ == "__main__":
         # Run git-clang-format in 'CI' context
         command = [
             "git-clang-format",
-            "--quiet",
             "--style=file",
             f"--commit={ci_pr_base_commit}",
         ]


### PR DESCRIPTION
when clang-format check fails, we should get info about which files are failing.