### PR TITLE
misc: Remove redundant importer.py PySource and gem5py_m5_env

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -644,7 +644,6 @@ gem5py_env.Command('python/m5/info.py',
             INFOPY_PY=build_tools.File('infopy.py'))
 PySource('m5', 'python/m5/info.py')
 
-gem5py_m5_env = gem5py_env.Clone()
 gem5py_env.Append(CPPPATH=env['CPPPATH'])
 gem5py_env.Append(LIBS='z')
 gem5py_env.Append(LINKFLAGS='-rdynamic')

--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -388,7 +388,6 @@ PySource('gem5.utils.multiprocessing',
 PySource('gem5.utils.multiprocessing',
     'gem5/utils/multiprocessing/popen_spawn_gem5.py')
 
-PySource('', 'importer.py')
 PySource('m5', 'm5/__init__.py')
 PySource('m5', 'm5/SimObject.py')
 PySource('m5', 'm5/citations.py')


### PR DESCRIPTION
importer.py will be dealt with the Blob, so it doesn't have to go throught the PySource and EmbeddedPython path.

https://github.com/gem5/gem5/blob/7a2b0e413d06c5ce7097104abef3b1d9eaabca91/src/python/SConscript#L445C1-L445C51