### PR TITLE
cpu: Implement ITTAGE

### DIFF
--- a/configs/common/cores/arm/neoverse_v2.py
+++ b/configs/common/cores/arm/neoverse_v2.py
@@ -224,6 +224,7 @@ class NeoverseV2_BTB(SimpleBTB):
 # TAGE Branch Predictor
 class NeoverseV2_BP(BranchPredictor):
     conditionalBranchPred = TAGE_SC_L_64KB()
+    indirectBranchPred = ITTAGE()
     btb = NeoverseV2_BTB()
     ras = ReturnAddrStack(numEntries=31)
     instShiftAmt = 2

--- a/src/cpu/pred/BranchPredictor.py
+++ b/src/cpu/pred/BranchPredictor.py
@@ -1166,3 +1166,60 @@ class GshareBP(BranchPredictor):
 
     global_predictor_size = Param.Unsigned(512, "Size of global predictor")
     global_counter_bits = Param.Unsigned(2, "Bits per counter")
+
+
+# 64KB ITTAGE indirect branch predictor as described in
+# https://jilp.org/jwac-2/program/cbp3_07_seznec.pdf
+class ITTAGE_TAGE(TAGEBase):
+    type = "ITTAGE_TAGE"
+    cxx_class = "gem5::branch_prediction::ITTAGE_TAGE"
+    cxx_header = "cpu/pred/it_tage.hh"
+
+    nHistoryTables = 15
+    minHist = 10
+    maxHist = 3881
+    tagTableTagWidths = [
+        0,
+        9,
+        9,
+        13,
+        13,
+        13,
+        13,
+        13,
+        13,
+        13,
+        13,
+        15,
+        15,
+        15,
+        15,
+        15,
+    ]
+    logTagTableSizes = [12, 11, 11, 9, 9, 9, 9, 9, 9, 9, 9, 8, 8, 8, 8, 8]
+
+
+class ITTAGE(IndirectPredictor):
+    type = "ITTAGE"
+    cxx_class = "gem5::branch_prediction::ITTAGE"
+    cxx_header = "cpu/pred/it_tage.hh"
+
+    itage = Param.ITTAGE_TAGE(ITTAGE_TAGE(), "Tage object")
+
+    histBitsConditional = Param.Unsigned(
+        0,
+        "Number of history bits per "
+        "conditional branch. Original ITTAGE does not use conditional",
+    )
+    histBitsIndBranch = Param.Unsigned(
+        10, "Number of history bits per indirect branch"
+    )
+    histBitsIndCall = Param.Unsigned(
+        5, "Number of history bits per indirect call"
+    )
+    histBitsCall = Param.Unsigned(
+        5, "Number of history bits for other calls than indirect"
+    )
+    instShiftAmt = Param.Unsigned(
+        Parent.instShiftAmt, "Number of bits to shift instructions by"
+    )

