### PR TITLE
stdlib: Turn off osxsave for non-KVM CPUs

### DIFF
--- a/src/python/gem5/prebuilt/viper/board.py
+++ b/src/python/gem5/prebuilt/viper/board.py
@@ -144,12 +144,14 @@ class ViperBoard(X86Board):
         avx_cpu_features = [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x1C803209]
         for core_wrapper in self.get_processor().get_cores():
             if not core_wrapper.is_kvm_core():
+                self.workload.enable_osxsave = 0
                 warn("AVX is only supported with KVM cores")
             core = core_wrapper.get_simobject()
             for isa in core.isa:
                 isa.vendor_string = "AuthenticAMD"
-                isa.ExtendedState = avx_extended_state
-                isa.FamilyModelStepping = avx_cpu_features
+                if self.workload.enable_osxsave:
+                    isa.ExtendedState = avx_extended_state
+                    isa.FamilyModelStepping = avx_cpu_features
 
         # By default stdlib creates multiple event queues whenever KVM CPU is
         # used. Multiple event queues break many things in the GPU model


### PR DESCRIPTION
Right now, running the GPUFS scripts under the stdlib using a CPU other KVM (namely, atomic) results in a kernel panic since AtomicCPU does not have support for AVX instructions (at least, I'm pretty sure this is the case given my output). The non-stdlib scripts account for this, as seen [here](https://github.com/gem5/gem5/blob/7a2b0e413d06c5ce7097104abef3b1d9eaabca91/configs/example/gpufs/system/system.py#L325).

I ran `x86-mi300x-gpu.py`, changed the CPU from KVM to Atomic and using a slightly modified version of the `x86-ubuntu-gpu-ml` that supports gem5-bridge (this is identical to the current image, just that m5-bin is replaced with running gem5-bridge in the kernel)
[Here](https://github.com/user-attachments/files/24890825/atomic-gpufs-noavx-board.pc.com_1.device) is the FS output.

After running gem5 with my fixes, my board output looks like [this](https://github.com/user-attachments/files/24891107/atomic-gpufs-avxfix-board.pc.com_1.device.txt) and square (as my example app) runs to completion. 

EDIT: Tagging @mattsinc and @abmerop to take a look 
