### PR TITLE
arch-riscv: save RISCV PMP table to checkpoint

### DIFF
--- a/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
@@ -91,7 +91,7 @@ board.set_se_binary_workload(
     # the workload should be the same as the one in the save-checkpoint script
     obtain_resource("riscv-hello"),
     checkpoint=obtain_resource(
-        "riscv-hello-example-checkpoint", resource_version="6.0.0"
+        "riscv-hello-example-checkpoint", resource_version="7.0.0"
     ),
 )
 

--- a/src/arch/riscv/pmp.cc
+++ b/src/arch/riscv/pmp.cc
@@ -292,5 +292,32 @@ PMP::pmpDecodeNapot(Addr pmpaddr)
     }
 }
 
+void
+PMP::serialize(CheckpointOut &cp) const
+{
+    SERIALIZE_SCALAR(numRules);
+    int cptPmpEntries = pmpEntries;
+    SERIALIZE_SCALAR(cptPmpEntries);
+    for (int i = 0; i < numRules; i++) {
+        pmpTable[i].serializeSection(cp, csprintf("Entry%d", i));
+    }
+}
+void
+PMP::unserialize(CheckpointIn &cp)
+{
+    UNSERIALIZE_SCALAR(numRules);
+    int cptPmpEntries;
+    UNSERIALIZE_SCALAR(cptPmpEntries);
+    if (cptPmpEntries != pmpEntries) {
+        fatal("Current PMP table size is different from the one stored in the "
+              "checkpoint!");
+    }
+
+    for (int i = 0; i < numRules; i++) {
+        PmpEntry *tmp = &pmpTable[i];
+        tmp->unserializeSection(cp, csprintf("Entry%d", i));
+    }
+}
+
 } // namespace RiscvISA
 } // namespace gem5

