### PR TITLE
python,sim: Unify simulation-exit handling through hypercalls

### DIFF
--- a/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
@@ -127,7 +127,7 @@ board.set_workload(workload)
 # handlers map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(ExitHandler, hypercall="KernelBooted"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -149,7 +149,7 @@ class SwitchProcessorAfterBootExitHandler(AfterBootExitHandler):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(ExitHandler, hypercall="AfterBootScript"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
@@ -61,6 +61,7 @@ from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     AfterBootExitHandler,
     ExitHandler,
+    ExitHypercall,
 )
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
@@ -123,12 +124,14 @@ board.set_workload(workload)
 # default after-boot exit handler to switch processors.
 
 # You can inherit from either the class that handles a certain hypercall,
-# or inherit directly from ExitHandler and specify a hypercall number.
+# or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # handlers map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -150,7 +153,9 @@ class SwitchProcessorAfterBootExitHandler(AfterBootExitHandler):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
@@ -61,6 +61,7 @@ from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     AfterBootExitHandler,
     ExitHandler,
+    ExitHypercall,
 )
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
@@ -122,12 +123,14 @@ board.set_workload(workload)
 # default after-boot exit handler to switch processors.
 
 # You can inherit from either the class that handles a certain hypercall,
-# or inherit directly from ExitHandler and specify a hypercall number.
+# or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # handlers map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -149,7 +152,9 @@ class SwitchProcessorAfterBootExitHandler(AfterBootExitHandler):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/arm-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-ubuntu-run.py
@@ -120,7 +120,7 @@ class CustomKernelBootedExitHandler(KernelBootedExitHandler):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(ExitHandler, hypercall="AfterBoot"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("Second exit: Started `after_boot.sh` script")
@@ -130,7 +130,7 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(ExitHandler, hypercall="AfterBootScript"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/arm-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-ubuntu-run.py
@@ -57,6 +57,7 @@ from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     ExitHandler,
+    ExitHypercall,
     KernelBootedExitHandler,
 )
 from gem5.simulate.simulator import Simulator
@@ -107,7 +108,7 @@ board.set_workload(workload)
 # want to modify/override their default behaviors.
 
 # You can inherit from either the class that handles a certain hypercall by
-# default, or inherit directly from ExitHandler and specify a hypercall number.
+# default, or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # handlers map to which hypercalls, and what the default behaviors are.
 
@@ -122,7 +123,9 @@ class CustomKernelBootedExitHandler(KernelBootedExitHandler):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("Second exit: Started `after_boot.sh` script")
@@ -132,7 +135,9 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/arm-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-ubuntu-run.py
@@ -57,6 +57,7 @@ from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     ExitHandler,
+    ExitHypercall,
     KernelBootedExitHandler,
 )
 from gem5.simulate.simulator import Simulator
@@ -105,7 +106,7 @@ board.set_workload(workload)
 # want to modify/override their default behaviors.
 
 # You can inherit from either the class that handles a certain hypercall by
-# default, or inherit directly from ExitHandler and specify a hypercall number.
+# default, or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # handlers map to which hypercalls, and what the default behaviors are.
 
@@ -120,7 +121,9 @@ class CustomKernelBootedExitHandler(KernelBootedExitHandler):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("Second exit: Started `after_boot.sh` script")
@@ -130,7 +133,9 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/exit_handling/user-exit-handler.py
+++ b/configs/example/gem5_library/exit_handling/user-exit-handler.py
@@ -85,7 +85,7 @@ board.set_se_binary_workload(
 
 
 # The exit handler which will be used to take checkpoints when the scheduled
-# exit event is triggered (hypercall ID 6).
+# exit event is triggered (SCHEDULED_EXIT hypercall (ID 6)).
 class MyExitHandler(ScheduledExitEventHandler):
     def _process(self, simulator: "Simulator") -> None:
         super()._process(simulator)

--- a/configs/example/gem5_library/exit_handling/user-exit-handler.py
+++ b/configs/example/gem5_library/exit_handling/user-exit-handler.py
@@ -83,7 +83,7 @@ board.set_se_binary_workload(
 
 
 # The exit handler which will be used to take checkpoints when the scheduled
-# exit event is triggered (hypercall ID 6).
+# exit event is triggered (SCHEDULED_EXIT hypercall (ID 6)).
 class MyExitHandler(ScheduledExitEventHandler):
     def _process(self, simulator: "Simulator") -> None:
         super()._process(simulator)

--- a/configs/example/gem5_library/multisim/multisim-fs-x86-npb.py
+++ b/configs/example/gem5_library/multisim/multisim-fs-x86-npb.py
@@ -120,8 +120,9 @@ for benchmark in ["bt", "cg", "ep", "ft", "is", "lu", "mg", "sp", "ua"]:
         # As this is just an example we will only run the simulation for a
         # billion ticks. An actual run could take days of time to simulate.
         #
-        # We use `set_hypercall_absolute_max_ticks` to schedule a hypercall 6
-        # exit at 1 billion ticks. The default hypercall 6 behavior is to
+        # We use `set_hypercall_absolute_max_ticks` to schedule a
+        # SCHEDULED_EXIT hypercall (ID 6) at 1 billion ticks. The default
+        # SCHEDULED_EXIT hypercall behavior is to
         # end simulation, but this can be overridden with a custom hypercall
         # handler. See `src/python/gem5/simulate/exit_handler.py` for more
         # information.

--- a/configs/example/gem5_library/multisim/multisim-fs-x86-npb.py
+++ b/configs/example/gem5_library/multisim/multisim-fs-x86-npb.py
@@ -119,8 +119,9 @@ for benchmark in ["bt", "cg", "ep", "ft", "is", "lu", "mg", "sp", "ua"]:
         # As this is just an example we will only run the simulation for a
         # billion ticks. An actual run could take days of time to simulate.
         #
-        # We use `set_hypercall_absolute_max_ticks` to schedule a hypercall 6
-        # exit at 1 billion ticks. The default hypercall 6 behavior is to
+        # We use `set_hypercall_absolute_max_ticks` to schedule a
+        # SCHEDULED_EXIT hypercall (ID 6) at 1 billion ticks. The default
+        # SCHEDULED_EXIT hypercall behavior is to
         # end simulation, but this can be overridden with a custom hypercall
         # handler. See `src/python/gem5/simulate/exit_handler.py` for more
         # information.

--- a/configs/example/gem5_library/riscv-ubuntu-run.py
+++ b/configs/example/gem5_library/riscv-ubuntu-run.py
@@ -110,7 +110,7 @@ class CustomKernelBootedExitHandler(KernelBootedExitHandler):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(ExitHandler, hypercall="AfterBoot"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("Second exit: Started `after_boot.sh` script")
@@ -120,7 +120,7 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(ExitHandler, hypercall="AfterBootScript"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/riscv-ubuntu-run.py
+++ b/configs/example/gem5_library/riscv-ubuntu-run.py
@@ -52,6 +52,7 @@ from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     ExitHandler,
+    ExitHypercall,
     KernelBootedExitHandler,
 )
 from gem5.simulate.simulator import Simulator
@@ -100,7 +101,7 @@ board.set_workload(
 
 
 # You can inherit from either the class that handles a certain hypercall, or
-# inherit directly from ExitHandler and specify a hypercall number.
+# inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # handlers map to which hypercalls, and what the default behaviors are.
 class CustomKernelBootedExitHandler(KernelBootedExitHandler):
@@ -113,7 +114,9 @@ class CustomKernelBootedExitHandler(KernelBootedExitHandler):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("Second exit: Started `after_boot.sh` script")
@@ -123,7 +126,9 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/riscv-ubuntu-run.py
+++ b/configs/example/gem5_library/riscv-ubuntu-run.py
@@ -52,6 +52,7 @@ from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     ExitHandler,
+    ExitHypercall,
     KernelBootedExitHandler,
 )
 from gem5.simulate.simulator import Simulator
@@ -97,7 +98,7 @@ board.set_workload(
 
 
 # You can inherit from either the class that handles a certain hypercall, or
-# inherit directly from ExitHandler and specify a hypercall number.
+# inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # handlers map to which hypercalls, and what the default behaviors are.
 class CustomKernelBootedExitHandler(KernelBootedExitHandler):
@@ -110,7 +111,9 @@ class CustomKernelBootedExitHandler(KernelBootedExitHandler):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("Second exit: Started `after_boot.sh` script")
@@ -120,7 +123,9 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
@@ -124,7 +124,7 @@ board.set_workload(workload)
 # behaviors map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(ExitHandler, hypercall="KernelBooted"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -146,7 +146,7 @@ class SwitchProcessorAfterBootExitHandler(AfterBootExitHandler):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(ExitHandler, hypercall="AfterBootScript"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
@@ -53,6 +53,7 @@ from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     AfterBootExitHandler,
     ExitHandler,
+    ExitHypercall,
 )
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
@@ -120,12 +121,14 @@ board.set_workload(workload)
 # default after-boot exit handler to switch processors.
 
 # You can inherit from either the class that handles a certain hypercall by
-# default, or inherit directly from ExitHandler and specify a hypercall number.
+# default, or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # behaviors map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -147,7 +150,9 @@ class SwitchProcessorAfterBootExitHandler(AfterBootExitHandler):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
@@ -53,6 +53,7 @@ from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     AfterBootExitHandler,
     ExitHandler,
+    ExitHypercall,
 )
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
@@ -119,12 +120,14 @@ board.set_workload(workload)
 # default after-boot exit handler to switch processors.
 
 # You can inherit from either the class that handles a certain hypercall by
-# default, or inherit directly from ExitHandler and specify a hypercall number.
+# default, or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # behaviors map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -146,7 +149,9 @@ class SwitchProcessorAfterBootExitHandler(AfterBootExitHandler):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
@@ -122,7 +122,7 @@ board.set_workload(workload)
 # behaviors map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(ExitHandler, hypercall="KernelBooted"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -132,7 +132,7 @@ class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(ExitHandler, hypercall="AfterBoot"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         simulator.switch_processor()
@@ -142,7 +142,7 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(ExitHandler, hypercall="AfterBootScript"):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
@@ -49,7 +49,10 @@ from gem5.components.processors.simple_switchable_processor import (
 )
 from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
-from gem5.simulate.exit_handler import ExitHandler
+from gem5.simulate.exit_handler import (
+    ExitHandler,
+    ExitHypercall,
+)
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
 from gem5.utils.requires import requires
@@ -118,12 +121,14 @@ board.set_workload(workload)
 # default after-boot exit handler to switch processors.
 
 # You can inherit from either the class that handles a certain hypercall by
-# default, or inherit directly from ExitHandler and specify a hypercall number.
+# default, or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # behaviors map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -133,7 +138,9 @@ class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         simulator.switch_processor()
@@ -143,7 +150,9 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
@@ -49,7 +49,10 @@ from gem5.components.processors.simple_switchable_processor import (
 )
 from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
-from gem5.simulate.exit_handler import ExitHandler
+from gem5.simulate.exit_handler import (
+    ExitHandler,
+    ExitHypercall,
+)
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
 from gem5.utils.requires import requires
@@ -117,12 +120,14 @@ board.set_workload(workload)
 # default after-boot exit handler to switch processors.
 
 # You can inherit from either the class that handles a certain hypercall by
-# default, or inherit directly from ExitHandler and specify a hypercall number.
+# default, or inherit directly from ExitHandler and specify an ExitHypercall.
 # See src/python/gem5/simulate/exit_handler.py for more information on which
 # behaviors map to which hypercalls, and what the default behaviors are.
 
 
-class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class CustomKernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print("First exit: kernel booted")
@@ -132,7 +137,9 @@ class CustomKernelBootedExitHandler(ExitHandler, hypercall_num=1):
         return False
 
 
-class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
+class CustomAfterBootExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         simulator.switch_processor()
@@ -142,7 +149,9 @@ class CustomAfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         print(f"Third exit: {self.get_handler_description()}")

--- a/ext/sst/gem5.cc
+++ b/ext/sst/gem5.cc
@@ -231,9 +231,9 @@ gem5Component::init(unsigned phase)
             threadInitialized = true;
             gem5::simulate_limit_event = new gem5::GlobalSimLoopExitEvent(
                 gem5::mainEventQueue[0]->getCurTick(),
-                "simulate() limit reached",
-                0
-            );
+                "simulate() limit reached", 0, 0,
+                static_cast<uint64_t>(gem5::ExitHypercall::CLASSIC_GENERATOR),
+                gem5::classicGeneratorPayload("simulate() limit reached"));
         }
 
     }
