### PR TITLE
misc: bump urllib3 to 2.6.3 in /ext/pybind11/docs

### DIFF
--- a/ext/pybind11/docs/requirements.txt
+++ b/ext/pybind11/docs/requirements.txt
@@ -85,7 +85,7 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 sphinxcontrib-svg2pdfconverter==1.2.2
     # via -r requirements.in
-urllib3==2.5.0
+urllib3==2.6.3
     # via requests
 zipp==3.23.0
     # via importlib-metadata


### PR DESCRIPTION
This commit bumps urllib3 from 2.5.0 to 2.6.3 in /ext/pybind11/docs/requirements.txt. 
https://github.com/gem5/gem5/pull/2875 was closed in favor of this PR.

Note: I'm not sure if this should be merged or not, since it touches dependencies for something external to gem5.