### PR TITLE
arch-x86: build return PC correctly for calls

### DIFF
--- a/src/arch/x86/insts/static_inst.hh
+++ b/src/arch/x86/insts/static_inst.hh
@@ -224,6 +224,7 @@ class X86StaticInst : public StaticInst
     {
         PCStateBase *ret_pc_ptr = call_pc.clone();
         ret_pc_ptr->as<PCState>().uEnd();
+        ret_pc_ptr->set(call_pc.instAddr() + size());
         return std::unique_ptr<PCStateBase>{ret_pc_ptr};
     }
 };


### PR DESCRIPTION
Fix #2901. Set a call's return PC to be the call's PC plus its (variable) instruction length. Previous behavior simply added a default +8 to the call PC, which is rarely correct for x86, resulting in consistently incorrect return address predictions.

Here are some performance stats on the SPEC CPU2017 benchmarks, collected by running the O3 CPU (using the default parameters aside from the following config) on the most representative SimPoint for each intspeed benchmark under the "train" inputs for 10/50 million instructions (most benchmarks crashed early, due to an apparent bug in the O3's decoupled frontend.

Config:
```
o3.fetchWidth = 16
o3.fetchTargetWidth = 128
o3.decoupledFrontEnd = True
o3.branchPred.conditionalBranchPred = TAGE_SC_L_64KB()
o3.branchPred.requiresBTBHit = True
```

Results:
| Benchmark | Instructions (warmup) | Return mispredict rate before fix | Reeturn mispredict rate after fix | Speedup after fix |
|---|---|---|---|---|
| 600.perlbench_s | crash | - | - | - |
| 602.gcc_s | crash | - | - | - |
| 605.mcf_s | 50M (10M) | 60.8% | 0.0% | 1.08x | 
| 620.omnetpp_s | 10M (-) | 72.5% | 27.8% | 1.10x | 
| 623.xalancbmk_s | 50M (10M) | 87.0% | 20.9% | 1.35x | 
| 625.x264_s | crash | - | - | - |
| 631.deepsjeng_s | 50M (10M) | 75.1% | 5.3% | 1.11x | 
| 641.leela_s | crash | - | - | - |
| 648.exchange2_s | 10M (-) | 60.3% | 0.6% | 1.06x | 
| 657.xz_s | 50M (10M) | 13.0% | 0.0% | 1.02x |
| average | - | 61.4% | 9.1% | 1.11x |
---
O3 cores with a better configuration would experience a better improvement from this fix. Anecdotally, an O3 core I configured to resemble an Intel Lion Cove P-core got >1.5x speedup (at least on one workload), if I remember correctly.

Change-Id: Id39d101de23e51d8ec2acffc02ef8d2222e6ca6f