### PR TITLE
mem-garnet: add support for hierarchical/chiplet topologies

### DIFF
--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -299,7 +299,7 @@ class BaseChipletSystem(SubSystem):
     # * Root ChipletSystem Methods
     # *
 
-    def getRoot(self) -> ChipletSystem:
+    def getRoot(self):  # -> ChipletSystem:
         """
         Retrieve a reference to the root `ChipletSystem`,
         i.e., the `ChipletSystem` at the top of the hierarchy.
@@ -307,7 +307,7 @@ class BaseChipletSystem(SubSystem):
 
         if (
             not hasattr(self, "_parent_sys") or self._parent_sys == None
-        ) and isinstance(self, ChipletSystem):
+        ):  # and isinstance(self, ChipletSystem):
             return self
         elif self._parent_sys is not None:
             return self._parent_sys.getRoot()
@@ -326,7 +326,7 @@ class BaseChipletSystem(SubSystem):
                 f"Self was {was_cs_or_not_str}ChipletSystem."
             )
             # below will never be reached, just to satisfy type checker
-            assert self is ChipletSystem
+            # assert self is ChipletSystem
             return self
 
     def isRoot(self):
@@ -522,11 +522,11 @@ class BaseChipletSystem(SubSystem):
         # the point of this is t
 
         # ! connect to main router
+        print(
+            f"Linking Routers with main for "
+            f"{self.__class__.__name__} ID {self.id}"
+        )
         for r in gnw.routers:
-            print(
-                f"Linking Routers with main for "
-                f"{self.__class__.__name__} ID {self.id}"
-            )
             self._biLinkGarnetRouters(self._main_router, r)
 
         # * add main router to my routers

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -7,7 +7,7 @@ from typing import (
     Type,
 )
 
-from m5.defines import buildEnv
+from m5.defines import buildEnv  # type: ignore
 from m5.objects import *
 from m5.util import (
     addToPath,
@@ -43,7 +43,10 @@ class BaseChipletSystem(ABC):
     protocol: str
 
     # the gem5 `System` SimObject that this object is part of
-    system: System
+    _system: System
+
+    # if full-system simulation mode is enabled in gem5
+    _is_full_system: bool
 
     # topology class. used internally to create the topology.
     # Ruby.py currently requires a name (string) to be specified
@@ -56,6 +59,9 @@ class BaseChipletSystem(ABC):
 
     # list of *direct* nodes/children (ChipletSystems or Chiplets)
     nodes: list[BaseChipletSystem]
+
+    # topology of the children for *only this layer of the hierarchy*
+    topology: BaseTopology | None
 
     # default latency (in cycles) of the links between nodes
     # for this layer of abstraction (i.e., direct child nodes)
@@ -71,9 +77,13 @@ class BaseChipletSystem(ABC):
     # ChipletSystem to which this node has *direct* connections
     connected_nodes: list[BaseChipletSystem]
 
+    # `GarnetNetwork` for this object
+    _garnet_network: GarnetNetwork
+
     def __init__(
         self,
         system: System,
+        full_system: bool,
         TopologyClass: type[BaseTopology],
         MemoryClass: type[AbstractMemory],
         nodes: Sequence[BaseChipletSystem],
@@ -89,6 +99,8 @@ class BaseChipletSystem(ABC):
             system (System):
                 The gem5 `System` SimObject that this `BaseChipletSystem`
                 is part of.
+            full_system (bool):
+                If gem5 is running in full-system simulation mode.
             TopologyClass (Type[BaseTopology]):
                 The class, derived from `BaseTopology`, corresponding
                 to the topology to be used in this `ChipletSystem`.
@@ -113,10 +125,13 @@ class BaseChipletSystem(ABC):
 
         self.nodes = list(nodes)
 
-        self.system = system
+        self._system = system
+        self._is_full_system = full_system
 
         self._topology_cls = TopologyClass
         self._memory_cls = MemoryClass
+
+        self.topology = None  # created in `createSystem()`
 
         self.default_inter_node_link_lat = inter_node_link_lat
         self.default_inter_node_router_lat = inter_node_router_lat
@@ -126,7 +141,7 @@ class BaseChipletSystem(ABC):
         self,
     ):
         """
-        Add a node/child to this Chiplet(System)
+        Add a node/child to this `Chiplet[System]`
         """
 
         # todo: implement
@@ -148,10 +163,10 @@ class BaseChipletSystem(ABC):
     ) -> GarnetIntLink | None:
         """
         Retrieve the Garnet link object, if one exists, between the two
-        specified nodes (which must be children of this Chiplet[System]).
-        Note that the Chiplet[System] abstracts the GarnetIntLink,
-        since an actual GarnetIntLink is between two routers, not two
-        Chiplet[System]s directly.
+        specified nodes, which must be children of this `Chiplet[System]`.
+        Note that the `Chiplet[System]` abstracts the `GarnetIntLink`,
+        since an actual `GarnetIntLink` is between two routers, not two
+        `Chiplet[System]`s directly.
 
         Args:
             node1 (BaseChipletSystem): One end of the link.
@@ -183,8 +198,7 @@ class BaseChipletSystem(ABC):
             fatal(
                 "This BaseChipletSystem has no parent, "
                 "but the user attempted to connect it "
-                "to another BaseChipletSystem sharing "
-                "the same parent."
+                "to another BaseChipletSystem."
             )
 
         if self.parent != node.parent:

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -20,7 +20,10 @@ if TYPE_CHECKING:
     from argparse import Namespace
 
     # below import only used to type check BaseChipletSystem.parent
-    from chiplets.ChipletSystem import ChipletSystem
+    from chiplets.ChipletSystem import (
+        ChipletSystem,
+        ChipletGarnetObjectInfo,
+    )
     from src.cpu.BaseCPU import BaseCPU
     from src.sim.System import System
     from src.sim.SubSystem import SubSystem
@@ -48,10 +51,15 @@ class FakeGarnetNetwork:
     ext_links: list[GarnetExtLink]
     int_links: list[GarnetIntLink]
 
-    def __init__(self):
-        self.routers = []
-        self.ext_links = []
-        self.int_links = []
+    def __init__(
+        self,
+        routers: list[GarnetRouter] = [],
+        ext_links: list[GarnetExtLink] = [],
+        int_links: list[GarnetIntLink] = [],
+    ):
+        self.routers = routers
+        self.ext_links = ext_links
+        self.int_links = int_links
 
 
 class BaseChipletSystem(SubSystem):
@@ -138,6 +146,7 @@ class BaseChipletSystem(SubSystem):
     _sibling_links: list[tuple[GarnetIntLink, GarnetIntLink]]
 
     # `GarnetNetwork` for this object
+    # ! will always be fake except for root after `createSystem()` is done
     _garnet_network: GarnetNetwork | FakeGarnetNetwork
 
     # `RubyController`s that correspond to this `Chiplet[System]`
@@ -248,7 +257,7 @@ class BaseChipletSystem(SubSystem):
         self._connected_nodes = []
 
         self._main_router = GarnetRouter(
-            router_id=-1,  # temporary, is replaced later
+            router_id=0,  # some hijinks occur with this later
             latency=self.default_inter_node_router_lat,
             # the following are default parameters
             # gem5 complains if I don't include these params
@@ -414,6 +423,28 @@ class BaseChipletSystem(SubSystem):
         options: Namespace,
         controllers: list[RubyController],
     ):
+        """
+        Instantiate and make the topology corresponding to
+        `self._topology_cls` (should've been specified in constructor),
+        using the specified `controllers`.
+
+        ! also connects all the passed `controllers` to the
+        ! main router of this `Chiplet[System]`
+
+        In the hierarchy scheme (using `_createChipletHierarchy()`),
+        the topology is used with a `FakeGarnetNetwork` to create the
+        topological structure of each node in the hierarchy without
+        instantiating an actual `GarnetNetwork`. Then all routers and
+        links are collected and instantiated into one root network.
+        See `_createChipletHierarchy()` for more details.
+
+        Args:
+            options (Namespace): _description_
+            controllers (list[RubyController]):
+                This should usually be `self._ruby_controllers`.
+                May or may not include the directory controllers
+                depending on what was passed to `createSystem()`.
+        """
         # for reference, this is what you would do for a flat topology
         if False:
             self._topology = self._topology_cls(
@@ -439,6 +470,14 @@ class BaseChipletSystem(SubSystem):
         ):
             # temp set CPU count option to number of nodes
             options.num_cpus = len(self._nodes)
+
+        if not isinstance(self._garnet_network, FakeGarnetNetwork):
+            warn(
+                "_createTopology() called, but self._garnet_network "
+                "is not a FakeGarnetNetwork. Either using legacy ruby, "
+                "user is calling methods in places they shouldn't be "
+                "called, or something is very broken."
+            )
 
         # * setup topology
         # latter 3 args are the literal classes for the
@@ -482,21 +521,21 @@ class BaseChipletSystem(SubSystem):
         # one controller can map to a given router.
         # the point of this is t
 
+        # ! connect to main router
         for r in gnw.routers:
-            pass
-
-        # store mappings of controller to router
-        # also connect to main router
-        print(
-            f"Linking Routers with main for "
-            f"{self.__class__.__name__} ID {self.id}"
-        )
-        for c, r in zip(controllers, gnw.routers, strict=True):
-            print(f"    controller {c} :: router {r.router_id} {r}")
-            # self._ruby_controller_router_map.append((c, r))
+            print(
+                f"Linking Routers with main for "
+                f"{self.__class__.__name__} ID {self.id}"
+            )
             self._biLinkGarnetRouters(self._main_router, r)
 
+        # * add main router to my routers
         gnw.routers += self._main_router
+
+        for c in controllers:
+            r = self._findRouterFromController(c, False)
+            if r is not None:
+                print(f"    controller {c} :: router {r.router_id} {r}")
 
     # *
     # * Low-Level Network Connection/Instantiation Methods

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -15,12 +15,16 @@ from m5.util import (
 )
 
 if TYPE_CHECKING:
+    from argparse import Namespace
+
     # below import only used to type check BaseChipletSystem.parent
     from chiplets.ChipletSystem import ChipletSystem
-
+    from src.cpu.BaseCPU import BaseCPU
     from src.sim.System import System
     from src.sim.SubSystem import SubSystem
+    from src.mem.ruby.system.RubySystem import RubySystem
     from src.mem.AbstractMemory import AbstractMemory
+    from src.mem.ruby.slicc_interface.Controller import RubyController
     from src.mem.ruby.network.garnet.GarnetLink import *
     from src.mem.ruby.network.garnet.GarnetNetwork import *
 
@@ -31,12 +35,12 @@ from topologies.BaseTopology import BaseTopology
 
 class BaseChipletSystem(ABC):
     """
-    See ChipletSystem and Chiplet. BaseChipletSystem acts
-    as a vessel for shared functionality between the two.
+    See `ChipletSystem` and `Chiplet`. `BaseChipletSystem`
+    acts as a vessel for shared functionality between the two.
     Do not instantiate directly; instead use a subclass.
     """
 
-    # TODO: should probably inherit SubSystem to prevent issues...
+    # TODO: should probably inherit `SubSystem` to prevent issues...
     # TODO: ...with (homogeneous) hierarchies
 
     # ruby/cache coherence protocol string
@@ -49,15 +53,15 @@ class BaseChipletSystem(ABC):
     _is_full_system: bool
 
     # topology class. used internally to create the topology.
-    # Ruby.py currently requires a name (string) to be specified
+    # `Ruby.py` currently requires a name (string) to be specified
     # to create the topology, instead of a class.
-    # Since Ruby.py may be deprecated, we use a class to enable
+    # Since `Ruby.py` may be deprecated, we use a class to enable
     # easier refactoring later on if needed.
     _topology_cls: type[BaseTopology]
 
     _memory_cls: type[AbstractMemory]
 
-    # list of *direct* nodes/children (ChipletSystems or Chiplets)
+    # list of *direct* nodes/children (`ChipletSystem`s or `Chiplet`s)
     nodes: list[BaseChipletSystem]
 
     # topology of the children for *only this layer of the hierarchy*
@@ -70,15 +74,43 @@ class BaseChipletSystem(ABC):
     # same as above, but for the routers corresponding to the links
     default_inter_node_router_lat: int
 
-    # parent ChipletSystem (if present)
+    # parent `ChipletSystem` (if present)
     parent: ChipletSystem | None
 
     # list of nodes on the same hierarchical level of this node's parent
-    # ChipletSystem to which this node has *direct* connections
+    # `ChipletSystem` to which this node has *direct* connections
     connected_nodes: list[BaseChipletSystem]
+
+    # main router for this node/`Chiplet[System]`
+    # used to make connections to parent and siblings
+    _main_router: GarnetRouter
+
+    # Garnet link (bidirectional pair/tuple) to/from parent (respectively)
+    _parent_link: tuple[GarnetIntLink, GarnetIntLink]
+
+    # list of Garnet link pairs for siblings
+    _sibling_links: list[tuple[GarnetIntLink, GarnetIntLink]]
 
     # `GarnetNetwork` for this object
     _garnet_network: GarnetNetwork
