### PR TITLE
mem-ruby: Fix ruby mem chi issues

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -57,7 +57,9 @@ class TlmGenerator(ClockedObject):
         PyBindMethod("enqueueBack"),
     ]
 
-    _transactions = []
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._transactions = []
 
     def inject(self, payload, phase, when=None):
         from m5.tlm_chi.utils import Transaction

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -42,6 +42,8 @@
 #include "mem/ruby/system/Sequencer.hh"
 
 #include "base/logging.hh"
+#include "base/str.hh"
+#include "config/ruby_protocol_chi.hh"
 #include "cpu/testers/rubytest/RubyTester.hh"
 #include "debug/LLSC.hh"
 #include "debug/ProtocolTrace.hh"
@@ -1007,7 +1009,7 @@ Sequencer::makeRequest(PacketPtr pkt)
     } else if (pkt->req->isTlbiCmd()) {
         primary_type = secondary_type = tlbiCmdToRubyRequestType(pkt);
         DPRINTF(RubySequencer, "Issuing TLBI\n");
-#if defined (PROTOCOL_CHI)
+#if defined(RUBY_PROTOCOL_CHI)
     } else if (pkt->isAtomicOp()) {
         if (pkt->req->isAtomicReturn()){
             DPRINTF(RubySequencer, "Issuing ATOMIC RETURN \n");

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -43,7 +43,6 @@
 
 #include "base/logging.hh"
 #include "base/str.hh"
-#include "config/ruby_protocol_chi.hh"
 #include "cpu/testers/rubytest/RubyTester.hh"
 #include "debug/LLSC.hh"
 #include "debug/ProtocolTrace.hh"
@@ -1009,19 +1008,16 @@ Sequencer::makeRequest(PacketPtr pkt)
     } else if (pkt->req->isTlbiCmd()) {
         primary_type = secondary_type = tlbiCmdToRubyRequestType(pkt);
         DPRINTF(RubySequencer, "Issuing TLBI\n");
-#if defined(RUBY_PROTOCOL_CHI)
-    } else if (pkt->isAtomicOp()) {
+    } else if (pkt->isAtomicOp() &&
+               (m_ruby_system->getProtocolInfo().getName() == "CHI")) {
         if (pkt->req->isAtomicReturn()){
             DPRINTF(RubySequencer, "Issuing ATOMIC RETURN \n");
             primary_type = secondary_type =
                            RubyRequestType_ATOMIC_RETURN;
         } else {
             DPRINTF(RubySequencer, "Issuing ATOMIC NO RETURN\n");
-            primary_type = secondary_type =
-                           RubyRequestType_ATOMIC_NO_RETURN;
-
+            primary_type = secondary_type = RubyRequestType_ATOMIC_NO_RETURN;
         }
-#endif
     } else if (pkt->req->hasNoAddr()) {
         primary_type = secondary_type = RubyRequestType_hasNoAddr;
     } else {


### PR DESCRIPTION
1. Fix an issue for multiple TlmGenerators sharing a common class variable #2870 
2. Fix an issue for packets cannot be converted to CHI Messages when they have ATOMIC_NO_RETURN_OP/ATOMIC_RETURN_OP flags