--- a/src/arch/riscv/pmp.cc
+++ b/src/arch/riscv/pmp.cc
@@ -309,8 +309,9 @@ PMP::unserialize(CheckpointIn &cp)
     int cptPmpEntries;
     UNSERIALIZE_SCALAR(cptPmpEntries);
     if (cptPmpEntries != pmpEntries) {
-        fatal("Current PMP table size is different from the one stored in the "
-              "checkpoint!");
+        fatal("Current PMP table size (%d) differs from checkpoint PMP table "
+              "size (%d).",
+              pmpEntries, cptPmpEntries);
     }
 
     for (int i = 0; i < pmpEntries; i++) {

--- a/src/arch/riscv/pmp.cc
+++ b/src/arch/riscv/pmp.cc
@@ -295,7 +295,6 @@ PMP::pmpDecodeNapot(Addr pmpaddr)
 void
 PMP::serialize(CheckpointOut &cp) const
 {
-    SERIALIZE_SCALAR(numRules);
     int cptPmpEntries = pmpEntries;
     SERIALIZE_SCALAR(cptPmpEntries);
     for (int i = 0; i < pmpEntries; i++) {
@@ -305,7 +304,6 @@ PMP::serialize(CheckpointOut &cp) const
 void
 PMP::unserialize(CheckpointIn &cp)
 {
-    UNSERIALIZE_SCALAR(numRules);
     int cptPmpEntries;
     UNSERIALIZE_SCALAR(cptPmpEntries);
     if (cptPmpEntries != pmpEntries) {
@@ -317,6 +315,7 @@ PMP::unserialize(CheckpointIn &cp)
     for (int i = 0; i < pmpEntries; i++) {
         PmpEntry *tmp = &pmpTable[i];
         tmp->unserializeSection(cp, csprintf("Entry%d", i));
+        pmpUpdateRule(i);
     }
 }
 

--- a/src/arch/riscv/pmp.cc
+++ b/src/arch/riscv/pmp.cc
@@ -298,7 +298,7 @@ PMP::serialize(CheckpointOut &cp) const
     SERIALIZE_SCALAR(numRules);
     int cptPmpEntries = pmpEntries;
     SERIALIZE_SCALAR(cptPmpEntries);
-    for (int i = 0; i < numRules; i++) {
+    for (int i = 0; i < pmpEntries; i++) {
         pmpTable[i].serializeSection(cp, csprintf("Entry%d", i));
     }
 }
@@ -313,7 +313,7 @@ PMP::unserialize(CheckpointIn &cp)
               "checkpoint!");
     }
 
-    for (int i = 0; i < numRules; i++) {
+    for (int i = 0; i < pmpEntries; i++) {
         PmpEntry *tmp = &pmpTable[i];
         tmp->unserializeSection(cp, csprintf("Entry%d", i));
     }

--- a/src/arch/riscv/pmp.hh
+++ b/src/arch/riscv/pmp.hh
@@ -36,6 +36,7 @@
 #include "base/types.hh"
 #include "mem/packet.hh"
 #include "params/PMP.hh"
+#include "sim/serialize.hh"
 #include "sim/sim_object.hh"
 
 /**
@@ -99,7 +100,7 @@ class PMP : public SimObject
     int numRules;
 
     /** single pmp entry struct*/
-    struct PmpEntry
+    struct PmpEntry : public Serializable
     {
         /** addr range corresponding to a single pmp entry */
         AddrRange pmpAddr = AddrRange(0, 0);
@@ -107,6 +108,29 @@ class PMP : public SimObject
         Addr rawAddr;
         /** pmpcfg reg value for a pmp entry */
         uint8_t pmpCfg = 0;
+
+        void
+        serialize(CheckpointOut &cp) const
+        {
+            Addr pmpAddrStart = pmpAddr.start();
+            Addr pmpAddrEnd = pmpAddr.end();
+            SERIALIZE_SCALAR(pmpAddrStart);
+            SERIALIZE_SCALAR(pmpAddrEnd);
+            SERIALIZE_SCALAR(rawAddr);
+            SERIALIZE_SCALAR(pmpCfg);
+        }
+        void
+        unserialize(CheckpointIn &cp)
+        {
+            Addr pmpAddrStart;
+            Addr pmpAddrEnd;
+
+            UNSERIALIZE_SCALAR(pmpAddrStart);
+            UNSERIALIZE_SCALAR(pmpAddrEnd);
+            pmpAddr = AddrRange(pmpAddrStart, pmpAddrEnd);
+            UNSERIALIZE_SCALAR(rawAddr);
+            UNSERIALIZE_SCALAR(pmpCfg);
+        }
     };
 
     /** a table of pmp entries */
@@ -205,6 +229,8 @@ class PMP : public SimObject
      */
     inline AddrRange pmpDecodeNapot(Addr pmpaddr);
 
+    void serialize(CheckpointOut &cp) const override;
+    void unserialize(CheckpointIn &cp) override;
 };
 
 } // namespace RiscvISA

--- a/src/arch/riscv/pmp.hh
+++ b/src/arch/riscv/pmp.hh
@@ -112,22 +112,12 @@ class PMP : public SimObject
         void
         serialize(CheckpointOut &cp) const
         {
-            Addr pmpAddrStart = pmpAddr.start();
-            Addr pmpAddrEnd = pmpAddr.end();
-            SERIALIZE_SCALAR(pmpAddrStart);
-            SERIALIZE_SCALAR(pmpAddrEnd);
             SERIALIZE_SCALAR(rawAddr);
             SERIALIZE_SCALAR(pmpCfg);
         }
         void
         unserialize(CheckpointIn &cp)
         {
-            Addr pmpAddrStart;
-            Addr pmpAddrEnd;
-
-            UNSERIALIZE_SCALAR(pmpAddrStart);
-            UNSERIALIZE_SCALAR(pmpAddrEnd);
-            pmpAddr = AddrRange(pmpAddrStart, pmpAddrEnd);
             UNSERIALIZE_SCALAR(rawAddr);
             UNSERIALIZE_SCALAR(pmpCfg);
         }

--- a/src/arch/riscv/pmp.hh
+++ b/src/arch/riscv/pmp.hh
@@ -105,7 +105,7 @@ class PMP : public SimObject
         /** addr range corresponding to a single pmp entry */
         AddrRange pmpAddr = AddrRange(0, 0);
         /** raw addr in pmpaddr register for a pmp entry */
-        Addr rawAddr;
+        Addr rawAddr = 0;
         /** pmpcfg reg value for a pmp entry */
         uint8_t pmpCfg = 0;
 


### PR DESCRIPTION
This PR modifies gem5 so that the PMP table is saved/restored when taking/restoring a checkpoint. This should resolve [Issue 2908](https://github.com/gem5/gem5/issues/2908).

Note: It won't be possible to set up a checkpoint upgrader for this, so older checkpoints will need to be retaken to be restored correctly.