@@ -349,7 +349,7 @@ gem5Component::doSimLoop(gem5::EventQueue* eventq)
 
             if (gem5::async_exit) {
                 gem5::async_exit = false;
-                gem5::exitSimLoop("user interrupt received");
+                gem5::exitSimulationLoopClassic("user interrupt received");
             }
 
             if (gem5::async_exception) {

--- a/include/gem5/exit_hypercalls.hh
+++ b/include/gem5/exit_hypercalls.hh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GEM5_EXIT_HYPERCALLS_HH__
+#define __GEM5_EXIT_HYPERCALLS_HH__
+
+/**
+ * Central list of hypercall-driven exit handlers. The list is expressed as a
+ * macro so multiple translation units (C and C++) can derive enums, constants,
+ * and documentation without duplicating the mapping.
+ *
+ * OP arguments: (EnumName, MacroName, Value, Description)
+ */
+#define GEM5_FOREACH_EXIT_HYPERCALL(OP)                                       \
+    OP(ClassicGenerator, CLASSIC_GENERATOR, 0,                                \
+       "Legacy generator-based exit handling (ExitEvent translation)")        \
+    OP(KernelBooted, KERNEL_BOOTED, 1, "Guest kernel reported it has booted") \
+    OP(AfterBoot, AFTER_BOOT, 2, "Guest entered the after_boot hook")         \
+    OP(AfterBootScript, AFTER_BOOT_SCRIPT, 3,                                 \
+       "Guest completed after_boot.sh")                                       \
+    OP(WorkBegin, WORK_BEGIN, 4, "Entered a region-of-interest (workbegin)")  \
+    OP(WorkEnd, WORK_END, 5, "Exited a region-of-interest (workend)")         \
+    OP(ScheduledExit, SCHEDULED_EXIT, 6,                                      \
+       "Simulator scheduled tick/max-tick exit")                              \
+    OP(Checkpoint, CHECKPOINT, 7, "Take a checkpoint and continue running")   \
+    OP(Orchestrator, ORCHESTRATOR, 1000,                                      \
+       "Orchestrator control/status hypercall")
+
+#endif // __GEM5_EXIT_HYPERCALLS_HH__

--- a/include/gem5/hypercall_ids.h
+++ b/include/gem5/hypercall_ids.h
@@ -29,14 +29,62 @@
 #ifndef HYPERCALL_IDS_H
 #define HYPERCALL_IDS_H
 
-// Standard exit hypercall IDs
-const int KERNEL_BOOTED_EXIT                = 1;
-const int STARTED_AFTERBOOT_SCRIPT_EXIT     = 2;
-const int FINISHED_AFTERBOOT_SCRIPT_EXIT    = 3;
-const int WORK_BEGIN_EXIT                   = 4;
-const int WORK_END_EXIT                     = 5;
-const int SCHEDULED_EXIT                    = 6;
-const int CHECKPOINT_EXIT                   = 7;
-const int ORCHESTRATOR_EXIT                 = 1000;
+/*
+ * Central list of gem5's built-in exit-handler hypercalls. A hypercall is the
+ * broader guest/simulator request mechanism; this list is the subset whose IDs
+ * dispatch through the simulation-exit/stdlib ExitHandler path. The list is
+ * expressed as a macro so multiple translation units (C and C++) can derive
+ * enums, constants, and documentation without duplicating the mapping.
+ *
+ * CLASSIC_GENERATOR is intentionally not included in
+ * GEM5_FOREACH_PUBLIC_EXIT_HYPERCALL. It is an internal compatibility path
+ * that requires a legacy cause/code payload; guest calls to m5_hypercall() can
+ * supply only an ID.
+ *
+ * OP arguments: (Name, Value, Description)
+ */
+#define GEM5_FOREACH_EXIT_HYPERCALL(OP)                                       \
+    OP(CLASSIC_GENERATOR, 0,                                                  \
+       "Legacy generator-based exit handling (ExitEvent translation)")        \
+    GEM5_FOREACH_PUBLIC_EXIT_HYPERCALL(OP)
+
+#define GEM5_FOREACH_PUBLIC_EXIT_HYPERCALL(OP)                                \
+    OP(KERNEL_BOOTED, 1, "Guest kernel reported it has booted")               \
+    OP(AFTER_BOOT, 2, "Guest entered the after_boot hook")                    \
+    OP(AFTER_BOOT_SCRIPT, 3, "Guest completed after_boot.sh")                 \
+    OP(WORK_BEGIN, 4, "Entered a region-of-interest (workbegin)")             \
+    OP(WORK_END, 5, "Exited a region-of-interest (workend)")                  \
+    OP(SCHEDULED_EXIT, 6, "Simulator scheduled tick/max-tick exit")           \
+    OP(CHECKPOINT, 7, "Take a checkpoint and continue running")               \
+    OP(ORCHESTRATOR, 1000, "Orchestrator control/status hypercall")
+
+/*
+ * Define C-compatible M5_HYPERCALL_* constants for IDs guest code may pass to
+ * m5_hypercall().
+ */
+enum
+{
+#define GEM5_DECLARE_M5_HYPERCALL(name, value, desc)                          \
+    M5_HYPERCALL_##name = value, /* desc */
+    GEM5_FOREACH_PUBLIC_EXIT_HYPERCALL(GEM5_DECLARE_M5_HYPERCALL)
+#undef GEM5_DECLARE_M5_HYPERCALL
+};
+
+/*
+ * Backwards-compatible C-style names (preserve older header semantics). These
+ * aliases intentionally point at the M5_HYPERCALL_* constants above so the
+ * numeric ABI is centralized in GEM5_FOREACH_EXIT_HYPERCALL.
+ */
+enum
+{
+    KERNEL_BOOTED_EXIT = M5_HYPERCALL_KERNEL_BOOTED,
+    STARTED_AFTERBOOT_SCRIPT_EXIT = M5_HYPERCALL_AFTER_BOOT,
+    FINISHED_AFTERBOOT_SCRIPT_EXIT = M5_HYPERCALL_AFTER_BOOT_SCRIPT,
+    WORK_BEGIN_EXIT = M5_HYPERCALL_WORK_BEGIN,
+    WORK_END_EXIT = M5_HYPERCALL_WORK_END,
+    SCHEDULED_EXIT = M5_HYPERCALL_SCHEDULED_EXIT,
+    CHECKPOINT_EXIT = M5_HYPERCALL_CHECKPOINT,
+    ORCHESTRATOR_EXIT = M5_HYPERCALL_ORCHESTRATOR,
+};
 
 #endif // HYPERCALL_IDS_H

--- a/include/gem5/m5ops.h
+++ b/include/gem5/m5ops.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <stdint.h>
 
 #include <gem5/asm/generic/m5ops.h>
+#include <gem5/exit_hypercalls.hh>
 
 void m5_arm(uint64_t address);
 void m5_quiesce(void);
@@ -66,6 +67,17 @@ void m5_load_symbol();
 void m5_panic(void);
 void m5_work_begin(uint64_t workid, uint64_t threadid);
 void m5_work_end(uint64_t workid, uint64_t threadid);
+/*
+ * Trigger a hypercall-based exit. Use the M5_HYPERCALL_* constants below (or
+ * the C++ gem5::ExitHypercall enum) instead of hard-coding numeric IDs.
+ */
+enum
+{
+#define GEM5_DECLARE_M5_HYPERCALL(enum_name, macro_name, value, desc)         \
+    M5_HYPERCALL_##macro_name = value, /* desc */
+    GEM5_FOREACH_EXIT_HYPERCALL(GEM5_DECLARE_M5_HYPERCALL)
+#undef GEM5_DECLARE_M5_HYPERCALL
+};
 void m5_hypercall(uint64_t hypercall_id);
 /*
  * Send a very generic poke to the workload so it can do something. It's up to

--- a/include/gem5/m5ops.h
+++ b/include/gem5/m5ops.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <stdint.h>
 
 #include <gem5/asm/generic/m5ops.h>
+#include <gem5/hypercall_ids.h>
 
 void m5_arm(uint64_t address);
 void m5_quiesce(void);
@@ -66,6 +67,12 @@ void m5_load_symbol();
 void m5_panic(void);
 void m5_work_begin(uint64_t workid, uint64_t threadid);
 void m5_work_end(uint64_t workid, uint64_t threadid);
+/*
+ * Trigger a hypercall-based exit. Guest code should use the M5_HYPERCALL_*
+ * constants from include/gem5/hypercall_ids.h instead of hard-coding numeric
+ * IDs. The simulator-side C++ enum (gem5::ExitHypercall) is derived from the
+ * same central mapping; ensure any changes remain consistent.
+ */
 void m5_hypercall(uint64_t hypercall_id);
 /*
  * Send a very generic poke to the workload so it can do something. It's up to

--- a/src/arch/arm/pmu.cc
+++ b/src/arch/arm/pmu.cc
@@ -459,14 +459,14 @@ PMU::pmuExitEvent(bool check_reset)
         pmuEnabled = any_counter_enabled;
         if (pmuEnabled) {
             inform("Exiting simulation: PMU enable detected");
-            exitSimLoop("performance counter enabled", 0);
+            exitSimulationLoopClassic("performance counter enabled");
         } else {
             inform("Exiting simulation: PMU disable detected");
-            exitSimLoop("performance counter disabled", 0);
+            exitSimulationLoopClassic("performance counter disabled");
         }
     } else if (check_reset && reg_pmcr.p) {
         inform("Exiting simulation: PMU reset detected");
-        exitSimLoop("performance counter reset", 0);
+        exitSimulationLoopClassic("performance counter reset");
     }
 }
 
@@ -738,7 +738,7 @@ PMU::raiseInterrupt()
 {
     if (exitOnPMUInterrupt) {
         inform("Exiting simulation: PMU interrupt detected");
-        exitSimLoop("performance counter interrupt", 0);
+        exitSimulationLoopClassic("performance counter interrupt");
     }
     if (interrupt) {
         DPRINTF(PMUVerbose, "Delivering PMU interrupt.\n");

--- a/src/arch/arm/tracers/tarmac_parser.cc
+++ b/src/arch/arm/tracers/tarmac_parser.cc
@@ -901,11 +901,15 @@ TarmacParserRecord::TarmacParserRecordEvent::process()
 
     if (mismatchOnPcOrOpcode && (parent.exitOnDiff ||
                                  parent.exitOnInsnDiff))
-        exitSimLoop("a mismatch with the TARMAC trace has been detected "
-                    "on PC or opcode", 1);
+        exitSimulationLoopClassic(
+            "a mismatch with the TARMAC trace has been detected "
+            "on PC or opcode",
+            1);
     if (mismatch && parent.exitOnDiff)
-        exitSimLoop("a mismatch with the TARMAC trace has been detected "
-                    "on data value", 1);
+        exitSimulationLoopClassic(
+            "a mismatch with the TARMAC trace has been detected "
+            "on data value",
+            1);
 }
 
 const char *
@@ -1044,8 +1048,10 @@ TarmacParserRecord::dump()
             mainEventQueue[0]->schedule(event, curTick());
         } else if (mismatchOnPcOrOpcode && (parent.exitOnDiff ||
                                             parent.exitOnInsnDiff)) {
-            exitSimLoop("a mismatch with the TARMAC trace has been detected "
-                        "on PC or opcode", 1);
+            exitSimulationLoopClassic(
+                "a mismatch with the TARMAC trace has been detected "
+                "on PC or opcode",
+                1);
         }
     } else {
         parent.macroopInProgress = true;

--- a/src/arch/generic/semihosting.cc
+++ b/src/arch/generic/semihosting.cc
@@ -549,9 +549,9 @@ BaseSemihosting::semiExit(uint64_t code, uint64_t subcode)
 {
     auto it = exitCodes.find(code);
     if (it != exitCodes.end()) {
-        exitSimLoop(it->second, subcode);
+        exitSimulationLoopClassic(it->second, subcode);
     } else {
-        exitSimLoop(csprintf("semi:0x%x", code), subcode);
+        exitSimulationLoopClassic(csprintf("semi:0x%x", code), subcode);
     }
 }
 

--- a/src/base/remote_gdb.cc
+++ b/src/base/remote_gdb.cc
@@ -1433,20 +1433,26 @@ class MonitorCallEvent : public GlobalSimLoopExitEvent
     BaseRemoteGDB& gdb;
     ContextID id;
     public:
-    MonitorCallEvent(BaseRemoteGDB& gdb,ContextID id,const std::string &_cause,
-                  int code):
-                  GlobalSimLoopExitEvent(_cause,code), gdb(gdb),id(id)
-                  {};
-    void process() override{
-        GlobalSimLoopExitEvent::process();
-    }
-    void clean() override{
-        //trapping now
-        //this is the only point in time when we can call trap
-        //before any breakpoint triggers
-        gdb.trap(id,GDBSignal::ZERO,"monitor_return");
-        delete this;
-    }
+      MonitorCallEvent(BaseRemoteGDB &gdb, ContextID id,
+                       const std::string &_cause, int code)
+          : GlobalSimLoopExitEvent(
+                _cause, code, 0,
+                static_cast<uint64_t>(ExitHypercall::CLASSIC_GENERATOR),
+                classicGeneratorPayload(_cause, code)),
+            gdb(gdb),
+            id(id) {};
+      void
+      process() override
+      { GlobalSimLoopExitEvent::process(); }
+      void
+      clean() override
+      {
+          // trapping now
+          // this is the only point in time when we can call trap
+          // before any breakpoint triggers
+          gdb.trap(id, GDBSignal::ZERO, "monitor_return");
+          delete this;
+      }
     ~MonitorCallEvent(){
         DPRINTF(Event,"MonitorCallEvent destructed\n");;
     }

--- a/src/base/remote_gdb.cc
+++ b/src/base/remote_gdb.cc
@@ -1421,20 +1421,26 @@ class MonitorCallEvent : public GlobalSimLoopExitEvent
     BaseRemoteGDB& gdb;
     ContextID id;
     public:
-    MonitorCallEvent(BaseRemoteGDB& gdb,ContextID id,const std::string &_cause,
-                  int code):
-                  GlobalSimLoopExitEvent(_cause,code), gdb(gdb),id(id)
-                  {};
-    void process() override{
-        GlobalSimLoopExitEvent::process();
-    }
-    void clean() override{
-        //trapping now
-        //this is the only point in time when we can call trap
-        //before any breakpoint triggers
-        gdb.trap(id,GDBSignal::ZERO,"monitor_return");
-        delete this;
-    }
+      MonitorCallEvent(BaseRemoteGDB &gdb, ContextID id,
+                       const std::string &_cause, int code)
+          : GlobalSimLoopExitEvent(
+                _cause, code, 0,
+                static_cast<uint64_t>(ExitHypercall::CLASSIC_GENERATOR),
+                classicGeneratorPayload(_cause, code)),
+            gdb(gdb),
+            id(id) {};
+      void
+      process() override
+      { GlobalSimLoopExitEvent::process(); }
+      void
+      clean() override
+      {
+          // trapping now
+          // this is the only point in time when we can call trap
+          // before any breakpoint triggers
+          gdb.trap(id, GDBSignal::ZERO, "monitor_return");
+          delete this;
+      }
     ~MonitorCallEvent(){
         DPRINTF(Event,"MonitorCallEvent destructed\n");;
     }

--- a/src/cpu/probes/inst_tracker.cc
+++ b/src/cpu/probes/inst_tracker.cc
@@ -92,7 +92,8 @@ GlobalInstTracker::updateAndCheckInstCount(const uint64_t& inst)
         // and exit event but it will not reset the instruction counter.
         // user can reset the counter by calling the resetCounter() function
         // in the simulation script.
-        exitSimLoopNow("a thread reached the max instruction count");
+        exitSimulationLoopClassicNow(
+            "a thread reached the max instruction count");
     }
 }
 

--- a/src/cpu/probes/pc_count_tracker_manager.cc
+++ b/src/cpu/probes/pc_count_tracker_manager.cc
@@ -67,7 +67,7 @@ PcCountTrackerManager::checkCount(Addr pc)
             DPRINTF(PcCountTracker,
                 "pc:%s encountered\n", currentPair.to_string());
 
-            exitSimLoopNow("simpoint starting point found");
+            exitSimulationLoopClassicNow("simpoint starting point found");
             // raise the SIMPOINT_BEGIN exit event
 
             targetPair.erase(currentPair);

--- a/src/cpu/simple/probes/looppoint_analysis.cc
+++ b/src/cpu/simple/probes/looppoint_analysis.cc
@@ -228,7 +228,7 @@ LooppointAnalysisManager::countBackwardBranch(const Addr pc)
                 globalInstCounter);
         DPRINTF(LooppointAnalysis, "regionLength = %lu\n",
                 regionLength);
-        exitSimLoopNow("simpoint starting point found");
+        exitSimulationLoopClassicNow("simpoint starting point found");
     }
 }
 

--- a/src/cpu/testers/directedtest/RubyDirectedTester.cc
+++ b/src/cpu/testers/directedtest/RubyDirectedTester.cc
@@ -136,7 +136,7 @@ RubyDirectedTester::wakeup()
             schedule(directedStartEvent, curTick() + 1);
         }
     } else {
-        exitSimLoop("Ruby DirectedTester completed");
+        exitSimulationLoopClassic("Ruby DirectedTester completed");
     }
 }
 

--- a/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.cc
+++ b/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.cc
@@ -174,7 +174,7 @@ GarnetSyntheticTraffic::tick()
 
     // Schedule wakeup
     if (curTick() >= simCycles)
-        exitSimLoop("Network Tester completed simCycles");
+        exitSimulationLoopClassic("Network Tester completed simCycles");
     else {
         if (!tickEvent.scheduled())
             schedule(tickEvent, clockEdge(Cycles(1)));

--- a/src/cpu/testers/gpu_ruby_test/protocol_tester.cc
+++ b/src/cpu/testers/gpu_ruby_test/protocol_tester.cc
@@ -293,7 +293,7 @@ ProtocolTester::checkExit()
         if (!sentExitSignal) {
             // all done
             inform("Total completed episodes: %d\n", nextEpisodeId - 1);
-            exitSimLoop("GPU Ruby Tester: Passed!");
+            exitSimulationLoopClassic("GPU Ruby Tester: Passed!");
             sentExitSignal = true;
         }
         return true;

--- a/src/cpu/testers/memtest/memtest.cc
+++ b/src/cpu/testers/memtest/memtest.cc
@@ -198,7 +198,7 @@ MemTest::completeRequest(PacketPtr pkt, bool functional)
             }
 
             if (maxLoads != 0 && numReads >= maxLoads)
-                exitSimLoop("maximum number of loads reached");
+                exitSimulationLoopClassic("maximum number of loads reached");
         } else if (pkt->isStashOnce()) {
             numStashes++;
             stats.numStashes++;

--- a/src/cpu/testers/memtest/memtest.cc
+++ b/src/cpu/testers/memtest/memtest.cc
@@ -193,7 +193,7 @@ MemTest::completeRequest(PacketPtr pkt, bool functional)
             }
 
             if (maxLoads != 0 && numReads >= maxLoads)
-                exitSimLoop("maximum number of loads reached");
+                exitSimulationLoopClassic("maximum number of loads reached");
         } else {
             assert(pkt->isWrite());
 

--- a/src/cpu/testers/rubytest/RubyTester.cc
+++ b/src/cpu/testers/rubytest/RubyTester.cc
@@ -249,7 +249,7 @@ RubyTester::wakeup()
 
         schedule(checkStartEvent, curTick() + m_wakeup_frequency);
     } else {
-        exitSimLoop("Ruby Tester completed");
+        exitSimulationLoopClassic("Ruby Tester completed");
     }
 }
 

--- a/src/cpu/testers/spatter_gen/spatter_gen.cc
+++ b/src/cpu/testers/spatter_gen/spatter_gen.cc
@@ -255,11 +255,9 @@ SpatterGen::checkForSimExit()
                 mode == SpatterProcessingMode::asynchronous
             );
         state = SpatterGenState::WAITING;
-        exitSimLoop(
-            csprintf("%s received all expected responses.", name()),
-            0,
-            nextCycle()
-        );
+        exitSimulationLoopClassic(
+            csprintf("%s received all expected responses.", name()), 0,
+            nextCycle());
     }
 }
 

--- a/src/cpu/testers/traffic_gen/exit_gen.cc
+++ b/src/cpu/testers/traffic_gen/exit_gen.cc
@@ -49,8 +49,9 @@ ExitGen::enter()
 {
     DPRINTF(TrafficGen, "%s has encountered the exit state and will "
             "terminate the simulation.\n", name());
-    exitSimLoop(name() + " has encountered the exit state and will "
-                "terminate the simulation.\n");
+    exitSimulationLoopClassic(name() +
+                              " has encountered the exit state and will "
+                              "terminate the simulation.\n");
 }
 
 PacketPtr

--- a/src/cpu/testers/traffic_gen/gups_gen.cc
+++ b/src/cpu/testers/traffic_gen/gups_gen.cc
@@ -166,7 +166,8 @@ GUPSGen::handleResponse(PacketPtr pkt)
         responsePool.push(pkt);
     }
     if (doneReading && requestPool.empty() && onTheFlyRequests == 0) {
-        exitSimLoop(name() + " is finished updating the memory.\n");
+        exitSimulationLoopClassic(name() +
+                                  " is finished updating the memory.\n");
         return;
     }
 

--- a/src/cpu/trace/trace_cpu.cc
+++ b/src/cpu/trace/trace_cpu.cc
@@ -192,7 +192,7 @@ TraceCPU::checkAndSchedExitEvent()
         // schedule the counted exit that counts down completion of each Trace
         // CPU.
         if (enableEarlyExit) {
-            exitSimLoop("End of trace reached");
+            exitSimulationLoopClassic("End of trace reached");
         } else {
             schedule(*execCompleteEvent, curTick());
         }

--- a/src/dev/amdgpu/amdgpu_device.cc
+++ b/src/dev/amdgpu/amdgpu_device.cc
@@ -397,7 +397,8 @@ AMDGPUDevice::readConfig(PacketPtr pkt)
         if (offset == PCI_INTERRUPT_PIN) {
             if (++init_interrupt_count == 3) {
                 DPRINTF(AMDGPUDevice, "Checkpointing before first MMIO\n");
-                exitSimLoop("checkpoint", 0, curTick() + configDelay + 1);
+                exitSimulationLoopClassic("checkpoint", 0,
+                                          curTick() + configDelay + 1);
             }
         } else {
             init_interrupt_count = 0;

--- a/src/dev/amdgpu/amdgpu_device.cc
+++ b/src/dev/amdgpu/amdgpu_device.cc
@@ -396,7 +396,8 @@ AMDGPUDevice::readConfig(PacketPtr pkt)
         if (offset == PCI_INTERRUPT_PIN) {
             if (++init_interrupt_count == 3) {
                 DPRINTF(AMDGPUDevice, "Checkpointing before first MMIO\n");
-                exitSimLoop("checkpoint", 0, curTick() + configDelay + 1);
+                exitSimulationLoopClassic("checkpoint", 0,
+                                          curTick() + configDelay + 1);
             }
         } else {
             init_interrupt_count = 0;

--- a/src/dev/arm/pl011.cc
+++ b/src/dev/arm/pl011.cc
@@ -174,7 +174,7 @@ Pl011::write(PacketPtr pkt)
     switch (daddr) {
         case UART_DR:
           if ((data & 0xFF) == 0x04 && endOnEOT)
-            exitSimLoop("UART received EOT", 0);
+              exitSimulationLoopClassic("UART received EOT");
 
         device->writeData(data & 0xFF);
         // We're supposed to clear TXINTR when this register is

--- a/src/dev/lupio/lupio_sys.cc
+++ b/src/dev/lupio/lupio_sys.cc
@@ -54,11 +54,13 @@ LupioSYS::lupioSYSWrite(uint8_t addr, uint64_t val64)
     switch (addr >> 2) {
         case LUPIO_SYS_HALT:
             DPRINTF(LupioSYS, "Trying to halt\n");
-            exitSimLoopNow("LUPIO_SYS_HALT called, exiting", val64, 0, false);
+            exitSimulationLoopClassicNow("LUPIO_SYS_HALT called, exiting",
+                                         static_cast<int>(val64));
             break;
         case LUPIO_SYS_REBT:
             DPRINTF(LupioSYS, "Trying to reboot\n");
-            exitSimLoopNow("LUPIO_SYS_REBT called, exiting", val64, 0, false);
+            exitSimulationLoopClassicNow("LUPIO_SYS_REBT called, exiting",
+                                         static_cast<int>(val64));
             break;
 
         default:

--- a/src/dev/net/dist_iface.cc
+++ b/src/dev/net/dist_iface.cc
@@ -398,9 +398,9 @@ DistIface::SyncEvent::process()
         // global sync completed
     }
     if (DistIface::sync->doCkpt)
-        exitSimLoop("checkpoint");
+        exitSimulationLoopClassic("checkpoint");
     if (DistIface::sync->doExit) {
-        exitSimLoop("exit request from gem5 peers");
+        exitSimulationLoopClassic("exit request from gem5 peers");
         return;
     }
     if (DistIface::sync->doStopSync) {
@@ -684,7 +684,7 @@ DistIface::recvThreadFunc(Event *recv_done, Tick link_delay)
             // because one of them called m5 exit. So we stop here.
             // Grab the eventq lock to stop the simulation thread
             curEventQueue()->lock();
-            exitSimLoop("connection to gem5 peer got closed");
+            exitSimulationLoopClassic("connection to gem5 peer got closed");
             curEventQueue()->unlock();
             // The simulation thread may be blocked in processing an on-going
             // global synchronisation. Abort the sync to give the simulation

--- a/src/dev/net/tcp_iface.cc
+++ b/src/dev/net/tcp_iface.cc
@@ -268,8 +268,8 @@ TCPIface::sendTCP(int sock, const void *buf, unsigned length)
     ret = ::send(sock, buf, length, MSG_NOSIGNAL);
     if (ret < 0) {
         if (errno == ECONNRESET || errno == EPIPE) {
-            exitSimLoop("Message server closed connection, simulation "
-                        "is exiting");
+            exitSimulationLoopClassic(
+                "Message server closed connection, simulation is exiting");
         } else {
             panic("send() failed: %s", strerror(errno));
         }

--- a/src/dev/serial/simple.cc
+++ b/src/dev/serial/simple.cc
@@ -74,7 +74,7 @@ SimpleUart::write(PacketPtr pkt)
 
     uint8_t data = (uint8_t)pkt->getUintX(byteOrder);
     if (data == 0x04 && endOnEOT)
-        exitSimLoop("UART received EOT", 0);
+        exitSimulationLoopClassic("UART received EOT");
 
     device->writeData(data);
 

--- a/src/gpu-compute/compute_unit.cc
+++ b/src/gpu-compute/compute_unit.cc
@@ -2180,7 +2180,7 @@ ComputeUnit::updateInstStats(GPUDynInstPtr gpuDynInst)
         if (gpuDynInst->isALU()) {
             shader->total_valu_insts++;
             if (shader->total_valu_insts == shader->max_valu_insts) {
-                exitSimLoop("max vALU insts");
+                exitSimulationLoopClassic("max vALU insts");
             }
             stats.vALUInsts++;
             stats.instCyclesVALU++;

--- a/src/gpu-compute/dispatcher.cc
+++ b/src/gpu-compute/dispatcher.cc
@@ -121,7 +121,7 @@ GPUDispatcher::dispatch(HSAQueueEntry *task)
     ++stats.numKernelLaunched;
 
     if (kernelExitEvents) {
-        exitSimLoopNow("GPU Kernel Started");
+        exitSimulationLoopClassicNow("GPU Kernel Started");
     }
 
     DPRINTF(GPUDisp, "launching kernel: %s, dispatch ID: %d\n",

--- a/src/gpu-compute/gpu_command_processor.cc
+++ b/src/gpu-compute/gpu_command_processor.cc
@@ -378,7 +378,7 @@ GPUCommandProcessor::dispatchKernelObject(AMDKernelCode *akc, void *raw_pkt,
 
         // This allows debug-at and exit-at GPU task options to work
         if (dispatcher.hasKernelExitEvents()) {
-            exitSimLoop("GPU Blit Kernel Completed");
+            exitSimulationLoopClassic("GPU Blit Kernel Completed");
         }
 
         ++dynamic_task_id;
@@ -411,7 +411,7 @@ GPUCommandProcessor::dispatchKernelObject(AMDKernelCode *akc, void *raw_pkt,
         delete akc;
 
         // Notify the run script that a kernel has been skipped
-        exitSimLoop("Skipping GPU Kernel");
+        exitSimulationLoopClassic("Skipping GPU Kernel");
 
         return;
     }

--- a/src/gpu-compute/gpu_command_processor.cc
+++ b/src/gpu-compute/gpu_command_processor.cc
@@ -393,7 +393,7 @@ GPUCommandProcessor::dispatchKernelObject(AMDKernelCode *akc, void *raw_pkt,
         delete akc;
 
         // Notify the run script that a kernel has been skipped
-        exitSimLoop("Skipping GPU Kernel");
+        exitSimulationLoopClassic("Skipping GPU Kernel");
 
         return;
     }

--- a/src/gpu-compute/shader.cc
+++ b/src/gpu-compute/shader.cc
@@ -567,9 +567,9 @@ Shader::notifyCuSleep()
         if (kernelExitRequested) {
             kernelExitRequested = false;
             if (blitKernel) {
-                exitSimLoop("GPU Blit Kernel Completed");
+                exitSimulationLoopClassic("GPU Blit Kernel Completed");
             } else {
-                exitSimLoop("GPU Kernel Completed");
+                exitSimulationLoopClassic("GPU Kernel Completed");
             }
         }
     }

--- a/src/kern/linux/events.cc
+++ b/src/kern/linux/events.cc
@@ -71,7 +71,8 @@ PanicOrOopsEvent::process(ThreadContext *tc)
     }
 
     if (behaviour == KernelPanicOopsBehaviour::DumpDmesgAndExit) {
-        exitSimLoop(descr(), static_cast<int>(1), curTick(), false);
+        exitSimulationLoopClassic(descr(), static_cast<int>(1), curTick(),
+                                  false);
     } else if (behaviour == KernelPanicOopsBehaviour::DumpDmesgAndPanic) {
         panic(descr());
     }

--- a/src/learning_gem5/part2/goodbye_object.cc
+++ b/src/learning_gem5/part2/goodbye_object.cc
@@ -94,7 +94,8 @@ GoodbyeObject::fillBuffer()
     } else {
         DPRINTF(HelloExample, "Goodbye done copying!\n");
         // Be sure to take into account the time for the last bytes
-        exitSimLoop(buffer, 0, curTick() + bandwidth * bytes_copied);
+        exitSimulationLoopClassic(buffer, 0,
+                                  curTick() + bandwidth * bytes_copied);
     }
 }
 

--- a/src/mem/cache/base.hh
+++ b/src/mem/cache/base.hh
@@ -1276,7 +1276,8 @@ class BaseCache : public ClockedObject
         if (missCount) {
             --missCount;
             if (missCount == 0)
-                exitSimLoop("A cache reached the maximum miss count");
+                exitSimulationLoopClassic(
+                    "A cache reached the maximum miss count");
         }
     }
     void incHitCount(PacketPtr pkt)

--- a/src/mem/ruby/network/MessageBufferTest.hh
+++ b/src/mem/ruby/network/MessageBufferTest.hh
@@ -102,7 +102,7 @@ class MessageBufferConsumerTest : public ClockedObject, Consumer
             scheduleEvent(Cycles(1));
         }
         if (num_msgs >= max_msgs) {
-            exitSimLoop("max number of operations reached");
+            exitSimulationLoopClassic("max number of operations reached");
         }
     }
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -309,7 +309,7 @@ TlmGenerator::terminate(Transaction *transaction)
         suiteFailure = suiteFailure || transaction->failed();
 
         if (!isActive()) {
-            exitSimLoop("TlmGenerator done");
+            exitSimulationLoopClassic("TlmGenerator done");
         }
     } else {
         panic("%u: Can't find transaction id.\n", phase.txn_id);

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -304,7 +304,7 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
     }
 
     if (!isActive()) {
-        exitSimLoop("TlmGenerator done");
+        exitSimulationLoopClassic("TlmGenerator done");
     }
 }
 

--- a/src/mem/ruby/system/CacheRecorder.cc
+++ b/src/mem/ruby/system/CacheRecorder.cc
@@ -103,7 +103,7 @@ CacheRecorder::enqueueNextFlushRequest()
 
     } else {
         if (m_records_flushed > 0) {
-            exitSimLoop("Finished Drain", 0);
+            exitSimulationLoopClassic("Finished Drain");
         }
         DPRINTF(RubyCacheTrace, "Flushed all %d records\n", m_records_flushed);
     }
@@ -157,7 +157,7 @@ CacheRecorder::enqueueNextFetchRequest()
         m_bytes_read += (sizeof(TraceRecord) + m_block_size_bytes);
         m_records_read++;
     } else {
-        exitSimLoop("Finished Warmup", 0);
+        exitSimulationLoopClassic("Finished Warmup");
         DPRINTF(RubyCacheTrace, "Fetched all %d records\n", m_records_read);
     }
 }

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -46,6 +46,8 @@ import m5
 from m5 import options
 from m5.util import warn
 
+from _m5 import event as _m5_event
+
 from ..utils.override import overrides
 from .exit_event import ExitEvent
 from .exit_event_generators import (
@@ -59,33 +61,86 @@ from .exit_event_generators import (
     warn_default_decorator,
 )
 
+HypercallSelector = Union[int, str, _m5_event.ExitHypercall]
+
+
+def _hypercall_name_candidates(raw: str) -> List[str]:
+    cleaned = raw.strip()
+    if not cleaned:
+        return []
+    snake = cleaned.replace("-", "_").replace(" ", "_")
+    pascal = "".join(part.capitalize() for part in snake.split("_") if part)
+    candidates = [cleaned, snake, snake.upper(), cleaned.upper(), pascal]
+    deduped = []
+    for candidate in candidates:
+        if candidate and candidate not in deduped:
+            deduped.append(candidate)
+    return deduped
+
+
+def _resolve_hypercall_id(selector: HypercallSelector) -> int:
+    if isinstance(selector, _m5_event.ExitHypercall):
+        return int(selector.value)
+    if isinstance(selector, str):
+        for candidate in _hypercall_name_candidates(selector):
+            if hasattr(_m5_event.ExitHypercall, candidate):
+                return int(getattr(_m5_event.ExitHypercall, candidate).value)
+        raise ValueError(
+            f"Unknown hypercall '{selector}'. Known values: "
+            f"{', '.join(member.name for member in _m5_event.ExitHypercall)}"
+        )
+    try:
+        return int(selector)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Unable to convert '{selector}' into a hypercall ID"
+        ) from exc
+
 
 class ExitHandlerMeta(ABCMeta):
     """Metaclass for ExitHandler that automatically registers subclasses"""
 
-    def __new__(mcs, name, bases, attrs, hypercall_num: int = None) -> Any:
+    def __new__(
+        mcs,
+        name,
+        bases,
+        attrs,
+        hypercall_num: Optional[HypercallSelector] = None,
+        hypercall: Optional[HypercallSelector] = None,
+    ) -> Any:
+        if hypercall is not None and hypercall_num is not None:
+            raise TypeError(
+                "Specify only one of 'hypercall' or 'hypercall_num'."
+            )
+        selector = hypercall if hypercall is not None else hypercall_num
+
         cls = super().__new__(mcs, name, bases, attrs)
         # Don't register the base ExitHandler class itself
         if name != "ExitHandler":
-            # If hypercall_num is not provided, and the class is a subclass
-            # of another ExitHandler, use the hypercall_num of the base class
+            hypercall_id = (
+                _resolve_hypercall_id(selector)
+                if selector is not None
+                else None
+            )
+            # If no hypercall is provided, and the class is a subclass of another
+            # ExitHandler, reuse the hypercall of the base class.
             for base in bases:
                 if base in ExitHandler.get_handler_map().values():
-                    hypercall_num = base.get_handler_id()
+                    hypercall_id = base.get_handler_id()
                     break
-            assert hypercall_num is not None, (
-                f"Hypercall number must be provided for {name}. Use "
-                "`class {name}(ExitHandler, hypercall_num={hypercall_num}):`"
+            assert hypercall_id is not None, (
+                f"Hypercall identifier must be provided for {name}. Use "
+                "`class {name}(ExitHandler, hypercall=<hypercall>):`"
             )
-            ExitHandler._handler_map[hypercall_num] = cls
-            cls._handler_id = hypercall_num
+            ExitHandler._handler_map[hypercall_id] = cls
+            cls._handler_id = hypercall_id
 
         return cls
 
 
 class ExitHandler(metaclass=ExitHandlerMeta):
 
-    _handler_map: Dict[str, Type["ExitHandler"]] = {}
+    _handler_map: Dict[int, Type["ExitHandler"]] = {}
     _handler_id: int = None
 
     @classmethod
@@ -94,7 +149,7 @@ class ExitHandler(metaclass=ExitHandlerMeta):
         return cls._handler_id
 
     @classmethod
-    def get_handler_map(cls) -> Dict[str, Type["ExitHandler"]]:
+    def get_handler_map(cls) -> Dict[int, Type["ExitHandler"]]:
         """Returns the mapping of exit handler IDs to handler classes"""
         return cls._handler_map
 
@@ -122,22 +177,15 @@ class ExitHandler(metaclass=ExitHandlerMeta):
 
 
 def _ExitHandlerFactory(
-    hypercall_num: int, func: Callable[["Simulator"], bool], description: str
+    hypercall: HypercallSelector,
+    func: Callable[["Simulator"], bool],
+    description: str,
 ) -> Type[ExitHandler]:
-    """
-    Factory function to create a new ExitHandler class with a specific hypercall number,
-    processing function, and description.
-    Args:
-        hypercall_num (int): The hypercall number associated with the exit handler.
-        func (Callable[["Simulator"], bool]): A callable that takes a Simulator instance
-            and returns a boolean indicating whether the simulation should exit.
-        description (str): A description of the exit handler.
-    Returns:
-        Type[ExitHandler]: A new ExitHandler class with the specified hypercall number,
-        processing function, and description.
-    """
+    """Factory for creating ExitHandlers bound to a specific hypercall."""
 
-    class NewExitHandler(ExitHandler, hypercall_num=hypercall_num):
+    resolved_id = _resolve_hypercall_id(hypercall)
+
+    class NewExitHandler(ExitHandler, hypercall=resolved_id):
         def __init__(self, payload):
             super().__init__(payload)
             self.should_exit = False
@@ -155,31 +203,39 @@ def _ExitHandlerFactory(
 
 
 def register_exit_handler(
-    hypercall_num: int,
+    hypercall: Optional[HypercallSelector],
     func: Callable[["Simulator", dict], bool],
     description: str,
+    *,
+    hypercall_num: Optional[HypercallSelector] = None,
 ) -> Type[ExitHandler]:
-    """This function registers a new exit handler with a specific hypercall
-    number. Whenever this hypercall is encountered, the provided function will
-    be called with the simulator instance and the payload of the hypercall. The
-    function should return a boolean indicating whether the simulation should
-    exit.
+    """Register a new exit handler for the provided hypercall.
+
+    ``hypercall`` (or the legacy ``hypercall_num`` keyword) may be an ``int``,
+    a string matching one of the ``ExitHypercall`` members (case-insensitive,
+    supporting ``snake_case`` or ``CamelCase``), or an
+    ``_m5.event.ExitHypercall`` enum value.
 
     Args:
-        hypercall_num (int): The hypercall number associated with the exit handler.
-        func (Callable[["Simulator", dict], bool]): A callable that takes a Simulator
-            instance and a dictionary containing the payload of the hypercall, and
-            returns a boolean indicating whether the simulation should exit.
-        description (str): A description of the exit handler.
+        hypercall: Identifier for the exit handler (preferred name).
+        func: Callable that receives the Simulator and hypercall payload.
+        description: Human-readable summary for logging.
+        hypercall_num: Backwards-compatible alias for ``hypercall``.
 
     Returns:
-        Type[ExitHandler]: A new ExitHandler class with the specified hypercall number,
-        processing function, and description.
+        Type[ExitHandler]: A new ExitHandler class bound to the requested hypercall.
     """
-    return _ExitHandlerFactory(hypercall_num, func, description)
+    if hypercall is None and hypercall_num is None:
+        raise ValueError("A hypercall identifier must be provided.")
+    if hypercall is not None and hypercall_num is not None:
+        raise ValueError("Specify only one of 'hypercall' or 'hypercall_num'.")
+    selector = hypercall if hypercall is not None else hypercall_num
+    return _ExitHandlerFactory(selector, func, description)
 
 
-class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
+class ScheduledExitEventHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.ScheduledExit
+):
     """A handler designed to be the default for  an Exit scheduled to occur
     at a specified tick. For example, these Exit exits can be triggered through be
     src/python/m5/simulate.py's `scheduleTickExitFromCurrent` and
@@ -228,7 +284,9 @@ class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
         return True
 
 
-class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class KernelBootedExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.KernelBooted
+):
 
     @overrides(ExitHandler)
     def get_handler_description(self):
@@ -243,7 +301,9 @@ class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
         return False
 
 
-class AfterBootExitHandler(ExitHandler, hypercall_num=2):
+class AfterBootExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.AfterBoot
+):
 
     @overrides(ExitHandler)
     def get_handler_description(self):
@@ -258,7 +318,9 @@ class AfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.AfterBootScript
+):
 
     @overrides(ExitHandler)
     def get_handler_description(self):
@@ -273,7 +335,9 @@ class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
         return True
 
 
-class CheckpointExitHandler(ExitHandler, hypercall_num=7):
+class CheckpointExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.Checkpoint
+):
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         checkpoint_dir = simulator._checkpoint_path
@@ -288,7 +352,9 @@ class CheckpointExitHandler(ExitHandler, hypercall_num=7):
         return False
 
 
-class WorkBeginExitHandler(ExitHandler, hypercall_num=4):
+class WorkBeginExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.WorkBegin
+):
 
     @overrides(ExitHandler)
     def get_handler_description(self):
@@ -303,7 +369,9 @@ class WorkBeginExitHandler(ExitHandler, hypercall_num=4):
         return False
 
 
-class WorkEndExitHandler(ExitHandler, hypercall_num=5):
+class WorkEndExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.WorkEnd
+):
 
     @overrides(ExitHandler)
     def get_handler_description(self):
@@ -318,7 +386,9 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
         return False
 
 
-class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
+class OrchestratorExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.Orchestrator
+):
 
     def _get_status(self, simulator: "Simulator") -> Dict[str, str]:
         import _m5.core
@@ -398,7 +468,9 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         return False
 
 
-class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
+class ClassicGeneratorExitHandler(
+    ExitHandler, hypercall=_m5_event.ExitHypercall.ClassicGenerator
+):
     """A handler designed to be the default for the classic exit event.
 
     ``on_exit_event`` usage notes

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -24,10 +24,62 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+"""Exit handler helpers for the gem5 Python stdlib.
+
+This module is the stdlib side of gem5's hypercall-driven simulation-exit
+infrastructure. A hypercall exit may originate inside the simulator, when a
+model calls an ``exitSimulationLoop`` API with a hypercall ID, or in the guest
+application, when code linked with the m5 library calls ``m5_hypercall``. The
+``Simulator`` run loop reads that ID from the resulting exit event, looks it up
+in ``ExitHandler.get_handler_map()``, constructs the matching ``ExitHandler``
+with the event payload, and calls ``handle()``.
+
+Terminology
+-----------
+
+``hypercall``
+    The broad guest/simulator request mechanism. In this file, hypercalls are
+    used to route simulation exits to Python handlers.
+
+``hypercall ID``
+    The integer value carried by the exit event. This is the runtime dispatch
+    key. All handler registration eventually resolves to this integer.
+
+``ExitHypercall``
+    The pybind11 enum exposing gem5's built-in exit-handler hypercall IDs,
+    generated from the C++ ``gem5::ExitHypercall`` enum. Use enum members such
+    as ``ExitHypercall.WORK_BEGIN`` for built-in handlers.
+
+``HypercallId``
+    The Python type accepted by registration helpers: either an
+    ``ExitHypercall`` enum member for a built-in hypercall or a raw ``int`` for
+    a custom/user-defined hypercall ID. Strings are intentionally not accepted
+    as selectors so call sites do not rely on loose name parsing.
+
+Typical usage
+-------------
+
+Subclass ``ExitHandler`` for full control::
+
+    class MyWorkBeginHandler(ExitHandler, hypercall=ExitHypercall.WORK_BEGIN):
+        def _process(self, simulator: "Simulator") -> None:
+            ...
+
+        def _exit_simulation(self) -> bool:
+            return False
+
+Use ``register_exit_handler`` for simple function-based handlers::
+
+    def handle_custom(simulator: "Simulator", payload: HypercallPayload) -> bool:
+        return False
+
+    register_exit_handler(None, handle_custom, "custom", hypercall_id=4096)
+"""
+
 import json
 import socket
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod,
 )
 from pathlib import Path
@@ -46,6 +98,13 @@ import m5
 from m5 import options
 from m5.util import warn
 
+from _m5 import event as _m5_event
+
+# Public finite-set selector for the hypercalls built into gem5. This pybind11
+# enum is generated from the same C++ ExitHypercall enum that is backed by
+# include/gem5/hypercall_ids.h.
+ExitHypercall = _m5_event.ExitHypercall
+
 from ..utils.override import overrides
 from .exit_event import ExitEvent
 from .exit_event_generators import (
@@ -59,86 +118,232 @@ from .exit_event_generators import (
     warn_default_decorator,
 )
 
+"""Structured key/value metadata attached to a hypercall exit event.
 
-class ExitHandlerMeta(ABCMeta):
-    """Metaclass for ExitHandler that automatically registers subclasses"""
+The C++/pybind interface currently transports payload values as strings, so
+handlers should parse values explicitly when they need integers, booleans, or
+other richer types.
+"""
+HypercallPayload = Dict[str, str]
 
-    def __new__(mcs, name, bases, attrs, hypercall_num: int = None) -> Any:
-        cls = super().__new__(mcs, name, bases, attrs)
-        # Don't register the base ExitHandler class itself
-        if name != "ExitHandler":
-            # If hypercall_num is not provided, and the class is a subclass
-            # of another ExitHandler, use the hypercall_num of the base class
-            for base in bases:
-                if base in ExitHandler.get_handler_map().values():
-                    hypercall_num = base.get_handler_id()
-                    break
-            assert hypercall_num is not None, (
-                f"Hypercall number must be provided for {name}. Use "
-                "`class {name}(ExitHandler, hypercall_num={hypercall_num}):`"
+"""A hypercall identifier accepted by the Python ExitHandler registry.
+
+Use ``ExitHypercall`` enum members for gem5-defined exit-handler hypercalls.
+Use a raw ``int`` only for custom/user-defined hypercall IDs that are not part
+of gem5's built-in ``ExitHypercall`` enum.
+"""
+HypercallId = Union[int, ExitHypercall]
+
+"""Callable used by ``register_exit_handler``.
+
+The function receives the active ``Simulator`` and the hypercall payload. It
+returns ``True`` when the simulator should leave the run loop after handling the
+event, or ``False`` to continue.
+"""
+ExitHandlerFunction = Callable[["Simulator", HypercallPayload], bool]
+
+
+def _resolve_hypercall_id(hypercall: HypercallId) -> int:
+    """Return the integer dispatch key for a hypercall selector.
+
+    Args:
+        hypercall: Either an ``ExitHypercall`` enum member for a gem5-defined
+            hypercall or an integer custom/user-defined hypercall ID.
+
+    Returns:
+        The integer hypercall ID used as the key in ``ExitHandler``'s registry.
+
+    Raises:
+        TypeError: If ``hypercall`` is not an ``ExitHypercall`` or ``int``.
+    """
+    if isinstance(hypercall, ExitHypercall):
+        return int(hypercall.value)
+    if isinstance(hypercall, int):
+        return hypercall
+    raise TypeError(
+        "hypercall must be an ExitHypercall enum member or an integer "
+        f"hypercall ID, not {type(hypercall).__name__}"
+    )
+
+
+def _select_hypercall(
+    hypercall: Optional[HypercallId],
+    hypercall_id: Optional[int],
+) -> Optional[HypercallId]:
+    """Choose one of the public selector arguments.
+
+    Args:
+        hypercall: Preferred selector argument. Use an ``ExitHypercall`` enum
+            member for gem5-defined hypercalls or an integer for custom IDs.
+        hypercall_id: Explicit integer-only alias for custom/raw IDs. This
+            exists to make custom ID registration self-documenting at call sites.
+
+    Returns:
+        The selected hypercall identifier, or ``None`` if neither was supplied.
+
+    Raises:
+        TypeError: If both selector arguments are supplied.
+    """
+    if hypercall is not None and hypercall_id is not None:
+        raise TypeError("Specify only one of 'hypercall' or 'hypercall_id'.")
+    return hypercall if hypercall is not None else hypercall_id
+
+
+class ExitHandler(ABC):
+    """Base class for all stdlib hypercall exit handlers.
+
+    Subclasses register themselves when the class is created. The class-level
+    registry maps an integer hypercall ID to the handler class responsible for
+    that ID. The ``Simulator`` run loop uses this map after each hypercall exit
+    event to choose which handler to instantiate.
+
+    A subclass normally specifies ``hypercall=ExitHypercall.SOME_VALUE``. For
+    custom hypercall IDs outside gem5's enum, use ``hypercall_id=<int>``.
+    Subclasses of an existing registered handler inherit the base handler's ID
+    unless they explicitly provide a different one.
+    """
+
+    # Shared registry used by the Simulator to map a hypercall ID to the
+    # ExitHandler subclass that should be instantiated for that exit event.
+    _handler_map: Dict[int, Type["ExitHandler"]] = {}
+
+    # Hypercall ID handled by this class. Each registered subclass gets its own
+    # value, while the base ExitHandler class keeps None.
+    _handler_id: Optional[int] = None
+
+    def __init_subclass__(
+        cls,
+        *,
+        hypercall: Optional[HypercallId] = None,
+        hypercall_id: Optional[int] = None,
+        hypercall_num: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Register subclasses by the hypercall ID they handle.
+
+        Args:
+            hypercall: Preferred selector. Use an ``ExitHypercall`` enum member
+                for a gem5-defined hypercall or an integer custom ID.
+            hypercall_id: Explicit integer-only selector for raw/custom IDs.
+            hypercall_num: Deprecated compatibility alias for ``hypercall_id``.
+            **kwargs: Additional subclass keyword arguments for other base
+                classes.
+
+        Raises:
+            TypeError: If both selector arguments are supplied, or if no
+                selector can be determined from this class or its bases.
+
+        ``hypercall_id`` is accepted when callers want to pass a raw/custom
+        integer ID explicitly. New handlers for gem5-defined hypercalls should
+        usually use ``hypercall`` with an ``ExitHypercall`` enum member.
+        Subclasses of existing handlers inherit the base handler's hypercall
+        unless they explicitly specify a different one.
+        """
+        super().__init_subclass__(**kwargs)
+
+        selector = _select_hypercall(hypercall, hypercall_id)
+        if hypercall_num is not None:
+            if selector is not None:
+                raise TypeError(
+                    "Specify only one of 'hypercall', 'hypercall_id', or "
+                    "'hypercall_num'."
+                )
+            selector = hypercall_num
+
+        if selector is None:
+            hypercall_id = cls._handler_id
+        else:
+            hypercall_id = _resolve_hypercall_id(selector)
+
+        if hypercall_id is None:
+            raise TypeError(
+                f"Hypercall identifier must be provided for {cls.__name__}. "
+                f"Use `class {cls.__name__}(ExitHandler, hypercall=<hypercall>):`"
             )
-            ExitHandler._handler_map[hypercall_num] = cls
-            cls._handler_id = hypercall_num
 
-        return cls
-
-
-class ExitHandler(metaclass=ExitHandlerMeta):
-
-    _handler_map: Dict[str, Type["ExitHandler"]] = {}
-    _handler_id: int = None
+        cls._handler_id = hypercall_id
+        ExitHandler._handler_map[hypercall_id] = cls
 
     @classmethod
-    def get_handler_id(cls) -> int:
-        """Returns the ID of the exit handler"""
+    def get_handler_id(cls) -> Optional[int]:
+        """Returns the hypercall ID handled by this class.
+
+        Returns ``None`` for the base ``ExitHandler`` class.
+        """
         return cls._handler_id
 
     @classmethod
-    def get_handler_map(cls) -> Dict[str, Type["ExitHandler"]]:
-        """Returns the mapping of exit handler IDs to handler classes"""
+    def get_handler_map(cls) -> Dict[int, Type["ExitHandler"]]:
+        """Returns the mapping of hypercall IDs to handler classes."""
         return cls._handler_map
 
-    def __init__(self, payload: Dict[str, str]) -> None:
+    def __init__(self, payload: HypercallPayload) -> None:
+        """Create a handler for a single hypercall exit event.
+
+        Args:
+            payload: String key/value metadata attached to the exit event.
+        """
         self._payload = payload
 
     def handle(self, simulator: "Simulator") -> bool:
+        """Run this handler and report whether simulation should stop.
+
+        Args:
+            simulator: The active ``Simulator`` instance.
+
+        Returns:
+            ``True`` if ``Simulator.run()`` should return after this handler;
+            ``False`` if the simulator should re-enter the event loop.
+        """
         self._process(simulator)
         return self._exit_simulation()
 
     def get_handler_description(self) -> str:
+        """Return a human-readable description for logs/status output."""
         return f"Exit Handler {self.__class__.__name__} called."
 
     @abstractmethod
     def _process(self, simulator: "Simulator") -> None:
+        """Perform the handler's side effects.
+
+        Args:
+            simulator: The active ``Simulator`` instance.
+        """
         raise NotImplementedError(
             "Method '_process' must be implemented by a subclass"
         )
 
     @abstractmethod
     def _exit_simulation(self) -> bool:
+        """Return whether simulation should stop after ``_process``.
+
+        Returns:
+            ``True`` to leave ``Simulator.run()``; ``False`` to continue.
+        """
         raise NotImplementedError(
             "Method '_exit_simulation' must be implemented by a subclass"
         )
 
 
 def _ExitHandlerFactory(
-    hypercall_num: int, func: Callable[["Simulator"], bool], description: str
+    hypercall: HypercallId,
+    func: ExitHandlerFunction,
+    description: str,
 ) -> Type[ExitHandler]:
-    """
-    Factory function to create a new ExitHandler class with a specific hypercall number,
-    processing function, and description.
+    """Create an ``ExitHandler`` subclass around a plain Python callable.
+
     Args:
-        hypercall_num (int): The hypercall number associated with the exit handler.
-        func (Callable[["Simulator"], bool]): A callable that takes a Simulator instance
-            and returns a boolean indicating whether the simulation should exit.
-        description (str): A description of the exit handler.
+        hypercall: Built-in ``ExitHypercall`` enum member or custom integer ID
+            to bind to the generated handler class.
+        func: Function to call when the hypercall is handled.
+        description: Human-readable description stored on the handler instance.
+
     Returns:
-        Type[ExitHandler]: A new ExitHandler class with the specified hypercall number,
-        processing function, and description.
+        A newly defined ``ExitHandler`` subclass registered for ``hypercall``.
     """
 
-    class NewExitHandler(ExitHandler, hypercall_num=hypercall_num):
-        def __init__(self, payload):
+    class NewExitHandler(ExitHandler, hypercall=hypercall):
+        def __init__(self, payload: HypercallPayload) -> None:
             super().__init__(payload)
             self.should_exit = False
             self.description = description
@@ -151,44 +356,69 @@ def _ExitHandlerFactory(
         def _exit_simulation(self) -> bool:
             return self.should_exit
 
+        @overrides(ExitHandler)
+        def get_handler_description(self) -> str:
+            return self.description
+
     return NewExitHandler
 
 
 def register_exit_handler(
-    hypercall_num: int,
-    func: Callable[["Simulator", dict], bool],
+    hypercall: Optional[HypercallId],
+    func: ExitHandlerFunction,
     description: str,
+    *,
+    hypercall_id: Optional[int] = None,
 ) -> Type[ExitHandler]:
-    """This function registers a new exit handler with a specific hypercall
-    number. Whenever this hypercall is encountered, the provided function will
-    be called with the simulator instance and the payload of the hypercall. The
-    function should return a boolean indicating whether the simulation should
-    exit.
+    """Register a new exit handler for the provided hypercall.
+
+    ``hypercall`` may be an ``ExitHypercall`` enum value for gem5-defined
+    hypercalls or an ``int`` for custom/user-defined hypercalls. Use the
+    ``hypercall_id`` keyword only when passing a raw/custom integer ID.
 
     Args:
-        hypercall_num (int): The hypercall number associated with the exit handler.
-        func (Callable[["Simulator", dict], bool]): A callable that takes a Simulator
-            instance and a dictionary containing the payload of the hypercall, and
-            returns a boolean indicating whether the simulation should exit.
-        description (str): A description of the exit handler.
+        hypercall: Preferred selector. Use an ``ExitHypercall`` enum member for
+            gem5-defined hypercalls or an integer for a custom ID. Pass ``None``
+            only when using the keyword-only ``hypercall_id`` argument.
+        func: Function called with ``(simulator, payload)`` when the hypercall
+            is handled. It returns whether simulation should stop.
+        description: Human-readable summary for logging/status output.
+        hypercall_id: Explicit raw/custom integer hypercall ID.
 
     Returns:
-        Type[ExitHandler]: A new ExitHandler class with the specified hypercall number,
-        processing function, and description.
+        A new ``ExitHandler`` subclass bound to the requested hypercall.
+
+    Raises:
+        ValueError: If neither selector is provided or both are provided.
+
+    Note:
+        Use ``hypercall`` with an ``ExitHypercall`` enum member for gem5-defined
+        hypercalls; use ``hypercall_id`` when registering a raw/custom integer
+        ID that is not part of the built-in enum.
     """
-    return _ExitHandlerFactory(hypercall_num, func, description)
+    try:
+        selector = _select_hypercall(hypercall, hypercall_id)
+    except TypeError as exc:
+        raise ValueError(str(exc)) from exc
+    if selector is None:
+        raise ValueError("A hypercall identifier must be provided.")
+    return _ExitHandlerFactory(selector, func, description)
 
 
-class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
-    """A handler designed to be the default for  an Exit scheduled to occur
-    at a specified tick. For example, these Exit exits can be triggered through be
-    src/python/m5/simulate.py's `scheduleTickExitFromCurrent` and
-    `scheduleTickExitAbsolute` functions.
+class ScheduledExitEventHandler(
+    ExitHandler, hypercall=ExitHypercall.SCHEDULED_EXIT
+):
+    """Default handler for simulator-scheduled tick exits.
 
-    It will exit the simulation loop by default.
+    ``SCHEDULED_EXIT`` is used when gem5 itself schedules a future exit, for
+    example via ``m5.scheduleTickExitFromCurrent`` or the stdlib
+    ``Simulator.set_hypercall_*_max_ticks`` helpers. This handler exits the
+    simulator run loop by default. The payload may include:
 
-    The `justification` and `scheduled_at_tick` methods are provided to give
-    richer information about this schedule exit.
+    ``justification``
+        Human-readable reason for scheduling the exit.
+    ``scheduled_at_tick``
+        Tick at which the scheduled exit was created.
     """
 
     @overrides(ExitHandler)
@@ -196,42 +426,29 @@ class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
         pass
 
     def justification(self) -> Optional[str]:
-        """Returns the justification for the scheduled exit event.
-
-        This information may be passed to when scheduling the event event to
-        remind the user why the event was scheduled, or used in cases where
-        lots of scheduled events are used and there is a need to differentiate
-        them.
-
-        Returns "None" if this information was not set.
-        """
-        return (
-            None
-            if "justification" not in self._payload
-            else self._payload["justification"]
-        )
+        """Returns why this scheduled exit event was created, if available."""
+        return self._payload.get("justification")
 
     def scheduled_at_tick(self) -> Optional[int]:
-        """Returns the tick in which the event was scheduled on (not scheduled
-        to occur, but the tick the event was created).
-
-        Returns "None" if this information is not available.
-        """
-        return (
-            None
-            if "scheduled_at_tick" not in self._payload
-            else int(self._payload["scheduled_at_tick"])
-        )
+        """Returns the tick at which this exit was scheduled, if available."""
+        tick = self._payload.get("scheduled_at_tick")
+        return None if tick is None else int(tick)
 
     @overrides(ExitHandler)
     def _exit_simulation(self) -> bool:
         return True
 
 
-class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class KernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
+    """Handle the guest reporting that the kernel has booted.
+
+    The default behavior is to continue simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Kernel booted."
 
     @overrides(ExitHandler)
@@ -243,10 +460,14 @@ class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
         return False
 
 
-class AfterBootExitHandler(ExitHandler, hypercall_num=2):
+class AfterBootExitHandler(ExitHandler, hypercall=ExitHypercall.AFTER_BOOT):
+    """Handle the guest entering the ``after_boot`` hook.
+
+    The default behavior is to continue simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Started `after_boot.sh` script."
 
     @overrides(ExitHandler)
@@ -258,10 +479,16 @@ class AfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
+    """Handle the guest completing ``after_boot.sh``.
+
+    The default behavior is to exit the simulator run loop.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Finished `after_boot.sh` script."
 
     @overrides(ExitHandler)
@@ -273,7 +500,13 @@ class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
         return True
 
 
-class CheckpointExitHandler(ExitHandler, hypercall_num=7):
+class CheckpointExitHandler(ExitHandler, hypercall=ExitHypercall.CHECKPOINT):
+    """Take a gem5 checkpoint and continue simulation.
+
+    The checkpoint is written below ``simulator._checkpoint_path`` when set,
+    otherwise below the current gem5 output directory.
+    """
+
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         checkpoint_dir = simulator._checkpoint_path
@@ -288,10 +521,14 @@ class CheckpointExitHandler(ExitHandler, hypercall_num=7):
         return False
 
 
-class WorkBeginExitHandler(ExitHandler, hypercall_num=4):
+class WorkBeginExitHandler(ExitHandler, hypercall=ExitHypercall.WORK_BEGIN):
+    """Handle the start of a region of interest.
+
+    The default behavior resets gem5 statistics and continues simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Started executing Region of Interest (ROI)."
 
     @overrides(ExitHandler)
@@ -303,10 +540,14 @@ class WorkBeginExitHandler(ExitHandler, hypercall_num=4):
         return False
 
 
-class WorkEndExitHandler(ExitHandler, hypercall_num=5):
+class WorkEndExitHandler(ExitHandler, hypercall=ExitHypercall.WORK_END):
+    """Handle the end of a region of interest.
+
+    The default behavior dumps gem5 statistics and continues simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Finished executing Region of Interest (ROI)."
 
     @overrides(ExitHandler)
@@ -318,9 +559,27 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
         return False
 
 
-class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
+class OrchestratorExitHandler(
+    ExitHandler, hypercall=ExitHypercall.ORCHESTRATOR
+):
+    """Handle out-of-band orchestration/status requests.
 
-    def _get_status(self, simulator: "Simulator") -> Dict[str, str]:
+    The orchestrator hypercall is used by tooling that wants to query or adjust
+    a running simulation. The payload selects a function and may include a Unix
+    domain socket path for the JSON response. Supported functions include
+    ``status``, ``get_stats``, and ``update_debug_flags``.
+    """
+
+    def _get_status(self, simulator: "Simulator") -> Dict[str, Any]:
+        """Collect basic simulator status for an orchestrator response.
+
+        Args:
+            simulator: The active ``Simulator`` instance.
+
+        Returns:
+            A JSON-serializable dictionary of workload, tick, simulator ID, and
+            instruction-count metadata.
+        """
         import _m5.core
 
         if not simulator.get_workload():
@@ -336,6 +595,17 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         }
 
     def _add_debug_flags(self, debug_flags: List[str]) -> Dict[str, str]:
+        """Enable or disable gem5 debug flags.
+
+        Args:
+            debug_flags: Flag names to enable. Prefix a name with ``-`` to
+                disable it instead.
+
+        Returns:
+            A dictionary listing enabled, disabled, and invalid flags. Values
+            are strings so the response is compatible with the current payload
+            conventions.
+        """
         from m5 import debug
 
         flags_disabled = []
@@ -398,7 +668,9 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         return False
 
 
-class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
+class ClassicGeneratorExitHandler(
+    ExitHandler, hypercall=ExitHypercall.CLASSIC_GENERATOR
+):
     """A handler designed to be the default for the classic exit event.
 
     ``on_exit_event`` usage notes
@@ -482,8 +754,8 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
     this example, the first ``EXIT`` type exit event will cause ``print_hello``
     to be executed, and the second ``EXIT`` type exit event will cause the
     ``switch_cpus`` function to run. The third will execute ``print_hello``
-    again before finally, on the forth exit event will call
-    ``stop_simulation`` which will stop the simulation as it returns ``False``.
+    again before finally, on the fourth exit event, ``stop_simulation`` will
+    stop the simulation by returning ``True``.
 
     With a function
     ===============
@@ -531,9 +803,15 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
     These generators can be found in the ``exit_event_generator.py`` module.
     """
 
-    def __init__(self, payload: Dict[str, str]) -> None:
+    def __init__(self, payload: HypercallPayload) -> None:
+        """Create a classic-generator compatibility handler instance.
+
+        Args:
+            payload: Payload containing at least the legacy ``cause`` when the
+                event came through the new structured hypercall path.
+        """
         super().__init__(payload)
-        self._exit_on_completion = None
+        self._exit_on_completion: Optional[bool] = None
 
     @classmethod
     def set_exit_event_map(
@@ -543,14 +821,31 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
                 ExitEvent,
                 Union[
                     Generator[Optional[bool], None, None],
-                    List[Callable],
-                    Callable,
+                    List[Callable[[], Optional[bool]]],
+                    Callable[[], Optional[bool]],
                 ],
             ]
         ],
         expected_execution_order: Optional[List[ExitEvent]],
         board: Optional["Board"],
     ) -> None:
+        """Configure legacy ``ExitEvent`` handling for classic exits.
+
+        This bridges the older message/cause based exit mechanism to the newer
+        hypercall-dispatch mechanism. ``ClassicGeneratorExitHandler`` receives
+        the classic exit cause, translates it to an ``ExitEvent``, then advances
+        the matching user-supplied or default generator.
+
+        Args:
+            on_exit_event: Optional mapping from ``ExitEvent`` to a generator,
+                list of zero-argument callables, or a single zero-argument
+                callable. Generators/callables yield or return ``True`` to exit
+                the simulator run loop and ``False``/``None`` to continue.
+            expected_execution_order: Optional sequence of ``ExitEvent`` values
+                used to validate that exits occur in the expected order.
+            board: Board whose processor is used by default handlers such as
+                CPU switching and spatter synchronization.
+        """
         # We specify a dictionary here outlining the default behavior for each
         # exit event. Each exit event is mapped to a generator.
         cls._default_on_exit_dict = {
@@ -626,7 +921,9 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
                             "of `ExitEvent.EVENT : gen`)"
                         )
 
-                    def function_generator(func: Callable):
+                    def function_generator(
+                        func: Callable[[], Optional[bool]],
+                    ) -> Generator[Optional[bool], None, None]:
                         while True:
                             yield func()
 
@@ -643,10 +940,13 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
 
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
-        #  # Translate the exit event cause to the exit event enum.
-        exit_enum = ExitEvent.translate_exit_status(
-            simulator.get_last_exit_event_cause()
-        )
+        # Translate the exit event cause to the exit event enum. New-style
+        # ClassicGenerator exits store the legacy cause in the structured
+        # payload rather than the GlobalSimLoopExitEvent cause field.
+        cause = self._payload.get("cause")
+        if cause is None:
+            cause = simulator.get_last_exit_event_cause()
+        exit_enum = ExitEvent.translate_exit_status(cause)
 
         # Check to see the run is corresponding to the expected execution
         # order (assuming this check is demanded by the user).

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -158,7 +158,13 @@ def _resolve_hypercall_id(hypercall: HypercallId) -> int:
     """
     if isinstance(hypercall, ExitHypercall):
         return int(hypercall.value)
+    if isinstance(hypercall, bool):
+        raise TypeError("hypercall IDs must be integers, not bool")
     if isinstance(hypercall, int):
+        if not 0 <= hypercall <= (1 << 64) - 1:
+            raise ValueError(
+                "hypercall IDs must fit in an unsigned 64-bit integer"
+            )
         return hypercall
     raise TypeError(
         "hypercall must be an ExitHypercall enum member or an integer "

--- a/src/python/gem5/simulate/exit_handler.py
+++ b/src/python/gem5/simulate/exit_handler.py
@@ -24,10 +24,60 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+"""Exit handler helpers for the gem5 Python stdlib.
+
+This module is the stdlib side of gem5's hypercall-driven simulation-exit
+infrastructure. A guest or simulator component emits a hypercall ID. The
+``Simulator`` run loop reads that ID from the resulting exit event, looks it up
+in ``ExitHandler.get_handler_map()``, constructs the matching ``ExitHandler``
+with the event payload, and calls ``handle()``.
+
+Terminology
+-----------
+
+``hypercall``
+    The broad guest/simulator request mechanism. In this file, hypercalls are
+    used to route simulation exits to Python handlers.
+
+``hypercall ID``
+    The integer value carried by the exit event. This is the runtime dispatch
+    key. All handler registration eventually resolves to this integer.
+
+``ExitHypercall``
+    The pybind11 enum exposing gem5's built-in exit-handler hypercall IDs,
+    generated from the C++ ``gem5::ExitHypercall`` enum. Use enum members such
+    as ``ExitHypercall.WORK_BEGIN`` for built-in handlers.
+
+``HypercallId``
+    The Python type accepted by registration helpers: either an
+    ``ExitHypercall`` enum member for a built-in hypercall or a raw ``int`` for
+    a custom/user-defined hypercall ID. Strings are intentionally not accepted
+    as selectors so call sites do not rely on loose name parsing.
+
+Typical usage
+-------------
+
+Subclass ``ExitHandler`` for full control::
+
+    class MyWorkBeginHandler(ExitHandler, hypercall=ExitHypercall.WORK_BEGIN):
+        def _process(self, simulator: "Simulator") -> None:
+            ...
+
+        def _exit_simulation(self) -> bool:
+            return False
+
+Use ``register_exit_handler`` for simple function-based handlers::
+
+    def handle_custom(simulator: "Simulator", payload: HypercallPayload) -> bool:
+        return False
+
+    register_exit_handler(None, handle_custom, "custom", hypercall_id=4096)
+"""
+
 import json
 import socket
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod,
 )
 from pathlib import Path
@@ -46,6 +96,13 @@ import m5
 from m5 import options
 from m5.util import warn
 
+from _m5 import event as _m5_event
+
+# Public finite-set selector for the hypercalls built into gem5. This pybind11
+# enum is generated from the same C++ ExitHypercall enum that is backed by
+# include/gem5/hypercall_ids.h.
+ExitHypercall = _m5_event.ExitHypercall
+
 from ..utils.override import overrides
 from .exit_event import ExitEvent
 from .exit_event_generators import (
@@ -59,86 +116,232 @@ from .exit_event_generators import (
     warn_default_decorator,
 )
 
+"""Structured key/value metadata attached to a hypercall exit event.
 
-class ExitHandlerMeta(ABCMeta):
-    """Metaclass for ExitHandler that automatically registers subclasses"""
+The C++/pybind interface currently transports payload values as strings, so
+handlers should parse values explicitly when they need integers, booleans, or
+other richer types.
+"""
+HypercallPayload = Dict[str, str]
 
-    def __new__(mcs, name, bases, attrs, hypercall_num: int = None) -> Any:
-        cls = super().__new__(mcs, name, bases, attrs)
-        # Don't register the base ExitHandler class itself
-        if name != "ExitHandler":
-            # If hypercall_num is not provided, and the class is a subclass
-            # of another ExitHandler, use the hypercall_num of the base class
-            for base in bases:
-                if base in ExitHandler.get_handler_map().values():
-                    hypercall_num = base.get_handler_id()
-                    break
-            assert hypercall_num is not None, (
-                f"Hypercall number must be provided for {name}. Use "
-                "`class {name}(ExitHandler, hypercall_num={hypercall_num}):`"
+"""A hypercall identifier accepted by the Python ExitHandler registry.
+
+Use ``ExitHypercall`` enum members for gem5-defined exit-handler hypercalls.
+Use a raw ``int`` only for custom/user-defined hypercall IDs that are not part
+of gem5's built-in ``ExitHypercall`` enum.
+"""
+HypercallId = Union[int, ExitHypercall]
+
+"""Callable used by ``register_exit_handler``.
+
+The function receives the active ``Simulator`` and the hypercall payload. It
+returns ``True`` when the simulator should leave the run loop after handling the
+event, or ``False`` to continue.
+"""
+ExitHandlerFunction = Callable[["Simulator", HypercallPayload], bool]
+
+
+def _resolve_hypercall_id(hypercall: HypercallId) -> int:
+    """Return the integer dispatch key for a hypercall selector.
+
+    Args:
+        hypercall: Either an ``ExitHypercall`` enum member for a gem5-defined
+            hypercall or an integer custom/user-defined hypercall ID.
+
+    Returns:
+        The integer hypercall ID used as the key in ``ExitHandler``'s registry.
+
+    Raises:
+        TypeError: If ``hypercall`` is not an ``ExitHypercall`` or ``int``.
+    """
+    if isinstance(hypercall, ExitHypercall):
+        return int(hypercall.value)
+    if isinstance(hypercall, int):
+        return hypercall
+    raise TypeError(
+        "hypercall must be an ExitHypercall enum member or an integer "
+        f"hypercall ID, not {type(hypercall).__name__}"
+    )
+
+
+def _select_hypercall(
+    hypercall: Optional[HypercallId],
+    hypercall_id: Optional[int],
+) -> Optional[HypercallId]:
+    """Choose one of the public selector arguments.
+
+    Args:
+        hypercall: Preferred selector argument. Use an ``ExitHypercall`` enum
+            member for gem5-defined hypercalls or an integer for custom IDs.
+        hypercall_id: Explicit integer-only alias for custom/raw IDs. This
+            exists to make custom ID registration self-documenting at call sites.
+
+    Returns:
+        The selected hypercall identifier, or ``None`` if neither was supplied.
+
+    Raises:
+        TypeError: If both selector arguments are supplied.
+    """
+    if hypercall is not None and hypercall_id is not None:
+        raise TypeError("Specify only one of 'hypercall' or 'hypercall_id'.")
+    return hypercall if hypercall is not None else hypercall_id
+
+
+class ExitHandler(ABC):
+    """Base class for all stdlib hypercall exit handlers.
+
+    Subclasses register themselves when the class is created. The class-level
+    registry maps an integer hypercall ID to the handler class responsible for
+    that ID. The ``Simulator`` run loop uses this map after each hypercall exit
+    event to choose which handler to instantiate.
+
+    A subclass normally specifies ``hypercall=ExitHypercall.SOME_VALUE``. For
+    custom hypercall IDs outside gem5's enum, use ``hypercall_id=<int>``.
+    Subclasses of an existing registered handler inherit the base handler's ID
+    unless they explicitly provide a different one.
+    """
+
+    # Shared registry used by the Simulator to map a hypercall ID to the
+    # ExitHandler subclass that should be instantiated for that exit event.
+    _handler_map: Dict[int, Type["ExitHandler"]] = {}
+
+    # Hypercall ID handled by this class. Each registered subclass gets its own
+    # value, while the base ExitHandler class keeps None.
+    _handler_id: Optional[int] = None
+
+    def __init_subclass__(
+        cls,
+        *,
+        hypercall: Optional[HypercallId] = None,
+        hypercall_id: Optional[int] = None,
+        hypercall_num: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Register subclasses by the hypercall ID they handle.
+
+        Args:
+            hypercall: Preferred selector. Use an ``ExitHypercall`` enum member
+                for a gem5-defined hypercall or an integer custom ID.
+            hypercall_id: Explicit integer-only selector for raw/custom IDs.
+            hypercall_num: Deprecated compatibility alias for ``hypercall_id``.
+            **kwargs: Additional subclass keyword arguments for other base
+                classes.
+
+        Raises:
+            TypeError: If both selector arguments are supplied, or if no
+                selector can be determined from this class or its bases.
+
+        ``hypercall_id`` is accepted when callers want to pass a raw/custom
+        integer ID explicitly. New handlers for gem5-defined hypercalls should
+        usually use ``hypercall`` with an ``ExitHypercall`` enum member.
+        Subclasses of existing handlers inherit the base handler's hypercall
+        unless they explicitly specify a different one.
+        """
+        super().__init_subclass__(**kwargs)
+
+        selector = _select_hypercall(hypercall, hypercall_id)
+        if hypercall_num is not None:
+            if selector is not None:
+                raise TypeError(
+                    "Specify only one of 'hypercall', 'hypercall_id', or "
+                    "'hypercall_num'."
+                )
+            selector = hypercall_num
+
+        if selector is None:
+            hypercall_id = cls._handler_id
+        else:
+            hypercall_id = _resolve_hypercall_id(selector)
+
+        if hypercall_id is None:
+            raise TypeError(
+                f"Hypercall identifier must be provided for {cls.__name__}. "
+                f"Use `class {cls.__name__}(ExitHandler, hypercall=<hypercall>):`"
             )
-            ExitHandler._handler_map[hypercall_num] = cls
-            cls._handler_id = hypercall_num
 
-        return cls
-
-
-class ExitHandler(metaclass=ExitHandlerMeta):
-
-    _handler_map: Dict[str, Type["ExitHandler"]] = {}
-    _handler_id: int = None
+        cls._handler_id = hypercall_id
+        ExitHandler._handler_map[hypercall_id] = cls
 
     @classmethod
-    def get_handler_id(cls) -> int:
-        """Returns the ID of the exit handler"""
+    def get_handler_id(cls) -> Optional[int]:
+        """Returns the hypercall ID handled by this class.
+
+        Returns ``None`` for the base ``ExitHandler`` class.
+        """
         return cls._handler_id
 
     @classmethod
-    def get_handler_map(cls) -> Dict[str, Type["ExitHandler"]]:
-        """Returns the mapping of exit handler IDs to handler classes"""
+    def get_handler_map(cls) -> Dict[int, Type["ExitHandler"]]:
+        """Returns the mapping of hypercall IDs to handler classes."""
         return cls._handler_map
 
-    def __init__(self, payload: Dict[str, str]) -> None:
+    def __init__(self, payload: HypercallPayload) -> None:
+        """Create a handler for a single hypercall exit event.
+
+        Args:
+            payload: String key/value metadata attached to the exit event.
+        """
         self._payload = payload
 
     def handle(self, simulator: "Simulator") -> bool:
+        """Run this handler and report whether simulation should stop.
+
+        Args:
+            simulator: The active ``Simulator`` instance.
+
+        Returns:
+            ``True`` if ``Simulator.run()`` should return after this handler;
+            ``False`` if the simulator should re-enter the event loop.
+        """
         self._process(simulator)
         return self._exit_simulation()
 
     def get_handler_description(self) -> str:
+        """Return a human-readable description for logs/status output."""
         return f"Exit Handler {self.__class__.__name__} called."
 
     @abstractmethod
     def _process(self, simulator: "Simulator") -> None:
+        """Perform the handler's side effects.
+
+        Args:
+            simulator: The active ``Simulator`` instance.
+        """
         raise NotImplementedError(
             "Method '_process' must be implemented by a subclass"
         )
 
     @abstractmethod
     def _exit_simulation(self) -> bool:
+        """Return whether simulation should stop after ``_process``.
+
+        Returns:
+            ``True`` to leave ``Simulator.run()``; ``False`` to continue.
+        """
         raise NotImplementedError(
             "Method '_exit_simulation' must be implemented by a subclass"
         )
 
 
 def _ExitHandlerFactory(
-    hypercall_num: int, func: Callable[["Simulator"], bool], description: str
+    hypercall: HypercallId,
+    func: ExitHandlerFunction,
+    description: str,
 ) -> Type[ExitHandler]:
-    """
-    Factory function to create a new ExitHandler class with a specific hypercall number,
-    processing function, and description.
+    """Create an ``ExitHandler`` subclass around a plain Python callable.
+
     Args:
-        hypercall_num (int): The hypercall number associated with the exit handler.
-        func (Callable[["Simulator"], bool]): A callable that takes a Simulator instance
-            and returns a boolean indicating whether the simulation should exit.
-        description (str): A description of the exit handler.
+        hypercall: Built-in ``ExitHypercall`` enum member or custom integer ID
+            to bind to the generated handler class.
+        func: Function to call when the hypercall is handled.
+        description: Human-readable description stored on the handler instance.
+
     Returns:
-        Type[ExitHandler]: A new ExitHandler class with the specified hypercall number,
-        processing function, and description.
+        A newly defined ``ExitHandler`` subclass registered for ``hypercall``.
     """
 
-    class NewExitHandler(ExitHandler, hypercall_num=hypercall_num):
-        def __init__(self, payload):
+    class NewExitHandler(ExitHandler, hypercall=hypercall):
+        def __init__(self, payload: HypercallPayload) -> None:
             super().__init__(payload)
             self.should_exit = False
             self.description = description
@@ -151,44 +354,69 @@ def _ExitHandlerFactory(
         def _exit_simulation(self) -> bool:
             return self.should_exit
 
+        @overrides(ExitHandler)
+        def get_handler_description(self) -> str:
+            return self.description
+
     return NewExitHandler
 
 
 def register_exit_handler(
-    hypercall_num: int,
-    func: Callable[["Simulator", dict], bool],
+    hypercall: Optional[HypercallId],
+    func: ExitHandlerFunction,
     description: str,
+    *,
+    hypercall_id: Optional[int] = None,
 ) -> Type[ExitHandler]:
-    """This function registers a new exit handler with a specific hypercall
-    number. Whenever this hypercall is encountered, the provided function will
-    be called with the simulator instance and the payload of the hypercall. The
-    function should return a boolean indicating whether the simulation should
-    exit.
+    """Register a new exit handler for the provided hypercall.
+
+    ``hypercall`` may be an ``ExitHypercall`` enum value for gem5-defined
+    hypercalls or an ``int`` for custom/user-defined hypercalls. Use the
+    ``hypercall_id`` keyword only when passing a raw/custom integer ID.
 
     Args:
-        hypercall_num (int): The hypercall number associated with the exit handler.
-        func (Callable[["Simulator", dict], bool]): A callable that takes a Simulator
-            instance and a dictionary containing the payload of the hypercall, and
-            returns a boolean indicating whether the simulation should exit.
-        description (str): A description of the exit handler.
+        hypercall: Preferred selector. Use an ``ExitHypercall`` enum member for
+            gem5-defined hypercalls or an integer for a custom ID. Pass ``None``
+            only when using the keyword-only ``hypercall_id`` argument.
+        func: Function called with ``(simulator, payload)`` when the hypercall
+            is handled. It returns whether simulation should stop.
+        description: Human-readable summary for logging/status output.
+        hypercall_id: Explicit raw/custom integer hypercall ID.
 
     Returns:
-        Type[ExitHandler]: A new ExitHandler class with the specified hypercall number,
-        processing function, and description.
+        A new ``ExitHandler`` subclass bound to the requested hypercall.
+
+    Raises:
+        ValueError: If neither selector is provided or both are provided.
+
+    Note:
+        Use ``hypercall`` with an ``ExitHypercall`` enum member for gem5-defined
+        hypercalls; use ``hypercall_id`` when registering a raw/custom integer
+        ID that is not part of the built-in enum.
     """
-    return _ExitHandlerFactory(hypercall_num, func, description)
+    try:
+        selector = _select_hypercall(hypercall, hypercall_id)
+    except TypeError as exc:
+        raise ValueError(str(exc)) from exc
+    if selector is None:
+        raise ValueError("A hypercall identifier must be provided.")
+    return _ExitHandlerFactory(selector, func, description)
 
 
-class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
-    """A handler designed to be the default for  an Exit scheduled to occur
-    at a specified tick. For example, these Exit exits can be triggered through be
-    src/python/m5/simulate.py's `scheduleTickExitFromCurrent` and
-    `scheduleTickExitAbsolute` functions.
+class ScheduledExitEventHandler(
+    ExitHandler, hypercall=ExitHypercall.SCHEDULED_EXIT
+):
+    """Default handler for simulator-scheduled tick exits.
 
-    It will exit the simulation loop by default.
+    ``SCHEDULED_EXIT`` is used when gem5 itself schedules a future exit, for
+    example via ``m5.scheduleTickExitFromCurrent`` or the stdlib
+    ``Simulator.set_hypercall_*_max_ticks`` helpers. This handler exits the
+    simulator run loop by default. The payload may include:
 
-    The `justification` and `scheduled_at_tick` methods are provided to give
-    richer information about this schedule exit.
+    ``justification``
+        Human-readable reason for scheduling the exit.
+    ``scheduled_at_tick``
+        Tick at which the scheduled exit was created.
     """
 
     @overrides(ExitHandler)
@@ -196,42 +424,29 @@ class ScheduledExitEventHandler(ExitHandler, hypercall_num=6):
         pass
 
     def justification(self) -> Optional[str]:
-        """Returns the justification for the scheduled exit event.
-
-        This information may be passed to when scheduling the event event to
-        remind the user why the event was scheduled, or used in cases where
-        lots of scheduled events are used and there is a need to differentiate
-        them.
-
-        Returns "None" if this information was not set.
-        """
-        return (
-            None
-            if "justification" not in self._payload
-            else self._payload["justification"]
-        )
+        """Returns why this scheduled exit event was created, if available."""
+        return self._payload.get("justification")
 
     def scheduled_at_tick(self) -> Optional[int]:
-        """Returns the tick in which the event was scheduled on (not scheduled
-        to occur, but the tick the event was created).
-
-        Returns "None" if this information is not available.
-        """
-        return (
-            None
-            if "scheduled_at_tick" not in self._payload
-            else int(self._payload["scheduled_at_tick"])
-        )
+        """Returns the tick at which this exit was scheduled, if available."""
+        tick = self._payload.get("scheduled_at_tick")
+        return None if tick is None else int(tick)
 
     @overrides(ExitHandler)
     def _exit_simulation(self) -> bool:
         return True
 
 
-class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
+class KernelBootedExitHandler(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
+    """Handle the guest reporting that the kernel has booted.
+
+    The default behavior is to continue simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Kernel booted."
 
     @overrides(ExitHandler)
@@ -243,10 +458,14 @@ class KernelBootedExitHandler(ExitHandler, hypercall_num=1):
         return False
 
 
-class AfterBootExitHandler(ExitHandler, hypercall_num=2):
+class AfterBootExitHandler(ExitHandler, hypercall=ExitHypercall.AFTER_BOOT):
+    """Handle the guest entering the ``after_boot`` hook.
+
+    The default behavior is to continue simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Started `after_boot.sh` script."
 
     @overrides(ExitHandler)
@@ -258,10 +477,16 @@ class AfterBootExitHandler(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
+class AfterBootScriptExitHandler(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
+    """Handle the guest completing ``after_boot.sh``.
+
+    The default behavior is to exit the simulator run loop.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Finished `after_boot.sh` script."
 
     @overrides(ExitHandler)
@@ -273,7 +498,13 @@ class AfterBootScriptExitHandler(ExitHandler, hypercall_num=3):
         return True
 
 
-class CheckpointExitHandler(ExitHandler, hypercall_num=7):
+class CheckpointExitHandler(ExitHandler, hypercall=ExitHypercall.CHECKPOINT):
+    """Take a gem5 checkpoint and continue simulation.
+
+    The checkpoint is written below ``simulator._checkpoint_path`` when set,
+    otherwise below the current gem5 output directory.
+    """
+
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
         checkpoint_dir = simulator._checkpoint_path
@@ -288,10 +519,14 @@ class CheckpointExitHandler(ExitHandler, hypercall_num=7):
         return False
 
 
-class WorkBeginExitHandler(ExitHandler, hypercall_num=4):
+class WorkBeginExitHandler(ExitHandler, hypercall=ExitHypercall.WORK_BEGIN):
+    """Handle the start of a region of interest.
+
+    The default behavior resets gem5 statistics and continues simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Started executing Region of Interest (ROI)."
 
     @overrides(ExitHandler)
@@ -303,10 +538,14 @@ class WorkBeginExitHandler(ExitHandler, hypercall_num=4):
         return False
 
 
-class WorkEndExitHandler(ExitHandler, hypercall_num=5):
+class WorkEndExitHandler(ExitHandler, hypercall=ExitHypercall.WORK_END):
+    """Handle the end of a region of interest.
+
+    The default behavior dumps gem5 statistics and continues simulation.
+    """
 
     @overrides(ExitHandler)
-    def get_handler_description(self):
+    def get_handler_description(self) -> str:
         return "Finished executing Region of Interest (ROI)."
 
     @overrides(ExitHandler)
@@ -318,9 +557,27 @@ class WorkEndExitHandler(ExitHandler, hypercall_num=5):
         return False
 
 
-class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
+class OrchestratorExitHandler(
+    ExitHandler, hypercall=ExitHypercall.ORCHESTRATOR
+):
+    """Handle out-of-band orchestration/status requests.
 
-    def _get_status(self, simulator: "Simulator") -> Dict[str, str]:
+    The orchestrator hypercall is used by tooling that wants to query or adjust
+    a running simulation. The payload selects a function and may include a Unix
+    domain socket path for the JSON response. Supported functions include
+    ``status``, ``get_stats``, and ``update_debug_flags``.
+    """
+
+    def _get_status(self, simulator: "Simulator") -> Dict[str, Any]:
+        """Collect basic simulator status for an orchestrator response.
+
+        Args:
+            simulator: The active ``Simulator`` instance.
+
+        Returns:
+            A JSON-serializable dictionary of workload, tick, simulator ID, and
+            instruction-count metadata.
+        """
         import _m5.core
 
         if not simulator.get_workload():
@@ -336,6 +593,17 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         }
 
     def _add_debug_flags(self, debug_flags: List[str]) -> Dict[str, str]:
+        """Enable or disable gem5 debug flags.
+
+        Args:
+            debug_flags: Flag names to enable. Prefix a name with ``-`` to
+                disable it instead.
+
+        Returns:
+            A dictionary listing enabled, disabled, and invalid flags. Values
+            are strings so the response is compatible with the current payload
+            conventions.
+        """
         from m5 import debug
 
         flags_disabled = []
@@ -398,7 +666,9 @@ class OrchestratorExitHandler(ExitHandler, hypercall_num=1000):
         return False
 
 
-class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
+class ClassicGeneratorExitHandler(
+    ExitHandler, hypercall=ExitHypercall.CLASSIC_GENERATOR
+):
     """A handler designed to be the default for the classic exit event.
 
     ``on_exit_event`` usage notes
@@ -482,8 +752,8 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
     this example, the first ``EXIT`` type exit event will cause ``print_hello``
     to be executed, and the second ``EXIT`` type exit event will cause the
     ``switch_cpus`` function to run. The third will execute ``print_hello``
-    again before finally, on the forth exit event will call
-    ``stop_simulation`` which will stop the simulation as it returns ``False``.
+    again before finally, on the fourth exit event, ``stop_simulation`` will
+    stop the simulation by returning ``True``.
 
     With a function
     ===============
@@ -531,9 +801,15 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
     These generators can be found in the ``exit_event_generator.py`` module.
     """
 
-    def __init__(self, payload: Dict[str, str]) -> None:
+    def __init__(self, payload: HypercallPayload) -> None:
+        """Create a classic-generator compatibility handler instance.
+
+        Args:
+            payload: Payload containing at least the legacy ``cause`` when the
+                event came through the new structured hypercall path.
+        """
         super().__init__(payload)
-        self._exit_on_completion = None
+        self._exit_on_completion: Optional[bool] = None
 
     @classmethod
     def set_exit_event_map(
@@ -543,14 +819,31 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
                 ExitEvent,
                 Union[
                     Generator[Optional[bool], None, None],
-                    List[Callable],
-                    Callable,
+                    List[Callable[[], Optional[bool]]],
+                    Callable[[], Optional[bool]],
                 ],
             ]
         ],
         expected_execution_order: Optional[List[ExitEvent]],
         board: Optional["Board"],
     ) -> None:
+        """Configure legacy ``ExitEvent`` handling for classic exits.
+
+        This bridges the older message/cause based exit mechanism to the newer
+        hypercall-dispatch mechanism. ``ClassicGeneratorExitHandler`` receives
+        the classic exit cause, translates it to an ``ExitEvent``, then advances
+        the matching user-supplied or default generator.
+
+        Args:
+            on_exit_event: Optional mapping from ``ExitEvent`` to a generator,
+                list of zero-argument callables, or a single zero-argument
+                callable. Generators/callables yield or return ``True`` to exit
+                the simulator run loop and ``False``/``None`` to continue.
+            expected_execution_order: Optional sequence of ``ExitEvent`` values
+                used to validate that exits occur in the expected order.
+            board: Board whose processor is used by default handlers such as
+                CPU switching and spatter synchronization.
+        """
         # We specify a dictionary here outlining the default behavior for each
         # exit event. Each exit event is mapped to a generator.
         cls._default_on_exit_dict = {
@@ -626,7 +919,9 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
                             "of `ExitEvent.EVENT : gen`)"
                         )
 
-                    def function_generator(func: Callable):
+                    def function_generator(
+                        func: Callable[[], Optional[bool]],
+                    ) -> Generator[Optional[bool], None, None]:
                         while True:
                             yield func()
 
@@ -643,10 +938,13 @@ class ClassicGeneratorExitHandler(ExitHandler, hypercall_num=0):
 
     @overrides(ExitHandler)
     def _process(self, simulator: "Simulator") -> None:
-        #  # Translate the exit event cause to the exit event enum.
-        exit_enum = ExitEvent.translate_exit_status(
-            simulator.get_last_exit_event_cause()
-        )
+        # Translate the exit event cause to the exit event enum. New-style
+        # ClassicGenerator exits store the legacy cause in the structured
+        # payload rather than the GlobalSimLoopExitEvent cause field.
+        cause = self._payload.get("cause")
+        if cause is None:
+            cause = simulator.get_last_exit_event_cause()
+        exit_enum = ExitEvent.translate_exit_status(cause)
 
         # Check to see the run is corresponding to the expected execution
         # order (assuming this check is demanded by the user).

--- a/src/python/gem5/simulate/simulator.py
+++ b/src/python/gem5/simulate/simulator.py
@@ -223,8 +223,8 @@ class Simulator:
 
     def get_exit_handler_id_map(self) -> Dict[int, Type[ExitHandler]]:
         """
-        Returns the exit handler ID map. This is a dictionary mapping exit
-        event IDs to the ExitEvent handler class responsible for handling them.
+        Returns the exit handler map. This is a dictionary mapping hypercall
+        IDs to the ExitHandler class responsible for handling them.
         """
         return ExitHandler.get_handler_map()
 
@@ -284,7 +284,7 @@ class Simulator:
             )
         if self._hypercall_max_ticks:
             warn(
-                "A hypercall 6 exit has already been scheduled for tick "
+                "A SCHEDULED_EXIT hypercall (ID 6) has already been scheduled for tick "
                 f"{self._hypercall_max_ticks}. Setting hypercall and classic "
                 "exits in the same simulation is not well tested and the "
                 "simulation may not behave as expected."
@@ -300,7 +300,7 @@ class Simulator:
         self, max_tick: int, exit_str: str = "Max ticks reached"
     ) -> None:
         """Set the maximum number of ticks to simulate before the simulation
-        exits with a hypercall 6 exit. This exit will be handled by
+        exits with a SCHEDULED_EXIT hypercall (ID 6). This exit will be handled by
         ScheduledExitEventHandler by default. See `src/python/gem5/simulate/
         exit_handler.py` for details.
 
@@ -328,7 +328,7 @@ class Simulator:
         self, ticks_from_current: int, exit_str: str = "Max ticks reached"
     ) -> None:
         """Set the number of ticks to simulate from the current tick before the
-        simulation exits with a hypercall 6 exit. This exit will be handled by
+        simulation exits with a SCHEDULED_EXIT hypercall (ID 6). This exit will be handled by
         ScheduledExitEventHandler by default. See `src/python/gem5/simulate/
         exit_handler.py` for details.
 
@@ -646,9 +646,9 @@ class Simulator:
                 not in self.get_exit_handler_id_map().keys()
             ):
                 warn(
-                    f"Warning: Exit event type ID "
+                    f"Warning: Hypercall ID "
                     f"{self._last_exit_event.getHypercallId()} "
-                    f"not in exit handler ID map. Reentering simulation loop."
+                    f"not in exit handler map. Reentering simulation loop."
                 )
                 continue
             exit_handler = self.get_exit_handler_id_map()[

--- a/src/python/m5/event.py
+++ b/src/python/m5/event.py
@@ -91,6 +91,22 @@ def create(func, priority=Event.Default_Pri):
     return EventWrapper(func, priority=priority)
 
 
+def exitSimulationLoopClassic(
+    message, exit_code=0, when=None, repeat=0, serialize=False
+):
+    """Schedule a classic exit while preserving its cause and code."""
+    return _m5.event.exitSimulationLoopClassic(
+        str(message), int(exit_code), when, repeat, serialize
+    )
+
+
+def exitSimulationLoop(hypercall_id, payload=None, when=None, repeat=None):
+    """Schedule an exit identified by a hypercall ID and payload."""
+    if payload is None:
+        payload = {}
+    return _m5.event.exitSimulationLoop(hypercall_id, payload, when, repeat)
+
+
 def exitSimLoop(message, exit_code=0, when=None, repeat=0, serialize=False):
     """Compatibility wrapper preserving the legacy exitSimLoop signature.
 
@@ -125,5 +141,7 @@ __all__ = [
     "SimExit",
     "mainq",
     "create",
+    "exitSimulationLoop",
+    "exitSimulationLoopClassic",
     "exitSimLoop",
 ]

--- a/src/python/m5/event.py
+++ b/src/python/m5/event.py
@@ -38,6 +38,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import warnings
+
 import m5
 
 import _m5.event
@@ -89,6 +91,33 @@ def create(func, priority=Event.Default_Pri):
     return EventWrapper(func, priority=priority)
 
 
+def exitSimLoop(message, exit_code=0, when=None, repeat=0, serialize=False):
+    """Compatibility wrapper preserving the legacy exitSimLoop signature.
+
+    This helper preserves the original signature and uses the classic
+    hypercall path so handlers can observe structured metadata.
+    """
+
+    warnings.warn(
+        "m5.event.exitSimLoop is deprecated. Use "
+        "exitSimulationLoopClassic to preserve legacy cause/code behavior, "
+        "or exitSimulationLoop for hypercall-based exits.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # Use the classic C++ helper so this compatibility wrapper keeps the
+    # legacy message/code, delay, repeat, and simQuantum behavior while also
+    # attaching structured hypercall metadata for ExitHandlers.
+    _m5.event.exitSimulationLoopClassic(
+        str(message),
+        int(exit_code),
+        when,
+        repeat,
+        serialize,
+    )
+
+
 __all__ = [
     "Event",
     "EventWrapper",
@@ -96,4 +125,5 @@ __all__ = [
     "SimExit",
     "mainq",
     "create",
+    "exitSimLoop",
 ]

--- a/src/python/m5/event.py
+++ b/src/python/m5/event.py
@@ -38,6 +38,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import warnings
+
 import m5
 
 import _m5.event
@@ -89,6 +91,32 @@ def create(func, priority=Event.Default_Pri):
     return EventWrapper(func, priority=priority)
 
 
+def exitSimLoop(message, exit_code=0, when=None, repeat=0, serialize=False):
+    """Compatibility wrapper preserving the legacy exitSimLoop signature.
+
+    This helper preserves the original signature and uses the classic
+    hypercall path so handlers can observe structured metadata.
+    """
+
+    warnings.warn(
+        "m5.event.exitSimLoop is deprecated. Use the hypercall-based "
+        "exitSimulationLoop APIs instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # Use the classic C++ helper so this compatibility wrapper keeps the
+    # legacy message/code, delay, repeat, and simQuantum behavior while also
+    # attaching structured hypercall metadata for ExitHandlers.
+    _m5.event.exitSimulationLoopClassic(
+        str(message),
+        int(exit_code),
+        when,
+        repeat,
+        serialize,
+    )
+
+
 __all__ = [
     "Event",
     "EventWrapper",
@@ -96,4 +124,5 @@ __all__ = [
     "SimExit",
     "mainq",
     "create",
+    "exitSimLoop",
 ]

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -343,7 +343,7 @@ def scheduleTickExitAbsolute(
         _m5_event.exitSimLoop(exit_string, 0, tick, 0, False)
     else:
         _m5_event.exitSimulationLoop(
-            6,
+            _m5_event.ExitHypercall.ScheduledExit,
             {
                 "scheduled_at_tick": str(curTick()),
                 "justification": exit_string,

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -397,6 +397,10 @@ def scheduleTickExitAbsolute(
     The default ``exit_string`` value is used by the stdlib Simulator module to
     declare this exit event as ``ExitEvent.SCHEDULED_TICK``.
 
+    Note: when a non-default ``exit_string`` is provided, this function uses
+    the newer ExitHypercall mechanism via ``_m5_event.exitSimulationLoop`` to
+    convey structured exit metadata to the simulator core.
+
     :param tick: The absolute simulation tick to schedule the exit event.
     :param exit_string: The exit string to return when the exit event is
                         triggered.
@@ -408,10 +412,16 @@ def scheduleTickExitAbsolute(
     # the exit string is used (as it maps the an ExitEvent enum value). For
     # other string values we use the newer approach.
     if exit_string == "Tick exit reached":
-        _m5_event.exitSimLoop(exit_string, 0, tick, 0, False)
+        _m5_event.exitSimulationLoopClassic(
+            exit_string,
+            0,
+            tick,
+            0,
+            False,
+        )
     else:
         _m5_event.exitSimulationLoop(
-            6,
+            _m5_event.ExitHypercall.SCHEDULED_EXIT,
             {
                 "scheduled_at_tick": str(curTick()),
                 "justification": exit_string,

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -329,6 +329,10 @@ def scheduleTickExitAbsolute(
     The default ``exit_string`` value is used by the stdlib Simulator module to
     declare this exit event as ``ExitEvent.SCHEDULED_TICK``.
 
+    Note: when a non-default ``exit_string`` is provided, this function uses
+    the newer ExitHypercall mechanism via ``_m5_event.exitSimulationLoop`` to
+    convey structured exit metadata to the simulator core.
+
     :param tick: The absolute simulation tick to schedule the exit event.
     :param exit_string: The exit string to return when the exit event is
                         triggered.
@@ -340,10 +344,16 @@ def scheduleTickExitAbsolute(
     # the exit string is used (as it maps the an ExitEvent enum value). For
     # other string values we use the newer approach.
     if exit_string == "Tick exit reached":
-        _m5_event.exitSimLoop(exit_string, 0, tick, 0, False)
+        _m5_event.exitSimulationLoopClassic(
+            exit_string,
+            0,
+            tick,
+            0,
+            False,
+        )
     else:
         _m5_event.exitSimulationLoop(
-            6,
+            _m5_event.ExitHypercall.SCHEDULED_EXIT,
             {
                 "scheduled_at_tick": str(curTick()),
                 "justification": exit_string,

--- a/src/python/pybind11/event.cc
+++ b/src/python/pybind11/event.cc
@@ -43,6 +43,8 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include <utility>
+
 #include "base/logging.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_events.hh"
@@ -111,12 +113,41 @@ pybind_init_event(py::module_ &m_native)
     m.def("getMaxTick", &get_max_tick, py::return_value_policy::copy);
     m.def("terminateEventQueueThreads", &terminateEventQueueThreads);
     m.def("exitSimLoop", &exitSimLoop);
-    m.def("exitSimulationLoop", &exitSimulationLoop);
+    m.def(
+        "exitSimulationLoop",
+        [](uint64_t type_id,
+           std::map<std::string, std::string> payload =
+               std::map<std::string, std::string>(),
+           py::object when = py::none()) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            exitSimulationLoop(type_id, std::move(payload), tick);
+        },
+        py::arg("type_id"),
+        py::arg("payload") = std::map<std::string, std::string>(),
+        py::arg("when") = py::none());
+    m.def(
+        "exitSimulationLoop",
+        [](ExitHypercall type_id,
+           std::map<std::string, std::string> payload =
+               std::map<std::string, std::string>(),
+           py::object when = py::none()) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            exitSimulationLoop(type_id, std::move(payload), tick);
+        },
+        py::arg("type_id"),
+        py::arg("payload") = std::map<std::string, std::string>(),
+        py::arg("when") = py::none());
     m.def("getEventQueue", []() { return curEventQueue(); },
           py::return_value_policy::reference);
     m.def("setEventQueue", [](EventQueue *q) { return curEventQueue(q); });
     m.def("getEventQueue", &getEventQueue,
           py::return_value_policy::reference);
+
+    auto exit_hypercall = py::enum_<ExitHypercall>(m, "ExitHypercall");
+    for (const auto &desc : kExitHypercallDescriptors) {
+        exit_hypercall.value(desc.name, desc.id, desc.description);
+    }
+    exit_hypercall.export_values();
 
     py::class_<EventQueue>(m, "EventQueue")
         .def("name",  [](EventQueue *eq) { return eq->name(); })

--- a/src/python/pybind11/event.cc
+++ b/src/python/pybind11/event.cc
@@ -43,6 +43,8 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include <utility>
+
 #include "base/logging.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_events.hh"
@@ -110,13 +112,97 @@ pybind_init_event(py::module_ &m_native)
     m.def("setMaxTick", &set_max_tick, py::arg("tick"));
     m.def("getMaxTick", &get_max_tick, py::return_value_policy::copy);
     m.def("terminateEventQueueThreads", &terminateEventQueueThreads);
-    m.def("exitSimLoop", &exitSimLoop);
-    m.def("exitSimulationLoop", &exitSimulationLoop);
+    /* Python-level deprecation wrapper for the legacy exitSimLoop API.
+     * Preserve the original behavior and ABI but emit a DeprecationWarning
+     * so Python callers start migrating to the replacement matching their
+     * compatibility requirements.
+     */
+    m.def(
+        "exitSimLoop",
+        [](const std::string &message, int exit_code = 0,
+           py::object when = py::none(), py::object repeat = py::none(),
+           bool serialize = false) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            py::module_ warnings = py::module_::import("warnings");
+            warnings.attr("warn")(
+                "exitSimLoop is deprecated; use exitSimulationLoopClassic "
+                "to preserve legacy cause/code behavior, or "
+                "exitSimulationLoop for hypercall-based exits",
+                py::module_::import("builtins").attr("DeprecationWarning"));
+            exitSimulationLoopClassic(message, exit_code, tick, repeat_tick,
+                                      serialize);
+        },
+        py::arg("message"), py::arg("exit_code") = 0,
+        py::arg("when") = py::none(), py::arg("repeat") = py::none(),
+        py::arg("serialize") = false);
+    m.def(
+        "exitSimulationLoop",
+        [](uint64_t hypercall_id,
+           std::map<std::string, std::string> payload =
+               std::map<std::string, std::string>(),
+           py::object when = py::none(), py::object repeat = py::none()) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoop(hypercall_id, std::move(payload), tick,
+                               repeat_tick);
+        },
+        py::arg("hypercall_id"),
+        py::arg("payload") = std::map<std::string, std::string>(),
+        py::arg("when") = py::none(), py::arg("repeat") = py::none());
+    m.def(
+        "exitSimulationLoop",
+        [](ExitHypercall hypercall,
+           std::map<std::string, std::string> payload =
+               std::map<std::string, std::string>(),
+           py::object when = py::none(), py::object repeat = py::none()) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoop(hypercall, std::move(payload), tick,
+                               repeat_tick);
+        },
+        py::arg("hypercall"),
+        py::arg("payload") = std::map<std::string, std::string>(),
+        py::arg("when") = py::none(), py::arg("repeat") = py::none());
+    m.def(
+        "exitSimulationLoopClassic",
+        [](const std::string &message, int exit_code = 0,
+           py::object when = py::none(), py::object repeat = py::none(),
+           bool serialize = false) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoopClassic(message, exit_code, tick, repeat_tick,
+                                      serialize);
+        },
+        py::arg("message"), py::arg("exit_code") = 0,
+        py::arg("when") = py::none(), py::arg("repeat") = py::none(),
+        py::arg("serialize") = false);
+    m.def(
+        "exitSimulationLoopClassicNow",
+        [](const std::string &message, int exit_code = 0,
+           py::object repeat = py::none(), bool serialize = false) {
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoopClassicNow(message, exit_code, repeat_tick,
+                                         serialize);
+        },
+        py::arg("message"), py::arg("exit_code") = 0,
+        py::arg("repeat") = py::none(), py::arg("serialize") = false);
     m.def("getEventQueue", []() { return curEventQueue(); },
           py::return_value_policy::reference);
     m.def("setEventQueue", [](EventQueue *q) { return curEventQueue(q); });
     m.def("getEventQueue", &getEventQueue,
           py::return_value_policy::reference);
