### PR TITLE
python: DRAMSys DDR3 example uses Store mode

### DIFF
--- a/configs/dramsys/ddr3-example-store.json
+++ b/configs/dramsys/ddr3-example-store.json
@@ -1,0 +1,19 @@
+{
+    "simulation": {
+        "addressmapping":
+            "ext/dramsys/DRAMSys/configs/addressmapping/am_ddr3_8x1Gbx8_dimm_p1KB_rbc.json",
+        "mcconfig": "ext/dramsys/DRAMSys/configs/mcconfig/fr_fcfs.json",
+        "memspec":
+            "ext/dramsys/DRAMSys/configs/memspec/MICRON_1Gb_DDR3-1600_8bit_G.json",
+        "simconfig": "configs/dramsys/simconfig/example-store.json",
+        "simulationid": "ddr3-example",
+        "tracesetup": [
+            {
+                "type": "player",
+                "clkMhz": 800,
+                "dataLength": 64,
+                "name": "ext/dramsys/DRAMSys/configs/traces/example.stl"
+            }
+        ]
+    }
+}

--- a/configs/dramsys/simconfig/example-store.json
+++ b/configs/dramsys/simconfig/example-store.json
@@ -1,0 +1,22 @@
+{
+    "simconfig": {
+        "AddressOffset": 0,
+        "DatabaseRecording": true,
+        "Debug": false,
+        "EnableWindowing": true,
+        "PowerAnalysis": false,
+        "SimulationName": "example",
+        "SimulationProgressBar": true,
+        "StoreMode": "Store",
+        "UseMalloc": false,
+        "WindowSize": 1000,
+        "TogglingRate": {
+            "togglingRateRead": 0.5,
+            "togglingRateWrite": 0.5,
+            "dutyCycleRead": 0.5,
+            "dutyCycleWrite": 0.5,
+            "idlePatternRead": "L",
+            "idlePatternWrite": "L"
+        }
+    }
+}

--- a/src/python/gem5/components/memory/dramsys.py
+++ b/src/python/gem5/components/memory/dramsys.py
@@ -139,11 +139,17 @@ class DRAMSysDDR3_1600(DRAMSysMem):
     """
 
     def __init__(self):
+        # NOTE: DRAMSys' default example simconfig uses StoreMode=NoStorage.
+        # gem5 may issue functional/debug transactions (transport_dbg) during
+        # SE-mode process initialization, which DRAMSys does not support with
+        # NoStorage enabled.
+        #
+        # We therefore provide a gem5-local example configuration which uses
+        # StoreMode=Store while still referencing the DRAMSys resources.
         super().__init__(
-            configuration=(
-                DEFAULT_DRAMSYS_DIRECTORY / "configs/ddr3-example.json"
-            ).as_posix(),
+            configuration="configs/dramsys/ddr3-example-store.json",
             size="1GiB",
+            resource_directory=".",
         )
 
 


### PR DESCRIPTION
This PR is opened as part of a forced CI triage test run.

The Daily Tests workflow currently fails in the DRAMSys job when running:

- `configs/example/gem5_library/dramsys/arm-hello-dramsys.py`

Failure signature:

- DRAMSys aborts with: `Fatal: DRAM: Debug Transport is used in combination with NoStorage`

During SE-mode initialization gem5 may issue functional/debug transactions (`transport_dbg`). DRAMSys' default example simconfig uses `StoreMode: NoStorage`, which does not support debug transport.

This change keeps the external DRAMSys resources untouched and instead provides a gem5-local example configuration which sets `StoreMode: Store`. The `DRAMSysDDR3_1600` convenience class is updated to use this configuration (with `resource_directory` set to the repo root) so the example scripts run successfully in CI.

If this approach is acceptable, we can extend it to the other DRAMSys example configs as needed.