--- a/src/cpu/pred/SConscript
+++ b/src/cpu/pred/SConscript
@@ -48,6 +48,7 @@ SimObject('BranchPredictor.py',
     'IndirectPredictor', 'SimpleIndirectPredictor',
     'BranchTargetBuffer', 'SimpleBTB', 'BTBIndexingPolicy', 'BTBSetAssociative',
     'ReturnAddrStack',
+    'ITTAGE', 'ITTAGE_TAGE',
     'LocalBP', 'TournamentBP', 'BiModeBP', 'TAGEBase', 'TAGE', 'LoopPredictor',
     'TAGE_SC_L_TAGE', 'TAGE_SC_L_TAGE_64KB', 'TAGE_SC_L_TAGE_8KB',
     'LTAGE', 'TAGE_SC_L_LoopPredictor', 'StatisticalCorrector', 'TAGE_SC_L',
@@ -66,6 +67,7 @@ Source('bpred_unit.cc')
 Source('2bit_local.cc')
 Source('simple_indirect.cc')
 Source('conditional.cc')
+Source('it_tage.cc')
 Source('indirect.cc')
 Source('ras.cc')
 Source('tournament.cc')

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -256,9 +256,8 @@ BPredUnit::predict(const StaticInstPtr &inst, const InstSeqNum &seqNum,
 
         ++stats.indirectLookups;
 
-        std::unique_ptr<const PCStateBase> itarget(
-            iPred->lookup(tid, seqNum, pc.instAddr(),
-                          hist->indirectHistory));
+        const PCStateBase *itarget =
+            iPred->lookup(tid, seqNum, pc.instAddr(), hist->indirectHistory);
 
         if (itarget) {
             // Indirect predictor hit

--- a/src/cpu/pred/it_tage.cc
+++ b/src/cpu/pred/it_tage.cc
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) 2023 University of Edinburgh
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* @file
+ * Implementation of a ITTAGE indirect branch predictor
+ */
+
+#include "cpu/pred/it_tage.hh"
+
+#include "base/intmath.hh"
+#include "base/logging.hh"
+#include "base/random.hh"
+#include "base/trace.hh"
+#include "cpu/pred/branch_type.hh"
+#include "debug/Indirect.hh"
+#include "debug/Tage.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+/** Internal TAGE component **/
+ITTAGE_TAGE::ITTAGE_TAGE(const ITTAGE_TAGEParams &p)
+    : TAGEBase(p), istats(this)
+{
+    TAGEBase::init();
+
+    // Build the target TAGE table
+    tgtTable = new TgtEntry *[nHistoryTables + 1];
+
+    for (int i = 1; i <= nHistoryTables; i++) {
+        tgtTable[i] = new TgtEntry[1 << (logTagTableSizes[i])];
+    }
+}
+
+ITTAGE_TAGE::ITTAGEBranchInfo *
+ITTAGE_TAGE::makeITTBranchInfo(Addr pc, BranchType type)
+{
+    return new ITTAGEBranchInfo(*this, pc, type == BranchType::DirectCond);
+}
+
+void
+ITTAGE_TAGE::ittTagePredict(ThreadID tid, Addr branch_pc, ITTAGEBranchInfo *bi)
+{
+    Addr pc = branch_pc;
+
+    // TAGE prediction
+    calculateIndicesAndTags(tid, pc, bi);
+
+    bi->bimodalIndex = bindex(pc);
+
+    bi->hitBank = 0;
+    bi->altBank = 0;
+    // Look for the bank with longest matching history
+    for (int i = nHistoryTables; i > 0; i--) {
+        if (noSkip[i] && gtable[i][tableIndices[i]].tag == tableTags[i] &&
+            tgtTable[i][tableIndices[i]].target != nullptr) {
+            bi->hitBank = i;
+            bi->hitBankIndex = tableIndices[bi->hitBank];
+            break;
+        }
+    }
+    // Look for the alternate bank
+    for (int i = bi->hitBank - 1; i > 0; i--) {
+        if (noSkip[i] && gtable[i][tableIndices[i]].tag == tableTags[i] &&
+            tgtTable[i][tableIndices[i]].target != nullptr) {
+            bi->altBank = i;
+            bi->altBankIndex = tableIndices[bi->altBank];
+            break;
+        }
+    }
+
+    DPRINTF(Indirect, "Hit %lx: longest(%i,%i), alt(%i,%i)\n", branch_pc,
+            bi->hitBank, bi->hitBankIndex, bi->altBank, bi->altBankIndex);
+
+    bi->provider = BTB;
+    bi->tagePred = false;
+    bi->longestMatchPred = false;
+    bi->predTarget = nullptr;
+
+    // Select the provider component
+    if (bi->hitBank > 0) {
+        if (bi->altBank > 0) {
+            bi->altTaken = gtable[bi->altBank][bi->altBankIndex].ctr > 0;
+            bi->altTarget =
+                tgtTable[bi->altBank][bi->altBankIndex].target->instAddr();
+        } else {
+            bi->altTaken = false;
+        }
+
+        bi->longestMatchPred = gtable[bi->hitBank][bi->hitBankIndex].ctr > 0;
+        bi->longestMatchTarget =
+            tgtTable[bi->hitBank][bi->hitBankIndex].target->instAddr();
+
+        // if (the confidence counter is non-null or
+        // USE ALT ON NA is negative) then the provider
+        // component provides the prediction
+        if ((useAltPredForNewlyAllocated[getUseAltIdx(bi, branch_pc)] < 0) ||
+            bi->longestMatchPred) {
+
+            bi->provider = TAGE_LONGEST_MATCH;
+            bi->tagePred = bi->longestMatchPred;
+        } else if (bi->altBank > 0) {
+            // Otherwise the alternate component provides the prediction
+            // if there was a hit by the alternate component
+            bi->provider = TAGE_ALT_MATCH;
+            bi->tagePred = bi->altTaken;
+        } else {
+            // If non of the predictors hit fall back to the BTB
+            // as target provider.
+        }
+    }
+
+    switch (bi->provider) {
+        case TAGE_LONGEST_MATCH:
+            set(bi->predTarget,
+                tgtTable[bi->hitBank][bi->hitBankIndex].target);
+            DPRINTF(Indirect, "Predict for %lx: provider:TAGE, target:%lx\n",
+                    branch_pc, *(bi->predTarget));
+            break;
+
+        case TAGE_ALT_MATCH:
+            set(bi->predTarget,
+                tgtTable[bi->altBank][bi->altBankIndex].target);
+            DPRINTF(Indirect,
+                    "Predict for %lx: provider:ALT_TAGE, target:%lx\n",
+                    branch_pc, *(bi->predTarget));
+            break;
+
+        case BTB:
+            DPRINTF(Indirect, "Fallback to BTB for %lx\n", branch_pc);
+            break;
+
+        default:
+            break;
+    }
+
+    // end TAGE prediction
+}
+
+void
+ITTAGE_TAGE::ittUpdateHistories(ThreadID tid, bool speculative, uint64_t hist,
+                                uint8_t nBits, ITTAGEBranchInfo *bi)
+{
+    if (speculative != speculativeHistUpdate) {
+        return;
+    }
+    if (nBits == 0) {
+        return;
+    }
+
+    // If this is the first time we see this branch record the current
+    // state of the history to be able to recover.
+    if (speculativeHistUpdate && (!bi->modified)) {
+        recordHistState(tid, bi);
+    }
+
+    // In case the branch already updated the history
+    // we need to revert the previous update first.
+    if (bi->modified) {
+        restoreHistState(tid, bi);
+    }
+
+    assert(bi->nGhist == 0);
+
+    ThreadHistory &tHist = threadHistory[tid];
+
+    bi->ghist = hist;
+    bi->nGhist = nBits;
+
+    //  Update the global history
+    updateGHist(tid, bi->ghist, bi->nGhist);
+    bi->modified = true;
+
+    DPRINTF(Indirect, "%s(hist:%#x, nbits:%i) pc:%#x; ptr:%d, GHR:%#x\n",
+            __func__, bi->ghist, bi->nGhist, bi->branchPC, tHist.ptGhist,
+            getGHR(tid));
+}
+
+void
+ITTAGE_TAGE::updateIndirect(ThreadID tid, ITTAGEBranchInfo *bi, int nrand,
+                            const PCStateBase &target)
+{
+    // TAGE UPDATE
+    // Try to allocate a  new entries only if prediction was wrong
+    bool alloc = (bi->squash) && (bi->hitBank < nHistoryTables);
+
+    if (bi->hitBank > 0) {
+        // Manage the selection between longest matching and alternate
+        // matching for "pseudo"-newly allocated longest matching entry
+        bool PseudoNewAlloc = !bi->longestMatchPred;
+        // an entry is considered as newly allocated if its prediction
+        // counter is weak
+        if (PseudoNewAlloc) {
+            // If one of the provider provides the correct target
+            // and if they are not the same update the new allocation counter
+            if ((bi->longestMatchTarget != bi->altTarget) &&
+                (((bi->longestMatchTarget == target.instAddr()) ||
+                  (bi->altTarget == target.instAddr())))) {
+                ctrUpdate(useAltPredForNewlyAllocated[getUseAltIdx(
+                              bi, bi->branchPC)],
+                          bi->altTarget == target.instAddr(), useAltOnNaBits);
+            }
+        }
+    }
+
+    handleAllocAndUReset(alloc, true, bi, nrand);
+
+    ittHandleTAGEUpdate(bi->branchPC, bi);
+}
+
+bool
+ITTAGE_TAGE::allocateEntry(int idx, TAGEBase::BranchInfo *bi, bool taken)
+{
+    if (TAGEBase::allocateEntry(idx, bi, taken)) {
+        ITTAGEBranchInfo *b = static_cast<ITTAGEBranchInfo *>(bi);
+        DPRINTF(Indirect, "%s table(%d,%d) PC:%#x, targ:%#x\n", __func__, idx,
+                b->tableIndices[idx], bi->branchPC, b->corrTarget->instAddr());
+
+        assert(idx <= nHistoryTables);
+        assert(b->tableIndices[idx] < (1 << (logTagTableSizes[idx])));
+        set(tgtTable[idx][b->tableIndices[idx]].target, b->corrTarget);
+        return true;
+    }
+    return false;
+}
+
+void
+ITTAGE_TAGE::ittHandleTAGEUpdate(Addr branch_pc, ITTAGEBranchInfo *bi)
+{
+    if (bi->hitBank > 0) {
+
+        uint8_t &ctr = (uint8_t &)gtable[bi->hitBank][bi->hitBankIndex].ctr;
+
+        DPRINTF(Indirect, "%s(%d,%d) for branch %lx: %i\n", __func__,
+                bi->hitBank, bi->hitBankIndex, branch_pc, ctr);
+
+        assert(bi->predTarget);
+
+        // For ITTAGE we only use possitive counter values as confidence.
+        // Increment in case the predicted target was correct.
+        // Decrement the confidence otherwise
+        unsignedCtrUpdate(ctr,
+                          bi->longestMatchTarget == bi->corrTarget->instAddr(),
+                          tagTableCounterBits);
+
+        // If the confidence reach 0 replace the target.
+        if (ctr == 0) {
+            set(tgtTable[bi->hitBank][bi->hitBankIndex].target,
+                bi->corrTarget);
+            DPRINTF(Indirect, "Replace target (%d,%d) with %lx:\n",
+                    bi->hitBank, bi->hitBankIndex, bi->corrTarget->instAddr());
+            istats.targetReplacements++;
+        }
+
+        // update the u counter
+        if (bi->longestMatchTarget != bi->altTarget) {
+            unsignedCtrUpdate(gtable[bi->hitBank][bi->hitBankIndex].u,
+                              bi->longestMatchTarget ==
+                                  bi->corrTarget->instAddr(),
+                              tagTableUBits);
+
+            DPRINTF(Indirect,
+                    "Updating the useful bit (%d,%d) for"
+                    " branch %lx: %i\n",
+                    bi->hitBank, bi->hitBankIndex, branch_pc,
+                    gtable[bi->hitBank][bi->hitBankIndex].u);
+        }
+    }
+}
+
+void
+ITTAGE_TAGE::ittUpdateStats(const PCStateBase &target, ITTAGEBranchInfo *bi)
+{
+    if (!bi->squash) {
+        // correct prediction
+        switch (bi->provider) {
+            case BIMODAL_ONLY:
+            case BIMODAL_ALT_MATCH:
+                assert(false);
+                break;
+
+            case TAGE_LONGEST_MATCH:
+                stats.longestMatchProviderCorrect++;
+                break;
+            case TAGE_ALT_MATCH:
+                stats.altMatchProviderCorrect++;
+                break;
+            case BTB:
+                istats.btbProviderCorrect++;
+                break;
+        }
+    } else {
+        // wrong prediction
+        switch (bi->provider) {
+            case BIMODAL_ONLY:
+            case BIMODAL_ALT_MATCH:
+                assert(false);
+                break;
+
+            case TAGE_LONGEST_MATCH:
+                stats.longestMatchProviderWrong++;
+                if (bi->altTarget == target.instAddr()) {
+                    stats.altMatchProviderWouldHaveHit++;
+                }
+                break;
+            case TAGE_ALT_MATCH:
+                stats.altMatchProviderWrong++;
+                if (bi->longestMatchTarget == target.instAddr()) {
+                    stats.longestMatchProviderWouldHaveHit++;
+                }
+                break;
+            case BTB:
+                istats.btbProviderWrong++;
+                break;
+        }
+    }
+
+    switch (bi->provider) {
+        case TAGE_LONGEST_MATCH:
+        case TAGE_ALT_MATCH:
+            stats.longestMatchProvider[bi->hitBank]++;
+            stats.altMatchProvider[bi->altBank]++;
+            break;
+    }
+}
+
+ITTAGE_TAGE::ITTAGE_TAGEStats::ITTAGE_TAGEStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(btbProviderCorrect, statistics::units::Count::get(),
+               "Number of times the BTB (fallback) is the provider and the "
+               "prediction is correct"),
+      ADD_STAT(btbProviderWrong, statistics::units::Count::get(),
+               "Number of times the BTB (fallback) is the provider and the "
+               "prediction is wrong"),
+      ADD_STAT(targetReplacements, statistics::units::Count::get(),
+               "Number of times the target was replaced")
+{}
+
+/*************** INDIRECT TAGE ****************/
+
+ITTAGE::ITTAGE(const ITTAGEParams &params)
+    : IndirectPredictor(params),
+      itage(params.itage),
+      histBitsConditional(params.histBitsConditional),
+      histBitsIndBranch(params.histBitsIndBranch),
+      histBitsIndCall(params.histBitsIndCall),
+      histBitsCall(params.histBitsCall),
+      stats(this)
+{
+    if (histBitsConditional > 1) {
+        panic("Only support one bit of direction history");
+    }
+}
+
+void
+ITTAGE::reset()
+{
+    DPRINTF(Indirect, "Reset Indirect predictor\n");
+}
+
+const PCStateBase *
+ITTAGE::lookup(ThreadID tid, InstSeqNum sn, Addr pc, void *&indirect_history)
+{
+    assert(indirect_history == nullptr);
+
+    stats.lookups++;
+    genIndirectInfo(tid, sn, pc, BranchType::NoBranch, indirect_history);
+
+    auto bi = static_cast<ITTAGE_TAGE::ITTAGEBranchInfo *>(indirect_history);
+
+    // First make the TAGE prediction.
+    itage->ittTagePredict(tid, pc, bi);
+
+    // If there was a TAGE it use the entry from the TAGE array.
+    // Otherwise return null and the BTB target will be taken.
+    if (bi->provider == ITTAGE_TAGE::BTB) {
+        stats.misses++;
+        return nullptr;
+    }
+    stats.hits++;
+    return bi->predTarget.get();
+}
+
+void
+ITTAGE::update(ThreadID tid, InstSeqNum sn, Addr pc, bool squash, bool taken,
+               const PCStateBase &target, BranchType brType,
+               void *&indirect_history)
+{
+    const auto [hist, nBits] =
+        calculateHistUpdate(brType, pc, taken, target.instAddr());
+
+    // Not all branches update the history
+    if (!nBits) {
+        return;
+    }
+
+    stats.updates++;
+
+    // If there is no history we did not use the indirect predictor yet.
+    // Create one
+    if (indirect_history == nullptr) {
+        genIndirectInfo(tid, sn, pc, brType, indirect_history);
+    }
+
+    auto bi = static_cast<ITTAGE_TAGE::ITTAGEBranchInfo *>(indirect_history);
+    assert(bi != nullptr);
+
+    DPRINTF(Indirect,
+            "%s(tid:%lu, sn:%lu, PC:%#x, squash:%i, targ:%#x, "
+            "taken:%i type:%s)\n",
+            __func__, tid, sn, bi->branchPC, squash, target.instAddr(), taken,
+            toString(brType));
+
+    assert(bi->branchPC > 0);
+
+    // If the target is provided by the
+    // BTB record it for the later update.
+    if (bi->provider == ITTAGE_TAGE::BTB && bi->predTarget == nullptr) {
+        set(bi->predTarget, target);
+    }
+
+    // Update the branch information
+    bi->indirect = isIndirectNoReturn(brType);
+    bi->type = brType;
+    bi->taken = taken;
+    set(bi->corrTarget, target);
+    if (squash) {
+        bi->squash = true;
+        stats.updateSquashed++;
+        if (bi->indirect) {
+            stats.updateIndSquashed++;
+        }
+    }
+
+    // Speculative update the history
+    itage->ittUpdateHistories(tid, true, hist, nBits, bi);
+}
+
+void
+ITTAGE::squash(ThreadID tid, InstSeqNum sn, void *&indirect_history)
+{
+    // If no history was created there is no need to delete it
+    if (indirect_history == nullptr) {
+        return;
+    }
+
+    // If restore the history state if the
+    // branch modified it.
+    auto bi = static_cast<ITTAGE_TAGE::ITTAGEBranchInfo *>(indirect_history);
+    itage->restoreHistState(tid, bi);
+
+    delete bi;
+    indirect_history = nullptr;
+}
+
+void
+ITTAGE::commit(ThreadID tid, InstSeqNum sn, void *&indirect_history)
+{
+    if (indirect_history == nullptr) {
+        return;
+    }
+
+    auto bi = static_cast<ITTAGE_TAGE::ITTAGEBranchInfo *>(indirect_history);
+    assert(bi->branchPC > 0);
+
+    DPRINTF(Indirect,
+            "%s(tid:%lu, sn:%lu, BI[PC:%#x, targ:%#x, taken:%#x, "
+            "type:%s])\n",
+            __func__, tid, sn, bi->branchPC, bi->corrTarget->instAddr(),
+            bi->taken, toString(bi->type));
+
+    int nrand = rng->random<int>() & 3;
+    if (bi->indirect) {
+        stats.indirectRecords++;
+
+        if (bi->squash) {
+            if (bi->type == BranchType::CallIndirect) {
+                stats.mispredictIndCall++;
+            } else {
+                stats.mispredictIndJump++;
+            }
+            stats.mispredictTotal++;
+        }
+
+        DPRINTF(Indirect, "Updating ITTAGE for PC:%#x, mispredict:%i, %s\n",
+                bi->branchPC, bi->squash, toString(bi->type));
+        itage->ittUpdateStats(*bi->corrTarget, bi);
+        itage->updateIndirect(tid, bi, nrand, *bi->corrTarget);
+    }
+
+    // Optional non speculative update of the histories
+    const auto [hist, nBits] = calculateHistUpdate(
+        bi->type, bi->branchPC, bi->taken, bi->corrTarget->instAddr());
+
+    itage->ittUpdateHistories(tid, false, hist, nBits, bi);
+
+    // The branch is done
+    delete bi;
+    indirect_history = nullptr;
+}
+
+void
+ITTAGE::genIndirectInfo(ThreadID tid, InstSeqNum sn, Addr pc,
+                        BranchType brType, void *&iHistory)
+{
+    // Record the GHR as it was before this prediction
+    // It will be used to recover the history in case this prediction is
+    // wrong or belongs to bad path
+    auto *bi = itage->makeITTBranchInfo(pc, brType);
+
+    bi->type = brType;
+    bi->indirect = isIndirectNoReturn(brType);
+    bi->taken = false;
+    bi->provider = ITTAGE_TAGE::BTB;
+
+    if (bi->indirect) {
+        itage->calculateIndicesAndTags(tid, pc, bi);
+    }
+
+    iHistory = (void *)(bi);
+}
+
+std::tuple<uint64_t, uint8_t>
+ITTAGE::calculateHistUpdate(BranchType type, Addr pc, bool taken, Addr target)
+{
+    uint8_t nBits = 0;
+    uint64_t hist = target ^ (target >> 3) ^ pc;
+
+    switch (type) {
+        case BranchType::DirectCond:
+            nBits = histBitsConditional;
+            hist = taken ? 1 : 0;
+            break;
+
+        case BranchType::IndirectUncond:
+            nBits = histBitsIndBranch;
+            break;
+        case BranchType::CallDirect:
+            nBits = histBitsCall;
+            break;
+        case BranchType::CallIndirect:
+            nBits = histBitsIndCall;
+            break;
+
+        default:
+            break;
+    }
+
+    hist &= (1 << nBits) - 1;
+    return std::make_tuple(hist, nBits);
+}
+
+ITTAGE::ITTAGEStats::ITTAGEStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(lookups, statistics::units::Count::get(), "Number of lookups"),
+      ADD_STAT(hits, statistics::units::Count::get(),
+               "Number of hits of a tag"),
+      ADD_STAT(misses, statistics::units::Count::get(), "Number of misses"),
+      ADD_STAT(targetRecords, statistics::units::Count::get(),
+               "Number of targets that where recorded/installed in the cache"),
+      ADD_STAT(indirectRecords, statistics::units::Count::get(),
+               "Number of indirect branches/calls recorded in the"
+               " indirect hist"),
+      ADD_STAT(mispredictIndCall, statistics::units::Count::get(),
+               "Number of mispredicted indirect calls"),
+      ADD_STAT(mispredictIndJump, statistics::units::Count::get(),
+               "Number of mispredicted indirect jumps"),
+      ADD_STAT(mispredictTotal, statistics::units::Count::get(),
+               "Number of all mispredicted indirect branches"),
+      ADD_STAT(updates, statistics::units::Count::get(),
+               "Number of all mispredicted indirect branches"),
+      ADD_STAT(updateSquashed, statistics::units::Count::get(),
+               "Number of all mispredicted indirect branches"),
+      ADD_STAT(updateIndSquashed, statistics::units::Count::get(),
+               "Number of all mispredicted indirect branches")
+{}
+
+} // namespace branch_prediction
+} // namespace gem5