+
+    auto exit_hypercall = py::enum_<ExitHypercall>(m, "ExitHypercall");
+    for (const auto &desc : kExitHypercallDescriptors) {
+        exit_hypercall.value(desc.name, desc.id, desc.description);
+    }
+    exit_hypercall.export_values();
 
     py::class_<EventQueue>(m, "EventQueue")
         .def("name",  [](EventQueue *eq) { return eq->name(); })
@@ -166,7 +252,7 @@ pybind_init_event(py::module_ &m_native)
 
 #define PRIO(n) c_event.attr(# n) = py::cast((int)Event::n)
     PRIO(Minimum_Pri);
-    PRIO(Minimum_Pri);
+    PRIO(CPU_Exit_Pri);
     PRIO(Debug_Enable_Pri);
     PRIO(Debug_Break_Pri);
     PRIO(CPU_Switch_Pri);

--- a/src/python/pybind11/event.cc
+++ b/src/python/pybind11/event.cc
@@ -43,6 +43,8 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include <utility>
+
 #include "base/logging.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_events.hh"
@@ -110,13 +112,94 @@ pybind_init_event(py::module_ &m_native)
     m.def("setMaxTick", &set_max_tick, py::arg("tick"));
     m.def("getMaxTick", &get_max_tick, py::return_value_policy::copy);
     m.def("terminateEventQueueThreads", &terminateEventQueueThreads);
