### PR TITLE
mem: Use DRAMSys gem5_se simconfig for SE configs

### DIFF
--- a/ext/dramsys/gem5_configs/ddr3-gem5-se.json
+++ b/ext/dramsys/gem5_configs/ddr3-gem5-se.json
@@ -1,0 +1,17 @@
+{
+    "simulation": {
+        "addressmapping": "addressmapping/am_ddr3_8x1Gbx8_dimm_p1KB_rbc.json",
+        "mcconfig": "mcconfig/fr_fcfs.json",
+        "memspec": "memspec/MICRON_1Gb_DDR3-1600_8bit_G.json",
+        "simconfig": "simconfig/gem5_se.json",
+        "simulationid": "ddr3-gem5-se",
+        "tracesetup": [
+            {
+                "type": "player",
+                "clkMhz": 800,
+                "dataLength": 64,
+                "name": "traces/example.stl"
+            }
+        ]
+    }
+}

--- a/ext/dramsys/gem5_configs/ddr4-gem5-se.json
+++ b/ext/dramsys/gem5_configs/ddr4-gem5-se.json
@@ -1,0 +1,17 @@
+{
+    "simulation": {
+        "addressmapping": "addressmapping/am_ddr4_8x4Gbx8_dimm_p1KB_brc.json",
+        "mcconfig": "mcconfig/fr_fcfs.json",
+        "memspec": "memspec/JEDEC_4Gb_DDR4-1866_8bit_A.json",
+        "simconfig": "simconfig/gem5_se.json",
+        "simulationid": "ddr4-gem5-se",
+        "tracesetup": [
+            {
+                "type": "player",
+                "clkMhz": 200,
+                "dataLength": 64,
+                "name": "traces/example.stl"
+            }
+        ]
+    }
+}

--- a/src/python/gem5/components/memory/dramsys.py
+++ b/src/python/gem5/components/memory/dramsys.py
@@ -120,28 +120,40 @@ class DRAMSysMem(AbstractMemorySystem):
 
 
 class DRAMSysDDR4_1866(DRAMSysMem):
-    """
-    An example DDR4 1866 DRAMSys configuration.
+    """An example DDR4 1866 DRAMSys configuration.
+
+    Notes
+    -----
+    gem5 uses functional accesses (i.e., TLM debug transport) during
+    SE-mode binary loading. DRAMSys requires a storage-backed configuration
+    for debug transport. Therefore, for gem5 SE usage we point to a
+    configuration using DRAMSys's `simconfig/gem5_se.json`.
     """
 
     def __init__(self):
         super().__init__(
-            configuration=(
-                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr4-example.json"
+            configuration=Path(
+                "ext/dramsys/gem5_configs/ddr4-gem5-se.json"
             ).as_posix(),
             size="4GiB",
         )
 
 
 class DRAMSysDDR3_1600(DRAMSysMem):
-    """
-    An example DDR3 1600 DRAMSys configuration.
+    """An example DDR3 1600 DRAMSys configuration.
+
+    Notes
+    -----
+    gem5 uses functional accesses (i.e., TLM debug transport) during
+    SE-mode binary loading. DRAMSys requires a storage-backed configuration
+    for debug transport. Therefore, for gem5 SE usage we point to a
+    configuration using DRAMSys's `simconfig/gem5_se.json`.
     """
 
     def __init__(self):
         super().__init__(
-            configuration=(
-                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr3-example.json"
+            configuration=Path(
+                "ext/dramsys/gem5_configs/ddr3-gem5-se.json"
             ).as_posix(),
             size="1GiB",
         )


### PR DESCRIPTION
DRAMSys aborts when TLM debug transport is used with StoreMode=NoStorage.

gem5 performs functional accesses during SE binary loading, which calls into DRAMSys's debug transport path. This PR points the gem5 library DRAMSys example configurations at gem5-provided base JSON files using DRAMSys's simconfig/gem5_se.json (Store mode) to avoid the abort.

Fixes the dramsys-tests failure in Daily Tests (Run DRAMSys Checks).