### PR TITLE
arch-riscv: refactor vpin µop to only write inactive elements

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -890,10 +890,11 @@ VCpyVsMicroInst::generateDisassembly(Addr pc,
 
 VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                                  uint32_t _numVdPins, uint32_t _elen,
-                                 uint32_t _vlen, bool _hasVdOffset)
+                                 uint32_t _vlen, bool _isSlideupVx,
+                                 bool _isReduction)
     : VectorArithMicroInst("vpinvd_v_micro", _machInst, SimdMiscOp, 0,
                            _microIdx, _elen, _vlen),
-      hasVdOffset(_hasVdOffset)
+      isSlideupVx(_isSlideupVx), isReduction(_isReduction)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -905,10 +906,20 @@ VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
     _numDestRegs = 0;
     setDestRegIdx(_numDestRegs++, vecRegClass[_machInst.vd + _microIdx]);
     _numTypedDestRegs[VecRegClass]++;
+
     if (!_machInst.vtype8.vta || (!_machInst.vm && !_machInst.vtype8.vma)
-                              || hasVdOffset) {
+                              || isSlideupVx) {
         setSrcRegIdx(_numSrcRegs++, vecRegClass[_machInst.vd + _microIdx]);
     }
+
+    if (isSlideupVx) {
+        setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs1]);
+    }
+
+    if (!_machInst.vm) {
+        setSrcRegIdx(_numSrcRegs++, vecRegClass[0]);
+    }
+
     RegId Vd = destRegIdx(0);
     Vd.setNumPinnedWrites(_numVdPins);
     setDestRegIdx(0, Vd);
@@ -922,19 +933,62 @@ VPinVdMicroInst::execute(ExecContext* xc, trace::InstRecord* traceData) const
     Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
     if (update_fault != NoFault) { return update_fault; }
 
+    const uint32_t vl = machInst.vl;
+    const uint32_t sewb = getSew(machInst.vtype8.vsew) >> 3;
+    const uint32_t micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
+    const uint32_t micro_vl = std::min(vl - micro_vlmax*microIdx, micro_vlmax);
+    const uint32_t active_bytes = isReduction ? sewb:micro_vl*sewb;
+    const uint32_t total_bytes  = micro_vlmax*sewb;
+
+    vreg_t& vd_container = *(vreg_t *)xc->getWritableRegOperand(this, 0);
+    uint8_t* vd = vd_container.as<uint8_t>();
+
     // tail/mask policy: both undisturbed if one is, 1s if none
-    vreg_t& vd = *(vreg_t *)xc->getWritableRegOperand(this, 0);
+    uint8_t* old_vd;
     if (!machInst.vtype8.vta || (!machInst.vm && !machInst.vtype8.vma)
-                            || hasVdOffset) {
-        vreg_t old_vd;
-        xc->getRegOperand(this, 0, &old_vd);
-        vd = old_vd;
+                             || isSlideupVx) {
+        vreg_t old_vd_container;
+        xc->getRegOperand(this, 0, &old_vd_container);
+        old_vd = old_vd_container.as<uint8_t>();
+    }
+
+    // pin on vslideup.vx: vd has a start offset that needs to be undisturbed
+    if (isSlideupVx) {
+        uint32_t offset = xc->getRegOperand(this, 1);
+        if (offset > micro_vlmax*microIdx) {
+            uint32_t micro_offset = std::min(offset - micro_vlmax*microIdx,
+                                             micro_vlmax);
+            uint32_t micro_offset_bytes = sewb*micro_offset;
+            memcpy(vd, old_vd, micro_offset_bytes);
+        }
+    }
+
+    // apply tail policy
+    if (machInst.vtype8.vta && (machInst.vm || machInst.vtype8.vma)) {
+        memset(vd+active_bytes, 0xff, total_bytes-active_bytes);
     } else {
-        vd.set(0xff);
+        memcpy(vd+active_bytes, old_vd+active_bytes, total_bytes-active_bytes);
+    }
+
+    // apply mask policy
+    if (!machInst.vm) {
+        vreg_t v0_container;
+        xc->getRegOperand(this, _numSrcRegs-1, &v0_container);
+        uint8_t* v0 = v0_container.as<uint8_t>();
+
+        for (uint32_t i=0; i<micro_vl; i++) {
+            if (!machInst.vm && !elem_mask(v0, i + microIdx*micro_vlmax)) {
+                if (machInst.vtype8.vma && machInst.vtype8.vta) {
+                    memset(vd + i*sewb, 0xff, sewb);
+                } else {
+                    memcpy(vd + i*sewb, old_vd + i*sewb, sewb);
+                }
+            }
+        }
     }
 
     if (traceData) {
-        traceData->setData(vecRegClass, &vd);
+        traceData->setData(vecRegClass, &vd_container);
     }
 
     return NoFault;
@@ -948,8 +1002,11 @@ VPinVdMicroInst::generateDisassembly(Addr pc,
     ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", ";
 
     if (!machInst.vtype8.vta || (!machInst.vm && !machInst.vtype8.vma)
-                             || hasVdOffset) {
+                             || isSlideupVx) {
         ss << registerName(srcRegIdx(0));
+        if (isSlideupVx) {
+            ss << ", " << registerName(srcRegIdx(1));
+        }
     } else {
         ss << "~0";
     }

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -808,14 +808,15 @@ class VCpyVsMicroInst : public VectorArithMicroInst
 class VPinVdMicroInst : public VectorArithMicroInst
 {
     private:
-        RegId srcRegIdxArr[1];
+        RegId srcRegIdxArr[2];
         RegId destRegIdxArr[1];
-        const bool hasVdOffset;
+        const bool isSlideupVx;
+        const bool isReduction;
 
       public:
         VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                         uint32_t _numVdPins, uint32_t _elen, uint32_t _vlen,
-                        bool _hasVdOffset = false);
+                        bool _isSlideupVx = false, bool _isReduction = false);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1728,7 +1728,8 @@ template<typename ElemType>
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
 
-    microop = new VPinVdMicroInst(machInst, 0, k, elen, vlen);
+    microop = new VPinVdMicroInst(machInst, 0, k, elen, vlen,
+                                  /*isSlideUpVx=*/false, /*isReduction=*/true);
     microop->setFlag(IsDelayedCommit);
     this->microops.push_back(microop);
 
@@ -2346,7 +2347,7 @@ template<typename ElemType>
 
     for (int i = 0; need_pin && i < ceil((float) this->vl/micro_vlmax); i++) {
         microop = new VPinVdMicroInst(machInst, i, std::max(i, 1), elen, vlen,
-                                      true);
+                                      /*isSlideUpVx=*/true);
         microop->setFlag(IsDelayedCommit);
         this->microops.push_back(microop);
     }
@@ -2469,8 +2470,8 @@ template<typename ElemType>
             this->microops.push_back(microop);
         }
         if (need_pin) {
-            microop = new VPinVdMicroInst(machInst, i,
-                std::max(num_microops-i-1, 1), elen, vlen, false);
+            uint32_t num_pins = std::max(num_microops-i-1, 1);
+            microop = new VPinVdMicroInst(machInst, i, num_pins, elen, vlen);
             microop->setFlag(IsDelayedCommit);
             this->microops.push_back(microop);
         }


### PR DESCRIPTION
This patch refactors the `VPinVdMicroInst` class to only write on inactive elements instead of the whole register. This way we remove any kind of pseudo race condition in OoO execution with other µops of the same macro instruction without serializing, as it no longer writes on active element indices that those write to.