### PR TITLE
mem-ruby: Add CHI lpid field to the CHIRequest

### DIFF
--- a/src/mem/ruby/protocol/RubySlicc_Exports.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Exports.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021,2023 ARM Limited
+ * Copyright (c) 2020-2021,2023,2025 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -43,6 +43,8 @@
 external_type(int, primitive="yes", default="0");
 external_type(bool, primitive="yes", default="false");
 external_type(std::string, primitive="yes");
+external_type(uint8_t, primitive="yes");
+external_type(uint16_t, primitive="yes");
 external_type(uint32_t, primitive="yes");
 external_type(uint64_t, primitive="yes");
 external_type(PacketPtr, primitive="yes");

--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Arm Limited
+ * Copyright (c) 2021-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -58,13 +58,21 @@ action(AllocateTBE_Request, desc="") {
     // we don't have resources to track this request; enqueue a retry
     peek(reqInPort, CHIRequestMsg) {
       assert(in_msg.allowRetry);
+
+      RetryQueueEntry e;
+      e.addr := in_msg.addr;
+      e.usesTxnId := false;
+      e.retryDest := in_msg.requestor;
+      e.lpid := in_msg.lpid;
+
       enqueue(retryTriggerOutPort, RetryTriggerMsg, 0) {
         out_msg.addr := in_msg.addr;
         out_msg.usesTxnId := false;
         out_msg.event := Event:SendRetryAck;
         out_msg.retryDest := in_msg.requestor;
         out_msg.txnId := in_msg.txnId;
-        retryQueue.emplace(in_msg.addr,false,in_msg.requestor);
+        out_msg.lpid := in_msg.lpid;
+        retryQueue.push(e);
       }
     }
   }
@@ -3339,6 +3347,7 @@ action(Send_RetryAck, desc="") {
       out_msg.responder := machineID;
       out_msg.Destination.add(in_msg.retryDest);
       out_msg.txnId := in_msg.txnId;
+      out_msg.lpid := in_msg.lpid;
     }
   }
 }
@@ -3351,6 +3360,7 @@ action(Send_PCrdGrant, desc="") {
       out_msg.type := CHIResponseType:PCrdGrant;
       out_msg.responder := machineID;
       out_msg.Destination.add(in_msg.retryDest);
+      out_msg.lpid := in_msg.lpid;
     }
   }
 }

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Arm Limited
+ * Copyright (c) 2021-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -762,6 +762,7 @@ void processRetryQueue() {
       out_msg.usesTxnId := e.usesTxnId;
       out_msg.retryDest := e.retryDest;
       out_msg.event := Event:SendPCrdGrant;
+      out_msg.lpid := e.lpid;
     }
   }
 }

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Arm Limited
+ * Copyright (c) 2021-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -618,6 +618,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     Addr addr,           desc="Line address";
     bool usesTxnId,      desc="Uses a transaction ID instead of a memory address";
     MachineID retryDest, desc="Retry destination";
+    uint8_t lpid,        desc="Retry destination";
   }
 
   // Queue for event triggers. Used to specify a list of actions that need
@@ -635,7 +636,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     void pushFrontNB(Event);
     void pop();
     // For the retry queue
-    void emplace(Addr,bool,MachineID);
+    void push(RetryQueueEntry);
     RetryQueueEntry next(); //SLICC won't allow to reuse front()
   }
 
@@ -855,6 +856,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     MachineID retryDest;
     bool usesTxnId;
     Addr txnId;
+    uint8_t lpid;
 
     bool functionalRead(Packet *pkt) { return false; }
     bool functionalRead(Packet *pkt, WriteMask &mask) { return false; }

--- a/src/mem/ruby/protocol/chi/CHI-msg.sm
+++ b/src/mem/ruby/protocol/chi/CHI-msg.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023-2024 Arm Limited
+ * Copyright (c) 2021, 2023-2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -123,6 +123,7 @@ structure(CHIRequestMsg, desc="", interface="Message") {
   bool usesTxnId,       desc="True if using a Transaction ID", default="false";
   Addr txnId,           desc="Transaction ID", default="0";
   bool ns,              desc="Secure State of the transaction. NS=NonSecure", default="true";
+  uint8_t lpid,         desc="Logical processor ID, used in conjunction with requestor field", default="0";
 
   MessageSizeType MessageSize, default="MessageSizeType_Control";
 
@@ -171,6 +172,7 @@ structure(CHIResponseMsg, desc="", interface="Message") {
   bool usesTxnId,       desc="True if using a Transaction ID", default="false";
   Addr txnId,           desc="Transaction ID", default="0";
   Addr dbid,            desc="Data Buffer ID", default="0";
+  uint8_t lpid,         desc="Logical processor ID, used in conjunction with responder field", default="0";
   //NOTE: not in CHI and for debuging only
 
   MessageSizeType MessageSize, default="MessageSizeType_Control";

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -104,8 +104,10 @@ CacheController::recvSnoopMsg(const CHIRequestMsg *msg)
 void
 CacheController::pCreditGrant(const CHIResponseMsg *msg)
 {
-    ARM::CHI::Phase phase;
     ARM::CHI::Payload *payload = ARM::CHI::Payload::new_payload();
+    payload->lpid = msg->m_lpid;
+
+    ARM::CHI::Phase phase;
     phase.channel = ARM::CHI::CHANNEL_RSP;
     phase.rsp_opcode = ARM::CHI::RSP_OPCODE_PCRD_GRANT;
     phase.pcrd_type = 0; // TODO: set this one depending on allow retry
@@ -338,6 +340,7 @@ CacheController::sendRequestMsg(ARM::CHI::Payload &payload,
 
     req_msg->m_txnId = phase.txn_id;
     req_msg->m_ns = payload.ns;
+    req_msg->m_lpid = payload.lpid;
 
     sendRequestMsg(req_msg);
 


### PR DESCRIPTION
This is solely used for now to disambiguate logical
processors when issuing a PCrdGrant.