### PR TITLE
mem-ruby: Fix warning in tlm::chi::CacheController

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -137,7 +137,7 @@ class CacheController : public ruby::CHIGenericController
         Transaction(CacheController *parent,
             ARM::CHI::Payload &_payload,
             ARM::CHI::Phase &_phase);
-        ~Transaction();
+        virtual ~Transaction();
 
         static std::unique_ptr<Transaction> gen(CacheController *parent,
             ARM::CHI::Payload &_payload,


### PR DESCRIPTION
CacheController::Transaction has a vtable but no virtual destructor. Flag the destructor as virtual to ensure that it gets called correctly.

Change-Id: I55a8f9fd3068e23e56a24ecddcd94de00175fe15

Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>