### PR TITLE
mem-ruby: Improve performance of NetDest::resize

### DIFF
--- a/src/mem/ruby/common/NetDest.cc
+++ b/src/mem/ruby/common/NetDest.cc
@@ -28,8 +28,10 @@
 
 #include "mem/ruby/common/NetDest.hh"
 
-#include <algorithm>
+#include <map>
+#include <vector>
 
+#include "mem/ruby/common/Set.hh"
 #include "mem/ruby/system/RubySystem.hh"
 
 namespace gem5
@@ -287,12 +289,26 @@ NetDest::resize()
 {
     assert(m_ruby_system != nullptr);
 
+    // This cache uses RubySystem * as a key. This is safe because in gem5,
+    // RubySystem objects are created at the beginning of the simulation and
+    // persist until the end. They are not destroyed and reallocated during
+    // the simulation run, preventing use-after-free issues with address reuse.
+    static std::map<RubySystem *, std::vector<Set>> resize_cache;
+    auto it = resize_cache.find(m_ruby_system);
+
+    if (it != resize_cache.end()) {
+        m_bits = it->second;
+        return;
+    }
+
     m_bits.resize(MachineType_base_level(MachineType_NUM));
     assert(m_bits.size() == MachineType_NUM);
 
     for (int i = 0; i < m_bits.size(); i++) {
         m_bits[i].setSize(MachineType_base_count((MachineType)i));
     }
+
+    resize_cache[m_ruby_system] = m_bits;
 }
 
 void


### PR DESCRIPTION
This function is on the critical path to many, many Ruby functions. It is one of the hottest functions in Ruby.

To optimize the code, we add a cache to keep a copy of a recent vector that has been allocated. Since most of the NetDest use is creating a NetDest for all machines in the RubySystem, the vector is almost always exactly the same size. Essentially, What we're doing is a simple vector copy instead of the for loop.

This works with multiple RubySystems (e.g., with the GPU) by using the RubySystem as the key to the map.

With this code, when running a simple traffic generator code the time goes from 28 seconds in NetDest::resize to less than 1 second (out of about 188 seconds in the baseline).

---

More performance details:
- When running Arm Linux boot with CHI (when testing the AddrRange change impacts #2861) I noticed that out of 2000 seconds, NetDest::resize was taking about 12% of the total time.
- In a more constrained environment, I ran a simple traffic generator test with the CHI protocol with a 3 level hierarchy where the data fit in the L3. I ran 10ms of simulated time. On the baseline NetDest::resize took 28 seconds out of 188 seconds. With this PR, it took less than 1 second. See the pprof diff below (colors represent differences). I've zoomed in just on this function.

<img width="2652" height="482" alt="image" src="https://github.com/user-attachments/assets/2613621f-fe1a-4067-8b85-af742c571110" />

Basically, with this change we see a 1.16x speedup.