### PR TITLE
mem-ruby: Optionally ignore debug accesses in TlmController

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmController.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmController.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, 2025 Arm Limited
+# Copyright (c) 2023, 2025-2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -47,3 +47,5 @@ class TlmController(CHIGenericController):
 
     in_port = TlmSinkPort("CHI TLM input port")
     out_port = TlmSourcePort("CHI TLM output port")
+
+    ignore_functional = Param.Bool(False, "Don't panic on functional accesses")

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2025 Arm Limited
+ * Copyright (c) 2023, 2025-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -153,6 +153,30 @@ CacheController::recvDataMsg(const CHIDataMsg *msg)
         panic("Not able to find transaction");
     }
     return true;
+}
+
+void
+CacheController::functionalRead(const Addr &param_addr, Packet *param_pkt,
+                                ruby::WriteMask &param_mask)
+{
+    if (!params().ignore_functional) {
+        panic("TlmController doesn't implement functionalRead.");
+    }
+
+    // Assume there are no caches behind this controller, so no need
+    // to read.
+}
+
+int
+CacheController::functionalWrite(const Addr &param_addr, Packet *param_pkt)
+{
+    if (!params().ignore_functional) {
+        panic("TlmController doesn't implement functionalWrite.");
+    }
+
+    // Assume that there are no caches behind this controller, so no
+    // need to perform a write.
+    return 0;
 }
 
 bool

--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2025 Arm Limited
+ * Copyright (c) 2023,2025-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -110,6 +110,10 @@ class CacheController : public ruby::CHIGenericController
     bool recvSnoopMsg(const CHIRequestMsg *msg) override;
     bool recvResponseMsg(const CHIResponseMsg *msg) override;
     bool recvDataMsg(const CHIDataMsg *msg) override;
+
+    void functionalRead(const Addr &param_addr, Packet *param_pkt,
+                        ruby::WriteMask &param_mask) override;
+    int functionalWrite(const Addr &param_addr, Packet *param_pkt) override;
 
     void sendMsg(ARM::CHI::Payload &payload, ARM::CHI::Phase &phase);
     using CHIGenericController::sendRequestMsg;


### PR DESCRIPTION
Add the option to ignore functionalRead and functionalWrite in the TlmController. This is useful in some cases where we need to perform functional accesses but know that the corresponding memory hasn't been cached on the TLM side.

Change-Id: If7bcbce2fe8c928a2aec9394ac2ebef7ac4ca87a

Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>