### PR TITLE
cpu: added missing simd operations to Neoverse V2 core

### DIFF
--- a/configs/common/cores/arm/neoverse_v2.py
+++ b/configs/common/cores/arm/neoverse_v2.py
@@ -51,7 +51,6 @@ class NeoverseV2_Complex_Int(FUDesc):
         OpDesc(opClass="IntDiv", opLat=11, pipelined=False),
         # Treat system register (IPR) accesses as regular integer ops.
         OpDesc(opClass="IntAlu", opLat=1, pipelined=True),
-
         OpDesc(opClass="InstPrefetch", opLat=4, pipelined=True),
         OpDesc(opClass="System", opLat=3, pipelined=True),
     ]

--- a/configs/common/cores/arm/neoverse_v2.py
+++ b/configs/common/cores/arm/neoverse_v2.py
@@ -47,10 +47,12 @@ class Neoverse_V2_SI_FUP(FUPool):
 # Complex ALU instructions have a variable latencies
 class NeoverseV2_Complex_Int(FUDesc):
     opList = [
-        OpDesc(opClass="IntMult", opLat=4, pipelined=True),
+        OpDesc(opClass="IntMult", opLat=2, pipelined=True),
         OpDesc(opClass="IntDiv", opLat=11, pipelined=False),
         # Treat system register (IPR) accesses as regular integer ops.
-        OpDesc(opClass="IntAlu", opLat=3, pipelined=True),
+        OpDesc(opClass="IntAlu", opLat=1, pipelined=True),
+
+        OpDesc(opClass="InstPrefetch", opLat=4, pipelined=True),
         OpDesc(opClass="System", opLat=3, pipelined=True),
     ]
 
@@ -62,35 +64,64 @@ class Neoverse_V2_CI_FUP(FUPool):
 # Floating point and SIMD instructions
 class NeoverseV2_FP(FUDesc):
     opList = [
-        OpDesc(opClass="SimdAdd", opLat=3),
+        OpDesc(opClass="SimdAdd", opLat=2),
         OpDesc(opClass="SimdAddAcc", opLat=4),
-        OpDesc(opClass="SimdAlu", opLat=4),
-        OpDesc(opClass="SimdCmp", opLat=4),
+        OpDesc(opClass="SimdAlu", opLat=2),
+        OpDesc(opClass="SimdCmp", opLat=2),
         OpDesc(opClass="SimdCvt", opLat=3),
         OpDesc(opClass="SimdMisc", opLat=3),
-        OpDesc(opClass="SimdMult", opLat=6),
-        OpDesc(opClass="SimdMultAcc", opLat=5),
-        OpDesc(opClass="SimdMatMultAcc", opLat=5),
+        OpDesc(opClass="SimdMult", opLat=4),
+        OpDesc(opClass="SimdMultAcc", opLat=4),
+        OpDesc(opClass="SimdMatMultAcc", opLat=3),
         OpDesc(opClass="SimdShift", opLat=3),
-        OpDesc(opClass="SimdShiftAcc", opLat=3),
-        OpDesc(opClass="SimdSqrt", opLat=9),
-        OpDesc(opClass="SimdFloatAdd", opLat=6),
-        OpDesc(opClass="SimdFloatAlu", opLat=5),
-        OpDesc(opClass="SimdFloatCmp", opLat=3),
-        OpDesc(opClass="SimdFloatCvt", opLat=3),
-        OpDesc(opClass="SimdFloatDiv", opLat=21),
+        OpDesc(opClass="SimdShiftAcc", opLat=4),
+        OpDesc(opClass="SimdDiv", opLat=11),
+        OpDesc(opClass="SimdSqrt", opLat=5),
+        OpDesc(opClass="SimdFloatAdd", opLat=2),
+        OpDesc(opClass="SimdFloatAlu", opLat=3),
+        OpDesc(opClass="SimdFloatCmp", opLat=2),
+        OpDesc(opClass="SimdFloatCvt", opLat=4),
+        OpDesc(opClass="SimdFloatDiv", opLat=11),
         OpDesc(opClass="SimdFloatMisc", opLat=3),
-        OpDesc(opClass="SimdFloatMult", opLat=6),
-        OpDesc(opClass="SimdFloatMultAcc", opLat=1),
-        OpDesc(opClass="SimdFloatMatMultAcc", opLat=1),
+        OpDesc(opClass="SimdFloatMult", opLat=3),
+        OpDesc(opClass="SimdFloatMultAcc", opLat=4),
+        OpDesc(opClass="SimdFloatMatMultAcc", opLat=6),
         OpDesc(opClass="SimdFloatSqrt", opLat=9),
+        OpDesc(opClass="SimdReduceAdd", opLat=4),
+        OpDesc(opClass="SimdReduceAlu", opLat=4),
+        OpDesc(opClass="SimdReduceCmp", opLat=4),
+        OpDesc(opClass="SimdFloatReduceAdd", opLat=6),
+        OpDesc(opClass="SimdFloatReduceCmp", opLat=6),
+        OpDesc(opClass="SimdExt", opLat=2),
+        OpDesc(opClass="SimdFloatExt", opLat=2),
+        OpDesc(opClass="SimdConfig", opLat=2),
+        OpDesc(opClass="SimdDotProd", opLat=3),
+        OpDesc(opClass="SimdAes", opLat=2),
+        OpDesc(opClass="SimdAesMix", opLat=2),
+        OpDesc(opClass="SimdSha1Hash", opLat=2),
+        OpDesc(opClass="SimdSha1Hash2", opLat=4),
+        OpDesc(opClass="SimdSha256Hash", opLat=4),
+        OpDesc(opClass="SimdSha256Hash2", opLat=4),
+        OpDesc(opClass="SimdShaSigma2", opLat=2),
+        OpDesc(opClass="SimdShaSigma3", opLat=2),
+        OpDesc(opClass="SimdSha3", opLat=2),
+        OpDesc(opClass="SimdSm4e", opLat=4),
+        OpDesc(opClass="SimdCrc", opLat=2),
+        OpDesc(opClass="SimdBf16Add", opLat=2),
+        OpDesc(opClass="SimdBf16Cmp", opLat=2),
+        OpDesc(opClass="SimdBf16Cvt", opLat=4),
+        OpDesc(opClass="SimdBf16DotProd", opLat=5),
+        OpDesc(opClass="SimdBf16MatMultAcc", opLat=6),
+        OpDesc(opClass="SimdBf16Mult", opLat=3),
+        OpDesc(opClass="SimdBf16MultAcc", opLat=5),
         OpDesc(opClass="FloatAdd", opLat=2),
         OpDesc(opClass="FloatCmp", opLat=2),
-        OpDesc(opClass="FloatCvt", opLat=2),
-        OpDesc(opClass="FloatDiv", opLat=12, pipelined=False),
-        OpDesc(opClass="FloatSqrt", opLat=33, pipelined=False),
+        OpDesc(opClass="FloatCvt", opLat=3),
+        OpDesc(opClass="FloatDiv", opLat=11, pipelined=False),
+        OpDesc(opClass="FloatSqrt", opLat=12, pipelined=False),
         OpDesc(opClass="FloatMult", opLat=3),
         OpDesc(opClass="FloatMisc", opLat=4),
+        OpDesc(opClass="FloatMultAcc", opLat=4),
     ]
 
 
