### PR TITLE
arch-arm: Include misc info metadata for KVM CPU

### DIFF
--- a/src/arch/arm/kvm/armv8_cpu.cc
+++ b/src/arch/arm/kvm/armv8_cpu.cc
@@ -40,6 +40,7 @@
 #include <linux/kvm.h>
 
 #include "arch/arm/regs/int.hh"
+#include "arch/arm/regs/misc_info.hh"
 #include "arch/arm/regs/vec.hh"
 #include "arch/arm/utility.hh"
 #include "debug/KvmContext.hh"


### PR DESCRIPTION
Fixes a build failure in `src/arch/arm/kvm/armv8_cpu.cc` when KVM support is enabled. The file uses `lookUpMiscReg` and the associated `MISCREG_*` flags but only included `regs/misc.hh`, so the compiler never saw the LUT/bitset definitions. This change explicitly include `arch/arm/regs/misc_info.hh` so the KVM sysreg mapper can see the metadata it consumes.

Without this fix the following build error was encountered withn trying to build gem5 in a Linux Ubuntu Docker container on a Mac Apple Arm (Apple Silicon) system:

```shell
src/arch/arm/kvm/armv8_cpu.cc:400:44: error: ‘MISCREG_PRI_NS_WR’ was not declared in this scope
  400 |             info[MISCREG_PRI_S_WR] || info[MISCREG_PRI_NS_WR] ||
      |                                            ^~~~~~~~~~~~~~~~~
src/arch/arm/kvm/armv8_cpu.cc:401:18: error: ‘MISCREG_HYP_NS_WR’ was not declared in this scope
  401 |             info[MISCREG_HYP_NS_WR] ||
      |                  ^~~~~~~~~~~~~~~~~

```
