### PR TITLE
arch-riscv: add isSerializeAfter on 1st unordered reduction µop

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1737,7 +1737,10 @@ template<typename ElemType>
     for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
         microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
                                                     _elen, _vlen);
-        if (flags[IsSerializeAfter] && i < num_microops-1) { // ordered
+        // serialize all ordered and initial unordered µop(s) (unless last) to
+        // guarantee architectural correcness with OoO execution
+        if ((flags[IsSerializeAfter] && i < num_microops-1)
+                || (i == 0 && num_microops > 1)) {
             microop->setFlag(StaticInst::IsSerializeAfter);
         }
         microop->setDelayedCommit();


### PR DESCRIPTION
This patch adds the `isSerializeAfter` flag to the first unordered reduction µop (that's not also the last) to guarantee correctness as it initializes the reduction (`vd[0]`) with `vs1[0]` apart from accumulating `vs2`.