### PR TITLE
arch-arm, sim-se: Implement arm linux syscall 403 clock_gettime

### DIFF
--- a/src/arch/arm/linux/se_workload.cc
+++ b/src/arch/arm/linux/se_workload.cc
@@ -493,6 +493,7 @@ class SyscallTable32 : public SyscallDescTable<EmuLinux::SyscallABI32>
               {base + 384, "getrandom", getrandomFunc<ArmLinux32>},
               {base + 397, "sys_statx", ignoreFunc},
               {base + 398, "sys_rseq", ignoreFunc},
+              {base + 403, "clock_gettime", clock_gettimeFunc<ArmLinux32, ArmLinux64::timespec>},
               {base + 435, "clone3", clone3Func<ArmLinux32>},
           })
     {}
@@ -788,6 +789,7 @@ class SyscallTable64 : public SyscallDescTable<EmuLinux::SyscallABI64>
                {base + 292, "io_pgetevents"},
                {base + 293, "rseq", rseqFunc<ArmLinux64>},
                {base + 294, "kexec_file_load"},
+               {base + 403, "clock_gettime", clock_gettimeFunc<ArmLinux64>},
                {base + 435, "clone3", clone3Func<ArmLinux64>},
                {base + 1024, "open", openFunc<ArmLinux64>},
                {base + 1025, "link"},

--- a/src/arch/arm/linux/se_workload.cc
+++ b/src/arch/arm/linux/se_workload.cc
@@ -493,7 +493,8 @@ class SyscallTable32 : public SyscallDescTable<EmuLinux::SyscallABI32>
               {base + 384, "getrandom", getrandomFunc<ArmLinux32>},
               {base + 397, "sys_statx", ignoreFunc},
               {base + 398, "sys_rseq", ignoreFunc},
-              {base + 403, "clock_gettime", clock_gettimeFunc<ArmLinux32, ArmLinux64::timespec>},
+              {base + 403, "clock_gettime",
+               clock_gettimeFunc<ArmLinux32, ArmLinux64::timespec>},
               {base + 435, "clone3", clone3Func<ArmLinux32>},
           })
     {}

--- a/src/kern/linux/linux.hh
+++ b/src/kern/linux/linux.hh
@@ -336,6 +336,19 @@ class Linux : public OperatingSystem
     static const unsigned TGT_WEXITED               = 0x00000004;
     static const unsigned TGT_WCONTINUED            = 0x00000008;
     static const unsigned TGT_WNOWAIT               = 0x01000000;
+
+    static const unsigned TGT_CLOCK_REALTIME        = 0x00000000;
+    static const unsigned TGT_CLOCK_MONOTONIC       = 0x00000001;
+    static const unsigned TGT_CLOCK_PROCESS_CPUTIME = 0x00000002;
+    static const unsigned TGT_CLOCK_THREAD_CPUTIME  = 0x00000003;
+    static const unsigned TGT_CLOCK_MONOTONIC_RAW   = 0x00000004;
+    static const unsigned TGT_CLOCK_REALTIME_COARSE = 0x00000005;
+    static const unsigned TGT_CLOCK_MONOTONIC_COARSE= 0x00000006;
+    static const unsigned TGT_CLOCK_BOOTTIME        = 0x00000007;
+    static const unsigned TGT_CLOCK_REALTIME_ALARM  = 0x00000008;
+    static const unsigned TGT_CLOCK_BOOTTIME_ALARM  = 0x00000009;
+    static const unsigned TGT_CLOCK_TAI             = 0x0000000b;
+    static const unsigned TGT_MAX_CLOCKS            = 0x00000010;
 };  // class Linux
 
 } // namespace gem5

--- a/src/kern/linux/linux.hh
+++ b/src/kern/linux/linux.hh
@@ -337,18 +337,18 @@ class Linux : public OperatingSystem
     static const unsigned TGT_WCONTINUED            = 0x00000008;
     static const unsigned TGT_WNOWAIT               = 0x01000000;
 
-    static const unsigned TGT_CLOCK_REALTIME        = 0x00000000;
-    static const unsigned TGT_CLOCK_MONOTONIC       = 0x00000001;
+    static const unsigned TGT_CLOCK_REALTIME = 0x00000000;
+    static const unsigned TGT_CLOCK_MONOTONIC = 0x00000001;
     static const unsigned TGT_CLOCK_PROCESS_CPUTIME = 0x00000002;
-    static const unsigned TGT_CLOCK_THREAD_CPUTIME  = 0x00000003;
-    static const unsigned TGT_CLOCK_MONOTONIC_RAW   = 0x00000004;
+    static const unsigned TGT_CLOCK_THREAD_CPUTIME = 0x00000003;
+    static const unsigned TGT_CLOCK_MONOTONIC_RAW = 0x00000004;
     static const unsigned TGT_CLOCK_REALTIME_COARSE = 0x00000005;