+
+    # class-local reference to `self.system.ruby`
+    # (gem5 system SimObject's RubySystem)
+    _ruby_system: RubySystem
+
+    # `RubyController`s that correspond to this `Chiplet[System]`
+    _ruby_controllers: list[RubyController]
+
+    # `GarnetExtLink`s that connect this object to parent `RubyController`s
+    _ruby_controller_links: list[GarnetExtLink]
+
+    # unique ID for each
+    __id = 0
+
+    @classmethod
+    def _generate_id(cls):
+        cls.__id += 1
+        return cls.__id - 1
 
     def __init__(
         self,
@@ -108,7 +140,7 @@ class BaseChipletSystem(ABC):
             MemoryClass (Type[AbstractMemory]):
                 The class corresponding to the memory configuration
                 for the gem5 `System` this `ChipletSystem` is part of.
-            nodes (list[BaseChipletSystem]):
+            nodes (Sequence[BaseChipletSystem]):
                 Optional list of nodes. May be passed to constructor
                 or added separately using `addNode()`.
             inter_node_link_lat (int):
@@ -137,6 +169,24 @@ class BaseChipletSystem(ABC):
         self.default_inter_node_router_lat = inter_node_router_lat
         self.connected_nodes = []
 
+        self._main_router = GarnetRouter(
+            router_id=-1,  # temporary, is replaced later
+            latency=self.default_inter_node_router_lat,
+            # the following are default parameters
+            # gem5 complains if I don't include these params
+            # vcs_per_vnet=4,
+        )
+
+        self._sibling_links = []
+
+        self._ruby_controllers = []
+        self._ruby_controller_links = []
+
+        self.id = BaseChipletSystem._generate_id()
+
+    def __getitem__(self, index):
+        return self.nodes[index]
+
     def addNode(
         self,
     ):
@@ -153,7 +203,7 @@ class BaseChipletSystem(ABC):
         i.e., the `ChipletSystem` at the top of the hierarchy.
         """
 
-        if self.parent == None:
+        if not hasattr(self, "parent") or self.parent == None:
             return self
         else:
             return self.parent.getRoot()
@@ -181,9 +231,55 @@ class BaseChipletSystem(ABC):
             # no nodes, or one or both nodes are not children of `self`
             return None
 
-        # todo: get the GarnetIntLink
+        # todo: get the GarnetIntLinks
 
         return None
+
+    def _getRouterParent(self, router: GarnetRouter, startRoot: bool = True):
+        # if we aren't already at the root, start search from there
+        if startRoot and hasattr(self, "parent"):
+            return self.getRoot()._getRouterParent(router, startRoot=False)
+
+        # grab routers and search
+        routers = self._garnet_network.routers
+        if router in routers:
+            return self
+        else:
+            for node in self.nodes:
+                if issubclass(node.__class__, BaseChipletSystem):
+                    res = node._getRouterParent(router, startRoot=False)
+                    if res is not None:
+                        return res
+            return None
+
+    def getAllLinksString(self):
+        str = ""
+        ext_links = self._garnet_network.ext_links
+        for link in ext_links:
+            int_parent = self._getRouterParent(link.int_node)
+            str += f"ext link {link.link_id} ({link}):\n"
+            str += f"    ext node: {link.ext_node}; "
+            str += f"int node: {link.int_node} "
+            if int_parent is not None:
+                str += f"(c{int_parent.id}:"
+                str += f"r{link.int_node.router_id})"
+            str += "\n"
+        int_links = self._garnet_network.int_links
+        for link in int_links:
+            src_parent = self._getRouterParent(link.src_node)
+            dst_parent = self._getRouterParent(link.dst_node)
+            str += f"int link {link.link_id} ({link}):\n"
+            str += "    from "
+            if src_parent is not None:
+                str += f"c{src_parent.id}:"
+            str += f"r{link.src_node.router_id} "
+            str += "to "
+            if dst_parent is not None:
+                str += f"c{dst_parent.id}:"
+            str += f"r{link.dst_node.router_id}"
+            str += "\n"
+
+        return str
 
     def connect(self, node: BaseChipletSystem):
         """
@@ -228,3 +324,229 @@ class BaseChipletSystem(ABC):
         """
 
         node1.connect(node2)
+
+    def to_string(self):
+        raise NotImplementedError
+
+    def getControllerCPU(
+        self,
+        controller: RubyController,
+        l2_is_private: bool = False,
+    ) -> BaseCPU | None:
+        # todo: improve this
+        # `RubyController` doesn't seem to provide any way to identify
+        # the corresponding CPU reliably, so right now we assume that
+        # cpu index corresponds to L1 (or L2, if private) controller index.
+        name = f"{controller}"
+        # example name: `<orphan System>.ruby.l1_cntrl0`
+        if "l1_cntrl" in name or (l2_is_private and "l2_cntrl" in name):
+            idx = name[-1]  # last digit
+            return self._system.cpu[int(idx)]
+        else:
+            return None  # doesn't correspond to a particular CPU
+
+    def _createTopology(self, options: Namespace):
+        # for reference, this is what you would do for a flat topology
+        if False:
+            self.topology = self._topology_cls(
+                self.getRoot()._meta_topology.nodes  # type: ignore
+            )
+
+        self.topology = self._topology_cls(
+            self._ruby_controllers  # type: ignore
+        )
+
+        # if mesh we need to temporarily adjust CPU count option
+        from topologies.Mesh_westfirst import Mesh_westfirst
+        from topologies.Mesh_XY import Mesh_XY
+        from topologies.MeshDirCorners_XY import MeshDirCorners_XY
+
+        if (
+            self._topology_cls is Mesh_westfirst
+            or self._topology_cls is Mesh_XY
+            or self._topology_cls is MeshDirCorners_XY
+        ):
+            # temp set CPU count option to number of nodes
+            options.num_cpus = len(self.nodes)
+
+        # * setup topology
+        # latter 3 args are the literal classes for the
+        # corresponding objects. they can technically be
+        # based on either `GarnetNetwork` or `SimpleNetwork`,
+        # but we're using Garnet and don't allow Simple.
+        self.topology.makeTopology(
+            options=options,
+            network=self._garnet_network,
+            IntLink=GarnetIntLink,
+            ExtLink=GarnetExtLink,
+            Router=GarnetRouter,
+        )
+
+        if (
+            self._topology_cls is Mesh_westfirst
+            or self._topology_cls is Mesh_XY
+            or self._topology_cls is MeshDirCorners_XY
+        ):
+            # set CPU count option back to what it was
+            options.num_cpus = len(self._system.cpu)
+            # ? this might interact very strangely with
+            # ? `registerTopology()`
+
+        # if in SE mode, register topology with (faux) filesystem
+        # only some topologies implement this (as of now, only
+        # `Mesh_XY` and `MeshDirCorners_XY` do.)
+        if not self._is_full_system:
+            # notes: `Mesh_XY` requires
+            # `options.num_cpus` and `options.mem_size`.
+            # `MeshDirCorners_XY` requires only `options.mem_size`.
+            self.topology.registerTopology(options)
+
+        gn = self._garnet_network
+        gn.routers = gn.routers + [self._main_router]
+
+    def _biLinkGarnetRouters(
+        self, router1: GarnetRouter, router2: GarnetRouter
+    ):
+        num_links = len(self._garnet_network.int_links) + len(
+            self._garnet_network.ext_links
+        )
+        print(
+            f"found {num_links} internal links for network {self._garnet_network}"
+        )
+
+        l12 = GarnetIntLink(
+            link_id=num_links,
+            src_node=router1,
+            dst_node=router2,
+            latency=self.default_inter_node_link_lat,
+        )
+
+        l21 = GarnetIntLink(
+            link_id=num_links + 1,
+            src_node=router2,
+            dst_node=router1,
+            latency=self.default_inter_node_link_lat,
+        )
+
+        # self._garnet_network.int_links.append(l12)
+        # self._garnet_network.int_links.append(l21)
+        self._garnet_network.int_links += l12
+        self._garnet_network.int_links += l21
+
+        return l12, l21
+
+    def _connectParentGarnet(self, copy_links_to_parent: bool = True):
+        if hasattr(self, "parent") and self.parent is not None:
+            self._parent_link = self._biLinkGarnetRouters(
+                self._main_router, self.parent._main_router
+            )
+            # if copy_links_to_parent:
+            #     pgn = self.parent._garnet_network
+            #     pgn.int_links.append(self._parent_link[0])
+            #     pgn.int_links.append(self._parent_link[1])
+
+    def _connectSiblingGarnet(self, sibl: BaseChipletSystem):
+        l_to, l_from = self._biLinkGarnetRouters(
+            self._main_router, sibl._main_router
+        )
+        self._sibling_links.append((l_to, l_from))
+
+    def _connectRubyControllerGarnet(
+        self, ctrl: RubyController, link_lat: int = -1
+    ):
+        if link_lat == -1:
+            link_lat = self.default_inter_node_link_lat
+        num_links = len(self._garnet_network.int_links) + len(
+            self._garnet_network.ext_links
+        )
+        print(
+            f"found {num_links} external links for network {self._garnet_network}"
+        )
+        link = GarnetExtLink(
+            link_id=num_links,
+            ext_node=ctrl,
+            int_node=self._main_router,
+            latency=link_lat,
+        )
+        self._garnet_network.ext_links += link
+        self._ruby_controller_links.append(link)
+        return link
+
+    def _defineMainRouterParams(self):
+        """
+        For some reason gem5 hates it when these aren't automatically
+        defined for `_main_router`, probably because it was instantiated
+        seperately. Should just nee to be called before `m5.instantiate()`.
+        """
+        # gem5 will complain if params aren't defined for main router
+        mr = self._main_router
+        gn = self._garnet_network
+        # mr.vcs_per_vnet = gn.vcs_per_vnet
+        # mr.virt_nets = self._garnet_network.number_of_virtual_networks
+        # mr.ni_flit_size = gn.ni_flit_size
+        mr.eventq_index = gn.eventq_index
+
+    def _connectHierarchyGarnet(self):
+        """
+        Should be called after `_createTopology()`.
+        Adds the main router to the `GarnetNetwork` list and
+        creates connections between the main routers of the current
+        level of the hierarchy and its parents/siblings.
+        """
+        # topologies tend to overwrite garnet links/routers entirely
+        # so just create our links (and add our main router) afterwards
+        num_routers = len(self._garnet_network.routers)
+        self._main_router.router_id = num_routers - 1
+        self._garnet_network.routers.append(self._main_router)
+        self._garnet_network.mainrouter = self._main_router  # load bearing
+        self._connectParentGarnet()
+        if hasattr(self, "parent") and self.parent is not None:
+            for node in self.parent.nodes:
+                if node is not self:
+                    self._connectSiblingGarnet(node)
+            for rc in self.parent._ruby_controllers:
+                self._connectRubyControllerGarnet(rc)
+        # setattr(
+        #     self._garnet_network,
+        #     f'mainrouterc{self.id}',
+        #     self._main_router
+        # )
+        self._combineHierarchyGarnetNetworks(self._garnet_network)
+
+    def _mergeGarnetNetworks(
+        self, merge_into: GarnetNetwork, merge_from: GarnetNetwork
+    ):
+        mi_router_ct = len(merge_into.routers)
+        mi_link_ct = len(merge_into.int_links) + len(merge_into.ext_links)
+        for r in merge_from.routers:
+            # ensure unique IDs in resulting network
+            mi_router_ct += 1
+            r.router_id = mi_router_ct
+            merge_into.routers.append(r)
+
+        for el in merge_from.ext_links:
+            mi_link_ct += 1
+            el.link_id = mi_link_ct
+            merge_into.ext_links.append(el)
+
+        for il in merge_from.int_links:
+            mi_link_ct += 1
+            il.link_id = mi_link_ct
+            merge_into.int_links.append(il)
+
+    def _combineHierarchyGarnetNetworks(self, merge_into: GarnetNetwork):
+        """
+        Call from parent `ChipletSystem` to combine all `GarnetNetwork`s
+        after topologies have been created.
+
+        Args:
+            merge_into (GarnetNetwork):
+                The `GarnetNetwork` to merge into. This should always be
+                the `GarnetNetwork` of the root `ChipletSystem`, so that
+                recursive calls continue merging properly.
+        """
+        for n in self.nodes:
+            if hasattr(n, "_garnet_network"):
+                self._mergeGarnetNetworks(merge_into, n._garnet_network)
+            if hasattr(n, "nodes"):
+                n._combineHierarchyGarnetNetworks(merge_into)

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -1215,7 +1215,7 @@ class BaseChipletSystem(SubSystem):
         if link_latency != -1:
             if l12 is not None:
                 if set_lat_link_1_to_2:
-                    l12.width = link_latency
+                    l12.latency = link_latency
 
                 if l21 is None:
                     warn(
@@ -1227,7 +1227,7 @@ class BaseChipletSystem(SubSystem):
 
             if l21 is not None:
                 if set_lat_link_2_to_1:
-                    l21.width = link_latency
+                    l21.latency = link_latency
 
                 if l12 is None:
                     warn(

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -12,6 +12,7 @@ from m5.objects import *
 from m5.util import (
     addToPath,
     fatal,
+    warn,
 )
 
 if TYPE_CHECKING:
@@ -28,23 +29,24 @@ if TYPE_CHECKING:
     from src.mem.ruby.network.garnet.GarnetLink import *
     from src.mem.ruby.network.garnet.GarnetNetwork import *
 
-from abc import ABC
-
 from topologies.BaseTopology import BaseTopology
 
 
-class BaseChipletSystem(ABC):
+class BaseChipletSystem(SubSystem):
     """
     See `ChipletSystem` and `Chiplet`. `BaseChipletSystem`
     acts as a vessel for shared functionality between the two.
     Do not instantiate directly; instead use a subclass.
     """
 
-    # TODO: should probably inherit `SubSystem` to prevent issues...
-    # TODO: ...with (homogeneous) hierarchies
+    type = "BaseChipletSystem"
+    abstract = True
+
+    # ID for this `Chiplet[System]`
+    id = Param.Int("ID in relation to other Chiplet[System]s")
 
     # ruby/cache coherence protocol string
-    protocol: str
+    protocol = Param.String("String name corresponding to Ruby protocol")
 
     # the gem5 `System` SimObject that this object is part of
     _system: System
@@ -62,24 +64,30 @@ class BaseChipletSystem(ABC):
     _memory_cls: type[AbstractMemory]
 
     # list of *direct* nodes/children (`ChipletSystem`s or `Chiplet`s)
-    nodes: list[BaseChipletSystem]
+    _nodes: list[BaseChipletSystem]
 
     # topology of the children for *only this layer of the hierarchy*
-    topology: BaseTopology | None
+    _topology: BaseTopology | None
 
     # default latency (in cycles) of the links between nodes
     # for this layer of abstraction (i.e., direct child nodes)
-    default_inter_node_link_lat: int
+    default_inter_node_link_lat = Param.Int(
+        "default latency (in cycles) of the links between nodes "
+        "in this level of the hierarchy"
+    )
 
     # same as above, but for the routers corresponding to the links
-    default_inter_node_router_lat: int
+    default_inter_node_router_lat = Param.Int(
+        "default latency (in cycles) of the routers corresponding to "
+        "the links between nodes in this level of the hierarchy"
+    )
 
     # parent `ChipletSystem` (if present)
-    parent: ChipletSystem | None
+    _parent_sys: ChipletSystem | None
 
     # list of nodes on the same hierarchical level of this node's parent
     # `ChipletSystem` to which this node has *direct* connections
-    connected_nodes: list[BaseChipletSystem]
+    _connected_nodes: list[BaseChipletSystem]
 
     # main router for this node/`Chiplet[System]`
     # used to make connections to parent and siblings
@@ -99,10 +107,17 @@ class BaseChipletSystem(ABC):
     _ruby_system: RubySystem
 
     # `RubyController`s that correspond to this `Chiplet[System]`
+    # excludes directory controllers
     _ruby_controllers: list[RubyController]
 
     # `GarnetExtLink`s that connect this object to parent `RubyController`s
-    _ruby_controller_links: list[GarnetExtLink]
+    _ruby_controller_link_map: list[GarnetExtLink]
+    _ruby_controller_router_map: list[tuple[RubyController, GarnetRouter]]
+
+    # directory controllers in this `Chiplet[System]`
+    _dir_controllers: list[RubyController]
+    _dir_controller_link_map: list[tuple[RubyController, GarnetExtLink]]
+    _dir_controller_router_map: list[tuple[RubyController, GarnetRouter]]
 
     # unique ID for each
     __id = 0
@@ -151,11 +166,11 @@ class BaseChipletSystem(ABC):
                 corresponding to the the links between nodes
                 for this layer of abstraction.
         """
-        # SubSystem.__init__(self)
+        super().__init__()
 
         self.protocol = buildEnv["PROTOCOL"]
 
-        self.nodes = list(nodes)
+        self._nodes = list(nodes)
 
         self._system = system
         self._is_full_system = full_system
@@ -163,29 +178,34 @@ class BaseChipletSystem(ABC):
         self._topology_cls = TopologyClass
         self._memory_cls = MemoryClass
 
-        self.topology = None  # created in `createSystem()`
+        self._topology = None  # created in `createSystem()`
 
         self.default_inter_node_link_lat = inter_node_link_lat
         self.default_inter_node_router_lat = inter_node_router_lat
-        self.connected_nodes = []
+        self._connected_nodes = []
 
         self._main_router = GarnetRouter(
             router_id=-1,  # temporary, is replaced later
             latency=self.default_inter_node_router_lat,
             # the following are default parameters
             # gem5 complains if I don't include these params
-            # vcs_per_vnet=4,
+            vcs_per_vnet=4,
         )
 
         self._sibling_links = []
 
         self._ruby_controllers = []
-        self._ruby_controller_links = []
+        self._ruby_controller_link_map = []
+        self._ruby_controller_router_map = []
+
+        self._dir_controllers = []
+        self._dir_controller_link_map = []
+        self._dir_controller_router_map = []
 
         self.id = BaseChipletSystem._generate_id()
 
     def __getitem__(self, index):
-        return self.nodes[index]
+        return self._nodes[index]
 
     def addNode(
         self,
@@ -203,10 +223,10 @@ class BaseChipletSystem(ABC):
         i.e., the `ChipletSystem` at the top of the hierarchy.
         """
 
-        if not hasattr(self, "parent") or self.parent == None:
+        if not hasattr(self, "_parent_sys") or self._parent_sys == None:
             return self
         else:
-            return self.parent.getRoot()
+            return self._parent_sys.getRoot()
 
     def getIntLink(
         self, node1: BaseChipletSystem, node2: BaseChipletSystem
@@ -224,9 +244,9 @@ class BaseChipletSystem(ABC):
         """
 
         if (
-            (len(self.nodes) == 0)
-            or node1 not in self.nodes
-            or node2 not in self.nodes
+            (len(self._nodes) == 0)
+            or node1 not in self._nodes
+            or node2 not in self._nodes
         ):
             # no nodes, or one or both nodes are not children of `self`
             return None
@@ -237,7 +257,7 @@ class BaseChipletSystem(ABC):
 
     def _getRouterParent(self, router: GarnetRouter, startRoot: bool = True):
         # if we aren't already at the root, start search from there
-        if startRoot and hasattr(self, "parent"):
+        if startRoot and hasattr(self, "_parent_sys"):
             return self.getRoot()._getRouterParent(router, startRoot=False)
 
         # grab routers and search
@@ -245,7 +265,7 @@ class BaseChipletSystem(ABC):
         if router in routers:
             return self
         else:
-            for node in self.nodes:
+            for node in self._nodes:
                 if issubclass(node.__class__, BaseChipletSystem):
                     res = node._getRouterParent(router, startRoot=False)
                     if res is not None:
@@ -281,50 +301,6 @@ class BaseChipletSystem(ABC):
 
         return str
 
-    def connect(self, node: BaseChipletSystem):
-        """
-        Register a connection between this `ChipletSystem` or `Chiplet`
-        and another `ChipletSystem` or `Chiplet` sharing the same parent.
-
-        Args:
-            node (BaseChipletSystem): The node to connect to.
-        """
-
-        if self.parent is None:
-            fatal(
-                "This BaseChipletSystem has no parent, "
-                "but the user attempted to connect it "
-                "to another BaseChipletSystem."
-            )
-
-        if self.parent != node.parent:
-            fatal(
-                "User attempted to connect two BaseChipletSystems "
-                "that do not share a parent ChipletSystem."
-            )
-
-        if node not in self.connected_nodes:
-            self.connected_nodes.append(node)
-
-        if self not in node.connected_nodes:
-            node.connected_nodes.append(self)
-
-        # ? instantiate a GarnetLink if one is not already present?
-
-    def connectChildren(
-        self, node1: BaseChipletSystem, node2: BaseChipletSystem
-    ):
-        """
-        Register a connection between two specified `ChipletSystem`s
-        or `Chiplet`s *which are children of this `ChipletSystem`.*
-
-        Args:
-            node1 (BaseChipletSystem): The node to connect from.
-            node2 (BaseChipletSystem): The node to connect to.
-        """
-
-        node1.connect(node2)
-
     def to_string(self):
         raise NotImplementedError
 
@@ -345,14 +321,19 @@ class BaseChipletSystem(ABC):
         else:
             return None  # doesn't correspond to a particular CPU
 
+    def isDirController(self, controller: RubyController):
+        name = f"{controller}"
+        # example name: `<orphan System>.ruby.dir_cntrl0`
+        return "dir_cntrl" in name
+
     def _createTopology(self, options: Namespace):
         # for reference, this is what you would do for a flat topology
         if False:
-            self.topology = self._topology_cls(
+            self._topology = self._topology_cls(
                 self.getRoot()._meta_topology.nodes  # type: ignore
             )
 
-        self.topology = self._topology_cls(
+        self._topology = self._topology_cls(
             self._ruby_controllers  # type: ignore
         )
 
@@ -367,14 +348,14 @@ class BaseChipletSystem(ABC):
             or self._topology_cls is MeshDirCorners_XY
         ):
             # temp set CPU count option to number of nodes
-            options.num_cpus = len(self.nodes)
+            options.num_cpus = len(self._nodes)
 
         # * setup topology
         # latter 3 args are the literal classes for the
         # corresponding objects. they can technically be
         # based on either `GarnetNetwork` or `SimpleNetwork`,
         # but we're using Garnet and don't allow Simple.
-        self.topology.makeTopology(
+        self._topology.makeTopology(
             options=options,
             network=self._garnet_network,
             IntLink=GarnetIntLink,
@@ -392,6 +373,14 @@ class BaseChipletSystem(ABC):
             # ? this might interact very strangely with
             # ? `registerTopology()`
 
+        # if `num_rows > 0` we will fail an assertion
+        # when the C++ objects are instantiated
+        # (`m_num_rows * m_num_cols == m_routers.size()`)
+        # (which will not be true since we added routers)
+        print(f"NUM ROWS is currently {self._garnet_network.num_rows}")
+        self._garnet_network.num_rows = 0
+        print(f"NUM ROWS is {self._garnet_network.num_rows} after set = 0")
+
         # if in SE mode, register topology with (faux) filesystem
         # only some topologies implement this (as of now, only
         # `Mesh_XY` and `MeshDirCorners_XY` do.)
@@ -399,20 +388,35 @@ class BaseChipletSystem(ABC):
             # notes: `Mesh_XY` requires
             # `options.num_cpus` and `options.mem_size`.
             # `MeshDirCorners_XY` requires only `options.mem_size`.
-            self.topology.registerTopology(options)
+            self._topology.registerTopology(options)
 
         gn = self._garnet_network
+
+        # store mappings of controller to router
+        # also connect to main router
+        print(
+            f"Linking Routers with main for "
+            f"{self.__class__.__name__} ID {self.id}"
+        )
+        for c, r in zip(self._ruby_controllers, gn.routers, strict=True):
+            print(f"    controller {c} :: router {r.router_id} {r}")
+            self._ruby_controller_router_map.append((c, r))
+            self._biLinkGarnetRouters(self._main_router, r)
+
         gn.routers = gn.routers + [self._main_router]
 
     def _biLinkGarnetRouters(
-        self, router1: GarnetRouter, router2: GarnetRouter
+        self,
+        router1: GarnetRouter,
+        router2: GarnetRouter,
+        auto_reg_parent: bool = True,
     ):
         num_links = len(self._garnet_network.int_links) + len(
             self._garnet_network.ext_links
         )
-        print(
-            f"found {num_links} internal links for network {self._garnet_network}"
-        )
+        # print(
+        #     f"found {num_links} links for network {self._garnet_network}"
+        # )
 
         l12 = GarnetIntLink(
             link_id=num_links,
@@ -433,12 +437,16 @@ class BaseChipletSystem(ABC):
         self._garnet_network.int_links += l12
         self._garnet_network.int_links += l21
 
+        if auto_reg_parent:
+            l12.set_parent(self._garnet_network, f"int_links{num_links}")
+            l21.set_parent(self._garnet_network, f"int_links{num_links + 1}")
+
         return l12, l21
 
     def _connectParentGarnet(self, copy_links_to_parent: bool = True):
-        if hasattr(self, "parent") and self.parent is not None:
+        if hasattr(self, "_parent_sys") and self._parent_sys is not None:
             self._parent_link = self._biLinkGarnetRouters(
-                self._main_router, self.parent._main_router
+                self._main_router, self._parent_sys._main_router
             )
             # if copy_links_to_parent:
             #     pgn = self.parent._garnet_network
@@ -446,30 +454,156 @@ class BaseChipletSystem(ABC):
             #     pgn.int_links.append(self._parent_link[1])
 
     def _connectSiblingGarnet(self, sibl: BaseChipletSystem):
+        warn("This may cause unexpected behavior.")
         l_to, l_from = self._biLinkGarnetRouters(
             self._main_router, sibl._main_router
         )
         self._sibling_links.append((l_to, l_from))
 
-    def _connectRubyControllerGarnet(
-        self, ctrl: RubyController, link_lat: int = -1
+    def _connectChildrenGarnet(
+        self, node1: BaseChipletSystem, node2: BaseChipletSystem
     ):
+        """
+        Don't call this directly; instead call `connectChildren()`.
+
+        Args:
+            node1 (BaseChipletSystem): The node to connect from.
+            node2 (BaseChipletSystem): The node to connect to.
+        """
+        l12, l21 = self._biLinkGarnetRouters(
+            node1._main_router, node2._main_router
+        )
+        node1._sibling_links.append((l12, l21))
+        node2._sibling_links.append((l12, l21))
+
+    def connect(self, node: BaseChipletSystem):
+        """
+        Register a connection between this `ChipletSystem` or `Chiplet`
+        and another `ChipletSystem` or `Chiplet` sharing the same parent.
+
+        Args:
+            node (BaseChipletSystem): The node to connect to.
+        """
+
+        if self._parent_sys is None:
+            fatal(
+                f"This {self.__class__.__name__} has no parent, "
+                f"but the user attempted to connect it "
+                f"to another {node.__class__.__name__}."
+            )
+        assert self._parent_sys is not None
+
+        if self._parent_sys != node._parent_sys:
+            fatal(
+                "User attempted to connect two nodes "
+                "that do not share a parent ChipletSystem."
+            )
+
+        self._parent_sys.connectChildren(self, node)
+
+    def connectChildren(
+        self, node1: BaseChipletSystem, node2: BaseChipletSystem
+    ):
+        """
+        Register a connection between two specified `ChipletSystem`s
+        or `Chiplet`s *which are children of this `ChipletSystem`.*
+
+        Args:
+            node1 (BaseChipletSystem): The node to connect from.
+            node2 (BaseChipletSystem): The node to connect to.
+        """
+
+        if node1 not in self._nodes:
+            fatal(
+                f"User attempted to connect from node {node1} to {node2}, "
+                f"but it is not a child of this {self.__class__.__name__}!"
+            )
+
+        if node2 not in self._nodes:
+            fatal(
+                f"User attempted to connect to node {node2} from {node1}, "
+                f"but it is not a child of this {self.__class__.__name__}!"
+            )
+
+        if (
+            node2 not in node1._connected_nodes
+            and node1 not in node2._connected_nodes
+        ):
+            self._connectChildrenGarnet(node1, node2)
+
+        if node2 not in node1._connected_nodes:
+            node1._connected_nodes.append(node2)
+
+        if node1 not in node2._connected_nodes:
+            node2._connected_nodes.append(node1)
+
+    def _connectRubyControllerGarnet(
+        self,
+        ctrl: RubyController,
+        router: GarnetRouter | None = None,
+        link_lat: int = -1,
+        auto_reg_parent: bool = True,
+    ):
+        """
+        Creates and registers a `GarnetExtLink` between the specified
+        `RubyController` object and the specified `GarnetRouter`
+        (defaults to the main router for this `Chiplet[System]`).
+
+        Args:
+            ctrl (RubyController):
+                The `RubyController` to link from.
+                This is the external node of the resulting `GarnetExtLink`.
+            router (GarnetRouter, optional):
+                The `GarnetRouter` to link the controller to.
+                This is the internal node of the resulting `GarnetExtLink`.
+                Defaults to None, which results in using the main router.
+                Usually this should be specified only when creating a link
+                to a directory controller, which does things differently.
+            link_lat (int, optional):
+                The link latency for the resulting `GarnetExtLink`.
+                Defaults to -1, which results in using the default link
+                latency stored in this `Chiplet[System]`.
+            auto_reg_parent (bool, optional):
+                Whether to automatically register the parent of the
+                resultant `GarnetExtLink`. Defaults to `True`, and usually
+                it should be left that way.
+
+        Returns:
+            GarnetExtLink:
+                The `GarnetExtLink` between the specified `RubyController`
+                and `GarnetRouter`.
+        """
+
+        # default to configured inter node link latency if not specified
         if link_lat == -1:
             link_lat = self.default_inter_node_link_lat
+
+        # use main router if not specified
+        if router is None:
+            router = self._main_router
+
         num_links = len(self._garnet_network.int_links) + len(
             self._garnet_network.ext_links
         )
-        print(
-            f"found {num_links} external links for network {self._garnet_network}"
-        )
+        # print(
+        #     f"found {num_links} links for network {self._garnet_network}"
+        # )
         link = GarnetExtLink(
             link_id=num_links,
             ext_node=ctrl,
-            int_node=self._main_router,
+            int_node=router,
             latency=link_lat,
         )
+
         self._garnet_network.ext_links += link
-        self._ruby_controller_links.append(link)
+
+        if self.isDirController(ctrl):
+            self._dir_controller_link_map.append(link)
+        else:
+            self._ruby_controller_link_map.append(link)
+
+        if auto_reg_parent:
+            link.set_parent(self._garnet_network, f"ext_links{num_links}")
         return link
 
     def _defineMainRouterParams(self):
@@ -481,10 +615,73 @@ class BaseChipletSystem(ABC):
         # gem5 will complain if params aren't defined for main router
         mr = self._main_router
         gn = self._garnet_network
-        # mr.vcs_per_vnet = gn.vcs_per_vnet
+        if int(mr.router_id) == -1:
+            num_routers = len(self._garnet_network.routers)
+            mr.router_id = num_routers - 1
+        mr.vcs_per_vnet = gn.vcs_per_vnet
         # mr.virt_nets = self._garnet_network.number_of_virtual_networks
         # mr.ni_flit_size = gn.ni_flit_size
-        mr.eventq_index = gn.eventq_index
+        # mr.eventq_index = gn.eventq_index
+
+    def _fixAllGarnetObjectParams(self):
+
+        def _recursiveUnproxyParams(sim_obj, set_clk_domain=False):
+            if len(sim_obj) > 1:
+                for i, obj in enumerate(sim_obj):
+                    _recursiveUnproxyParams(obj, set_clk_domain)
+                return
+            if not isSimObject(sim_obj):
+                warn(f"{sim_obj} is not a SimObject.")
+                return
+            if set_clk_domain:
+                if hasattr(sim_obj, "clk_domain"):
+                    # warn(f"setting clock domain for {sim_obj}")
+                    sim_obj.clk_domain = self._system.clk_domain
+                # if hasattr(sim_obj, 'vcs_per_vnet'):
+                #     vcs = self._garnet_network.vcs_per_vnet
+                #     warn(f"setting vcs_per_vnet for {sim_obj} = {vcs}")
+                #     sim_obj.vcs_per_vnet = vcs
+            sim_obj.unproxyParams()
+            children = sim_obj._children.values()
+            for child in children:
+                _recursiveUnproxyParams(child, set_clk_domain)
+
+        # fix network params
+        if not hasattr(self._garnet_network, "number_of_virtual_networks"):
+            self._garnet_network.number_of_virtual_networks = (
+                self._system.ruby.network.number_of_virtual_networks
+            )
+
+        # fix router params
+        for r in self._garnet_network.routers:
+            # print(f"setting clk_domain for {r}")
+            r.clk_domain = self._system.clk_domain
+            # print(f"setting eqidx = 0 for {r}")
+            # default for all `SimObject`s should be 0
+            r.eventq_index = 0
+            r.power_state.eventq_index = r.eventq_index
+            r.unproxyParams()
+
+        # fix int link params
+        for il in self._garnet_network.int_links:
+            # il.clk_domain = self._system.clk_domain
+            il.eventq_index = 0
+            _recursiveUnproxyParams(il)
+            # il.unproxyParams()
+            # il_attrs = dir(il)
+            # for attr_str in il_attrs:
+            #     attr = getattr(il, attr)
+            #     if isSimObject(attr):
+            #         attr.unproxyParams()
+            # if hasattr(il, 'credit_link'):
+            #     il.credit_link.unproxyParams()
+            #     il.credit_link.power_state.unproxyParams()
+            # #     il.credit_link.clk_domain = self._system.clk_domain
+
+        # fix ext link params
+        for el in self._garnet_network.ext_links:
+            el.eventq_index = 0
+            _recursiveUnproxyParams(el, True)
 
     def _connectHierarchyGarnet(self):
         """
@@ -496,22 +693,29 @@ class BaseChipletSystem(ABC):
         # topologies tend to overwrite garnet links/routers entirely
         # so just create our links (and add our main router) afterwards
         num_routers = len(self._garnet_network.routers)
-        self._main_router.router_id = num_routers - 1
-        self._garnet_network.routers.append(self._main_router)
-        self._garnet_network.mainrouter = self._main_router  # load bearing
+        if self._main_router.router_id == -1:
+            self._main_router.router_id = num_routers  # - 1
+        if self._main_router not in self._garnet_network.routers:
+            self._garnet_network.routers.append(self._main_router)
+        # self._garnet_network.mainrouter = self._main_router  # load bearing
         self._connectParentGarnet()
-        if hasattr(self, "parent") and self.parent is not None:
-            for node in self.parent.nodes:
+        if hasattr(self, "_parent_sys") and self._parent_sys is not None:
+            for node in self._parent_sys._nodes:
                 if node is not self:
-                    self._connectSiblingGarnet(node)
-            for rc in self.parent._ruby_controllers:
-                self._connectRubyControllerGarnet(rc)
+                    self._parent_sys.connectChildren(self, node)
+                    # self._connectSiblingGarnet(node)
+            # for rc in self._parent_sys._ruby_controllers:
+            #     self._connectRubyControllerGarnet(rc)
         # setattr(
         #     self._garnet_network,
         #     f'mainrouterc{self.id}',
         #     self._main_router
         # )
-        self._combineHierarchyGarnetNetworks(self._garnet_network)
+        # setattr(
+        #     self._garnet_network,
+        #     f'routers{self.id}',
+        #     self._main_router
+        # )
 
     def _mergeGarnetNetworks(
         self, merge_into: GarnetNetwork, merge_from: GarnetNetwork
@@ -520,19 +724,25 @@ class BaseChipletSystem(ABC):
         mi_link_ct = len(merge_into.int_links) + len(merge_into.ext_links)
         for r in merge_from.routers:
             # ensure unique IDs in resulting network
-            mi_router_ct += 1
             r.router_id = mi_router_ct
             merge_into.routers.append(r)
+            mi_router_ct += 1
+
+        # merge_from.routers = []
 
         for el in merge_from.ext_links:
-            mi_link_ct += 1
             el.link_id = mi_link_ct
             merge_into.ext_links.append(el)
+            mi_link_ct += 1
+
+        # merge_from.ext_links = []
 
         for il in merge_from.int_links:
-            mi_link_ct += 1
             il.link_id = mi_link_ct
             merge_into.int_links.append(il)
+            mi_link_ct += 1
+
+        # merge_from.int_links = []
 
     def _combineHierarchyGarnetNetworks(self, merge_into: GarnetNetwork):
         """
@@ -545,8 +755,8 @@ class BaseChipletSystem(ABC):
                 the `GarnetNetwork` of the root `ChipletSystem`, so that
                 recursive calls continue merging properly.
         """
-        for n in self.nodes:
+        for n in self._nodes:
             if hasattr(n, "_garnet_network"):
                 self._mergeGarnetNetworks(merge_into, n._garnet_network)
-            if hasattr(n, "nodes"):
+            if hasattr(n, "_nodes"):
                 n._combineHierarchyGarnetNetworks(merge_into)

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -12,6 +12,7 @@ from m5.objects import *
 from m5.util import (
     addToPath,
     fatal,
+    panic,
     warn,
 )
 
@@ -26,10 +27,31 @@ if TYPE_CHECKING:
     from src.mem.ruby.system.RubySystem import RubySystem
     from src.mem.AbstractMemory import AbstractMemory
     from src.mem.ruby.slicc_interface.Controller import RubyController
+    from src.mem.ruby.system.Sequencer import RubySequencer
     from src.mem.ruby.network.garnet.GarnetLink import *
     from src.mem.ruby.network.garnet.GarnetNetwork import *
 
 from topologies.BaseTopology import BaseTopology
+
+
+class FakeGarnetNetwork:
+    """
+    Used to collect routers and links from topologies without
+    actually instantiating a `GarnetNetwork` C++ object.
+    !! It is assumed that topologies only use the `network`
+    !! param to add routers and links to the `GarnetNetwork`.
+    This is currently true for all existing topologies, but
+    if it is ever not true for a topology you use, it will break.
+    """
+
+    routers: list[GarnetRouter]
+    ext_links: list[GarnetExtLink]
+    int_links: list[GarnetIntLink]
+
+    def __init__(self):
+        self.routers = []
+        self.ext_links = []
+        self.int_links = []
 
 
 class BaseChipletSystem(SubSystem):
@@ -48,26 +70,9 @@ class BaseChipletSystem(SubSystem):
     # ruby/cache coherence protocol string
     protocol = Param.String("String name corresponding to Ruby protocol")
 
-    # the gem5 `System` SimObject that this object is part of
-    _system: System
-
-    # if full-system simulation mode is enabled in gem5
-    _is_full_system: bool
-
-    # topology class. used internally to create the topology.
-    # `Ruby.py` currently requires a name (string) to be specified
-    # to create the topology, instead of a class.
-    # Since `Ruby.py` may be deprecated, we use a class to enable
-    # easier refactoring later on if needed.
-    _topology_cls: type[BaseTopology]
-
-    _memory_cls: type[AbstractMemory]
-
-    # list of *direct* nodes/children (`ChipletSystem`s or `Chiplet`s)
-    _nodes: list[BaseChipletSystem]
-
-    # topology of the children for *only this layer of the hierarchy*
-    _topology: BaseTopology | None
+    # *
+    # * Latency parameters
+    # *
 
     # default latency (in cycles) of the links between nodes
     # for this layer of abstraction (i.e., direct child nodes)
@@ -82,12 +87,45 @@ class BaseChipletSystem(SubSystem):
         "the links between nodes in this level of the hierarchy"
     )
 
+    # *
+    # * Attributes related to gem5 logistics
+    # *
+
+    # the gem5 `System` SimObject that this object is part of
+    _system: System
+
+    # if full-system simulation mode is enabled in gem5
+    _is_full_system: bool
+
+    # memory class of the gem5 system
+    _memory_cls: type[AbstractMemory]
+
+    # *
+    # * Topology and Nodes
+    # *
+
+    # topology of the children for *only this layer of the hierarchy*
+    _topology: BaseTopology | None
+
+    # topology class. used internally to create the topology.
+    # legacy Ruby (`Ruby.py`) requires a name (string) to be specified
+    # to create the topology; this is obtained from the class.
+    # hierarchical chiplet construction uses the class directly.
+    _topology_cls: type[BaseTopology]
+
+    # list of *direct* nodes/children (`ChipletSystem`s or `Chiplet`s)
+    _nodes: list[BaseChipletSystem] | list[BaseCPU]
+
     # parent `ChipletSystem` (if present)
     _parent_sys: ChipletSystem | None
 
     # list of nodes on the same hierarchical level of this node's parent
     # `ChipletSystem` to which this node has *direct* connections
     _connected_nodes: list[BaseChipletSystem]
+
+    # *
+    # * Links, Routers, and Controllers
+    # *
 
     # main router for this node/`Chiplet[System]`
     # used to make connections to parent and siblings
@@ -100,32 +138,57 @@ class BaseChipletSystem(SubSystem):
     _sibling_links: list[tuple[GarnetIntLink, GarnetIntLink]]
 
     # `GarnetNetwork` for this object
-    _garnet_network: GarnetNetwork
-
-    # class-local reference to `self.system.ruby`
-    # (gem5 system SimObject's RubySystem)
-    _ruby_system: RubySystem
+    _garnet_network: GarnetNetwork | FakeGarnetNetwork
 
     # `RubyController`s that correspond to this `Chiplet[System]`
-    # excludes directory controllers
+    # includes all controllers used to create the topology
     _ruby_controllers: list[RubyController]
 
     # `GarnetExtLink`s that connect this object to parent `RubyController`s
-    _ruby_controller_link_map: list[GarnetExtLink]
-    _ruby_controller_router_map: list[tuple[RubyController, GarnetRouter]]
+    _ruby_controller_links: list[GarnetExtLink]
+    # _ruby_controller_router_map: list[tuple[RubyController, GarnetRouter]]
 
     # directory controllers in this `Chiplet[System]`
+    # these are returned by `create_system()` of the Ruby protocol
     _dir_controllers: list[RubyController]
-    _dir_controller_link_map: list[tuple[RubyController, GarnetExtLink]]
-    _dir_controller_router_map: list[tuple[RubyController, GarnetRouter]]
+    # _dir_controller_link_map: list[tuple[RubyController, GarnetExtLink]]
+    # _dir_controller_router_map: list[tuple[RubyController, GarnetRouter]]
 
-    # unique ID for each
+    # controllers that are not directory controllers
+    # e.g., LLC controller
+    _non_dir_controllers: list[RubyController]
+
+    # Ruby CPU sequencers for this `Chiplet[System]`
+    # includes sequencers for all CPUs
+    _cpu_sequencers: list[RubySequencer]
+
+    # *
+    # * Other
+    # *
+
+    # used to generate a unique ID for each `Chiplet[System]`
+    # note that this is global to all classes that inherit from
+    # `BaseChipletSystem`, regardless of their actual class.
+    # do not override `_generate_id()`.
     __id = 0
 
     @classmethod
     def _generate_id(cls):
+        """
+        Used to generate a unique ID for each `Chiplet[System]`.
+        The ID is unique among all instances of classes that
+        inherit from `BaseChipletSystem`.
+        !! Do not override this method !!
+
+        Returns:
+            int: an ID for the `Chiplet[System]`.
+        """
         cls.__id += 1
         return cls.__id - 1
+
+    # *
+    # * Constructor
+    # *
 
     def __init__(
         self,
@@ -133,7 +196,7 @@ class BaseChipletSystem(SubSystem):
         full_system: bool,
         TopologyClass: type[BaseTopology],
         MemoryClass: type[AbstractMemory],
-        nodes: Sequence[BaseChipletSystem],
+        nodes: Sequence[BaseChipletSystem] | Sequence[BaseCPU],
         inter_node_link_lat: int,
         inter_node_router_lat: int,
     ):
@@ -155,7 +218,7 @@ class BaseChipletSystem(SubSystem):
             MemoryClass (Type[AbstractMemory]):
                 The class corresponding to the memory configuration
                 for the gem5 `System` this `ChipletSystem` is part of.
-            nodes (Sequence[BaseChipletSystem]):
+            nodes (Sequence[BaseChipletSystem] | Sequence[BaseCPU]):
                 Optional list of nodes. May be passed to constructor
                 or added separately using `addNode()`.
             inter_node_link_lat (int):
@@ -195,12 +258,14 @@ class BaseChipletSystem(SubSystem):
         self._sibling_links = []
 
         self._ruby_controllers = []
-        self._ruby_controller_link_map = []
-        self._ruby_controller_router_map = []
+        self._ruby_controller_links = []
+        # self._ruby_controller_router_map = []
 
         self._dir_controllers = []
-        self._dir_controller_link_map = []
-        self._dir_controller_router_map = []
+        # self._dir_controller_link_map = []
+        # self._dir_controller_router_map = []
+
+        self._non_dir_controllers = []
 
         self.id = BaseChipletSystem._generate_id()
 
@@ -215,62 +280,55 @@ class BaseChipletSystem(SubSystem):
         """
 
         # todo: implement
+        warn(
+            "As of now, Chiplet[System] nodes must be specified "
+            "at instantiation time in the constructor."
+        )
         raise NotImplementedError
 
-    def getRoot(self):
+    # *
+    # * Root ChipletSystem Methods
+    # *
+
+    def getRoot(self) -> ChipletSystem:
         """
         Retrieve a reference to the root `ChipletSystem`,
         i.e., the `ChipletSystem` at the top of the hierarchy.
         """
 
-        if not hasattr(self, "_parent_sys") or self._parent_sys == None:
-            return self
-        else:
-            return self._parent_sys.getRoot()
-
-    def getIntLink(
-        self, node1: BaseChipletSystem, node2: BaseChipletSystem
-    ) -> GarnetIntLink | None:
-        """
-        Retrieve the Garnet link object, if one exists, between the two
-        specified nodes, which must be children of this `Chiplet[System]`.
-        Note that the `Chiplet[System]` abstracts the `GarnetIntLink`,
-        since an actual `GarnetIntLink` is between two routers, not two
-        `Chiplet[System]`s directly.
-
-        Args:
-            node1 (BaseChipletSystem): One end of the link.
-            node2 (BaseChipletSystem): The other end of the link.
-        """
-
         if (
-            (len(self._nodes) == 0)
-            or node1 not in self._nodes
-            or node2 not in self._nodes
-        ):
-            # no nodes, or one or both nodes are not children of `self`
-            return None
-
-        # todo: get the GarnetIntLinks
-
-        return None
-
-    def _getRouterParent(self, router: GarnetRouter, startRoot: bool = True):
-        # if we aren't already at the root, start search from there
-        if startRoot and hasattr(self, "_parent_sys"):
-            return self.getRoot()._getRouterParent(router, startRoot=False)
-
-        # grab routers and search
-        routers = self._garnet_network.routers
-        if router in routers:
+            not hasattr(self, "_parent_sys") or self._parent_sys == None
+        ) and isinstance(self, ChipletSystem):
             return self
-        else:
-            for node in self._nodes:
-                if issubclass(node.__class__, BaseChipletSystem):
-                    res = node._getRouterParent(router, startRoot=False)
-                    if res is not None:
-                        return res
-            return None
+        elif self._parent_sys is not None:
+            return self._parent_sys.getRoot()
+        else:  # major failure
+            if not hasattr(self, "_parent_sys"):
+                par_str = " attribute doesn't exist"
+            else:  # is none
+                par_str = " was None"
+            was_cs_or_not_str = ""
+            if not isinstance(self, ChipletSystem):
+                was_cs_or_not_str = "not "
+            fatal(
+                f"Failed to retrieve root ChipletSystem for "
+                f"{self.__class__.__name__} ID {self.id}. "
+                f"_parent_sys {par_str}. "
+                f"Self was {was_cs_or_not_str}ChipletSystem."
+            )
+            # below will never be reached, just to satisfy type checker
+            assert self is ChipletSystem
+            return self
+
+    def isRoot(self):
+        """
+        Determine if this `Chiplet[System]` is the root or not.
+        """
+        return not hasattr(self, "_parent_sys") or self._parent_sys == None
+
+    # *
+    # * Debugging Methods
+    # *
 
     def getAllLinksString(self):
         str = ""
@@ -304,6 +362,27 @@ class BaseChipletSystem(SubSystem):
     def to_string(self):
         raise NotImplementedError
 
+    # *
+    # * Network and Controller Classification
+    # *
+
+    def _getRouterParent(self, router: GarnetRouter, startRoot: bool = True):
+        # if we aren't already at the root, start search from there
+        if startRoot and hasattr(self, "_parent_sys"):
+            return self.getRoot()._getRouterParent(router, startRoot=False)
+
+        # grab routers and search
+        routers = self._garnet_network.routers
+        if router in routers:
+            return self
+        else:
+            for node in self._nodes:
+                if issubclass(node.__class__, BaseChipletSystem):
+                    res = node._getRouterParent(router, startRoot=False)
+                    if res is not None:
+                        return res
+            return None
+
     def getControllerCPU(
         self,
         controller: RubyController,
@@ -326,18 +405,29 @@ class BaseChipletSystem(SubSystem):
         # example name: `<orphan System>.ruby.dir_cntrl0`
         return "dir_cntrl" in name
 
-    def _createTopology(self, options: Namespace):
+    # *
+    # * `_createTopology()`
+    # *
+
+    def _createTopology(
+        self,
+        options: Namespace,
+        controllers: list[RubyController],
+    ):
         # for reference, this is what you would do for a flat topology
         if False:
             self._topology = self._topology_cls(
                 self.getRoot()._meta_topology.nodes  # type: ignore
             )
 
-        self._topology = self._topology_cls(
-            self._ruby_controllers  # type: ignore
-        )
+        # actually instantiate the topology
+        self._topology = self._topology_cls(controllers)  # type: ignore
 
-        # if mesh we need to temporarily adjust CPU count option
+        # if mesh, we need to temporarily adjust CPU count option
+        # so that the topology is generated correctly
+        # and its assertions don't fail.
+        # mesh topology understandably assumes it is in a vacuum
+        # and that number of routers = number of CPUs
         from topologies.Mesh_westfirst import Mesh_westfirst
         from topologies.Mesh_XY import Mesh_XY
         from topologies.MeshDirCorners_XY import MeshDirCorners_XY
@@ -353,7 +443,7 @@ class BaseChipletSystem(SubSystem):
         # * setup topology
         # latter 3 args are the literal classes for the
         # corresponding objects. they can technically be
-        # based on either `GarnetNetwork` or `SimpleNetwork`,
+        # from either `GarnetNetwork` or `SimpleNetwork`,
         # but we're using Garnet and don't allow Simple.
         self._topology.makeTopology(
             options=options,
@@ -373,14 +463,6 @@ class BaseChipletSystem(SubSystem):
             # ? this might interact very strangely with
             # ? `registerTopology()`
 
-        # if `num_rows > 0` we will fail an assertion
-        # when the C++ objects are instantiated
-        # (`m_num_rows * m_num_cols == m_routers.size()`)
-        # (which will not be true since we added routers)
-        print(f"NUM ROWS is currently {self._garnet_network.num_rows}")
-        self._garnet_network.num_rows = 0
-        print(f"NUM ROWS is {self._garnet_network.num_rows} after set = 0")
-
         # if in SE mode, register topology with (faux) filesystem
         # only some topologies implement this (as of now, only
         # `Mesh_XY` and `MeshDirCorners_XY` do.)
@@ -390,7 +472,18 @@ class BaseChipletSystem(SubSystem):
             # `MeshDirCorners_XY` requires only `options.mem_size`.
             self._topology.registerTopology(options)
 
-        gn = self._garnet_network
+        # grab reference to my network
+        # is ok (and expected) for this to be a `FakeGarnetNetwork`
+        # since all we care about here is iterating and adding
+        gnw = self._garnet_network
+
+        # iterate through ext_links and map controllers to routers
+        # note that this is (one or more)-to-one, i.e., more than
+        # one controller can map to a given router.
+        # the point of this is t
+
+        for r in gnw.routers:
+            pass
 
         # store mappings of controller to router
         # also connect to main router
@@ -398,18 +491,70 @@ class BaseChipletSystem(SubSystem):
             f"Linking Routers with main for "
             f"{self.__class__.__name__} ID {self.id}"
         )
-        for c, r in zip(self._ruby_controllers, gn.routers, strict=True):
+        for c, r in zip(controllers, gnw.routers, strict=True):
             print(f"    controller {c} :: router {r.router_id} {r}")
-            self._ruby_controller_router_map.append((c, r))
+            # self._ruby_controller_router_map.append((c, r))
             self._biLinkGarnetRouters(self._main_router, r)
 
-        gn.routers = gn.routers + [self._main_router]
+        gnw.routers += self._main_router
+
+    # *
+    # * Low-Level Network Connection/Instantiation Methods
+    # *
+
+    def _findExtLinkFromController(
+        self,
+        controller: RubyController,
+        searchFromRoot: bool = True,
+    ) -> GarnetExtLink | None:
+        if searchFromRoot and not self.isRoot():
+            return self.getRoot()._findExtLinkFromController(controller, False)
+            # don't need to set searchFromRoot = False but why not
+
+        ext_links = self._garnet_network.ext_links
+        for ext_link in ext_links:
+            if controller == ext_link.ext_node:
+                return ext_link
+
+        return None
+
+    def _findRouterFromController(
+        self,
+        controller: RubyController,
+        searchFromRoot: bool = True,
+    ) -> GarnetRouter | None:
+        ext_link = self._findExtLinkFromController(controller, searchFromRoot)
+        if ext_link is not None:
+            return ext_link.int_node
+        else:
+            return None
+
+    def _findIntLinkFromRouters(
+        self,
+        routerFrom: GarnetRouter,
+        routerTo: GarnetRouter,
+        searchFromRoot: bool = True,
+    ) -> GarnetIntLink | None:
+        if searchFromRoot and not self.isRoot():
+            return self.getRoot()._findIntLinkFromRouters(
+                routerFrom, routerTo, False
+            )
+            # don't need to set searchFromRoot = False but why not
+
+        int_links = self._garnet_network.int_links
+        for int_link in int_links:
+            if (
+                int_link.src_node == routerFrom
+                and int_link.dst_node == routerTo
+            ):
+                return int_link
+        return None
 
     def _biLinkGarnetRouters(
         self,
         router1: GarnetRouter,
         router2: GarnetRouter,
-        auto_reg_parent: bool = True,
+        # auto_reg_parent: bool = True,
     ):
         num_links = len(self._garnet_network.int_links) + len(
             self._garnet_network.ext_links
@@ -437,9 +582,10 @@ class BaseChipletSystem(SubSystem):
         self._garnet_network.int_links += l12
         self._garnet_network.int_links += l21
 
-        if auto_reg_parent:
-            l12.set_parent(self._garnet_network, f"int_links{num_links}")
-            l21.set_parent(self._garnet_network, f"int_links{num_links + 1}")
+        # TODO NEW HIERARCHY: remove this
+        # if auto_reg_parent:
+        #     l12.set_parent(self._garnet_network, f"int_links{num_links}")
+        #     l21.set_parent(self._garnet_network, f"int_links{num_links + 1}")
 
         return l12, l21
 
@@ -465,6 +611,7 @@ class BaseChipletSystem(SubSystem):
     ):
         """
         Don't call this directly; instead call `connectChildren()`.
+        This function doesn't do any checks (is relatively unsafe).
 
         Args:
             node1 (BaseChipletSystem): The node to connect from.
@@ -475,67 +622,6 @@ class BaseChipletSystem(SubSystem):
         )
         node1._sibling_links.append((l12, l21))
         node2._sibling_links.append((l12, l21))
-
-    def connect(self, node: BaseChipletSystem):
-        """
-        Register a connection between this `ChipletSystem` or `Chiplet`
-        and another `ChipletSystem` or `Chiplet` sharing the same parent.
-
-        Args:
-            node (BaseChipletSystem): The node to connect to.
-        """
-
-        if self._parent_sys is None:
-            fatal(
-                f"This {self.__class__.__name__} has no parent, "
-                f"but the user attempted to connect it "
-                f"to another {node.__class__.__name__}."
-            )
-        assert self._parent_sys is not None
-
-        if self._parent_sys != node._parent_sys:
-            fatal(
-                "User attempted to connect two nodes "
-                "that do not share a parent ChipletSystem."
-            )
-
-        self._parent_sys.connectChildren(self, node)
-
-    def connectChildren(
-        self, node1: BaseChipletSystem, node2: BaseChipletSystem
-    ):
-        """
-        Register a connection between two specified `ChipletSystem`s
-        or `Chiplet`s *which are children of this `ChipletSystem`.*
-
-        Args:
-            node1 (BaseChipletSystem): The node to connect from.
-            node2 (BaseChipletSystem): The node to connect to.
-        """
-
-        if node1 not in self._nodes:
-            fatal(
-                f"User attempted to connect from node {node1} to {node2}, "
-                f"but it is not a child of this {self.__class__.__name__}!"
-            )
-
-        if node2 not in self._nodes:
-            fatal(
-                f"User attempted to connect to node {node2} from {node1}, "
-                f"but it is not a child of this {self.__class__.__name__}!"
-            )
-
-        if (
-            node2 not in node1._connected_nodes
-            and node1 not in node2._connected_nodes
-        ):
-            self._connectChildrenGarnet(node1, node2)
-
-        if node2 not in node1._connected_nodes:
-            node1._connected_nodes.append(node2)
-
-        if node1 not in node2._connected_nodes:
-            node2._connected_nodes.append(node1)
 
     def _connectRubyControllerGarnet(
         self,
@@ -597,14 +683,322 @@ class BaseChipletSystem(SubSystem):
 
         self._garnet_network.ext_links += link
 
-        if self.isDirController(ctrl):
-            self._dir_controller_link_map.append(link)
-        else:
-            self._ruby_controller_link_map.append(link)
+        # TODO NEW HIERARCHY: remove this
+        # if self.isDirController(ctrl):
+        #     self._dir_controller_link_map.append(link)
+        # else:
+        #     self._ruby_controller_links.append(link)
 
-        if auto_reg_parent:
-            link.set_parent(self._garnet_network, f"ext_links{num_links}")
+        # TODO NEW HIERARCHY: remove this
+        # if auto_reg_parent:
+        #     link.set_parent(self._garnet_network, f"ext_links{num_links}")
         return link
+
+    def _getNodeLinks(
+        self, node1: BaseChipletSystem, node2: BaseChipletSystem
+    ) -> tuple[GarnetIntLink | None, GarnetIntLink | None]:
+        """
+        Retrieve the Garnet link objects, if they exist, between the two
+        specified nodes, which must be children of this `Chiplet[System]`.
+        Note that the `Chiplet[System]` abstracts the `GarnetIntLink`,
+        since an actual `GarnetIntLink` is between two routers, not two
+        `Chiplet[System]`s directly.
+
+        Args:
+            node1 (BaseChipletSystem): One end of the link.
+            node2 (BaseChipletSystem): The other end of the link.
+        """
+
+        if (
+            (len(self._nodes) == 0)
+            or node1 not in self._nodes
+            or node2 not in self._nodes
+        ):
+            # no nodes, or one or both nodes are not children of `self`
+            warn(
+                f"_getNodeLinks() was called, but either there are no "
+                f"nodes (actual len = {len(self._nodes)}), or one of "
+                f"the nodes is not a child of this Chiplet[System] "
+                f"(node1 is child? {node1 in self._nodes}) "
+                f"(node2 is child? {node2 in self._nodes})."
+            )
+            return (None, None)
+
+        n1r = node1._main_router
+        n2r = node2._main_router
+
+        l12 = self._findIntLinkFromRouters(n1r, n2r)
+        l21 = self._findIntLinkFromRouters(n2r, n1r)
+
+        return (l12, l21)
+
+    # *
+    # * High-Level Chiplet-to-Chiplet Connection Methods
+    # *
+
+    def connect(self, node: BaseChipletSystem):
+        """
+        Register a connection between this `ChipletSystem` or `Chiplet`
+        and another `ChipletSystem` or `Chiplet` sharing the same parent.
+
+        Args:
+            node (BaseChipletSystem): The node to connect to.
+        """
+
+        if self._parent_sys is None:
+            fatal(
+                f"This {self.__class__.__name__} has no parent, "
+                f"but the user attempted to connect it "
+                f"to another {node.__class__.__name__}."
+            )
+        assert self._parent_sys is not None
+
+        if self._parent_sys != node._parent_sys:
+            fatal(
+                "User attempted to connect two nodes "
+                "that do not share a parent ChipletSystem."
+            )
+
+        self._parent_sys.connectChildren(self, node)
+
+    def connectChildren(
+        self, node1: BaseChipletSystem, node2: BaseChipletSystem
+    ):
+        """
+        Register a connection between two specified `ChipletSystem`s
+        or `Chiplet`s *which are children of this `ChipletSystem`.*
+
+        Args:
+            node1 (BaseChipletSystem): The node to connect from.
+            node2 (BaseChipletSystem): The node to connect to.
+        """
+
+        if node1 not in self._nodes:
+            fatal(
+                f"User attempted to connect from node {node1} to {node2}, "
+                f"but it is not a child of this {self.__class__.__name__}!"
+            )
+
+        if node2 not in self._nodes:
+            fatal(
+                f"User attempted to connect to node {node2} from {node1}, "
+                f"but it is not a child of this {self.__class__.__name__}!"
+            )
+
+        # check if they are already connected
+        (l12, l21) = self._getNodeLinks(node1, node2)
+        if l12 is not None and l21 is not None:
+            warn(
+                f"Attempted to connect to node {node2} from {node1}, "
+                f"but these nodes are already connected."
+            )
+            return
+        elif l12 is not None or l21 is not None:
+            panic(
+                f"Attempted to connect to node {node2} from {node1}, "
+                f"but only one direction of int link was found. "
+                f"Link 1->2: {l12}; Link 2->1: {l21}"
+                f"(one of these should be None)."
+            )
+        elif l12 is None and l21 is None:
+
+            if (
+                node2 not in node1._connected_nodes
+                and node1 not in node2._connected_nodes
+            ):
+                self._connectChildrenGarnet(node1, node2)
+
+            if node2 not in node1._connected_nodes:
+                node1._connected_nodes.append(node2)
+
+            if node1 not in node2._connected_nodes:
+                node2._connected_nodes.append(node1)
+
+        else:
+            panic("This shouldn't be possible to reach in connectChildren()!")
+
+    # *
+    # * Granular Connection Configuration Methods
+    # *
+
+    def enableNodeLinkSerDes(
+        self,
+        node1: BaseChipletSystem,
+        node2: BaseChipletSystem,
+        enable_node_1: bool = True,
+        enable_node_2: bool = True,
+    ):
+        """
+        Enable the serializer-deserializer units on either end of
+        the links between the two specified nodes (`ChipletSystem`s
+        or `Chiplet`s) *which are children of this `ChipletSystem`.*
+
+        Args:
+            node1 (BaseChipletSystem): One node.
+            node2 (BaseChipletSystem): The other node.
+            enable_node_1 (bool):
+                Whether to enable SerDes on node 1. Defaults to True.
+            enable_node_2 (bool):
+                Whether to enable SerDes on node 2. Defaults to True.
+        """
+        (l12, l21) = self._getNodeLinks(node1, node2)
+
+        if l12 is None and l21 is None:
+            warn(
+                f"int links between {node1.__class__.__name__}{node1.id} "
+                f"and {node2.__class__.__name__}{node2.id} do not exist!"
+            )
+            return
+
+        if l12 is not None:
+            if enable_node_1:
+                l12.src_serdes = True
+            if enable_node_2:
+                l12.dst_serdes = True
+
+            if l21 is None:
+                warn(
+                    f"int link from {node1.__class__.__name__}{node1.id} "
+                    f"to {node2.__class__.__name__}{node2.id} exists "
+                    f"but int link in other direction does not. "
+                )
+
+        if l21 is not None:
+            if enable_node_2:
+                l21.src_serdes = True
+            if enable_node_1:
+                l21.dst_serdes = True
+
+            if l12 is None:
+                warn(
+                    f"int link from {node1.__class__.__name__}{node1.id} "
+                    f"to {node2.__class__.__name__}{node2.id} exists "
+                    f"but int link in other direction does not. "
+                )
+
+    def enableNodeLinkCDC(
+        self,
+        node1: BaseChipletSystem,
+        node2: BaseChipletSystem,
+        enable_node_1: bool = True,
+        enable_node_2: bool = True,
+    ):
+        """
+        Enable the clock domain crossing units on either end of
+        the links between the two specified nodes (`ChipletSystem`s
+        or `Chiplet`s) *which are children of this `ChipletSystem`.*
+
+        Args:
+            node1 (BaseChipletSystem): One node.
+            node2 (BaseChipletSystem): The other node.
+            enable_node_1 (bool):
+                Whether to enable CDC on node 1. Defaults to True.
+            enable_node_2 (bool):
+                Whether to enable CDC on node 2. Defaults to True.
+        """
+        (l12, l21) = self._getNodeLinks(node1, node2)
+
+        if l12 is None and l21 is None:
+            warn(
+                f"int links between {node1.__class__.__name__}{node1.id} "
+                f"and {node2.__class__.__name__}{node2.id} do not exist!"
+            )
+            return
+
+        if l12 is not None:
+            if enable_node_1:
+                l12.src_cdc = True
+            if enable_node_2:
+                l12.dst_cdc = True
+
+            if l21 is None:
+                warn(
+                    f"int link from {node1.__class__.__name__}{node1.id} "
+                    f"to {node2.__class__.__name__}{node2.id} exists "
+                    f"but int link in other direction does not. "
+                )
+
+        if l21 is not None:
+            if enable_node_2:
+                l21.src_cdc = True
+            if enable_node_1:
+                l21.dst_cdc = True
+
+            if l12 is None:
+                warn(
+                    f"int link from {node1.__class__.__name__}{node1.id} "
+                    f"to {node2.__class__.__name__}{node2.id} exists "
+                    f"but int link in other direction does not. "
+                )
+
+    def setNodeLinkFlitWidth(
+        self,
+        node1: BaseChipletSystem,
+        node2: BaseChipletSystem,
+        width: int,
+        set_width_link_1_to_2: bool = True,
+        set_width_link_2_to_1: bool = True,
+    ):
+        """
+        Adjust flit size (width) of the links between the two specified
+        nodes (`ChipletSystem`s or `Chiplet`s) *which are children of
+        this `ChipletSystem`.*
+
+        Note that since internal links are unidirectional, the user has
+        the option to change the flit size for only one of the links
+        (i.e., only for traffic from node1 to node2, or vice versa)
+        by setting the set_width_link_1_to_2 (or ...2_to_1) flags.
+
+        By default, both unidirectional links comprising the connection
+        between node1 and node2 will have their width/flit size changed.
+
+        Args:
+            node1 (BaseChipletSystem): _description_
+            node2 (BaseChipletSystem): _description_
+            width (int): The flit width to set on the link.
+            set_width_link_1_to_2 (bool, optional):
+                Whether to set the width of the unidirectional
+                internal link from node1 to node2.
+                Defaults to True.
+            set_width_link_2_to_1 (bool, optional):
+                Whether to set the width of the unidirectional
+                internal link from node2 to node1.
+                Defaults to True.
+        """
+        (l12, l21) = self._getNodeLinks(node1, node2)
+
+        if l12 is None and l21 is None:
+            warn(
+                f"int links between {node1.__class__.__name__}{node1.id} "
+                f"and {node2.__class__.__name__}{node2.id} do not exist!"
+            )
+            return
+
+        if l12 is not None:
+            if set_width_link_1_to_2:
+                l12.width = width
+
+            if l21 is None:
+                warn(
+                    f"int link from {node1.__class__.__name__}{node1.id} "
+                    f"to {node2.__class__.__name__}{node2.id} exists "
+                    f"but int link in other direction does not. "
+                )
+
+        if l21 is not None:
+            if set_width_link_2_to_1:
+                l21.width = width
+
+            if l12 is None:
+                warn(
+                    f"int link from {node1.__class__.__name__}{node1.id} "
+                    f"to {node2.__class__.__name__}{node2.id} exists "
+                    f"but int link in other direction does not. "
+                )
+
+    # *
+    # * Deprecated
+    # *
 
     def _defineMainRouterParams(self):
         """
@@ -612,6 +1006,7 @@ class BaseChipletSystem(SubSystem):
         defined for `_main_router`, probably because it was instantiated
         seperately. Should just nee to be called before `m5.instantiate()`.
         """
+        assert isinstance(self._garnet_network, GarnetNetwork)
         # gem5 will complain if params aren't defined for main router
         mr = self._main_router
         gn = self._garnet_network
@@ -624,6 +1019,12 @@ class BaseChipletSystem(SubSystem):
         # mr.eventq_index = gn.eventq_index
 
     def _fixAllGarnetObjectParams(self):
+
+        import traceback
+
+        fatal(f"do not use this function! tb: {traceback.print_stack()}")
+
+        assert isinstance(self._garnet_network, GarnetNetwork)
 
         def _recursiveUnproxyParams(sim_obj, set_clk_domain=False):
             if len(sim_obj) > 1:
@@ -690,6 +1091,9 @@ class BaseChipletSystem(SubSystem):
         creates connections between the main routers of the current
         level of the hierarchy and its parents/siblings.
         """
+        import traceback
+
+        fatal(f"do not use this function! tb: {traceback.print_stack()}")
         # topologies tend to overwrite garnet links/routers entirely
         # so just create our links (and add our main router) afterwards
         num_routers = len(self._garnet_network.routers)
@@ -720,6 +1124,9 @@ class BaseChipletSystem(SubSystem):
     def _mergeGarnetNetworks(
         self, merge_into: GarnetNetwork, merge_from: GarnetNetwork
     ):
+        import traceback
+
+        fatal(f"do not use this function! tb: {traceback.print_stack()}")
         mi_router_ct = len(merge_into.routers)
         mi_link_ct = len(merge_into.int_links) + len(merge_into.ext_links)
         for r in merge_from.routers:
@@ -728,21 +1135,21 @@ class BaseChipletSystem(SubSystem):
             merge_into.routers.append(r)
             mi_router_ct += 1
 
-        # merge_from.routers = []
+        merge_from.routers = []
 
         for el in merge_from.ext_links:
             el.link_id = mi_link_ct
             merge_into.ext_links.append(el)
             mi_link_ct += 1
 
-        # merge_from.ext_links = []
+        merge_from.ext_links = []
 
         for il in merge_from.int_links:
             il.link_id = mi_link_ct
             merge_into.int_links.append(il)
             mi_link_ct += 1
 
-        # merge_from.int_links = []
+        merge_from.int_links = []
 
     def _combineHierarchyGarnetNetworks(self, merge_into: GarnetNetwork):
         """
@@ -755,8 +1162,13 @@ class BaseChipletSystem(SubSystem):
                 the `GarnetNetwork` of the root `ChipletSystem`, so that
                 recursive calls continue merging properly.
         """
+        import traceback
+
+        fatal(f"do not use this function! tb: {traceback.print_stack()}")
+
         for n in self._nodes:
             if hasattr(n, "_garnet_network"):
+                assert isinstance(n._garnet_network, GarnetNetwork)
                 self._mergeGarnetNetworks(merge_into, n._garnet_network)
             if hasattr(n, "_nodes"):
                 n._combineHierarchyGarnetNetworks(merge_into)

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Self,
+    Sequence,
+    Type,
+)
+
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.util import (
+    addToPath,
+    fatal,
+)
+
+if TYPE_CHECKING:
+    # below import only used to type check BaseChipletSystem.parent
+    from chiplets.ChipletSystem import ChipletSystem
+
+    from src.sim.System import System
+    from src.sim.SubSystem import SubSystem
+    from src.mem.AbstractMemory import AbstractMemory
+    from src.mem.ruby.network.garnet.GarnetLink import *
+    from src.mem.ruby.network.garnet.GarnetNetwork import *
+
+from abc import ABC
+
+from topologies.BaseTopology import BaseTopology
+
+
+class BaseChipletSystem(ABC):
+    """
+    See ChipletSystem and Chiplet. BaseChipletSystem acts
+    as a vessel for shared functionality between the two.
+    Do not instantiate directly; instead use a subclass.
+    """
+
+    # TODO: should probably inherit SubSystem to prevent issues...
+    # TODO: ...with (homogeneous) hierarchies
+
+    # ruby/cache coherence protocol string
+    protocol: str
+
+    # the gem5 `System` SimObject that this object is part of
+    system: System
+
+    # topology class. used internally to create the topology.
+    # Ruby.py currently requires a name (string) to be specified
+    # to create the topology, instead of a class.
+    # Since Ruby.py may be deprecated, we use a class to enable
+    # easier refactoring later on if needed.
+    _topology_cls: type[BaseTopology]
+
+    _memory_cls: type[AbstractMemory]
+
+    # list of *direct* nodes/children (ChipletSystems or Chiplets)
+    nodes: list[BaseChipletSystem]
+
+    # default latency (in cycles) of the links between nodes
+    # for this layer of abstraction (i.e., direct child nodes)
+    default_inter_node_link_lat: int
+
+    # same as above, but for the routers corresponding to the links
+    default_inter_node_router_lat: int
+
+    # parent ChipletSystem (if present)
+    parent: ChipletSystem | None
+
+    # list of nodes on the same hierarchical level of this node's parent
+    # ChipletSystem to which this node has *direct* connections
+    connected_nodes: list[BaseChipletSystem]
+
+    def __init__(
+        self,
+        system: System,
+        TopologyClass: type[BaseTopology],
+        MemoryClass: type[AbstractMemory],
+        nodes: Sequence[BaseChipletSystem],
+        inter_node_link_lat: int,
+        inter_node_router_lat: int,
+    ):
+        """
+        Create a `BaseChipletSystem`.
+        This should only be invoked by the constructors of
+        `ChipletSystem`, `Chiplet`, or other subclasses.
+
+        Args:
+            system (System):
+                The gem5 `System` SimObject that this `BaseChipletSystem`
+                is part of.
+            TopologyClass (Type[BaseTopology]):
+                The class, derived from `BaseTopology`, corresponding
+                to the topology to be used in this `ChipletSystem`.
+                Only the root `ChipletSystem` needs to specify this.
+            MemoryClass (Type[AbstractMemory]):
+                The class corresponding to the memory configuration
+                for the gem5 `System` this `ChipletSystem` is part of.
+            nodes (list[BaseChipletSystem]):
+                Optional list of nodes. May be passed to constructor
+                or added separately using `addNode()`.
+            inter_node_link_lat (int):
+                The default latency (in cycles) of the links between
+                nodes for this layer of abstraction.
+            inter_node_router_lat (int):
+                The default latency (in cycles) of the routers
+                corresponding to the the links between nodes
+                for this layer of abstraction.
+        """
+        # SubSystem.__init__(self)
+
+        self.protocol = buildEnv["PROTOCOL"]
+
+        self.nodes = list(nodes)
+
+        self.system = system
+
+        self._topology_cls = TopologyClass
+        self._memory_cls = MemoryClass
+
+        self.default_inter_node_link_lat = inter_node_link_lat
+        self.default_inter_node_router_lat = inter_node_router_lat
+        self.connected_nodes = []
+
+    def addNode(
+        self,
+    ):
+        """
+        Add a node/child to this Chiplet(System)
+        """
+
+        # todo: implement
+        raise NotImplementedError
+
+    def getRoot(self):
+        """
+        Retrieve a reference to the root `ChipletSystem`,
+        i.e., the `ChipletSystem` at the top of the hierarchy.
+        """
+
+        if self.parent == None:
+            return self
+        else:
+            return self.parent.getRoot()
+
+    def getIntLink(
+        self, node1: BaseChipletSystem, node2: BaseChipletSystem
+    ) -> GarnetIntLink | None:
+        """
+        Retrieve the Garnet link object, if one exists, between the two
+        specified nodes (which must be children of this Chiplet[System]).
+        Note that the Chiplet[System] abstracts the GarnetIntLink,
+        since an actual GarnetIntLink is between two routers, not two
+        Chiplet[System]s directly.
+
+        Args:
+            node1 (BaseChipletSystem): One end of the link.
+            node2 (BaseChipletSystem): The other end of the link.
+        """
+
+        if (
+            (len(self.nodes) == 0)
+            or node1 not in self.nodes
+            or node2 not in self.nodes
+        ):
+            # no nodes, or one or both nodes are not children of `self`
+            return None
+
+        # todo: get the GarnetIntLink
+
+        return None
+
+    def connect(self, node: BaseChipletSystem):
+        """
+        Register a connection between this `ChipletSystem` or `Chiplet`
+        and another `ChipletSystem` or `Chiplet` sharing the same parent.
+
+        Args:
+            node (BaseChipletSystem): The node to connect to.
+        """
+
+        if self.parent is None:
+            fatal(
+                "This BaseChipletSystem has no parent, "
+                "but the user attempted to connect it "
+                "to another BaseChipletSystem sharing "
+                "the same parent."
+            )
+
+        if self.parent != node.parent:
+            fatal(
+                "User attempted to connect two BaseChipletSystems "
+                "that do not share a parent ChipletSystem."
+            )
+
+        if node not in self.connected_nodes:
+            self.connected_nodes.append(node)
+
+        if self not in node.connected_nodes:
+            node.connected_nodes.append(self)
+
+        # ? instantiate a GarnetLink if one is not already present?
+
+    def connectChildren(
+        self, node1: BaseChipletSystem, node2: BaseChipletSystem
+    ):
+        """
+        Register a connection between two specified `ChipletSystem`s
+        or `Chiplet`s *which are children of this `ChipletSystem`.*
+
+        Args:
+            node1 (BaseChipletSystem): The node to connect from.
+            node2 (BaseChipletSystem): The node to connect to.
+        """
+
+        node1.connect(node2)

--- a/configs/chiplets/BaseChipletSystem.py
+++ b/configs/chiplets/BaseChipletSystem.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from src.cpu.BaseCPU import BaseCPU
     from src.sim.System import System
     from src.sim.SubSystem import SubSystem
+    from src.sim.ClockDomain import ClockDomain
     from src.mem.ruby.system.RubySystem import RubySystem
     from src.mem.AbstractMemory import AbstractMemory
     from src.mem.ruby.slicc_interface.Controller import RubyController
@@ -76,7 +77,7 @@ class BaseChipletSystem(SubSystem):
     id = Param.Int("ID in relation to other Chiplet[System]s")
 
     # ruby/cache coherence protocol string
-    protocol = Param.String("String name corresponding to Ruby protocol")
+    protocol = Param.String("String name corresponding to the Ruby protocol")
 
     # *
     # * Latency parameters
@@ -85,14 +86,49 @@ class BaseChipletSystem(SubSystem):
     # default latency (in cycles) of the links between nodes
     # for this layer of abstraction (i.e., direct child nodes)
     default_inter_node_link_lat = Param.Int(
-        "default latency (in cycles) of the links between nodes "
-        "in this level of the hierarchy"
+        "Default latency (in cycles) of the links between nodes "
+        "in this level of the hierarchy."
     )
 
-    # same as above, but for the routers corresponding to the links
-    default_inter_node_router_lat = Param.Int(
-        "default latency (in cycles) of the routers corresponding to "
-        "the links between nodes in this level of the hierarchy"
+    # same as above, but for links within a ChipletSystem that
+    # aren't from one child node to another
+    default_intra_node_link_lat = Param.Int(
+        "Default latency (in cycles) of the routers corresponding to "
+        "the links between routers *within one node* in this level of "
+        "the hierarchy."
+    )
+
+    # same as default_inter_node_link_lat,
+    # but for the routers corresponding to the links
+    default_node_main_router_lat = Param.Int(
+        "Default latency (in cycles) of the routers corresponding to "
+        "the links between nodes in this level of the hierarchy."
+    )
+
+    default_cache_controller_link_lat = Param.Int(
+        "Default latency (in cycles) of the links between "
+        "each cache controller and its corresponding router. "
+        "(*not* between that router and the main router of this "
+        "`ChipletSystem`). Defaults to `default_inter_node_link_lat`."
+    )
+
+    default_cache_controller_router_lat = Param.Int(
+        "The default latency (in cycles) of the router "
+        "corresponding to each cache controller. "
+        "Defaults to `default_node_main_router_lat`."
+    )
+
+    default_dir_controller_link_lat = Param.Int(
+        "Default latency (in cycles) of the links between "
+        "each directory controller and its corresponding router "
+        "(*not* between that router and the main router of this "
+        "`ChipletSystem`). Defaults to `default_inter_node_link_lat`."
+    )
+
+    default_dir_controller_router_lat = Param.Int(
+        "The default latency (in cycles) of the router "
+        "corresponding to each dir controller. "
+        "Defaults to `default_node_main_router_lat`."
     )
 
     # *
@@ -143,32 +179,33 @@ class BaseChipletSystem(SubSystem):
     _parent_link: tuple[GarnetIntLink, GarnetIntLink]
 
     # list of Garnet link pairs for siblings
+    # corresponds to `_connected_nodes`, which holds the relevant node refs
     _sibling_links: list[tuple[GarnetIntLink, GarnetIntLink]]
 
     # `GarnetNetwork` for this object
     # ! will always be fake except for root after `createSystem()` is done
     _garnet_network: GarnetNetwork | FakeGarnetNetwork
 
-    # `RubyController`s that correspond to this `Chiplet[System]`
-    # includes all controllers used to create the topology
-    _ruby_controllers: list[RubyController]
-
-    # `GarnetExtLink`s that connect this object to parent `RubyController`s
-    _ruby_controller_links: list[GarnetExtLink]
-    # _ruby_controller_router_map: list[tuple[RubyController, GarnetRouter]]
+    # `RubyController`s corresponding to the topology of this
+    # `Chiplet[System]` specifically. in other words, this
+    # includes all controllers used to generate the core topology via
+    # `_createTopology()`. However, it may not include *all* controllers
+    # present in this `Chiplet[System]` depending on the parameters
+    # specified when calling `createSystem()`.
+    _topology_controllers: list[RubyController]
 
     # directory controllers in this `Chiplet[System]`
     # these are returned by `create_system()` of the Ruby protocol
     _dir_controllers: list[RubyController]
-    # _dir_controller_link_map: list[tuple[RubyController, GarnetExtLink]]
-    # _dir_controller_router_map: list[tuple[RubyController, GarnetRouter]]
 
     # controllers that are not directory controllers
     # e.g., LLC controller
-    _non_dir_controllers: list[RubyController]
+    # does not include *all* cache controllers in the system
+    _cache_controllers: list[RubyController]
 
     # Ruby CPU sequencers for this `Chiplet[System]`
     # includes sequencers for all CPUs
+    # should only be populated at the root
     _cpu_sequencers: list[RubySequencer]
 
     # *
@@ -207,7 +244,12 @@ class BaseChipletSystem(SubSystem):
         MemoryClass: type[AbstractMemory],
         nodes: Sequence[BaseChipletSystem] | Sequence[BaseCPU],
         inter_node_link_lat: int,
-        inter_node_router_lat: int,
+        intra_node_link_lat: int,
+        node_main_router_lat: int,
+        cache_controller_link_lat: int,
+        cache_controller_router_lat: int,
+        dir_controller_link_lat: int,
+        dir_controller_router_lat: int,
     ):
         """
         Create a `BaseChipletSystem`.
@@ -222,8 +264,8 @@ class BaseChipletSystem(SubSystem):
                 If gem5 is running in full-system simulation mode.
             TopologyClass (Type[BaseTopology]):
                 The class, derived from `BaseTopology`, corresponding
-                to the topology to be used in this `ChipletSystem`.
-                Only the root `ChipletSystem` needs to specify this.
+                to the topology to be used in this level of the
+                `ChipletSystem` hierarchy.
             MemoryClass (Type[AbstractMemory]):
                 The class corresponding to the memory configuration
                 for the gem5 `System` this `ChipletSystem` is part of.
@@ -233,10 +275,32 @@ class BaseChipletSystem(SubSystem):
             inter_node_link_lat (int):
                 The default latency (in cycles) of the links between
                 nodes for this layer of abstraction.
-            inter_node_router_lat (int):
-                The default latency (in cycles) of the routers
+            intra_node_link_lat (int):
+                The default latency (in cycles) of the links between
+                each routers in the same level of the hierarchy;
+                e.g., between the main router and the router corresponding
+                to a directory controller or cache controller.
+            node_main_router_lat (int):
+                The default latency (in cycles) of the main router
+                for this `Chiplet[System]`. This is also the router
                 corresponding to the the links between nodes
                 for this layer of abstraction.
+            cache_controller_link_lat (int, optional):
+                The default latency (in cycles) of the links between
+                each cache controller and its corresponding router.
+                Defaults to `inter_node_link_lat`.
+            cache_controller_router_lat (int, optional):
+                The default latency (in cycles) of the router
+                corresponding to each cache controller.
+                Defaults to `node_main_router_lat`.
+            dir_controller_link_lat (int, optional):
+                The default latency (in cycles) of the links between
+                each directory controller and its corresponding router.
+                Defaults to `inter_node_link_lat`.
+            dir_controller_router_lat (int, optional):
+                The default latency (in cycles) of the router
+                corresponding to each directory controller.
+                Defaults to `node_main_router_lat`.
         """
         super().__init__()
 
@@ -253,12 +317,34 @@ class BaseChipletSystem(SubSystem):
         self._topology = None  # created in `createSystem()`
 
         self.default_inter_node_link_lat = inter_node_link_lat
-        self.default_inter_node_router_lat = inter_node_router_lat
+        self.default_intra_node_link_lat = intra_node_link_lat
+        self.default_node_main_router_lat = node_main_router_lat
+
+        if cache_controller_link_lat == -1:
+            self.default_cache_controller_link_lat = (
+                self.default_inter_node_link_lat
+            )
+
+        if cache_controller_router_lat == -1:
+            self.default_cache_controller_router_lat = (
+                self.default_node_main_router_lat
+            )
+
+        if dir_controller_link_lat == -1:
+            self.default_dir_controller_link_lat = (
+                self.default_inter_node_link_lat
+            )
+
+        if dir_controller_router_lat == -1:
+            self.default_dir_controller_router_lat = (
+                self.default_node_main_router_lat
+            )
+
         self._connected_nodes = []
 
         self._main_router = GarnetRouter(
             router_id=0,  # some hijinks occur with this later
-            latency=self.default_inter_node_router_lat,
+            latency=self.default_node_main_router_lat,
             # the following are default parameters
             # gem5 complains if I don't include these params
             vcs_per_vnet=4,
@@ -266,15 +352,9 @@ class BaseChipletSystem(SubSystem):
 
         self._sibling_links = []
 
-        self._ruby_controllers = []
-        self._ruby_controller_links = []
-        # self._ruby_controller_router_map = []
-
+        self._topology_controllers = []
         self._dir_controllers = []
-        # self._dir_controller_link_map = []
-        # self._dir_controller_router_map = []
-
-        self._non_dir_controllers = []
+        self._cache_controllers = []
 
         self.id = BaseChipletSystem._generate_id()
 
@@ -368,6 +448,11 @@ class BaseChipletSystem(SubSystem):
 
         return str
 
+    @classmethod
+    def recursivelyPrintClockDomains(cls, base):
+        print(f"Starting clock domain traversal from {base}.")
+        cls._traverseClockDomains(base, True, False)
+
     def to_string(self):
         raise NotImplementedError
 
@@ -441,7 +526,7 @@ class BaseChipletSystem(SubSystem):
         Args:
             options (Namespace): _description_
             controllers (list[RubyController]):
-                This should usually be `self._ruby_controllers`.
+                This should usually be `self._topology_controllers`.
                 May or may not include the directory controllers
                 depending on what was passed to `createSystem()`.
         """
@@ -478,6 +563,17 @@ class BaseChipletSystem(SubSystem):
                 "user is calling methods in places they shouldn't be "
                 "called, or something is very broken."
             )
+
+        # assert options.network == "garnet"
+
+        # * set topology latencies
+        # the topology will configure router and link latencies based
+        # on `options`, so we have to set that here.
+        options.router_latency = self.default_node_main_router_lat
+        options.link_latency = self.default_intra_node_link_lat
+        # we don't really care what these values were because all
+        # our latency values are specified elsewhere,
+        # and we (probably) don't want them to be all uniform either.
 
         # * setup topology
         # latter 3 args are the literal classes for the
@@ -533,7 +629,7 @@ class BaseChipletSystem(SubSystem):
         gnw.routers += self._main_router
 
         for c in controllers:
-            r = self._findRouterFromController(c, False)
+            r = self._getRouterFromController(c, False)
             if r is not None:
                 print(f"    controller {c} :: router {r.router_id} {r}")
 
@@ -541,13 +637,13 @@ class BaseChipletSystem(SubSystem):
     # * Low-Level Network Connection/Instantiation Methods
     # *
 
-    def _findExtLinkFromController(
+    def _getExtLinkFromController(
         self,
         controller: RubyController,
         searchFromRoot: bool = True,
     ) -> GarnetExtLink | None:
         if searchFromRoot and not self.isRoot():
-            return self.getRoot()._findExtLinkFromController(controller, False)
+            return self.getRoot()._getExtLinkFromController(controller, False)
             # don't need to set searchFromRoot = False but why not
 
         ext_links = self._garnet_network.ext_links
@@ -557,25 +653,25 @@ class BaseChipletSystem(SubSystem):
 
         return None
 
-    def _findRouterFromController(
+    def _getRouterFromController(
         self,
         controller: RubyController,
         searchFromRoot: bool = True,
     ) -> GarnetRouter | None:
-        ext_link = self._findExtLinkFromController(controller, searchFromRoot)
+        ext_link = self._getExtLinkFromController(controller, searchFromRoot)
         if ext_link is not None:
             return ext_link.int_node
         else:
             return None
 
-    def _findIntLinkFromRouters(
+    def _getIntLinkFromRouters(
         self,
         routerFrom: GarnetRouter,
         routerTo: GarnetRouter,
         searchFromRoot: bool = True,
     ) -> GarnetIntLink | None:
         if searchFromRoot and not self.isRoot():
-            return self.getRoot()._findIntLinkFromRouters(
+            return self.getRoot()._getIntLinkFromRouters(
                 routerFrom, routerTo, False
             )
             # don't need to set searchFromRoot = False but why not
@@ -589,12 +685,57 @@ class BaseChipletSystem(SubSystem):
                 return int_link
         return None
 
+    def _getRoutersFromIntLink(
+        self, int_link: GarnetIntLink
+    ) -> tuple[GarnetRouter | None, GarnetRouter | None]:
+        if int_link is None:
+            return (None, None)
+
+        return int_link.src_node, int_link.dst_node
+
+    def _setLinkLatency(
+        self,
+        link: GarnetIntLink | GarnetExtLink,
+        new_latency: int,
+    ):
+        """
+        Manually set the latency for a specific network link.
+        If using externally to `Chiplet[System]`, find the link
+        with `_getIntLinkFromRouters()` for internal links between
+        two routers, or `_getExtLinkFromController()` for external
+        links between a router and a `RubyController`.
+
+        Args:
+            link (GarnetIntLink | GarnetExtLink):
+                The link for which to set the latency.
+            new_latency (int): The new latency to set.
+        """
+        link.latency = new_latency
+
     def _biLinkGarnetRouters(
         self,
         router1: GarnetRouter,
         router2: GarnetRouter,
-        # auto_reg_parent: bool = True,
-    ):
+        link_latency: int = -1,
+    ) -> tuple[GarnetIntLink | None, GarnetIntLink | None]:
+        """
+        Create internal links (`GarnetIntLink`s) between two specified
+        routers in a `GarnetNetwork` (can be a `FakeGarnetNetwork`).
+
+        Args:
+            router1 (GarnetRouter): The first router to link.
+            router2 (GarnetRouter): The second router to link.
+            link_latency (int, optional):
+                The link latency.
+                Defaults to `self.default_inter_node_link_lat`.
+
+        Returns:
+            tuple[GarnetIntLink | None, GarnetIntLink | None]:
+                the internal links, if successfully created.
+        """
+        if link_latency == -1:
+            link_latency = self.default_inter_node_link_lat
+
         num_links = len(self._garnet_network.int_links) + len(
             self._garnet_network.ext_links
         )
@@ -606,14 +747,14 @@ class BaseChipletSystem(SubSystem):
             link_id=num_links,
             src_node=router1,
             dst_node=router2,
-            latency=self.default_inter_node_link_lat,
+            latency=link_latency,
         )
 
         l21 = GarnetIntLink(
             link_id=num_links + 1,
             src_node=router2,
             dst_node=router1,
-            latency=self.default_inter_node_link_lat,
+            latency=link_latency,
         )
 
         # self._garnet_network.int_links.append(l12)
@@ -621,29 +762,14 @@ class BaseChipletSystem(SubSystem):
         self._garnet_network.int_links += l12
         self._garnet_network.int_links += l21
 
-        # TODO NEW HIERARCHY: remove this
-        # if auto_reg_parent:
-        #     l12.set_parent(self._garnet_network, f"int_links{num_links}")
-        #     l21.set_parent(self._garnet_network, f"int_links{num_links + 1}")
-
         return l12, l21
 
-    def _connectParentGarnet(self, copy_links_to_parent: bool = True):
+    def _connectParentGarnet(self):
+        warn("It is recommended to connect from parent instead of child.")
         if hasattr(self, "_parent_sys") and self._parent_sys is not None:
             self._parent_link = self._biLinkGarnetRouters(
                 self._main_router, self._parent_sys._main_router
             )
-            # if copy_links_to_parent:
-            #     pgn = self.parent._garnet_network
-            #     pgn.int_links.append(self._parent_link[0])
-            #     pgn.int_links.append(self._parent_link[1])
-
-    def _connectSiblingGarnet(self, sibl: BaseChipletSystem):
-        warn("This may cause unexpected behavior.")
-        l_to, l_from = self._biLinkGarnetRouters(
-            self._main_router, sibl._main_router
-        )
-        self._sibling_links.append((l_to, l_from))
 
     def _connectChildrenGarnet(
         self, node1: BaseChipletSystem, node2: BaseChipletSystem
@@ -667,8 +793,7 @@ class BaseChipletSystem(SubSystem):
         ctrl: RubyController,
         router: GarnetRouter | None = None,
         link_lat: int = -1,
-        auto_reg_parent: bool = True,
-    ):
+    ) -> GarnetExtLink:
         """
         Creates and registers a `GarnetExtLink` between the specified
         `RubyController` object and the specified `GarnetRouter`
@@ -681,17 +806,13 @@ class BaseChipletSystem(SubSystem):
             router (GarnetRouter, optional):
                 The `GarnetRouter` to link the controller to.
                 This is the internal node of the resulting `GarnetExtLink`.
-                Defaults to None, which results in using the main router.
+                Defaults to the main router.
                 Usually this should be specified only when creating a link
                 to a directory controller, which does things differently.
             link_lat (int, optional):
                 The link latency for the resulting `GarnetExtLink`.
                 Defaults to -1, which results in using the default link
                 latency stored in this `Chiplet[System]`.
-            auto_reg_parent (bool, optional):
-                Whether to automatically register the parent of the
-                resultant `GarnetExtLink`. Defaults to `True`, and usually
-                it should be left that way.
 
         Returns:
             GarnetExtLink:
@@ -722,15 +843,6 @@ class BaseChipletSystem(SubSystem):
 
         self._garnet_network.ext_links += link
 
-        # TODO NEW HIERARCHY: remove this
-        # if self.isDirController(ctrl):
-        #     self._dir_controller_link_map.append(link)
-        # else:
-        #     self._ruby_controller_links.append(link)
-
-        # TODO NEW HIERARCHY: remove this
-        # if auto_reg_parent:
-        #     link.set_parent(self._garnet_network, f"ext_links{num_links}")
         return link
 
     def _getNodeLinks(
@@ -766,8 +878,8 @@ class BaseChipletSystem(SubSystem):
         n1r = node1._main_router
         n2r = node2._main_router
 
-        l12 = self._findIntLinkFromRouters(n1r, n2r)
-        l21 = self._findIntLinkFromRouters(n2r, n1r)
+        l12 = self._getIntLinkFromRouters(n1r, n2r)
+        l21 = self._getIntLinkFromRouters(n2r, n1r)
 
         return (l12, l21)
 
@@ -811,6 +923,14 @@ class BaseChipletSystem(SubSystem):
             node1 (BaseChipletSystem): The node to connect from.
             node2 (BaseChipletSystem): The node to connect to.
         """
+
+        if hasattr(self, "_created"):
+            if self._created:
+                warn(
+                    f"connectChildren() was called after createSystem()! "
+                    f"This may result in unexpected behavior! "
+                    f"Nodes: {node1}; {node2}"
+                )
 
         if node1 not in self._nodes:
             fatal(
@@ -986,14 +1106,14 @@ class BaseChipletSystem(SubSystem):
         Note that since internal links are unidirectional, the user has
         the option to change the flit size for only one of the links
         (i.e., only for traffic from node1 to node2, or vice versa)
-        by setting the set_width_link_1_to_2 (or ...2_to_1) flags.
+        by setting the `set_width_link_1_to_2` (or `...2_to_1`) flags.
 
         By default, both unidirectional links comprising the connection
         between node1 and node2 will have their width/flit size changed.
 
         Args:
-            node1 (BaseChipletSystem): _description_
-            node2 (BaseChipletSystem): _description_
+            node1 (BaseChipletSystem): One node.
+            node2 (BaseChipletSystem): The other node.
             width (int): The flit width to set on the link.
             set_width_link_1_to_2 (bool, optional):
                 Whether to set the width of the unidirectional
@@ -1035,179 +1155,286 @@ class BaseChipletSystem(SubSystem):
                     f"but int link in other direction does not. "
                 )
 
-    # *
-    # * Deprecated
-    # *
-
-    def _defineMainRouterParams(self):
-        """
-        For some reason gem5 hates it when these aren't automatically
-        defined for `_main_router`, probably because it was instantiated
-        seperately. Should just nee to be called before `m5.instantiate()`.
-        """
-        assert isinstance(self._garnet_network, GarnetNetwork)
-        # gem5 will complain if params aren't defined for main router
-        mr = self._main_router
-        gn = self._garnet_network
-        if int(mr.router_id) == -1:
-            num_routers = len(self._garnet_network.routers)
-            mr.router_id = num_routers - 1
-        mr.vcs_per_vnet = gn.vcs_per_vnet
-        # mr.virt_nets = self._garnet_network.number_of_virtual_networks
-        # mr.ni_flit_size = gn.ni_flit_size
-        # mr.eventq_index = gn.eventq_index
-
-    def _fixAllGarnetObjectParams(self):
-
-        import traceback
-
-        fatal(f"do not use this function! tb: {traceback.print_stack()}")
-
-        assert isinstance(self._garnet_network, GarnetNetwork)
-
-        def _recursiveUnproxyParams(sim_obj, set_clk_domain=False):
-            if len(sim_obj) > 1:
-                for i, obj in enumerate(sim_obj):
-                    _recursiveUnproxyParams(obj, set_clk_domain)
-                return
-            if not isSimObject(sim_obj):
-                warn(f"{sim_obj} is not a SimObject.")
-                return
-            if set_clk_domain:
-                if hasattr(sim_obj, "clk_domain"):
-                    # warn(f"setting clock domain for {sim_obj}")
-                    sim_obj.clk_domain = self._system.clk_domain
-                # if hasattr(sim_obj, 'vcs_per_vnet'):
-                #     vcs = self._garnet_network.vcs_per_vnet
-                #     warn(f"setting vcs_per_vnet for {sim_obj} = {vcs}")
-                #     sim_obj.vcs_per_vnet = vcs
-            sim_obj.unproxyParams()
-            children = sim_obj._children.values()
-            for child in children:
-                _recursiveUnproxyParams(child, set_clk_domain)
-
-        # fix network params
-        if not hasattr(self._garnet_network, "number_of_virtual_networks"):
-            self._garnet_network.number_of_virtual_networks = (
-                self._system.ruby.network.number_of_virtual_networks
-            )
-
-        # fix router params
-        for r in self._garnet_network.routers:
-            # print(f"setting clk_domain for {r}")
-            r.clk_domain = self._system.clk_domain
-            # print(f"setting eqidx = 0 for {r}")
-            # default for all `SimObject`s should be 0
-            r.eventq_index = 0
-            r.power_state.eventq_index = r.eventq_index
-            r.unproxyParams()
-
-        # fix int link params
-        for il in self._garnet_network.int_links:
-            # il.clk_domain = self._system.clk_domain
-            il.eventq_index = 0
-            _recursiveUnproxyParams(il)
-            # il.unproxyParams()
-            # il_attrs = dir(il)
-            # for attr_str in il_attrs:
-            #     attr = getattr(il, attr)
-            #     if isSimObject(attr):
-            #         attr.unproxyParams()
-            # if hasattr(il, 'credit_link'):
-            #     il.credit_link.unproxyParams()
-            #     il.credit_link.power_state.unproxyParams()
-            # #     il.credit_link.clk_domain = self._system.clk_domain
-
-        # fix ext link params
-        for el in self._garnet_network.ext_links:
-            el.eventq_index = 0
-            _recursiveUnproxyParams(el, True)
-
-    def _connectHierarchyGarnet(self):
-        """
-        Should be called after `_createTopology()`.
-        Adds the main router to the `GarnetNetwork` list and
-        creates connections between the main routers of the current
-        level of the hierarchy and its parents/siblings.
-        """
-        import traceback
-
-        fatal(f"do not use this function! tb: {traceback.print_stack()}")
-        # topologies tend to overwrite garnet links/routers entirely
-        # so just create our links (and add our main router) afterwards
-        num_routers = len(self._garnet_network.routers)
-        if self._main_router.router_id == -1:
-            self._main_router.router_id = num_routers  # - 1
-        if self._main_router not in self._garnet_network.routers:
-            self._garnet_network.routers.append(self._main_router)
-        # self._garnet_network.mainrouter = self._main_router  # load bearing
-        self._connectParentGarnet()
-        if hasattr(self, "_parent_sys") and self._parent_sys is not None:
-            for node in self._parent_sys._nodes:
-                if node is not self:
-                    self._parent_sys.connectChildren(self, node)
-                    # self._connectSiblingGarnet(node)
-            # for rc in self._parent_sys._ruby_controllers:
-            #     self._connectRubyControllerGarnet(rc)
-        # setattr(
-        #     self._garnet_network,
-        #     f'mainrouterc{self.id}',
-        #     self._main_router
-        # )
-        # setattr(
-        #     self._garnet_network,
-        #     f'routers{self.id}',
-        #     self._main_router
-        # )
-
-    def _mergeGarnetNetworks(
-        self, merge_into: GarnetNetwork, merge_from: GarnetNetwork
+    def setNodeLatencies(
+        self,
+        node1: BaseChipletSystem,
+        node2: BaseChipletSystem,
+        link_latency: int = -1,
+        router_latency: int = -1,
+        set_lat_link_1_to_2: bool = True,
+        set_lat_link_2_to_1: bool = True,
+        set_lat_router_1: bool = True,
+        set_lat_router_2: bool = True,
     ):
-        import traceback
-
-        fatal(f"do not use this function! tb: {traceback.print_stack()}")
-        mi_router_ct = len(merge_into.routers)
-        mi_link_ct = len(merge_into.int_links) + len(merge_into.ext_links)
-        for r in merge_from.routers:
-            # ensure unique IDs in resulting network
-            r.router_id = mi_router_ct
-            merge_into.routers.append(r)
-            mi_router_ct += 1
-
-        merge_from.routers = []
-
-        for el in merge_from.ext_links:
-            el.link_id = mi_link_ct
-            merge_into.ext_links.append(el)
-            mi_link_ct += 1
-
-        merge_from.ext_links = []
-
-        for il in merge_from.int_links:
-            il.link_id = mi_link_ct
-            merge_into.int_links.append(il)
-            mi_link_ct += 1
-
-        merge_from.int_links = []
-
-    def _combineHierarchyGarnetNetworks(self, merge_into: GarnetNetwork):
         """
-        Call from parent `ChipletSystem` to combine all `GarnetNetwork`s
-        after topologies have been created.
+        Adjust latency of the links (and their routers) between the two
+        specified nodes (`ChipletSystem`s or `Chiplet`s) *which are
+        children of this `ChipletSystem`.*
+
+        Note that since internal links are unidirectional, the user has
+        the option to change the latencies for only one of the links
+        (i.e., only for traffic from node1 to node2, or vice versa)
+        by setting the `set_lat_link_1_to_2` (or `...2_to_1`) flags, and
+        similarly for the routers with set_lat_router_1 (or `..._2`).
 
         Args:
-            merge_into (GarnetNetwork):
-                The `GarnetNetwork` to merge into. This should always be
-                the `GarnetNetwork` of the root `ChipletSystem`, so that
-                recursive calls continue merging properly.
+            node1 (BaseChipletSystem): One node.
+            node2 (BaseChipletSystem): The other node.
+            link_latency (int):
+                The link latency to set.
+                If none is provided, it will not be set.
+            router_latency (int):
+                The router latency to set.
+                If none is provided, it will not be set.
+            set_lat_link_1_to_2 (bool, optional):
+                Whether to set the latency of the unidirectional
+                internal link from node1 to node2.
+                Defaults to True.
+            set_lat_link_2_to_1 (bool, optional):
+                Whether to set the latency of the unidirectional
+                internal link from node2 to node1.
+                Defaults to True.
+            set_lat_router_1 (bool, optional):
+                Whether to set the latency of the router on
+                node1's end of the internal links.
+                Defaults to True.
+            set_lat_router_2 (bool, optional):
+                Whether to set the latency of the router on
+                node2's end of the internal links.
+                Defaults to True.
         """
-        import traceback
+        (l12, l21) = self._getNodeLinks(node1, node2)
 
-        fatal(f"do not use this function! tb: {traceback.print_stack()}")
+        if l12 is None and l21 is None:
+            warn(
+                f"int links between {node1.__class__.__name__}{node1.id} "
+                f"and {node2.__class__.__name__}{node2.id} do not exist!"
+            )
+            return
 
-        for n in self._nodes:
-            if hasattr(n, "_garnet_network"):
-                assert isinstance(n._garnet_network, GarnetNetwork)
-                self._mergeGarnetNetworks(merge_into, n._garnet_network)
-            if hasattr(n, "_nodes"):
-                n._combineHierarchyGarnetNetworks(merge_into)
+        if link_latency != -1:
+            if l12 is not None:
+                if set_lat_link_1_to_2:
+                    l12.width = link_latency
+
+                if l21 is None:
+                    warn(
+                        f"int link "
+                        f"from {node1.__class__.__name__}{node1.id} "
+                        f"to {node2.__class__.__name__}{node2.id} exists "
+                        f"but int link in other direction does not. "
+                    )
+
+            if l21 is not None:
+                if set_lat_link_2_to_1:
+                    l21.width = link_latency
+
+                if l12 is None:
+                    warn(
+                        f"int link "
+                        f"from {node1.__class__.__name__}{node1.id} "
+                        f"to {node2.__class__.__name__}{node2.id} exists "
+                        f"but int link in other direction does not. "
+                    )
+
+        if router_latency != -1:
+            node1_router = None
+            node2_router = None
+            if l12 is not None:
+                node1_router, node2_router = self._getRoutersFromIntLink(l12)
+            elif l21 is not None:
+                node1_router, node2_router = self._getRoutersFromIntLink(l21)
+
+            if node1_router is None:
+                warn(
+                    f"main router for node1 may be missing! "
+                    f"latency not set for router belonging to "
+                    f"node {node1}"
+                )
+            elif set_lat_router_1:
+                node1_router.latency = router_latency
+
+            if node2_router is None:
+                warn(
+                    f"main router for node2 may be missing! "
+                    f"latency not set for router belonging to "
+                    f"node {node1}"
+                )
+            elif set_lat_router_2:
+                node2_router.latency = router_latency
+
+    @classmethod
+    def setClockDomain(
+        cls,
+        obj: BaseChipletSystem | BaseCPU | GarnetRouter | GarnetExtLink,
+        new_clk_domain: ClockDomain,
+        recursive: bool = False,
+        print_clk_domains: bool = False,
+    ):
+        """
+        Set the clock domain of the specified `SimObject` (typically a
+        `BaseChipletSystem`, CPU, or Garnet router/link).
+        Optionally, recursively traverse down `SimObject` hierarchy
+        starting at `obj`, setting a new (specified) clock domain
+        for any `SimObject` that has a clock domain.
+
+        Note that this is a class method, not an instance method.
+        This method does NOT automatically set the clock domain of the
+        `BaseChipletSystem` it is called on, or its children (although
+        this method should be called from the class, not any instance).
+        Instead, a base `SimObject` `obj` must be specified.
+
+        Args:
+            obj (BaseChipletSystem|BaseCPU|GarnetRouter|GarnetExtLink):
+                `SimObject` to set the clock domain of, or, if `recursive`,
+                to traverse from. Specified types are generally what
+                might be used. This method should be used alongside
+                `enableNodeLinkCDC()`, `_findExtLinkFromController()`,
+                `_getNodeLinks()`, and/or `_findRouterFromController()`,
+                as these methods will be needed to find `obj` and enable
+                the CDC units corresponding to the appropriate links.
+            new_clk_domain (ClockDomain):
+                Any clock domains found will be updated/set to
+                this new clock domain.
+            recursive (bool, optional):
+                Whether to recursively traverse the `SimObject` hierarchy
+                and explicitly set all child clock domains.
+                Generally this should be done if the clock domains are not
+                properly inherited (you can check this using the method
+                `recursivelyPrintClockDomains()`). Typically, `SimObject`s
+                should automatically inherit the clock domain of their
+                parent, so setting the parent object's clock domain should
+                be sufficient. Defaults to `False`.
+            print_clk_domains (bool, optional):
+                Whether to print the clock domain(s) *before* they are set.
+        """
+        if print_clk_domains:
+            print(f"Setting clock domain for {obj} to {new_clk_domain}.")
+        if hasattr(obj, "clk_domain"):
+            if print_clk_domains:
+                print(f"{obj} : {obj.clk_domain}")
+            if obj.clk_domain == new_clk_domain:
+                warn(
+                    f"The clock domain of {obj} is already set to "
+                    f"{new_clk_domain}!"
+                )
+            obj.clk_domain = new_clk_domain
+        elif hasattr(obj, "_clk_domain"):
+            if print_clk_domains:
+                print(f"{obj} : {obj._clk_domain}")
+            if obj._clk_domain == new_clk_domain:
+                warn(
+                    f"The clock domain of {obj} is already set to "
+                    f"{new_clk_domain}!"
+                )
+            obj._clk_domain = new_clk_domain
+        if recursive:
+            if print_clk_domains:
+                print(f"Starting clock domain traversal from {obj}.")
+            cls._traverseClockDomains(
+                obj, print_clk_domains, True, new_clk_domain
+            )
+
+    @classmethod
+    def _traverseClockDomains(
+        cls,
+        base: BaseChipletSystem | BaseCPU | GarnetRouter | GarnetExtLink,
+        print_clk_domains: bool = True,
+        set_clk_domains: bool = False,
+        new_clk_domain: ClockDomain | None = None,
+    ):
+        """
+        Recursively traverse down `SimObject` hierarchy starting at `base`.
+        Optionally print found clock domains or recursively set new ones.
+
+        Args:
+            base (BaseChipletSystem|BaseCPU|GarnetRouter|GarnetExtLink):
+                `SimObject` to traverse from. Specified types are generally
+                what might be used. This method should be used alongside
+                `enableNodeLinkCDC()`, `_findExtLinkFromController()`,
+                `_getNodeLinks()`, and/or `_findRouterFromController()`,
+                as these methods will be needed to find `base` and enable
+                the CDC units corresponding to the appropriate links.
+            print_clk_domains (bool, optional):
+                Whether to print the clock domains that are found during
+                traversal. Defaults to True. Note that if also setting
+                new clock domains, `m5.instantiate()` should probably be
+                called before checking the hierarchy.
+            set_clk_domains (bool, optional):
+                Whether to set the clock domains found during traversal
+                to `new_clk_domain`. Defaults to False. Has no effect
+                if `new_clk_domain` is unspecified (`None`).
+            new_clk_domain (ClockDomain, optional):
+                If `set` is `True`, any clock domains found will be updated
+                to this new clock domain. Defaults to None. Has no effect
+                if `set` is `False`.
+        """
+        if not print_clk_domains and not set_clk_domains:
+            warn(
+                f"_traverseClockDomains() was called, but no actions "
+                f"were specified (base = {base})."
+            )
+            return
+        if set_clk_domains is True and new_clk_domain is None:
+            warn(
+                f"_traverseClockDomains() was called, and "
+                f"`set_clock_domains` was set to True, but no "
+                f"clock domain was specified (base = {base})."
+            )
+            return
+
+        if hasattr(base, "clk_domain"):
+            if print_clk_domains:
+                print(f"{base} : {base.clk_domain}")
+            if set_clk_domains:
+                base.clk_domain = new_clk_domain
+        elif hasattr(base, "_clk_domain"):
+            if print_clk_domains:
+                print(f"{base} : {base._clk_domain}")
+            if set_clk_domains:
+                base._clk_domain = new_clk_domain
+
+        if isSimObject(base):
+            # * check for SimObject children
+            # print(f"{base} is SimObject")
+            for child in base._children.values():
+                #   print(f"   child: {child}")
+                cls._traverseClockDomains(
+                    child, print_clk_domains, set_clk_domains, new_clk_domain
+                )
+
+            # * check for `ChipletSystem` children
+            if hasattr(base, "_nodes"):
+                for node in base._nodes:
+                    # but don't print/set redundantly
+                    if node not in base._children.values():
+                        cls._traverseClockDomains(
+                            node,
+                            print_clk_domains,
+                            set_clk_domains,
+                            new_clk_domain,
+                        )
+        elif isSimObjectSequence(base):
+            # * handle lists of SimObjects
+            # print(f"{base} is SimObject Vector")
+            for obj in base:
+                if isinstance(obj, list):
+                    # list in a list
+                    # type checker seems to think this will happen
+                    # not sure about that
+                    for child in obj:
+                        cls._traverseClockDomains(
+                            child,
+                            print_clk_domains,
+                            set_clk_domains,
+                            new_clk_domain,
+                        )
+                else:  # not a list in a list
+                    for child in obj._children.values():
+                        # print(f"   child: {child}")
+                        cls._traverseClockDomains(
+                            child,
+                            print_clk_domains,
+                            set_clk_domains,
+                            new_clk_domain,
+                        )

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -7,13 +7,19 @@ from typing import (
     Type,
 )
 
-from chiplets.BaseChipletSystem import BaseChipletSystem
+from chiplets.BaseChipletSystem import (
+    BaseChipletSystem,
+    FakeGarnetNetwork,
+)
 from network.Network import init_network
 from topologies.BaseTopology import BaseTopology
 
 from m5.defines import buildEnv  # type: ignore
 from m5.objects import *
-from m5.util import panic
+from m5.util import (
+    fatal,
+    panic,
+)
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -52,28 +58,67 @@ class Chiplet(BaseChipletSystem):
             full_system=full_system,
             TopologyClass=TopologyClass,
             MemoryClass=MemoryClass,
-            nodes=cores,  #! note below
+            nodes=cores,
             inter_node_link_lat=inter_node_link_lat,
             inter_node_router_lat=inter_node_router_lat,
         )
-        # nodes=cores: this is a type issue, but it's okay for now because
-        # it will let other things that depend on `.nodes` work properly.
-        # todo: refactor this ^ better
 
-        self._cores = cores
+    # * alias Chiplet._cores to Chiplet._nodes
+    def get_cores(self):
+        return self._nodes
+
+    def set_cores(self, cores):
+        self._nodes = cores
+
+    _cores = property(get_cores, set_cores)
 
     def createChiplet(
         self,
         options: Namespace,
         l2_is_private: bool,
     ):
+        self._garnet_network = FakeGarnetNetwork()
+
+        root = self.getRoot()
+        if root == self:  # could use `self.isRoot()` but alr have `root`
+            panic("Chiplet is root, this should never happen!")
+
+        all_controllers = root._meta_topology.nodes  # type: ignore
+
+        for c in all_controllers:
+            controller_cpu = self.getControllerCPU(c, l2_is_private)
+
+            if controller_cpu is None:
+                continue
+            elif controller_cpu in self._cores:
+                self._ruby_controllers.append(c)
+                # print(
+                #     f"Chiplet {self.id} found controller {c} "
+                #     f"(v{c.version})"
+                # )
+
+        # TODO NEW HIERARCHY: revise/refactor to indicate that ...
+        # TODO ... it's more of generating routers/links than ...
+        # TODO ... actually creating a topology
+        #! create topology
+        # need to populate `self._ruby_controllers` first
+        self._createTopology(options, self._ruby_controllers)
+
+    def createChipletOld(
+        self,
+        options: Namespace,
+        l2_is_private: bool,
+    ):
+        import traceback
+
+        fatal(f"do not use this function! tb: {traceback.print_stack()}")
         # print(f"createChiplet() called for chiplet ID {self.id}")
 
         # todo: currently this is basically just duplicate code from...
         # todo: ...`ChipletSystem`, refactor somehow
         # Create the `GarnetNetwork` for this level of the hierarchy
         self._garnet_network = GarnetNetwork(
-            ruby_system=self._ruby_system,
+            ruby_system=self.getRoot()._ruby_system,
             topology=self._topology_cls.__name__,
             routers=[],
             ext_links=[],
@@ -110,7 +155,7 @@ class Chiplet(BaseChipletSystem):
 
         #! create topology
         # need to populate `self._ruby_controllers` first
-        self._createTopology(options)
+        self._createTopology(options, self._ruby_controllers)
 
         # self._defineMainRouterParams()
 

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -1,0 +1,45 @@
+from typing import (
+    TYPE_CHECKING,
+    Self,
+    Sequence,
+    Type,
+)
+
+from chiplets.BaseChipletSystem import BaseChipletSystem
+from chiplets.ChipletSystem import ChipletSystem
+from topologies.BaseTopology import BaseTopology
+
+from m5.defines import buildEnv
+from m5.objects import *
+
+if TYPE_CHECKING:
+    from src.mem.AbstractMemory import AbstractMemory
+    from src.sim.SubSystem import SubSystem
+    from src.sim.System import System
+
+
+class Chiplet(BaseChipletSystem):
+    """
+    A Chiplet denotes a node at the innermost level of a ChipletSystem.
+    A Chiplet does not have any child ChipletSystems; all of its children
+    are processor objects (cores) -- in other words, "leaf" nodes.
+    """
+
+    def __init__(
+        self,
+        system: System,
+        TopologyClass: Type[BaseTopology],
+        MemoryClass: Type[AbstractMemory],
+        inter_node_link_lat: int,
+        inter_node_router_lat: int,
+        nodes: list[BaseChipletSystem] = [],
+    ):
+        BaseChipletSystem.__init__(
+            self,
+            system=system,
+            TopologyClass=TopologyClass,
+            MemoryClass=MemoryClass,
+            nodes=nodes,
+            inter_node_link_lat=inter_node_link_lat,
+            inter_node_router_lat=inter_node_router_lat,
+        )

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Self,
@@ -6,13 +8,19 @@ from typing import (
 )
 
 from chiplets.BaseChipletSystem import BaseChipletSystem
+from network.Network import init_network
 from topologies.BaseTopology import BaseTopology
 
 from m5.defines import buildEnv  # type: ignore
 from m5.objects import *
 
 if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from src.cpu.BaseCPU import BaseCPU
     from src.mem.AbstractMemory import AbstractMemory
+    from src.mem.ruby.network.garnet.GarnetNetwork import *
+    from src.mem.ruby.system.RubySystem import RubySystem
     from src.sim.SubSystem import SubSystem
     from src.sim.System import System
 
@@ -28,11 +36,11 @@ class Chiplet(BaseChipletSystem):
         self,
         system: System,
         full_system: bool,
-        TopologyClass: Type[BaseTopology],
-        MemoryClass: Type[AbstractMemory],
+        TopologyClass: type[BaseTopology],
+        MemoryClass: type[AbstractMemory],
         inter_node_link_lat: int,
         inter_node_router_lat: int,
-        nodes: list[BaseChipletSystem] = [],
+        cores: Sequence[BaseCPU],
     ):
         BaseChipletSystem.__init__(
             self,
@@ -40,7 +48,88 @@ class Chiplet(BaseChipletSystem):
             full_system=full_system,
             TopologyClass=TopologyClass,
             MemoryClass=MemoryClass,
-            nodes=nodes,
+            nodes=cores,  #! note below
             inter_node_link_lat=inter_node_link_lat,
             inter_node_router_lat=inter_node_router_lat,
         )
+        # nodes=cores: this is a type issue, but it's okay for now because
+        # it will let other things that depend on `.nodes` work properly.
+        # todo: refactor this ^ better
+
+        self.cores = cores
+
+    def createChiplet(
+        self,
+        options: Namespace,
+        l2_is_private: bool,
+    ):
+        print(f"createChiplet() called for chiplet ID {self.id}")
+
+        # todo: currently this is basically just duplicate code from...
+        # todo: ...`ChipletSystem`, refactor somehow
+        # Create the `GarnetNetwork` for this level of the hierarchy
+        self._garnet_network = GarnetNetwork(
+            ruby_system=self._ruby_system,
+            topology=self._topology_cls.__name__,
+            routers=[],
+            ext_links=[],
+            int_links=[],
+            netifs=[],
+        )
+
+        root = self.getRoot()
+        all_controllers = root._meta_topology.nodes  # type: ignore
+
+        for c in all_controllers:
+            controller_cpu = self.getControllerCPU(c, l2_is_private)
+
+            if controller_cpu is None:
+                continue
+            elif controller_cpu in self.cores:
+                self._ruby_controllers.append(c)
+                print(
+                    f"Chiplet {self.id} found controller {c} "
+                    f"(v{c.version})"
+                )
+
+        #! create topology
+        # need to populate `self._ruby_controllers` first
+        self._createTopology(options)
+
+        self._connectHierarchyGarnet()
+
+        # * initialize network
+        # `Network.py` does this without any major obstacles to
+        # what we're doing in `ChipletSystem` as of now
+        #! effectively requires `.int_links` and `.ext_links` of
+        #! our `GarnetNetwork` to be set before this
+        # todo: we might have to adapt this so that we can add ...
+        # todo: ...links after calling `createSystem()`, not sure
+        options.network = "garnet"  # only required by `Network.py`
+        init_network(
+            options=options,
+            network=self._garnet_network,
+            InterfaceClass=GarnetNetworkInterface,
+        )
+
+        # self._defineMainRouterParams()
+
+    def to_string(self):
+        import textwrap
+
+        parent_id = "None"
+        if hasattr(self, "parent") and self.parent is not None:
+            parent_id = self.parent.id
+        return f"""{self.__class__.__name__} (ID: {self.id}) [
+            Parent ID: {parent_id}
+            Protocol: {self.protocol}
+            Topology: {self._topology_cls.__name__}
+            Connections (IDs): {[n.id for n in self.connected_nodes]}
+            Cores: [
+        {textwrap.indent(
+            "\n        ".join([f"{n}\n" for n in self.nodes]),
+            "        "
+        ).rstrip('\n')
+        }
+            ]:{self.id}c
+        ]:{self.id}"""

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -6,10 +6,9 @@ from typing import (
 )
 
 from chiplets.BaseChipletSystem import BaseChipletSystem
-from chiplets.ChipletSystem import ChipletSystem
 from topologies.BaseTopology import BaseTopology
 
-from m5.defines import buildEnv
+from m5.defines import buildEnv  # type: ignore
 from m5.objects import *
 
 if TYPE_CHECKING:
@@ -28,6 +27,7 @@ class Chiplet(BaseChipletSystem):
     def __init__(
         self,
         system: System,
+        full_system: bool,
         TopologyClass: Type[BaseTopology],
         MemoryClass: Type[AbstractMemory],
         inter_node_link_lat: int,
@@ -37,6 +37,7 @@ class Chiplet(BaseChipletSystem):
         BaseChipletSystem.__init__(
             self,
             system=system,
+            full_system=full_system,
             TopologyClass=TopologyClass,
             MemoryClass=MemoryClass,
             nodes=nodes,

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -13,6 +13,7 @@ from topologies.BaseTopology import BaseTopology
 
 from m5.defines import buildEnv  # type: ignore
 from m5.objects import *
+from m5.util import panic
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -32,6 +33,9 @@ class Chiplet(BaseChipletSystem):
     are processor objects (cores) -- in other words, "leaf" nodes.
     """
 
+    type = "Chiplet"
+    abstract = False
+
     def __init__(
         self,
         system: System,
@@ -42,8 +46,8 @@ class Chiplet(BaseChipletSystem):
         inter_node_router_lat: int,
         cores: Sequence[BaseCPU],
     ):
-        BaseChipletSystem.__init__(
-            self,
+        super().__init__(
+            # self,
             system=system,
             full_system=full_system,
             TopologyClass=TopologyClass,
@@ -56,14 +60,14 @@ class Chiplet(BaseChipletSystem):
         # it will let other things that depend on `.nodes` work properly.
         # todo: refactor this ^ better
 
-        self.cores = cores
+        self._cores = cores
 
     def createChiplet(
         self,
         options: Namespace,
         l2_is_private: bool,
     ):
-        print(f"createChiplet() called for chiplet ID {self.id}")
+        # print(f"createChiplet() called for chiplet ID {self.id}")
 
         # todo: currently this is basically just duplicate code from...
         # todo: ...`ChipletSystem`, refactor somehow
@@ -75,9 +79,21 @@ class Chiplet(BaseChipletSystem):
             ext_links=[],
             int_links=[],
             netifs=[],
+            ignore_mesh_chk=True,
         )
 
+        # set `SimObject` parent hierarchy
+        # make sure not to set root `GarnetNetwork` parent
+        # if we did, it would break Ruby because it expects
+        # the gem5 `System` to have a `.network` param
+        if not self._garnet_network.has_parent():
+            # print(f"setting gem5 parent for GarnetNetwork of "
+            #       f"Chiplet ID {self.id}")
+            self._garnet_network.set_parent(self, "network")
+
         root = self.getRoot()
+        if root == self:
+            panic("Chiplet is root, this should never happen!")
         all_controllers = root._meta_topology.nodes  # type: ignore
 
         for c in all_controllers:
@@ -85,16 +101,18 @@ class Chiplet(BaseChipletSystem):
 
             if controller_cpu is None:
                 continue
-            elif controller_cpu in self.cores:
+            elif controller_cpu in self._cores:
                 self._ruby_controllers.append(c)
-                print(
-                    f"Chiplet {self.id} found controller {c} "
-                    f"(v{c.version})"
-                )
+                # print(
+                #     f"Chiplet {self.id} found controller {c} "
+                #     f"(v{c.version})"
+                # )
 
         #! create topology
         # need to populate `self._ruby_controllers` first
         self._createTopology(options)
+
+        # self._defineMainRouterParams()
 
         self._connectHierarchyGarnet()
 
@@ -112,22 +130,32 @@ class Chiplet(BaseChipletSystem):
             InterfaceClass=GarnetNetworkInterface,
         )
 
+        self._fixAllGarnetObjectParams()
+
+        # if hasattr(self._garnet_network, "number_of_virtual_networks"):
+        #     print(f"Chiplet{self.id}'s GarnetNetwork has param "
+        #           f"number_of_virtual_networks = "
+        #           f"{self._garnet_network.number_of_virtual_networks}")
+        # else:
+        #     print(f"Chiplet{self.id}'s GarnetNetwork has NO param "
+        #           f"number_of_virtual_networks!")
+
         # self._defineMainRouterParams()
 
     def to_string(self):
         import textwrap
 
         parent_id = "None"
-        if hasattr(self, "parent") and self.parent is not None:
-            parent_id = self.parent.id
+        if hasattr(self, "_parent_sys") and self._parent_sys is not None:
+            parent_id = self._parent_sys.id
         return f"""{self.__class__.__name__} (ID: {self.id}) [
             Parent ID: {parent_id}
             Protocol: {self.protocol}
             Topology: {self._topology_cls.__name__}
-            Connections (IDs): {[n.id for n in self.connected_nodes]}
+            Connections (IDs): {[int(f"{n.id}") for n in self._connected_nodes]}
             Cores: [
         {textwrap.indent(
-            "\n        ".join([f"{n}\n" for n in self.nodes]),
+            "\n        ".join([f"{n}\n" for n in self._nodes]),
             "        "
         ).rstrip('\n')
         }

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -49,9 +49,63 @@ class Chiplet(BaseChipletSystem):
         TopologyClass: type[BaseTopology],
         MemoryClass: type[AbstractMemory],
         inter_node_link_lat: int,
-        inter_node_router_lat: int,
+        intra_node_link_lat: int,
+        node_main_router_lat: int,
         cores: Sequence[BaseCPU],
+        cache_controller_link_lat: int = -1,
+        cache_controller_router_lat: int = -1,
+        dir_controller_link_lat: int = -1,
+        dir_controller_router_lat: int = -1,
     ):
+        """
+        Instantiate a `Chiplet` object.
+
+        Args:
+            system (System):
+                The gem5 `System` SimObject that this `Chiplet`
+                is part of.
+            full_system (bool):
+                If gem5 is running in full-system simulation mode.
+            TopologyClass (Type[BaseTopology]):
+                The class, derived from `BaseTopology`, corresponding
+                to the topology to be used in this level of the
+                `ChipletSystem` hierarchy.
+            MemoryClass (Type[AbstractMemory]):
+                The class corresponding to the memory configuration
+                for the gem5 `System` this `ChipletSystem` is part of.
+            inter_node_link_lat (int):
+                The default latency (in cycles) of the links between
+                nodes for this layer of abstraction.
+            intra_node_link_lat (int):
+                The default latency (in cycles) of the links between
+                each routers in the same level of the hierarchy;
+                e.g., between the main router and the router corresponding
+                to a directory controller or cache controller.
+            node_main_router_lat (int):
+                The default latency (in cycles) of the main router
+                for this `Chiplet[System]`. This is also the router
+                corresponding to the the links between nodes
+                for this layer of abstraction.
+            nodes (Sequence[BaseChipletSystem]):
+                Optional list of nodes. May be passed to constructor
+                or added separately using `addNode()`.
+            cache_controller_link_lat (int, optional):
+                The default latency (in cycles) of the links between
+                each cache controller and its corresponding router.
+                Defaults to `inter_node_link_lat`.
+            cache_controller_router_lat (int, optional):
+                The default latency (in cycles) of the router
+                corresponding to each cache controller.
+                Defaults to `inter_node_router_lat`.
+            dir_controller_link_lat (int, optional):
+                The default latency (in cycles) of the links between
+                each directory controller and its corresponding router.
+                Defaults to `inter_node_link_lat`.
+            dir_controller_router_lat (int, optional):
+                The default latency (in cycles) of the router
+                corresponding to each directory controller.
+                Defaults to `inter_node_router_lat`.
+        """
         super().__init__(
             # self,
             system=system,
@@ -60,8 +114,15 @@ class Chiplet(BaseChipletSystem):
             MemoryClass=MemoryClass,
             nodes=cores,
             inter_node_link_lat=inter_node_link_lat,
-            inter_node_router_lat=inter_node_router_lat,
+            node_main_router_lat=node_main_router_lat,
+            intra_node_link_lat=intra_node_link_lat,
+            cache_controller_link_lat=cache_controller_link_lat,
+            cache_controller_router_lat=cache_controller_router_lat,
+            dir_controller_link_lat=dir_controller_link_lat,
+            dir_controller_router_lat=dir_controller_router_lat,
         )
+
+        self._garnet_network = FakeGarnetNetwork()
 
     # * alias Chiplet._cores to Chiplet._nodes
     def get_cores(self):
@@ -77,7 +138,7 @@ class Chiplet(BaseChipletSystem):
         options: Namespace,
         l2_is_private: bool,
     ):
-        self._garnet_network = FakeGarnetNetwork()
+        # self._garnet_network = FakeGarnetNetwork()
 
         root = self.getRoot()
         if root == self:  # could use `self.isRoot()` but alr have `root`
@@ -95,98 +156,15 @@ class Chiplet(BaseChipletSystem):
             if controller_cpu is None:
                 continue
             elif controller_cpu in self._cores:
-                self._ruby_controllers.append(c)
+                self._topology_controllers.append(c)
                 # print(
                 #     f"Chiplet {self.id} found controller {c} "
                 #     f"(v{c.version})"
                 # )
 
         #! create topology
-        # need to populate `self._ruby_controllers` first
-        self._createTopology(options, self._ruby_controllers)
-
-    def createChipletOld(
-        self,
-        options: Namespace,
-        l2_is_private: bool,
-    ):
-        import traceback
-
-        fatal(f"do not use this function! tb: {traceback.print_stack()}")
-        # print(f"createChiplet() called for chiplet ID {self.id}")
-
-        # todo: currently this is basically just duplicate code from...
-        # todo: ...`ChipletSystem`, refactor somehow
-        # Create the `GarnetNetwork` for this level of the hierarchy
-        self._garnet_network = GarnetNetwork(
-            ruby_system=self.getRoot()._ruby_system,
-            topology=self._topology_cls.__name__,
-            routers=[],
-            ext_links=[],
-            int_links=[],
-            netifs=[],
-            ignore_mesh_chk=True,
-        )
-
-        # set `SimObject` parent hierarchy
-        # make sure not to set root `GarnetNetwork` parent
-        # if we did, it would break Ruby because it expects
-        # the gem5 `System` to have a `.network` param
-        if not self._garnet_network.has_parent():
-            # print(f"setting gem5 parent for GarnetNetwork of "
-            #       f"Chiplet ID {self.id}")
-            self._garnet_network.set_parent(self, "network")
-
-        root = self.getRoot()
-        if root == self:
-            panic("Chiplet is root, this should never happen!")
-        all_controllers = root._meta_topology.nodes  # type: ignore
-
-        for c in all_controllers:
-            controller_cpu = self.getControllerCPU(c, l2_is_private)
-
-            if controller_cpu is None:
-                continue
-            elif controller_cpu in self._cores:
-                self._ruby_controllers.append(c)
-                # print(
-                #     f"Chiplet {self.id} found controller {c} "
-                #     f"(v{c.version})"
-                # )
-
-        #! create topology
-        # need to populate `self._ruby_controllers` first
-        self._createTopology(options, self._ruby_controllers)
-
-        # self._defineMainRouterParams()
-
-        self._connectHierarchyGarnet()
-
-        # * initialize network
-        # `Network.py` does this without any major obstacles to
-        # what we're doing in `ChipletSystem` as of now
-        #! effectively requires `.int_links` and `.ext_links` of
-        #! our `GarnetNetwork` to be set before this
-        # todo: we might have to adapt this so that we can add ...
-        # todo: ...links after calling `createSystem()`, not sure
-        options.network = "garnet"  # only required by `Network.py`
-        init_network(
-            options=options,
-            network=self._garnet_network,
-            InterfaceClass=GarnetNetworkInterface,
-        )
-
-        self._fixAllGarnetObjectParams()
-
-        # if hasattr(self._garnet_network, "number_of_virtual_networks"):
-        #     print(f"Chiplet{self.id}'s GarnetNetwork has param "
-        #           f"number_of_virtual_networks = "
-        #           f"{self._garnet_network.number_of_virtual_networks}")
-        # else:
-        #     print(f"Chiplet{self.id}'s GarnetNetwork has NO param "
-        #           f"number_of_virtual_networks!")
-
-        # self._defineMainRouterParams()
+        # need to populate `self._topology_controllers` first
+        self._createTopology(options, self._topology_controllers)
 
     def to_string(self):
         import textwrap

--- a/configs/chiplets/Chiplet.py
+++ b/configs/chiplets/Chiplet.py
@@ -83,8 +83,12 @@ class Chiplet(BaseChipletSystem):
         if root == self:  # could use `self.isRoot()` but alr have `root`
             panic("Chiplet is root, this should never happen!")
 
+        # at this time, `create_system()` should've been called by
+        # the root `ChipletSystem`, so the meta topology should be
+        # populated with all controllers
         all_controllers = root._meta_topology.nodes  # type: ignore
 
+        # now let's figure out which controllers belong to this Chiplet
         for c in all_controllers:
             controller_cpu = self.getControllerCPU(c, l2_is_private)
 
@@ -97,9 +101,6 @@ class Chiplet(BaseChipletSystem):
                 #     f"(v{c.version})"
                 # )
 
-        # TODO NEW HIERARCHY: revise/refactor to indicate that ...
-        # TODO ... it's more of generating routers/links than ...
-        # TODO ... actually creating a topology
         #! create topology
         # need to populate `self._ruby_controllers` first
         self._createTopology(options, self._ruby_controllers)

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from src.mem.AbstractMemory import AbstractMemory
     from src.mem.ruby.network.garnet.GarnetLink import *
     from src.mem.ruby.network.garnet.GarnetNetwork import *
+    from src.mem.ruby.network.Network import RubyNetwork
     from src.mem.ruby.system.RubySystem import RubySystem
     from src.mem.ruby.system.Sequencer import RubyPortProxy
     from src.mem.SimpleMemory import SimpleMemory
@@ -50,7 +51,7 @@ class ChipletSystem(BaseChipletSystem):
     multiple chiplets linked by interconnects. Uses Ruby and Garnet.
     """
 
-    #! see BaseChipletSystem for additional key properties, namely:
+    #! see BaseChipletSystem for additional key properties, including:
     #  - nodes
     #  - default_inter_node_link_lat
     #  - default_inter_node_router_lat
@@ -59,10 +60,6 @@ class ChipletSystem(BaseChipletSystem):
 
     # whether createSystem() has been called (successfully)
     _created: bool
-
-    # class-local reference to `self.system.ruby`
-    # (gem5 system SimObject's RubySystem)
-    _ruby_system: RubySystem
 
     # see `createSystem()` or `class ChipletMetaTopology`
     _meta_topology: ChipletMetaTopology
@@ -75,7 +72,7 @@ class ChipletSystem(BaseChipletSystem):
         MemoryClass: Type[AbstractMemory],
         inter_node_link_lat: int,
         inter_node_router_lat: int,
-        nodes: list[BaseChipletSystem] = [],
+        nodes: Sequence[BaseChipletSystem] = [],
     ):
         """
         Instantiate a `ChipletSystem` object.
@@ -100,7 +97,7 @@ class ChipletSystem(BaseChipletSystem):
                 The default latency (in cycles) of the routers
                 corresponding to the the links between nodes
                 for this layer of abstraction.
-            nodes (list[BaseChipletSystem]):
+            nodes (Sequence[BaseChipletSystem]):
                 Optional list of nodes. May be passed to constructor
                 or added separately using `addNode()`.
         """
@@ -129,6 +126,7 @@ class ChipletSystem(BaseChipletSystem):
         piobus: IOXBar | None = None,
         dma_ports: list[DmaDevice] = [],
         bootmem: AbstractMemory | None = None,
+        l2_is_private: bool = False,
     ):
         """
         Recursively construct this `ChipletSystem` based on the list
@@ -154,6 +152,10 @@ class ChipletSystem(BaseChipletSystem):
             bootmem (AbstractMemory, optional):
                 Boot memory. Defaults to None.
                 Usually not needed, seemingly only for some FS configs.
+            l2_is_private (bool, optional):
+                If the L2 cache is private (one per CPU).
+                Used for distributing controllers.
+                Defaults to False.
         """
 
         if self._created is True:
@@ -163,7 +165,10 @@ class ChipletSystem(BaseChipletSystem):
             )
             return
 
-        if use_legacy_ruby and options is not None:
+        if options is None:
+            fatal("Called createSystem() with no argparse options.")
+
+        if use_legacy_ruby:
             # at top level, run `Ruby.create_system()`
             # the way Ruby seems to be set up right now,
             # this should only run once, and not sure if
@@ -208,6 +213,7 @@ class ChipletSystem(BaseChipletSystem):
                 netifs=[],
             )
 
+            #! create Ruby system
             # * this block should only run for the parent `ChipletSystem`.
             if self._system.ruby is not None:
                 # `Ruby.py` does this, not sure why since `RubySystem`
@@ -267,61 +273,65 @@ class ChipletSystem(BaseChipletSystem):
                         cpus=self._system.cpu,
                     )
                     # `options.topology` should've initially been the same
-                    # as `self.TopologyClass`, but just in case it wasn't:
+                    # as `self._topology_cls`, but just in case it wasn't:
                     if tmp:
                         options.topology = tmp
-
-                    protocol_controllers = self._meta_topology.nodes
                 except Exception as e:
                     panic(
                         "Could not create Ruby system for Ruby protocol "
                         f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
                     )
 
-                #! instantiate topology for this layer of the hierarchy
-                # type error ignorable because subclasses of `BaseTopology`
-                # typically override constructor with this signature
-                # todo: actually distribute controllers properly
-                self.topology = self._topology_cls(
-                    protocol_controllers  # type: ignore
-                )
+            #! instantiate topology for this layer of the hierarchy
+            # type error ignorable because subclasses of `BaseTopology`
+            # typically override constructor with this signature
+            all_controllers = self.getRoot()._meta_topology.nodes
 
-                # * setup topology
-                # latter 3 args are the literal classes for the
-                # corresponding objects. they can technically be
-                # based on either `GarnetNetwork` or `SimpleNetwork`,
-                # but we're using Garnet and don't allow Simple.
-                self.topology.makeTopology(
-                    options=options,
-                    network=self._garnet_network,
-                    IntLink=GarnetIntLink,
-                    ExtLink=GarnetExtLink,
-                    Router=GarnetRouter,
-                )
+            for c in all_controllers:
+                if self.getControllerCPU(c, l2_is_private) is None:
+                    # if it doesn't belong to a CPU, it doesn't belong
+                    # to a Chiplet, so it should be ours
+                    #! for now this assumes that LLC is globally shared.
+                    # todo: make ^ not the case
+                    self._ruby_controllers.append(c)
 
-                # if in SE mode, register topology with (faux) filesystem
-                # only some topologies implement this (as of now, only
-                # `Mesh_XY` and `MeshDirCorners_XY` do.)
-                if not self._is_full_system:
-                    # notes: `Mesh_XY` requires
-                    # `options.num_cpus` and `options.mem_size`.
-                    # `MeshDirCorners_XY` requires only `options.mem_size`.
-                    self.topology.registerTopology(options)
+            #! create topology
+            # need to populate `self._ruby_controllers` first
+            self._createTopology(options)
 
-                # * initialize network
-                # `Network.py` does this without any major obstacles to
-                # what we're doing in `ChipletSystem` as of now
-                #! effectively requires `.int_links` and `.ext_links` of
-                #! our `GarnetNetwork` to be set before this
-                # todo: we might have to adapt this so that we can add ...
-                # todo: ...links after calling `createSystem()`, not sure
-                options.network = "garnet"  # only required by `Network.py`
-                init_network(
-                    options=options,
-                    network=self._garnet_network,
-                    InterfaceClass=GarnetNetworkInterface,
-                )
+            self._defineMainRouterParams()
 
+        # * need to instantiate children before we connect hierarchy
+        # * and init networks
+        for node in self.nodes:
+            node._ruby_system = self._ruby_system
+            if node is ChipletSystem:
+                node.createSystem(options, use_legacy_ruby)
+            elif isinstance(node, Chiplet):
+                # not sure why, but `is` doesn't work here
+                node.createChiplet(options, l2_is_private)
+
+        if not use_legacy_ruby:
+
+            self._connectHierarchyGarnet()
+
+            # * initialize network
+            # `Network.py` does this without any major obstacles to
+            # what we're doing in `ChipletSystem` as of now
+            #! effectively requires `.int_links` and `.ext_links` of
+            #! our `GarnetNetwork` to be set before this
+            # todo: we might have to adapt this so that we can add ...
+            # todo: ...links after calling `createSystem()`, not sure
+            options.network = "garnet"  # only required by `Network.py`
+            init_network(
+                options=options,
+                network=self._garnet_network,
+                InterfaceClass=GarnetNetworkInterface,
+            )
+
+            #! other Ruby config
+            # * this block should only run for the parent `ChipletSystem`.
+            if self._system.ruby is not None:
                 # * do some port configuration from `Ruby.py`
                 self._ruby_connect_system_ports(piobus)
 
@@ -355,13 +365,13 @@ class ChipletSystem(BaseChipletSystem):
                         range=self._system.mem_ranges[0], in_addr_map=False
                     )
 
-        for node in self.nodes:
-            if node is ChipletSystem:
-                node._ruby_system = self._ruby_system
-                node.createSystem(options, use_legacy_ruby)
-            elif node is Chiplet:
-                # todo: initialize chiplet
-                pass
+        # for node in self.nodes:
+        #     node._ruby_system = self._ruby_system
+        #     if node is ChipletSystem:
+        #         node.createSystem(options, use_legacy_ruby)
+        #     elif isinstance(node, Chiplet):
+        #         # not sure why, but `is` doesn't work here
+        #         node.createChiplet(options, l2_is_private)
 
         self._x86_connect_ruby_ports()
 
@@ -427,3 +437,24 @@ class ChipletSystem(BaseChipletSystem):
                                 "Interrupt controller was created, "
                                 "but no interrupts were found."
                             )
+
+    def to_string(self):
+        import textwrap
+
+        parent_id = "None"
+        if hasattr(self, "parent") and self.parent is not None:
+            parent_id = self.parent.id
+        return f"""
+        {self.__class__.__name__} (ID: {self.id}) [
+            Parent ID: {parent_id}
+            Created: {self._created}
+            Protocol: {self.protocol}
+            Topology: {self._topology_cls.__name__}
+            Connections: {self.connected_nodes}
+            Nodes: [
+        {textwrap.indent(
+            "\n\n        ".join([n.to_string() for n in self.nodes]),
+            "        "
+        )}
+            ]:{self.id}n
+        ]:{self.id}"""

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -58,6 +58,10 @@ class ChipletSystem(BaseChipletSystem):
     #  - parent
     #  - connected_nodes
 
+    type = "ChipletSystem"
+    abstract = False
+    clk_domain = Param.ClockDomain(Parent.clk_domain, "Clock domain")
+
     # whether createSystem() has been called (successfully)
     _created: bool
 
@@ -112,9 +116,19 @@ class ChipletSystem(BaseChipletSystem):
             inter_node_router_lat=inter_node_router_lat,
         )
 
