### PR TITLE
mem: Fix DRAMSys gem5_se config paths

### DIFF
--- a/ext/dramsys/gem5_configs/ddr3-gem5-se.json
+++ b/ext/dramsys/gem5_configs/ddr3-gem5-se.json
@@ -1,16 +1,18 @@
 {
     "simulation": {
-        "addressmapping": "addressmapping/am_ddr3_8x1Gbx8_dimm_p1KB_rbc.json",
-        "mcconfig": "mcconfig/fr_fcfs.json",
-        "memspec": "memspec/MICRON_1Gb_DDR3-1600_8bit_G.json",
-        "simconfig": "simconfig/gem5_se.json",
+        "addressmapping":
+            "../DRAMSys/configs/addressmapping/am_ddr3_8x1Gbx8_dimm_p1KB_rbc.json",
+        "mcconfig": "../DRAMSys/configs/mcconfig/fr_fcfs.json",
+        "memspec":
+            "../DRAMSys/configs/memspec/MICRON_1Gb_DDR3-1600_8bit_G.json",
+        "simconfig": "../DRAMSys/configs/simconfig/gem5_se.json",
         "simulationid": "ddr3-gem5-se",
         "tracesetup": [
             {
                 "type": "player",
                 "clkMhz": 800,
                 "dataLength": 64,
-                "name": "traces/example.stl"
+                "name": "../DRAMSys/configs/traces/example.stl"
             }
         ]
     }

--- a/ext/dramsys/gem5_configs/ddr4-gem5-se.json
+++ b/ext/dramsys/gem5_configs/ddr4-gem5-se.json
@@ -1,16 +1,18 @@
 {
     "simulation": {
-        "addressmapping": "addressmapping/am_ddr4_8x4Gbx8_dimm_p1KB_brc.json",
-        "mcconfig": "mcconfig/fr_fcfs.json",
-        "memspec": "memspec/JEDEC_4Gb_DDR4-1866_8bit_A.json",
-        "simconfig": "simconfig/gem5_se.json",
+        "addressmapping":
+            "../DRAMSys/configs/addressmapping/am_ddr4_8x4Gbx8_dimm_p1KB_brc.json",
+        "mcconfig": "../DRAMSys/configs/mcconfig/fr_fcfs.json",
+        "memspec":
+            "../DRAMSys/configs/memspec/JEDEC_4Gb_DDR4-1866_8bit_A.json",
+        "simconfig": "../DRAMSys/configs/simconfig/gem5_se.json",
         "simulationid": "ddr4-gem5-se",
         "tracesetup": [
             {
                 "type": "player",
                 "clkMhz": 200,
                 "dataLength": 64,
-                "name": "traces/example.stl"
+                "name": "../DRAMSys/configs/traces/example.stl"
             }
         ]
     }


### PR DESCRIPTION
Fixes Daily CI failure in dramsys-tests:
- RuntimeError: Failed to open file ext/dramsys/gem5_configs/addressmapping/...

The SE DRAMSys example configs in ext/dramsys/gem5_configs referenced config files as if they were co-located under gem5_configs. The actual files live under ext/dramsys/DRAMSys/configs.

This change updates the paths to be relative to gem5_configs (../DRAMSys/configs/...).

CI reference: https://github.com/gem5/gem5/actions/runs/21549781718