### PR TITLE
python: Allow VectorParams of NULL SimObjects

### DIFF
--- a/src/python/m5/params/null_params.py
+++ b/src/python/m5/params/null_params.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2014, 2017-2019, 2021, 2024-2025 Arm Limited
+# Copyright (c) 2012-2014, 2017-2019, 2021, 2024-2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -47,7 +47,7 @@ from ..util import Singleton
 class NullSimObject(metaclass=Singleton):
     _name = "Null"
 
-    def __call__(cls):
+    def __call__(cls, **kwargs):
         return cls
 
     def _instantiate(self, parent=None, path=""):


### PR DESCRIPTION
Without this patch, it is not possible to initialize a VectorParam with NULL SimObjects since the constructor does not allow keyword arguments [1].

class SimObjectVector(VectorParamValue):
    # support clone operation
    def __call__(self, **kwargs):
        return SimObjectVector([v(**kwargs) for v in self])

https://github.com/gem5/gem5/blob/stable/\
    src/python/m5/params/base_params.py#L319

Change-Id: Icda87b0debbc585f2f82fed551fb88674d5ac56f