### PR TITLE
cpu-o3: Revert "incorrect `vtype` and `vl` generates `assert` fail in  `O3 IQ`"

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1452,9 +1452,8 @@ InstructionQueue::doSquash(ThreadID tid)
             if (dest_reg->isAlwaysReady()) {
                 continue;
             }
-            if (!dependGraph.empty(dest_reg->flatIndex())) {
-                dependGraph.clearInst(dest_reg->flatIndex());
-            }
+            assert(dependGraph.empty(dest_reg->flatIndex()));
+            dependGraph.clearInst(dest_reg->flatIndex());
         }
         instList[tid].erase(squash_it--);
         ++iqStats.squashedInstsExamined;
@@ -1536,8 +1535,7 @@ InstructionQueue::addToProducers(const DynInstPtr &new_inst)
             continue;
         }
 
-        if (!dependGraph.empty(dest_reg->flatIndex()) &&
-            new_inst->isNonSpeculative()) {
+        if (!dependGraph.empty(dest_reg->flatIndex())) {
             dependGraph.dump();
             panic("Dependency graph %i (%s) (flat: %i) not empty!",
                   dest_reg->index(), dest_reg->className(),


### PR DESCRIPTION
Reverts gem5/gem5#2657

I believe gem5/gem5#2657 is causing a failure in the o3 CPU which is triggering our weekly tests to fail (see: https://github.com/gem5/gem5/actions/runs/21298731348/job/61310974117). I had previously created PR #2909 to fix this issue but discussions with @powerjg led me to the conclusion it was safer to revert this PR for now.

This specific failure in the weekly tests is due to the following assertion being raised when running the o3 CPU:

`gem5::o3::DynInst::DynInst(...) Assertion 'cpu->instcount <= 1500' failed.`

To reproduce the bug (warning, this takes a while):

```
../build/ALL/gem5.opt tests/gem5/x86_boot_tests/configs/ x86_boot_exit_run.py --cpu o3 --num-cpus 8 --mem-system classic --dram-class DualChannelDDR4_2400 --boot-type init
```