### PR TITLE
util: Fix checkpoint upgrade for non-X86 ISAs

### DIFF
--- a/util/cpt_upgraders/x86-add-xcr0.py
+++ b/util/cpt_upgraders/x86-add-xcr0.py
@@ -44,11 +44,3 @@ def upgrader(cpt):
                 # Add the default value of XCR0 (1) if missing
                 regVals = f"{regVals} 1"
                 cpt.set(sec, "regVal", regVals)
-        elif re.search(rf"board\.processor\.cores.*isa$", sec):
-            # ISA name doesn't appear to be anywhere in the checkpoint.
-            # Assume it is X86.
-            regVals = cpt.get(sec, "regVal")
-
-            # Add the default value of XCR0 (1) if missing
-            regVals = f"{regVals} 1"
-            cpt.set(sec, "regVal", regVals)


### PR DESCRIPTION
A 2 years-old PR [1] breaks cpt-upgrading for non X86 ISAs with the following assumption:

" ISA name doesn't appear to be anywhere in the checkpoint. Assume it is X86."

This is another example of how the checkpoint upgrading is severly broken and if we force contributors to provide cpt upgraders, they better be tested properly.

This PR is removing compatibility with non isaName checkpoints. isaName was necessary the moment we passed from being a single ISA build-only simulator into multi-ISA support as the existing root.isa section was removed.

Older checkpoints should just be invalidated. Or do you want to upgrade your checkpoint without isaName? Just add the ISA of interest manually in the core.isa section.

[1]: https://github.com/gem5/gem5/pull/1040


Change-Id: Ib7632d89e5ab78936a71586adde87e65641245a7