-    m.def("exitSimLoop", &exitSimLoop);
-    m.def("exitSimulationLoop", &exitSimulationLoop);
+    /* Python-level deprecation wrapper for the legacy exitSimLoop API.
+     * Preserve the original behavior and ABI but emit a DeprecationWarning
+     * so Python callers start migrating to exitSimulationLoop.
+     */
+    m.def(
+        "exitSimLoop",
+        [](const std::string &message, int exit_code = 0,
+           py::object when = py::none(), py::object repeat = py::none(),
+           bool serialize = false) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            py::module_ warnings = py::module_::import("warnings");
+            warnings.attr("warn")(
+                "exitSimLoop is deprecated; prefer exitSimulationLoop",
+                py::module_::import("builtins").attr("DeprecationWarning"));
+            exitSimulationLoopClassic(message, exit_code, tick, repeat_tick,
+                                      serialize);
+        },
+        py::arg("message"), py::arg("exit_code") = 0,
+        py::arg("when") = py::none(), py::arg("repeat") = py::none(),
+        py::arg("serialize") = false);
+    m.def(
+        "exitSimulationLoop",
+        [](uint64_t hypercall_id,
+           std::map<std::string, std::string> payload =
+               std::map<std::string, std::string>(),
+           py::object when = py::none(), py::object repeat = py::none()) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoop(hypercall_id, std::move(payload), tick,
+                               repeat_tick);
+        },
+        py::arg("hypercall_id"),
+        py::arg("payload") = std::map<std::string, std::string>(),
+        py::arg("when") = py::none(), py::arg("repeat") = py::none());
+    m.def(
+        "exitSimulationLoop",
+        [](ExitHypercall hypercall,
+           std::map<std::string, std::string> payload =
+               std::map<std::string, std::string>(),
+           py::object when = py::none(), py::object repeat = py::none()) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoop(hypercall, std::move(payload), tick,
+                               repeat_tick);
+        },
+        py::arg("hypercall"),
+        py::arg("payload") = std::map<std::string, std::string>(),
+        py::arg("when") = py::none(), py::arg("repeat") = py::none());
+    m.def(
+        "exitSimulationLoopClassic",
+        [](const std::string &message, int exit_code = 0,
+           py::object when = py::none(), py::object repeat = py::none(),
+           bool serialize = false) {
+            const Tick tick = when.is_none() ? curTick() : when.cast<Tick>();
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoopClassic(message, exit_code, tick, repeat_tick,
+                                      serialize);
+        },
+        py::arg("message"), py::arg("exit_code") = 0,
+        py::arg("when") = py::none(), py::arg("repeat") = py::none(),
+        py::arg("serialize") = false);
+    m.def(
+        "exitSimulationLoopClassicNow",
+        [](const std::string &message, int exit_code = 0,
+           py::object repeat = py::none(), bool serialize = false) {
+            const Tick repeat_tick =
+                repeat.is_none() ? 0 : repeat.cast<Tick>();
+            exitSimulationLoopClassicNow(message, exit_code, repeat_tick,
+                                         serialize);
+        },
+        py::arg("message"), py::arg("exit_code") = 0,
+        py::arg("repeat") = py::none(), py::arg("serialize") = false);
     m.def("getEventQueue", []() { return curEventQueue(); },
           py::return_value_policy::reference);
     m.def("setEventQueue", [](EventQueue *q) { return curEventQueue(q); });
     m.def("getEventQueue", &getEventQueue,
           py::return_value_policy::reference);
