### PR TITLE
arch-arm: Fix crc32cx instruction

### DIFF
--- a/src/arch/arm/isa/insts/data64.isa
+++ b/src/arch/arm/isa/insts/data64.isa
@@ -237,7 +237,7 @@ let {{
     uint64_t data = htole(Op264);
     auto data_buffer = reinterpret_cast<uint8_t*>(&data);
 
-    Dest = crc32<poly>(
+    WDest = crc32<poly>(
         data_buffer,   /* Message register */
         initial_crc,   /* Initial value of the CRC */
         size_bytes     /* Size of the original Message */


### PR DESCRIPTION
Previously, when executing the crc32cx instruction the next PC would be 0.

Because Dest used the legacy IntReg mapping, gem5 incorrectly intercepted the write to register 15 and forcefully treated the crc32cx output as a branch target, thereby writing 0 into the PC. The ARM Architecture Reference Manual dictates that crc32cx writes to a 32-bit accumulator register Wd (which zero-extends into Xd). So, instead of Dest, we must use WDest.

Testing: The code that executed the crc32cx instruction now runs past that instruction.