### PR TITLE
RISC-V: Refine CSR Serialization Handling in O3 CPU

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -6383,32 +6383,32 @@ decode QUADRANT default Unknown::unknown() {
                     Rd = rvSext(data);
                     data = rvZext(Rs1);
                 }}, 'RD != 0', 'true'
-                  , IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                  , IsCsrInst, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                 0x2: csrrs({{
                     Rd = rvSext(data);
                     data = rvZext(data | Rs1);
                 }}, 'true', 'RS1 != 0'
-                  , IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                  , IsCsrInst, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                 0x3: csrrc({{
                     Rd = rvSext(data);
                     data = rvZext(data & ~Rs1);
                 }}, 'true', 'RS1 != 0'
-                  , IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                  , IsCsrInst, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                 0x5: csrrwi({{
                     Rd = rvSext(data);
                     data = rvZext(uimm);
                 }}, 'RD != 0', 'true'
-                  , IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                  , IsCsrInst, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                 0x6: csrrsi({{
                     Rd = rvSext(data);
                     data = rvZext(data | uimm);
                 }}, 'true', 'uimm != 0'
-                  , IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                  , IsCsrInst, IsSerializeAfter, IsNonSpeculative, No_OpClass);
                 0x7: csrrci({{
                     Rd = rvSext(data);
                     data = rvZext(data & ~uimm);
                 }}, 'true', 'uimm != 0'
-                  , IsSerializeAfter, IsNonSpeculative, No_OpClass);
+                  , IsCsrInst, IsSerializeAfter, IsNonSpeculative, No_OpClass);
             }
             0x4: decode FUNCT7{
                 0x30: decode RS2 {

--- a/src/cpu/StaticInstFlags.py
+++ b/src/cpu/StaticInstFlags.py
@@ -100,4 +100,5 @@ class StaticInstFlags(Enum):
         "IsHtmStop",  # Stops (commits) a HTM transaction
         "IsHtmCancel",  # Explicitely aborts a HTM transaction
         "IsInvalid",  # An invalid instruction
+        "IsCsrInst",  # Is a riscv csr op
     ]

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -595,6 +595,12 @@ class DynInst : public ExecContext, public RefCounted
     bool isHtmCancel() const { return staticInst->isHtmCancel(); }
     bool isHtmCmd() const { return staticInst->isHtmCmd(); }
 
+    bool
+    isCsrInst() const
+    {
+        return staticInst->isCsrInst();
+    }
+
     uint64_t
     getHtmTransactionUid() const override
     {

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -701,6 +701,31 @@ Rename::renameInsts(ThreadID tid)
             handleMiscRegWaW(inst, tid);
         }
 
+        //***clear the serialization of csr read***///
+        /**for riscv isa specificly**/
+        gem5::ThreadContext *tc = inst->tcBase();
+        UnifiedRenameMap *map = renameMap[tid];
+        auto *isa = tc->getIsaPtr();
+        //check csr inst in user mode
+        if (isa->readMiscRegNoEffect(0) == 0 && inst->isCsrInst()){
+            bool writesCsr = false;
+
+            for (int i = 0; i < inst->numDestRegs(); i++) {
+                const RegId &dest_reg = inst->destRegIdx(i);
+                const RegId flat_reg = dest_reg.flatten(*isa);
+                PhysRegIdPtr phys_reg = map->lookup(flat_reg);
+                if (phys_reg->classValue() == MiscRegClass) {
+                    writesCsr = true;
+                    break;
+                }
+            }
+
+            if (!writesCsr){
+                //inst->clearSerializeAfter();
+                inst->setSerializeHandled();
+            }
+        }
+
         // Handle serializeAfter/serializeBefore instructions.
         // serializeAfter marks the next instruction as serializeBefore.
         // serializeBefore makes the instruction wait in rename until the ROB

--- a/src/cpu/static_inst.hh
+++ b/src/cpu/static_inst.hh
@@ -198,6 +198,8 @@ class StaticInst : public RefCounted, public StaticInstFlags
 
     bool isInvalid() const { return flags[IsInvalid]; }
 
+    bool isCsrInst() const { return flags[IsCsrInst]; }
+
     bool
     isHtmCmd() const
     {


### PR DESCRIPTION
**Summary**

This PR addresses an incompatibility between the changes proposed in [#2700](https://github.com/gem5/gem5/pull/2700) and the RISC-V ISA. The original implementation is not directly adaptable to RISC-V due to differences in CSR semantics and serialization requirements.

To resolve this, we introduce RISCV-specific handling for CSR operations in the O3 CPU pipeline.

**Motivation**

In RISC-V, not all CSR operations require serialization. While CSR writes must remain serialized to preserve architectural correctness, CSR reads do not require full pipeline serialization in user mode.

**Changes Introduced**

1. New Instruction Flag for RISC-V CSR Operations

- A dedicated instruction flag is introduced for CSR-related operations in the RISC-V ISA.

2. Refined Serialization Handling in O3 Rename Stage

- During renaming, CSR operations are examined:

- If the operation is a CSR write, it remains serialized.

- If the operation is a CSR read, the serialized flag is cleared, since serialization is not required.

- This avoids unnecessary pipeline serialization for CSR reads.

3.User-Mode Restriction

- The optimization is applied only in user mode.

In kernel mode, all CSR operations remain serialized to preserve correct RISC-V semantics, particularly for first-use and privileged CSR handling.