### PR TITLE
arch-x86: ignore cs/ds/ss/es segments in long mode

### DIFF
--- a/src/arch/x86/decoder.cc
+++ b/src/arch/x86/decoder.cc
@@ -161,12 +161,16 @@ Decoder::doPrefixState(uint8_t nextByte)
       case CSOverride:
       case DSOverride:
       case ESOverride:
+      case SSOverride:
+          if (emi.mode.submode == SixtyFourBitMode) {
+              break;
+          }
+          [[fallthrough]];
       case FSOverride:
       case GSOverride:
-      case SSOverride:
-        DPRINTF(Decoder, "Found segment override.\n");
-        emi.legacy.seg = prefix;
-        break;
+          DPRINTF(Decoder, "Found segment override.\n");
+          emi.legacy.seg = prefix;
+          break;
       case Lock:
         DPRINTF(Decoder, "Found lock prefix.\n");
         emi.legacy.lock = true;


### PR DESCRIPTION
Fix #2879 by completely ignoring CS, DS, SS, and ES segment overrides in 64-bit long mode (by not
updating the ExtMachInst's segment prefix).

Change-Id: I49b6220b5c08599089e516b1de5da2b21adbea3e