### PR TITLE
ext: Fix DRAMPower warning

### DIFF
--- a/ext/drampower/src/Parametrisable.h
+++ b/ext/drampower/src/Parametrisable.h
@@ -114,8 +114,8 @@ class Parametrisable {
       *m = static_cast<T>(getParameter(paramName));
       return true;
     } else {
-      *m = static_cast<T>(0);
-      return false;
+        *m = T();
+        return false;
     }
   }
 


### PR DESCRIPTION
Note: our version of DRAMPower has deviated significantly from the upstream version. Thus, I am making this change here instead of pulling in a new version of DRAMPower. The upstream version no longer has this file (and, presumably, no longer has this warning). If we pull in a new version, it's OK to lose this code.

```
In file included from ext/drampower/src/MemorySpecification.cc:38: In file included from ext/drampower/src/MemorySpecification.h:44: In file included from ext/drampower/src/MemArchitectureSpec.h:43: ext/drampower/src/Parametrisable.h:117:27: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
  117 |       *m = static_cast<T>(0);
      |                           ^
ext/drampower/src/MemorySpecification.cc:46:3: note: in instantiation of function template specialization 'Data::Parametrisable::setVarFromParam<std::string>' requested here
   46 |   setVarFromParam(&id,"memoryId");
      |   ^
1 warning generated.
```