### PR TITLE
mem: Fixing logic data pointer for PrefetchInfo.

### DIFF
--- a/src/mem/cache/prefetch/base.cc
+++ b/src/mem/cache/prefetch/base.cc
@@ -64,7 +64,7 @@ Base::PrefetchInfo::PrefetchInfo(PacketPtr pkt, Addr addr, bool miss)
     paddress(pkt->req->getPaddr()), cacheMiss(miss)
 {
     unsigned int req_size = pkt->req->getSize();
-    if ((!write && miss) || !pkt->hasData()) {
+    if ((!write && miss) && !pkt->hasData()) {
         data = nullptr;
     } else {
         data = new uint8_t[req_size];


### PR DESCRIPTION
This change fixes an error when deciding whether an object of PrefetchInfo should have a valid data pointer. This bug impacts those prefetchers that need the data stored in the cache blocks such as IndirectMemoryPrefetcher.