-        for node in self.nodes:
-            if not hasattr(node, "parent"):
-                node.parent = self
+        if not self.has_parent():
+            self.set_parent(
+                self._system, f"{self.__class__.__name__}{self.id}"
+            )
+
+        for node in self._nodes:
+            if not hasattr(node, "_parent_sys"):
+                node._parent_sys = self
+
+        # clock domain must propagate down to routers
+        if not hasattr(self, "clk_domain"):
+            print(f"ChipletSystem {self.id} has no clock domain!")
+            # self.clk_domain = self._system.clk_domain
 
         self._created = False
         self._ruby_system = None
@@ -173,7 +187,7 @@ class ChipletSystem(BaseChipletSystem):
             # the way Ruby seems to be set up right now,
             # this should only run once, and not sure if
             # hierarchical topologies are plausible
-            if not hasattr(self, "parent"):
+            if not hasattr(self, "_parent_sys"):
                 # configure options that Ruby.py expects
                 options.network = "garnet"
                 options.topology = self._topology_cls.__name__
@@ -211,6 +225,7 @@ class ChipletSystem(BaseChipletSystem):
                 ext_links=[],
                 int_links=[],
                 netifs=[],
+                ignore_mesh_chk=True,
             )
 
             #! create Ruby system
@@ -254,7 +269,7 @@ class ChipletSystem(BaseChipletSystem):
                     # Thus, we must temporarily change `options.topology`
                     # to get the Ruby protocol to use our meta topology.
                     tmp = None