--- a/src/cpu/pred/it_tage.hh
+++ b/src/cpu/pred/it_tage.hh
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2023 University of Edinburgh
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* @file
+ * Implementation of the ITTAGE indirect branch predictor
+ * Reference: https://jilp.org/jwac-2/program/cbp3_07_seznec.pdf
+ * Author: André Seznec
+ */
+
+#ifndef __CPU_PRED_ITTAGE_HH__
+#define __CPU_PRED_ITTAGE_HH__
+
+#include <tuple>
+#include <vector>
+
+#include "base/random.hh"
+#include "base/statistics.hh"
+#include "base/types.hh"
+#include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/indirect.hh"
+#include "cpu/pred/tage_base.hh"
+#include "enums/BranchType.hh"
+#include "params/ITTAGE.hh"
+#include "params/ITTAGE_TAGE.hh"
+
+namespace gem5
+{
+
+namespace branch_prediction
+{
+
+class ITTAGE;
+
+/** Base TAGE with target array */
+class ITTAGE_TAGE : public TAGEBase
+{
+    typedef enums::BranchType BranchType;
+    friend ITTAGE;
+
+  public:
+    ITTAGE_TAGE(const ITTAGE_TAGEParams &p);
+
+  private:
+    struct TgtEntry
+    {
+        std::unique_ptr<PCStateBase> target;
+        TgtEntry() : target(nullptr) {}
+    };
+
+    /** Extended TAGE gtable by the target field */
+    TgtEntry **tgtTable;
+
+    // more provider types
+    enum
+    {
+        BTB = TAGEBase::LAST_TAGE_PROVIDER_TYPE + 1,
+        LAST_LTAGE_PROVIDER_TYPE = BTB
+    };
+
+    struct ITTAGEBranchInfo : public TAGEBase::BranchInfo
+    {
+        ITTAGEBranchInfo(TAGEBase &tage, Addr pc, bool conditional)
+            : TAGEBase::BranchInfo(tage, pc, conditional),
+              predTarget(nullptr),
+              corrTarget(nullptr),
+              longestMatchTarget(MaxAddr),
+              altTarget(MaxAddr),
+              indirect(false),
+              type(BranchType::NoBranch),
+              taken(false),
+              squash(false)
+        {}
+
+        ~ITTAGEBranchInfo() {}
+
+        /** Predicted and correct target of a branch */
+        std::unique_ptr<PCStateBase> predTarget;
+        std::unique_ptr<PCStateBase> corrTarget;
+
+        /** Predicted targets for alt and provider components */
+        Addr longestMatchTarget;
+        Addr altTarget;
+
+        /** A prediction for this branch was made */
+        bool indirect;
+        BranchType type;
+        bool taken;
+        bool squash;
+    };
+
+    ITTAGEBranchInfo *makeITTBranchInfo(Addr pc, BranchType type);
+
+    void ittTagePredict(ThreadID tid, Addr branch_pc, ITTAGEBranchInfo *bi);
+
+    /**
+     * Internal history update function. This function shifts
+     * nBits into the global history vector. If the update
+     * is speculative the functions makes a copy of the
+     * GHR to rollback.
+     * @param tid The thread ID to select the histories to update.
+     * @param speculative Whether the update is speculative or not
+     * @param hist The bit vector with n bits that will be shifted
+     * into the global history vector.
+     * @param nBits The number of bits to be updated
+     * @param bi Wrapping pointer to BranchInfo (to allow
+     * storing derived class prediction information in the
+     * base class).
+     */
+    void ittUpdateHistories(ThreadID tid, bool speculative, uint64_t hist,
+                            uint8_t nBits, ITTAGEBranchInfo *bi);
+
+    void updateIndirect(ThreadID tid, ITTAGEBranchInfo *bi, int nrand,
+                        const PCStateBase &target);
+
+    bool allocateEntry(int idx, TAGEBase::BranchInfo *bi, bool taken) override;
+
+    /**
+     * Handles the update of the TAGE entries
+     */
+    void ittHandleTAGEUpdate(Addr branch_pc, ITTAGEBranchInfo *bi);
+
+    void ittUpdateStats(const PCStateBase &target, ITTAGEBranchInfo *bi);
+
+    struct ITTAGE_TAGEStats : public statistics::Group
+    {
+        ITTAGE_TAGEStats(statistics::Group *parent);
+        statistics::Scalar btbProviderCorrect;
+        statistics::Scalar btbProviderWrong;
+        statistics::Scalar targetReplacements;
+    } istats;
+};
+
+class ITTAGE : public IndirectPredictor
+{
+    typedef enums::BranchType BranchType;
+
+  protected:
+    ITTAGE_TAGE *itage;
+
+    Random::RandomPtr rng = Random::genRandom();
+
+  public:
+    ITTAGE(const ITTAGEParams &params);
+    ~ITTAGE() = default;
+
+    /** Interface function to override */
+    void reset() override;
+
+    const PCStateBase *lookup(ThreadID tid, InstSeqNum sn, Addr pc,
+                              void *&indirect_history) override;
+    void update(ThreadID tid, InstSeqNum sn, Addr pc, bool squash, bool taken,
+                const PCStateBase &target, BranchType brType,
+                void *&indirect_history) override;
+    void squash(ThreadID tid, InstSeqNum seq_num,
+                void *&indirect_history) override;
+    void commit(ThreadID tid, InstSeqNum seq_num,
+                void *&indirect_history) override;
+
+  private:
+    /** Number of bits in the history for different branch types */
+    const unsigned histBitsConditional;
+    const unsigned histBitsIndBranch;
+    const unsigned histBitsIndCall;
+    const unsigned histBitsCall;
+
+    inline bool
+    isIndirectNoReturn(BranchType type)
+    {
+        return (type == BranchType::CallIndirect) ||
+               (type == BranchType::IndirectUncond);
+    }
+
+    /**
+     * Calculates the history update based on the instruction type
+     * @param inst The branch instruction.
+     * @param pc Branch pc.
+     * @param taken branch direction.
+     * @param target branch target.
+     * @return A tuple: 1. A bit vector to update the history with
+     *                  2. The number of bits in the bit vector
+     */
+    std::tuple<uint64_t, uint8_t> calculateHistUpdate(BranchType type, Addr pc,
+                                                      bool taken, Addr target);
+    void genIndirectInfo(ThreadID tid, InstSeqNum sn, Addr pc,
+                         BranchType brType, void *&iHistory);
+
+  protected:
+    struct ITTAGEStats : public statistics::Group
+    {
+        ITTAGEStats(statistics::Group *parent);
+
+        statistics::Scalar lookups;
+        statistics::Scalar hits;
+        statistics::Scalar misses;
+        statistics::Scalar targetRecords;
+        statistics::Scalar indirectRecords;
+        statistics::Scalar mispredictIndCall;
+        statistics::Scalar mispredictIndJump;
+        statistics::Scalar mispredictTotal;
+        statistics::Scalar updates;
+        statistics::Scalar updateSquashed;
+        statistics::Scalar updateIndSquashed;
+    } stats;
+};
+
+} // namespace branch_prediction
+} // namespace gem5
+
+#endif // __CPU_PRED_ITTAGE_HH__

