### PR TITLE
arch-arm: Do not assume EL2 requires NS in SVE veclen

### DIFF
--- a/src/arch/arm/isa.cc
+++ b/src/arch/arm/isa.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Arm Limited
+ * Copyright (c) 2010-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1645,8 +1645,7 @@ ISA::getCurSveVecLenInBits() const
 
     if (el == EL2 || (el == EL0 && ELIsInHost(tc, el))) {
         len = static_cast<ZCR>(miscRegs[MISCREG_ZCR_EL2]).len;
-    } else if (release->has(ArmExtension::VIRTUALIZATION) && !isSecure(tc) &&
-               (el == EL0 || el == EL1)) {
+    } else if ((el == EL0 || el == EL1) && EL2Enabled(tc)) {
         len = std::min(
             len,
             static_cast<unsigned>(


### PR DESCRIPTION
With FEAT_SEL2, we can run EL2 in secure mode as well. Replace the virtualization check with the generic EL2Enabled helper.

This effectively fixes a bug in SVE when run with secure EL2


Change-Id: If499eeb9f0e2884e33c321b849daf41f4fc6ab87