+
+    auto exit_hypercall = py::enum_<ExitHypercall>(m, "ExitHypercall");
+    for (const auto &desc : kExitHypercallDescriptors) {
+        exit_hypercall.value(desc.name, desc.id, desc.description);
+    }
+    exit_hypercall.export_values();
 
     py::class_<EventQueue>(m, "EventQueue")
         .def("name",  [](EventQueue *eq) { return eq->name(); })
@@ -166,7 +249,7 @@ pybind_init_event(py::module_ &m_native)
 
 #define PRIO(n) c_event.attr(# n) = py::cast((int)Event::n)
     PRIO(Minimum_Pri);
-    PRIO(Minimum_Pri);
+    PRIO(CPU_Exit_Pri);
     PRIO(Debug_Enable_Pri);
     PRIO(Debug_Break_Pri);
     PRIO(CPU_Switch_Pri);

--- a/src/sim/debug.cc
+++ b/src/sim/debug.cc
@@ -100,7 +100,7 @@ takeCheckpoint(Tick when)
 {
     if (!when)
         when = curTick() + 1;
-    exitSimLoop("checkpoint", 0, when, 0);
+    exitSimulationLoopClassic("checkpoint", 0, when, 0);
 }
 
 void

--- a/src/sim/drain.cc
+++ b/src/sim/drain.cc
@@ -149,7 +149,7 @@ DrainManager::signalDrainDone()
     assert(_count > 0);
     if (--_count == 0) {
         DPRINTF(Drain, "All %u objects drained..\n", drainableCount());
-        exitSimLoop("Finished drain", 0);
+        exitSimulationLoopClassic("Finished drain");
     }
 }
 

--- a/src/sim/init_signals.cc
+++ b/src/sim/init_signals.cc
@@ -47,7 +47,9 @@
 #include <csignal>
 #include <cstring>
 #include <iostream>
+#include <map>
 #include <string>
+#include <utility>
 
 #if defined(__FreeBSD__)
 #include <sys/param.h>
@@ -391,8 +393,8 @@ processExternalSignal(void)
     munmap(shm_ptr, shared_mem_size);
     close(shm_fd);
 
-    exitSimLoopWithHypercall("Handling external signal!", 0, curTick(), 0,
-                             payload_map, hypercall_id, false);
+    exitSimulationLoop(hypercall_id, std::move(payload_map),
+                       curTick() + simQuantum);
 }
 
 std::string

--- a/src/sim/pseudo_inst.cc
+++ b/src/sim/pseudo_inst.cc
@@ -62,6 +62,7 @@
 #include "mem/se_translating_port_proxy.hh"
 #include "mem/translating_port_proxy.hh"
 #include "params/BaseCPU.hh"
+#include "sim/eventq.hh"
 #include "sim/full_system.hh"
 #include "sim/process.hh"
 #include "sim/serialize.hh"
@@ -200,7 +201,8 @@ m5exit(ThreadContext *tc, Tick delay)
     DPRINTF(PseudoInst, "pseudo_inst::m5exit(%i)\n", delay);
     if (DistIface::readyToExit(delay)) {
         Tick when = curTick() + delay * sim_clock::as_int::ns;
-        exitSimLoop("m5_exit instruction encountered", 0, when, 0, true);
+        exitSimulationLoopClassic("m5_exit instruction encountered", 0, when,
+                                  0, true);
     }
 }
 
@@ -219,7 +221,8 @@ m5fail(ThreadContext *tc, Tick delay, uint64_t code)
 {
     DPRINTF(PseudoInst, "pseudo_inst::m5fail(%i, %i)\n", delay, code);
     Tick when = curTick() + delay * sim_clock::as_int::ns;
-    exitSimLoop("m5_fail instruction encountered", code, when, 0, true);
+    exitSimulationLoopClassic("m5_fail instruction encountered", code, when, 0,
+                              true);
 }
 
 void
@@ -383,7 +386,7 @@ m5checkpoint(ThreadContext *tc, Tick delay, Tick period)
     if (DistIface::readyToCkpt(delay, period)) {
         Tick when = curTick() + delay * sim_clock::as_int::ns;
         Tick repeat = period * sim_clock::as_int::ns;
-        exitSimLoop("checkpoint", 0, when, repeat);
+        exitSimulationLoopClassic("checkpoint", 0, when, repeat);
     }
 }
 
@@ -497,7 +500,7 @@ void
 switchcpu(ThreadContext *tc)
 {
     DPRINTF(PseudoInst, "pseudo_inst::switchcpu()\n");
-    exitSimLoop("switchcpu");
+    exitSimulationLoopClassic("switchcpu");
 }
 
 void
@@ -527,7 +530,7 @@ workbegin(ThreadContext *tc, uint64_t workid, uint64_t threadid)
     const System::Params &params = sys->params();
 
     if (params.exit_on_work_items) {
-        exitSimLoop("workbegin", static_cast<int>(workid));
+        exitSimulationLoopClassic("workbegin", static_cast<int>(workid));
         return;
     }
 
@@ -550,7 +553,7 @@ workbegin(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             //
             // If active cpus equals checkpoint count, create checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (systemWorkBeginCount == params.work_begin_ckpt_count) {
@@ -558,21 +561,21 @@ workbegin(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             // Note: the string specified as the cause of the exit event must
             // exactly equal "checkpoint" inorder to create a checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (systemWorkBeginCount == params.work_begin_exit_count) {
             //
             // If a certain number of work items started, exit simulation
             //
-            exitSimLoop("work started count reach");
+            exitSimulationLoopClassic("work started count reach");
         }
 
         if (cpuId == params.work_begin_cpu_id_exit) {
             //
             // If work started on the cpu id specified, exit simulation
             //
-            exitSimLoop("work started on specific cpu");
+            exitSimulationLoopClassic("work started on specific cpu");
         }
     }
 }
@@ -590,7 +593,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
     const System::Params &params = sys->params();
 
     if (params.exit_on_work_items) {
-        exitSimLoop("workend", static_cast<int>(workid));
+        exitSimulationLoopClassic("workend", static_cast<int>(workid));
         return;
     }
 
@@ -612,7 +615,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             //
             // If active cpus equals checkpoint count, create checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (params.work_end_ckpt_count != 0 &&
@@ -621,7 +624,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             // If total work items completed equals checkpoint count, create
             // checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (params.work_end_exit_count != 0 &&
@@ -629,7 +632,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             //
             // If total work items completed equals exit count, exit simulation
             //
-            exitSimLoop("work items exit count reached");
+            exitSimulationLoopClassic("work items exit count reached");
         }
     }
 }
@@ -638,8 +641,7 @@ void
 m5Hypercall(ThreadContext *tc, uint64_t hypercall_id)
 {
     DPRINTF(PseudoInst, "pseudo_inst::m5Hypercall(%i)\n", hypercall_id);
-    exitSimLoopWithHypercall("m5_hypercall instruction encountered", 0,
-    curTick(),0, std::map<std::string, std::string>(), hypercall_id, true);
+    exitSimulationLoop(hypercall_id, ExitPayload(), curTick() + simQuantum);
 }
 
 } // namespace pseudo_inst

--- a/src/sim/pseudo_inst.cc
+++ b/src/sim/pseudo_inst.cc
@@ -62,6 +62,7 @@
 #include "mem/se_translating_port_proxy.hh"
 #include "mem/translating_port_proxy.hh"
 #include "params/BaseCPU.hh"
+#include "sim/eventq.hh"
 #include "sim/full_system.hh"
 #include "sim/process.hh"
 #include "sim/serialize.hh"
@@ -180,7 +181,8 @@ m5exit(ThreadContext *tc, Tick delay)
     DPRINTF(PseudoInst, "pseudo_inst::m5exit(%i)\n", delay);
     if (DistIface::readyToExit(delay)) {
         Tick when = curTick() + delay * sim_clock::as_int::ns;
-        exitSimLoop("m5_exit instruction encountered", 0, when, 0, true);
+        exitSimulationLoopClassic("m5_exit instruction encountered", 0, when,
+                                  0, true);
     }
 }
 
@@ -199,7 +201,8 @@ m5fail(ThreadContext *tc, Tick delay, uint64_t code)
 {
     DPRINTF(PseudoInst, "pseudo_inst::m5fail(%i, %i)\n", delay, code);
     Tick when = curTick() + delay * sim_clock::as_int::ns;
-    exitSimLoop("m5_fail instruction encountered", code, when, 0, true);
+    exitSimulationLoopClassic("m5_fail instruction encountered", code, when, 0,
+                              true);
 }
 
 void
@@ -363,7 +366,7 @@ m5checkpoint(ThreadContext *tc, Tick delay, Tick period)
     if (DistIface::readyToCkpt(delay, period)) {
         Tick when = curTick() + delay * sim_clock::as_int::ns;
         Tick repeat = period * sim_clock::as_int::ns;
-        exitSimLoop("checkpoint", 0, when, repeat);
+        exitSimulationLoopClassic("checkpoint", 0, when, repeat);
     }
 }
 
@@ -471,7 +474,7 @@ void
 switchcpu(ThreadContext *tc)
 {
     DPRINTF(PseudoInst, "pseudo_inst::switchcpu()\n");
-    exitSimLoop("switchcpu");
+    exitSimulationLoopClassic("switchcpu");
 }
 
 void
@@ -501,7 +504,7 @@ workbegin(ThreadContext *tc, uint64_t workid, uint64_t threadid)
     const System::Params &params = sys->params();
 
     if (params.exit_on_work_items) {
-        exitSimLoop("workbegin", static_cast<int>(workid));
+        exitSimulationLoopClassic("workbegin", static_cast<int>(workid));
         return;
     }
 
@@ -524,7 +527,7 @@ workbegin(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             //
             // If active cpus equals checkpoint count, create checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (systemWorkBeginCount == params.work_begin_ckpt_count) {
@@ -532,21 +535,21 @@ workbegin(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             // Note: the string specified as the cause of the exit event must
             // exactly equal "checkpoint" inorder to create a checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (systemWorkBeginCount == params.work_begin_exit_count) {
             //
             // If a certain number of work items started, exit simulation
             //
-            exitSimLoop("work started count reach");
+            exitSimulationLoopClassic("work started count reach");
         }
 
         if (cpuId == params.work_begin_cpu_id_exit) {
             //
             // If work started on the cpu id specified, exit simulation
             //
-            exitSimLoop("work started on specific cpu");
+            exitSimulationLoopClassic("work started on specific cpu");
         }
     }
 }
@@ -564,7 +567,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
     const System::Params &params = sys->params();
 
     if (params.exit_on_work_items) {
-        exitSimLoop("workend", static_cast<int>(workid));
+        exitSimulationLoopClassic("workend", static_cast<int>(workid));
         return;
     }
 
@@ -586,7 +589,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             //
             // If active cpus equals checkpoint count, create checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (params.work_end_ckpt_count != 0 &&
@@ -595,7 +598,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             // If total work items completed equals checkpoint count, create
             // checkpoint
             //
-            exitSimLoop("checkpoint");
+            exitSimulationLoopClassic("checkpoint");
         }
 
         if (params.work_end_exit_count != 0 &&
@@ -603,7 +606,7 @@ workend(ThreadContext *tc, uint64_t workid, uint64_t threadid)
             //
             // If total work items completed equals exit count, exit simulation
             //
-            exitSimLoop("work items exit count reached");
+            exitSimulationLoopClassic("work items exit count reached");
         }
     }
 }
@@ -612,8 +615,7 @@ void
 m5Hypercall(ThreadContext *tc, uint64_t hypercall_id)
 {
     DPRINTF(PseudoInst, "pseudo_inst::m5Hypercall(%i)\n", hypercall_id);
-    exitSimLoopWithHypercall("m5_hypercall instruction encountered", 0,
-    curTick(),0, std::map<std::string, std::string>(), hypercall_id, true);
+    exitSimulationLoop(hypercall_id, ExitPayload(), curTick() + simQuantum);
 }
 
 } // namespace pseudo_inst

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -42,9 +42,13 @@
 
 #include "sim/sim_events.hh"
 
+#include <charconv>
 #include <string>
+#include <system_error>
+#include <utility>
 
 #include "base/callback.hh"
+#include "base/logging.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_exit.hh"
 #include "sim/stats.hh"
@@ -52,30 +56,103 @@
 namespace gem5
 {
 
-GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(Tick when,
-                                               const std::string &_cause,
-                                               int c, Tick r,
-                                               uint64_t hypercall_id,
-        std::map<std::string, std::string> payload)
+namespace
+{
+
+constexpr uint64_t
+classicGeneratorHypercallId()
+{ return static_cast<uint64_t>(ExitHypercall::CLASSIC_GENERATOR); }
+
+std::string
+classicGeneratorCause(const ExitPayload &payload)
+{
+    const auto it = payload.find("cause");
+    return it == payload.end() ? "" : it->second;
+}
+
+int
+classicGeneratorCode(const ExitPayload &payload)
+{
+    const auto it = payload.find("code");
+    fatal_if(it == payload.end(),
+             "ExitHypercall::CLASSIC_GENERATOR requires a 'code' payload "
+             "entry.");
+
+    int code;
+    const auto &value = it->second;
+    const auto [end, error] =
+        std::from_chars(value.data(), value.data() + value.size(), code);
+    fatal_if(value.empty() || error != std::errc() ||
+                 end != value.data() + value.size(),
+             "ExitHypercall::CLASSIC_GENERATOR requires 'code' to be a "
+             "base-10 integer; got '%s'.",
+             value.c_str());
+    return code;
+}
+
+void
+validateClassicGeneratorPayload(const ExitPayload &payload)
+{
+    const auto cause = payload.find("cause");
+    fatal_if(cause == payload.end() || payload.find("code") == payload.end(),
+             "ExitHypercall::CLASSIC_GENERATOR requires 'cause' and 'code' "
+             "payload entries.");
+    fatal_if(cause->second.empty(),
+             "ExitHypercall::CLASSIC_GENERATOR requires a non-empty 'cause' "
+             "payload entry.");
+    classicGeneratorCode(payload);
+}
+
+void
+syncClassicGeneratorFields(std::string &cause, int &code, ExitPayload &payload)
+{
+    if (payload.empty()) {
+        payload = classicGeneratorPayload(cause, code);
+        return;
+    }
+
+    validateClassicGeneratorPayload(payload);
+    cause = classicGeneratorCause(payload);
+    code = classicGeneratorCode(payload);
+}
+
+} // anonymous namespace
+
+GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(
+    Tick when, const std::string &_cause, int c, Tick r, uint64_t hypercall_id,
+    std::map<std::string, std::string> payload)
     : GlobalEvent(when, Sim_Exit_Pri, IsExitEvent),
-      cause(_cause), code(c), repeat(r), hypercall_id(hypercall_id),
-      payload(payload)
+      cause(_cause),
+      code(c),
+      repeat(r),
+      hypercall_id(hypercall_id),
+      payload(std::move(payload))
 {
+    if (this->hypercall_id == classicGeneratorHypercallId()) {
+        syncClassicGeneratorFields(cause, code, this->payload);
+    }
 }
 
-GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(const std::string &_cause,
-                                               int c, Tick r,
-                                               uint64_t hypercall_id,
-        std::map<std::string, std::string> payload)
+GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(
+    const std::string &_cause, int c, Tick r, uint64_t hypercall_id,
+    std::map<std::string, std::string> payload)
     : GlobalEvent(curTick(), Minimum_Pri, IsExitEvent),
-      cause(_cause), code(c), repeat(r), hypercall_id(hypercall_id),
-      payload(payload)
+      cause(_cause),
+      code(c),
+      repeat(r),
+      hypercall_id(hypercall_id),
+      payload(std::move(payload))
 {
+    if (this->hypercall_id == classicGeneratorHypercallId()) {
+        syncClassicGeneratorFields(cause, code, this->payload);
+    }
 }
 
-GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(Tick when,
-    uint64_t hypercall_id, std::map<std::string, std::string> payload)
-    : GlobalSimLoopExitEvent(when, "", 0, 0, hypercall_id, payload)
+GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(
+    Tick when, uint64_t hypercall_id,
+    std::map<std::string, std::string> payload, Tick repeat)
+    : GlobalSimLoopExitEvent(when, "", 0, repeat, hypercall_id,
+                             std::move(payload))
 {
 }
 
@@ -104,51 +181,73 @@ GlobalSimLoopExitEvent::process()
 }
 
 /**
- * The "old style" exitSimLoop functions.
+ * Deprecated compatibility wrappers for the old-style exitSimLoop API.
  */
 
 void
 exitSimLoop(const std::string &message, int exit_code, Tick when, Tick repeat,
             bool serialize)
