### PR TITLE
misc,tests: Remove `continue-on-error: true` from Daily/Weekly Workflows

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -166,7 +166,6 @@ jobs:
             - name: Run long ${{ matrix.test-type }} tests
               id: run-tests
               timeout-minutes: 1410
-              continue-on-error: true
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run ${{ matrix.test-type }} -j$(nproc) --length=long -vv -t $(nproc) --exclude-tags gcn_gpu
 
@@ -207,7 +206,6 @@ jobs:
             - name: Run Testlib GPU Tests
               id: run-tests
               timeout-minutes: 1410
-              continue-on-error: true
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run --length=long -vvv -j $(nproc) --host gcn_gpu
 

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -74,7 +74,6 @@ jobs:
             - name: Run very-long ${{ matrix.test-type }} tests
               id: run-tests
               timeout-minutes: 4290
-              continue-on-error: true
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run ${{ matrix.test-type }} --length very-long -j$(nproc) -vv --exclude-tags gcn_gpu
 
@@ -113,7 +112,6 @@ jobs:
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run --length=very-long -vvv -j $(nproc) --host gcn_gpu
               timeout-minutes: 1410
-              continue-on-error: true
 
             - name: Upload results
               if: always()


### PR DESCRIPTION
Fixes Daily and Weekly workflows: These workflows were using `continue-on-error: true`  in long/very-long test steps, which masks test failures. `continue-on-error` results in a step continuing _as passing_ even if it failed. This  was added in #2877 and has since disguised a failing Weekly test as passing.

This change removes `continue-on-error: true` from Daily + Weekly workflows so failing tests are reported as failures. Note: we keep result/artifact processing running via existing `if: always()` on the sanitize/upload steps so outputs are still uploaded for debugging if the preceding tests failed or timeout (the original intended behavior of #2877).

