### PR TITLE
arch-x86: fatal error on multi-level TLB

### DIFF
--- a/src/arch/x86/tlb.cc
+++ b/src/arch/x86/tlb.cc
@@ -69,6 +69,9 @@ TLB::TLB(const Params &p)
     if (!size)
         fatal("TLBs must have a non-zero size.\n");
 
+    fatal_if(nextLevel(), "The x86 backend does not support multi-level "
+                          "TLBs.\n");
+
     for (int x = 0; x < size; x++) {
         tlb[x].trieHandle = NULL;
         freeList.push_back(&tlb[x]);


### PR DESCRIPTION
Report a fatal error if the user configures
a multi-level X86 TLB, as the X86 backend
currently does not support multi-level TLBs.

Change-Id: I819a3b354bd5e75b9e0c9bffbfcc2645253954b0