### PR TITLE
misc: bump werkzeug to 3.1.5 in util/gem5-resources-manager

### DIFF
--- a/util/gem5-resources-manager/requirements.txt
+++ b/util/gem5-resources-manager/requirements.txt
@@ -25,5 +25,5 @@ python-dotenv==1.0.0
 requests==2.32.4
 sentinels==1.0.0
 urllib3==2.6.0
-Werkzeug==3.1.4
+Werkzeug==3.1.5
 zipp==3.19.1


### PR DESCRIPTION
This commit bumps werkzeug from 3.1.4 to 3.1.5 in util/gem5-resources-manager/requirements.txt.
https://github.com/gem5/gem5/pull/2878 was closed in favor of this PR.