### PR TITLE
CI: always upload artifacts even when test steps fail

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -211,7 +211,7 @@ jobs:
 
             - name: Sanitize build-target for artifact name
               id: sanitize-build-target
-              if: success() || failure()
+              if: always()
               run: echo "sanitized-build-target=$(echo '${{ matrix.build-target }}' | sed 's/[\\|\.]/-/g' | sed 's/[\/|__w|gem5|build]//g')" >> $GITHUB_OUTPUT
 
         # Upload the gem5 binary as an artifact.
@@ -266,12 +266,12 @@ jobs:
         # Get the basename of the matrix.test-dir path (to name the artifact).
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
-              if: success() || failure()
+              if: always()
               run: echo "sanitized-test-dir=$(echo '${{ matrix.test-dir }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
         # Upload the tests/testing-results directory as an artifact.
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-quick-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
@@ -304,7 +304,7 @@ jobs:
 
             # Upload the tests/testing-results directory as an artifact.
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -158,11 +158,11 @@ jobs:
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
-              if: success() || failure()
+              if: always()
               run: echo "sanitized-test-dir=$(echo '${{ matrix.test-type }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               env:
                   MY_STEP_VAR: ${{ steps.sanitize-test-dir.outputs.sanitized-test-dir }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
@@ -196,7 +196,7 @@ jobs:
               run: ./main.py run --length=long -vvv -j $(nproc) --host gcn_gpu
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -78,11 +78,11 @@ jobs:
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
-              if: success() || failure()
+              if: always()
               run: echo "sanitized-test-dir=$(echo '${{ matrix.test-type }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-very-long-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
@@ -112,7 +112,7 @@ jobs:
               run: ./main.py run --length=very-long -vvv -j $(nproc) --host gcn_gpu
 
             - name: Upload results
-              if: success() || failure()
+              if: always()
               uses: actions/upload-artifact@v4
               with:
                   name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output


### PR DESCRIPTION
This PR ensures result/artifact upload steps still run when earlier test/compile steps fail (so failures are still reported, but outputs are preserved for debugging).

Changes:
- Replace if: success() || failure() with if: always() for artifact-related steps in CI/Daily/Weekly workflows.
- Verified no continue-on-error: true exists in these workflows on stable.