-{
-    warn_if(serialize && (when != curTick() || repeat),
-            "exitSimLoop called with a delay and auto serialization. This is "
-            "currently unsupported.");
-
-    new GlobalSimLoopExitEvent(when + simQuantum, message, exit_code, repeat);
-}
-
+{ exitSimulationLoopClassic(message, exit_code, when, repeat, serialize); }
 
 void
 exitSimLoopNow(const std::string &message, int exit_code, Tick repeat,
                bool serialize)
+{ exitSimulationLoopClassicNow(message, exit_code, repeat, serialize); }
+
+void
+exitSimulationLoopClassic(const std::string &message, int exit_code, Tick when,
+                          Tick repeat, bool serialize)
 {
-    new GlobalSimLoopExitEvent(message, exit_code, repeat);
+    warn_if(serialize && (when != curTick() || repeat),
+            "exitSimulationLoopClassic called with serialize=true for a "
+            "delayed or repeating exit. Delay and repeat are supported, but "
+            "auto-serialization of scheduled global exit events is not; the "
+            "serialize argument is kept only for legacy API compatibility.");
+
+    exitSimulationLoop(ExitHypercall::CLASSIC_GENERATOR,
+                       classicGeneratorPayload(message, exit_code),
+                       when + simQuantum, repeat);
 }
 
 void
-exitSimLoopWithHypercall (const::std::string &message, int exit_code,
-                Tick when, Tick repeat, std::map<std::string,
-                std::string> payload, uint64_t hypercall_id,
-                bool serialize)
+exitSimulationLoopClassicNow(const std::string &message, int exit_code,
+                             Tick repeat, bool /*serialize*/)
 {
-    new GlobalSimLoopExitEvent(when + simQuantum, message, exit_code, repeat,
-                hypercall_id, payload);
+    new GlobalSimLoopExitEvent(message, exit_code, repeat,
+                               classicGeneratorHypercallId(),
+                               classicGeneratorPayload(message, exit_code));
 }
+
 /**
- * The "new style" exitSimLoop functions.
+ * The hypercall-based exitSimulationLoop functions.
  */
-void exitSimulationLoop(uint64_t type_id,
-    std::map<std::string, std::string> payload, Tick when)
+void
+exitSimulationLoop(ExitHypercallId hypercall_id, ExitPayload payload,
+                   Tick when, Tick repeat)
 {
-    new GlobalSimLoopExitEvent(when, type_id, payload);
+    if (hypercall_id == classicGeneratorHypercallId()) {
+        validateClassicGeneratorPayload(payload);
+        new GlobalSimLoopExitEvent(when, classicGeneratorCause(payload),
+                                   classicGeneratorCode(payload), repeat,
+                                   hypercall_id, std::move(payload));
+        return;
+    }
+
+    new GlobalSimLoopExitEvent(when, hypercall_id, std::move(payload), repeat);
 }
 
 void
-exitSimulationLoopNow(uint64_t type_id,
-    std::map<std::string, std::string> payload)
+exitSimulationLoopNow(ExitHypercallId hypercall_id, ExitPayload payload)
 {
-    new GlobalSimLoopExitEvent(type_id, payload);
+    if (hypercall_id == classicGeneratorHypercallId()) {
+        validateClassicGeneratorPayload(payload);
+        new GlobalSimLoopExitEvent(classicGeneratorCause(payload),
+                                   classicGeneratorCode(payload), 0,
+                                   hypercall_id, payload);
+        return;
+    }
+
+    new GlobalSimLoopExitEvent(hypercall_id, payload);
 }
 
 LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
@@ -163,10 +262,7 @@ LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
 //
 void
 LocalSimLoopExitEvent::process()
-{
-    exitSimLoop(cause, 0);
-}
-
+{ exitSimulationLoopClassic(cause, 0); }
 
 const char *
 LocalSimLoopExitEvent::description() const
@@ -212,7 +308,7 @@ void
 CountedExitEvent::process()
 {
     if (--downCounter == 0) {
-        exitSimLoop(cause, 0);
+        exitSimulationLoopClassic(cause, 0);
     }
 }
 

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -227,9 +227,10 @@ exitSimulationLoop(ExitHypercallId hypercall_id, ExitPayload payload,
 {
     if (hypercall_id == classicGeneratorHypercallId()) {
         validateClassicGeneratorPayload(payload);
-        new GlobalSimLoopExitEvent(when, classicGeneratorCause(payload),
-                                   classicGeneratorCode(payload), repeat,
-                                   hypercall_id, std::move(payload));
+        const auto cause = classicGeneratorCause(payload);
+        const auto code = classicGeneratorCode(payload);
+        new GlobalSimLoopExitEvent(when, cause, code, repeat, hypercall_id,
+                                   std::move(payload));
         return;
     }
 
@@ -241,9 +242,10 @@ exitSimulationLoopNow(ExitHypercallId hypercall_id, ExitPayload payload)
 {
     if (hypercall_id == classicGeneratorHypercallId()) {
         validateClassicGeneratorPayload(payload);
-        new GlobalSimLoopExitEvent(classicGeneratorCause(payload),
-                                   classicGeneratorCode(payload), 0,
-                                   hypercall_id, payload);
+        const auto cause = classicGeneratorCause(payload);
+        const auto code = classicGeneratorCode(payload);
+        new GlobalSimLoopExitEvent(cause, code, 0, hypercall_id,
+                                   std::move(payload));
         return;
     }
 

--- a/src/sim/sim_events.cc
+++ b/src/sim/sim_events.cc
@@ -43,8 +43,10 @@
 #include "sim/sim_events.hh"
 
 #include <string>
+#include <utility>
 
 #include "base/callback.hh"
+#include "base/logging.hh"
 #include "sim/eventq.hh"
 #include "sim/sim_exit.hh"
 #include "sim/stats.hh"
@@ -52,30 +54,86 @@
 namespace gem5
 {
 
-GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(Tick when,
-                                               const std::string &_cause,
-                                               int c, Tick r,
-                                               uint64_t hypercall_id,
-        std::map<std::string, std::string> payload)
+namespace
+{
+
+constexpr uint64_t
+classicGeneratorHypercallId()
+{ return static_cast<uint64_t>(ExitHypercall::CLASSIC_GENERATOR); }
+
+std::string
+classicGeneratorCause(const ExitPayload &payload)
+{
+    const auto it = payload.find("cause");
+    return it == payload.end() ? "" : it->second;
+}
+
+int
+classicGeneratorCode(const ExitPayload &payload)
+{
+    const auto it = payload.find("code");
+    return it == payload.end() ? 0 : std::stoi(it->second);
+}
+
+void
+validateClassicGeneratorPayload(const ExitPayload &payload)
+{
+    fatal_if(payload.find("cause") == payload.end() ||
+                 payload.find("code") == payload.end(),
+             "ExitHypercall::CLASSIC_GENERATOR requires 'cause' and 'code' "
+             "payload entries.");
+}
+
+void
+syncClassicGeneratorFields(std::string &cause, int &code, ExitPayload &payload)
+{
+    if (payload.empty()) {
+        payload = classicGeneratorPayload(cause, code);
+        return;
+    }
+
+    validateClassicGeneratorPayload(payload);
+    cause = classicGeneratorCause(payload);
+    code = classicGeneratorCode(payload);
+}
+
+} // anonymous namespace
+
+GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(
+    Tick when, const std::string &_cause, int c, Tick r, uint64_t hypercall_id,
+    std::map<std::string, std::string> payload)
     : GlobalEvent(when, Sim_Exit_Pri, IsExitEvent),
-      cause(_cause), code(c), repeat(r), hypercall_id(hypercall_id),
-      payload(payload)
+      cause(_cause),
+      code(c),
+      repeat(r),
+      hypercall_id(hypercall_id),
+      payload(std::move(payload))
 {
+    if (this->hypercall_id == classicGeneratorHypercallId()) {
+        syncClassicGeneratorFields(cause, code, this->payload);
+    }
 }
 
-GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(const std::string &_cause,
-                                               int c, Tick r,
-                                               uint64_t hypercall_id,
-        std::map<std::string, std::string> payload)
+GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(
+    const std::string &_cause, int c, Tick r, uint64_t hypercall_id,
+    std::map<std::string, std::string> payload)
     : GlobalEvent(curTick(), Minimum_Pri, IsExitEvent),
-      cause(_cause), code(c), repeat(r), hypercall_id(hypercall_id),
-      payload(payload)
+      cause(_cause),
+      code(c),
+      repeat(r),
+      hypercall_id(hypercall_id),
+      payload(std::move(payload))
 {
+    if (this->hypercall_id == classicGeneratorHypercallId()) {
+        syncClassicGeneratorFields(cause, code, this->payload);
+    }
 }
 
-GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(Tick when,
-    uint64_t hypercall_id, std::map<std::string, std::string> payload)
-    : GlobalSimLoopExitEvent(when, "", 0, 0, hypercall_id, payload)
+GlobalSimLoopExitEvent::GlobalSimLoopExitEvent(
+    Tick when, uint64_t hypercall_id,
+    std::map<std::string, std::string> payload, Tick repeat)
+    : GlobalSimLoopExitEvent(when, "", 0, repeat, hypercall_id,
+                             std::move(payload))
 {
 }
 
@@ -104,51 +162,73 @@ GlobalSimLoopExitEvent::process()
 }
 
 /**
- * The "old style" exitSimLoop functions.
+ * Deprecated compatibility wrappers for the old-style exitSimLoop API.
  */
 
 void
 exitSimLoop(const std::string &message, int exit_code, Tick when, Tick repeat,
             bool serialize)
-{
-    warn_if(serialize && (when != curTick() || repeat),
-            "exitSimLoop called with a delay and auto serialization. This is "
-            "currently unsupported.");
-
-    new GlobalSimLoopExitEvent(when + simQuantum, message, exit_code, repeat);
-}
-
+{ exitSimulationLoopClassic(message, exit_code, when, repeat, serialize); }
 
 void
 exitSimLoopNow(const std::string &message, int exit_code, Tick repeat,
                bool serialize)
+{ exitSimulationLoopClassicNow(message, exit_code, repeat, serialize); }
+
+void
+exitSimulationLoopClassic(const std::string &message, int exit_code, Tick when,
+                          Tick repeat, bool serialize)
 {
-    new GlobalSimLoopExitEvent(message, exit_code, repeat);
+    warn_if(serialize && (when != curTick() || repeat),
+            "exitSimulationLoopClassic called with serialize=true for a "
+            "delayed or repeating exit. Delay and repeat are supported, but "
+            "auto-serialization of scheduled global exit events is not; the "
+            "serialize argument is kept only for legacy API compatibility.");
+
+    exitSimulationLoop(ExitHypercall::CLASSIC_GENERATOR,
+                       classicGeneratorPayload(message, exit_code),
+                       when + simQuantum, repeat);
 }
 
 void
-exitSimLoopWithHypercall (const::std::string &message, int exit_code,
-                Tick when, Tick repeat, std::map<std::string,
-                std::string> payload, uint64_t hypercall_id,
-                bool serialize)
+exitSimulationLoopClassicNow(const std::string &message, int exit_code,
+                             Tick repeat, bool /*serialize*/)
 {
-    new GlobalSimLoopExitEvent(when + simQuantum, message, exit_code, repeat,
-                hypercall_id, payload);
+    new GlobalSimLoopExitEvent(message, exit_code, repeat,
+                               classicGeneratorHypercallId(),
+                               classicGeneratorPayload(message, exit_code));
 }
+
 /**
- * The "new style" exitSimLoop functions.
+ * The hypercall-based exitSimulationLoop functions.
  */
-void exitSimulationLoop(uint64_t type_id,
-    std::map<std::string, std::string> payload, Tick when)
+void
+exitSimulationLoop(ExitHypercallId hypercall_id, ExitPayload payload,
+                   Tick when, Tick repeat)
 {
-    new GlobalSimLoopExitEvent(when, type_id, payload);
+    if (hypercall_id == classicGeneratorHypercallId()) {
+        validateClassicGeneratorPayload(payload);
+        new GlobalSimLoopExitEvent(when, classicGeneratorCause(payload),
+                                   classicGeneratorCode(payload), repeat,
+                                   hypercall_id, std::move(payload));
+        return;
+    }
+
+    new GlobalSimLoopExitEvent(when, hypercall_id, std::move(payload), repeat);
 }
 
 void
-exitSimulationLoopNow(uint64_t type_id,
-    std::map<std::string, std::string> payload)
+exitSimulationLoopNow(ExitHypercallId hypercall_id, ExitPayload payload)
 {
-    new GlobalSimLoopExitEvent(type_id, payload);
+    if (hypercall_id == classicGeneratorHypercallId()) {
+        validateClassicGeneratorPayload(payload);
+        new GlobalSimLoopExitEvent(classicGeneratorCause(payload),
+                                   classicGeneratorCode(payload), 0,
+                                   hypercall_id, payload);
+        return;
+    }
+
+    new GlobalSimLoopExitEvent(hypercall_id, payload);
 }
 
 LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
@@ -163,10 +243,7 @@ LocalSimLoopExitEvent::LocalSimLoopExitEvent(const std::string &_cause, int c,
 //
 void
 LocalSimLoopExitEvent::process()
-{
-    exitSimLoop(cause, 0);
-}
-
+{ exitSimulationLoopClassic(cause, 0); }
 
 const char *
 LocalSimLoopExitEvent::description() const
@@ -212,7 +289,7 @@ void
 CountedExitEvent::process()
 {
     if (--downCounter == 0) {
-        exitSimLoop(cause, 0);
+        exitSimulationLoopClassic(cause, 0);
     }
 }
 

--- a/src/sim/sim_events.hh
+++ b/src/sim/sim_events.hh
@@ -45,6 +45,7 @@
 
 #include "sim/global_event.hh"
 #include "sim/serialize.hh"
+#include "sim/sim_exit.hh"
 
 namespace gem5
 {
@@ -63,33 +64,31 @@ class GlobalSimLoopExitEvent : public GlobalEvent
     std::map<std::string, std::string> payload;
 
   public:
-
     /**
-     * The "old style" constructor for GlobalSimLoopExitEvent.
-     * Not the `type_id` parameter is set to 0. Zero is reserved for the "old
-     * style" exitSimLoop handling via generators in the Simulator module.
-     * The payload is unused.
+     * Constructor for exits that must preserve the legacy cause/code fields
+     * while still dispatching through a hypercall-aware ExitHandler.
+     *
+     * CLASSIC_GENERATOR callers should supply the matching cause/code payload.
+     * If they pass an empty payload, it is synthesized from the legacy fields.
      */
     GlobalSimLoopExitEvent(Tick when, const std::string &_cause, int c,
-        Tick repeat = 0, uint64_t hypercall_id = 0,
-        std::map<std::string, std::string> payload =
-            std::map<std::string, std::string>());
+                           Tick repeat, uint64_t hypercall_id,
+                           std::map<std::string, std::string> payload);
 
-    GlobalSimLoopExitEvent(const std::string &_cause, int c,
-         Tick repeat = 0, uint64_t hypercall_id = 0,
-        std::map<std::string, std::string> payload =
-            std::map<std::string, std::string>());
+    GlobalSimLoopExitEvent(const std::string &_cause, int c, Tick repeat,
+                           uint64_t hypercall_id,
+                           std::map<std::string, std::string> payload);
 
     /**
-     * The "new style" constructor for GlobalSimLoopExitEvent.
-     * Here the "type_id" parameter is used to specify the type of the exit
-     * and the payload is used to pass additional information about the exit.
+     * Constructor for exits that only dispatch through the hypercall-aware
+     * ExitHandler path. Legacy cause/code fields are left empty/zero.
      *
      * These are used to construct Exit Handlers on the Python side.
      */
     GlobalSimLoopExitEvent(Tick when, uint64_t hypercall_id,
-        std::map<std::string, std::string> payload =
-            std::map<std::string, std::string>());
+                           std::map<std::string, std::string> payload =
+                               std::map<std::string, std::string>(),
+                           Tick repeat = 0);
 
     GlobalSimLoopExitEvent(uint64_t hypercall_id,
         std::map<std::string, std::string> payload =

--- a/src/sim/sim_exit.hh
+++ b/src/sim/sim_exit.hh
@@ -32,44 +32,150 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "base/types.hh"
+#include "gem5/exit_hypercalls.hh"
 
 namespace gem5
 {
 
 Tick curTick();
 
+/// Hypercall identifiers used when scheduling exits with
+/// exitSimulationLoop(). These values mirror the IDs consumed by the
+/// standard library ``ExitHandler`` implementations. ID 0 is reserved for the
+/// legacy generator-based exit handling path.
+enum class ExitHypercall : uint64_t
+{
+#define GEM5_DEFINE_EXIT_ENUM(enum_name, macro_name, value, desc)             \
+    enum_name = value,
+    GEM5_FOREACH_EXIT_HYPERCALL(GEM5_DEFINE_EXIT_ENUM)
+#undef GEM5_DEFINE_EXIT_ENUM
+};
+
+#define GEM5_DEFINE_EXIT_CONST(enum_name, macro_name, value, desc)            \
+    inline constexpr uint64_t kExitHypercall##enum_name =                     \
+        static_cast<uint64_t>(ExitHypercall::enum_name);
+GEM5_FOREACH_EXIT_HYPERCALL(GEM5_DEFINE_EXIT_CONST)
+#undef GEM5_DEFINE_EXIT_CONST
+
+struct ExitHypercallDescriptor
+{
+    ExitHypercall id;
+    const char *name;
+    const char *description;
+};
+
+#define GEM5_DEFINE_EXIT_DESCRIPTOR(enum_name, macro_name, value, desc)       \
+    {ExitHypercall::enum_name, #enum_name, desc},
+inline constexpr ExitHypercallDescriptor kExitHypercallDescriptors[] = {
+    GEM5_FOREACH_EXIT_HYPERCALL(GEM5_DEFINE_EXIT_DESCRIPTOR)};
+#undef GEM5_DEFINE_EXIT_DESCRIPTOR
+
 /// Register a callback to be called when Python exits.  Defined in
 /// sim/main.cc.
 void registerExitCallback(const std::function<void()> &);
 
-/// Schedule an event to exit the simulation loop (returning to
-/// Python) at the end of the current cycle (curTick()).  The message
-/// and exit_code parameters are saved in the SimLoopExitEvent to
-/// indicate why the exit occurred.
+/**
+ * Legacy “classic” exit path that predates hypercalls. This schedules a
+ * generator-based exit event that reports only a human-readable message and an
+ * optional integer code. Modern stdlib simulations should prefer the
+ * hypercall-based APIs below so Python ExitHandlers can dispatch on a specific
+ * ID and payload.
+ */
 void exitSimLoop(const std::string &message, int exit_code = 0,
                  Tick when = curTick(), Tick repeat = 0,
                  bool serialize = false);
-/// Schedule an event as above, but make it high priority so it runs before
-/// any normal events which are schedule at the current time.
+
+/// Legacy high-priority variant of ``exitSimLoop`` (see note above).
 void exitSimLoopNow(const std::string &message, int exit_code = 0,
                     Tick repeat = 0, bool serialize = false);
 
+/**
+ * Transitional helper that emits the legacy message/code *and* a hypercall
+ * payload. This is what pseudo instructions such as ``m5_hypercall`` use: the
+ * simulator still records the textual cause, but ExitHandlers can make
+ * decisions based on ``hypercall_id`` and ``payload``.
+ *
+ * Prefer the ``exitSimulationLoop*`` helpers below when you do not need the
+ * legacy string/code at all.
+ *
+ * @param message     Human-readable reason displayed when the exit triggers.
+ * @param exit_code   Optional numeric code paired with ``message``.
+ * @param when        Tick at which to queue the exit event (defaults to now).
+ * @param repeat      Interval to reschedule the event; 0 disables repetition.
+ * @param payload     Key/value data forwarded to the ExitHandler.
+ * @param hypercall_id Identifier that selects the ExitHandler implementation.
+ * @param serialize   Request automatic checkpointing before exiting.
+ */
 void exitSimLoopWithHypercall(const std::string &message, int exit_code,
                               Tick when, Tick repeat,
                               std::map<std::string, std::string> payload,
                               uint64_t hypercall_id, bool serialize);
 
+/**
+ * Preferred hypercall-based exit API. ``type_id`` should be one of the
+ * ``ExitHypercall`` enum values (or a custom ID if you've registered your own
+ * ExitHandler).
+ *
+ * The ``payload`` map is copied so Python handlers can inspect arbitrary
+ * metadata (justification strings, schedule time, etc.).
+ *
+ * Examples:
+ *
+ * ```
+ * exitSimulationLoop(ExitHypercall::ScheduledExit,
+ *     { {"justification", "Stop after ROI"} },
+ *     curTick() + 1000);
+ * exitSimulationLoop(static_cast<uint64_t>(myCustomId), {{"foo", "bar"}});
+ * ```
+ *
+ * @param type_id   Identifier for the ExitHandler to run.
+ * @param payload   Optional metadata consumed by the ExitHandler.
+ * @param when      Tick at which the exit event should fire.
+ */
 void exitSimulationLoop(uint64_t type_id,
     std::map<std::string, std::string> payload=
         std::map<std::string, std::string>(),
     Tick when=curTick());
 
+/**
+ * Immediate variant of ``exitSimulationLoop`` that schedules the event for
+ * the current tick and does not repeat.
+ */
 void
 exitSimulationLoopNow(uint64_t type_id,
     std::map<std::string, std::string> payload=
         std::map<std::string, std::string>());
+
+/// Convenience overloads so callers can pass ``ExitHypercall`` directly.
+inline void
+exitSimLoopWithHypercall(const std::string &message, int exit_code, Tick when,
+                         Tick repeat,
+                         std::map<std::string, std::string> payload,
+                         ExitHypercall hypercall_id, bool serialize)
+{
+    exitSimLoopWithHypercall(message, exit_code, when, repeat,
+                             std::move(payload),
+                             static_cast<uint64_t>(hypercall_id), serialize);
+}
+
+inline void
+exitSimulationLoop(ExitHypercall type_id,
+                   std::map<std::string, std::string> payload =
+                       std::map<std::string, std::string>(),
+                   Tick when = curTick())
+{
+    exitSimulationLoop(static_cast<uint64_t>(type_id), std::move(payload),
+                       when);
+}
+
+inline void
+exitSimulationLoopNow(ExitHypercall type_id,
+                      std::map<std::string, std::string> payload =
+                          std::map<std::string, std::string>())
+{ exitSimulationLoopNow(static_cast<uint64_t>(type_id), std::move(payload)); }
 
 } // namespace gem5
 

--- a/src/sim/sim_exit.hh
+++ b/src/sim/sim_exit.hh
@@ -32,44 +32,159 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "base/types.hh"
+#include "gem5/hypercall_ids.h"
 
 namespace gem5
 {
 
 Tick curTick();
 
+/// Built-in hypercall identifiers used when scheduling exits with
+/// exitSimulationLoop(). A hypercall is the broader guest/simulator request
+/// mechanism; ``ExitHypercall`` is gem5's finite set of hypercalls that route
+/// through the simulation-exit/stdlib ``ExitHandler`` path. Users may still
+/// use custom integer hypercall IDs with custom handlers. ID 0 is reserved for
+/// the legacy generator-based exit handling path.
+enum class ExitHypercall : uint64_t
+{
+#define GEM5_DEFINE_EXIT_ENUM(name, value, desc) name = value,
+    GEM5_FOREACH_EXIT_HYPERCALL(GEM5_DEFINE_EXIT_ENUM)
+#undef GEM5_DEFINE_EXIT_ENUM
+};
+
+struct ExitHypercallDescriptor
+{
+    ExitHypercall id;
+    const char *name;
+    const char *description;
+};
+
+#define GEM5_DEFINE_EXIT_DESCRIPTOR(name, value, desc)                        \
+    {ExitHypercall::name, #name, desc},
+inline constexpr ExitHypercallDescriptor kExitHypercallDescriptors[] = {
+    GEM5_FOREACH_EXIT_HYPERCALL(GEM5_DEFINE_EXIT_DESCRIPTOR)};
+#undef GEM5_DEFINE_EXIT_DESCRIPTOR
+
+using ExitHypercallId = uint64_t;
+using ExitPayload = std::map<std::string, std::string>;
+
+inline ExitPayload
+classicGeneratorPayload(const std::string &cause, int code = 0)
+{ return {{"cause", cause}, {"code", std::to_string(code)}}; }
+
 /// Register a callback to be called when Python exits.  Defined in
 /// sim/main.cc.
 void registerExitCallback(const std::function<void()> &);
 
-/// Schedule an event to exit the simulation loop (returning to
-/// Python) at the end of the current cycle (curTick()).  The message
-/// and exit_code parameters are saved in the SimLoopExitEvent to
-/// indicate why the exit occurred.
+/**
+ * Legacy "classic" exit path that predates hypercalls. This schedules a
+ * generator-based exit event that reports only a human-readable message and an
+ * optional integer code. Modern stdlib simulations should prefer the
+ * hypercall-based APIs below so Python ExitHandlers can dispatch on an ID and
+ * structured payload.
+ *
+ * Use ``exitSimulationLoopClassic`` for legacy generator exits that must
+ * still preserve ``getCause()``/``getCode()``.
+ */
+[[deprecated("exitSimLoop is deprecated. Use exitSimulationLoop for "
+             "hypercall-based exits, or exitSimulationLoopClassic only "
+             "when legacy cause/code compatibility is required.")]]
 void exitSimLoop(const std::string &message, int exit_code = 0,
                  Tick when = curTick(), Tick repeat = 0,
                  bool serialize = false);
-/// Schedule an event as above, but make it high priority so it runs before
-/// any normal events which are schedule at the current time.
+
+/// Legacy high-priority variant of ``exitSimLoop`` (see note above).
+[[deprecated("exitSimLoopNow is deprecated. Use exitSimulationLoopNow for "
+             "hypercall-based exits, or exitSimulationLoopClassicNow only "
+             "when legacy cause/code compatibility is required.")]]
 void exitSimLoopNow(const std::string &message, int exit_code = 0,
                     Tick repeat = 0, bool serialize = false);
 
-void exitSimLoopWithHypercall(const std::string &message, int exit_code,
-                              Tick when, Tick repeat,
-                              std::map<std::string, std::string> payload,
-                              uint64_t hypercall_id, bool serialize);
+/**
+ * Compatibility helper for legacy "classic" simulation exits.
+ *
+ * "Classic" means the exit is still identified by the legacy string message
+ * instead of by a dedicated hypercall ID. This helper sends that string and
+ * code through the ``CLASSIC_GENERATOR`` hypercall payload. The Python
+ * classic-generator handler then maps the string into the legacy
+ * ``ExitEvent`` path, for example ``"checkpoint"`` maps to
+ * ``ExitEvent.CHECKPOINT``.
+ *
+ * This preserves ``GlobalSimLoopExitEvent::getCause()/getCode()`` and supplies
+ * the matching ``{"cause": message, "code": exit_code}`` payload expected by
+ * the Python classic-generator handler. Use this only when legacy cause/code
+ * or ``ExitEvent`` string-dispatch compatibility is required.
+ */
+void exitSimulationLoopClassic(const std::string &message, int exit_code = 0,
+                               Tick when = curTick(), Tick repeat = 0,
+                               bool serialize = false);
 
-void exitSimulationLoop(uint64_t type_id,
-    std::map<std::string, std::string> payload=
-        std::map<std::string, std::string>(),
-    Tick when=curTick());
+/**
+ * Immediate variant of ``exitSimulationLoopClassic`` that preserves the
+ * minimum-priority scheduling behavior of the legacy ``exitSimLoopNow`` API.
+ *
+ * The ``serialize`` parameter is accepted for compatibility with
+ * ``exitSimLoopNow``. That API has ignored the parameter since it was added.
+ */
+void exitSimulationLoopClassicNow(const std::string &message,
+                                  int exit_code = 0, Tick repeat = 0,
+                                  bool serialize = false);
 
-void
-exitSimulationLoopNow(uint64_t type_id,
-    std::map<std::string, std::string> payload=
-        std::map<std::string, std::string>());
+/**
+ * Preferred hypercall-based exit API. ``hypercall_id`` should be one of
+ * ``ExitHypercall``'s values, or a custom ID if you have registered a matching
+ * ExitHandler.
+ *
+ * This API does not normally populate legacy ``getCause()``/``getCode()``.
+ * ``ExitHypercall::CLASSIC_GENERATOR`` is the compatibility exception: callers
+ * must provide ``cause`` and ``code`` payload entries, which are mirrored into
+ * the legacy fields.
+ *
+ * Examples:
+ *
+ * ```
+ * exitSimulationLoop(ExitHypercall::SCHEDULED_EXIT,
+ *     { {"justification", "Stop after ROI"} },
+ *     curTick() + 1000);
+ * exitSimulationLoop(static_cast<uint64_t>(myCustomId), {{"foo", "bar"}});
+ * ```
+ *
+ * @param hypercall_id Identifier for the ExitHandler to run.
+ * @param payload   Optional metadata consumed by the ExitHandler.
+ * @param when      Tick at which the exit event should fire.
+ * @param repeat    Interval to reschedule the event; 0 disables repetition.
+ */
+void exitSimulationLoop(ExitHypercallId hypercall_id,
+                        ExitPayload payload = ExitPayload(),
+                        Tick when = curTick(), Tick repeat = 0);
+
+/**
+ * Immediate variant of ``exitSimulationLoop`` that schedules the event for
+ * the current tick and does not repeat.
+ */
+void exitSimulationLoopNow(ExitHypercallId hypercall_id,
+                           ExitPayload payload = ExitPayload());
+
+/// Convenience overloads so callers can pass ``ExitHypercall`` directly.
+inline void
+exitSimulationLoop(ExitHypercall hypercall,
+                   ExitPayload payload = ExitPayload(), Tick when = curTick(),
+                   Tick repeat = 0)
+{
+    exitSimulationLoop(static_cast<uint64_t>(hypercall), std::move(payload),
+                       when, repeat);
+}
+
+inline void
+exitSimulationLoopNow(ExitHypercall hypercall,
+                      ExitPayload payload = ExitPayload())
+{
+    exitSimulationLoopNow(static_cast<uint64_t>(hypercall),
+                          std::move(payload));
+}
 
 } // namespace gem5
 

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -258,8 +258,9 @@ void set_max_tick(Tick tick)
 {
     if (!simulate_limit_event) {
         simulate_limit_event = new GlobalSimLoopExitEvent(
-            mainEventQueue[0]->getCurTick(),
-            "simulate() limit reached", 0);
+            mainEventQueue[0]->getCurTick(), "simulate() limit reached", 0, 0,
+            static_cast<uint64_t>(ExitHypercall::CLASSIC_GENERATOR),
+            classicGeneratorPayload("simulate() limit reached"));
     }
     simulate_limit_event->reschedule(tick);
 }
@@ -323,7 +324,7 @@ doSimLoop(EventQueue *eventq)
 
             if (async_exit) {
                 async_exit = false;
-                exitSimLoop("user interrupt received");
+                exitSimulationLoopClassic("user interrupt received");
             }
 
             if (async_exception) {

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -257,7 +257,8 @@ exitImpl(SyscallDesc *desc, ThreadContext *tc, bool group, int status,
             return status;
         }
 
-        exitSimLoop("exiting with last active thread context", status & 0xff);
+        exitSimulationLoopClassic("exiting with last active thread context",
+                                  status & 0xff);
         return status;
     }
 

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -247,7 +247,8 @@ exitImpl(SyscallDesc *desc, ThreadContext *tc, bool group, int status)
             return status;
         }
 
-        exitSimLoop("exiting with last active thread context", status & 0xff);
+        exitSimulationLoopClassic("exiting with last active thread context",
+                                  status & 0xff);
         return status;
     }
 

--- a/src/systemc/core/scheduler.cc
+++ b/src/systemc/core/scheduler.cc
@@ -374,7 +374,7 @@ Scheduler::pause()
         if (scMainFiber.finished())
             fatal("Pausing systemc after sc_main completed.");
         else
-            gem5::exitSimLoopNow("systemc pause");
+            exitSimulationLoopClassicNow("systemc pause");
     }
 }
 
@@ -396,7 +396,7 @@ Scheduler::stop()
         if (scMainFiber.finished())
             fatal("Stopping systemc after sc_main completed.");
         else
-            gem5::exitSimLoopNow("systemc stop");
+            exitSimulationLoopClassicNow("systemc stop");
     }
 }
 

