### PR TITLE
misc: Add a PyPort to write to physmem from python

### DIFF
--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -1,5 +1,17 @@
 # -*- mode:python -*-
 
+# Copyright (c) 2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2004-2005 The Regents of The University of Michigan
 # All rights reserved.
 #
@@ -437,6 +449,7 @@ Source('pybind11/core.cc', tags=['python'])
 Source('pybind11/debug.cc', tags=['python'])
 Source('pybind11/event.cc', tags=['python'])
 Source('pybind11/object_file.cc', tags=['python'])
+Source('pybind11/port.cc', tags=['python'])
 Source('pybind11/stats.cc', tags=['python'])
 
 SimObject('m5/objects/SimObject.py', sim_objects=['SimObject'],

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 ARM Limited
+# Copyright (c) 2017, 2019, 2025 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -59,6 +59,7 @@ class System(SimObject):
     cxx_exports = [
         PyBindMethod("getMemoryMode"),
         PyBindMethod("setMemoryMode"),
+        PyBindProperty("physProxy", writable=False),
     ]
 
     memories = VectorParam.AbstractMemory(

--- a/src/sim/init.cc
+++ b/src/sim/init.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 ARM Limited
+ * Copyright (c) 2012, 2017, 2025 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -133,6 +133,8 @@ EmbeddedPyBind::initAll(py::module_ &_m5)
 
     pybind_init_event(_m5);
     pybind_init_stats(_m5);
+
+    pybind_init_port(_m5);
 
     mod = &_m5;
 

--- a/tests/gem5/py_port/read-write.py
+++ b/tests/gem5/py_port/read-write.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+
+import m5
+from m5.objects import *
+
+
+def check_value(name, result, expected):
+    if result != expected:
+        print(f"Test {name} FAILED")
+        exit(1)
+    else:
+        print(f"Test {name} SUCCESS")
+
+
+parser = argparse.ArgumentParser(description="Simple PyPort tester")
+
+args = parser.parse_args()
+
+# even if this is only a traffic generator, call it cpu to make sure
+# the scripts are happy
+
+# system simulated
+system = System(
+    physmem=SimpleMemory(range=AddrRange("512MiB")),
+    membus=SystemXBar(),
+    clk_domain=SrcClockDomain(clock="1GHz", voltage_domain=VoltageDomain()),
+)
+
+# connect the system port even if it is not used in this example
+system.system_port = system.membus.cpu_side_ports
+
+# connect memory to the membus
+system.physmem.port = system.membus.mem_side_ports
+
+# -----------------------
+# run simulation
+# -----------------------
+
+root = Root(full_system=False, system=system)
+
+m5.instantiate()
+
+# Get a system PyPort
+port = root.system.physProxy
+
+# Test a bytearray as write argument
+address = 0
+ba = bytearray(b"\xaa\xbb\xcc")
+port.write(address, ba)
+result = port.read(address, len(ba))
+check_value("bytearray test", result, ba)
+
+# Test a byte literal as write argument
+address = 0
+bl = b"\xaa\xbb\xcc"
+port.write(address, bl)
+result = port.read(address, len(bl))
+check_value("byte literal test", result, bl)
+
+# Test a integer converted in byte format
+address = 64
+value = 35
+port.write(address, value.to_bytes())
+result = port.read(address, 1)
+check_value("byte from integer test", int.from_bytes(result), value)
+
+sys.exit(0)

--- a/tests/gem5/py_port/test.py
+++ b/tests/gem5/py_port/test.py
@@ -1,0 +1,50 @@
+# -*- mode:python -*-
+# Copyright (c) 2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Test file for PyPort test
+"""
+
+from testlib import *
+
+gem5_verify_config(
+    name="simple_py_port",
+    verifiers=(),  # No need for verfiers this will return non-zero on fail
+    config=joinpath(getcwd(), "read-write.py"),
+    config_args=[],
+    valid_isas=(constants.all_compiled_tag,),
+    length=constants.quick_tag,
+)


### PR DESCRIPTION
The PyPort is the pybind11 interface around the PortProxy class.  It is meant to be used to read and write binary blobs to the guest memory from python.

As an example, a PyPort can be returned from the System:

port = system.physPort

Its main APIs are the python based methods defined in src/python/pybind11/port.cc. Those are simply:

def read(addr, size) -> bytes
def write(addr, data) -> None

To write an arbitrary binary blob to memory: at the moment we have an heterogeneous set of solutions to do so. One is through the extras parameters:

extras = VectorParam.String([], "Additional object files to load") extras_addrs = VectorParam.Addr(
    [], "Load addresses for additional object files"
)

Though for some obscure reason those are only defined for KernelWorkloads. "Simpler" environments (e.g. a traffic generator platform with no binary) would not be able to use this static interface. It also requires a path to a file in the the host FS for things to work and does not allow inline slamming of binary data (sure, a python platform can always write a binary blob to /tmp/ disk but it is not ideal)

Another alternative is via the AbstractMemory.image_file parameter. The caveat (on top of the requiring a file as solution above) is that

a) there is no way of specifying the offset of the image_file b) I cannot specify multiple image files at the same time, so the only workaround to this is to define multiple memories

This python port solution fixes all aforementioned shortcomings and therefore has the following perks:

1) It's a generall solution which works with every configuration

2) We can use it to dynamically patch (write) the content of memory during simulation from python

3) We can use it to dynamicall read the content of memory during simulation from python for debug purposes

Change-Id: I99b274fb64504d922044c0b8cf24e6ad75060886