### PR TITLE
mem: Remove shadow declaration of m_ruby_system.

### DIFF
--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -68,8 +68,6 @@ Sequencer::Sequencer(const Params &p)
 {
     m_outstanding_count = 0;
 
-    m_ruby_system = p.ruby_system;
-
     m_dataCache_ptr = p.dcache;
     m_max_outstanding_requests = p.max_outstanding_requests;
     m_deadlock_threshold = p.deadlock_threshold;

--- a/src/mem/ruby/system/Sequencer.hh
+++ b/src/mem/ruby/system/Sequencer.hh
@@ -252,8 +252,6 @@ class Sequencer : public RubyPort
                                         RubyRequestType primary_type,
                                         RubyRequestType secondary_type);
 
-    RubySystem *m_ruby_system;
-
   private:
     int m_max_outstanding_requests;
 


### PR DESCRIPTION
This change removes a shadow declaration of m_ruby_system from Sequencer that is already declared by its parent class RubyPort.