### PR TITLE
cpu-o3: Clear IQ dep-graph producer on squash

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1452,9 +1452,9 @@ InstructionQueue::doSquash(ThreadID tid)
             if (dest_reg->isAlwaysReady()) {
                 continue;
             }
-            if (!dependGraph.empty(dest_reg->flatIndex())) {
-                dependGraph.clearInst(dest_reg->flatIndex());
-            }
+            // Clear the producer even if there are no dependents; otherwise
+            // the head node can retain a DynInstPtr and leak squashed insts.
+            dependGraph.clearInst(dest_reg->flatIndex());
         }
         instList[tid].erase(squash_it--);
         ++iqStats.squashedInstsExamined;


### PR DESCRIPTION
Without this, debug builds can abort with:
`gem5::o3::DynInst::DynInst(...) Assertion 'cpu->instcount <= 1500' failed.`

This was causing our Weekly tests to fail:
https://github.com/gem5/gem5/actions/runs/21298731348/job/61310974117

To reproduce the bug (warning, this takes a while):

```
../build/ALL/gem5.opt tests/gem5/x86_boot_tests/configs/ x86_boot_exit_run.py --cpu o3 --num-cpus 8 --mem-system classic --dram-class DualChannelDDR4_2400 --boot-type init
```