### PR TITLE
tests: Update tests to upload artifact on timeout

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -165,16 +165,18 @@ jobs:
 
             - name: Run long ${{ matrix.test-type }} tests
               id: run-tests
+              timeout-minutes: 1410
+              continue-on-error: true
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run ${{ matrix.test-type }} -j$(nproc) --length=long -vv -t $(nproc) --exclude-tags gcn_gpu
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
-              if: success() || failure()
+              if: always()
               run: echo "sanitized-test-dir=$(echo '${{ matrix.test-type }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               env:
                   MY_STEP_VAR: ${{ steps.sanitize-test-dir.outputs.sanitized-test-dir }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
@@ -204,11 +206,13 @@ jobs:
 
             - name: Run Testlib GPU Tests
               id: run-tests
+              timeout-minutes: 1410
+              continue-on-error: true
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run --length=long -vvv -j $(nproc) --host gcn_gpu
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -73,16 +73,18 @@ jobs:
 
             - name: Run very-long ${{ matrix.test-type }} tests
               id: run-tests
+              timeout-minutes: 4290
+              continue-on-error: true
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run ${{ matrix.test-type }} --length very-long -j$(nproc) -vv --exclude-tags gcn_gpu
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
-              if: success() || failure()
+              if: always()
               run: echo "sanitized-test-dir=$(echo '${{ matrix.test-type }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-very-long-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
@@ -110,9 +112,11 @@ jobs:
               id: run-tests
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run --length=very-long -vvv -j $(nproc) --host gcn_gpu
+              timeout-minutes: 1410
+              continue-on-error: true
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output


### PR DESCRIPTION
This PR adds a step level timeout for the long daily tests and updates the artifact upload code to always upload.