### PR TITLE
arch-x86: widen regop immediates

### DIFF
--- a/src/arch/x86/insts/microop_args.hh
+++ b/src/arch/x86/insts/microop_args.hh
@@ -312,9 +312,11 @@ struct Imm64Op
     using ArgType = uint64_t;
 
     uint64_t imm64;
+    uint8_t imm8;
 
     template <class InstType>
-    Imm64Op(InstType *inst, ArgType _imm64) : imm64(_imm64) {}
+    Imm64Op(InstType *inst, ArgType _imm64) : imm64(_imm64), imm8(_imm64)
+    {}
 
     void
     print(std::ostream &os) const

--- a/src/arch/x86/isa/insts/general_purpose/arithmetic/add_and_subtract.py
+++ b/src/arch/x86/isa/insts/general_purpose/arithmetic/add_and_subtract.py
@@ -41,33 +41,29 @@ def macroop ADD_R_R
 
 def macroop ADD_R_I
 {
-    limm t1, imm
-    add reg, reg, t1, flags=(OF,SF,ZF,AF,PF,CF)
+    addi reg, reg, imm, flags=(OF,SF,ZF,AF,PF,CF)
 };
 
 def macroop ADD_M_I
 {
-    limm t2, imm
     ldst t1, seg, sib, disp
-    add t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    addi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, sib, disp
 };
 
 def macroop ADD_P_I
 {
     rdip t7
-    limm t2, imm
     ldst t1, seg, riprel, disp
-    add t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    addi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, riprel, disp
 };
 
 def macroop ADD_LOCKED_M_I
 {
-    limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    add t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    addi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -75,10 +71,9 @@ def macroop ADD_LOCKED_M_I
 def macroop ADD_LOCKED_P_I
 {
     rdip t7
-    limm t2, imm
     mfence
     ldstl t1, seg, riprel, disp
-    add t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    addi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -137,8 +132,7 @@ def macroop SUB_R_R
 
 def macroop SUB_R_I
 {
-    limm t1, imm
-    sub reg, reg, t1, flags=(OF,SF,ZF,AF,PF,CF)
+    subi reg, reg, imm, flags=(OF,SF,ZF,AF,PF,CF)
 };
 
 def macroop SUB_R_M
@@ -156,27 +150,24 @@ def macroop SUB_R_P
 
 def macroop SUB_M_I
 {
-    limm t2, imm
     ldst t1, seg, sib, disp
-    sub t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    subi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, sib, disp
 };
 
 def macroop SUB_P_I
 {
     rdip t7
-    limm t2, imm
     ldst t1, seg, riprel, disp
-    sub t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    subi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, riprel, disp
 };
 
 def macroop SUB_LOCKED_M_I
 {
-    limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    sub t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    subi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -184,10 +175,9 @@ def macroop SUB_LOCKED_M_I
 def macroop SUB_LOCKED_P_I
 {
     rdip t7
-    limm t2, imm
     mfence
     ldstl t1, seg, riprel, disp
-    sub t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    subi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -233,33 +223,29 @@ def macroop ADC_R_R
 
 def macroop ADC_R_I
 {
-    limm t1, imm
-    adc reg, reg, t1, flags=(OF,SF,ZF,AF,PF,CF)
+    adci reg, reg, imm, flags=(OF,SF,ZF,AF,PF,CF)
 };
 
 def macroop ADC_M_I
 {
-    limm t2, imm
     ldst t1, seg, sib, disp
-    adc t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    adci t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, sib, disp
 };
 
 def macroop ADC_P_I
 {
     rdip t7
-    limm t2, imm
     ldst t1, seg, riprel, disp
-    adc t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    adci t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, riprel, disp
 };
 
 def macroop ADC_LOCKED_M_I
 {
-    limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    adc t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    adci t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -267,10 +253,9 @@ def macroop ADC_LOCKED_M_I
 def macroop ADC_LOCKED_P_I
 {
     rdip t7
-    limm t2, imm
     mfence
     ldstl t1, seg, riprel, disp
-    adc t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    adci t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -329,8 +314,7 @@ def macroop SBB_R_R
 
 def macroop SBB_R_I
 {
-    limm t1, imm
-    sbb reg, reg, t1, flags=(OF,SF,ZF,AF,PF,CF)
+    sbbi reg, reg, imm, flags=(OF,SF,ZF,AF,PF,CF)
 };
 
 def macroop SBB_R_M
@@ -348,27 +332,24 @@ def macroop SBB_R_P
 
 def macroop SBB_M_I
 {
-    limm t2, imm
     ldst t1, seg, sib, disp
-    sbb t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    sbbi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, sib, disp
 };
 
 def macroop SBB_P_I
 {
     rdip t7
-    limm t2, imm
     ldst t1, seg, riprel, disp
-    sbb t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    sbbi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     st t1, seg, riprel, disp
 };
 
 def macroop SBB_LOCKED_M_I
 {
-    limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    sbb t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    sbbi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, sib, disp
     mfence
 };
@@ -376,10 +357,9 @@ def macroop SBB_LOCKED_M_I
 def macroop SBB_LOCKED_P_I
 {
     rdip t7
-    limm t2, imm
     mfence
     ldstl t1, seg, riprel, disp
-    sbb t1, t1, t2, flags=(OF,SF,ZF,AF,PF,CF)
+    sbbi t1, t1, imm, flags=(OF,SF,ZF,AF,PF,CF)
     stul t1, seg, riprel, disp
     mfence
 };

--- a/src/arch/x86/isa/insts/general_purpose/compare_and_test/compare.py
+++ b/src/arch/x86/isa/insts/general_purpose/compare_and_test/compare.py
@@ -49,17 +49,15 @@ def macroop CMP_R_P
 
 def macroop CMP_M_I
 {
-    limm t2, imm
     ld t1, seg, sib, disp
-    sub t0, t1, t2, flags=(OF, SF, ZF, AF, PF, CF)
+    subi t0, t1, imm, flags=(OF, SF, ZF, AF, PF, CF)
 };
 
 def macroop CMP_P_I
 {
-    limm t2, imm
     rdip t7
     ld t1, seg, riprel, disp
-    sub t0, t1, t2, flags=(OF, SF, ZF, AF, PF, CF)
+    subi t0, t1, imm, flags=(OF, SF, ZF, AF, PF, CF)
 };
 
 def macroop CMP_M_R
@@ -82,7 +80,6 @@ def macroop CMP_R_R
 
 def macroop CMP_R_I
 {
-    limm t1, imm
-    sub t0, reg, t1, flags=(OF, SF, ZF, AF, PF, CF)
+    subi t0, reg, imm, flags=(OF, SF, ZF, AF, PF, CF)
 };
 """

--- a/src/arch/x86/isa/insts/general_purpose/compare_and_test/test.py
+++ b/src/arch/x86/isa/insts/general_purpose/compare_and_test/test.py
@@ -55,21 +55,18 @@ def macroop TEST_R_R
 def macroop TEST_M_I
 {
     ld t1, seg, sib, disp
-    limm t2, imm
-    and t0, t1, t2, flags=(OF, SF, ZF, PF, CF, AF)
+    andi t0, t1, imm, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_P_I
 {
     rdip t7
     ld t1, seg, riprel, disp
-    limm t2, imm
-    and t0, t1, t2, flags=(OF, SF, ZF, PF, CF, AF)
+    andi t0, t1, imm, flags=(OF, SF, ZF, PF, CF, AF)
 };
 
 def macroop TEST_R_I
 {
-    limm t1, imm
-    and t0, reg, t1, flags=(OF, SF, ZF, PF, CF, AF)
+    andi t0, reg, imm, flags=(OF, SF, ZF, PF, CF, AF)
 };
 """

--- a/src/arch/x86/isa/insts/general_purpose/control_transfer/conditional_jump.py
+++ b/src/arch/x86/isa/insts/general_purpose/control_transfer/conditional_jump.py
@@ -41,8 +41,7 @@ def macroop JZ_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CZF,)
+    wripi t1, imm, flags=(CZF,)
 };
 
 def macroop JNZ_I
@@ -52,8 +51,7 @@ def macroop JNZ_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCZF,)
+    wripi t1, imm, flags=(nCZF,)
 };
 
 def macroop JB_I
@@ -63,8 +61,7 @@ def macroop JB_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CCF,)
+    wripi t1, imm, flags=(CCF,)
 };
 
 def macroop JNB_I