-    static const unsigned TGT_CLOCK_MONOTONIC_COARSE= 0x00000006;
-    static const unsigned TGT_CLOCK_BOOTTIME        = 0x00000007;
-    static const unsigned TGT_CLOCK_REALTIME_ALARM  = 0x00000008;
-    static const unsigned TGT_CLOCK_BOOTTIME_ALARM  = 0x00000009;
-    static const unsigned TGT_CLOCK_TAI             = 0x0000000b;
-    static const unsigned TGT_MAX_CLOCKS            = 0x00000010;
+    static const unsigned TGT_CLOCK_MONOTONIC_COARSE = 0x00000006;
+    static const unsigned TGT_CLOCK_BOOTTIME = 0x00000007;
+    static const unsigned TGT_CLOCK_REALTIME_ALARM = 0x00000008;
+    static const unsigned TGT_CLOCK_BOOTTIME_ALARM = 0x00000009;
+    static const unsigned TGT_CLOCK_TAI = 0x0000000b;
+    static const unsigned TGT_MAX_CLOCKS = 0x00000010;
 };  // class Linux
 
 } // namespace gem5

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -2381,13 +2381,30 @@ prlimitFunc(SyscallDesc *desc, ThreadContext *tc,
 }
 
 /// Target clock_gettime() function.
-template <class OS>
+template <class OS, typename TS = typename OS::timespec>
 SyscallReturn
 clock_gettimeFunc(SyscallDesc *desc, ThreadContext *tc,
-                  int clk_id, VPtr<typename OS::timespec> tp)
+                  int clk_id, VPtr<TS> tp)
 {
     getElapsedTimeNano(tp->tv_sec, tp->tv_nsec);
-    tp->tv_sec += seconds_since_epoch;
+    switch(clk_id) {
+    case OS::TGT_CLOCK_REALTIME:
+    case OS::TGT_CLOCK_REALTIME_ALARM:
+    case OS::TGT_CLOCK_REALTIME_COARSE:
+    case OS::TGT_CLOCK_TAI:
+      tp->tv_sec += seconds_since_epoch;
+      break;
+    case OS::TGT_CLOCK_MONOTONIC:
+    case OS::TGT_CLOCK_MONOTONIC_COARSE:
+    case OS::TGT_CLOCK_MONOTONIC_RAW:
+    case OS::TGT_CLOCK_BOOTTIME:
+    case OS::TGT_CLOCK_BOOTTIME_ALARM:
+      break;
+    case OS::TGT_CLOCK_PROCESS_CPUTIME:
+    case OS::TGT_CLOCK_THREAD_CPUTIME:
+    default:
+      return -EINVAL;
+    }
     tp->tv_sec = htog(tp->tv_sec, OS::byteOrder);
     tp->tv_nsec = htog(tp->tv_nsec, OS::byteOrder);
 

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -2383,27 +2383,27 @@ prlimitFunc(SyscallDesc *desc, ThreadContext *tc,
 /// Target clock_gettime() function.
 template <class OS, typename TS = typename OS::timespec>
 SyscallReturn
-clock_gettimeFunc(SyscallDesc *desc, ThreadContext *tc,
-                  int clk_id, VPtr<TS> tp)
+clock_gettimeFunc(SyscallDesc *desc, ThreadContext *tc, int clk_id,
+                  VPtr<TS> tp)
 {
     getElapsedTimeNano(tp->tv_sec, tp->tv_nsec);
-    switch(clk_id) {
-    case OS::TGT_CLOCK_REALTIME:
-    case OS::TGT_CLOCK_REALTIME_ALARM:
-    case OS::TGT_CLOCK_REALTIME_COARSE:
-    case OS::TGT_CLOCK_TAI:
-      tp->tv_sec += seconds_since_epoch;
-      break;
-    case OS::TGT_CLOCK_MONOTONIC:
-    case OS::TGT_CLOCK_MONOTONIC_COARSE:
-    case OS::TGT_CLOCK_MONOTONIC_RAW:
-    case OS::TGT_CLOCK_BOOTTIME:
-    case OS::TGT_CLOCK_BOOTTIME_ALARM:
-      break;
-    case OS::TGT_CLOCK_PROCESS_CPUTIME:
-    case OS::TGT_CLOCK_THREAD_CPUTIME:
-    default:
-      return -EINVAL;
+    switch (clk_id) {
+        case OS::TGT_CLOCK_REALTIME:
+        case OS::TGT_CLOCK_REALTIME_ALARM:
+        case OS::TGT_CLOCK_REALTIME_COARSE:
+        case OS::TGT_CLOCK_TAI:
+            tp->tv_sec += seconds_since_epoch;
+            break;
+        case OS::TGT_CLOCK_MONOTONIC:
+        case OS::TGT_CLOCK_MONOTONIC_COARSE:
+        case OS::TGT_CLOCK_MONOTONIC_RAW:
+        case OS::TGT_CLOCK_BOOTTIME:
+        case OS::TGT_CLOCK_BOOTTIME_ALARM:
+            break;
+        case OS::TGT_CLOCK_PROCESS_CPUTIME:
+        case OS::TGT_CLOCK_THREAD_CPUTIME:
+        default:
+            return -EINVAL;
     }
     tp->tv_sec = htog(tp->tv_sec, OS::byteOrder);
     tp->tv_nsec = htog(tp->tv_nsec, OS::byteOrder);


### PR DESCRIPTION
This PR implements syscall 403 for arm. This is essentially the same as the existing clock_gettime syscall except the timespec is 64-bit even on 32-bit arm. I also implemented the monotonic clock so it is different from the wall clock.