### PR TITLE
util: fix util/tlm scons error when using random

### DIFF
--- a/util/tlm/examples/master_port/traffic_generator.cc
+++ b/util/tlm/examples/master_port/traffic_generator.cc
@@ -51,24 +51,24 @@ TrafficGenerator::process()
 
     while (true) {
 
-        wait(sc_core::sc_time((double)rnd->random(1,100), sc_core::SC_NS));
+        wait(sc_core::sc_time((double)rnd->random(1, 100), sc_core::SC_NS));
 
         auto trans = mm.allocate();
         trans->acquire();
 
         std::string cmdStr;
-        if (rnd->random(0,1)) // Generate a write request?
+        if (rnd->random(0, 1)) // Generate a write request?
         {
             cmdStr = "write";
             trans->set_command(tlm::TLM_WRITE_COMMAND);
-            dataBuffer = rnd->random(0,0xffff);
+            dataBuffer = rnd->random(0, 0xffff);
         } else {
             cmdStr = "read";
             trans->set_command(tlm::TLM_READ_COMMAND);
         }
 
         trans->set_data_ptr(reinterpret_cast<unsigned char*>(&dataBuffer));
-        trans->set_address(rnd->random(0, (int)(memSize-1)));
+        trans->set_address(rnd->random(0, (int)(memSize - 1)));
         trans->set_data_length(4);
         trans->set_streaming_width(4);
         trans->set_byte_enable_ptr(0);

--- a/util/tlm/examples/master_port/traffic_generator.cc
+++ b/util/tlm/examples/master_port/traffic_generator.cc
@@ -45,30 +45,30 @@ TrafficGenerator::TrafficGenerator(sc_core::sc_module_name name)
 void
 TrafficGenerator::process()
 {
-    auto rnd = gem5::Random(time(NULL));
+    auto rnd = gem5::Random::genRandom(time(NULL));
 
     unsigned const memSize = (1 << 10); // 512 MB
 
     while (true) {
 
-        wait(sc_core::sc_time((double)rnd.random(1,100), sc_core::SC_NS));
+        wait(sc_core::sc_time((double)rnd->random(1,100), sc_core::SC_NS));
 
         auto trans = mm.allocate();
         trans->acquire();
 
         std::string cmdStr;
-        if (rnd.random(0,1)) // Generate a write request?
+        if (rnd->random(0,1)) // Generate a write request?
         {
             cmdStr = "write";
             trans->set_command(tlm::TLM_WRITE_COMMAND);
-            dataBuffer = rnd.random(0,0xffff);
+            dataBuffer = rnd->random(0,0xffff);
         } else {
             cmdStr = "read";
             trans->set_command(tlm::TLM_READ_COMMAND);
         }
 
         trans->set_data_ptr(reinterpret_cast<unsigned char*>(&dataBuffer));
-        trans->set_address(rnd.random(0, (int)(memSize-1)));
+        trans->set_address(rnd->random(0, (int)(memSize-1)));
         trans->set_data_length(4);
         trans->set_streaming_width(4);
         trans->set_byte_enable_ptr(0);

--- a/util/tlm/examples/master_port/traffic_generator.cc
+++ b/util/tlm/examples/master_port/traffic_generator.cc
@@ -45,7 +45,7 @@ TrafficGenerator::TrafficGenerator(sc_core::sc_module_name name)
 void
 TrafficGenerator::process()
 {
-    auto rnd = gem5::Random::genRandom(time(NULL));
+    auto rnd = gem5::Random::genRandom();
 
     unsigned const memSize = (1 << 10); // 512 MB
 


### PR DESCRIPTION
## Description
### Summary
This PR resolves a compilation error in `util/tlm` when building the traffic_generator example. The issue stems from an attempt to directly instantiate gem5::Random, whose constructor is private.

### Problem
When running scons in util/tlm, the build fails with the following error:
```
build/examples/master_port/traffic_generator.cc:48:39: error: 'gem5::Random::Random(uint32_t)' is private within this context
   48 |     auto rnd = gem5::Random(time(NULL));
      |                                       ^
In file included from build/examples/master_port/traffic_generator.cc:33:
gem5/src/base/random.hh:149:5: note: declared private here
  149 |     Random(uint32_t s);
```

The gem5::Random class enforces the use of factory methods for instantiation to manage instances globally and prevent the "Static Initialization Order Fiasco". Direct constructor calls are prohibited as per the architectural design in base/random.hh.

### Solution
The fix involves the following changes in `tlm/examples/master_port/traffic_generator.cc`:

* Instantiation: Replaced the direct private constructor call `gem5::Random(time(NULL))` with the public static factory method `gem5::Random::genRandom(time(NULL))`.

* Member Access: Since `genRandom()` returns a `std::shared_ptr<Random>` (aliased as RandomPtr), updated all member function calls from dot notation (`rnd.random()`) to arrow notation (`rnd->random()`).

### Verification
Environment: gem5 util/tlm workspace.

Command: cd util/tlm && scons

Result: The build completed successfully without errors. I can provide detailed build log if needed.