@@ -74,8 +71,7 @@ def macroop JNB_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCCF,)
+    wripi t1, imm, flags=(nCCF,)
 };
 
 def macroop JBE_I
@@ -85,8 +81,7 @@ def macroop JBE_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CCvZF,)
+    wripi t1, imm, flags=(CCvZF,)
 };
 
 def macroop JNBE_I
@@ -96,8 +91,7 @@ def macroop JNBE_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCCvZF,)
+    wripi t1, imm, flags=(nCCvZF,)
 };
 
 def macroop JS_I
@@ -107,8 +101,7 @@ def macroop JS_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CSF,)
+    wripi t1, imm, flags=(CSF,)
 };
 
 def macroop JNS_I
@@ -118,8 +111,7 @@ def macroop JNS_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCSF,)
+    wripi t1, imm, flags=(nCSF,)
 };
 
 def macroop JP_I
@@ -129,8 +121,7 @@ def macroop JP_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CPF,)
+    wripi t1, imm, flags=(CPF,)
 };
 
 def macroop JNP_I
@@ -140,8 +131,7 @@ def macroop JNP_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCPF,)
+    wripi t1, imm, flags=(nCPF,)
 };
 
 def macroop JL_I
@@ -151,8 +141,7 @@ def macroop JL_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CSxOF,)
+    wripi t1, imm, flags=(CSxOF,)
 };
 
 def macroop JNL_I