--- a/tests/gem5/processor_switch_tests/configs/cross-product-switch-afterboot.py
+++ b/tests/gem5/processor_switch_tests/configs/cross-product-switch-afterboot.py
@@ -109,7 +109,7 @@ class WorkBeginExit(WorkBeginExitHandler):
         return False
 
 
-class ScheduledStatsDumpHandler(ExitHandler, hypercall_num=6):
+class ScheduledStatsDumpHandler(ExitHandler, hypercall="ScheduledExit"):
     process_count = 0
 
     @overrides(ExitHandler)

--- a/tests/gem5/processor_switch_tests/configs/cross-product-switch-afterboot.py
+++ b/tests/gem5/processor_switch_tests/configs/cross-product-switch-afterboot.py
@@ -56,6 +56,7 @@ from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import (
     ExitHandler,
+    ExitHypercall,
     WorkBeginExitHandler,
 )
 from gem5.simulate.simulator import Simulator
@@ -109,7 +110,9 @@ class WorkBeginExit(WorkBeginExitHandler):
         return False
 
 
-class ScheduledStatsDumpHandler(ExitHandler, hypercall_num=6):
+class ScheduledStatsDumpHandler(
+    ExitHandler, hypercall=ExitHypercall.SCHEDULED_EXIT
+):
     process_count = 0
 
     @overrides(ExitHandler)

--- a/tests/gem5/processor_switch_tests/configs/cross-product-switch-matmul.py
+++ b/tests/gem5/processor_switch_tests/configs/cross-product-switch-matmul.py
@@ -50,7 +50,7 @@ parser.add_argument("--isa", type=str, required=True)
 args = parser.parse_args()
 
 
-class ScheduledProcessorSwitchHandler(ExitHandler, hypercall_num=6):
+class ScheduledProcessorSwitchHandler(ExitHandler, hypercall="ScheduledExit"):
     process_count = 0
 
     @overrides(ExitHandler)

--- a/tests/gem5/processor_switch_tests/configs/cross-product-switch-matmul.py
+++ b/tests/gem5/processor_switch_tests/configs/cross-product-switch-matmul.py
@@ -37,7 +37,10 @@ from gem5.components.processors.simple_switchable_processor import (
 )
 from gem5.isas import get_isa_from_str
 from gem5.resources.resource import obtain_resource
-from gem5.simulate.exit_handler import ExitHandler
+from gem5.simulate.exit_handler import (
+    ExitHandler,
+    ExitHypercall,
+)
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
 
@@ -50,7 +53,9 @@ parser.add_argument("--isa", type=str, required=True)
 args = parser.parse_args()
 
 
-class ScheduledProcessorSwitchHandler(ExitHandler, hypercall_num=6):
+class ScheduledProcessorSwitchHandler(
+    ExitHandler, hypercall=ExitHypercall.SCHEDULED_EXIT
+):
     process_count = 0
 
     @overrides(ExitHandler)

--- a/tests/pyunit/stdlib/pyunit_exit_handler.py
+++ b/tests/pyunit/stdlib/pyunit_exit_handler.py
@@ -55,6 +55,11 @@ class TestExitHandlerCompatibility(unittest.TestCase):
         )
         self.assertEqual(resolved_int, int(member.value))
         self.assertEqual(exit_handler_mod._resolve_hypercall_id(4096), 4096)
+        self.assertEqual(exit_handler_mod._resolve_hypercall_id(0), 0)
+        self.assertEqual(
+            exit_handler_mod._resolve_hypercall_id((1 << 64) - 1),
+            (1 << 64) - 1,
+        )
 
     def test_resolve_hypercall_id_rejects_unknown_selectors(self):
         from gem5.simulate import exit_handler as exit_handler_mod
@@ -64,6 +69,12 @@ class TestExitHandlerCompatibility(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError, "ExitHypercall enum"):
             exit_handler_mod._resolve_hypercall_id(object())
+        with self.assertRaisesRegex(TypeError, "not bool"):
+            exit_handler_mod._resolve_hypercall_id(True)
+        with self.assertRaisesRegex(ValueError, "unsigned 64-bit"):
+            exit_handler_mod._resolve_hypercall_id(-1)
+        with self.assertRaisesRegex(ValueError, "unsigned 64-bit"):
+            exit_handler_mod._resolve_hypercall_id(1 << 64)
 
     def test_exit_handler_class_registration_accepts_exit_hypercall(self):
         from gem5.simulate import exit_handler as exit_handler_mod
@@ -433,6 +444,40 @@ class TestExitHandlerCompatibility(unittest.TestCase):
 
         finally:
             _m5_event.exitSimulationLoopClassic = original
+
+    def test_public_exit_helpers_forward_to_native_bindings(self):
+        import m5.event as m5_event
+
+        import _m5.event as _m5_event
+
+        original_classic = _m5_event.exitSimulationLoopClassic
+        original_hypercall = _m5_event.exitSimulationLoop
+        calls = []
+
+        try:
+            _m5_event.exitSimulationLoopClassic = lambda *args: calls.append(
+                ("classic", args)
+            )
+            _m5_event.exitSimulationLoop = lambda *args: calls.append(
+                ("hypercall", args)
+            )
+
+            m5_event.exitSimulationLoopClassic("cause", 3, 10, 4, False)
+            m5_event.exitSimulationLoop(4096, {"key": "value"}, 20, 5)
+
+            self.assertEqual(
+                calls,
+                [
+                    ("classic", ("cause", 3, 10, 4, False)),
+                    ("hypercall", (4096, {"key": "value"}, 20, 5)),
+                ],
+            )
+            self.assertIn("exitSimulationLoop", m5_event.__all__)
+            self.assertIn("exitSimulationLoopClassic", m5_event.__all__)
+
+        finally:
+            _m5_event.exitSimulationLoopClassic = original_classic
+            _m5_event.exitSimulationLoop = original_hypercall
 
     def test_default_tick_exit_uses_compatibility_path(self):
         # The internal scheduled-tick helper should no longer call the

