### PR TITLE
arch-riscv: Implement several RVV integer instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3817,16 +3817,19 @@ decode QUADRANT default Unknown::unknown() {
                     0x27: vsmul_vv({{
                         vi max = std::numeric_limits<vi>::max();
                         vi min = std::numeric_limits<vi>::min();
-                        bool overflow = Vs1_vi[i] == Vs2_vi[i] &&
-                                        Vs1_vi[i] == min;
+                        bool overflow = (Vs1_vi[i] == Vs2_vi[i] &&
+                                        Vs1_vi[i] == min);
                         __int128_t result = (__int128_t)Vs1_vi[i] *
                                             (__int128_t)Vs2_vi[i];
                         result = int_rounding<__int128_t>(
-                            result, 0 /* TODO */, sew - 1);
+                            result,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            sew - 1
+                        );
                         result = result >> (sew - 1);
                         if (overflow) {
                             result = max;
-                            *vxsatptr = true;
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vi[i] = (vi)result;
@@ -3934,11 +3937,15 @@ decode QUADRANT default Unknown::unknown() {
                         unsigned shift = Vs1_vu[i + offset] & ((sew * 2) - 1);
 
                         res = int_rounding<__uint128_t>(
-                            res, 0 /* TODO */, shift) >> shift;
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            shift
+                        );
+                        res = res >> shift;
 
                         if (res & sign_mask) {
                             res = max;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vu[i + offset] = (vu)res;
@@ -3950,14 +3957,18 @@ decode QUADRANT default Unknown::unknown() {
                         unsigned shift = Vs1_vi[i + offset] & ((sew * 2) - 1);
 
                         res = int_rounding<__int128_t>(
-                            res, 0 /* TODO */, shift) >> shift;
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            shift
+                        );
+                        res = res >> shift;
 
                         if (res < min) {
                             res = min;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         } else if (res > max) {
                             res = max;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vi[i + offset] = (vi)res;
@@ -4369,22 +4380,41 @@ decode QUADRANT default Unknown::unknown() {
                 format VectorIntFormat {
                     0x8: vaaddu_vv({{
                         __uint128_t res = (__uint128_t)Vs2_vu[i] + Vs1_vu[i];
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        res = int_rounding<__uint128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vu[i] = res >> 1;
-                    }}, OPMVV, SimdAddOp);
+                        }}, OPMVV, SimdAddOp);
+
                     0x9: vaadd_vv({{
                         __uint128_t res = (__uint128_t)Vs2_vi[i] + Vs1_vi[i];
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        res = int_rounding<__uint128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vi[i] = res >> 1;
-                    }}, OPMVV, SimdAddOp);
+                        }}, OPMVV, SimdAddOp);
+
                     0xa: vasubu_vv({{
                         __uint128_t res = (__uint128_t)Vs2_vu[i] - Vs1_vu[i];
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        res = int_rounding<__uint128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vu[i] = res >> 1;
-                    }}, OPMVV, SimdAddOp);
+                        }}, OPMVV, SimdAddOp);
+
                     0xb: vasub_vv({{
                         __uint128_t res = (__uint128_t)Vs2_vi[i] - Vs1_vi[i];
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        res = int_rounding<__uint128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vi[i] = res >> 1;
                     }}, OPMVV, SimdAddOp);
                     0x0c: vclmul_vv({{
@@ -4876,10 +4906,11 @@ decode QUADRANT default Unknown::unknown() {
                     0x2a: vssrl_vi({{
                         int sh = SIMM5 & (vtype_SEW(vtype) - 1);
                         __uint128_t res = Vs2_vu[i];
-
                         res = int_rounding<__uint128_t>(
-                            res, 0 /* TODO */, sh) >> sh;
-
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            sh
+                        ) >> sh;
                         Vd_vu[i] = res;
                     }}, OPIVI, SimdShiftOp);
                     0x29: vsra_vi({{
@@ -4966,11 +4997,15 @@ decode QUADRANT default Unknown::unknown() {
                         unsigned shift = VS1 & ((sew * 2) - 1);
 
                         res = int_rounding<__uint128_t>(
-                            res, 0 /* TODO */, shift) >> shift;
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            shift
+                        );
+                        res = res >> shift;
 
                         if (res & sign_mask) {
-                            // TODO: vxsat
                             res = max;
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vu[i + offset] = (vu)res;
@@ -4982,14 +5017,18 @@ decode QUADRANT default Unknown::unknown() {
                         unsigned shift = VS1 & ((sew * 2) - 1);
 
                         res = int_rounding<__int128_t>(
-                            res, 0 /* TODO */, shift) >> shift;
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            shift
+                        );
+                        res = res >> shift;
 
                         if (res < min) {
                             res = min;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         } else if (res > max) {
                             res = max;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vi[i + offset] = (vi)res;
@@ -5204,15 +5243,19 @@ decode QUADRANT default Unknown::unknown() {
                     0x27: vsmul_vx({{
                         vi max = std::numeric_limits<vi>::max();
                         vi min = std::numeric_limits<vi>::min();
-                        bool overflow = Rs1_vi == Vs2_vi[i] && Rs1_vi == min;
+                        bool overflow = (Rs1_vi == Vs2_vi[i] &&
+                                        Rs1_vi == min);
                         __int128_t result =
                             (__int128_t)Rs1_vi * (__int128_t)Vs2_vi[i];
-                        result = int_rounding<__uint128_t>(
-                            result, 0 /* TODO */, sew - 1);
+                        result = int_rounding<__int128_t>(
+                            result,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            sew - 1
+                        );
                         result = result >> (sew - 1);
                         if (overflow) {
                             result = max;
-                            *vxsatptr = true;
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vi[i] = (vi)result;
@@ -5262,11 +5305,15 @@ decode QUADRANT default Unknown::unknown() {
                         unsigned shift = Rs1_vu & ((sew * 2) - 1);
 
                         res = int_rounding<__uint128_t>(
-                            res, 0 /* TODO */, shift) >> shift;
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            shift
+                        );
+                        res = res >> shift;
 
                         if (res & sign_mask) {
-                            // TODO: vxsat
                             res = max;
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vu[i + offset] = (vu)res;
@@ -5278,14 +5325,18 @@ decode QUADRANT default Unknown::unknown() {
                         unsigned shift = Rs1_vi & ((sew * 2) - 1);
 
                         res = int_rounding<__int128_t>(
-                            res, 0 /* TODO */, shift) >> shift;
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            shift
+                        );
+                        res = res >> shift;
 
                         if (res < min) {
                             res = min;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         } else if (res > max) {
                             res = max;
-                            // TODO: vxsat
+                            xc->setMiscReg(MISCREG_VXSAT, 1);
                         }
 
                         Vd_vi[i + offset] = (vi)res;
@@ -5707,12 +5758,20 @@ decode QUADRANT default Unknown::unknown() {
                 format VectorIntFormat {
                     0x08: vaaddu_vx({{
                         __uint128_t res = (__uint128_t)Vs2_vu[i] + Rs1_vu;
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        res = int_rounding<__uint128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vu[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
                     0x09: vaadd_vx({{
-                        __uint128_t res = (__uint128_t)Vs2_vi[i] + Rs1_vi;
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        __int128_t res = (__int128_t)Vs2_vi[i] + Rs1_vi;
+                        res = int_rounding<__int128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vi[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
                    0x0c: vclmul_vx({{
@@ -5866,12 +5925,20 @@ decode QUADRANT default Unknown::unknown() {
                 format VectorIntFormat {
                     0x0a: vasubu_vx({{
                         __uint128_t res = (__uint128_t)Vs2_vu[i] - Rs1_vu;
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        res = int_rounding<__uint128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vu[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
                     0x0b: vasub_vx({{
-                        __uint128_t res = (__uint128_t)Vs2_vi[i] - Rs1_vi;
-                        res = int_rounding<__uint128_t>(res, 0 /* TODO */, 1);
+                        __int128_t res = (__int128_t)Vs2_vi[i] - Rs1_vi;
+                        res = int_rounding<__int128_t>(
+                            res,
+                            xc->readMiscReg(MISCREG_VXRM),
+                            1
+                        );
                         Vd_vi[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
                     0x20: vdivu_vx({{

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3829,7 +3829,7 @@ decode QUADRANT default Unknown::unknown() {
                         result = result >> (sew - 1);
                         if (overflow) {
                             result = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vi[i] = (vi)result;
@@ -3945,7 +3945,7 @@ decode QUADRANT default Unknown::unknown() {
 
                         if (res & sign_mask) {
                             res = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vu[i + offset] = (vu)res;
@@ -3965,10 +3965,10 @@ decode QUADRANT default Unknown::unknown() {
 
                         if (res < min) {
                             res = min;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         } else if (res > max) {
                             res = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vi[i + offset] = (vi)res;
@@ -5005,7 +5005,7 @@ decode QUADRANT default Unknown::unknown() {
 
                         if (res & sign_mask) {
                             res = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vu[i + offset] = (vu)res;
@@ -5025,10 +5025,10 @@ decode QUADRANT default Unknown::unknown() {
 
                         if (res < min) {
                             res = min;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         } else if (res > max) {
                             res = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vi[i + offset] = (vi)res;
@@ -5255,7 +5255,7 @@ decode QUADRANT default Unknown::unknown() {
                         result = result >> (sew - 1);
                         if (overflow) {
                             result = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vi[i] = (vi)result;
@@ -5313,7 +5313,7 @@ decode QUADRANT default Unknown::unknown() {
 
                         if (res & sign_mask) {
                             res = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vu[i + offset] = (vu)res;
@@ -5333,10 +5333,10 @@ decode QUADRANT default Unknown::unknown() {
 
                         if (res < min) {
                             res = min;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         } else if (res > max) {
                             res = max;
-                            xc->setMiscReg(MISCREG_VXSAT, 1);
+                            *vxsatptr = true;
                         }
 
                         Vd_vi[i + offset] = (vi)res;

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -558,10 +558,10 @@ def format VectorIntNarrowingFormat(code, category, *flags) {{
         flags)
 
     header_output = \
-        VectorIntWideningMicroDeclare.subst(microiop) + \
-        VectorIntWideningMacroDeclare.subst(iop)
+        VectorIntNarrowingMicroDeclare.subst(microiop) + \
+        VectorIntNarrowingMacroDeclare.subst(iop)
     decoder_output = \
-        VectorIntWideningMicroConstructor.subst(microiop) + \
+        VectorIntNarrowingMicroConstructor.subst(microiop) + \
         VectorIntNarrowingMacroConstructor.subst(iop)
     exec_output = VectorIntNarrowingMicroExecute.subst(microiop)
     decode_block = VectorIntWideningDecodeBlock.subst(iop)
@@ -1014,10 +1014,10 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
         flags)
 
     header_output = \
-        VectorFloatCvtMicroDeclare.subst(microiop) + \
-        VectorFloatCvtMacroDeclare.subst(iop)
+        VectorIntNarrowingMicroDeclare.subst(microiop) + \
+        VectorIntNarrowingMacroDeclare.subst(iop)
     decoder_output = \
-        VectorIntWideningMicroConstructor.subst(microiop) + \
+        VectorIntNarrowingMicroConstructor.subst(microiop) + \
         VectorIntNarrowingMacroConstructor.subst(iop)
     exec_output = VectorFloatNarrowingMicroExecute.subst(microiop)
     decode_block = VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -489,6 +489,20 @@ Fault
 
 }};
 
+def template VectorIntNarrowingMacroDeclare {{
+
+template<typename ElemType>
+class %(class_name)s : public %(base_class)s {
+private:
+    %(reg_idx_arr_decl)s;
+    bool vxsat = false;
+public:
+    %(class_name)s(ExtMachInst _machInst, uint32_t _elen, uint32_t _vlen);
+    using %(base_class)s::generateDisassembly;
+};
+
+}};
+
 def template VectorIntNarrowingMacroConstructor {{
 
 template<typename ElemType>
@@ -537,7 +551,7 @@ template<typename ElemType>
 
         microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
                                                     _elen, _vlen, copy_vs1,
-                                                    copy_vs2);
+                                                    copy_vs2, &vxsat);
         microop->setDelayedCommit();
         this->microops.push_back(microop);
         micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
@@ -545,8 +559,59 @@ template<typename ElemType>
         copy_vs2 = false;
     }
 
+    if (_opClass == SimdCvtOp){
+        microop = new VxsatMicroInst(&vxsat, _machInst, _elen, _vlen);
+        microop->setFlag(StaticInst::IsSerializeAfter);
+        microop->setFlag(StaticInst::IsNonSpeculative);
+        this->microops.push_back(microop);
+    }
+
     this->microops.front()->setFirstMicroop();
     this->microops.back()->setLastMicroop();
+}
+
+%(declare_varith_template)s;
+
+}};
+
+def template VectorIntNarrowingMicroDeclare {{
+
+template<typename ElemType>
+class %(class_name)s : public %(base_class)s
+{
+private:
+    // vs1, vs2, vs3(old_vd), vm for *.vv, *.vx
+    RegId srcRegIdxArr[4];
+    RegId destRegIdxArr[1];
+    bool vm;
+    bool *vxsatptr;
+public:
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+                   bool _copyVs1=false, bool _copyVs2=false, bool* vxsatptr=nullptr);
+    Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
+    using %(base_class)s::generateDisassembly;
+};
+
+}};
+
+
+def template VectorIntNarrowingMicroConstructor {{
+
+template<typename ElemType>
+%(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
+        uint32_t _microVl, uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
+        bool _copyVs1, bool _copyVs2, bool* vxsatptr)
+    : %(base_class)s("%(mnemonic)s", _machInst,
+                     %(op_class)s, _microVl, _microIdx, _elen, _vlen)
+{
+    this->vm = _machInst.vm;
+    this->vxsatptr = vxsatptr;
+    %(set_reg_idx_arr)s;
+    _numSrcRegs = 0;
+    _numDestRegs = 0;
+    %(set_dest_reg_idx)s;
+    %(set_src_reg_idx)s;
 }
 
 %(declare_varith_template)s;


### PR DESCRIPTION
This patch completes and fixes several RVV (RISC-V Vector Extension) integer instructions in the decoder.

Main changes:
- Integrate the correct vector rounding mode (VXRM) into integer rounding operations.
- Improve saturation handling by setting the VXSAT flag when saturation occurs, following the RVV specification.

Instructions affected:
- vsmul
- vnclip / vnclipu
- vaadd / vaaddu
- vasub / vasubu
- vssrl