-                    if hasattr(options, "topology"):
+                    if hasattr(options, "_topology"):
                         tmp = options.topology
                     options.topology = "ChipletMetaTopology"
                     (
@@ -282,13 +297,28 @@ class ChipletSystem(BaseChipletSystem):
                         f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
                     )
 
+            # set `SimObject` parent hierarchy
+            # make sure not to set root `GarnetNetwork` parent
+            # if we did, it would break Ruby because it expects
+            # the gem5 `System` to have a `.network` param
+            if not self._garnet_network.has_parent():
+                print(
+                    f"setting gem5 parent for GarnetNetwork of "
+                    f"ChipletSystem ID {self.id}"
+                )
+                self._garnet_network.set_parent(self, "network")
+
             #! instantiate topology for this layer of the hierarchy
             # type error ignorable because subclasses of `BaseTopology`
             # typically override constructor with this signature
             all_controllers = self.getRoot()._meta_topology.nodes
 
             for c in all_controllers:
-                if self.getControllerCPU(c, l2_is_private) is None:
+                if self.isDirController(c):
+                    # if directory controller, don't include in main
+                    # ruby controllers list
+                    self._dir_controllers.append(c)
+                elif self.getControllerCPU(c, l2_is_private) is None:
                     # if it doesn't belong to a CPU, it doesn't belong
                     # to a Chiplet, so it should be ours
                     #! for now this assumes that LLC is globally shared.