--- a/tests/pyunit/stdlib/pyunit_exit_handler.py
+++ b/tests/pyunit/stdlib/pyunit_exit_handler.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+
+class TestExitHandlerCompatibility(unittest.TestCase):
+    def test_exit_hypercall_is_publicly_reexported(self):
+        import _m5.event as _m5_event
+
+        from gem5.simulate.exit_handler import ExitHypercall
+
+        self.assertIs(ExitHypercall, _m5_event.ExitHypercall)
+        self.assertEqual(
+            int(ExitHypercall.SCHEDULED_EXIT.value),
+            int(_m5_event.ExitHypercall.SCHEDULED_EXIT.value),
+        )
+
+    def test_resolve_hypercall_id(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        # Enum selector.
+        enum_sel = exit_handler_mod.ExitHypercall.SCHEDULED_EXIT
+        resolved_enum = exit_handler_mod._resolve_hypercall_id(enum_sel)
+        self.assertEqual(resolved_enum, int(enum_sel.value))
+
+        member = exit_handler_mod.ExitHypercall.CLASSIC_GENERATOR
+
+        # Integer selector, including custom/user-defined IDs.
+        resolved_int = exit_handler_mod._resolve_hypercall_id(
+            int(member.value)
+        )
+        self.assertEqual(resolved_int, int(member.value))
+        self.assertEqual(exit_handler_mod._resolve_hypercall_id(4096), 4096)
+
+    def test_resolve_hypercall_id_rejects_unknown_selectors(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        with self.assertRaisesRegex(TypeError, "ExitHypercall enum"):
+            exit_handler_mod._resolve_hypercall_id("not-a-hypercall")
+
+        with self.assertRaisesRegex(TypeError, "ExitHypercall enum"):
+            exit_handler_mod._resolve_hypercall_id(object())
+
+    def test_exit_handler_class_registration_accepts_exit_hypercall(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.KERNEL_BOOTED.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+
+            class EnumRegisteredHandler(
+                exit_handler_mod.ExitHandler,
+                hypercall=exit_handler_mod.ExitHypercall.KERNEL_BOOTED,
+            ):
+                def _process(self, simulator):
+                    pass
+
+                def _exit_simulation(self):
+                    return False
+
+            self.assertIs(handler_map[h_id], EnumRegisteredHandler)
+            self.assertEqual(EnumRegisteredHandler.get_handler_id(), h_id)
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_exit_handler_class_registration_accepts_legacy_hypercall_num(
+        self,
+    ):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.KERNEL_BOOTED.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+
+            class LegacyRegisteredHandler(
+                exit_handler_mod.ExitHandler,
+                hypercall_num=h_id,
+            ):
+                def _process(self, simulator):
+                    pass
+
+                def _exit_simulation(self):
+                    return False
+
+            self.assertIs(handler_map[h_id], LegacyRegisteredHandler)
+            self.assertEqual(LegacyRegisteredHandler.get_handler_id(), h_id)
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_exit_handler_subclass_inherits_registered_hypercall(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.KERNEL_BOOTED.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+
+            class CustomKernelBootedExitHandler(
+                exit_handler_mod.KernelBootedExitHandler
+            ):
+                def _process(self, simulator):
+                    pass
+
+            self.assertIs(handler_map[h_id], CustomKernelBootedExitHandler)
+            self.assertEqual(
+                CustomKernelBootedExitHandler.get_handler_id(), h_id
+            )
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_exit_handler_class_registration_rejects_ambiguous_selector(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        with self.assertRaisesRegex(TypeError, "Specify only one"):
+
+            class AmbiguousExitHandler(
+                exit_handler_mod.ExitHandler,
+                hypercall=exit_handler_mod.ExitHypercall.WORK_BEGIN,
+                hypercall_id=int(
+                    exit_handler_mod.ExitHypercall.WORK_END.value
+                ),
+            ):
+                def _process(self, simulator):
+                    pass
+
+                def _exit_simulation(self):
+                    return False
+
+    def test_register_exit_handler_and_invocation(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.CLASSIC_GENERATOR.value)
+
+        invocations = []
+
+        def handler_func(simulator, payload):
+            invocations.append((simulator, payload))
+            return True
+
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+            handler_cls = exit_handler_mod.register_exit_handler(
+                exit_handler_mod.ExitHypercall.CLASSIC_GENERATOR,
+                handler_func,
+                "test handler",
+            )
+
+            payload = {"cause": "test", "code": "0"}
+            handler = handler_cls(payload)
+            result = handler.handle(None)
+            self.assertTrue(result)
+            self.assertEqual(handler.get_handler_description(), "test handler")
+            self.assertEqual(len(invocations), 1)
+            self.assertEqual(invocations[0][1], payload)
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_register_exit_handler_supports_hypercall_id_alias(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.WORK_END.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+            handler_cls = exit_handler_mod.register_exit_handler(
+                None,
+                lambda simulator, payload: False,
+                "custom hypercall_id handler",
+                hypercall_id=int(
+                    exit_handler_mod.ExitHypercall.WORK_END.value
+                ),
+            )
+
+            self.assertIs(handler_map[h_id], handler_cls)
+            self.assertFalse(handler_cls({}).handle(None))
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_register_exit_handler_rejects_missing_or_ambiguous_selector(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        def handler_func(simulator, payload):
+            return False
+
+        with self.assertRaisesRegex(ValueError, "must be provided"):
+            exit_handler_mod.register_exit_handler(
+                None, handler_func, "missing hypercall"
+            )
+
+        with self.assertRaisesRegex(ValueError, "Specify only one"):
+            exit_handler_mod.register_exit_handler(
+                exit_handler_mod.ExitHypercall.WORK_BEGIN,
+                handler_func,
+                "ambiguous hypercall",
+                hypercall_id=int(
+                    exit_handler_mod.ExitHypercall.WORK_END.value
+                ),
+            )
+
+    def test_classic_generator_uses_payload_cause_when_present(self):
+        from gem5.simulate.exit_event import ExitEvent
+        from gem5.simulate.exit_handler import ClassicGeneratorExitHandler
+
+        self._with_classic_generator_maps(
+            ExitEvent.MAX_TICK,
+            payload={"cause": "simulate() limit reached", "code": "0"},
+            legacy_cause="legacy cause should not be read",
+            should_read_legacy_cause=False,
+        )
+
+    def test_classic_generator_falls_back_to_legacy_cause(self):
+        from gem5.simulate.exit_event import ExitEvent
+        from gem5.simulate.exit_handler import ClassicGeneratorExitHandler
+
+        simulator = self._with_classic_generator_maps(
+            ExitEvent.SCHEDULED_TICK,
+            payload={"code": "0"},
+            legacy_cause="Tick exit reached",
+            should_read_legacy_cause=True,
+        )
+        self.assertEqual(simulator.legacy_cause_reads, 1)
+
+    def _with_classic_generator_maps(
+        self,
+        exit_event,
+        payload,
+        legacy_cause,
+        should_read_legacy_cause,
+    ):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        handler_cls = exit_handler_mod.ClassicGeneratorExitHandler
+        missing = object()
+        old_on_exit_event = getattr(handler_cls, "_on_exit_event", missing)
+        old_default_on_exit_dict = getattr(
+            handler_cls, "_default_on_exit_dict", missing
+        )
+        old_expected_execution_order = getattr(
+            handler_cls, "_expected_execution_order", missing
+        )
+
+        def restore_attr(name, value):
+            if value is missing:
+                try:
+                    delattr(handler_cls, name)
+                except AttributeError:
+                    pass
+            else:
+                setattr(handler_cls, name, value)
+
+        def single_yield(value):
+            yield value
+
+        class FakeSimulator:
+            def __init__(self):
+                self._exit_event_count = 0
+                self._tick_stopwatch = []
+                self.legacy_cause_reads = 0
+
+            def get_current_tick(self):
+                return 100
+
+            def get_last_exit_event_cause(self):
+                self.legacy_cause_reads += 1
+                if not should_read_legacy_cause:
+                    raise AssertionError(
+                        "payload cause should avoid legacy cause lookup"
+                    )
+                return legacy_cause
+
+        try:
+            handler_cls._on_exit_event = {exit_event: single_yield(False)}
+            handler_cls._default_on_exit_dict = {
+                exit_event: single_yield(True)
+            }
+            handler_cls._expected_execution_order = [exit_event]
+
+            simulator = FakeSimulator()
+            handler = handler_cls(payload)
+            self.assertFalse(handler.handle(simulator))
+            self.assertEqual(simulator._tick_stopwatch, [(exit_event, 100)])
+            return simulator
+
+        finally:
+            restore_attr("_on_exit_event", old_on_exit_event)
+            restore_attr("_default_on_exit_dict", old_default_on_exit_dict)
+            restore_attr(
+                "_expected_execution_order", old_expected_execution_order
+            )
+
+    def test_exitSimLoop_forwards_to_exitSimulationLoopClassic(self):
+        # Ensure the legacy helper preserves legacy scheduling arguments while
+        # forwarding through the classic hypercall-aware path.
+        import m5.event as m5_event
+
+        import _m5.event as _m5_event
+
+        original = _m5_event.exitSimulationLoopClassic
+        calls = []
+
+        def fake_exitSimulationLoopClassic(
+            message,
+            exit_code,
+            when,
+            repeat,
+            serialize,
+        ):
+            calls.append(
+                (
+                    message,
+                    exit_code,
+                    when,
+                    repeat,
+                    serialize,
+                )
+            )
+
+        try:
+            _m5_event.exitSimulationLoopClassic = (
+                fake_exitSimulationLoopClassic
+            )
+
+            with self.assertWarnsRegex(
+                DeprecationWarning, "exitSimulationLoopClassic"
+            ):
+                m5_event.exitSimLoop(
+                    "legacy-cause",
+                    exit_code=7,
+                    when=123,
+                    repeat=11,
+                    serialize=True,
+                )
+
+            self.assertEqual(len(calls), 1)
+            (
+                message,
+                exit_code,
+                tick,
+                repeat,
+                serialize,
+            ) = calls[0]
+            self.assertEqual(message, "legacy-cause")
+            self.assertEqual(exit_code, 7)
+            self.assertEqual(tick, 123)
+            self.assertEqual(repeat, 11)
+            self.assertTrue(serialize)
+
+        finally:
+            _m5_event.exitSimulationLoopClassic = original
+
+    def test_exitSimLoop_defaults_when_to_native_curTick(self):
+        # With no explicit tick, leave the default as None so the native
+        # helper resolves curTick() inside the embedded runtime.
+        import m5.event as m5_event
+
+        import _m5.event as _m5_event
+
+        original = _m5_event.exitSimulationLoopClassic
+        calls = []
+
+        def fake_exitSimulationLoopClassic(
+            message,
+            exit_code,
+            when,
+            repeat,
+            serialize,
+        ):
+            calls.append((when, repeat))
+
+        try:
+            _m5_event.exitSimulationLoopClassic = (
+                fake_exitSimulationLoopClassic
+            )
+
+            with self.assertWarnsRegex(
+                DeprecationWarning, "exitSimulationLoopClassic"
+            ):
+                m5_event.exitSimLoop("legacy-cause")
+
+            self.assertEqual(calls, [(None, 0)])
+
+        finally:
+            _m5_event.exitSimulationLoopClassic = original
+
+    def test_default_tick_exit_uses_compatibility_path(self):
+        # The internal scheduled-tick helper should no longer call the
+        # deprecated pybind exitSimLoop entry point, but it must still preserve
+        # the classic ExitEvent.SCHEDULED_TICK cause for existing users.
+        import importlib
+
+        import _m5.event as _m5_event
+
+        m5_simulate = importlib.import_module("m5.simulate")
+
+        original_exitSimulationLoopClassic = (
+            _m5_event.exitSimulationLoopClassic
+        )
+        original_curTick = m5_simulate.curTick
+        calls = []
+
+        def fake_exitSimLoop(*args, **kwargs):
+            raise AssertionError("deprecated exitSimLoop should not be called")
+
+        def fake_exitSimulationLoopClassic(
+            message,
+            exit_code,
+            when,
+            repeat,
+            serialize,
+        ):
+            calls.append(
+                (
+                    message,
+                    exit_code,
+                    when,
+                    repeat,
+                    serialize,
+                )
+            )
+
+        try:
+            original_exitSimLoop = getattr(_m5_event, "exitSimLoop", None)
+            if original_exitSimLoop is not None:
+                _m5_event.exitSimLoop = fake_exitSimLoop
+            _m5_event.exitSimulationLoopClassic = (
+                fake_exitSimulationLoopClassic
+            )
+            m5_simulate.curTick = lambda: 0
+
+            m5_simulate.scheduleTickExitAbsolute(123)
+
+            self.assertEqual(len(calls), 1)
+            (
+                message,
+                exit_code,
+                when,
+                repeat,
+                serialize,
+            ) = calls[0]
+            self.assertEqual(message, "Tick exit reached")
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(when, 123)
+            self.assertEqual(repeat, 0)
+            self.assertFalse(serialize)
+
+        finally:
+            if original_exitSimLoop is not None:
+                _m5_event.exitSimLoop = original_exitSimLoop
+            _m5_event.exitSimulationLoopClassic = (
+                original_exitSimulationLoopClassic
+            )
+            m5_simulate.curTick = original_curTick

--- a/tests/pyunit/stdlib/pyunit_exit_handler.py
+++ b/tests/pyunit/stdlib/pyunit_exit_handler.py
@@ -1,0 +1,500 @@
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+
+class TestExitHandlerCompatibility(unittest.TestCase):
+    def test_exit_hypercall_is_publicly_reexported(self):
+        import _m5.event as _m5_event
+
+        from gem5.simulate.exit_handler import ExitHypercall
+
+        self.assertIs(ExitHypercall, _m5_event.ExitHypercall)
+        self.assertEqual(
+            int(ExitHypercall.SCHEDULED_EXIT.value),
+            int(_m5_event.ExitHypercall.SCHEDULED_EXIT.value),
+        )
+
+    def test_resolve_hypercall_id(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        # Enum selector.
+        enum_sel = exit_handler_mod.ExitHypercall.SCHEDULED_EXIT
+        resolved_enum = exit_handler_mod._resolve_hypercall_id(enum_sel)
+        self.assertEqual(resolved_enum, int(enum_sel.value))
+
+        member = exit_handler_mod.ExitHypercall.CLASSIC_GENERATOR
+
+        # Integer selector, including custom/user-defined IDs.
+        resolved_int = exit_handler_mod._resolve_hypercall_id(
+            int(member.value)
+        )
+        self.assertEqual(resolved_int, int(member.value))
+        self.assertEqual(exit_handler_mod._resolve_hypercall_id(4096), 4096)
+
+    def test_resolve_hypercall_id_rejects_unknown_selectors(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        with self.assertRaisesRegex(TypeError, "ExitHypercall enum"):
+            exit_handler_mod._resolve_hypercall_id("not-a-hypercall")
+
+        with self.assertRaisesRegex(TypeError, "ExitHypercall enum"):
+            exit_handler_mod._resolve_hypercall_id(object())
+
+    def test_exit_handler_class_registration_accepts_exit_hypercall(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.KERNEL_BOOTED.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+
+            class EnumRegisteredHandler(
+                exit_handler_mod.ExitHandler,
+                hypercall=exit_handler_mod.ExitHypercall.KERNEL_BOOTED,
+            ):
+                def _process(self, simulator):
+                    pass
+
+                def _exit_simulation(self):
+                    return False
+
+            self.assertIs(handler_map[h_id], EnumRegisteredHandler)
+            self.assertEqual(EnumRegisteredHandler.get_handler_id(), h_id)
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_exit_handler_class_registration_accepts_legacy_hypercall_num(
+        self,
+    ):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.KERNEL_BOOTED.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+
+            class LegacyRegisteredHandler(
+                exit_handler_mod.ExitHandler,
+                hypercall_num=h_id,
+            ):
+                def _process(self, simulator):
+                    pass
+
+                def _exit_simulation(self):
+                    return False
+
+            self.assertIs(handler_map[h_id], LegacyRegisteredHandler)
+            self.assertEqual(LegacyRegisteredHandler.get_handler_id(), h_id)
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_exit_handler_subclass_inherits_registered_hypercall(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.KERNEL_BOOTED.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+
+            class CustomKernelBootedExitHandler(
+                exit_handler_mod.KernelBootedExitHandler
+            ):
+                def _process(self, simulator):
+                    pass
+
+            self.assertIs(handler_map[h_id], CustomKernelBootedExitHandler)
+            self.assertEqual(
+                CustomKernelBootedExitHandler.get_handler_id(), h_id
+            )
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_exit_handler_class_registration_rejects_ambiguous_selector(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        with self.assertRaisesRegex(TypeError, "Specify only one"):
+
+            class AmbiguousExitHandler(
+                exit_handler_mod.ExitHandler,
+                hypercall=exit_handler_mod.ExitHypercall.WORK_BEGIN,
+                hypercall_id=int(
+                    exit_handler_mod.ExitHypercall.WORK_END.value
+                ),
+            ):
+                def _process(self, simulator):
+                    pass
+
+                def _exit_simulation(self):
+                    return False
+
+    def test_register_exit_handler_and_invocation(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.CLASSIC_GENERATOR.value)
+
+        invocations = []
+
+        def handler_func(simulator, payload):
+            invocations.append((simulator, payload))
+            return True
+
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+            handler_cls = exit_handler_mod.register_exit_handler(
+                exit_handler_mod.ExitHypercall.CLASSIC_GENERATOR,
+                handler_func,
+                "test handler",
+            )
+
+            payload = {"cause": "test", "code": "0"}
+            handler = handler_cls(payload)
+            result = handler.handle(None)
+            self.assertTrue(result)
+            self.assertEqual(handler.get_handler_description(), "test handler")
+            self.assertEqual(len(invocations), 1)
+            self.assertEqual(invocations[0][1], payload)
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_register_exit_handler_supports_hypercall_id_alias(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        h_id = int(exit_handler_mod.ExitHypercall.WORK_END.value)
+        handler_map = exit_handler_mod.ExitHandler.get_handler_map()
+        existing = handler_map.get(h_id)
+
+        try:
+            handler_cls = exit_handler_mod.register_exit_handler(
+                None,
+                lambda simulator, payload: False,
+                "custom hypercall_id handler",
+                hypercall_id=int(
+                    exit_handler_mod.ExitHypercall.WORK_END.value
+                ),
+            )
+
+            self.assertIs(handler_map[h_id], handler_cls)
+            self.assertFalse(handler_cls({}).handle(None))
+
+        finally:
+            if existing is None:
+                handler_map.pop(h_id, None)
+            else:
+                handler_map[h_id] = existing
+
+    def test_register_exit_handler_rejects_missing_or_ambiguous_selector(self):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        def handler_func(simulator, payload):
+            return False
+
+        with self.assertRaisesRegex(ValueError, "must be provided"):
+            exit_handler_mod.register_exit_handler(
+                None, handler_func, "missing hypercall"
+            )
+
+        with self.assertRaisesRegex(ValueError, "Specify only one"):
+            exit_handler_mod.register_exit_handler(
+                exit_handler_mod.ExitHypercall.WORK_BEGIN,
+                handler_func,
+                "ambiguous hypercall",
+                hypercall_id=int(
+                    exit_handler_mod.ExitHypercall.WORK_END.value
+                ),
+            )
+
+    def test_classic_generator_uses_payload_cause_when_present(self):
+        from gem5.simulate.exit_event import ExitEvent
+        from gem5.simulate.exit_handler import ClassicGeneratorExitHandler
+
+        self._with_classic_generator_maps(
+            ExitEvent.MAX_TICK,
+            payload={"cause": "simulate() limit reached", "code": "0"},
+            legacy_cause="legacy cause should not be read",
+            should_read_legacy_cause=False,
+        )
+
+    def test_classic_generator_falls_back_to_legacy_cause(self):
+        from gem5.simulate.exit_event import ExitEvent
+        from gem5.simulate.exit_handler import ClassicGeneratorExitHandler
+
+        simulator = self._with_classic_generator_maps(
+            ExitEvent.SCHEDULED_TICK,
+            payload={"code": "0"},
+            legacy_cause="Tick exit reached",
+            should_read_legacy_cause=True,
+        )
+        self.assertEqual(simulator.legacy_cause_reads, 1)
+
+    def _with_classic_generator_maps(
+        self,
+        exit_event,
+        payload,
+        legacy_cause,
+        should_read_legacy_cause,
+    ):
+        from gem5.simulate import exit_handler as exit_handler_mod
+
+        handler_cls = exit_handler_mod.ClassicGeneratorExitHandler
+        missing = object()
+        old_on_exit_event = getattr(handler_cls, "_on_exit_event", missing)
+        old_default_on_exit_dict = getattr(
+            handler_cls, "_default_on_exit_dict", missing
+        )
+        old_expected_execution_order = getattr(
+            handler_cls, "_expected_execution_order", missing
+        )
+
+        def restore_attr(name, value):
+            if value is missing:
+                try:
+                    delattr(handler_cls, name)
+                except AttributeError:
+                    pass
+            else:
+                setattr(handler_cls, name, value)
+
+        def single_yield(value):
+            yield value
+
+        class FakeSimulator:
+            def __init__(self):
+                self._exit_event_count = 0
+                self._tick_stopwatch = []
+                self.legacy_cause_reads = 0
+
+            def get_current_tick(self):
+                return 100
+
+            def get_last_exit_event_cause(self):
+                self.legacy_cause_reads += 1
+                if not should_read_legacy_cause:
+                    raise AssertionError(
+                        "payload cause should avoid legacy cause lookup"
+                    )
+                return legacy_cause
+
+        try:
+            handler_cls._on_exit_event = {exit_event: single_yield(False)}
+            handler_cls._default_on_exit_dict = {
+                exit_event: single_yield(True)
+            }
+            handler_cls._expected_execution_order = [exit_event]
+
+            simulator = FakeSimulator()
+            handler = handler_cls(payload)
+            self.assertFalse(handler.handle(simulator))
+            self.assertEqual(simulator._tick_stopwatch, [(exit_event, 100)])
+            return simulator
+
+        finally:
+            restore_attr("_on_exit_event", old_on_exit_event)
+            restore_attr("_default_on_exit_dict", old_default_on_exit_dict)
+            restore_attr(
+                "_expected_execution_order", old_expected_execution_order
+            )
+
+    def test_exitSimLoop_forwards_to_exitSimulationLoopClassic(self):
+        # Ensure the legacy helper preserves legacy scheduling arguments while
+        # forwarding through the classic hypercall-aware path.
+        import m5.event as m5_event
+
+        import _m5.event as _m5_event
+
+        original = _m5_event.exitSimulationLoopClassic
+        calls = []
+
+        def fake_exitSimulationLoopClassic(
+            message,
+            exit_code,
+            when,
+            repeat,
+            serialize,
+        ):
+            calls.append(
+                (
+                    message,
+                    exit_code,
+                    when,
+                    repeat,
+                    serialize,
+                )
+            )
+
+        try:
+            _m5_event.exitSimulationLoopClassic = (
+                fake_exitSimulationLoopClassic
+            )
+
+            with self.assertWarns(DeprecationWarning):
+                m5_event.exitSimLoop(
+                    "legacy-cause",
+                    exit_code=7,
+                    when=123,
+                    repeat=11,
+                    serialize=True,
+                )
+
+            self.assertEqual(len(calls), 1)
+            (
+                message,
+                exit_code,
+                tick,
+                repeat,
+                serialize,
+            ) = calls[0]
+            self.assertEqual(message, "legacy-cause")
+            self.assertEqual(exit_code, 7)
+            self.assertEqual(tick, 123)
+            self.assertEqual(repeat, 11)
+            self.assertTrue(serialize)
+
+        finally:
+            _m5_event.exitSimulationLoopClassic = original
+
+    def test_exitSimLoop_defaults_when_to_native_curTick(self):
+        # With no explicit tick, leave the default as None so the native
+        # helper resolves curTick() inside the embedded runtime.
+        import m5.event as m5_event
+
+        import _m5.event as _m5_event
+
+        original = _m5_event.exitSimulationLoopClassic
+        calls = []
+
+        def fake_exitSimulationLoopClassic(
+            message,
+            exit_code,
+            when,
+            repeat,
+            serialize,
+        ):
+            calls.append((when, repeat))
+
+        try:
+            _m5_event.exitSimulationLoopClassic = (
+                fake_exitSimulationLoopClassic
+            )
+
+            with self.assertWarns(DeprecationWarning):
+                m5_event.exitSimLoop("legacy-cause")
+
+            self.assertEqual(calls, [(None, 0)])
+
+        finally:
+            _m5_event.exitSimulationLoopClassic = original
+
+    def test_default_tick_exit_uses_compatibility_path(self):
+        # The internal scheduled-tick helper should no longer call the
+        # deprecated pybind exitSimLoop entry point, but it must still preserve
+        # the classic ExitEvent.SCHEDULED_TICK cause for existing users.
+        import importlib
+
+        import _m5.event as _m5_event
+
+        m5_simulate = importlib.import_module("m5.simulate")
+
+        original_exitSimulationLoopClassic = (
+            _m5_event.exitSimulationLoopClassic
+        )
+        original_curTick = m5_simulate.curTick
+        calls = []
+
+        def fake_exitSimLoop(*args, **kwargs):
+            raise AssertionError("deprecated exitSimLoop should not be called")
+
+        def fake_exitSimulationLoopClassic(
+            message,
+            exit_code,
+            when,
+            repeat,
+            serialize,
+        ):
+            calls.append(
+                (
+                    message,
+                    exit_code,
+                    when,
+                    repeat,
+                    serialize,
+                )
+            )
+
+        try:
+            original_exitSimLoop = getattr(_m5_event, "exitSimLoop", None)
+            if original_exitSimLoop is not None:
+                _m5_event.exitSimLoop = fake_exitSimLoop
+            _m5_event.exitSimulationLoopClassic = (
+                fake_exitSimulationLoopClassic
+            )
+            m5_simulate.curTick = lambda: 0
+
+            m5_simulate.scheduleTickExitAbsolute(123)
+
+            self.assertEqual(len(calls), 1)
+            (
+                message,
+                exit_code,
+                when,
+                repeat,
+                serialize,
+            ) = calls[0]
+            self.assertEqual(message, "Tick exit reached")
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(when, 123)
+            self.assertEqual(repeat, 0)
+            self.assertFalse(serialize)
+
+        finally:
+            if original_exitSimLoop is not None:
+                _m5_event.exitSimLoop = original_exitSimLoop
+            _m5_event.exitSimulationLoopClassic = (
+                original_exitSimulationLoopClassic
+            )
+            m5_simulate.curTick = original_curTick

--- a/util/disk-image-validator/README.md
+++ b/util/disk-image-validator/README.md
@@ -8,7 +8,7 @@ This utility is used to verify that full system workloads in gem5 function as ex
 
 ## gem5-Bridge Driver Validator
 
-To validate the `gem5-bridge` driver, run the `gem5-bridge-driver-validate.py` script. This script verifies the driver installation by executing a simple C program that makes an m5 hypercall (hypercall number 1234), without requiring superuser privileges.
+To validate the `gem5-bridge` driver, run the `gem5-bridge-driver-validate.py` script. This script verifies the driver installation by executing a simple C program that makes an m5 hypercall (hypercall ID 1234), without requiring superuser privileges.
 
 ### Usage
 
@@ -44,7 +44,7 @@ build/ALL/gem5.opt util/disk-image-validator/gem5-bridge-driver-validate.py --is
 
 - Selects the appropriate demo board based on the specified ISA (`x86`, `arm`, or `riscv`)
 - Loads the given workload and optional resource version
-- Runs a shell script (`test_gem5_bridge.sh`) during the simulation to test whether m5 hypercall 1234 executes successfully (without requiring `sudo`)
+- Runs a shell script (`test_gem5_bridge.sh`) during the simulation to test whether m5 hypercall ID 1234 executes successfully (without requiring `sudo`)
 - Prints a success message if the test passes
 
 ### Exit Conditions

--- a/util/disk-image-validator/config_tester.py
+++ b/util/disk-image-validator/config_tester.py
@@ -76,7 +76,7 @@ def MESI_cache_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with MESI cache. Test Passed")
 
@@ -107,7 +107,7 @@ def KVM_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with KVM CPU. Test Passed")
 
@@ -136,7 +136,7 @@ def O3_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with O3 CPU. Test Passed")
 
@@ -167,7 +167,7 @@ def MINOR_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with MINOR CPU. Test Passed")
 
@@ -198,7 +198,7 @@ def TIMING_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with TIMING CPU. Test Passed")
 
@@ -229,7 +229,7 @@ def ATOMIC_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU. Test Passed")
 
@@ -260,7 +260,7 @@ def ATOMIC_2_core_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU, 2 cores. Test Passed")
 
@@ -291,7 +291,7 @@ def ATOMIC_4_core_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU, 4 cores. Test Passed")
 
@@ -322,7 +322,7 @@ def ATOMIC_8_core_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall="KernelBooted"):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU, 8 cores. Test Passed")
 

--- a/util/disk-image-validator/config_tester.py
+++ b/util/disk-image-validator/config_tester.py
@@ -44,7 +44,10 @@ from gem5.components.processors.simple_switchable_processor import (
 from gem5.isas import ISA
 from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_event import ExitEvent
-from gem5.simulate.exit_handler import ExitHandler
+from gem5.simulate.exit_handler import (
+    ExitHandler,
+    ExitHypercall,
+)
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires
 
@@ -76,7 +79,7 @@ def MESI_cache_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with MESI cache. Test Passed")
 
@@ -107,7 +110,7 @@ def KVM_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with KVM CPU. Test Passed")
 
@@ -136,7 +139,7 @@ def O3_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with O3 CPU. Test Passed")
 
@@ -167,7 +170,7 @@ def MINOR_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with MINOR CPU. Test Passed")
 
@@ -198,7 +201,7 @@ def TIMING_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with TIMING CPU. Test Passed")
 
@@ -229,7 +232,7 @@ def ATOMIC_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU. Test Passed")
 
@@ -260,7 +263,7 @@ def ATOMIC_2_core_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU, 2 cores. Test Passed")
 
@@ -291,7 +294,7 @@ def ATOMIC_4_core_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU, 4 cores. Test Passed")
 
@@ -322,7 +325,7 @@ def ATOMIC_8_core_test(workload_id, resource_version):
         obtain_resource(workload_id, resource_version=resource_version)
     )
 
-    class KernelBootedExit(ExitHandler, hypercall_num=1):
+    class KernelBootedExit(ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED):
         def _process(self, simulator: "Simulator") -> None:
             print("Kernel Booted with ATOMIC CPU, 8 cores. Test Passed")
 

--- a/util/disk-image-validator/disk-image-validate.py
+++ b/util/disk-image-validator/disk-image-validate.py
@@ -131,7 +131,7 @@ exit_order = []
 from gem5.simulate.exit_handler import ExitHandler
 
 
-class KernelBootedDumpReset(ExitHandler, hypercall_num=1):
+class KernelBootedDumpReset(ExitHandler, hypercall="KernelBooted"):
     def _process(self, simulator: "Simulator") -> None:
         print("Dumping and resetting stats after kernel boot! Hypercall 1")
         m5.stats.dump()
@@ -142,7 +142,7 @@ class KernelBootedDumpReset(ExitHandler, hypercall_num=1):
         return False
 
 
-class AfterBootDumpReset(ExitHandler, hypercall_num=2):
+class AfterBootDumpReset(ExitHandler, hypercall="AfterBoot"):
     def _process(self, simulator: "Simulator") -> None:
         print("Dumping and resetting stats after Ubuntu boot! Hypercall 2")
         m5.stats.dump()
@@ -153,7 +153,7 @@ class AfterBootDumpReset(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptDumpReset(ExitHandler, hypercall_num=3):
+class AfterBootScriptDumpReset(ExitHandler, hypercall="AfterBootScript"):
     def _process(self, simulator: "Simulator") -> None:
         print(
             "Dumping and resetting stats before exiting simulation! Hypercall 3"
@@ -166,7 +166,7 @@ class AfterBootScriptDumpReset(ExitHandler, hypercall_num=3):
         return True
 
 
-class WorkBeginDumpReset(ExitHandler, hypercall_num=4):
+class WorkBeginDumpReset(ExitHandler, hypercall="WorkBegin"):
     def _process(self, simulator: "Simulator") -> None:
         m5.stats.dump()
         m5.stats.reset()
@@ -177,7 +177,7 @@ class WorkBeginDumpReset(ExitHandler, hypercall_num=4):
         return False
 
 
-class WorkEndDumpReset(ExitHandler, hypercall_num=5):
+class WorkEndDumpReset(ExitHandler, hypercall="WorkEnd"):
     def _process(self, simulator: "Simulator") -> None:
         print("Dumping and resetting stats at ROI end! Hypercall 5")
         m5.stats.dump()

--- a/util/disk-image-validator/disk-image-validate.py
+++ b/util/disk-image-validator/disk-image-validate.py
@@ -128,10 +128,15 @@ board.set_workload(
 simulator = Simulator(board=board)
 
 exit_order = []
-from gem5.simulate.exit_handler import ExitHandler
+from gem5.simulate.exit_handler import (
+    ExitHandler,
+    ExitHypercall,
+)
 
 
-class KernelBootedDumpReset(ExitHandler, hypercall_num=1):
+class KernelBootedDumpReset(
+    ExitHandler, hypercall=ExitHypercall.KERNEL_BOOTED
+):
     def _process(self, simulator: "Simulator") -> None:
         print("Dumping and resetting stats after kernel boot! Hypercall 1")
         m5.stats.dump()
@@ -142,7 +147,7 @@ class KernelBootedDumpReset(ExitHandler, hypercall_num=1):
         return False
 
 
-class AfterBootDumpReset(ExitHandler, hypercall_num=2):
+class AfterBootDumpReset(ExitHandler, hypercall=ExitHypercall.AFTER_BOOT):
     def _process(self, simulator: "Simulator") -> None:
         print("Dumping and resetting stats after Ubuntu boot! Hypercall 2")
         m5.stats.dump()
@@ -153,7 +158,9 @@ class AfterBootDumpReset(ExitHandler, hypercall_num=2):
         return False
 
 
-class AfterBootScriptDumpReset(ExitHandler, hypercall_num=3):
+class AfterBootScriptDumpReset(
+    ExitHandler, hypercall=ExitHypercall.AFTER_BOOT_SCRIPT
+):
     def _process(self, simulator: "Simulator") -> None:
         print(
             "Dumping and resetting stats before exiting simulation! Hypercall 3"
@@ -166,7 +173,7 @@ class AfterBootScriptDumpReset(ExitHandler, hypercall_num=3):
         return True
 
 
-class WorkBeginDumpReset(ExitHandler, hypercall_num=4):
+class WorkBeginDumpReset(ExitHandler, hypercall=ExitHypercall.WORK_BEGIN):
     def _process(self, simulator: "Simulator") -> None:
         m5.stats.dump()
         m5.stats.reset()
@@ -177,7 +184,7 @@ class WorkBeginDumpReset(ExitHandler, hypercall_num=4):
         return False
 
 
-class WorkEndDumpReset(ExitHandler, hypercall_num=5):
+class WorkEndDumpReset(ExitHandler, hypercall=ExitHypercall.WORK_END):
     def _process(self, simulator: "Simulator") -> None:
         print("Dumping and resetting stats at ROI end! Hypercall 5")
         m5.stats.dump()

--- a/util/disk-image-validator/gem5-bridge-driver-validate.py
+++ b/util/disk-image-validator/gem5-bridge-driver-validate.py
@@ -117,7 +117,7 @@ board.set_binary_to_run(
 from gem5.simulate.exit_handler import ExitHandler
 
 
-class Gem5BridgeDriverTestExitHandler(ExitHandler, hypercall_num=1234):
+class Gem5BridgeDriverTestExitHandler(ExitHandler, hypercall=1234):
     def _process(self, simulator):
         print("Successfully called m5 hypercall without superuser privileges")
         print("Test passed")

--- a/util/disk-image-validator/gem5-bridge-driver-validate.py
+++ b/util/disk-image-validator/gem5-bridge-driver-validate.py
@@ -34,13 +34,14 @@ from gem5.resources.resource import (
     obtain_resource,
 )
 from gem5.simulate.exit_event import ExitEvent
+from gem5.simulate.exit_handler import ExitHandler
 from gem5.simulate.simulator import Simulator
 
 """
 gem5 Bridge Driver Test Script
 
 This script tests whether the gem5-bridge driver is correctly installed by
-running a simple C program that makes an m5 hypercall (hypercall number 1234)
+running a simple C program that makes an m5 hypercall (hypercall ID 1234)
 without requiring superuser privileges.
 
 Usage:
@@ -64,7 +65,7 @@ Requirements:
 Functionality:
     - Selects the appropriate demo board (X86, Arm, or RISC-V) based on the given ISA.
     - Loads the specified workload and resource version (if provided).
-    - Runs a shell script (`test_gem5_bridge.sh`) to check whether m5 hypercall 1234
+    - Runs a shell script (`test_gem5_bridge.sh`) to check whether m5 hypercall ID 1234
       executes successfully without requiring `sudo`.
     - Prints a success message if the test passes.
 
@@ -73,6 +74,16 @@ Exit Conditions:
     - If an invalid ISA is provided, the script raises an exception.
 
 """
+
+"""Custom hypercall ID used only by the gem5-bridge validation test.
+
+The matching guest program in ``test_gem5_bridge.sh`` issues this same raw ID
+with ``m5_hypercall_addr``. It deliberately does not use the built-in
+``ExitHypercall`` enum because the test is validating that arbitrary m5
+hypercalls can be delivered through the gem5 bridge driver without superuser
+privileges.
+"""
+GEM5_BRIDGE_TEST_HYPERCALL_ID = 1234
 
 
 parser = argparse.ArgumentParser()
@@ -114,10 +125,10 @@ board.set_binary_to_run(
     args=[],
 )
 
-from gem5.simulate.exit_handler import ExitHandler
 
-
-class Gem5BridgeDriverTestExitHandler(ExitHandler, hypercall_num=1234):
+class Gem5BridgeDriverTestExitHandler(
+    ExitHandler, hypercall_id=GEM5_BRIDGE_TEST_HYPERCALL_ID
+):
     def _process(self, simulator):
         print("Successfully called m5 hypercall without superuser privileges")
         print("Test passed")

--- a/util/disk-image-validator/test_gem5_bridge.sh
+++ b/util/disk-image-validator/test_gem5_bridge.sh
@@ -26,6 +26,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+# Custom hypercall ID used by the matching Python exit handler in
+# gem5-bridge-driver-validate.py. It is intentionally outside gem5
+# built-in ExitHypercall enum so the test validates that arbitrary m5
+# hypercalls can be delivered through the gem5 bridge driver.
+GEM5_BRIDGE_TEST_HYPERCALL_ID=1234
+
 # Create the test.c file that
 # maps m5 mem and calls m5 exit
 # if the test passes that means that the gem5 bridge driver is working
@@ -35,7 +41,7 @@ cat << EOF > test.c
 void map_m5_mem();
 int main() {
     map_m5_mem();
-    m5_hypercall_addr(1234);
+    m5_hypercall_addr(${GEM5_BRIDGE_TEST_HYPERCALL_ID});
     return 0;
 }
 EOF

--- a/util/systemc/gem5_within_systemc/sc_module.cc
+++ b/util/systemc/gem5_within_systemc/sc_module.cc
@@ -164,7 +164,7 @@ Module::serviceAsyncEvent()
 
     if (gem5::async_exit) {
         gem5::async_exit = false;
-        gem5::exitSimLoop("user interrupt received");
+        gem5::exitSimulationLoopClassic("user interrupt received");
     }
 
     if (gem5::async_io) {
@@ -261,9 +261,10 @@ Module::simulate(gem5::Tick num_cycles)
     else /* counter would roll over or be set to MaxTick anyhow */
         num_cycles = gem5::MaxTick;
 
-    gem5::GlobalEvent *limit_event =
-        new gem5::GlobalSimLoopExitEvent(num_cycles,
-            "simulate() limit reached", 0, 0);
+    gem5::GlobalEvent *limit_event = new gem5::GlobalSimLoopExitEvent(
+        num_cycles, "simulate() limit reached", 0, 0,
+        static_cast<uint64_t>(gem5::ExitHypercall::CLASSIC_GENERATOR),
+        gem5::classicGeneratorPayload("simulate() limit reached"));
 
     exitEvent = NULL;
 

--- a/util/systemc/systemc_within_gem5/systemc_simple_object/feeder.cc
+++ b/util/systemc/systemc_within_gem5/systemc_simple_object/feeder.cc
@@ -53,7 +53,7 @@ void
 Feeder::feed()
 {
     if (index >= strings.size())
-        gem5::exitSimLoop("Printed all the words.");
+        gem5::exitSimulationLoopClassic("Printed all the words.");
     else
         buf.write(strings[index++].c_str());
 


### PR DESCRIPTION
## Summary

This PR establishes hypercall ID and payload dispatch as the primary model for
handling simulation exits in the gem5 Python standard library. It centralizes
gem5's built-in simulation-exit hypercall IDs, exposes the same identifiers to
guest code, C++, and Python, and migrates internal callers to clearly defined
exit APIs.

Legacy string-based exits remain supported through an explicit compatibility
path that preserves their cause, code, scheduling, priority, and repetition
semantics.

## Motivation

Classic gem5 exits are identified primarily by human-readable cause strings,
such as `"checkpoint"` or `"Finished drain"`, with an optional integer code.
Python translates those strings into `ExitEvent` values and selects the
corresponding behavior. As a result:

- Exact message spelling forms part of the behavioral interface.
- A diagnostic string can be mistaken for a stable event identity.
- Similar events may be conflated, while unrelated events may be assigned an
  incorrect cause through copy-and-modify errors.
- The classic cause/code interface cannot naturally carry structured event
  metadata.
- Guest code, simulator code, and Python may represent the same event using
  separate numeric constants, strings, or registration rules.

Hypercall exits provide a distinct event identity and an optional key/value
payload. Python can dispatch the event to a registered handler, which performs
the required action and determines whether simulation should continue.
Before this change, however, built-in IDs remained distributed across several
layers, the intended use of the overlapping exit APIs was unclear, and many
internal callers still depended on classic behavior.

## Background

- #947 introduced hypercall exit events and demonstrated that exits could
  originate from guest software, simulator components, or an external control
  signal and be handled through Python using an ID and payload.
- #1995 moved hypercall registration and default behavior into `ExitHandler`
  classes, reducing the `Simulator` object's dependency on individual event
  types and allowing users to register custom handlers.
- #2514 attempted to migrate maximum-instruction exits to a new hypercall. That
  work showed that a partial migration could conflate semantically distinct
  events such as `MAX_INSTS` and `SIMPOINT_BEGIN`, expose additional exits to
  Python, and change legacy behavior. It also highlighted the need for a
  central allocation and definition of built-in hypercall IDs.

This PR provides the common identifier, dispatch, documentation, and
compatibility infrastructure required for subsequent exit-event migrations.

## Design

### Canonical hypercall identifiers

`include/gem5/hypercall_ids.h` is the authoritative definition of gem5's
built-in simulation-exit hypercall IDs and their descriptions. The same list
generates:

- Guest-facing `M5_HYPERCALL_*` constants.
- The C++ `gem5::ExitHypercall` enum.
- Descriptors used by the Python bindings.
- The Python `_m5.event.ExitHypercall` enum.

This prevents the guest, simulator, and Python layers from independently
assigning different meanings to the same numeric value.

Python `ExitHandler` registration accepts an `ExitHypercall` enum member for a
built-in event or an explicit integer for a custom event. String selectors are
intentionally rejected so handler registration does not depend on name parsing
or spelling conventions.

### Hypercall-based dispatch

The preferred simulator API is `exitSimulationLoop`, which accepts an
`ExitHypercall` or custom integer ID and an optional string key/value payload.
The resulting `GlobalSimLoopExitEvent` carries both values to the Python
`Simulator` run loop. The run loop selects an `ExitHandler` by ID, invokes it
with the payload, and uses its result to decide whether to continue or leave
the simulation loop.

The event may originate inside the simulator through `exitSimulationLoop`, in
guest software through `m5_hypercall`, or through the external hypercall signal
interface. All sources use the same Python dispatch model.

### Classic compatibility boundary

Existing configurations and simulator code may observe legacy
`getCause()`/`getCode()` fields, match exact cause strings, or depend on the
scheduling behavior of `exitSimLoop` and `exitSimLoopNow`. Converting those
callers directly to an ordinary hypercall exit would change observable
behavior.

`exitSimulationLoopClassic` and `exitSimulationLoopClassicNow` therefore carry
the legacy cause and code through an internal `CLASSIC_GENERATOR` hypercall
payload. `ClassicGeneratorExitHandler` translates the cause into the existing
`ExitEvent` path. This preserves:

- Legacy cause and code reporting.
- `simQuantum` scheduling for global exits.
- Immediate minimum-priority exit behavior.
- Repeating exit scheduling.
- Existing `on_exit_event` generator and function behavior.

`CLASSIC_GENERATOR` is not exported as a guest-facing `M5_HYPERCALL_*`
constant because guest `m5_hypercall` calls cannot supply its required cause
and code payload. Generic callers that use this internal ID must provide a
non-empty cause and a valid base-10 integer code.

### API consolidation and migration

- Deprecate the C++ and Python `exitSimLoop` compatibility APIs.
- Direct new hypercall-based code to `exitSimulationLoop` and
  `exitSimulationLoopNow`.
- Direct code that requires legacy cause/code behavior to
  `exitSimulationLoopClassic` or `exitSimulationLoopClassicNow`.
- Remove the transitional `exitSimLoopWithHypercall` and
  `exitSimLoopWithClassicGenerator` APIs.
- Migrate internal callers across CPU models, Ruby, GPU components, devices,
  SystemC, SST, utilities, examples, and tests to the appropriate API.

## Architectural benefits

- Replaces distributed magic numbers with named, shared identifiers.
- Separates event identity from human-readable diagnostics.
- Separates event identity, event metadata, handler behavior, and the decision
  to continue or stop simulation.
- Allows payload-bearing events without expanding the classic cause/code
  interface.
- Detects invalid or incomplete compatibility payloads at the C++ boundary.
- Provides a documented migration path without changing established classic
  exit behavior.
- Gives future exit types a central, reviewable identifier allocation point.

## Enabled capabilities

The unified dispatch model supports:

- Guest-reported kernel and after-boot milestones.
- Region-of-interest begin and end handling.
- Simulator-scheduled exits with justification metadata.
- Checkpoint requests.
- External status, statistics, and debug-control requests.
- Custom user-defined IDs and handlers.
- Handler specialization through subclassing or function registration.
- Future separation of currently conflated events, including distinct
  maximum-instruction and SimPoint identities.

## Compatibility and scope

This change does not remove the classic `ExitEvent` interface. Classic events
continue to be handled through the compatibility handler while new code can use
the hypercall-based path directly.

This PR does not complete the maximum-instruction migration proposed in #2514.
It establishes the identifier and compatibility infrastructure needed to
implement that migration without combining distinct event meanings or changing
legacy behavior.

Delayed and repeating classic exits are supported, but pending global exit
events are not saved in checkpoints and therefore are not automatically
rescheduled when a checkpoint is restored. The legacy `serialize` argument is
retained for API compatibility but has no effect.

## Validation

- Changed-file `pre-commit` checks.
- `scons -Q build/ALL/gem5.opt -j10`.
- `build/ALL/gem5.opt tests/run_pyunit.py --directory tests/pyunit/stdlib`
  (109 tests passed).
- Compiled runtime smoke tests for classic cause/code preservation and
  malformed `CLASSIC_GENERATOR` payload rejection.
