### PR TITLE
mem-ruby: Add backpressure mechanism in TlmController

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -54,7 +54,7 @@ class TlmGenerator(ClockedObject):
 
     cxx_exports = [
         PyBindMethod("scheduleTransaction"),
-        PyBindMethod("enqueueTransaction"),
+        PyBindMethod("enqueueBack"),
     ]
 
     _transactions = []
@@ -67,7 +67,7 @@ class TlmGenerator(ClockedObject):
         if when:
             self._transactions.append((when, transaction))
         else:
-            self.getCCObject().enqueueTransaction(transaction)
+            self.getCCObject().enqueueBack(transaction)
 
         return transaction
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -159,6 +159,7 @@ TlmGenerator::TlmGenerator(const Params &p)
       transPerCycle(p.tran_per_cycle),
       maxPendingTrans(
           p.max_pending_tran.value_or(std::numeric_limits<uint16_t>::max())),
+      pCredit(0),
       tickEvent([this] { tick(); }, "TlmGenerator tick", false,
                 Event::CPU_Tick_Pri),
       outPort(name() + ".out_port", 0, this),
@@ -204,9 +205,19 @@ TlmGenerator::scheduleTransaction(Tick when, Transaction *transaction)
 }
 
 void
-TlmGenerator::enqueueTransaction(Transaction *transaction)
+TlmGenerator::enqueueBack(Transaction *transaction)
 {
     unscheduledTransactions.push_back(transaction);
+
+    if (!tickEvent.scheduled()) {
+        schedule(tickEvent, nextCycle());
+    }
+}
+
+void
+TlmGenerator::enqueueFront(Transaction *transaction)
+{
+    unscheduledTransactions.push_front(transaction);
 
     if (!tickEvent.scheduled()) {
         schedule(tickEvent, nextCycle());
@@ -251,14 +262,38 @@ TlmGenerator::terminate(Transaction *transaction)
     }
 }
 
+TlmGenerator::Transaction *
+TlmGenerator::getPCrdWaiting()
+{
+    if (waitingForPCrd.empty()) {
+        return nullptr;
+    } else {
+        auto waiting = waitingForPCrd.front();
+        waitingForPCrd.pop_front();
+        return waiting;
+    }
+}
+
+bool
+TlmGenerator::getPCrd()
+{
+    if (pCredit > 0) {
+        return pCredit--;
+    } else {
+        return pCredit;
+    }
+}
+
 void
 TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
 {
     DPRINTF(TLM, "[c%d] rcvd %s\n", cpuId, transactionToString(*payload, *phase));
 
-    auto txn_id = phase->txn_id;
-    if (auto it = pendingTransactions.find(txn_id);
-        it != pendingTransactions.end()) {
+    if (handlePCredit(phase)) {
+        return;
+    } else if (auto it = pendingTransactions.find(phase->txn_id);
+               it != pendingTransactions.end()) {
+
         // Copy the new phase
         it->second->phase() = *phase;
 
@@ -266,6 +301,53 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
         it->second->runCallbacks();
     } else {
         warn("Transaction untested\n");
+    }
+}
+
+bool
+TlmGenerator::isRetryAck(ARM::CHI::Phase *phase) const
+{
+    return phase->channel == ARM::CHI::CHANNEL_RSP &&
+           phase->rsp_opcode == ARM::CHI::RSP_OPCODE_RETRY_ACK;
+}
+
+bool
+TlmGenerator::isPCrdGrant(ARM::CHI::Phase *phase) const
+{
+    return phase->channel == ARM::CHI::CHANNEL_RSP &&
+           phase->rsp_opcode == ARM::CHI::RSP_OPCODE_PCRD_GRANT;
+}
+
+bool
+TlmGenerator::handlePCredit(ARM::CHI::Phase *phase)
+{
+    if (isPCrdGrant(phase)) {
+        if (auto tran = getPCrdWaiting(); tran) {
+            // There is a waiting transaction, pass it the credit
+            tran->phase().allow_retry = false;
+            enqueueFront(tran);
+        } else {
+            pCredit++;
+        }
+        return true;
+    } else if (isRetryAck(phase)) {
+        auto it = pendingTransactions.find(phase->txn_id);
+        panic_if(it == pendingTransactions.end(),
+                 "Can't find transaction id: %u\n", phase->txn_id);
+
+        auto tran = it->second;
+
+        pendingTransactions.erase(it);
+
+        if (getPCrd()) {
+            tran->phase().allow_retry = false;
+            enqueueFront(tran);
+        } else {
+            waitingForPCrd.push_back(tran);
+        }
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -276,7 +276,8 @@ class TlmGenerator : public ClockedObject
     void tick();
 
     void scheduleTransaction(Tick when, Transaction *tr);
-    void enqueueTransaction(Transaction *tr);
+    void enqueueFront(Transaction *tr);
+    void enqueueBack(Transaction *tr);
 
     Port &getPort(const std::string &if_name, PortID idx) override;
 
@@ -317,6 +318,35 @@ class TlmGenerator : public ClockedObject
     void recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
     void passFailCheck();
 
+    /**
+     * Check if incoming request is a RetryAck
+     */
+    bool isRetryAck(ARM::CHI::Phase *phase) const;
+
+    /**
+     * Check if incoming request is a PCrdGrant
+     */
+    bool isPCrdGrant(ARM::CHI::Phase *phase) const;
+
+    /**
+     * Require a P-credit from the generator
+     * Returns true if a p-credit is available
+     */
+    bool getPCrd();
+
+    /**
+     * Return a list of transactions waiting for
+     * a p-credit
+     */
+    Transaction *getPCrdWaiting();
+
+    /**
+     * Potentially handle a P-credit related
+     * response. Return true if the response was
+     * a RetryAck or a PCrdGrant, false otherwise
+     */
+    bool handlePCredit(ARM::CHI::Phase *phase);
+
   protected:
     /** cpuId to mimic the behaviour of a CPU */
     uint8_t cpuId;
@@ -326,6 +356,9 @@ class TlmGenerator : public ClockedObject
 
     /** Max number of pending transactions allowed */
     const uint16_t maxPendingTrans;
+
+    /** Numbers of p-credit available to the generator */
+    unsigned pCredit;
 
     /** tick event used to schedule unscheduled transactions */
     EventFunctionWrapper tickEvent;
@@ -339,6 +372,9 @@ class TlmGenerator : public ClockedObject
 
     /** List of transactions whose injection needs to be scheduled */
     std::list<Transaction *> unscheduledTransactions;
+
+    /** List of processes waiting for a P-credit grant */
+    std::list<Transaction *> waitingForPCrd;
 
     /** Map of pending (injected) transactions indexed by the txn_id */
     std::unordered_map<uint16_t, Transaction*> pendingTransactions;


### PR DESCRIPTION
This patch implements p-credit handling in the TlmGenerator to model backpressure from downstream components
(e.g. the HNF).

If a transaction cannot be accepted from the HNF, a RetryAck will be forwarded back. The requester will have to wait until a p-credit has been granted to it (via the PCrdGrant response message).

A TlmGenerator test suite will probably fail at the moment whenever it receives a RetryAck. For example if a transaction is a ReadUnique, the test is possibly expecting a CompData as a response. We could consider handling RetryAck in the python suite file, however this comes with the following issues:

1) Complication of the suite tests (need to explicitly handle a transaction retry)

2) The PCrdGrant message is not linked to a specific transaction (txn_id field is invalid) and as such handling it in a transaction python object adds extra complications

Change-Id: I2b06dc850c385b41919d1ed57f467d4bb68222d7

Reviewed-by: Andreas Sandberg <andreas.sandberg@arm.com>