@@ -301,9 +331,35 @@ class ChipletSystem(BaseChipletSystem):
 
             self._defineMainRouterParams()
 
+            # # goal of this block is to create only one ext_link for
+            # # each directory controller
+            linked_dcs = [dc for dc, lnk in self._dir_controller_link_map]
+            for dir_ctrl in self._dir_controllers:
+                if dir_ctrl not in linked_dcs:
+                    num_routers = len(self._garnet_network.routers)
+                    dir_router = GarnetRouter(
+                        router_id=num_routers,
+                        latency=self.default_inter_node_router_lat,
+                        # the following are default parameters
+                        # gem5 complains if I don't include these params
+                        vcs_per_vnet=4,
+                    )
+                    self._garnet_network.routers.append(dir_router)
+                    self._connectRubyControllerGarnet(
+                        ctrl=dir_ctrl,
+                        router=dir_router,
+                        link_lat=self.default_inter_node_link_lat,
+                    )
+                    self._biLinkGarnetRouters(self._main_router, dir_router)
+                    self._dir_controller_router_map.append(
+                        (dir_ctrl, dir_router)
+                    )
+
         # * need to instantiate children before we connect hierarchy
         # * and init networks
-        for node in self.nodes:
+        for node in self._nodes:
+            # set `SimObject` parent hierarchy
+            node.set_parent(self, f"{node.__class__.__name__}{node.id}")
             node._ruby_system = self._ruby_system
             if node is ChipletSystem:
                 node.createSystem(options, use_legacy_ruby)
@@ -314,6 +370,10 @@ class ChipletSystem(BaseChipletSystem):
         if not use_legacy_ruby:
 
             self._connectHierarchyGarnet()
+
+            # * this block should only run for the parent `ChipletSystem`.
+            if self._system.ruby is not None:
+                self._combineHierarchyGarnetNetworks(self._garnet_network)
 
             # * initialize network
             # `Network.py` does this without any major obstacles to
@@ -328,6 +388,8 @@ class ChipletSystem(BaseChipletSystem):
                 network=self._garnet_network,
                 InterfaceClass=GarnetNetworkInterface,
             )
+
+            self._fixAllGarnetObjectParams()
 
             #! other Ruby config
             # * this block should only run for the parent `ChipletSystem`.
@@ -364,14 +426,6 @@ class ChipletSystem(BaseChipletSystem):
                     self._ruby_system.phys_mem = SimpleMemory(
                         range=self._system.mem_ranges[0], in_addr_map=False
                     )
-
-        # for node in self.nodes:
-        #     node._ruby_system = self._ruby_system
-        #     if node is ChipletSystem:
-        #         node.createSystem(options, use_legacy_ruby)
-        #     elif isinstance(node, Chiplet):
-        #         # not sure why, but `is` doesn't work here
-        #         node.createChiplet(options, l2_is_private)
 
         self._x86_connect_ruby_ports()
 
@@ -442,18 +496,18 @@ class ChipletSystem(BaseChipletSystem):
         import textwrap
 
         parent_id = "None"
-        if hasattr(self, "parent") and self.parent is not None:
-            parent_id = self.parent.id
+        if hasattr(self, "_parent_sys") and self._parent_sys is not None:
+            parent_id = self._parent_sys.id
         return f"""
         {self.__class__.__name__} (ID: {self.id}) [
             Parent ID: {parent_id}
             Created: {self._created}
             Protocol: {self.protocol}
             Topology: {self._topology_cls.__name__}
-            Connections: {self.connected_nodes}
+            Connections: {self._connected_nodes}
             Nodes: [
         {textwrap.indent(
-            "\n\n        ".join([n.to_string() for n in self.nodes]),
+            "\n\n        ".join([n.to_string() for n in self._nodes]),
             "        "
         )}
             ]:{self.id}n

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -88,6 +88,11 @@ class ChipletSystem(BaseChipletSystem):
     package, a multi-chip module (MCM), or CCD, insofar as its role in
     containing multiple processors (heterogeneous or homogenous) across
     multiple chiplets linked by interconnects. Uses Ruby and Garnet.
+
+    As of now, it is intended to be used to build a hierarchy bottom-up,
+    i.e., first create `Chiplet`s with the system CPUs, then instantiate
+    `ChipletSystem`s, passing in those `Chiplet`s into the constructor as
+    nodes, and so on.
     """
 
     #! see BaseChipletSystem for additional important attributes
@@ -100,6 +105,8 @@ class ChipletSystem(BaseChipletSystem):
     # (gem5 system SimObject's RubySystem)
     _ruby_system: RubySystem
 
+    _root_garnet_network: GarnetNetwork
+
     # whether createSystem() has been called (successfully)
     _created: bool
 
@@ -111,7 +118,14 @@ class ChipletSystem(BaseChipletSystem):
     _root_all_ext_links_dict: dict[GarnetExtLink, ChipletGarnetObjectInfo]
     _root_all_int_links_dict: dict[GarnetIntLink, ChipletGarnetObjectInfo]
 
-    _fake_garnet_networks_dict: dict[BaseChipletSystem, FakeGarnetNetwork]
+    _global_router_count: int
+    _global_link_count: int
+
+    # store direct ref to main routers
+    _root_main_routers_dict: dict[BaseChipletSystem, GarnetRouter]
+
+    # store fake garnet networks (mostly for the one for the root)
+    _root_fake_garnet_networks_dict: dict[BaseChipletSystem, FakeGarnetNetwork]
 
     def __init__(
         self,
@@ -167,11 +181,24 @@ class ChipletSystem(BaseChipletSystem):
                 self._system, f"{self.__class__.__name__}{self.id}"
             )
 
+        # * set gem5 `SimObject` parent property for nodes
         # * set _parent_sys property for children
         # currently only adding nodes in constructor is really supported
         for node in self._nodes:
+            node.set_parent(self, f"{node.__class__.__name__}{node.id}")
             if not hasattr(node, "_parent_sys"):
                 node._parent_sys = self
+
+        self._global_router_count = 0
+        self._global_link_count = 0
+
+        self._garnet_network = FakeGarnetNetwork()
+
+        self._main_router = self.create_and_register_router(
+            latency=inter_node_router_lat,
+            description=f"{self.__class__.__name__}{self.id} main router",
+        )
+        # register to dict later, `getRoot()` won't work right now
 
         self._created = False
         self._ruby_system = None
@@ -211,21 +238,215 @@ class ChipletSystem(BaseChipletSystem):
         if info is not None:
             return info.original_parent
 
-    # * helper methods for `createSystem()`
-
-    def _createChildren(
+    # * helper methods for creating and registering network objects
+    def _registerNetworkObject(
         self,
-        options: Namespace,  # argparse Namespace (parsed args)
-        l2_is_private: bool = False,
+        object: GarnetRouter | GarnetExtLink | GarnetIntLink,
+        info: ChipletGarnetObjectInfo,
     ):
-        pass
+        """
+        Registers a Garnet network object (router or link) in
+        the root dictionaries mapping routers/links to information
+        such as original parent, original ID, and description.
 
+        ! Does NOT add the specified object to any `GarnetNetwork`
+        ! or `FakeGarnetNetwork`!
+
+        Args:
+            object (GarnetRouter | GarnetExtLink | GarnetIntLink):
+                The network object to register.
+            info (ChipletGarnetObjectInfo): _description_
+        """
+        if isinstance(object, GarnetRouter):
+            self.getRoot()._root_all_routers_dict[object] = info
+
+        if isinstance(object, GarnetExtLink):
+            self.getRoot()._root_all_ext_links_dict[object] = info
+
+        if isinstance(object, GarnetIntLink):
+            self.getRoot()._root_all_int_links_dict[object] = info
+
+    def _generate_router_id(self):
+        self._global_router_count += 1
+        return self._global_router_count - 1
+
+    def _generate_link_id(self):
+        self._global_link_count += 1
+        return self._global_link_count - 1
+
+    def create_and_register_router(
+        self,
+        latency: int = -1,
+        vcs_per_vnet: int = 4,
+        description: str = "",
+        add_router_to_self: bool = False,
+    ) -> GarnetRouter:
+        if latency == -1:
+            latency = self.default_inter_node_router_lat
+
+        root = self.getRoot()
+
+        new_router_id = self._generate_router_id()
+
+        new_router = GarnetRouter(
+            router_id=new_router_id,
+            latency=latency,
+            vcs_per_vnet=vcs_per_vnet,
+        )
+
+        new_router_info = ChipletGarnetObjectInfo(
+            original_parent=self,
+            original_id=new_router_id,
+            description=description,
+        )
+
+        root._registerNetworkObject(new_router, new_router_info)
+
+        if add_router_to_self:
+            self._garnet_network.routers.append(new_router)
+
+        return new_router
+
+    def create_and_register_and_add_router(
+        self,
+        latency: int = -1,
+        vcs_per_vnet: int = 4,
+        description: str = "",
+    ) -> GarnetRouter:
+        return self.create_and_register_router(
+            latency, vcs_per_vnet, description
+        )
+
+    def _mergeFakeGarnetNetworks(
+        self,
+        net1: FakeGarnetNetwork,
+        net2: FakeGarnetNetwork,
+        add_to_dict_if_missing: bool = True,
+        skip_duplicates: bool = True,
+    ):
+        local_router_id = len(net1.routers)
+        local_link_id = len(net1.ext_links) + len(net1.int_links)
+
+        root = self.getRoot()
+
+        for router in net2.routers:
+            if root is not None:
+                info = root._root_all_routers_dict[router]
+                if info is not None:
+                    info.original_id = router.router_id
+                elif add_to_dict_if_missing:
+                    root._registerNetworkObject(
+                        router,
+                        ChipletGarnetObjectInfo(
+                            # assume that callee is parent of `net1`
+                            original_parent=self,
+                            original_id=router.router_id,
+                            description=f"combined into "
+                            f"{net1} from {net2}",
+                        ),
+                    )
+            if router in net1.routers:
+                if skip_duplicates:
+                    continue
+                else:
+                    warn(
+                        f"adding duplicate router {router}"
+                        f"during FakeGarnetNetwork merge"
+                    )
+            router.router_id = local_router_id
+            local_router_id += 1
+            net1.routers.append(router)
+
+        for ext_link in net2.ext_links:
+            if root is not None:
+                info = root._root_all_ext_links_dict[ext_link]
+                if info is not None:
+                    info.original_id = ext_link.link_id
+                elif add_to_dict_if_missing:
+                    root._registerNetworkObject(
+                        router,
+                        ChipletGarnetObjectInfo(
+                            # assume that callee is parent of `net1`
+                            original_parent=self,
+                            original_id=ext_link.link_id,
+                            description=f"combined into "
+                            f"{net1} from {net2}",
+                        ),
+                    )
+            if ext_link in net1.ext_links:
+                if skip_duplicates:
+                    continue
+                else:
+                    warn(
+                        f"adding duplicate ext_link {ext_link}"
+                        f"during FakeGarnetNetwork merge"
+                    )
+            ext_link.link_id = local_link_id
+            local_link_id += 1
+            net1.ext_links.append(ext_link)
+
+        for int_link in net2.int_links:
+            if root is not None:
+                info = root._root_all_int_links_dict[int_link]
+                if info is not None:
+                    info.original_id = int_link.link_id
+                elif add_to_dict_if_missing:
+                    root._registerNetworkObject(
+                        router,
+                        ChipletGarnetObjectInfo(
+                            # assume that callee is parent of `net1`
+                            original_parent=self,
+                            original_id=int_link.link_id,
+                            description=f"combined into "
+                            f"{net1} from {net2}",
+                        ),
+                    )
+            if int_link in net1.int_links:
+                if skip_duplicates:
+                    continue
+                else:
+                    warn(
+                        f"adding duplicate int_link {int_link}"
+                        f"during FakeGarnetNetwork merge"
+                    )
+            int_link.link_id = local_link_id
+            local_link_id += 1
+            net1.int_links.append(int_link)
+
+    def _rootAccumulateNetworkObjects(
+        self,
+        net: FakeGarnetNetwork,
+    ):
+        """
+        Given a `FakeGarnetNetwork`, add all of its network objects
+        to the root network object dictionaries.
+        After this, accessing the lists via the appropriate getters
+        (e.g., `self.getRootRouters()`) should include the objects
+        in `net` appended to any existing registered objects.
+
+        Args:
+            net (FakeGarnetNetwork):
+                The `FakeGarnetNetwork` to accumulate objects from.
+        """
+        root_existing = FakeGarnetNetwork(
+            self.getRootRouters(),
+            self.getRootExtLinks(),
+            self.getRootIntLinks(),
+        )
+        self._mergeFakeGarnetNetworks(
+            root_existing,
+            net,
+            add_to_dict_if_missing=True,
+            skip_duplicates=True,
+        )
+
+    # * helper methods for `createSystem()`
     def _createLegacyRubyChiplet(
         self,
         options: Namespace,  # argparse Namespace (parsed args)
-        piobus: IOXBar | None = None,
-        dma_ports: list[DmaDevice] = [],
-        bootmem: AbstractMemory | None = None,
+        piobus: IOXBar | None,
+        dma_ports: list[DmaDevice],
+        bootmem: AbstractMemory | None,
     ):
         """
         Creates a `ChipletSystem` using `Ruby.py`'s `create_system()`
@@ -264,10 +485,7 @@ class ChipletSystem(BaseChipletSystem):
 
             self._x86_connect_ruby_ports()
 
-    def _createRootGarnetNetwork(
-        self,
-        options: Namespace,  # argparse Namespace (parsed args)
-    ):
+    def _instantiateRootGarnetNetwork(self):
         if not self.isRoot():
             fatal(
                 f"User tried to instantiate GarnetNetwork for "
@@ -283,15 +501,18 @@ class ChipletSystem(BaseChipletSystem):
             )
 
         # Create the `GarnetNetwork` for the entire `ChipletSystem`
-        self._garnet_network = GarnetNetwork(
+        root_garnet_network = GarnetNetwork(
             ruby_system=self._ruby_system,
             topology=self._topology_cls.__name__,
-            routers=self.getRootRouters(),
-            ext_links=self.getRootExtLinks(),
-            int_links=self.getRootIntLinks(),
+            routers=[],  # populate later
+            ext_links=[],  # populate later
+            int_links=[],  # populate later
             netifs=[],  # will be populated by `init_network()`
             ignore_mesh_chk=True,
         )
+        #! routers, ext/int links, and netifs will be assigned
+        #! in `_initializeRootGarnetNetwork()`, after being
+        #! created via topology templates.
 
         # * ignore_mesh_chk:
         # if `num_rows > 0` we will fail an assertion
@@ -301,14 +522,28 @@ class ChipletSystem(BaseChipletSystem):
         # so we had to add an override to prevent this
         # TODO NEW HIERARCHY: this might not be needed anymore
 
+        return root_garnet_network
+
+    def _initializeRootGarnetNetwork(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+    ):
+        assert isinstance(self._garnet_network, GarnetNetwork)
+
+        # * populate `GarnetNetwork` with routers and links.
+        # these should've been created since calling
+        # `_instantiateRootGarnetNetwork()` by all `Chiplet[System]`s
+        # using `_createTopology()` (and thus `makeTopology()`).
+        self._garnet_network.routers = self.getRootRouters()
+        self._garnet_network.ext_links = self.getRootExtLinks()
+        self._garnet_network.int_links = self.getRootIntLinks()
+
         # * initialize network
-        # `Network.py` does this without any major obstacles to
-        # what we're doing in `ChipletSystem` as of now
-        #! effectively requires `.int_links` and `.ext_links` of
-        #! our `GarnetNetwork` to be set before this
-        # todo: we might have to adapt this so that we can add ...
-        # todo: ...links after calling `createSystem()`, not sure
+        # `Network.py:init_network()` does what we need without
+        # any major problems as of now
         options.network = "garnet"  # only required by `Network.py`
+        #! `init_network` requires the int and ext links to be set.
+        #! it also instantiates all the requisite network interfaces.
         init_network(
             options=options,
             network=self._garnet_network,
@@ -339,7 +574,7 @@ class ChipletSystem(BaseChipletSystem):
                 f"{self.__class__.__name__} {self.id}!"
             )
 
-    def _createRubySystem(
+    def _rubyProtocolCreateSystem(
         self,
         options: Namespace,  # argparse Namespace (parsed args)
         dma_ports: list[DmaDevice] = [],
@@ -348,6 +583,8 @@ class ChipletSystem(BaseChipletSystem):
         """
         Creates the Ruby system.
         The `RubySystem` object must be instantiated first.
+        ! `self._system.ruby.network` must be set to a valid
+        ! `GarnetNetwork` before calling this method.
         Sets the following attributes of this `ChipletSystem`:
          - `self._cpu_sequencers`
          - `self._dir_controllers`
@@ -373,20 +610,20 @@ class ChipletSystem(BaseChipletSystem):
                     "gem5 System!"
                 )
 
-        if not hasattr(self, "_garnet_network"):
-            fatal(
-                "User tried to create Ruby system, but Garnet network "
-                "has not yet been created. Do not call "
-                "_createRubySystem() from outside ChipletSystem."
-            )
+        # if not hasattr(self, "_garnet_network"):
+        #     fatal(
+        #         "User tried to create Ruby system, but Garnet network "
+        #         "has not yet been created. Do not call "
+        #         "_createRubySystem() from outside ChipletSystem."
+        #     )
 
-        if isinstance(self._garnet_network, FakeGarnetNetwork):
-            panic(
-                "ChipletSystem's GarnetNetwork is FakeGarnetNetwork! "
-                "Either GarnetNetwork failed to instantiate, or "
-                "_createRubySystem() was called before "
-                "_createRootGarnetNetwork()!"
-            )
+        # if isinstance(self._garnet_network, FakeGarnetNetwork):
+        #     panic(
+        #         "ChipletSystem's GarnetNetwork is FakeGarnetNetwork! "
+        #         "Either GarnetNetwork failed to instantiate, or "
+        #         "_createRubySystem() was called before "
+        #         "_createRootGarnetNetwork()!"
+        #     )
 
         # * Create the Ruby/memory system
         try:
@@ -460,6 +697,7 @@ class ChipletSystem(BaseChipletSystem):
          - `self._ruby_controllers`
          - `self._dir_controllers`
          - `self._non_dir_controllers`
+        ! `_rubyProtocolCreateSystem()` needs to be called before this.
         """
 
         # grab all controllers
@@ -498,14 +736,82 @@ class ChipletSystem(BaseChipletSystem):
                         f"belong to a CPU: {c}"
                     )
 
+    def _linkDirectoryControllers(self):
+        for dir_ctrl in self._dir_controllers:
+            # is dir ctrl linked?
+            lnk = self._findExtLinkFromController(dir_ctrl)
+            if lnk is None:
+                dir_router = self.create_and_register_and_add_router(
+                    latency=self.default_inter_node_router_lat,
+                )
+                self._connectRubyControllerGarnet(
+                    ctrl=dir_ctrl,
+                    router=dir_router,
+                    link_lat=self.default_inter_node_link_lat,
+                )
+                self._biLinkGarnetRouters(self._main_router, dir_router)
+
+    def _rubyFinalSetup(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+        piobus: IOXBar | None,
+    ):
+        if not self.isRoot():
+            fatal(
+                "User tried to call _rubyFinalSetup() on "
+                "non-root ChipletSystem."
+            )
+
+        if not isinstance(self._garnet_network, GarnetNetwork):
+            fatal(
+                "_rubyFinalSetup() was called before "
+                "GarnetNetwork was properly initialized. "
+                "(Probably out of order with respect to "
+                "`_createChipletHierarchy()`)"
+            )
+        # * do some port configuration from `Ruby.py`
+        self._ruby_connect_system_ports(piobus)
+
+        # todo: don't rely on `Ruby.py` for this
+        # unfortunately, in order to get `dir_cntrls`, the Ruby
+        # protocols also call back to `Ruby.create_directories`.
+        # so can't completely avoid it without major refactoring
+        options.mem_type = self._memory_cls.__name__
+        Ruby.setup_memory_controllers(
+            system=self._system,
+            ruby=self._ruby_system,
+            dir_cntrls=self._dir_controllers,
+            options=options,
+        )
+
+        # * more stuff from `Ruby.py`
+        # Connect the cpu sequencers and the piobus
+        if piobus != None:
+            for cpu_seq in self._cpu_sequencers:
+                cpu_seq.connectIOPorts(piobus)
+
+        assert isinstance(self._ruby_system.network, GarnetNetwork)
+        self._ruby_system.number_of_virtual_networks = (
+            self._ruby_system.network.number_of_virtual_networks
+        )  # implicit line break on assign due to 76 char limit
+        self._ruby_system._cpu_ports = self._cpu_sequencers
+        self._ruby_system.num_of_sequencers = len(self._cpu_sequencers)
+
+        # Create a backing copy of physical memory in case required
+        if options.access_backing_store:
+            self._ruby_system.access_backing_store = True
+            self._ruby_system.phys_mem = SimpleMemory(
+                range=self._system.mem_ranges[0], in_addr_map=False
+            )
+
     def _createChipletHierarchy(
         self,
         options: Namespace,  # argparse Namespace (parsed args)
-        piobus: IOXBar | None = None,
-        dma_ports: list[DmaDevice] = [],
-        bootmem: AbstractMemory | None = None,
-        l2_is_private: bool = False,
-        include_dir_ctrls_in_topology: bool = False,
+        piobus: IOXBar | None,
+        dma_ports: list[DmaDevice],
+        bootmem: AbstractMemory | None,
+        l2_is_private: bool,
+        include_dir_ctrls_in_topology: bool,
     ):
         """
         Recursively create this chiplet hierarchy.