@@ -100,11 +131,17 @@ class Neoverse_V2_FP_FUP(FUPool):
 
 # Load/Store Unit
 class NeoverseV2_Load(FUDesc):
-    opList = [OpDesc(opClass="MemRead", opLat=2)]
+    opList = [
+        OpDesc(opClass="MemRead", opLat=4),
+        OpDesc(opClass="FloatMemRead", opLat=6),
+    ]
 
 
 class NeoverseV2_Store(FUDesc):
-    opList = [OpDesc(opClass="MemWrite", opLat=2)]
+    opList = [
+        OpDesc(opClass="MemWrite", opLat=1),
+        OpDesc(opClass="FloatMemWrite", opLat=2),
+    ]
 
 
 # Load only pool


### PR DESCRIPTION
I have access to a server running the Nvidia Grace Hopper Neoverse V2 chip, and after taking a checkpoint and reloading I realized that instructions where missing from the functional units in the implementation. The latencies have been added based on [this datasheet](https://developer.arm.com/documentation/109898/latest/). 

Below is how I have mapped the latencies:

OpClass | Instruction Group | Exec Latency
-- | -- | --
IntMult | Integer multiply (MUL, MNEG) | 2
IntDiv | Integer divide (SDIV, UDIV) | 9 (guide: W-form 5–12, X-form 5–20; representative pick)
IntAlu | Integer ALU (basic data-processing) | 1
InstPrefetch | Prefetch (PRFM/prefetch family) | 4
System | System/sysreg ops bucket | 3
SimdAdd | Vector integer add/sub (basic) | 2
SimdAddAcc | Vector integer add/accumulate family | 4
SimdAlu | Vector integer logical (AND/ORR/EOR/…) | 2
SimdCmp | Vector integer compare/max/min bucket | 2
SimdCvt | Vector convert/move bucket | 3 (guide: ~2–5 depending on specific op; representative pick)
SimdMisc | Vector misc (permute/table/zip/…) | 3 (guide: ~2–6 depending on op; representative pick)
SimdMult | Vector integer multiply | 4
SimdMultAcc | Vector integer multiply-accumulate (MLA/MLS class) | 4 (guide varies by element width; representative pick)
SimdMatMultAcc | Matrix multiply accumulate (SMMLA/UMMLA/…) | 3
SimdShift | Vector shift bucket | 3 (guide: ~2–4 depending on op; representative pick)
SimdShiftAcc | Shift accumulate (SSRA/USRA/…) | 4
SimdDiv | Vector divide bucket | 11 (guide: ~7–20; representative pick)
SimdSqrt | “sqrt/estimate-like” vector bucket | 5 (guide: ~4–6; representative pick)
SimdFloatAdd | Vector FP add/sub (FADD/FSUB) | 2
SimdFloatAlu | Vector FP ALU misc (abs/neg/min/max/…) | 3 (guide: ~2–4; representative pick)
SimdFloatCmp | Vector FP compare (FCMP-class) | 2
SimdFloatCvt | Vector FP convert (FCVT*, SCVTF, UCVTF) | 4 (guide: ~3–6; representative pick)
SimdFloatDiv | Vector FP divide (FDIV) | 11 (guide: ~7–15; representative pick)
SimdFloatMisc | Vector FP misc (rounding/etc.) | 3 (guide: ~3–6; representative pick)
SimdFloatMult | Vector FP multiply (FMUL) | 3
SimdFloatMultAcc | Vector FP multiply-accumulate (FMLA/FMADD class) | 4
SimdFloatMatMultAcc | Vector FP “matmul/MAC” bucket | 6 (not found in guide; placeholder/TODO)
SimdFloatSqrt | Vector FP sqrt (FSQRT) | 9 (guide: ~7–16; representative pick)
SimdReduceAdd | Reduction arithmetic (e.g., SADDV, UADDV) | 4 (guide is element-size dependent; you picked the 64-bit/D-form representative)
SimdReduceAlu | Reduction logical (ANDV, EORV, ORV) | 4 (representative pick)
SimdReduceCmp | Reduction compare/max/min bucket | 4 (not explicitly found; representative pick)
SimdFloatReduceAdd | FP reduction (e.g., FADDV) | 6 (not explicitly found; representative pick)
SimdFloatReduceCmp | FP reduction max/min bucket | 6 (not explicitly found; representative pick)
SimdExt | Extract (EXT) | 2
SimdFloatExt | Extract (EXT) | 2
SimdConfig | Move prefix (MOVPRFX) | 2
SimdDotProd | ASIMD dot product (SDOT, UDOT) | 3 (1)
SimdAes | AES (AESE, AESD) | 2
SimdAesMix | AES mix (AESMC, AESIMC) | 2
SimdSha1Hash | SHA1 (SHA1H) | 2
SimdSha1Hash2 | SHA1 major ops (SHA1C, SHA1M, SHA1P) | 4
SimdSha256Hash | SHA256 (SHA256H) | 4
SimdSha256Hash2 | SHA256 (SHA256H2) | 4
SimdShaSigma2 | SHA256 schedule (SHA256SU0, SHA256SU1) | 2
SimdShaSigma3 | SHA1 schedule (SHA1SU0, SHA1SU1) | 2
SimdSha3 | SHA3 ops (BCAX, EOR3, RAX1, XAR) | 2
SimdSm4e | SM4 (SM4E, SM4EKEY) | 4
SimdCrc | CRC (CRC32, CRC32C) | 2
SimdBf16Cvt | BF16 convert (BFCVT* / BFCVTNT*) | 4
SimdBf16DotProd | BF16 dot (BFDOT) | 5 (3)
SimdBf16MatMultAcc | BF16 matrix MAC (BFMMLA) | 6 (4)
SimdBf16MultAcc | BF16 MAC long (BFMLALB, BFMLALT) | 5 (2)
SimdBf16Add | Not listed as distinct BF16 add group in guide | 2 (kept as FP-add-class default)
SimdBf16Cmp | Not listed as distinct BF16 compare group in guide | 2 (kept as FP-cmp-class default)
SimdBf16Mult | Not listed as distinct BF16 multiply group in guide | 3 (kept as FP-mul-class default)
FloatAdd | Scalar FP add/sub (FADD, FSUB) | 2
FloatCmp | Scalar FP compare (FCMP{E}, FCCMP{E}) | 2
FloatCvt | Scalar FP convert (FCVT*, SCVTF, UCVTF) | 3
FloatDiv | Scalar FP divide (FDIV) | 11 (guide: ~7–15; representative pick)
FloatSqrt | Scalar FP sqrt (FSQRT) | 12 (guide: ~7–16; representative pick)
FloatMult | Scalar FP multiply (FMUL) | 3
FloatMisc | Scalar FP misc bucket | 4
FloatMultAcc | Scalar FP mul-acc (FMADD etc.) | 4
MemRead | Integer load (LDR etc.) | 4 (guide: ~4–5; representative pick)
FloatMemRead | FP/ASIMD load (vector regs) | 6 (guide: ~6–7; representative pick)
MemWrite | Integer store (STR etc.) | 1
FloatMemWrite | FP/ASIMD store | 2

Please let me know if I have made any mistakes :)