### PR TITLE
systemc: Add more systemc symbols

### DIFF
--- a/src/systemc/core/sc_object.cc
+++ b/src/systemc/core/sc_object.cc
@@ -161,4 +161,7 @@ sc_find_object(const char *name)
     return sc_gem5::findObject(name);
 }
 
+// Non-standard symbol.
+const char SC_HIERARCHY_CHAR = '.';
+
 } // namespace sc_core

--- a/src/systemc/ext/core/sc_object.hh
+++ b/src/systemc/ext/core/sc_object.hh
@@ -88,6 +88,9 @@ class sc_object
 const std::vector<sc_object *> &sc_get_top_level_objects();
 sc_object *sc_find_object(const char *);
 
+// Non-standard symbol.
+extern const char SC_HIERARCHY_CHAR;
+
 } // namespace sc_core
 
 #endif  //__SYSTEMC_EXT_CORE_SC_OBJECT_HH__

--- a/src/systemc/ext/core/sc_process_handle.hh
+++ b/src/systemc/ext/core/sc_process_handle.hh
@@ -161,6 +161,11 @@ class sc_process_handle
     // actually tracks the process within gem5. By making them operators, we
     // can minimize the symbols added to the class namespace.
     operator ::sc_gem5::Process * () const { return _gem5_process; }
+    operator sc_process_b *()
+    {
+        return reinterpret_cast<sc_process_b *>(_gem5_process);
+    }
+
     sc_process_handle &
     operator = (::sc_gem5::Process *p)
     {

--- a/src/systemc/ext/core/sc_time.hh
+++ b/src/systemc/ext/core/sc_time.hh
@@ -49,6 +49,8 @@ enum sc_time_unit {
 class sc_time
 {
   public:
+    using value_type = sc_dt::uint64;
+
     sc_time();
     sc_time(double, sc_time_unit);
     sc_time(const sc_time &);

--- a/src/systemc/ext/systemc_home/include/sysc/kernel/sc_module.h
+++ b/src/systemc/ext/systemc_home/include/sysc/kernel/sc_module.h
@@ -1,0 +1,20 @@
+/*****************************************************************************
+
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+
+ *****************************************************************************/
+
+#include "../../../../core/sc_module.hh"

--- a/src/systemc/ext/systemc_home/include/sysc/kernel/sc_time.h
+++ b/src/systemc/ext/systemc_home/include/sysc/kernel/sc_time.h
@@ -1,0 +1,20 @@
+/*****************************************************************************
+
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+
+ *****************************************************************************/
+
+#include "../../../../core/sc_time.hh"

--- a/src/systemc/ext/systemc_home/include/sysc/utils/sc_report.h
+++ b/src/systemc/ext/systemc_home/include/sysc/utils/sc_report.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+
+  Licensed to Accellera Systems Initiative Inc. (Accellera) under one or
+  more contributor license agreements.  See the NOTICE file distributed
+  with this work for additional information regarding copyright ownership.
+  Accellera licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with the
+  License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied.  See the License for the specific language governing
+  permissions and limitations under the License.
+
+ *****************************************************************************/
+
+#include <cassert>
+#include "../../../../utils/sc_report.hh"

--- a/src/systemc/ext/utils/sc_vector.hh
+++ b/src/systemc/ext/utils/sc_vector.hh
@@ -487,6 +487,16 @@ class sc_vector : public sc_vector_base
         unforceParent();
     }
 
+    // SystemC IEEE 1666-2023 standard
+    template <typename... Args>
+    void
+    emplace_back(Args &&...args)
+    {
+        const char *unique_name = sc_gen_unique_name(this->basename());
+        T *p = new T(unique_name, std::forward<Args>(args)...);
+        objs.push_back(p);
+    }
+
     T &operator [] (size_type index) { return *static_cast<T *>(objs[index]); }
     const T &
     operator [] (size_type index) const


### PR DESCRIPTION
Add more symbols following

1. Add IEEE 2016-2023 stardard sc_vector::emplace_back
2. Add required include headers for systemc common practice (SCP)
   - sysc/kernel/sc_module.h
   - sysc/kernel/sc_time.h
   - sysc/utils/sc_report.h
   - sc_time::value_type
   - <cassert> in sc_module header
3. Add required symbols for SystemC CCI
   - SC_HIERARCHY_CHAR
4. New method in sc_process_handle
   - operator sc_process_b * ()

Change-Id: Ie106447c07d1ced6ea7312a363b24eb3263ee9a7