### PR TITLE
mem: Fix DramSys DRAMSysDDR3_1600 config path for v5.3.1

### DIFF
--- a/src/python/gem5/components/memory/dramsys.py
+++ b/src/python/gem5/components/memory/dramsys.py
@@ -141,7 +141,7 @@ class DRAMSysDDR3_1600(DRAMSysMem):
     def __init__(self):
         super().__init__(
             configuration=(
-                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr3-gem5-se.json"
+                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr3-example.json"
             ).as_posix(),
             size="1GiB",
         )


### PR DESCRIPTION
The old "ddr3-gem5-se.json" file does not exist in v5.3.1 of DRAMSys. DRAMSys was upgraded from v5.1 to v5.3.1 in PR #2898.

The DDR3 example which should replace this in v5.3.1 is "ddr3-example.json". As such the path in "dramsys.py" has been updated.