--- a/src/cpu/pred/tage_base.cc
+++ b/src/cpu/pred/tage_base.cc
@@ -481,9 +481,11 @@ TAGEBase::handleAllocAndUReset(bool alloc, bool taken, BranchInfo* bi,
         //Allocate entries
         unsigned numAllocated = 0;
         for (int i = X; i <= nHistoryTables; i++) {
-            if (gtable[i][bi->tableIndices[i]].u == 0) {
-                gtable[i][bi->tableIndices[i]].tag = bi->tableTags[i];
-                gtable[i][bi->tableIndices[i]].ctr = (taken) ? 0 : -1;
+            if (allocateEntry(i, bi, taken)) {
+                DPRINTF(Tage, "Allocate for %llx: i:%i Tidx:%i, Ttag:%x\n",
+                        bi->branchPC, i, bi->tableIndices[i],
+                        bi->tableTags[i]);
+
                 ++numAllocated;
                 if (numAllocated == maxNumAlloc) {
                     break;
@@ -495,6 +497,18 @@ TAGEBase::handleAllocAndUReset(bool alloc, bool taken, BranchInfo* bi,
     tCounter++;
 
     handleUReset();
+}
+
+bool
+TAGEBase::allocateEntry(int idx, BranchInfo *bi, bool taken)
+{
+    if (gtable[idx][bi->tableIndices[idx]].u != 0) {
+        return false;
+    }
+
+    gtable[idx][bi->tableIndices[idx]].tag = bi->tableTags[idx];
+    gtable[idx][bi->tableIndices[idx]].ctr = (taken) ? 0 : -1;
+    return true;
 }
 
 void
@@ -862,8 +876,8 @@ TAGEBase::TAGEBaseStats::TAGEBaseStats(
       ADD_STAT(altMatchProvider, statistics::units::Count::get(),
                "TAGE provider for alt match")
 {
-    longestMatchProvider.init(nHistoryTables + 1);
-    altMatchProvider.init(nHistoryTables + 1);
+    longestMatchProvider.init(nHistoryTables + 1).flags(statistics::total);
+    altMatchProvider.init(nHistoryTables + 1).flags(statistics::total);
 }
 
 int8_t

--- a/src/cpu/pred/tage_base.hh
+++ b/src/cpu/pred/tage_base.hh
@@ -396,8 +396,8 @@ class TAGEBase : public SimObject
      * @param cond_branch True if the branch is conditional.
      * @param bi Pointer to the BranchInfo
      */
-    bool tagePredict(
-        ThreadID tid, Addr branch_pc, bool cond_branch, BranchInfo* bi);
+    virtual bool tagePredict(ThreadID tid, Addr branch_pc, bool cond_branch,
+                             BranchInfo *bi);
 
     /**
      * Update the stats
@@ -459,6 +459,12 @@ class TAGEBase : public SimObject
      * Algorithm for resetting a single U counter
      */
     virtual void resetUctr(uint8_t & u);
+
+    /**
+     * Try to allocate an entry at index idx.
+     * Returns true if the allocation was successful
+     */
+    virtual bool allocateEntry(int idx, BranchInfo *bi, bool taken = false);
 
     /**
      * Extra steps for calculating altTaken


### PR DESCRIPTION
Implementation of the indirect target TAGE (ITTAGE) after "A 64-Kbytes ITTAGE indirect branch predictor" from Andre Seznec. As compared to the work above this implementation does not use shared tables. Furthermore, instead of using a decicated base predictor this implementation uses the BTB as fallback. That means only indirect branches that have a changing target will use the indirect predictor

Signed-off-by: David Schall <david.schall@tum.de>