### PR TITLE
arch-riscv: fix vm* instructions when mask undisturbed

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -454,10 +454,6 @@ VMaskMergeMicroInst::execute(ExecContext* xc,
     auto Vd = tmp_d0.as<uint8_t>();
     uint32_t vlenb = vlen >> 3;
     const uint32_t elems_per_vreg = vlenb / elemSize;
-    size_t bit_cnt = 0;
-
-    // mask tails are always treated as agnostic: writting 1s
-    tmp_d0.set(0xff);
 
     vreg_t tmp_s;
     for (uint8_t i = 0; i < this->_numSrcRegs; i++) {
@@ -467,14 +463,21 @@ VMaskMergeMicroInst::execute(ExecContext* xc,
             const uint32_t m = (1 << elems_per_vreg) - 1;
             const uint32_t mask = m << (i * elems_per_vreg % 8);
             // clr & ext bits
-            Vd[bit_cnt/8] ^= Vd[bit_cnt/8] & mask;
-            Vd[bit_cnt/8] |= s[bit_cnt/8] & mask;
-            bit_cnt += elems_per_vreg;
+            Vd[(i * elems_per_vreg) / 8] &= ~mask;
+            Vd[(i * elems_per_vreg) / 8] |= s[(i * elems_per_vreg) / 8] & mask;
         } else {
             const uint32_t byte_offset = elems_per_vreg / 8;
             memcpy(Vd + i * byte_offset, s + i * byte_offset, byte_offset);
         }
     }
+
+    // Handle tail: mask-producing instructions are always tail-agnostic.
+    // We treat agnostic as 1s.
+    uint32_t vl = machInst.vl;
+    for (uint32_t i = vl; i < vlen; ++i) {
+        Vd[i / 8] |= (1 << (i % 8));
+    }
+
     if (traceData) {
         traceData->setData(vecRegClass, &tmp_d0);
     }

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -591,11 +591,16 @@ def format VectorIntMaskFormat(code, category, *flags) {{
     else:
         error("not supported category for VectorIntFormat: %s" % category)
     src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
+    old_vd_idx = 2 if category != "OPIVI" else 1
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = ""
     if category != "OPIVI":
         set_src_reg_idx += setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
+
+    dest_set_src_reg_idx = setSrcWrapper("vecRegClass[_machInst.vd]")
+    set_src_reg_idx += tailMaskCondSetSrcWrapper(dest_set_src_reg_idx)
+
     if v0_required:
         set_src_reg_idx += setSrcVm()
 
@@ -620,6 +625,7 @@ def format VectorIntMaskFormat(code, category, *flags) {{
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
+         'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': declareVArithTemplate(Name + "Micro")},
         flags)
 
@@ -1040,11 +1046,15 @@ def format VectorFloatMaskFormat(code, category, *flags) {{
     else:
         error("not supported category for VectorFloatFormat: %s" % category)
     src2_reg_id = "vecRegClass[_machInst.vs2 + _microIdx]"
-    old_dest_reg_id = "vecRegClass[_machInst.vd]"
+    old_vd_idx = 2
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = ""
     set_src_reg_idx += setSrcWrapper(src1_reg_id)
     set_src_reg_idx += setSrcWrapper(src2_reg_id)
+
+    dest_set_src_reg_idx = setSrcWrapper("vecRegClass[_machInst.vd]")
+    set_src_reg_idx += tailMaskCondSetSrcWrapper(dest_set_src_reg_idx)
+
     set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
@@ -1063,6 +1073,7 @@ def format VectorFloatMaskFormat(code, category, *flags) {{
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
+         'copy_old_vd': copyOldVd(old_vd_idx),
          'declare_varith_template': varith_micro_declare},
         flags)
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1200,9 +1200,9 @@ template<typename ElemType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    // vs1(rs1), vs2, v0 for *.vv[m] or *.vx[m]
-    // vs2, v0 for *.vi[m]
-    RegId srcRegIdxArr[3];
+    // vs1(rs1), vs2, old_vd, v0 for *.vv[m] or *.vx[m]
+    // vs2, old_vd, v0 for *.vi[m]
+    RegId srcRegIdxArr[4];
     RegId destRegIdxArr[1];
     bool vm;
 public:
@@ -1255,6 +1255,7 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
+    %(copy_old_vd)s;
 
     const uint32_t bit_offset = vlenb / sizeof(ElemType);
     const uint32_t offset = bit_offset * microIdx;
@@ -1321,8 +1322,8 @@ template<typename ElemType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    // vs1(rs1), vs2, v0 for *.vv or *.vf
-    RegId srcRegIdxArr[3];
+    // vs1(rs1), vs2, old_vd, v0 for *.vv or *.vf
+    RegId srcRegIdxArr[4];
     RegId destRegIdxArr[1];
     bool vm;
 public:
@@ -1375,6 +1376,7 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
+    %(copy_old_vd)s;
 
     const uint32_t bit_offset = vlenb / sizeof(ElemType);
     const uint32_t offset = bit_offset * microIdx;


### PR DESCRIPTION
This patch is a small fix to correct vector mask producing instructions when using a mask with an undisturbed policy.

Note: This code has been generated with an LLM which I reviewed for correctness.