@@ -519,23 +825,7 @@ class ChipletSystem(BaseChipletSystem):
         #! this code is adapted from `Ruby.py` and `Network.py`,
         #! as changes were needed in order to support hierarchies.
         is_root = self.isRoot()
-
-        #! this is where (some of) the magic happens.
-        """
-        We recursively "create" the children (nodes). Each has its own
-        topology (from `configs/topologies`). To create a Ruby system and
-        Garnet network representing a hierarchical topology without
-        breaking all the existing topologies and interfering with the
-        cache coherence protocol, for each child/node, we use
-        `makeTopology()` on a fake Garnet network to collect all the
-        Garnet routers and links, all structured according to the topology
-        of the child. Creating multiple `GarnetNetwork`s and trying to
-        combine them does not work properly, so this method is better.
-        The root `ChipletSystem` also has a topology, so we also need to
-        do the same thing for it (this), and we do that first.
-        """
-        self._garnet_network = FakeGarnetNetwork()
-        self._fake_garnet_networks_dict[self] = self._garnet_network
+        root = self.getRoot()
 
         # TODO NEW HIERARCHY:
         """
@@ -562,6 +852,112 @@ class ChipletSystem(BaseChipletSystem):
             # also some filesystem config
             self._instantiateRubySystem(options)
 
+            root_garnet_network = self._instantiateRootGarnetNetwork()
+
+            # Ruby expects the `System` object to have a `ruby` attr,
+            # and that the `ruby` property has a `network` attribute.
+            self._system.ruby.network = root_garnet_network
+            # note that our `self._ruby_system` should reference the same
+            # object as `self._system.ruby`, but Ruby doesn't know or care
+            # about our `self._ruby_system`, so avoid setting its attrs.
+            # reading or using it as a `RubySystem` is fine.
+
+            # call `create_system()` for the appropriate Ruby protocol
+            # this populates the lists of sequencers, dir controllers,
+            # and creates the meta topology (to get list of all ctrls)
+            self._rubyProtocolCreateSystem(options, dma_ports, bootmem)
+
+            # after this, our lists of controllers should be populated
+            self._sortRubyControllers(
+                l2_is_private,
+                include_dir_ctrls_in_topology,
+            )
+
+            if not include_dir_ctrls_in_topology:
+                self._linkDirectoryControllers()
+
+        #! this is where (some of) the magic happens.
+        """
+        We recursively "create" the children (nodes). Each has its own
+        topology (from `configs/topologies`). To create a Ruby system and
+        Garnet network representing a hierarchical topology without
+        breaking all the existing topologies and interfering with the
+        cache coherence protocol, for each child/node, we use
+        `makeTopology()` on a fake Garnet network to collect all the
+        Garnet routers and links, all structured according to the topology
+        of the child. Creating multiple `GarnetNetwork`s and trying to
+        combine them does not work properly, so this method is better.
+        The root `ChipletSystem` also has a topology, so we also need to
+        do the same thing for it (this), and we do that first.
+        """
+        # instantiating FakeGarnetNetwork has no prereqs
+        # so just do it in the constructor
+        # self._garnet_network = FakeGarnetNetwork()
+        root._root_fake_garnet_networks_dict[self] = self._garnet_network
+
+        # register main router in main routers dict
+        root._root_main_routers_dict[self] = self._main_router
+
+        # * some topologies override network's lists of routers/links,
+        # * so we expect that and prepare accordingly
+        # we likely don't have many routers/links in the fake network yet,
+        # but better to be safe
+        gn = self._garnet_network
+        tmp_routers = [r for r in gn.routers]
+        tmp_ext_links = [l for l in gn.ext_links]
+        tmp_int_links = [l for l in gn.int_links]
+        tmp_network = FakeGarnetNetwork(
+            tmp_routers, tmp_ext_links, tmp_int_links
+        )
+
+        # populate `FakeGarnetNetwork` with routers and links
+        # based on the specified topology for this `Chiplet[System]`
+        self._createTopology(options, self._ruby_controllers)
+
+        # recombine existing routers/links with those from the topology
+        self._mergeFakeGarnetNetworks(
+            tmp_network,
+            self._garnet_network,
+            add_to_dict_if_missing=True,
+            skip_duplicates=True,
+        )
+        self._garnet_network = tmp_network
+        root._root_fake_garnet_networks_dict[self] = self._garnet_network
+
+        # * need to instantiate and connect to children before init network
+        for node in self._nodes:
+            # todo: SimObject parenting to __init__(), hopefully that works
+            # set `SimObject` parent hierarchy
+            # node.set_parent(self, f"{node.__class__.__name__}{node.id}")
+
+            # * create node
+            if isinstance(node, ChipletSystem):
+                # cascade ruby system, although it shouldn't be needed
+                node._ruby_system = self._ruby_system
+
+                # most of these args technically shouldn't be needed
+                # for any child systems, since they're only used by root
+                node._createChipletHierarchy(
+                    options,
+                    piobus,
+                    dma_ports,
+                    bootmem,
+                    l2_is_private,
+                    include_dir_ctrls_in_topology,
+                )
+            elif isinstance(node, Chiplet):
+                node.createChiplet(options, l2_is_private)
+
+            # * connect to node
+            self._biLinkGarnetRouters(self._main_router, node._main_router)
+
+            #! renumber all of the routers and links as we
+            #! transfer all of them into the root lists
+            # since this triggers for all `ChipletSystem`s, it should
+            # work on any hierarchy, although it might be rather slow
+            self._rootAccumulateNetworkObjects(node._garnet_network)
+
+        if is_root:
             #! this where the rest of the magic happens.
             """
             Once we have created all of the topologies of all children,
@@ -571,21 +967,16 @@ class ChipletSystem(BaseChipletSystem):
             topologies (from `configs/topologies`), without having to
             manually define the hierarchical topology at a low level.
             """
-            self._createRootGarnetNetwork(options)
-            #! ^ also instantiates network via `init_network()`...
-            #! not sure if this needs to be done later
 
-            # Ruby expects the `System` object to have a `ruby` attr,
-            # and that the `ruby` property has a `network` attribute.
-            self._ruby_system.network = self._garnet_network
+            # replace the root's `FakeGarnetNetwork` with the real one here
+            self._garnet_network = root_garnet_network
 
-            self._createRubySystem(options, dma_ports, bootmem)
+            # * do the actual combination into the real `GarnetNetwork`
+            self._initializeRootGarnetNetwork(options)
 
-            # after this, our lists of controllers should be populated
-            self._sortRubyControllers(
-                l2_is_private,
-                include_dir_ctrls_in_topology,
-            )
+            self._rubyFinalSetup(options, piobus)
+
+            self._x86_connect_ruby_ports()
 
     def createSystem(
         self,
@@ -644,9 +1035,21 @@ class ChipletSystem(BaseChipletSystem):
             fatal("Called createSystem() with no argparse options.")
 
         if use_legacy_ruby:
-            self._createLegacyRubyChiplet(options)
+            self._createLegacyRubyChiplet(
+                options,
+                piobus,
+                dma_ports,
+                bootmem,
+            )
         else:
-            self._createChipletHierarchy(options)
+            self._createChipletHierarchy(
+                options,
+                piobus,
+                dma_ports,
+                bootmem,
+                l2_is_private,
+                include_dir_ctrls_in_topology,
+            )
 
         self._created = True
 

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -12,6 +12,9 @@ from chiplets.BaseChipletSystem import (
     FakeGarnetNetwork,
 )
 from chiplets.Chiplet import Chiplet
+from chiplets.ChipletSystemMainRouterTopology import (
+    ChipletSystemMainRouterTopology as CSMRT,
+)
 from common import (
     FileSystemConfig,
     MemConfig,
@@ -38,6 +41,7 @@ if TYPE_CHECKING:
     from src.mem.ruby.network.garnet.GarnetLink import *
     from src.mem.ruby.network.garnet.GarnetNetwork import *
     from src.mem.ruby.network.Network import RubyNetwork
+    from src.mem.ruby.slicc_interface.Controller import RubyController
     from src.mem.ruby.system.RubySystem import RubySystem
     from src.mem.ruby.system.Sequencer import (
         RubyPortProxy,
@@ -134,8 +138,13 @@ class ChipletSystem(BaseChipletSystem):
         TopologyClass: Type[BaseTopology],
         MemoryClass: Type[AbstractMemory],
         inter_node_link_lat: int,
-        inter_node_router_lat: int,
+        intra_node_link_lat: int,
+        node_main_router_lat: int,
         nodes: Sequence[BaseChipletSystem] = [],
+        cache_controller_link_lat: int = -1,
+        cache_controller_router_lat: int = -1,
+        dir_controller_link_lat: int = -1,
+        dir_controller_router_lat: int = -1,
     ):
         """
         Instantiate a `ChipletSystem` object.
@@ -148,23 +157,44 @@ class ChipletSystem(BaseChipletSystem):
                 If gem5 is running in full-system simulation mode.
             TopologyClass (Type[BaseTopology]):
                 The class, derived from `BaseTopology`, corresponding
-                to the topology to be used in this `ChipletSystem`.
-                Only the root `ChipletSystem` needs to specify this.
+                to the topology to be used in this level of the
+                `ChipletSystem` hierarchy.
             MemoryClass (Type[AbstractMemory]):
                 The class corresponding to the memory configuration
                 for the gem5 `System` this `ChipletSystem` is part of.
             inter_node_link_lat (int):
                 The default latency (in cycles) of the links between
                 nodes for this layer of abstraction.
-            inter_node_router_lat (int):
-                The default latency (in cycles) of the routers
+            intra_node_link_lat (int):
+                The default latency (in cycles) of the links between
+                each routers in the same level of the hierarchy;
+                e.g., between the main router and the router corresponding
+                to a directory controller or cache controller.
+            node_main_router_lat (int):
+                The default latency (in cycles) of the main router
+                for this `Chiplet[System]`. This is also the router
                 corresponding to the the links between nodes
                 for this layer of abstraction.
             nodes (Sequence[BaseChipletSystem]):
                 Optional list of nodes. May be passed to constructor
                 or added separately using `addNode()`.
+            cache_controller_link_lat (int, optional):
+                The default latency (in cycles) of the links between
+                each cache controller and its corresponding router.
+                Defaults to `inter_node_link_lat`.
+            cache_controller_router_lat (int, optional):
+                The default latency (in cycles) of the router
+                corresponding to each cache controller.
+                Defaults to `inter_node_router_lat`.
+            dir_controller_link_lat (int, optional):
+                The default latency (in cycles) of the links between
+                each directory controller and its corresponding router.
+                Defaults to `inter_node_link_lat`.
+            dir_controller_router_lat (int, optional):
+                The default latency (in cycles) of the router
+                corresponding to each directory controller.
+                Defaults to `inter_node_router_lat`.
         """
-
         super().__init__(
             system=system,
             full_system=full_system,
@@ -172,7 +202,12 @@ class ChipletSystem(BaseChipletSystem):
             MemoryClass=MemoryClass,
             nodes=nodes,
             inter_node_link_lat=inter_node_link_lat,
-            inter_node_router_lat=inter_node_router_lat,
+            node_main_router_lat=node_main_router_lat,
+            intra_node_link_lat=intra_node_link_lat,
+            cache_controller_link_lat=cache_controller_link_lat,
+            cache_controller_router_lat=cache_controller_router_lat,
+            dir_controller_link_lat=dir_controller_link_lat,
+            dir_controller_router_lat=dir_controller_router_lat,
         )
 
         # * set gem5 SimObject parent-child relationship
@@ -202,7 +237,7 @@ class ChipletSystem(BaseChipletSystem):
         self._garnet_network = FakeGarnetNetwork()
 
         self._main_router = self.create_and_register_router(
-            latency=inter_node_router_lat,
+            latency=node_main_router_lat,
             description=f"{self.__class__.__name__}{self.id} main router",
         )
 
@@ -288,7 +323,7 @@ class ChipletSystem(BaseChipletSystem):
         add_router_to_self: bool = False,
     ) -> GarnetRouter:
         if latency == -1:
-            latency = self.default_inter_node_router_lat
+            latency = self.default_node_main_router_lat
 
         root = self.getRoot()
 
@@ -723,18 +758,19 @@ class ChipletSystem(BaseChipletSystem):
                 f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
             )
 
-    def _sortRubyControllers(
+    def _sortTopologyControllers(
         self,
         l2_is_private: bool,
         include_dir_ctrls_in_topology: bool = False,
+        include_cache_ctrls_in_topology: bool = False,
     ):
         """
         Populates lists of Ruby controllers for this `Chiplet[System]`
         based on what `create_system()` of the Ruby protocol generated.
         Specifically, populates:
-         - `self._ruby_controllers`
+         - `self._topology_controllers`
          - `self._dir_controllers`
-         - `self._non_dir_controllers`
+         - `self._cache_controllers`
         ! `_rubyProtocolCreateSystem()` needs to be called before this.
         """
 
@@ -756,7 +792,7 @@ class ChipletSystem(BaseChipletSystem):
                     )
                     self._dir_controllers.append(c)
                 if include_dir_ctrls_in_topology:
-                    self._ruby_controllers.append(c)
+                    self._topology_controllers.append(c)
             else:
                 # not directory controller, should be a different cache
                 # controller (or perhaps a DMA controller)
@@ -766,23 +802,77 @@ class ChipletSystem(BaseChipletSystem):
                 # todo: make ^ not the case
 
                 if self.getControllerCPU(c, l2_is_private) is None:
-                    self._non_dir_controllers.append(c)
-                    self._ruby_controllers.append(c)
+                    self._cache_controllers.append(c)
+                    if include_cache_ctrls_in_topology:
+                        self._topology_controllers.append(c)
 
-    def _linkDirectoryControllers(self):
-        for dir_ctrl in self._dir_controllers:
+    def _manualLinkControllers(
+        self,
+        controllers: list[RubyController],
+        ctrl_router_lat: int,
+        ctrl_to_router_link_lat: int,
+        ctrl_router_to_main_link_lat: int,
+    ):
+        """
+        Manually link a list of controllers to routers.
+        For each controller, this method creates, registers, and adds
+        a new routers with latency `ctrl_router_lat`. Then, the new router
+        is connected to the controller with a link latency of
+        `ctrl_to_router_link_lat`. Finally, the new router is linked to the
+        main router for this `Chiplet[System]` with a link latency of
+        `ctrl_router_to_main_link_lat`.
+
+        Args:
+            controllers (list[RubyController]):
+                List of controllers to link and create routers for.
+            ctrl_router_lat (int):
+                Latency of the new `GarnetRouter` corresponding to
+                each controller.
+            ctrl_to_router_link_lat (int):
+                Latency of the `GarnetExtLink`s between each controller
+                and its corresponding router.
+            ctrl_router_to_main_link_lat (int):
+                Latency of the `GarnetIntLink`s between the router
+                corresponding to each controller and the main router
+                for this `Chiplet[System]`. Note that two such links
+                are created, since `GarnetIntLink`s are unidirectional.
+        """
+        for ctrl in controllers:
             # is dir ctrl linked?
-            lnk = self._findExtLinkFromController(dir_ctrl)
+            lnk = self._getExtLinkFromController(ctrl)
             if lnk is None:
-                dir_router = self.create_and_register_and_add_router(
-                    latency=self.default_inter_node_router_lat,
+                ctrl_router = self.create_and_register_and_add_router(
+                    latency=ctrl_router_lat,
                 )
                 self._connectRubyControllerGarnet(
-                    ctrl=dir_ctrl,
-                    router=dir_router,
-                    link_lat=self.default_inter_node_link_lat,
+                    ctrl=ctrl,
+                    router=ctrl_router,
+                    link_lat=ctrl_to_router_link_lat,
                 )
-                self._biLinkGarnetRouters(self._main_router, dir_router)
+
+                # if you want to change the latency of this link,
+                # use `_findIntLinkFromRouters(main_router, ctrl_router)`
+                self._biLinkGarnetRouters(
+                    self._main_router,
+                    ctrl_router,
+                    ctrl_router_to_main_link_lat,
+                )
+
+    def _manualLinkDirectoryControllers(self):
+        self._manualLinkControllers(
+            controllers=self._dir_controllers,
+            ctrl_router_lat=self.default_dir_controller_router_lat,
+            ctrl_to_router_link_lat=self.default_dir_controller_link_lat,
+            ctrl_router_to_main_link_lat=self.default_intra_node_link_lat,
+        )
+
+    def _manualLinkCacheControllers(self):
+        self._manualLinkControllers(
+            controllers=self._cache_controllers,
+            ctrl_router_lat=self.default_cache_controller_router_lat,
+            ctrl_to_router_link_lat=self.default_cache_controller_link_lat,
+            ctrl_router_to_main_link_lat=self.default_intra_node_link_lat,
+        )
 
     def _rubyFinalSetup(
         self,
@@ -845,6 +935,8 @@ class ChipletSystem(BaseChipletSystem):
         bootmem: AbstractMemory | None,
         l2_is_private: bool,
         include_dir_ctrls_in_topology: bool,
+        include_cache_ctrls_in_topology: bool,
+        node_router_topology: CSMRT,
     ):
         """
         Recursively create this chiplet hierarchy.
@@ -901,13 +993,17 @@ class ChipletSystem(BaseChipletSystem):
             self._rubyProtocolCreateSystem(options, dma_ports, bootmem)
 
             # after this, our lists of controllers should be populated