@@ -162,8 +151,7 @@ def macroop JNL_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCSxOF,)
+    wripi t1, imm, flags=(nCSxOF,)
 };
 
 def macroop JLE_I
@@ -173,8 +161,7 @@ def macroop JLE_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(CSxOvZF,)
+    wripi t1, imm, flags=(CSxOvZF,)
 };
 
 def macroop JNLE_I
@@ -184,8 +171,7 @@ def macroop JNLE_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCSxOvZF,)
+    wripi t1, imm, flags=(nCSxOvZF,)
 };
 
 def macroop JO_I
@@ -195,8 +181,7 @@ def macroop JO_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(COF,)
+    wripi t1, imm, flags=(COF,)
 };
 
 def macroop JNO_I
@@ -206,8 +191,7 @@ def macroop JNO_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2, flags=(nCOF,)
+    wripi t1, imm, flags=(nCOF,)
 };
 
 def macroop JRCXZ_I

--- a/src/arch/x86/isa/insts/general_purpose/control_transfer/jump.py
+++ b/src/arch/x86/isa/insts/general_purpose/control_transfer/jump.py
@@ -42,8 +42,7 @@ def macroop JMP_I
     .control_direct
 
     rdip t1
-    limm t2, imm
-    wrip t1, t2
+    wripi t1, imm
 };
 
 def macroop JMP_R

