### PR TITLE
mem-ruby: Exit simulation when TlmGenerator is done

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -1,5 +1,5 @@
 # -*- mode:python -*-
-# Copyright (c) 2024-2025 Arm Limited
+# Copyright (c) 2024-2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -55,6 +55,7 @@ class TlmGenerator(ClockedObject):
     cxx_exports = [
         PyBindMethod("scheduleTransaction"),
         PyBindMethod("enqueueBack"),
+        PyBindMethod("isActive"),
     ]
 
     def __init__(self, *args, **kwargs):

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Arm Limited
+ * Copyright (c) 2024-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -47,7 +47,8 @@ namespace tlm::chi {
 bool
 TlmGenerator::Transaction::Expectation::run(Transaction *tran)
 {
-    auto res_print = csprintf("Checking %s...", name());
+    auto res_print =
+        csprintf("%u: Checking %s...", tran->phase().txn_id, name());
     if (cb(tran)) {
         inform("%s\n", res_print + " Success ");
         return true;
@@ -63,7 +64,7 @@ TlmGenerator::Transaction::Assertion::run(Transaction *tran)
     if (Expectation::run(tran)) {
         return true;
     } else {
-        panic("Failing assertion\n");
+        panic("%u: Failing assertion\n", tran->phase().txn_id);
     }
 }
 
@@ -256,7 +257,7 @@ TlmGenerator::terminate(Transaction *transaction)
         // If the transaction has failed, mark the suite as failure
         suiteFailure = suiteFailure || transaction->failed();
     } else {
-        panic("Can't find transaction id: %u\n", phase.txn_id);
+        panic("%u: Can't find transaction id.\n", phase.txn_id);
     }
 }
 
@@ -298,7 +299,7 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
         // Check existing expectations
         it->second->runCallbacks();
     } else {
-        warn("Transaction untested\n");
+        warn("%u: Transaction untested\n", phase->txn_id);
     }
 }
 
@@ -331,7 +332,7 @@ TlmGenerator::handlePCredit(ARM::CHI::Phase *phase)
     } else if (isRetryAck(phase)) {
         auto it = pendingTransactions.find(phase->txn_id);
         panic_if(it == pendingTransactions.end(),
-                 "Can't find transaction id: %u\n", phase->txn_id);
+                 "%u: Can't find transaction id\n", phase->txn_id);
 
         auto tran = it->second;
 
@@ -358,6 +359,10 @@ TlmGenerator::passFailCheck()
         inform(" Suite Fail: failed transaction ");
     } else if (!pendingTransactions.empty()) {
         inform(" Suite Fail: non-empty transaction queue ");
+        inform(" Pending transactions:");
+        for (auto &[txn_id, txn] : pendingTransactions) {
+            inform("\t%s", txn->str());
+        }
     } else {
         inform(" Suite Success ");
     }

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -37,8 +37,9 @@
 
 #include "mem/ruby/protocol/chi/tlm/generator.hh"
 
-#include "mem/ruby/protocol/chi/tlm/controller.hh"
 #include "debug/TLM.hh"
+#include "mem/ruby/protocol/chi/tlm/controller.hh"
+#include "sim/sim_exit.hh"
 
 namespace gem5 {
 
@@ -300,6 +301,10 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
         it->second->runCallbacks();
     } else {
         warn("%u: Transaction untested\n", phase->txn_id);
+    }
+
+    if (!isActive()) {
+        exitSimLoop("TlmGenerator done");
     }
 }
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -199,8 +199,6 @@ TlmGenerator::scheduleTransaction(Tick when, Transaction *transaction)
 
     auto event = new TransactionEvent(transaction, when);
 
-    scheduledTransactions.push(event);
-
     schedule(event, when);
 }
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Arm Limited
+ * Copyright (c) 2024-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -278,6 +278,12 @@ class TlmGenerator : public ClockedObject
     void scheduleTransaction(Tick when, Transaction *tr);
     void enqueueFront(Transaction *tr);
     void enqueueBack(Transaction *tr);
+    bool
+    isActive() const
+    {
+        return !pendingTransactions.empty() ||
+               !unscheduledTransactions.empty() || !waitingForPCrd.empty();
+    }
 
     Port &getPort(const std::string &if_name, PortID idx) override;
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -363,13 +363,6 @@ class TlmGenerator : public ClockedObject
     /** tick event used to schedule unscheduled transactions */
     EventFunctionWrapper tickEvent;
 
-    using SchedulingQueue = std::priority_queue<TransactionEvent*,
-        std::vector<TransactionEvent*>,
-        TransactionEvent::Compare>;
-
-    /** PQ of transactions whose injection has been scheduled */
-    SchedulingQueue scheduledTransactions;
-
     /** List of transactions whose injection needs to be scheduled */
     std::list<Transaction *> unscheduledTransactions;
 

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ARM Limited
+ * Copyright (c) 2023, 2026 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -234,11 +234,11 @@ std::string
 transactionToString(const Payload &payload,
                     const Phase &phase)
 {
-    return csprintf("%s %s addr=0x%08lx ns=%d size=%d attrs=0x%x",
-        phaseToChannelName(phase),
-        phaseToOpcodeName(phase).c_str(),
-        payload.address, payload.ns,
-        (int)payload.size, (int)payload.mem_attr);
+    return csprintf("%s %s addr=0x%08lx ns=%d size=%d attrs=0x%x txnid=%u",
+                    phaseToChannelName(phase),
+                    phaseToOpcodeName(phase).c_str(), payload.address,
+                    payload.ns, (int)payload.size, (int)payload.mem_attr,
+                    phase.txn_id);
 }
 
 namespace tlm_to_ruby {


### PR DESCRIPTION
The TlmGenerator currently doesn't exit the simulator when the packet
has been processed. This is not a big problem if using SimpleMemory
since we just skip to the end of time. For more complex systems, we
end up simulating for a very long time since other components continue
to schedule events even after we stop injecting packets.

Add support a method to check if the component is active
(TlmGenerator::isActive) which is used to check if we should exit
after when receiving a reply to an injected packet. The isActive
method is exported to Python to simplify cases where we have multiple
TlmGenerators and we need to wait for all of them to exit.