-            self._sortRubyControllers(
+            self._sortTopologyControllers(
                 l2_is_private,
                 include_dir_ctrls_in_topology,
+                include_cache_ctrls_in_topology,
             )
 
             if not include_dir_ctrls_in_topology:
-                self._linkDirectoryControllers()
+                self._manualLinkDirectoryControllers()
+
+            if not include_cache_ctrls_in_topology:
+                self._manualLinkCacheControllers()
 
         #! this is where (some of) the magic happens.
         """
@@ -947,7 +1043,7 @@ class ChipletSystem(BaseChipletSystem):
 
         # populate `FakeGarnetNetwork` with routers and links
         # based on the specified topology for this `Chiplet[System]`
-        self._createTopology(options, self._ruby_controllers)
+        self._createTopology(options, self._topology_controllers)
 
         # recombine existing routers/links with those from the topology
         # self._mergeFakeGarnetNetworks(
@@ -979,12 +1075,41 @@ class ChipletSystem(BaseChipletSystem):
                     bootmem,
                     l2_is_private,
                     include_dir_ctrls_in_topology,
+                    include_cache_ctrls_in_topology,
+                    node_router_topology,
                 )
             elif isinstance(node, Chiplet):
                 node.createChiplet(options, l2_is_private)
 
-            # * connect to node
-            self._biLinkGarnetRouters(self._main_router, node._main_router)
+            # * connect child nodes to main router
+            # this will result in a topology where the child main routers
+            # are not connected to each other, but only to the parent's
+            # main router. this may or may not be desirable,
+            # depending on what you are trying to model.
+            if (
+                node_router_topology == CSMRT.ParentOnly
+                or node_router_topology == CSMRT.Pt2Pt
+            ):
+                # * connect each node's main router to our main router
+                # i.e., connect child directly to parents
+                # this is `ParentOnly`, but Pt2Pt also requires this
+                # so let's reuse the code
+                self._biLinkGarnetRouters(
+                    self._main_router,
+                    node._main_router,
+                    self.default_inter_node_link_lat,
+                )
+
+                # * connect all nodes to each other if using
+                # * point-to-point main router topology
+                if node_router_topology == CSMRT.Pt2Pt:
+                    for other in self._nodes:
+                        if node != other:
+                            self._biLinkGarnetRouters(
+                                node._main_router,
+                                other._main_router,
+                                self.default_inter_node_link_lat,
+                            )
 
             #! renumber all of the routers and links as we
             #! transfer all of them into the root lists
@@ -1024,7 +1149,9 @@ class ChipletSystem(BaseChipletSystem):
         dma_ports: list[DmaDevice] = [],
         bootmem: AbstractMemory | None = None,
         l2_is_private: bool = False,
-        include_dir_ctrls_in_topology: bool = False,
+        include_dir_ctrls_in_topology: bool = True,
+        include_cache_ctrls_in_topology: bool = True,
+        node_router_topology: CSMRT = CSMRT.ParentOnly,
     ):
         """
         Recursively construct this `ChipletSystem` based on the list
@@ -1054,12 +1181,37 @@ class ChipletSystem(BaseChipletSystem):
                 If the L2 cache is private (one per CPU).
                 Used for distributing controllers.
                 Defaults to False.
+
             include_dir_ctrls_in_topology (bool, optional):
                 If the directory controllers should be included directly
-                in the specified topology of the root `ChipletSystem`.
+                in the specified topology of this `ChipletSystem`.
+
+                However, if the specified topology is a mesh, unless the
+                number of directory controllers matches the number of
+                directory controllers expected by the mesh, the directory
+                controllers will not be included in the topology.
+
                 If this is `False`, directory controllers will only be
-                connected to the main router of the root `ChipletSystem`.
-                Defaults to False.
+                connected to the main router of this `ChipletSystem`.
+                Defaults to True.
+
+            include_cache_ctrls_in_topology (bool, optional):
+                If the cache controllers for this level of the hierarchy
+                should be included directly in the specified topology
+                of this `ChipletSystem`.
+
+                However, if the specified topology is a mesh, the cache
+                controllers will not be included in the topology.
+
+                If this is `False`, cache controllers will only be
+                connected to the main router of this `ChipletSystem`.
+                Defaults to True.
+
+            node_router_topology (ChipletSystemMainRouterTopology):
+                See `class ChipletSystemMainRouterTopology`.
+                Import name is `CSMRT`.
+                Currently valid options are `ParentOnly` and `Pt2Pt`.
+                Defaults to `ParentOnly`.
         """
 
         if self._created is True:
@@ -1087,352 +1239,9 @@ class ChipletSystem(BaseChipletSystem):
                 bootmem,
                 l2_is_private,
                 include_dir_ctrls_in_topology,
+                include_cache_ctrls_in_topology,
+                node_router_topology,
             )
-
-        self._created = True
-
-    def createSystemOld(
-        self,
-        options: Namespace,  # argparse Namespace (parsed args)
-        use_legacy_ruby: bool = False,
-        piobus: IOXBar | None = None,
-        dma_ports: list[DmaDevice] = [],
-        bootmem: AbstractMemory | None = None,
-        l2_is_private: bool = False,
-    ):
-        """
-        Recursively construct this `ChipletSystem` based on the list
-        of nodes and other parameters (e.g., latencies) specified
-        upon creation of the object(s).
-        Specifically, create the backing Garnet network(s) and other
-        necessary objects.
-
-        Args:
-            options (Namespace):
-                argparse options from CLI and/or other definitions
-                such as `Network.define_options()`.
-            use_legacy_ruby (bool):
-                Whether to use (legacy) `Ruby.py` or not.
-                Defaults to False.
-            piobus (IOXBar, optional):
-                System proxy port IO bus. Defaults to None.
-                Needed only to support direct memory access (DMA).
-                See Also: `AbstractBoard.get_io_bus()`.
-            dma_ports (list[DmaDevice], optional):
-                Direct memory access ports. Defaults to an empty list.
-                Needed to support DMA.
-            bootmem (AbstractMemory, optional):
-                Boot memory. Defaults to None.
-                Usually not needed, seemingly only for some FS configs.
-            l2_is_private (bool, optional):
-                If the L2 cache is private (one per CPU).
-                Used for distributing controllers.
-                Defaults to False.
-        """
-
-        if self._created is True:
-            warn(
-                "Attempted to call createSystem() on this "
-                "ChipletSystem, but it has already been created."
-            )
-            return
-
-        if options is None:
-            fatal("Called createSystem() with no argparse options.")
-
-        if use_legacy_ruby:
-            # at top level, run `Ruby.create_system()`
-            # the way Ruby seems to be set up right now,
-            # this should only run once, and not sure if
-            # hierarchical topologies are plausible
-            if not hasattr(self, "_parent_sys"):
-                # configure options that Ruby.py expects
-                options.network = "garnet"
-                options.topology = self._topology_cls.__name__
-                options.mem_type = self._memory_cls.__name__
-
-                # create ruby system
-                Ruby.create_system(
-                    options=options,
-                    full_system=self._is_full_system,
-                    system=self._system,
-                )
-
-                self._x86_connect_ruby_ports()
-        else:
-            #! this branch is adapted from `Ruby.py` and `Network.py`,
-            #! as changes were needed in order to support hierarchies.
-
-            # upon review I don't think that the previous condition(s) for
-            # checking root actually would've worked, so added isRoot().
-
-            # * this block should only run for the parent `ChipletSystem`.
-            # if not hasattr(self._system, "ruby"):
-            if self.isRoot():
-                # instantiate `RubySystem`, to be "created" next
-                self._system.ruby = RubySystem()
-                self._ruby_system = self._system.ruby
-
-                # Generate pseudo filesystem
-                FileSystemConfig.config_filesystem(self._system, options)
-
-            if self._ruby_system is None:
-                panic(
-                    f"RubySystem is None for "
-                    f"{self.__class__.__name__} {self.id}!"
-                )
-
-            # only create a `GarnetNetwork` at the root.
-            # otherwise, use `FakeGarnetNetwork` to collect routers and
-            # links, then construct the root `GarnetNetwork` with them.
-            if self.isRoot():
-                # Create the `GarnetNetwork` for the entire `ChipletSystem`
-                self._garnet_network = GarnetNetwork(
-                    ruby_system=self._ruby_system,
-                    topology=self._topology_cls.__name__,
-                    routers=[],
-                    ext_links=[],
-                    int_links=[],
-                    netifs=[],
-                    ignore_mesh_chk=True,
-                )
-
-                # ignore_mesh_chk:
-                # if `num_rows > 0` we will fail an assertion
-                # when the C++ objects are instantiated
-                # (`m_num_rows * m_num_cols == m_routers.size()`)
-                # (which will not be true since we added routers)
-                # so we had to add an override to prevent this
-            else:  # not root
-                self._garnet_network = FakeGarnetNetwork()
-
-            #! create Ruby system
-            # * this block should only run for the parent `ChipletSystem`.
-            # if self._system.ruby is not None:
-            if self.isRoot():
-                # Ruby expects the `System` object to have a `ruby` attr,
-                # and that the `ruby` property has a `network` attribute.
-                self._ruby_system.network = self._garnet_network
-
-                # * Create the Ruby/memory system
-                try:
-                    # Call `create_system()` corresponding to the
-                    # Ruby protocol that gem5 was compiled with.
-                    # Note: this can be the `MULTIPLE`` protocol.
-                    # The corresponding `create_system()` method can
-                    # be found in `configs/ruby/<PROTOCOL>.py`.
-                    # For example/reference:
-                    if TYPE_CHECKING:
-                        from ruby.MESI_Two_Level import create_system
-                    # Currently, MOST of the protocols (except GPU_VIPER
-                    # and MOESI_AMD_Base, which use the `Cluster` topology)
-                    # call `create_topology()` from `Ruby.py`, passing
-                    # in the controllers created in the `create_system()`
-                    # for that Ruby protocol.
-                    #
-                    # Since we have a hierarchy, and all topologies
-                    # inheriting from `SimpleTopology` are flat, this
-                    # doesn't quite work as is.
-                    #
-                    # Instead, we want to control how the controllers
-                    # are distributed across the hierarchy ourselves.
-                    # To accomplish this without breaking/changing
-                    # everything, we created a "dummy"/"meta" topology
-                    # (`topologies.ChipletMetaTopology`) which we use
-                    # to avoid affecting the actual topology that the
-                    # user intended the parent `ChipletSystem` to use.
-                    #
-                    # This topology is then used to retrieve the
-                    # controllers and distribute them appropriately.
-                    #
-                    # Thus, we must temporarily change `options.topology`
-                    # to get the Ruby protocol to use our meta topology.
-                    tmp = None
-                    if hasattr(options, "_topology"):
-                        tmp = options.topology
-                    options.topology = "ChipletMetaTopology"
-                    (
-                        cpu_sequencers,
-                        dir_controllers,
-                        self._meta_topology,
-                    ) = import_module(
-                        f"ruby.{buildEnv['PROTOCOL']}"
-                    ).create_system(
-                        options,
-                        full_system=self._is_full_system,
-                        system=self._system,
-                        dma_ports=dma_ports,
-                        bootmem=bootmem,
-                        ruby_system=self._ruby_system,
-                        cpus=self._system.cpu,
-                    )
-                    # `options.topology` should've initially been the same
-                    # as `self._topology_cls`, but just in case it wasn't:
-                    if tmp:
-                        options.topology = tmp
-                except Exception as e:
-                    panic(
-                        "Could not create Ruby system for Ruby protocol "
-                        f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
-                    )
-
-            # TODO NEW HIERARCHY: shouldn't be needed
-            # ? with new network building strategy this shouldn't be needed
-            # # set `SimObject` parent hierarchy
-            # # make sure not to set root `GarnetNetwork` parent
-            # # if we did, it would break Ruby because it expects
-            # # the gem5 `System` to have a `.network` param
-            # if not self._garnet_network.has_parent():
-            #     print(
-            #         f"setting gem5 parent for GarnetNetwork of "
-            #         f"ChipletSystem ID {self.id}"
-            #     )
-            #     self._garnet_network.set_parent(self, "network")
-
-            # * collect controllers for this layer of the hierarchy
-            # type error ignorable because subclasses of `BaseTopology`
-            # typically override constructor with this signature
-            all_controllers = self.getRoot()._meta_topology.nodes
-
-            for c in all_controllers:
-                if self.isDirController(c):
-                    # if directory controller, don't include in main
-                    # ruby controllers list
-                    self._dir_controllers.append(c)
-                elif self.getControllerCPU(c, l2_is_private) is None:
-                    # if it doesn't belong to a CPU, it doesn't belong
-                    # to a Chiplet, so it should be ours
-                    #! for now this assumes that LLC is globally shared.
-                    # todo: make ^ not the case
-                    self._ruby_controllers.append(c)
-
-            # TODO NEW HIERARCHY: revise/refactor to indicate that ...
-            # TODO ... it's more of generating routers/links than ...
-            # TODO ... actually creating a topology
-            #! create topology
-            # need to populate `self._ruby_controllers` first
-            self._createTopology(options, self._ruby_controllers)
-
-            # TODO NEW HIERARCHY: maybe needed, not sure yet
-            # self._defineMainRouterParams()
-
-            # # goal of this block is to create only one ext_link for
-            # # each directory controller
-            linked_dcs = [dc for dc, lnk in self._dir_controller_link_map]
-            for dir_ctrl in self._dir_controllers:
-                if dir_ctrl not in linked_dcs:
-                    num_routers = len(self._garnet_network.routers)
-                    dir_router = GarnetRouter(
-                        router_id=num_routers,
-                        latency=self.default_inter_node_router_lat,
-                        # the following are default parameters
-                        # gem5 complains if I don't include these params
-                        vcs_per_vnet=4,
-                    )
-                    self._garnet_network.routers.append(dir_router)
-                    self._connectRubyControllerGarnet(
-                        ctrl=dir_ctrl,
-                        router=dir_router,
-                        link_lat=self.default_inter_node_link_lat,
-                    )
-                    self._biLinkGarnetRouters(self._main_router, dir_router)
-                    self._dir_controller_router_map.append(
-                        (dir_ctrl, dir_router)
-                    )
-
-            # # try linking L2s to children main routers directly
-            # non_private_cache_routers = [
-            #     r for c, r in self._ruby_controller_router_map
-            # ]
-            # for r in non_private_cache_routers:
-            #     for n in self._nodes:
-            #         self._biLinkGarnetRouters(
-            #             r, n._main_router
-            #         )
-
-        # * need to instantiate children before we connect hierarchy
-        # * and init networks
-        for node in self._nodes:
-            # set `SimObject` parent hierarchy
-            node.set_parent(self, f"{node.__class__.__name__}{node.id}")
-            node._ruby_system = self._ruby_system
-            if node is ChipletSystem:
-                node.createSystem(options, use_legacy_ruby)
-            elif isinstance(node, Chiplet):
-                # not sure why, but `is` doesn't work here
-                node.createChiplet(options, l2_is_private)
-
-        if not use_legacy_ruby:
-
-            # TODO NEW HIERARCHY: remove this
-            # self._connectHierarchyGarnet()
-
-            # * this block should only run for the parent `ChipletSystem`.
-            # if self._system.ruby is not None:
-            if self.isRoot():
-                # TODO NEW HIERARCHY: remove this
-                # self._combineHierarchyGarnetNetworks(self._garnet_network)
-                pass
-
-            if self.isRoot():
-                # * initialize network
-                # `Network.py` does this without any major obstacles to
-                # what we're doing in `ChipletSystem` as of now
-                #! effectively requires `.int_links` and `.ext_links` of
-                #! our `GarnetNetwork` to be set before this
-                # todo: we might have to adapt this so that we can add ...
-                # todo: ...links after calling `createSystem()`, not sure
-                options.network = "garnet"  # only required by `Network.py`
-                init_network(
-                    options=options,
-                    network=self._garnet_network,
-                    InterfaceClass=GarnetNetworkInterface,
-                )
-
-            # TODO NEW HIERARCHY: remove this
-            # self._fixAllGarnetObjectParams()
-
-            #! other Ruby config
-            # * this block should only run for the parent `ChipletSystem`.
-            # if self._system.ruby is not None:
-            if self.isRoot():
-                # * do some port configuration from `Ruby.py`
-                self._ruby_connect_system_ports(piobus)
-
-                # todo: don't rely on `Ruby.py` for this
-                # unfortunately, in order to get `dir_cntrls`, the Ruby
-                # protocols also call back to `Ruby.create_directories`.
-                # so can't completely avoid it without major refactoring
-                options.mem_type = self._memory_cls.__name__
-                Ruby.setup_memory_controllers(
-                    system=self._system,
-                    ruby=self._ruby_system,
-                    dir_cntrls=dir_controllers,
-                    options=options,
-                )
-
-                # * more stuff from `Ruby.py`
-                # Connect the cpu sequencers and the piobus
-                if piobus != None:
-                    for cpu_seq in cpu_sequencers:
-                        cpu_seq.connectIOPorts(piobus)
-
-                assert isinstance(self._ruby_system.network, GarnetNetwork)
-                self._ruby_system.number_of_virtual_networks = (
-                    self._ruby_system.network.number_of_virtual_networks
-                )  # implicit line break on assign due to 76 char limit
-                self._ruby_system._cpu_ports = cpu_sequencers
-                self._ruby_system.num_of_sequencers = len(cpu_sequencers)
-
-                # Create a backing copy of physical memory in case required
-                if options.access_backing_store:
-                    self._ruby_system.access_backing_store = True
-                    self._ruby_system.phys_mem = SimpleMemory(
-                        range=self._system.mem_ranges[0], in_addr_map=False
-                    )
-
-        if self.isRoot():
-            self._x86_connect_ruby_ports()
 
         self._created = True
 

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -495,7 +495,7 @@ class ChipletSystem(BaseChipletSystem):
             info.original_id = router.router_id
             router.router_id = root._generate_router_id()
             str += f", new id = {router.router_id}; info = {info}"
-            print(str)
+            # print(str)
 
         for ext_link in root.getRootExtLinks():
             str = f"ext_link id {ext_link.link_id}"
@@ -503,7 +503,7 @@ class ChipletSystem(BaseChipletSystem):
             info.original_id = ext_link.link_id
             ext_link.link_id = root._generate_link_id()
             str += f", new id = {ext_link.link_id}; info = {info}"
-            print(str)
+            # print(str)
 
         for int_link in root.getRootIntLinks():
             str = f"int_link id {int_link.link_id}"
@@ -511,7 +511,7 @@ class ChipletSystem(BaseChipletSystem):
             info.original_id = int_link.link_id
             int_link.link_id = root._generate_link_id()
             str += f", new id = {int_link.link_id}; info = {info}"
-            print(str)
+            # print(str)
 
     # * helper methods for `createSystem()`
     def _createLegacyRubyChiplet(

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -1,4 +1,5 @@
 from argparse import Namespace  # for type checking
+from importlib import import_module
 from typing import (
     TYPE_CHECKING,
     Self,
@@ -7,10 +8,18 @@ from typing import (
 )
 
 from chiplets.BaseChipletSystem import BaseChipletSystem
+from chiplets.Chiplet import Chiplet
+from common import (
+    FileSystemConfig,
+    MemConfig,
+    ObjectList,
+)
+from network.Network import init_network
 from ruby import Ruby
 from topologies.BaseTopology import BaseTopology
+from topologies.ChipletMetaTopology import ChipletMetaTopology
 
-from m5.defines import buildEnv
+from m5.defines import buildEnv  # type: ignore
 from m5.objects import *
 from m5.util import (
     addToPath,
@@ -21,14 +30,21 @@ from m5.util import (
 
 if TYPE_CHECKING:
     from src.cpu.BaseCPU import BaseCPU
+    from src.dev.Device import DmaDevice
     from src.mem.AbstractMemory import AbstractMemory
+    from src.mem.ruby.network.garnet.GarnetLink import *
+    from src.mem.ruby.network.garnet.GarnetNetwork import *
+    from src.mem.ruby.system.RubySystem import RubySystem
+    from src.mem.ruby.system.Sequencer import RubyPortProxy
+    from src.mem.SimpleMemory import SimpleMemory
+    from src.mem.XBar import IOXBar
     from src.sim.System import System
 
 
 class ChipletSystem(BaseChipletSystem):
     """
-    A ChipletSystem encapsulates a collection of child Chiplets and/or
-    ChipletSystems. It acts as an abstraction of a physical processor
+    A `ChipletSystem` encapsulates a collection of child `Chiplet`s and/or
+    `ChipletSystem`s. It acts as an abstraction of a physical processor
     package, a multi-chip module (MCM), or CCD, insofar as its role in
     containing multiple processors (heterogeneous or homogenous) across
     multiple chiplets linked by interconnects. Uses Ruby and Garnet.
@@ -42,11 +58,19 @@ class ChipletSystem(BaseChipletSystem):
     #  - connected_nodes
 
     # whether createSystem() has been called (successfully)
-    created: bool
+    _created: bool
+
+    # class-local reference to `self.system.ruby`
+    # (gem5 system SimObject's RubySystem)
+    _ruby_system: RubySystem
+
+    # see `createSystem()` or `class ChipletMetaTopology`
+    _meta_topology: ChipletMetaTopology
 
     def __init__(
         self,
         system: System,
+        full_system: bool,
         TopologyClass: Type[BaseTopology],
         MemoryClass: Type[AbstractMemory],
         inter_node_link_lat: int,
@@ -60,6 +84,8 @@ class ChipletSystem(BaseChipletSystem):
             system (System):
                 The gem5 `System` SimObject that this `ChipletSystem`
                 is part of.
+            full_system (bool):
+                If gem5 is running in full-system simulation mode.
             TopologyClass (Type[BaseTopology]):
                 The class, derived from `BaseTopology`, corresponding
                 to the topology to be used in this `ChipletSystem`.
@@ -81,6 +107,7 @@ class ChipletSystem(BaseChipletSystem):
 
         super().__init__(
             system=system,
+            full_system=full_system,
             TopologyClass=TopologyClass,
             MemoryClass=MemoryClass,
             nodes=nodes,
@@ -92,79 +119,311 @@ class ChipletSystem(BaseChipletSystem):
             if not hasattr(node, "parent"):
                 node.parent = self
 
-        self.created = False
+        self._created = False
+        self._ruby_system = None
 
     def createSystem(
         self,
-        options: Namespace,  # argparse Namespace (parsed options/args)
-        full_system: bool,
+        options: Namespace,  # argparse Namespace (parsed args)
+        use_legacy_ruby: bool = False,
+        piobus: IOXBar | None = None,
+        dma_ports: list[DmaDevice] = [],
+        bootmem: AbstractMemory | None = None,
     ):
         """
-        Recursively construct this ChipletSystem based on the list of
-        nodes and other parameters (e.g., latencies) specified.
-        Specifically, create the backing Garnet network and other
+        Recursively construct this `ChipletSystem` based on the list
+        of nodes and other parameters (e.g., latencies) specified
+        upon creation of the object(s).
+        Specifically, create the backing Garnet network(s) and other
         necessary objects.
+
+        Args:
+            options (Namespace):
+                argparse options from CLI and/or other definitions
+                such as `Network.define_options()`.
+            use_legacy_ruby (bool):
+                Whether to use (legacy) `Ruby.py` or not.
+                Defaults to False.
+            piobus (IOXBar, optional):
+                System proxy port IO bus. Defaults to None.
+                Needed only to support direct memory access (DMA).
+                See Also: `AbstractBoard.get_io_bus()`.
+            dma_ports (list[DmaDevice], optional):
+                Direct memory access ports. Defaults to an empty list.
+                Needed to support DMA.
+            bootmem (AbstractMemory, optional):
+                Boot memory. Defaults to None.
+                Usually not needed, seemingly only for some FS configs.
         """
 
-        if self.created is True:
+        if self._created is True:
             warn(
                 "Attempted to call createSystem() on this "
                 "ChipletSystem, but it has already been created."
             )
             return
 
-        for node in self.nodes:
-            if node is ChipletSystem:
-                node.createSystem(options, full_system)
+        if use_legacy_ruby and options is not None:
+            # at top level, run `Ruby.create_system()`
+            # the way Ruby seems to be set up right now,
+            # this should only run once, and not sure if
+            # hierarchical topologies are plausible
+            if not hasattr(self, "parent"):
+                # configure options that Ruby.py expects
+                options.network = "garnet"
+                options.topology = self._topology_cls.__name__
+                options.mem_type = self._memory_cls.__name__
 
-        # at top level, run Ruby.create_system()
-        # the way Ruby seems to be set up right now,
-        # this should only run once, and not sure if
-        # hierarchical topologies are plausible
-        if not hasattr(self, "parent"):
-            # configure options that Ruby.py expects
-            options.network = "garnet"
-            options.topology = self._topology_cls.__name__
-            options.mem_type = self._memory_cls.__name__
+                # create ruby system
+                Ruby.create_system(
+                    options=options,
+                    full_system=self._is_full_system,
+                    system=self._system,
+                )
 
-            # create ruby system
-            # todo: may need to call MULTIPLE.py create_system()
-            Ruby.create_system(
-                options=options, full_system=full_system, system=self.system
+                self._x86_connect_ruby_ports()
+        else:
+            #! this branch is adapted from `Ruby.py` and `Network.py`,
+            #! as changes were needed in order to support hierarchies.
+
+            # * this block should only run for the parent `ChipletSystem`.
+            if not hasattr(self._system, "ruby"):
+                # instantiate `RubySystem`, to be "created" next
+                self._system.ruby = RubySystem()
+                self._ruby_system = self._system.ruby
+
+                # Generate pseudo filesystem
+                FileSystemConfig.config_filesystem(self._system, options)
+
+            if self._ruby_system is None:
+                panic("ChipletSystem's RubySystem is None!")
+
+            # Create the `GarnetNetwork` for this level of the hierarchy
+            self._garnet_network = GarnetNetwork(
+                ruby_system=self._ruby_system,
+                topology=self._topology_cls.__name__,
+                routers=[],
+                ext_links=[],
+                int_links=[],
+                netifs=[],
             )
 
-            # todo: make this not a hack
-            # connect ruby ports if x86
-            for i, cpu in enumerate(self.system.cpu):
-                if issubclass(cpu.__class__, BaseCPU):
-                    # figure out if we're using x86 ISA
-                    archs_enabled = list(
-                        filter(lambda var: buildEnv[var], ["USE_X86_ISA"])
+            # * this block should only run for the parent `ChipletSystem`.
+            if self._system.ruby is not None:
+                # `Ruby.py` does this, not sure why since `RubySystem`
+                # doesn't have a 'network' param
+                self._ruby_system.network = self._garnet_network
+
+                # * Create the Ruby/memory system
+                try:
+                    # Call `create_system()` corresponding to the
+                    # Ruby protocol that gem5 was compiled with.
+                    # Note: this can be the `MULTIPLE`` protocol.
+                    # The corresponding `create_system()` method can
+                    # be found in `configs/ruby/<PROTOCOL>.py`.
+                    # For example/reference:
+                    if TYPE_CHECKING:
+                        from ruby.MESI_Two_Level import create_system
+                    # Currently, MOST of the protocols (except GPU_VIPER
+                    # and MOESI_AMD_Base, which use the `Cluster` topology)
+                    # call `create_topology()` from `Ruby.py`, passing
+                    # in the controllers created in the `create_system()`
+                    # for that Ruby protocol.
+                    #
+                    # Since we have a hierarchy, and all topologies
+                    # inheriting from `SimpleTopology` are flat, this
+                    # doesn't quite work as is.
+                    #
+                    # Instead, we want to control how the controllers
+                    # are distributed across the hierarchy ourselves.
+                    # To accomplish this without breaking/changing
+                    # everything, we created a "dummy"/"meta" topology
+                    # (`topologies.ChipletMetaTopology`) which we use
+                    # to avoid affecting the actual topology that the
+                    # user intended the parent `ChipletSystem` to use.
+                    #
+                    # This topology is then used to retrieve the
+                    # controllers and distribute them appropriately.
+                    #
+                    # Thus, we must temporarily change `options.topology`
+                    # to get the Ruby protocol to use our meta topology.
+                    tmp = None
+                    if hasattr(options, "topology"):
+                        tmp = options.topology
+                    options.topology = "ChipletMetaTopology"
+                    (
+                        cpu_sequencers,
+                        dir_controllers,
+                        self._meta_topology,
+                    ) = import_module(
+                        f"ruby.{buildEnv['PROTOCOL']}"
+                    ).create_system(
+                        options,
+                        full_system=self._is_full_system,
+                        system=self._system,
+                        dma_ports=dma_ports,
+                        bootmem=bootmem,
+                        ruby_system=self._ruby_system,
+                        cpus=self._system.cpu,
                     )
-                    if len(archs_enabled) == 1:
-                        arch = archs_enabled[0]
-                        if arch == "USE_X86_ISA":
-                            # has the interrupt controller
-                            # been created yet?
-                            if len(cpu.interrupts) == 0:
-                                cpu.createInterruptController()
-                                # probably should let the user do this,
-                                # but this should be done near when
-                                # create_system() is called, which
-                                # would then require another method
-                                warn(
-                                    "ChipletSystem: detected x86 "
-                                    "ISA and created interrupt "
-                                    "controller automatically."
-                                )
+                    # `options.topology` should've initially been the same
+                    # as `self.TopologyClass`, but just in case it wasn't:
+                    if tmp:
+                        options.topology = tmp
 
-                            if len(cpu.interrupts) != 0:
-                                ruby_port = self.system.ruby._cpu_ports[i]
-                                ruby_port.connectCpuPorts(cpu)
-                            else:
-                                panic(
-                                    "Interrupt controller was created, "
-                                    "but no interrupts were found."
-                                )
+                    protocol_controllers = self._meta_topology.nodes
+                except Exception as e:
+                    panic(
+                        "Could not create Ruby system for Ruby protocol "
+                        f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
+                    )
 
-        self.created = True
+                #! instantiate topology for this layer of the hierarchy
+                # type error ignorable because subclasses of `BaseTopology`
+                # typically override constructor with this signature
+                # todo: actually distribute controllers properly
+                self.topology = self._topology_cls(
+                    protocol_controllers  # type: ignore
+                )
+
+                # * setup topology
+                # latter 3 args are the literal classes for the
+                # corresponding objects. they can technically be
+                # based on either `GarnetNetwork` or `SimpleNetwork`,
+                # but we're using Garnet and don't allow Simple.
+                self.topology.makeTopology(
+                    options=options,
+                    network=self._garnet_network,
+                    IntLink=GarnetIntLink,
+                    ExtLink=GarnetExtLink,
+                    Router=GarnetRouter,
+                )
+
+                # if in SE mode, register topology with (faux) filesystem
+                # only some topologies implement this (as of now, only
+                # `Mesh_XY` and `MeshDirCorners_XY` do.)
+                if not self._is_full_system:
+                    # notes: `Mesh_XY` requires
+                    # `options.num_cpus` and `options.mem_size`.
+                    # `MeshDirCorners_XY` requires only `options.mem_size`.
+                    self.topology.registerTopology(options)
+
+                # * initialize network
+                # `Network.py` does this without any major obstacles to
+                # what we're doing in `ChipletSystem` as of now
+                #! effectively requires `.int_links` and `.ext_links` of
+                #! our `GarnetNetwork` to be set before this
+                # todo: we might have to adapt this so that we can add ...
+                # todo: ...links after calling `createSystem()`, not sure
+                options.network = "garnet"  # only required by `Network.py`
+                init_network(
+                    options=options,
+                    network=self._garnet_network,
+                    InterfaceClass=GarnetNetworkInterface,
+                )
+
+                # * do some port configuration from `Ruby.py`
+                self._ruby_connect_system_ports(piobus)
+
+                # todo: don't rely on `Ruby.py` for this
+                # unfortunately, in order to get `dir_cntrls`, the Ruby
+                # protocols also call back to `Ruby.create_directories`.
+                options.mem_type = self._memory_cls.__name__
+                Ruby.setup_memory_controllers(
+                    system=self._system,
+                    ruby=self._ruby_system,
+                    dir_cntrls=dir_controllers,
+                    options=options,
+                )
+
+                # * more stuff from `Ruby.py`
+                # Connect the cpu sequencers and the piobus
+                if piobus != None:
+                    for cpu_seq in cpu_sequencers:
+                        cpu_seq.connectIOPorts(piobus)
+
+                self._ruby_system.number_of_virtual_networks = (
+                    self._ruby_system.network.number_of_virtual_networks
+                )  # implicit line break on assign due to 76 char limit
+                self._ruby_system._cpu_ports = cpu_sequencers
+                self._ruby_system.num_of_sequencers = len(cpu_sequencers)
+
+                # Create a backing copy of physical memory in case required
+                if options.access_backing_store:
+                    self._ruby_system.access_backing_store = True
+                    self._ruby_system.phys_mem = SimpleMemory(
+                        range=self._system.mem_ranges[0], in_addr_map=False
+                    )
+
+        for node in self.nodes:
+            if node is ChipletSystem:
+                node._ruby_system = self._ruby_system
+                node.createSystem(options, use_legacy_ruby)
+            elif node is Chiplet:
+                # todo: initialize chiplet
+                pass
+
+        self._x86_connect_ruby_ports()
+
+        self._created = True
+
+    def _ruby_connect_system_ports(self, piobus: IOXBar):
+        # * some port configuration lifted from `Ruby.py`
+        # ? not sure why some of this stuff errors. perhaps...
+        # ? ...things may have flipped since `Ruby.py` was written?
+        # Create a port proxy for connecting the system port. This is
+        # independent of the protocol and kept in the protocol-agnostic
+        # part (i.e. here).
+        system = self._system  # only for staying under 76 chars/line
+        sys_port_proxy = RubyPortProxy(ruby_system=self._ruby_system)
+        if piobus is not None:
+            #! the line below type-errors (response port = request port)
+            sys_port_proxy.pio_request_port = (  # type: ignore
+                piobus.cpu_side_ports
+            )  # implicit line break on assign due to 76 char limit
+
+        # Give the system port proxy a SimObject parent without creating
+        # a full-fledged controller
+        system.sys_port_proxy = sys_port_proxy
+
+        # Connect the system port for loading of binaries etc
+        #! the line below type-errors (response port = request port)
+        system.system_port = system.sys_port_proxy.in_ports  # type: ignore
+
+    def _x86_connect_ruby_ports(self):
+        """
+        Connects ruby ports for x86 CPUs present in the system.
+        """
+
+        # todo: make this not a hack
+        for i, cpu in enumerate(self._system.cpu):
+            if issubclass(cpu.__class__, BaseCPU):
+                # figure out if we're using x86 ISA
+                archs_enabled = list(
+                    filter(lambda var: buildEnv[var], ["USE_X86_ISA"])
+                )
+                if len(archs_enabled) == 1:
+                    arch = archs_enabled[0]
+                    if arch == "USE_X86_ISA":
+                        # has the interrupt controller
+                        # been created yet?
+                        if len(cpu.interrupts) == 0:
+                            cpu.createInterruptController()
+                            # probably should let the user do this,
+                            # but this should be done near when
+                            # create_system() is called, which
+                            # would then require another method
+                            warn(
+                                "ChipletSystem: detected x86 "
+                                "ISA and created interrupt "
+                                "controller automatically."
+                            )
+
+                        if len(cpu.interrupts) != 0:
+                            ruby_port = self._system.ruby._cpu_ports[i]
+                            ruby_port.connectCpuPorts(cpu)
+                        else:
+                            panic(
+                                "Interrupt controller was created, "
+                                "but no interrupts were found."
+                            )

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -192,13 +192,19 @@ class ChipletSystem(BaseChipletSystem):
         self._global_router_count = 0
         self._global_link_count = 0
 
+        self._root_all_routers_dict = {}
+        self._root_all_ext_links_dict = {}
+        self._root_all_int_links_dict = {}
+
+        self._root_main_routers_dict = {}
+        self._root_fake_garnet_networks_dict = {}
+
         self._garnet_network = FakeGarnetNetwork()
 
         self._main_router = self.create_and_register_router(
             latency=inter_node_router_lat,
             description=f"{self.__class__.__name__}{self.id} main router",
         )
-        # register to dict later, `getRoot()` won't work right now
 
         self._created = False
         self._ruby_system = None
@@ -286,7 +292,7 @@ class ChipletSystem(BaseChipletSystem):
 
         root = self.getRoot()
 
-        new_router_id = self._generate_router_id()
+        new_router_id = root._generate_router_id()
 
         new_router = GarnetRouter(
             router_id=new_router_id,
@@ -331,8 +337,8 @@ class ChipletSystem(BaseChipletSystem):
 
         for router in net2.routers:
             if root is not None:
-                info = root._root_all_routers_dict[router]
-                if info is not None:
+                if router in root._root_all_routers_dict.keys():
+                    info = root._root_all_routers_dict[router]
                     info.original_id = router.router_id
                 elif add_to_dict_if_missing:
                     root._registerNetworkObject(
@@ -359,12 +365,12 @@ class ChipletSystem(BaseChipletSystem):
 
         for ext_link in net2.ext_links:
             if root is not None:
-                info = root._root_all_ext_links_dict[ext_link]
-                if info is not None:
+                if ext_link in root._root_all_ext_links_dict.keys():
+                    info = root._root_all_ext_links_dict[ext_link]
                     info.original_id = ext_link.link_id
                 elif add_to_dict_if_missing:
                     root._registerNetworkObject(
-                        router,
+                        ext_link,
                         ChipletGarnetObjectInfo(
                             # assume that callee is parent of `net1`
                             original_parent=self,
@@ -387,12 +393,12 @@ class ChipletSystem(BaseChipletSystem):
 
         for int_link in net2.int_links:
             if root is not None:
-                info = root._root_all_int_links_dict[int_link]
-                if info is not None:
+                if int_link in root._root_all_int_links_dict.keys():
+                    info = root._root_all_int_links_dict[int_link]
                     info.original_id = int_link.link_id
                 elif add_to_dict_if_missing:
                     root._registerNetworkObject(
-                        router,
+                        int_link,
                         ChipletGarnetObjectInfo(
                             # assume that callee is parent of `net1`
                             original_parent=self,
@@ -439,6 +445,38 @@ class ChipletSystem(BaseChipletSystem):
             add_to_dict_if_missing=True,
             skip_duplicates=True,
         )
+
+    def _rootReAssignAllIDs(self):
+        root = self.getRoot()
+        rnet = root._garnet_network
+
+        # reset counters
+        root._global_router_count = 0
+        root._global_link_count = 0
+
+        for router in root.getRootRouters():
+            str = f"router id {router.router_id}"
+            info = root._root_all_routers_dict[router]
+            info.original_id = router.router_id
+            router.router_id = root._generate_router_id()
+            str += f", new id = {router.router_id}; info = {info}"
+            print(str)
+
+        for ext_link in root.getRootExtLinks():
+            str = f"ext_link id {ext_link.link_id}"
+            info = root._root_all_ext_links_dict[ext_link]
+            info.original_id = ext_link.link_id
+            ext_link.link_id = root._generate_link_id()
+            str += f", new id = {ext_link.link_id}; info = {info}"
+            print(str)
+
+        for int_link in root.getRootIntLinks():
+            str = f"int_link id {int_link.link_id}"
+            info = root._root_all_int_links_dict[int_link]
+            info.original_id = int_link.link_id
+            int_link.link_id = root._generate_link_id()
+            str += f", new id = {int_link.link_id}; info = {info}"
+            print(str)
 
     # * helper methods for `createSystem()`
     def _createLegacyRubyChiplet(
@@ -727,14 +765,9 @@ class ChipletSystem(BaseChipletSystem):
                 #! for now this assumes that LLC is globally shared.
                 # todo: make ^ not the case
 
-                self._non_dir_controllers.append(c)
-                self._ruby_controllers.append(c)
-
-                if self.getControllerCPU(c, l2_is_private) is not None:
-                    warn(
-                        f"Found non-directory controller that seems to "
-                        f"belong to a CPU: {c}"
-                    )
+                if self.getControllerCPU(c, l2_is_private) is None:
+                    self._non_dir_controllers.append(c)
+                    self._ruby_controllers.append(c)
 
     def _linkDirectoryControllers(self):
         for dir_ctrl in self._dir_controllers:
@@ -902,27 +935,29 @@ class ChipletSystem(BaseChipletSystem):
         # * so we expect that and prepare accordingly
         # we likely don't have many routers/links in the fake network yet,
         # but better to be safe
-        gn = self._garnet_network
-        tmp_routers = [r for r in gn.routers]
-        tmp_ext_links = [l for l in gn.ext_links]
-        tmp_int_links = [l for l in gn.int_links]
-        tmp_network = FakeGarnetNetwork(
-            tmp_routers, tmp_ext_links, tmp_int_links
-        )
+        self._rootAccumulateNetworkObjects(self._garnet_network)
+
+        # gn = self._garnet_network
+        # tmp_routers = [r for r in gn.routers]
+        # tmp_ext_links = [l for l in gn.ext_links]
+        # tmp_int_links = [l for l in gn.int_links]
+        # tmp_network = FakeGarnetNetwork(
+        #     tmp_routers, tmp_ext_links, tmp_int_links
+        # )
 
         # populate `FakeGarnetNetwork` with routers and links
         # based on the specified topology for this `Chiplet[System]`
         self._createTopology(options, self._ruby_controllers)
 
         # recombine existing routers/links with those from the topology
-        self._mergeFakeGarnetNetworks(
-            tmp_network,
-            self._garnet_network,
-            add_to_dict_if_missing=True,
-            skip_duplicates=True,
-        )
-        self._garnet_network = tmp_network
-        root._root_fake_garnet_networks_dict[self] = self._garnet_network
+        # self._mergeFakeGarnetNetworks(
+        #     tmp_network,
+        #     self._garnet_network,
+        #     add_to_dict_if_missing=True,
+        #     skip_duplicates=True,
+        # )
+        # self._garnet_network = tmp_network
+        # root._root_fake_garnet_networks_dict[self] = self._garnet_network
 
         # * need to instantiate and connect to children before init network
         for node in self._nodes:
@@ -957,6 +992,8 @@ class ChipletSystem(BaseChipletSystem):
             # work on any hierarchy, although it might be rather slow
             self._rootAccumulateNetworkObjects(node._garnet_network)
 
+        self._rootAccumulateNetworkObjects(self._garnet_network)
+
         if is_root:
             #! this where the rest of the magic happens.
             """
@@ -967,6 +1004,7 @@ class ChipletSystem(BaseChipletSystem):
             topologies (from `configs/topologies`), without having to
             manually define the hierarchical topology at a low level.
             """
+            self._rootReAssignAllIDs()
 
             # replace the root's `FakeGarnetNetwork` with the real one here
             self._garnet_network = root_garnet_network

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -7,7 +7,10 @@ from typing import (
     Type,
 )
 
-from chiplets.BaseChipletSystem import BaseChipletSystem
+from chiplets.BaseChipletSystem import (
+    BaseChipletSystem,
+    FakeGarnetNetwork,
+)
 from chiplets.Chiplet import Chiplet
 from common import (
     FileSystemConfig,
@@ -36,10 +39,46 @@ if TYPE_CHECKING:
     from src.mem.ruby.network.garnet.GarnetNetwork import *
     from src.mem.ruby.network.Network import RubyNetwork
     from src.mem.ruby.system.RubySystem import RubySystem
-    from src.mem.ruby.system.Sequencer import RubyPortProxy
+    from src.mem.ruby.system.Sequencer import (
+        RubyPortProxy,
+        RubySequencer,
+    )
     from src.mem.SimpleMemory import SimpleMemory
     from src.mem.XBar import IOXBar
     from src.sim.System import System
+
+
+class ChipletGarnetObjectInfo:
+    """
+    Used to hold information corresponding to a Garnet/Ruby object that has
+    been aggregated into the main `GarnetNetwork` of a `ChipletSystem`.
+    This should be the value of a `dict` whose keys are the corresponding
+    Garnet/Ruby object (e.g., router or link).
+    """
+
+    def __init__(
+        self,
+        original_parent: BaseChipletSystem | BaseCPU,
+        original_id: int = -1,
+        description: str = "",
+    ):
+        """
+        Args:
+            original_parent (BaseChipletSystem | BaseCPU):
+                A reference to the original parent of the object
+                corresponding to this `GarnetObjectInfo` instance.
+            original_id (int, optional):
+                If the object corresponding to this `GarnetObjectInfo`
+                instance has an ID attribute, and it was changed in
+                the network aggregation, set this to the original ID.
+                Defaults to -1.
+            description (str, optional):
+                A string description of what the corresponding object
+                represents.
+        """
+        self.original_parent = original_parent
+        self.original_id = original_id
+        self.description = description
 
 
 class ChipletSystem(BaseChipletSystem):
@@ -51,22 +90,28 @@ class ChipletSystem(BaseChipletSystem):
     multiple chiplets linked by interconnects. Uses Ruby and Garnet.
     """
 
-    #! see BaseChipletSystem for additional key properties, including:
-    #  - nodes
-    #  - default_inter_node_link_lat
-    #  - default_inter_node_router_lat
-    #  - parent
-    #  - connected_nodes
+    #! see BaseChipletSystem for additional important attributes
 
     type = "ChipletSystem"
     abstract = False
     clk_domain = Param.ClockDomain(Parent.clk_domain, "Clock domain")
+
+    # class-local reference to `self.system.ruby`
+    # (gem5 system SimObject's RubySystem)
+    _ruby_system: RubySystem
 
     # whether createSystem() has been called (successfully)
     _created: bool
 
     # see `createSystem()` or `class ChipletMetaTopology`
     _meta_topology: ChipletMetaTopology
+
+    # storage for objects for network aggregation
+    _root_all_routers_dict: dict[GarnetRouter, ChipletGarnetObjectInfo]
+    _root_all_ext_links_dict: dict[GarnetExtLink, ChipletGarnetObjectInfo]
+    _root_all_int_links_dict: dict[GarnetIntLink, ChipletGarnetObjectInfo]
+
+    _fake_garnet_networks_dict: dict[BaseChipletSystem, FakeGarnetNetwork]
 
     def __init__(
         self,
@@ -116,24 +161,496 @@ class ChipletSystem(BaseChipletSystem):
             inter_node_router_lat=inter_node_router_lat,
         )
 
+        # * set gem5 SimObject parent-child relationship
         if not self.has_parent():
             self.set_parent(
                 self._system, f"{self.__class__.__name__}{self.id}"
             )
 
+        # * set _parent_sys property for children
+        # currently only adding nodes in constructor is really supported
         for node in self._nodes:
             if not hasattr(node, "_parent_sys"):
                 node._parent_sys = self
 
-        # clock domain must propagate down to routers
-        if not hasattr(self, "clk_domain"):
-            print(f"ChipletSystem {self.id} has no clock domain!")
-            # self.clk_domain = self._system.clk_domain
-
         self._created = False
         self._ruby_system = None
 
+    # * helper methods for retrieving data on Garnet network objects
+    def getRootRouters(self) -> list[GarnetRouter]:
+        return list(self.getRoot()._root_all_routers_dict.keys())
+
+    def getRootExtLinks(self) -> list[GarnetExtLink]:
+        return list(self.getRoot()._root_all_ext_links_dict.keys())
+
+    def getRootIntLinks(self) -> list[GarnetIntLink]:
+        return list(self.getRoot()._root_all_int_links_dict.keys())
+
+    def getGarnetObjectInfo(self, object):
+        info = None
+
+        if isinstance(object, GarnetRouter):
+            routers = self.getRootRouters()
+            if object in routers:
+                info = self._root_all_routers_dict[object]
+
+        if isinstance(object, GarnetExtLink):
+            ext_links = self.getRootExtLinks()
+            if object in ext_links:
+                info = self._root_all_ext_links_dict[object]
+
+        if isinstance(object, GarnetIntLink):
+            int_links = self.getRootIntLinks()
+            if object in int_links:
+                info = self._root_all_int_links_dict[object]
+
+        return info
+
+    def getOriginalParent(self, object):
+        info = self.getGarnetObjectInfo(object)
+        if info is not None:
+            return info.original_parent
+
+    # * helper methods for `createSystem()`
+
+    def _createChildren(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+        l2_is_private: bool = False,
+    ):
+        pass
+
+    def _createLegacyRubyChiplet(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+        piobus: IOXBar | None = None,
+        dma_ports: list[DmaDevice] = [],
+        bootmem: AbstractMemory | None = None,
+    ):
+        """
+        Creates a `ChipletSystem` using `Ruby.py`'s `create_system()`
+        directly. Probably won't work well with hierarchical topologies.
+
+        Args:
+            See `_createChipletHierarchy()`.
+        """
+        # warn if hierarchical topology
+        for node in self._nodes:
+            if isinstance(node, ChipletSystem):
+                warn(
+                    "Using legacy ruby (Ruby.py) with hierarchical "
+                    "chiplet topology. Unexpected behavior may occur."
+                )
+
+        # at top level, run `Ruby.create_system()`
+        # the way Ruby seems to be set up right now,
+        # this should only run once, and not sure if
+        # hierarchical topologies are plausible
+        if not hasattr(self, "_parent_sys"):
+            # configure options that Ruby.py expects
+            options.network = "garnet"
+            options.topology = self._topology_cls.__name__
+            options.mem_type = self._memory_cls.__name__
+
+            # create ruby system
+            Ruby.create_system(
+                options=options,
+                full_system=self._is_full_system,
+                system=self._system,
+                piobus=piobus,
+                dma_ports=dma_ports,
+                bootmem=bootmem,
+            )
+
+            self._x86_connect_ruby_ports()
+
+    def _createRootGarnetNetwork(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+    ):
+        if not self.isRoot():
+            fatal(
+                f"User tried to instantiate GarnetNetwork for "
+                f"non-root ChipletSystem (ID {self.id})."
+            )
+
+        if hasattr(self, "_garnet_network") and isinstance(
+            self._garnet_network, GarnetNetwork
+        ):
+            fatal(
+                f"GarnetNetwork already exists for ChipletSystem "
+                f"ID {self.id}!"
+            )
+
+        # Create the `GarnetNetwork` for the entire `ChipletSystem`
+        self._garnet_network = GarnetNetwork(
+            ruby_system=self._ruby_system,
+            topology=self._topology_cls.__name__,
+            routers=self.getRootRouters(),
+            ext_links=self.getRootExtLinks(),
+            int_links=self.getRootIntLinks(),
+            netifs=[],  # will be populated by `init_network()`
+            ignore_mesh_chk=True,
+        )
+
+        # * ignore_mesh_chk:
+        # if `num_rows > 0` we will fail an assertion
+        # when the C++ objects are instantiated
+        # (`m_num_rows * m_num_cols == m_routers.size()`)
+        # (which will not be true since we added routers)
+        # so we had to add an override to prevent this
+        # TODO NEW HIERARCHY: this might not be needed anymore
+
+        # * initialize network
+        # `Network.py` does this without any major obstacles to
+        # what we're doing in `ChipletSystem` as of now
+        #! effectively requires `.int_links` and `.ext_links` of
+        #! our `GarnetNetwork` to be set before this
+        # todo: we might have to adapt this so that we can add ...
+        # todo: ...links after calling `createSystem()`, not sure
+        options.network = "garnet"  # only required by `Network.py`
+        init_network(
+            options=options,
+            network=self._garnet_network,
+            InterfaceClass=GarnetNetworkInterface,
+        )
+
+    def _instantiateRubySystem(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+    ):
+        if self.isRoot():  # redundant but just in case
+            # instantiate `RubySystem`, to be "created" next
+            self._system.ruby = RubySystem()
+            self._ruby_system = self._system.ruby
+
+            # Generate pseudo filesystem
+            FileSystemConfig.config_filesystem(self._system, options)
+        else:
+            fatal(
+                f"User tried to instantiate Ruby system on non-root "
+                f"ChipletSystem (ID {self.id}). Do not call "
+                f"_instantiateRubySystem() from outside ChipletSystem."
+            )
+
+        if self.getRoot()._ruby_system is None:
+            panic(
+                f"RubySystem is None for "
+                f"{self.__class__.__name__} {self.id}!"
+            )
+
+    def _createRubySystem(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+        dma_ports: list[DmaDevice] = [],
+        bootmem: AbstractMemory | None = None,
+    ):
+        """
+        Creates the Ruby system.
+        The `RubySystem` object must be instantiated first.
+        Sets the following attributes of this `ChipletSystem`:
+         - `self._cpu_sequencers`
+         - `self._dir_controllers`
+         - `self._meta_topology`
+
+        Args:
+            See `_createChipletHierarchy()`.
+        """
+        if not hasattr(self._system, "ruby"):
+            if hasattr(self, "_ruby_system"):
+                panic("RubySystem was not properly assigned to gem5 System!")
+            else:
+                fatal(
+                    "User tried to create Ruby system, but it hasn't been "
+                    "instantiated. Do not call _createRubySystem() "
+                    "from outside ChipletSystem."
+                )
+
+        if not hasattr(self._system.ruby, "network"):
+            if hasattr(self, "_garnet_network"):
+                panic(
+                    "Garnet network was not properly assigned to "
+                    "gem5 System!"
+                )
+
+        if not hasattr(self, "_garnet_network"):
+            fatal(
+                "User tried to create Ruby system, but Garnet network "
+                "has not yet been created. Do not call "
+                "_createRubySystem() from outside ChipletSystem."
+            )
+
+        if isinstance(self._garnet_network, FakeGarnetNetwork):
+            panic(
+                "ChipletSystem's GarnetNetwork is FakeGarnetNetwork! "
+                "Either GarnetNetwork failed to instantiate, or "
+                "_createRubySystem() was called before "
+                "_createRootGarnetNetwork()!"
+            )
+
+        # * Create the Ruby/memory system
+        try:
+            # Call `create_system()` corresponding to the
+            # Ruby protocol that gem5 was compiled with.
+            # Note: this can be the `MULTIPLE` protocol.
+            # The corresponding `create_system()` method can
+            # be found in `configs/ruby/<PROTOCOL>.py`.
+            # For example/reference:
+            if TYPE_CHECKING:
+                from ruby.MESI_Two_Level import create_system
+            # Currently, MOST of the protocols (except GPU_VIPER
+            # and MOESI_AMD_Base, which use the `Cluster` topology)
+            # call `create_topology()` from `Ruby.py`, passing
+            # in the controllers created in the `create_system()`
+            # for that Ruby protocol.
+            #
+            # Since we have a hierarchy, and all topologies
+            # inheriting from `SimpleTopology` are flat, this
+            # doesn't quite work as is.
+            #
+            # Instead, we want to control how the controllers
+            # are distributed across the hierarchy ourselves.
+            # To accomplish this without breaking/changing
+            # everything, we created a "dummy"/"meta" topology
+            # (`topologies.ChipletMetaTopology`) which we use
+            # to avoid affecting the actual topology that the
+            # user intended the parent `ChipletSystem` to use.
+            #
+            # This topology is then used to retrieve the
+            # controllers and distribute them appropriately.
+            #
+            # Thus, we must temporarily change `options.topology`
+            # to get the Ruby protocol to use our meta topology.
+            tmp = None
+            if hasattr(options, "_topology"):
+                tmp = options.topology
+            options.topology = "ChipletMetaTopology"
+            (
+                self._cpu_sequencers,
+                self._dir_controllers,
+                self._meta_topology,
+            ) = import_module(f"ruby.{buildEnv['PROTOCOL']}").create_system(
+                options,
+                full_system=self._is_full_system,
+                system=self._system,
+                dma_ports=dma_ports,
+                bootmem=bootmem,
+                ruby_system=self._ruby_system,
+                cpus=self._system.cpu,
+            )
+            # `options.topology` should've initially been the same
+            # as `self._topology_cls`, but just in case it wasn't:
+            if tmp:
+                options.topology = tmp
+        except Exception as e:
+            panic(
+                "Could not create Ruby system for Ruby protocol "
+                f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
+            )
+
+    def _sortRubyControllers(
+        self,
+        l2_is_private: bool,
+        include_dir_ctrls_in_topology: bool = False,
+    ):
+        """
+        Populates lists of Ruby controllers for this `Chiplet[System]`
+        based on what `create_system()` of the Ruby protocol generated.
+        Specifically, populates:
+         - `self._ruby_controllers`
+         - `self._dir_controllers`
+         - `self._non_dir_controllers`
+        """
+
+        # grab all controllers
+        # this includes every controller, since that's what's
+        # returned from `create_system()` of the Ruby protocol
+        # (see `_createRubySystem()` for more details).
+        all_controllers = self.getRoot()._meta_topology.nodes
+
+        for c in all_controllers:
+            # we should already have a list of all directory controllers in
+            # `_dir_controllers` after `_createRubySystem()`, but verify
+            if self.isDirController(c):
+                if c not in self._dir_controllers:
+                    warn(
+                        f"Found directory controller that was not in this "
+                        f"ChipletSystem's list of directory controllers: "
+                        f"{c}"
+                    )
+                    self._dir_controllers.append(c)
+                if include_dir_ctrls_in_topology:
+                    self._ruby_controllers.append(c)
+            else:
+                # not directory controller, should be a different cache
+                # controller (or perhaps a DMA controller)
+                # todo: we don't really handle DMA controllers specially
+
+                #! for now this assumes that LLC is globally shared.
+                # todo: make ^ not the case
+
+                self._non_dir_controllers.append(c)
+                self._ruby_controllers.append(c)
+
+                if self.getControllerCPU(c, l2_is_private) is not None:
+                    warn(
+                        f"Found non-directory controller that seems to "
+                        f"belong to a CPU: {c}"
+                    )
+
+    def _createChipletHierarchy(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+        piobus: IOXBar | None = None,
+        dma_ports: list[DmaDevice] = [],
+        bootmem: AbstractMemory | None = None,
+        l2_is_private: bool = False,
+        include_dir_ctrls_in_topology: bool = False,
+    ):
+        """
+        Recursively create this chiplet hierarchy.
+        This contains most of the core logic for creating
+        the `ChipletSystem` and its children.
+
+        Args:
+            See `createSystem()`.
+        """
+
+        #! this code is adapted from `Ruby.py` and `Network.py`,
+        #! as changes were needed in order to support hierarchies.
+        is_root = self.isRoot()
+
+        #! this is where (some of) the magic happens.
+        """
+        We recursively "create" the children (nodes). Each has its own
+        topology (from `configs/topologies`). To create a Ruby system and
+        Garnet network representing a hierarchical topology without
+        breaking all the existing topologies and interfering with the
+        cache coherence protocol, for each child/node, we use
+        `makeTopology()` on a fake Garnet network to collect all the
+        Garnet routers and links, all structured according to the topology
+        of the child. Creating multiple `GarnetNetwork`s and trying to
+        combine them does not work properly, so this method is better.
+        The root `ChipletSystem` also has a topology, so we also need to
+        do the same thing for it (this), and we do that first.
+        """
+        self._garnet_network = FakeGarnetNetwork()
+        self._fake_garnet_networks_dict[self] = self._garnet_network
+
+        # TODO NEW HIERARCHY:
+        """
+        # TODO | Figure out how to properly divide list of controllers
+        # TODO | across multiple `ChipletSystem`s.
+        # TODO | Currently, this doesn't really happen.
+        # TODO | This will probably involve adjusting how
+        # TODO | `_sortRubyControllers()` works.
+        # TODO |
+        # TODO | It's relatively easy to determine if a controller belongs
+        # TODO | to a `Chiplet`, because we can just check if it
+        # TODO | corresponds to one of that `Chiplet`'s cores.
+        # TODO | Determining if a controller belongs to a `ChipletSystem`
+        # TODO | will require some additional infrastructure.
+        # TODO |
+        # TODO | Right now, it's structured so that each `Chiplet[System]`
+        # TODO | grabs the entire list of all controllers from the meta
+        # TODO | topology / Ruby protocol, and tries to figure out if
+        # TODO | each belongs to it or not.
+        """
+
+        if is_root:
+            # create `RubySystem` and assign to `self._ruby_system`
+            # also some filesystem config
+            self._instantiateRubySystem(options)
+
+            #! this where the rest of the magic happens.
+            """
+            Once we have created all of the topologies of all children,
+            and collected all routers, links, etc., we can then combine
+            everything into a singular `GarnetNetwork` that aligns with
+            a hierarchical topology, constructed from multiple simpler
+            topologies (from `configs/topologies`), without having to
+            manually define the hierarchical topology at a low level.
+            """
+            self._createRootGarnetNetwork(options)
+            #! ^ also instantiates network via `init_network()`...
+            #! not sure if this needs to be done later
+
+            # Ruby expects the `System` object to have a `ruby` attr,
+            # and that the `ruby` property has a `network` attribute.
+            self._ruby_system.network = self._garnet_network
+
+            self._createRubySystem(options, dma_ports, bootmem)
+
+            # after this, our lists of controllers should be populated
+            self._sortRubyControllers(
+                l2_is_private,
+                include_dir_ctrls_in_topology,
+            )
+
     def createSystem(
+        self,
+        options: Namespace,  # argparse Namespace (parsed args)
+        use_legacy_ruby: bool = False,
+        piobus: IOXBar | None = None,
+        dma_ports: list[DmaDevice] = [],
+        bootmem: AbstractMemory | None = None,
+        l2_is_private: bool = False,
+        include_dir_ctrls_in_topology: bool = False,
+    ):
+        """
+        Recursively construct this `ChipletSystem` based on the list
+        of nodes and other parameters (e.g., latencies) specified
+        upon creation of the object(s).
+        Specifically, create the backing Garnet network(s) and other
+        necessary objects.
+
+        Args:
+            options (Namespace):
+                argparse options from CLI and/or other definitions
+                such as `Network.define_options()`.
+            use_legacy_ruby (bool):
+                Whether to use (legacy) `Ruby.py` or not.
+                Defaults to False.
+            piobus (IOXBar, optional):
+                System proxy port IO bus. Defaults to None.
+                Needed only to support direct memory access (DMA).
+                See Also: `AbstractBoard.get_io_bus()`.
+            dma_ports (list[DmaDevice], optional):
+                Direct memory access ports. Defaults to an empty list.
+                Needed to support DMA.
+            bootmem (AbstractMemory, optional):
+                Boot memory. Defaults to None.
+                Usually not needed, seemingly only for some FS configs.
+            l2_is_private (bool, optional):
+                If the L2 cache is private (one per CPU).
+                Used for distributing controllers.
+                Defaults to False.
+            include_dir_ctrls_in_topology (bool, optional):
+                If the directory controllers should be included directly
+                in the specified topology of the root `ChipletSystem`.
+                If this is `False`, directory controllers will only be
+                connected to the main router of the root `ChipletSystem`.
+                Defaults to False.
+        """
+
+        if self._created is True:
+            warn(
+                "Attempted to call createSystem() on this "
+                "ChipletSystem, but it has already been created."
+            )
+            return
+
+        if options is None:
+            fatal("Called createSystem() with no argparse options.")
+
+        if use_legacy_ruby:
+            self._createLegacyRubyChiplet(options)
+        else:
+            self._createChipletHierarchy(options)
+
+        self._created = True
+
+    def createSystemOld(
         self,
         options: Namespace,  # argparse Namespace (parsed args)
         use_legacy_ruby: bool = False,
@@ -205,8 +722,12 @@ class ChipletSystem(BaseChipletSystem):
             #! this branch is adapted from `Ruby.py` and `Network.py`,
             #! as changes were needed in order to support hierarchies.
 
+            # upon review I don't think that the previous condition(s) for
+            # checking root actually would've worked, so added isRoot().
+
             # * this block should only run for the parent `ChipletSystem`.
-            if not hasattr(self._system, "ruby"):
+            # if not hasattr(self._system, "ruby"):
+            if self.isRoot():
                 # instantiate `RubySystem`, to be "created" next
                 self._system.ruby = RubySystem()
                 self._ruby_system = self._system.ruby
@@ -215,24 +736,41 @@ class ChipletSystem(BaseChipletSystem):
                 FileSystemConfig.config_filesystem(self._system, options)
 
             if self._ruby_system is None:
-                panic("ChipletSystem's RubySystem is None!")
+                panic(
+                    f"RubySystem is None for "
+                    f"{self.__class__.__name__} {self.id}!"
+                )
 
-            # Create the `GarnetNetwork` for this level of the hierarchy
-            self._garnet_network = GarnetNetwork(
-                ruby_system=self._ruby_system,
-                topology=self._topology_cls.__name__,
-                routers=[],
-                ext_links=[],
-                int_links=[],
-                netifs=[],
-                ignore_mesh_chk=True,
-            )
+            # only create a `GarnetNetwork` at the root.
+            # otherwise, use `FakeGarnetNetwork` to collect routers and
+            # links, then construct the root `GarnetNetwork` with them.
+            if self.isRoot():
+                # Create the `GarnetNetwork` for the entire `ChipletSystem`
+                self._garnet_network = GarnetNetwork(
+                    ruby_system=self._ruby_system,
+                    topology=self._topology_cls.__name__,
+                    routers=[],
+                    ext_links=[],
+                    int_links=[],
+                    netifs=[],
+                    ignore_mesh_chk=True,
+                )
+
+                # ignore_mesh_chk:
+                # if `num_rows > 0` we will fail an assertion
+                # when the C++ objects are instantiated
+                # (`m_num_rows * m_num_cols == m_routers.size()`)
+                # (which will not be true since we added routers)
+                # so we had to add an override to prevent this
+            else:  # not root
+                self._garnet_network = FakeGarnetNetwork()
 
             #! create Ruby system
             # * this block should only run for the parent `ChipletSystem`.
-            if self._system.ruby is not None:
-                # `Ruby.py` does this, not sure why since `RubySystem`
-                # doesn't have a 'network' param
+            # if self._system.ruby is not None:
+            if self.isRoot():
+                # Ruby expects the `System` object to have a `ruby` attr,
+                # and that the `ruby` property has a `network` attribute.
                 self._ruby_system.network = self._garnet_network
 
                 # * Create the Ruby/memory system
@@ -297,18 +835,20 @@ class ChipletSystem(BaseChipletSystem):
                         f"{buildEnv['PROTOCOL']}; exception thrown: {e}"
                     )
 
-            # set `SimObject` parent hierarchy
-            # make sure not to set root `GarnetNetwork` parent
-            # if we did, it would break Ruby because it expects
-            # the gem5 `System` to have a `.network` param
-            if not self._garnet_network.has_parent():
-                print(
-                    f"setting gem5 parent for GarnetNetwork of "
-                    f"ChipletSystem ID {self.id}"
-                )
-                self._garnet_network.set_parent(self, "network")
+            # TODO NEW HIERARCHY: shouldn't be needed
+            # ? with new network building strategy this shouldn't be needed
+            # # set `SimObject` parent hierarchy
+            # # make sure not to set root `GarnetNetwork` parent
+            # # if we did, it would break Ruby because it expects
+            # # the gem5 `System` to have a `.network` param
+            # if not self._garnet_network.has_parent():
+            #     print(
+            #         f"setting gem5 parent for GarnetNetwork of "
+            #         f"ChipletSystem ID {self.id}"
+            #     )
+            #     self._garnet_network.set_parent(self, "network")
 
-            #! instantiate topology for this layer of the hierarchy
+            # * collect controllers for this layer of the hierarchy
             # type error ignorable because subclasses of `BaseTopology`
             # typically override constructor with this signature
             all_controllers = self.getRoot()._meta_topology.nodes
@@ -325,11 +865,15 @@ class ChipletSystem(BaseChipletSystem):
                     # todo: make ^ not the case
                     self._ruby_controllers.append(c)
 
+            # TODO NEW HIERARCHY: revise/refactor to indicate that ...
+            # TODO ... it's more of generating routers/links than ...
+            # TODO ... actually creating a topology
             #! create topology
             # need to populate `self._ruby_controllers` first
-            self._createTopology(options)
+            self._createTopology(options, self._ruby_controllers)
 
-            self._defineMainRouterParams()
+            # TODO NEW HIERARCHY: maybe needed, not sure yet
+            # self._defineMainRouterParams()
 
             # # goal of this block is to create only one ext_link for
             # # each directory controller
@@ -355,6 +899,16 @@ class ChipletSystem(BaseChipletSystem):
                         (dir_ctrl, dir_router)
                     )
 
+            # # try linking L2s to children main routers directly
+            # non_private_cache_routers = [
+            #     r for c, r in self._ruby_controller_router_map
+            # ]
+            # for r in non_private_cache_routers:
+            #     for n in self._nodes:
+            #         self._biLinkGarnetRouters(
+            #             r, n._main_router
+            #         )
+
         # * need to instantiate children before we connect hierarchy
         # * and init networks
         for node in self._nodes:
@@ -369,37 +923,45 @@ class ChipletSystem(BaseChipletSystem):
 
         if not use_legacy_ruby:
 
-            self._connectHierarchyGarnet()
+            # TODO NEW HIERARCHY: remove this
+            # self._connectHierarchyGarnet()
 
             # * this block should only run for the parent `ChipletSystem`.
-            if self._system.ruby is not None:
-                self._combineHierarchyGarnetNetworks(self._garnet_network)
+            # if self._system.ruby is not None:
+            if self.isRoot():
+                # TODO NEW HIERARCHY: remove this
+                # self._combineHierarchyGarnetNetworks(self._garnet_network)
+                pass
 
-            # * initialize network
-            # `Network.py` does this without any major obstacles to
-            # what we're doing in `ChipletSystem` as of now
-            #! effectively requires `.int_links` and `.ext_links` of
-            #! our `GarnetNetwork` to be set before this
-            # todo: we might have to adapt this so that we can add ...
-            # todo: ...links after calling `createSystem()`, not sure
-            options.network = "garnet"  # only required by `Network.py`
-            init_network(
-                options=options,
-                network=self._garnet_network,
-                InterfaceClass=GarnetNetworkInterface,
-            )
+            if self.isRoot():
+                # * initialize network
+                # `Network.py` does this without any major obstacles to
+                # what we're doing in `ChipletSystem` as of now
+                #! effectively requires `.int_links` and `.ext_links` of
+                #! our `GarnetNetwork` to be set before this
+                # todo: we might have to adapt this so that we can add ...
+                # todo: ...links after calling `createSystem()`, not sure
+                options.network = "garnet"  # only required by `Network.py`
+                init_network(
+                    options=options,
+                    network=self._garnet_network,
+                    InterfaceClass=GarnetNetworkInterface,
+                )
 
-            self._fixAllGarnetObjectParams()
+            # TODO NEW HIERARCHY: remove this
+            # self._fixAllGarnetObjectParams()
 
             #! other Ruby config
             # * this block should only run for the parent `ChipletSystem`.
-            if self._system.ruby is not None:
+            # if self._system.ruby is not None:
+            if self.isRoot():
                 # * do some port configuration from `Ruby.py`
                 self._ruby_connect_system_ports(piobus)
 
                 # todo: don't rely on `Ruby.py` for this
                 # unfortunately, in order to get `dir_cntrls`, the Ruby
                 # protocols also call back to `Ruby.create_directories`.
+                # so can't completely avoid it without major refactoring
                 options.mem_type = self._memory_cls.__name__
                 Ruby.setup_memory_controllers(
                     system=self._system,
@@ -414,6 +976,7 @@ class ChipletSystem(BaseChipletSystem):
                     for cpu_seq in cpu_sequencers:
                         cpu_seq.connectIOPorts(piobus)
 
+                assert isinstance(self._ruby_system.network, GarnetNetwork)
                 self._ruby_system.number_of_virtual_networks = (
                     self._ruby_system.network.number_of_virtual_networks
                 )  # implicit line break on assign due to 76 char limit
@@ -427,7 +990,8 @@ class ChipletSystem(BaseChipletSystem):
                         range=self._system.mem_ranges[0], in_addr_map=False
                     )
 
-        self._x86_connect_ruby_ports()
+        if self.isRoot():
+            self._x86_connect_ruby_ports()
 
         self._created = True
 

--- a/configs/chiplets/ChipletSystem.py
+++ b/configs/chiplets/ChipletSystem.py
@@ -1,0 +1,170 @@
+from argparse import Namespace  # for type checking
+from typing import (
+    TYPE_CHECKING,
+    Self,
+    Sequence,
+    Type,
+)
+
+from chiplets.BaseChipletSystem import BaseChipletSystem
+from ruby import Ruby
+from topologies.BaseTopology import BaseTopology
+
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.util import (
+    addToPath,
+    fatal,
+    panic,
+    warn,
+)
+
+if TYPE_CHECKING:
+    from src.cpu.BaseCPU import BaseCPU
+    from src.mem.AbstractMemory import AbstractMemory
+    from src.sim.System import System
+
+
+class ChipletSystem(BaseChipletSystem):
+    """
+    A ChipletSystem encapsulates a collection of child Chiplets and/or
+    ChipletSystems. It acts as an abstraction of a physical processor
+    package, a multi-chip module (MCM), or CCD, insofar as its role in
+    containing multiple processors (heterogeneous or homogenous) across
+    multiple chiplets linked by interconnects. Uses Ruby and Garnet.
+    """
+
+    #! see BaseChipletSystem for additional key properties, namely:
+    #  - nodes
+    #  - default_inter_node_link_lat
+    #  - default_inter_node_router_lat
+    #  - parent
+    #  - connected_nodes
+
+    # whether createSystem() has been called (successfully)
+    created: bool
+
+    def __init__(
+        self,
+        system: System,
+        TopologyClass: Type[BaseTopology],
+        MemoryClass: Type[AbstractMemory],
+        inter_node_link_lat: int,
+        inter_node_router_lat: int,
+        nodes: list[BaseChipletSystem] = [],
+    ):
+        """
+        Instantiate a `ChipletSystem` object.
+
+        Args:
+            system (System):
+                The gem5 `System` SimObject that this `ChipletSystem`
+                is part of.
+            TopologyClass (Type[BaseTopology]):
+                The class, derived from `BaseTopology`, corresponding
+                to the topology to be used in this `ChipletSystem`.
+                Only the root `ChipletSystem` needs to specify this.
+            MemoryClass (Type[AbstractMemory]):
+                The class corresponding to the memory configuration
+                for the gem5 `System` this `ChipletSystem` is part of.
+            inter_node_link_lat (int):
+                The default latency (in cycles) of the links between
+                nodes for this layer of abstraction.
+            inter_node_router_lat (int):
+                The default latency (in cycles) of the routers
+                corresponding to the the links between nodes
+                for this layer of abstraction.
+            nodes (list[BaseChipletSystem]):
+                Optional list of nodes. May be passed to constructor
+                or added separately using `addNode()`.
+        """
+
+        super().__init__(
+            system=system,
+            TopologyClass=TopologyClass,
+            MemoryClass=MemoryClass,
+            nodes=nodes,
+            inter_node_link_lat=inter_node_link_lat,
+            inter_node_router_lat=inter_node_router_lat,
+        )
+
+        for node in self.nodes:
+            if not hasattr(node, "parent"):
+                node.parent = self
+
+        self.created = False
+
+    def createSystem(
+        self,
+        options: Namespace,  # argparse Namespace (parsed options/args)
+        full_system: bool,
+    ):
+        """
+        Recursively construct this ChipletSystem based on the list of
+        nodes and other parameters (e.g., latencies) specified.
+        Specifically, create the backing Garnet network and other
+        necessary objects.
+        """
+
+        if self.created is True:
+            warn(
+                "Attempted to call createSystem() on this "
+                "ChipletSystem, but it has already been created."
+            )
+            return
+
+        for node in self.nodes:
+            if node is ChipletSystem:
+                node.createSystem(options, full_system)
+
+        # at top level, run Ruby.create_system()
+        # the way Ruby seems to be set up right now,
+        # this should only run once, and not sure if
+        # hierarchical topologies are plausible
+        if not hasattr(self, "parent"):
+            # configure options that Ruby.py expects
+            options.network = "garnet"
+            options.topology = self._topology_cls.__name__
+            options.mem_type = self._memory_cls.__name__
+
+            # create ruby system
+            # todo: may need to call MULTIPLE.py create_system()
+            Ruby.create_system(
+                options=options, full_system=full_system, system=self.system
+            )
+
+            # todo: make this not a hack
+            # connect ruby ports if x86
+            for i, cpu in enumerate(self.system.cpu):
+                if issubclass(cpu.__class__, BaseCPU):
+                    # figure out if we're using x86 ISA
+                    archs_enabled = list(
+                        filter(lambda var: buildEnv[var], ["USE_X86_ISA"])
+                    )
+                    if len(archs_enabled) == 1:
+                        arch = archs_enabled[0]
+                        if arch == "USE_X86_ISA":
+                            # has the interrupt controller
+                            # been created yet?
+                            if len(cpu.interrupts) == 0:
+                                cpu.createInterruptController()
+                                # probably should let the user do this,
+                                # but this should be done near when
+                                # create_system() is called, which
+                                # would then require another method
+                                warn(
+                                    "ChipletSystem: detected x86 "
+                                    "ISA and created interrupt "
+                                    "controller automatically."
+                                )
+
+                            if len(cpu.interrupts) != 0:
+                                ruby_port = self.system.ruby._cpu_ports[i]
+                                ruby_port.connectCpuPorts(cpu)
+                            else:
+                                panic(
+                                    "Interrupt controller was created, "
+                                    "but no interrupts were found."
+                                )
+
+        self.created = True

--- a/configs/chiplets/ChipletSystemMainRouterTopology.py
+++ b/configs/chiplets/ChipletSystemMainRouterTopology.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class ChipletSystemMainRouterTopology(Enum):
+    """
+    `Chiplet[System]` is currently implemented so that nodes (or, in
+    other words, the main routers) are connected via `GarnetIntLink`s.
+    Thus, they cannot use the template topologies in `configs/topologies/`
+    to generate a topology because those require the nodes to be
+    `RubyController`s (which `GarnetRouter`s are not).
+    Instead, there are presently two options for connecting chiplets.
+    Either all cross-chiplet requests must travel through the parent
+    ChipletSystem (`ParentOnly`), or the main routers of all nodes are
+    connected to all other nodes on the same level of the hierarchy in
+    a point-to-point topology (`Pt2Pt`).
+    """
+
+    ParentOnly = "ParentOnly"
+    Pt2Pt = "Pt2Pt"
+    # todo: implement a general mesh topolgoy

--- a/configs/example/chiplets/8CPU_2CCD_SE.py
+++ b/configs/example/chiplets/8CPU_2CCD_SE.py
@@ -1,0 +1,245 @@
+# import the m5 (gem5) library created when gem5 is built
+import m5
+from m5.defines import buildEnv  # type: ignore
+
+# import all of the SimObjects
+from m5.objects import *
+
+# Needed for running C++ threads
+m5.util.addToPath("../../")  # add /configs/ to path
+from typing import TYPE_CHECKING
+
+from chiplets.BaseChipletSystem import BaseChipletSystem
+from chiplets.Chiplet import Chiplet
+from chiplets.ChipletSystem import ChipletSystem
+from common.FileSystemConfig import config_filesystem
+from common.Options import *
+from network import Network
+from ruby import Ruby
+from topologies.Mesh_XY import Mesh_XY
+from topologies.Pt2Pt import Pt2Pt
+
+if TYPE_CHECKING:
+    from src.arch.x86.X86CPU import *
+    from src.mem.DRAMInterface import *
+    from src.sim.ClockDomain import *
+    from src.sim.Process import Process
+    from src.sim.Root import Root
+    from src.sim.System import System
+    from src.sim.VoltageDomain import VoltageDomain
+    from src.sim.Workload import *
+
+### Configuration
+
+CACHE_PROTOCOL = buildEnv["PROTOCOL"]
+
+CPU_CLS = X86TimingSimpleCPU
+CPU_FREQ = "4GHz"
+
+MEM_CLS = DDR3_1600_8x8
+DEFAULT_MEM_CFG = "DDR3_1600_8x8"
+MEM_SIZE = "8192MiB"
+
+### Command-Line Argument Handling
+
+import argparse
+
+parser = argparse.ArgumentParser(
+    description="A hierarchical chiplet system with a two-level cache and 2 CCDs, each with 4 CPUs."
+)
+
+parser.add_argument(
+    "binary",
+    default="",
+    nargs="?",
+    type=str,
+    help="Path to the binary to execute.",
+)
+
+#! key ruby/garnet network options
+Ruby.define_options(parser)  # also calls Network.define_options()
+# Network.define_options(parser)
+
+options = parser.parse_args()
+
+### System Parameters
+
+# instantiate system SimObject
+system = System()
+
+# set system clock
+system.clk_domain = SrcClockDomain()
+system.clk_domain.clock = CPU_FREQ
+system.clk_domain.voltage_domain = VoltageDomain()
+
+## set up system memory
+
+# use timing mode for memory simulation
+# (do this unless fast-forwarding or restoring from checkpoint)
+system.mem_mode = "timing"
+
+# define a single 512MiB memory range
+system.mem_ranges = [AddrRange(MEM_SIZE)]
+
+### CPU
+
+# create the CPUs
+# assumed homogenous CPUs
+
+options.num_cpus = 8
+system.cpu = [CPU_CLS() for _ in range(options.num_cpus)]
+options.ports = options.num_cpus
+
+### Memory
+
+# one directory for the system for example, you will probably want to increase this
+options.num_dirs = 1
+
+options.enable_dram_powerdown = False
+
+#! latencies
+# default latencies for topology, overridden by chiplet specified latencies
+# options.link_latency = 2
+# options.router_latency = 1
+
+# small cache
+# optionally use this to "encourage" ruby network activity
+# options.l1d_size = "256B"
+# options.l1i_size = "256B"
+# options.l2_size = "512B"
+# options.l1d_assoc = 2
+# options.l1i_assoc = 2
+# options.l2_assoc = 2
+
+# reasonable size cache
+options.l1d_size = "4KiB"
+options.l1i_size = "16KiB"
+options.l2_size = "64KiB"
+options.l1d_assoc = 2
+options.l1i_assoc = 2
+options.l2_assoc = 2
+options.num_l2caches = 1
+options.cacheline_size = 64
+
+# example of 2-CCD processor with 4 cores per CCD
+ccd: list[Chiplet] = []
+
+ccd.append(
+    Chiplet(
+        system=system,
+        full_system=False,
+        TopologyClass=Mesh_XY,
+        MemoryClass=MEM_CLS,
+        inter_node_link_lat=1,
+        intra_node_link_lat=1,
+        node_main_router_lat=1,
+        cores=system.cpu[0:4],
+    )
+)
+
+ccd.append(
+    Chiplet(
+        system=system,
+        full_system=False,
+        TopologyClass=Mesh_XY,
+        MemoryClass=MEM_CLS,
+        inter_node_link_lat=1,
+        intra_node_link_lat=1,
+        node_main_router_lat=1,
+        cores=system.cpu[4:8],
+    )
+)
+
+# needed for `Mesh_XY`. because of how mesh topologies currently
+# work and how options are passed, this is currently global.
+# i.e., ALL meshes created will have two rows.
+options.mesh_rows = 2
+
+# meshes also require the mem size to be set in options
+options.mem_size = MEM_SIZE
+
+# * create a ChipletSystem containing our CCDs
+cs = ChipletSystem(
+    system=system,
+    full_system=False,
+    TopologyClass=Pt2Pt,
+    MemoryClass=MEM_CLS,
+    inter_node_link_lat=2,
+    intra_node_link_lat=1,
+    node_main_router_lat=3,
+    nodes=ccd,
+)
+
+cs.createSystem(options)
+
+print(f"ChipletSystem:\n{cs.to_string()}\n\n")
+
+### run simulation
+
+# specify binary/executable to run
+if not options.binary:
+    print(
+        "No binary file(path) specified gem5 to run, defaulting to hello-world."
+    )
+    binary = f"tests/test-progs/hello/bin/x86/linux/hello"
+elif options.binary == "threads":
+    binary = f"tests/test-progs/threads/bin/x86/linux/threads"
+else:
+    binary = options.binary
+
+# load the binary in syscall emulation mode
+system.workload = SEWorkload.init_compatible(binary)
+
+# Set up the pseudo file system for the threads function above
+config_filesystem(system)
+
+# create process SimObject
+process = Process()
+process.cmd = [binary]
+
+# set workload and create workload threads
+# same workload for each CPU
+for i, cpu in enumerate(system.cpu):
+    # print(f"setting workload = {process} for cpu {cpu}")
+    cpu.workload = process
+    cpu.createThreads()
+
+# instantiate system
+root = Root(full_system=False, system=system)
+m5.instantiate()
+
+# * uncomment to see routers
+# print(f"all cs routers:")
+# for r in cs._garnet_network.routers:
+#     print(f"    {r.router_id}: {r} @ {hex(id(r))}")
+
+# print(f"cs main router id: {cs._main_router.router_id}; router: {cs._main_router}")
+# print(f"ccd[0] main router id: {ccd[0]._main_router.router_id}")
+# print(f"ccd[1] main router id: {ccd[1]._main_router.router_id}")
+
+# * uncomment to see clock domain hierarchy
+# # must be done after m5.instantiate() to be correct
+# print("="*30)
+# print("Garnet Network Children with Clock Domains")
+# print("="*30)
+# BaseChipletSystem.recursivelyPrintClockDomains(cs._garnet_network)
+# print("="*30)
+# print("\n\n")
+
+# print("="*30)
+# print("CCD 0 Children with Clock Domains")
+# print("="*30)
+# BaseChipletSystem.recursivelyPrintClockDomains(ccd[0])
+# print("="*30)
+# print("\n\n")
+
+# print("="*30)
+# print("CCD 1 Children with Clock Domains")
+# print("="*30)
+# BaseChipletSystem.recursivelyPrintClockDomains(ccd[1])
+# print("="*30)
+# print("\n\n")
+
+exit_event = m5.simulate()
+
+print(f"Exiting @ tick {m5.curTick()} because {exit_event.getCause()}")

--- a/configs/ruby/Ruby.py
+++ b/configs/ruby/Ruby.py
@@ -256,7 +256,7 @@ def create_system(
         )
     except:
         print(
-            "Error: could not create sytem for ruby protocol "
+            "Error: could not create system for ruby protocol "
             f"{buildEnv['PROTOCOL']}"
         )
         raise

--- a/configs/topologies/ChipletMetaTopology.py
+++ b/configs/topologies/ChipletMetaTopology.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING
+
+from topologies.BaseTopology import BaseTopology
+
+from m5.util import fatal
+
+if TYPE_CHECKING:
+    from chiplets.ChipletSystem import ChipletSystem
+
+
+class ChipletMetaTopology(BaseTopology):
+    """
+    This is a dummy/meta/internal topology used by `ChipletSystem`
+    to enable hierarchical topologies while maintaining compatibility
+    with existing topologies and Ruby protocols.
+    """
+
+    description = "ChipletMetaTopology"
+
+    # use same constructor format as `SimpleTopology` for compat with
+    # existing Ruby protocols, which mostly call `create_topology()`
+    # from `Ruby.py`, which assumes this constructor format.
+    def __init__(self, controllers):
+        self.nodes = controllers
+
+    def makeTopology(self, options, network, IntLink, ExtLink, Router):
+        fatal("makeTopology() should not be called on ChipletMetaTopology!")

--- a/src/mem/ruby/network/garnet/GarnetLink.py
+++ b/src/mem/ruby/network/garnet/GarnetLink.py
@@ -141,7 +141,7 @@ class GarnetExtLink(BasicExtLink):
     _cls.append(CreditLink())
     credit_links = VectorParam.CreditLink(_cls, "backward flow-control links")
 
-    # The ext_cdc and intt_cdc flags are used to enable the
+    # The ext_cdc and int_cdc flags are used to enable the
     # clock domain crossing(CDC) at the external and internal
     # end of the link respectively. This is required when the
     # link and the objected connected to the link are operating

--- a/src/mem/ruby/network/garnet/GarnetNetwork.cc
+++ b/src/mem/ruby/network/garnet/GarnetNetwork.cc
@@ -76,6 +76,8 @@ GarnetNetwork::GarnetNetwork(const Params &p)
     if (m_enable_fault_model)
         fault_model = p.fault_model;
 
+    m_ignore_mesh_chk = p.ignore_mesh_chk;
+
     m_vnet_type.resize(m_virtual_networks);
 
     for (int i = 0 ; i < m_virtual_networks ; i++) {
@@ -122,7 +124,7 @@ GarnetNetwork::init()
     m_topology_ptr->createLinks(this);
 
     // Initialize topology specific parameters
-    if (getNumRows() > 0) {
+    if (getNumRows() > 0 && !m_ignore_mesh_chk) {
         // Only for Mesh topology
         // m_num_rows and m_num_cols are only used for
         // implementing XY or custom routing in RoutingUnit.cc
@@ -309,6 +311,13 @@ GarnetNetwork::makeInternalLink(SwitchID src, SwitchID dest, BasicLink* link,
                                 PortDirection src_outport_dirn,
                                 PortDirection dst_inport_dirn)
 {
+    DPRINTF(RubyNetwork,
+        "makeInternalLink(): src=%d -> dst=%d (link=%s) dests:\n",
+        src, dest, link->name()
+    );
+    for (auto d : routing_table_entry) {
+        DPRINTF(RubyNetwork, "    %s\n", d);
+    }
     GarnetIntLink* garnet_link = safe_cast<GarnetIntLink*>(link);
 
     // GarnetIntLink is unidirectional

--- a/src/mem/ruby/network/garnet/GarnetNetwork.hh
+++ b/src/mem/ruby/network/garnet/GarnetNetwork.hh
@@ -167,6 +167,7 @@ class GarnetNetwork : public Network
     uint32_t m_buffers_per_data_vc;
     int m_routing_algorithm;
     bool m_enable_fault_model;
+    bool m_ignore_mesh_chk;
 
     // Statistical variables
     statistics::Vector m_packets_received;

--- a/src/mem/ruby/network/garnet/GarnetNetwork.py
+++ b/src/mem/ruby/network/garnet/GarnetNetwork.py
@@ -52,6 +52,11 @@ class GarnetNetwork(RubyNetwork):
     garnet_deadlock_threshold = Param.UInt32(
         50000, "network-level deadlock threshold"
     )
+    ignore_mesh_chk = Param.Bool(
+        False,
+        "Whether to ignore mesh router count checking. "
+        "Should only be used with chiplets where a mesh is a subnet.",
+    )
 
 
 class GarnetNetworkInterface(ClockedObject):


### PR DESCRIPTION
These changes add the following:
- Python classes to model chiplets and groups of chiplets
- a streamlined method for configuring hierarchical topologies with Garnet
- an example script modeling a Zen-like processor with a hierarchical topology
- fixes for a couple of typos in strings/comments

Just rebased on top of `gem5/develop`, so should be able to merge cleanly.

See #2801 for more details. 

Any feedback would be much appreciated.