--- a/src/arch/x86/isa/insts/general_purpose/logical.py
+++ b/src/arch/x86/isa/insts/general_purpose/logical.py
@@ -41,38 +41,34 @@ def macroop OR_R_R
 
 def macroop OR_M_I
 {
-    limm t2, imm
     ldst t1, seg, sib, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    ori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
 def macroop OR_P_I
 {
-    limm t2, imm
     rdip t7
     ldst t1, seg, riprel, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    ori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
 def macroop OR_LOCKED_M_I
 {
-    limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    ori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
 
 def macroop OR_LOCKED_P_I
 {
-    limm t2, imm
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    or t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    ori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -126,8 +122,7 @@ def macroop OR_R_P
 
 def macroop OR_R_I
 {
-    limm t1, imm
-    or reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    ori reg, reg, imm, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop XOR_R_R
@@ -137,44 +132,39 @@ def macroop XOR_R_R
 
 def macroop XOR_R_I
 {
-    limm t1, imm
-    xor reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    xori reg, reg, imm, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop XOR_M_I
 {
-    limm t2, imm
     ldst t1, seg, sib, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    xori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, sib, disp
 };
 
 def macroop XOR_P_I
 {
-    limm t2, imm
     rdip t7
     ldst t1, seg, riprel, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    xori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     st t1, seg, riprel, disp
 };
 
 def macroop XOR_LOCKED_M_I
 {
-    limm t2, imm
     mfence
     ldstl t1, seg, sib, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    xori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, sib, disp
     mfence
 };
 
 def macroop XOR_LOCKED_P_I
 {
-    limm t2, imm
     rdip t7
     mfence
     ldstl t1, seg, riprel, disp
-    xor t1, t1, t2, flags=(OF,SF,ZF,PF,CF,AF)
+    xori t1, t1, imm, flags=(OF,SF,ZF,PF,CF,AF)
     stul t1, seg, riprel, disp
     mfence
 };
@@ -246,15 +236,13 @@ def macroop AND_R_P
 
 def macroop AND_R_I
 {
-    limm t1, imm
-    and reg, reg, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    andi reg, reg, imm, flags=(OF,SF,ZF,PF,CF,AF)
 };
 
 def macroop AND_M_I
 {
     ldst t2, seg, sib, disp
-    limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    andi t2, t2, imm, flags=(OF,SF,ZF,PF,CF,AF)
     st t2, seg, sib, disp
 };
 
@@ -262,8 +250,7 @@ def macroop AND_P_I
 {
     rdip t7
     ldst t2, seg, riprel, disp
-    limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    andi t2, t2, imm, flags=(OF,SF,ZF,PF,CF,AF)
     st t2, seg, riprel, disp
 };
 
@@ -271,8 +258,7 @@ def macroop AND_LOCKED_M_I
 {
     mfence
     ldstl t2, seg, sib, disp
-    limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    andi t2, t2, imm, flags=(OF,SF,ZF,PF,CF,AF)
     stul t2, seg, sib, disp
     mfence
 };
@@ -282,8 +268,7 @@ def macroop AND_LOCKED_P_I
     rdip t7
     mfence
     ldstl t2, seg, riprel, disp
-    limm t1, imm
-    and t2, t2, t1, flags=(OF,SF,ZF,PF,CF,AF)
+    andi t2, t2, imm, flags=(OF,SF,ZF,PF,CF,AF)
     stul t2, seg, riprel, disp
     mfence
 };

--- a/src/arch/x86/isa/microops/base.isa
+++ b/src/arch/x86/isa/microops/base.isa
@@ -201,7 +201,7 @@ let {{
 
         RegType = FoldedSrc2Op
         FloatType = FloatSrc2Op
-        ImmType = Imm8Op
+        ImmType = Imm64Op
 
     class Op3(object):
         @classmethod

--- a/src/arch/x86/isa/microops/regop.isa
+++ b/src/arch/x86/isa/microops/regop.isa
@@ -229,7 +229,7 @@ let {{
                         matcher.sub(src2_name, cond_control_flag_init),
                         matcher.sub(src2_name, invalidate_srcs),
                         op_class, operand_types)
-                imm_name = '(int8_t)imm8' if match.group("prefix") else 'imm8'
+                imm_name = '(int64_t)imm64' if match.group("prefix") else 'imm64'
                 self.buildCppClasses(name + "i", Name, suffix + "Imm",
                         matcher.sub(imm_name, code),
                         matcher.sub(imm_name, big_code),


### PR DESCRIPTION
Widen micro-op immediates from 8 to 64 bits
for micro-ops defined in regop.isa, where arithmetic and control-flow micro-ops are defined.
Elide now-unnecessary `limm` micro-ops by folding
the immediate into the main arithmetic/control-flow micro-op, reducing the micro-op count for
arithmetic/control-flow micro-ops by 1.