### PR TITLE
cpu-o3: restore PR #2657 and fix dependency graph cleanup on squash

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1452,8 +1452,9 @@ InstructionQueue::doSquash(ThreadID tid)
             if (dest_reg->isAlwaysReady()) {
                 continue;
             }
-            assert(dependGraph.empty(dest_reg->flatIndex()));
-            dependGraph.clearInst(dest_reg->flatIndex());
+            if (!dependGraph.empty(dest_reg->flatIndex())) {
+                dependGraph.clearInst(dest_reg->flatIndex());
+            }
         }
         instList[tid].erase(squash_it--);
         ++iqStats.squashedInstsExamined;
@@ -1535,7 +1536,8 @@ InstructionQueue::addToProducers(const DynInstPtr &new_inst)
             continue;
         }
 
-        if (!dependGraph.empty(dest_reg->flatIndex())) {
+        if (!dependGraph.empty(dest_reg->flatIndex()) &&
+            new_inst->isNonSpeculative()) {
             dependGraph.dump();
             panic("Dependency graph %i (%s) (flat: %i) not empty!",
                   dest_reg->index(), dest_reg->className(),

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1452,9 +1452,14 @@ InstructionQueue::doSquash(ThreadID tid)
             if (dest_reg->isAlwaysReady()) {
                 continue;
             }
-            if (!dependGraph.empty(dest_reg->flatIndex())) {
-                dependGraph.clearInst(dest_reg->flatIndex());
+            // When squashing, remove any remaining dependents and clear the
+            // producer pointer. Squash ordering can leave dependents
+            // temporarily present, and keeping them around can trip later
+            // dependency graph sanity checks.
+            while (!dependGraph.empty(dest_reg->flatIndex())) {
+                dependGraph.pop(dest_reg->flatIndex());
             }
+            dependGraph.clearInst(dest_reg->flatIndex());
         }
         instList[tid].erase(squash_it--);
         ++iqStats.squashedInstsExamined;
@@ -1536,8 +1541,7 @@ InstructionQueue::addToProducers(const DynInstPtr &new_inst)
             continue;
         }
 
-        if (!dependGraph.empty(dest_reg->flatIndex()) &&
-            new_inst->isNonSpeculative()) {
+        if (!dependGraph.empty(dest_reg->flatIndex())) {
             dependGraph.dump();
             panic("Dependency graph %i (%s) (flat: %i) not empty!",
                   dest_reg->index(), dest_reg->className(),


### PR DESCRIPTION
This PR fixes the Weekly x86 failure by addressing an O3 Instruction Queue dependency-graph invariant violation triggered by squash ordering.

The Weekly test failure first appeared after merging PR #2891. This PR alters the guest-visible CPU feature set which changes the Linux boot instruction mix/timing in a way that triggers a buggy corner case in O3 IQ dependency-graph cleanup. As such, this PR does not undo #2891, but fixes the bug #2891 exposes. During squash, destination physical registers can still have dependent nodes present transiently, and leaving those nodes behind can later trip the “dependency graph not empty” sanity check when a new producer is installed for the same register.

The first commit reverts PR #2914, which had reverted PR #2657 under the false assumption it caused the Weekly failures. The Weekly failures persist with that revert in place, so this PR restores the behavior from PR #2657 and then applies the actual fix.

The second commit updates the squash path to drain any remaining dependents for each destination physical register (by popping the list) and clears the producer pointer unconditionally. This ensures the dependency graph does not retain stale nodes/producer pointers for squashed instructions and preserves the intended producer-side invariant check in addToProducers().