### PR TITLE
arch-arm: Do not assume EL2 requires NS in PF aborts

### DIFF
--- a/src/arch/arm/faults.cc
+++ b/src/arch/arm/faults.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012-2014, 2016-2019, 2022, 2024 Arm Limited
+ * Copyright (c) 2010,2012-2014,2016-2019,2022,2024,2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1292,16 +1292,15 @@ PrefetchAbort::routeToMonitor(ThreadContext *tc) const
 bool
 PrefetchAbort::routeToHyp(ThreadContext *tc) const
 {
-    bool toHyp;
+    bool to_hyp;
 
     HCR  hcr  = tc->readMiscRegNoEffect(MISCREG_HCR_EL2);
     HDCR hdcr = tc->readMiscRegNoEffect(MISCREG_HDCR);
 
-    toHyp = fromEL == EL2;
-    toHyp |=  ArmSystem::haveEL(tc, EL2) && !isSecure(tc) &&
-        currEL(tc) <= EL1 && (hcr.tge || stage2 ||
-                              (source == DebugEvent && hdcr.tde));
-     return toHyp;
+    to_hyp = fromEL == EL2;
+    to_hyp |= EL2Enabled(tc) && currEL(tc) <= EL1 &&
+              (hcr.tge || stage2 || (source == DebugEvent && hdcr.tde));
+    return to_hyp;
 }
 
 ExceptionClass


### PR DESCRIPTION
This is similar to other FEAT_SEL2 related PRs [1]

[1]: https://github.com/gem5/gem5/pull/2974


Change-Id: Ia765ca288a821e5d690a026b8493f729e4463258