### PR TITLE
mem-cache: fix memory leakage in fetch directed prefetcher

### DIFF
--- a/src/mem/cache/prefetch/fdp.cc
+++ b/src/mem/cache/prefetch/fdp.cc
@@ -135,6 +135,10 @@ FetchDirectedPrefetcher::notifyFTQRemove(const o3::FetchTargetPtr &ft)
     auto it = pfq.begin();
     while (it != pfq.end()) {
         if (it->ftn == ft->ftNum()) {
+            // Delete packet: created but never sent to the cache.
+            if (it->pkt != nullptr) {
+                delete it->pkt;
+            }
             it = pfq.erase(it);
             stats.pfSquashed++;
         } else {


### PR DESCRIPTION
`notifyFTQRemove()` is triggered by certain O3CPU events (e.g., squash events), which results in flushing the `pfq`. At this point, the pfq may contain `PrefetchRequests` that have already generated a `pkt` but have not yet sent it to the cache (i.e., their `pkt` was never retrieved via `getPacket()`). For these requests, the `pkt` must be manually deleted before the requests are evicted from the `pfq`.