### PR TITLE
arch-arm: Implement 64-bit PMULL for AA64

### DIFF
--- a/src/arch/arm/isa/formats/neon64.isa
+++ b/src/arch/arm/isa/formats/neon64.isa
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2013, 2020, 2025 Arm Limited
+// Copyright (c) 2012-2013, 2020, 2025-2026 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -944,13 +944,34 @@ namespace Aarch64
                 }
             }
           case 0xe:
-            if (u || size != 0) {
+            if (u) {
                 return new Unknown64(machInst);
             } else {
-                if (q)
-                    return new Pmull2X<uint8_t>(machInst, vd, vn, vm);
-                else
-                    return new PmullX<uint8_t>(machInst, vd, vn, vm);
+                if (q) {
+                    switch (size) {
+                      case 0:
+                        return new Pmull2X<uint8_t>(machInst, vd, vn, vm);
+                      case 1:
+                      case 2:
+                        return new Unknown64(machInst);
+                      case 3:
+                        return new Pmull2X<uint64_t>(machInst, vd, vn, vm);
+                      default:
+                        return new Unknown64(machInst);
+                    }
+                } else {
+                    switch (size) {
+                      case 0:
+                        return new PmullX<uint8_t>(machInst, vd, vn, vm);
+                      case 1:
+                      case 2:
+                        return new Unknown64(machInst);
+                      case 3:
+                        return new PmullX<uint64_t>(machInst, vd, vn, vm);
+                      default:
+                        return new Unknown64(machInst);
+                    }
+                }
             }
           default:
             return new Unknown64(machInst);

--- a/src/arch/arm/isa/insts/neon64.isa
+++ b/src/arch/arm/isa/insts/neon64.isa
@@ -1,6 +1,6 @@
 // -*- mode: c++ -*-
 
-// Copyright (c) 2012-2013, 2015-2018, 2020, 2024-2025 Arm Limited
+// Copyright (c) 2012-2013, 2015-2018, 2020, 2024-2026 Arm Limited
 // All rights reserved
 //
 // The license below extends only to copyright in the software and shall
@@ -2225,7 +2225,6 @@ let {{
     threeEqualRegInstX("pmul", "PmulQX", "SimdMultOp", ("uint8_t",), 4,
                        pmulCode)
     # PMULL, PMULL2
-    # Note: 64-bit PMULL is not available (Crypto. Extension)
     pmullCode = '''
             destElem = 0;
             for (unsigned j = 0; j < sizeof(Element) * 8; j++) {
@@ -2233,9 +2232,10 @@ let {{
                     destElem ^= (BigElement)srcElem1 << j;
             }
     '''
-    threeRegLongInstX("pmull", "PmullX", "SimdMultOp", ("uint8_t",), pmullCode)
-    threeRegLongInstX("pmull", "Pmull2X", "SimdMultOp", ("uint8_t",),
-                      pmullCode, hi=True)
+    threeRegLongInstX("pmull", "PmullX", "SimdMultOp",
+                      ("uint8_t","uint64_t",), pmullCode)
+    threeRegLongInstX("pmull", "Pmull2X", "SimdMultOp",
+                      ("uint8_t","uint64_t",), pmullCode, hi=True)
     # RADDHN, RADDHN2
     raddhnCode = '''
             destElem = ((BigElement)srcElem1 + (BigElement)srcElem2 +


### PR DESCRIPTION
We were not not supporing 64-bit PMULL(2) which is required when FEAT_PMULL is implemented.

Change-Id: If541d4654b35ad75a4c37d1dff860f7edd51c97f

Reviewed-by: Richard Cooper <richard.cooper@arm.com>