### PR TITLE
misc: bump urllib3 to 2.6.3 in util/gem5-resources-manager

### DIFF
--- a/util/gem5-resources-manager/requirements.txt
+++ b/util/gem5-resources-manager/requirements.txt
@@ -24,6 +24,6 @@ pyrsistent==0.19.3
 python-dotenv==1.0.0
 requests==2.32.4
 sentinels==1.0.0
-urllib3==2.6.0
+urllib3==2.6.3
 Werkzeug==3.1.4
 zipp==3.19.1


### PR DESCRIPTION
This commit bumps urllib3 from 2.5.0 to 2.6.3 in util/gem5-resources-manager/requirements.txt. https://github.com/gem5/gem5/pull/2874 was closed in favor of this PR.