### PR TITLE
ext: Update integration of DRAMSys

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -266,7 +266,7 @@ jobs:
             - uses: actions/checkout@v4
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
-              run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.1 --depth 1 DRAMSys
+              run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.3.1 --depth 1 DRAMSys
 
               # gem5 is built separately because it depends on the DRAMSys library
             - name: Build gem5

--- a/ext/dramsys/README
+++ b/ext/dramsys/README
@@ -1,9 +1,9 @@
 Follow these steps to build DRAMSys as part of gem5
 
 1. Go to ext/dramsys (this directory)
-2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys --branch v5.1 --depth 1 DRAMSys'
+2. Clone DRAMSys: 'git clone https://github.com/tukl-msd/DRAMSys --branch v5.3.1 --depth 1 DRAMSys'
 
-The latest verified working version is v5.1, but later versions might work too.
+The latest verified working version is v5.3.1, but later versions might work too.
 gem5 will automatically pick up DRAMSys as an external module when it is rebuilt.
 
 If you wish to run a simulation using the gem5 processor cores, make sure to enable the storage mode in DRAMSys.

--- a/ext/dramsys/SConscript
+++ b/ext/dramsys/SConscript
@@ -65,7 +65,7 @@ subprocess.run(
         f"-DSCONS_SOURCE_DIR:STRING={scons_root}",
         "-DDRAMSYS_BUILD_CLI=OFF",
         "-DDRAMSYS_USE_FETCH_CONTENT=ON",
-        "-DDRAMSYS_USE_FETCH_CONTENT_INTERNAL=OFF",
+        "-DDRAMSYS_USE_FETCH_CONTENT_INTERNAL=ON",
         "-DDRAMSYS_USE_FETCH_CONTENT_SYSTEMC=OFF",
     ],
     check=True
@@ -76,21 +76,18 @@ subprocess.run(
     check=True
 )
 
-env.Append(LIBS="liblibdramsys")
-env.Append(LIBPATH=Dir("./DRAMSys/src/libdramsys").abspath)
+env.Append(LIBS="dramsys")
+env.Append(LIBPATH=Dir("./DRAMSys/src").abspath)
 
-env.Append(LIBS="libconfiguration")
-env.Append(LIBPATH=Dir("./DRAMSys/src/configuration").abspath)
+env.Append(LIBS="DRAMPower")
+env.Append(LIBPATH=Dir("./_deps/drampower-build/src/DRAMPower").abspath)
 
 env.Append(LIBS="sqlite3")
 env.Append(LIBPATH=Dir("./DRAMSys/lib/sqlite3").abspath)
 
-env.Append(CPPPATH=src_root + "/DRAMSys/src/libdramsys")
-env.Append(CPPPATH=src_root + "/DRAMSys/src/configuration")
-env.Append(CPPPATH=src_root + "/DRAMSys/src/util")
-
+env.Append(CPPPATH=src_root + "/DRAMSys/src")
 env.Append(CPPPATH=build_current + "/_deps/nlohmann_json-src/include/")
+env.Append(CPPPATH=build_current + "/_deps/dramutils-src/include/")
+env.Append(CPPPATH=build_current + "/_deps/drampower-src/src/DRAMPower")
 
 env.Prepend(CPPDEFINES=[("SYSTEMC_VERSION", 20191203)])
-env.Prepend(CPPDEFINES=[("DRAMSYS_RESOURCE_DIR",
-                         '\\"' + os.getcwd() + '/DRAMSys/configs' + '\\"')])

--- a/src/mem/dramsys.cc
+++ b/src/mem/dramsys.cc
@@ -28,19 +28,20 @@
 
 #include "dramsys.hh"
 
+#include "DRAMSys/common/Deserialize.h"
+#include "DRAMSys/common/Serialize.h"
+
 namespace gem5
 {
 
 namespace memory
 {
 
-DRAMSys::DRAMSys(Params const& params) :
-    AbstractMemory(params),
-    tlmWrapper(dramSysWrapper.tSocket, params.name + ".tlm", InvalidPortID),
-    config(::DRAMSys::Config::from_path(params.configuration,
-                                        params.resource_directory)),
-    dramSysWrapper(
-        params.name.c_str(), config, params.range)
+DRAMSys::DRAMSys(Params const &params)
+    : AbstractMemory(params),
+      tlmWrapper(dramSysWrapper.tSocket, params.name + ".tlm", InvalidPortID),
+      config(::DRAMSys::Config::from_path(params.configuration)),
+      dramSysWrapper(params.name.c_str(), config, params.range)
 {
     dramSysWrapper.dramsys->registerIdleCallback(
         [this]

--- a/src/mem/dramsys.hh
+++ b/src/mem/dramsys.hh
@@ -29,10 +29,11 @@
 #ifndef __MEM_DRAMSYS_H__
 #define __MEM_DRAMSYS_H__
 
-#include "DRAMSys/config/DRAMSysConfiguration.h"
+#include "DRAMSys/configuration/json/DRAMSysConfiguration.h"
+
 #include "mem/abstract_mem.hh"
 #include "mem/dramsys_wrapper.hh"
-#include "params/DRAMSys.hh"
+#include "systemc/tlm_port_wrapper.hh"
 
 namespace gem5
 {

--- a/src/mem/dramsys_wrapper.cc
+++ b/src/mem/dramsys_wrapper.cc
@@ -28,6 +28,9 @@
 
 #include "dramsys_wrapper.hh"
 
+#include "sim/core.hh"
+#include "systemc/core/kernel.hh"
+
 namespace gem5
 {
 

--- a/src/mem/dramsys_wrapper.hh
+++ b/src/mem/dramsys_wrapper.hh
@@ -29,21 +29,15 @@
 #ifndef __MEM_DRAMSYS_WRAPPER_HH__
 #define __MEM_DRAMSYS_WRAPPER_HH__
 
-#include <iostream>
 #include <memory>
 
-#include "DRAMSys/config/DRAMSysConfiguration.h"
-#include "DRAMSys/simulation/DRAMSys.h"
-#include "mem/abstract_mem.hh"
+#include "DRAMSys/DRAMSys.h"
+#include "DRAMSys/configuration/json/DRAMSysConfiguration.h"
 #include "params/DRAMSys.hh"
-#include "sim/core.hh"
-#include "systemc/core/kernel.hh"
-#include "systemc/ext/core/sc_module_name.hh"
 
-#include "systemc/ext/systemc"
-#include "systemc/ext/tlm"
+#include "systemc/ext/core/sc_module_name.hh"
+#include "systemc/ext/tlm_utils/simple_initiator_socket.h"
 #include "systemc/ext/tlm_utils/simple_target_socket.h"
-#include "systemc/tlm_port_wrapper.hh"
 
 namespace gem5
 {


### PR DESCRIPTION
Update DRAMSys integration to support the newest version `v5.3.1`, as there were some breaking changes.