### PR TITLE
Project Files

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -930,6 +930,7 @@ LSQ::SingleDataRequest::initiateTranslation()
     if (_reqs.size() > 0) {
         _reqs.back()->setReqInstSeqNum(_inst->seqNum);
         _reqs.back()->taskId(_taskId);
+        _reqs.back()->setInstCount(_inst->getCpuPtr()->totalInsts());
         _inst->translationStarted(true);
         setState(State::Translation);
         flags.set(Flag::TranslationStarted);
@@ -966,6 +967,7 @@ LSQ::SplitDataRequest::initiateTranslation()
                 _size, _flags, _inst->requestorId(),
                 _inst->pcState().instAddr(), _inst->contextId());
     _mainReq->setByteEnable(_byteEnable);
+    _mainReq->setInstCount(_inst->getCpuPtr()->totalInsts());
 
     // Paddr is not used in _mainReq. However, we will accumulate the flags
     // from the sub requests into _mainReq by calling setFlags() in finish().
@@ -1004,6 +1006,7 @@ LSQ::SplitDataRequest::initiateTranslation()
         for (auto& r: _reqs) {
             r->setReqInstSeqNum(_inst->seqNum);
             r->taskId(_taskId);
+            r->setInstCount(_inst->getCpuPtr()->totalInsts());
         }
 
         _inst->translationStarted(true);

--- a/src/mem/cache/base.cc
+++ b/src/mem/cache/base.cc
@@ -1666,6 +1666,12 @@ BaseCache::handleFill(PacketPtr pkt, CacheBlk *blk, PacketList &writebacks,
 CacheBlk*
 BaseCache::allocateBlock(const PacketPtr pkt, PacketList &writebacks)
 {
+    if (tags->shouldBypass(pkt)) {
+        DPRINTF(CacheRepl, "Bypassing allocation for %#llx (%s)\n",
+                pkt->getAddr(), pkt->isSecure() ? "s" : "ns");
+        return nullptr;
+    }
+
     // Get address
     const Addr addr = pkt->getAddr();
 

--- a/src/mem/cache/replacement_policies/ReplacementPolicies.py
+++ b/src/mem/cache/replacement_policies/ReplacementPolicies.py
@@ -175,3 +175,15 @@ class WeightedLRURP(LRURP):
     type = "WeightedLRURP"
     cxx_class = "gem5::replacement_policy::WeightedLRU"
     cxx_header = "mem/cache/replacement_policies/weighted_lru_rp.hh"
+
+
+class SPAIBRP(LRURP):
+    type = "SPAIBRP"
+    cxx_class = "gem5::replacement_policy::SPAIB"
+    cxx_header = "mem/cache/replacement_policies/spaib_rp.hh"
+    history_length = Param.Unsigned(
+        32, "Number of resolved line outcomes used for phase detection"
+    )
+    dead_threshold = Param.Percent(
+        75, "Dead-line rate that triggers near-LRU insertion"
+    )

--- a/src/mem/cache/replacement_policies/ReplacementPolicies.py
+++ b/src/mem/cache/replacement_policies/ReplacementPolicies.py
@@ -187,3 +187,24 @@ class SPAIBRP(LRURP):
     dead_threshold = Param.Percent(
         75, "Dead-line rate that triggers near-LRU insertion"
     )
+    enable_bypass = Param.Bool(
+        False, "Enable bypassing fills during strong streaming phases"
+    )
+    bypass_threshold = Param.Percent(
+        90, "Dead-line rate threshold that triggers fill bypass"
+    )
+
+
+class SPAIBMPKIRP(LRURP):
+    type = "SPAIBMPKIRP"
+    cxx_class = "gem5::replacement_policy::SPAIBMPKI"
+    cxx_header = "mem/cache/replacement_policies/spaib_mpki_rp.hh"
+    instruction_window = Param.Unsigned(
+        100000, "Instruction window used to compute MPKI"
+    )
+    mpki_threshold = Param.Float(
+        10.0, "MPKI threshold that triggers streaming mode"
+    )
+    enable_bypass = Param.Bool(
+        False, "Enable bypassing fills during high-MPKI phases"
+    )

--- a/src/mem/cache/replacement_policies/SConscript
+++ b/src/mem/cache/replacement_policies/SConscript
@@ -31,7 +31,7 @@ Import('*')
 SimObject('ReplacementPolicies.py', sim_objects=[
     'BaseReplacementPolicy', 'DuelingRP', 'FIFORP', 'SecondChanceRP',
     'LFURP', 'LRURP', 'BIPRP', 'MRURP', 'RandomRP', 'BRRIPRP', 'SHiPRP',
-    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP'])
+    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP', 'SPAIBRP'])
 
 Source('bip_rp.cc')
 Source('brrip_rp.cc')
@@ -43,6 +43,7 @@ Source('mru_rp.cc')
 Source('random_rp.cc')
 Source('second_chance_rp.cc')
 Source('ship_rp.cc')
+Source('spaib_rp.cc')
 Source('tree_plru_rp.cc')
 Source('weighted_lru_rp.cc')
 

--- a/src/mem/cache/replacement_policies/SConscript
+++ b/src/mem/cache/replacement_policies/SConscript
@@ -31,7 +31,7 @@ Import('*')
 SimObject('ReplacementPolicies.py', sim_objects=[
     'BaseReplacementPolicy', 'DuelingRP', 'FIFORP', 'SecondChanceRP',
     'LFURP', 'LRURP', 'BIPRP', 'MRURP', 'RandomRP', 'BRRIPRP', 'SHiPRP',
-    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP', 'SPAIBRP'])
+    'SHiPMemRP', 'SHiPPCRP', 'TreePLRURP', 'WeightedLRURP', 'SPAIBRP', 'SPAIBMPKIRP'])
 
 Source('bip_rp.cc')
 Source('brrip_rp.cc')
@@ -44,6 +44,7 @@ Source('random_rp.cc')
 Source('second_chance_rp.cc')
 Source('ship_rp.cc')
 Source('spaib_rp.cc')
+Source('spaib_mpki_rp.cc')
 Source('tree_plru_rp.cc')
 Source('weighted_lru_rp.cc')
 
@@ -54,3 +55,7 @@ GTest('fifo_rp.test', 'fifo_rp.cc', 'fifo_rp.test.cc',
     with_tag('gem5 simobject'))
 GTest('lfu_rp.test', 'lfu_rp.cc', 'lfu_rp.test.cc', with_tag('gem5 simobject'))
 GTest('mru_rp.test', 'mru_rp.cc', 'mru_rp.test.cc', with_tag('gem5 simobject'))
+GTest('spaib_rp.test', 'spaib_rp.cc', 'lru_rp.cc', 'spaib_rp.test.cc',
+    with_tag('gem5 simobject'))
+GTest('spaib_mpki_rp.test', 'spaib_mpki_rp.cc', 'lru_rp.cc',
+    '../../packet.cc', '../../../sim/bufval.cc', 'spaib_mpki_rp.test.cc', with_tag('gem5 simobject'))

--- a/src/mem/cache/replacement_policies/base.hh
+++ b/src/mem/cache/replacement_policies/base.hh
@@ -95,6 +95,19 @@ class Base : public SimObject
         replacement_data) const = 0;
 
     /**
+     * Decide whether this fill should bypass cache allocation.
+     *
+     * Policies that do not support bypass should return false.
+     *
+     * pkt: Packet that triggered the potential fill.
+     * return: True when allocation should be skipped.
+     */
+    virtual bool shouldBypass(const PacketPtr) const
+    {
+        return false;
+    }
+
+    /**
      * Find replacement victim among candidates.
      *
      * @param candidates Replacement candidates, selected by indexing policy.

--- a/src/mem/cache/replacement_policies/spaib_mpki_rp.cc
+++ b/src/mem/cache/replacement_policies/spaib_mpki_rp.cc
@@ -1,0 +1,105 @@
+#include "mem/cache/replacement_policies/spaib_mpki_rp.hh"
+
+#include <memory>
+
+#include "base/logging.hh"
+#include "params/SPAIBMPKIRP.hh"
+#include "sim/cur_tick.hh"
+
+namespace gem5
+{
+
+namespace replacement_policy
+{
+
+SPAIBMPKI::SPAIBMPKI(const Params &p)
+  : LRU(p), enableBypass(p.enable_bypass),
+    mpkiThreshold(p.mpki_threshold),
+    instructionWindow(p.instruction_window),
+    missCount(0), baseInstCount(0), hasBaseInstCount(false),
+    currentMpki(0.0), streamingPhase(false)
+{
+    fatal_if(instructionWindow == 0,
+        "SPAIBMPKI requires instruction_window to be greater than zero.");
+}
+
+void
+SPAIBMPKI::recordMiss(const PacketPtr pkt) const
+{
+    if (!pkt || !pkt->req || !pkt->req->hasInstCount()) {
+        return;
+    }
+
+    const uint64_t instCount = pkt->req->getInstCount();
+
+    if (!hasBaseInstCount) {
+        baseInstCount = instCount;
+        hasBaseInstCount = true;
+    }
+
+    missCount++;
+
+    if (instCount < baseInstCount) {
+        baseInstCount = instCount;
+        missCount = 1;
+        return;
+    }
+
+    const uint64_t instDelta = instCount - baseInstCount;
+
+    if (instDelta >= instructionWindow && instDelta > 0) {
+        currentMpki = (static_cast<double>(missCount) * 1000.0) /
+            static_cast<double>(instDelta);
+        streamingPhase = currentMpki >= mpkiThreshold;
+
+        baseInstCount = instCount;
+        missCount = 0;
+    }
+}
+
+bool
+SPAIBMPKI::shouldInsertNearLRU() const
+{
+    return streamingPhase && !shouldBypassFill();
+}
+
+bool
+SPAIBMPKI::shouldBypassFill() const
+{
+    return enableBypass && streamingPhase;
+}
+
+bool
+SPAIBMPKI::shouldBypass(const PacketPtr pkt) const
+{
+    recordMiss(pkt);
+    return shouldBypassFill();
+}
+
+void
+SPAIBMPKI::reset(const std::shared_ptr<ReplacementData>& replacement_data,
+    const PacketPtr pkt)
+{
+    panic_if(!pkt, "SPAIBMPKI requires packet-aware reset for insertion.");
+
+    auto data = std::static_pointer_cast<LRUReplData>(replacement_data);
+    if (shouldInsertNearLRU()) {
+        data->lastTouchTick = Tick(1);
+    } else {
+        data->lastTouchTick = curTick();
+    }
+}
+
+void
+SPAIBMPKI::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+{
+    auto data = std::static_pointer_cast<LRUReplData>(replacement_data);
+    if (shouldInsertNearLRU()) {
+        data->lastTouchTick = Tick(1);
+    } else {
+        data->lastTouchTick = curTick();
+    }
+}
+
+} // namespace replacement_policy
+} // namespace gem5

--- a/src/mem/cache/replacement_policies/spaib_mpki_rp.hh
+++ b/src/mem/cache/replacement_policies/spaib_mpki_rp.hh
@@ -1,0 +1,48 @@
+#ifndef __MEM_CACHE_REPLACEMENT_POLICIES_SPAIB_MPKI_RP_HH__
+#define __MEM_CACHE_REPLACEMENT_POLICIES_SPAIB_MPKI_RP_HH__
+
+#include "mem/cache/replacement_policies/lru_rp.hh"
+#include "mem/packet.hh"
+
+namespace gem5
+{
+
+struct SPAIBMPKIRPParams;
+
+namespace replacement_policy
+{
+
+class SPAIBMPKI : public LRU
+{
+  protected:
+    const bool enableBypass;
+    const double mpkiThreshold;
+    const uint64_t instructionWindow;
+
+    mutable uint64_t missCount;
+    mutable uint64_t baseInstCount;
+    mutable bool hasBaseInstCount;
+    mutable double currentMpki;
+    mutable bool streamingPhase;
+
+    void recordMiss(const PacketPtr pkt) const;
+    bool shouldInsertNearLRU() const;
+    bool shouldBypassFill() const;
+
+  public:
+    typedef SPAIBMPKIRPParams Params;
+    SPAIBMPKI(const Params &p);
+    ~SPAIBMPKI() = default;
+
+    void reset(const std::shared_ptr<ReplacementData>& replacement_data,
+        const PacketPtr pkt) override;
+    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+        override;
+
+    bool shouldBypass(const PacketPtr pkt) const override;
+};
+
+} // namespace replacement_policy
+} // namespace gem5
+
+#endif // __MEM_CACHE_REPLACEMENT_POLICIES_SPAIB_MPKI_RP_HH__

--- a/src/mem/cache/replacement_policies/spaib_mpki_rp.test.cc
+++ b/src/mem/cache/replacement_policies/spaib_mpki_rp.test.cc
@@ -1,0 +1,130 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "mem/cache/replacement_policies/spaib_mpki_rp.hh"
+#include "mem/request.hh"
+#include "params/SPAIBMPKIRP.hh"
+
+namespace
+{
+
+gem5::EventQueue eventQueue("SPAIBMPKITest Queue");
+
+class SPAIBMPKIRPTestF : public ::testing::Test
+{
+  protected:
+    std::shared_ptr<gem5::replacement_policy::SPAIBMPKI>
+    makePolicy(bool enable_bypass, double mpki_threshold,
+               uint64_t instruction_window)
+    {
+        gem5::SPAIBMPKIRPParams params;
+        params.eventq_index = 0;
+        params.enable_bypass = enable_bypass;
+        params.mpki_threshold = mpki_threshold;
+        params.instruction_window = instruction_window;
+        return std::make_shared<gem5::replacement_policy::SPAIBMPKI>(params);
+    }
+
+    std::unique_ptr<gem5::Packet>
+    makePacket(gem5::Addr addr, uint64_t inst_count)
+    {
+        auto req = std::make_shared<gem5::Request>(addr, 64, 0, 0);
+        req->setInstCount(inst_count);
+        return std::make_unique<gem5::Packet>(req, gem5::MemCmd::ReadReq);
+    }
+
+    void
+    tick()
+    {
+        eventQueue.setCurTick(gem5::curTick() + 1);
+    }
+
+    void SetUp() override
+    {
+        gem5::curEventQueue(&eventQueue);
+        eventQueue.setCurTick(1);
+    }
+};
+
+TEST_F(SPAIBMPKIRPTestF, BypassEnabledAfterHighMpki)
+{
+    auto rp = makePolicy(true, 10.0, 100);
+
+    auto pkt1 = makePacket(0x1000, 100);
+    auto pkt2 = makePacket(0x2000, 200);
+
+    ASSERT_FALSE(rp->shouldBypass(pkt1.get()));
+    ASSERT_TRUE(rp->shouldBypass(pkt2.get()));
+}
+
+TEST_F(SPAIBMPKIRPTestF, BypassClearsAfterLowMpki)
+{
+    auto rp = makePolicy(true, 10.0, 100);
+
+    auto pkt1 = makePacket(0x1000, 100);
+    auto pkt2 = makePacket(0x2000, 200);
+    auto pkt3 = makePacket(0x3000, 1200);
+
+    ASSERT_FALSE(rp->shouldBypass(pkt1.get()));
+    ASSERT_TRUE(rp->shouldBypass(pkt2.get()));
+    ASSERT_FALSE(rp->shouldBypass(pkt3.get()));
+}
+
+TEST_F(SPAIBMPKIRPTestF, StreamingInsertionMovesNewLineTowardLRU)
+{
+    auto rp = makePolicy(false, 10.0, 100);
+
+    auto pkt1 = makePacket(0x1000, 100);
+    auto pkt2 = makePacket(0x2000, 200);
+
+    ASSERT_FALSE(rp->shouldBypass(pkt1.get()));
+    ASSERT_FALSE(rp->shouldBypass(pkt2.get()));
+
+    gem5::ReplaceableEntry older_entry;
+    gem5::ReplaceableEntry new_entry;
+    older_entry.replacementData = rp->instantiateEntry();
+    new_entry.replacementData = rp->instantiateEntry();
+
+    rp->reset(older_entry.replacementData, pkt2.get());
+    tick();
+    rp->touch(older_entry.replacementData);
+    tick();
+    rp->reset(new_entry.replacementData, pkt2.get());
+
+    gem5::ReplacementCandidates candidates;
+    candidates.push_back(&older_entry);
+    candidates.push_back(&new_entry);
+
+    ASSERT_EQ(rp->getVictim(candidates), &new_entry);
+}
+
+TEST_F(SPAIBMPKIRPTestF, NonStreamingInsertionKeepsNewLineAwayFromLRU)
+{
+    auto rp = makePolicy(false, 10.0, 100);
+
+    auto pkt1 = makePacket(0x1000, 100);
+    auto pkt2 = makePacket(0x2000, 2100);
+
+    ASSERT_FALSE(rp->shouldBypass(pkt1.get()));
+    ASSERT_FALSE(rp->shouldBypass(pkt2.get()));
+
+    gem5::ReplaceableEntry older_entry;
+    gem5::ReplaceableEntry new_entry;
+    older_entry.replacementData = rp->instantiateEntry();
+    new_entry.replacementData = rp->instantiateEntry();
+
+    rp->reset(older_entry.replacementData, pkt2.get());
+    tick();
+    rp->touch(older_entry.replacementData);
+    tick();
+    rp->reset(new_entry.replacementData, pkt2.get());
+
+    gem5::ReplacementCandidates candidates;
+    candidates.push_back(&older_entry);
+    candidates.push_back(&new_entry);
+
+    ASSERT_EQ(rp->getVictim(candidates), &older_entry);
+}
+
+} // anonymous namespace

--- a/src/mem/cache/replacement_policies/spaib_rp.cc
+++ b/src/mem/cache/replacement_policies/spaib_rp.cc
@@ -1,0 +1,123 @@
+#include "mem/cache/replacement_policies/spaib_rp.hh"
+
+#include <memory>
+
+#include "base/logging.hh"
+#include "params/SPAIBRP.hh"
+#include "sim/cur_tick.hh"
+
+namespace gem5
+{
+
+namespace replacement_policy
+{
+
+SPAIB::SPAIB(const Params &p)
+  : LRU(p), historyLength(p.history_length),
+    deadThreshold(p.dead_threshold / 100.0), recentOutcomes(),
+    deadCount(0), streamingPhase(false)
+{
+    fatal_if(historyLength == 0,
+        "SPAIB requires history_length to be greater than zero.");
+}
+
+void
+SPAIB::recordOutcome(bool dead) const
+{
+    recentOutcomes.push_back(dead);
+    deadCount += dead ? 1 : 0;
+
+    if (recentOutcomes.size() > historyLength) {
+        deadCount -= recentOutcomes.front() ? 1 : 0;
+        recentOutcomes.pop_front();
+    }
+
+    if (recentOutcomes.size() == historyLength) {
+        const double deadRate =
+            static_cast<double>(deadCount) / recentOutcomes.size();
+        streamingPhase = deadRate >= deadThreshold;
+    }
+}
+
+bool
+SPAIB::shouldInsertNearLRU() const
+{
+    return streamingPhase && recentOutcomes.size() == historyLength;
+}
+
+void
+SPAIB::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+{
+    auto data = std::static_pointer_cast<SPAIBReplData>(replacement_data);
+
+    if (data->lastTouchTick != Tick(0) && !data->reused) {
+        recordOutcome(true);
+    }
+
+    data->reused = false;
+    LRU::invalidate(replacement_data);
+}
+
+void
+SPAIB::touch(const std::shared_ptr<ReplacementData>& replacement_data,
+    const PacketPtr pkt)
+{
+    auto data = std::static_pointer_cast<SPAIBReplData>(replacement_data);
+
+    if (!data->reused) {
+        recordOutcome(false);
+        data->reused = true;
+    }
+
+    LRU::touch(replacement_data);
+}
+
+void
+SPAIB::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+{
+    auto data = std::static_pointer_cast<SPAIBReplData>(replacement_data);
+
+    if (!data->reused) {
+        recordOutcome(false);
+        data->reused = true;
+    }
+
+    LRU::touch(replacement_data);
+}
+
+void
+SPAIB::reset(const std::shared_ptr<ReplacementData>& replacement_data,
+    const PacketPtr pkt)
+{
+    auto data = std::static_pointer_cast<SPAIBReplData>(replacement_data);
+    panic_if(!pkt, "SPAIB requires packet-aware reset for insertion.");
+
+    data->reused = false;
+    if (shouldInsertNearLRU()) {
+        data->lastTouchTick = Tick(1);
+    } else {
+        data->lastTouchTick = curTick();
+    }
+}
+
+void
+SPAIB::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+{
+    auto data = std::static_pointer_cast<SPAIBReplData>(replacement_data);
+
+    data->reused = false;
+    if (shouldInsertNearLRU()) {
+        data->lastTouchTick = Tick(1);
+    } else {
+        data->lastTouchTick = curTick();
+    }
+}
+
+std::shared_ptr<ReplacementData>
+SPAIB::instantiateEntry()
+{
+    return std::shared_ptr<ReplacementData>(new SPAIBReplData());
+}
+
+} // namespace replacement_policy
+} // namespace gem5

--- a/src/mem/cache/replacement_policies/spaib_rp.cc
+++ b/src/mem/cache/replacement_policies/spaib_rp.cc
@@ -14,8 +14,10 @@ namespace replacement_policy
 
 SPAIB::SPAIB(const Params &p)
   : LRU(p), historyLength(p.history_length),
-    deadThreshold(p.dead_threshold / 100.0), recentOutcomes(),
-    deadCount(0), streamingPhase(false)
+    deadThreshold(p.dead_threshold / 100.0),
+    enableBypass(p.enable_bypass),
+    bypassThreshold(p.bypass_threshold / 100.0),
+    recentOutcomes(), deadCount(0), deadRate(0.0), streamingPhase(false)
 {
     fatal_if(historyLength == 0,
         "SPAIB requires history_length to be greater than zero.");
@@ -33,16 +35,33 @@ SPAIB::recordOutcome(bool dead) const
     }
 
     if (recentOutcomes.size() == historyLength) {
-        const double deadRate =
-            static_cast<double>(deadCount) / recentOutcomes.size();
+        deadRate = static_cast<double>(deadCount) / recentOutcomes.size();
         streamingPhase = deadRate >= deadThreshold;
+    } else {
+        deadRate = 0.0;
+        streamingPhase = false;
     }
+}
+
+bool
+SPAIB::shouldBypassFill() const
+{
+    return enableBypass && recentOutcomes.size() == historyLength &&
+        deadRate >= bypassThreshold;
 }
 
 bool
 SPAIB::shouldInsertNearLRU() const
 {
-    return streamingPhase && recentOutcomes.size() == historyLength;
+    return streamingPhase && recentOutcomes.size() == historyLength &&
+        !shouldBypassFill();
+}
+
+bool
+SPAIB::shouldBypass(const PacketPtr pkt) const
+{
+    (void)pkt;
+    return shouldBypassFill();
 }
 
 void

--- a/src/mem/cache/replacement_policies/spaib_rp.hh
+++ b/src/mem/cache/replacement_policies/spaib_rp.hh
@@ -26,12 +26,16 @@ class SPAIB : public LRU
 
     const unsigned historyLength;
     const double deadThreshold;
+    const bool enableBypass;
+    const double bypassThreshold;
     mutable std::deque<bool> recentOutcomes;
     mutable unsigned deadCount;
+    mutable double deadRate;
     mutable bool streamingPhase;
 
     void recordOutcome(bool dead) const;
     bool shouldInsertNearLRU() const;
+    bool shouldBypassFill() const;
 
   public:
     typedef SPAIBRPParams Params;
@@ -52,6 +56,8 @@ class SPAIB : public LRU
         override;
 
     std::shared_ptr<ReplacementData> instantiateEntry() override;
+
+    bool shouldBypass(const PacketPtr pkt) const override;
 };
 
 } // namespace replacement_policy

--- a/src/mem/cache/replacement_policies/spaib_rp.hh
+++ b/src/mem/cache/replacement_policies/spaib_rp.hh
@@ -1,0 +1,60 @@
+#ifndef __MEM_CACHE_REPLACEMENT_POLICIES_SPAIB_RP_HH__
+#define __MEM_CACHE_REPLACEMENT_POLICIES_SPAIB_RP_HH__
+
+#include <deque>
+
+#include "mem/cache/replacement_policies/lru_rp.hh"
+#include "mem/packet.hh"
+
+namespace gem5
+{
+
+struct SPAIBRPParams;
+
+namespace replacement_policy
+{
+
+class SPAIB : public LRU
+{
+  protected:
+    struct SPAIBReplData : LRUReplData
+    {
+        bool reused;
+
+        SPAIBReplData() : LRUReplData(), reused(false) {}
+    };
+
+    const unsigned historyLength;
+    const double deadThreshold;
+    mutable std::deque<bool> recentOutcomes;
+    mutable unsigned deadCount;
+    mutable bool streamingPhase;
+
+    void recordOutcome(bool dead) const;
+    bool shouldInsertNearLRU() const;
+
+  public:
+    typedef SPAIBRPParams Params;
+    SPAIB(const Params &p);
+    ~SPAIB() = default;
+
+    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+        override;
+
+    void touch(const std::shared_ptr<ReplacementData>& replacement_data,
+        const PacketPtr pkt) override;
+    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+        override;
+
+    void reset(const std::shared_ptr<ReplacementData>& replacement_data,
+        const PacketPtr pkt) override;
+    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+        override;
+
+    std::shared_ptr<ReplacementData> instantiateEntry() override;
+};
+
+} // namespace replacement_policy
+} // namespace gem5
+
+#endif // __MEM_CACHE_REPLACEMENT_POLICIES_SPAIB_RP_HH__

--- a/src/mem/cache/replacement_policies/spaib_rp.test.cc
+++ b/src/mem/cache/replacement_policies/spaib_rp.test.cc
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "mem/cache/replacement_policies/spaib_rp.hh"
+#include "params/SPAIBRP.hh"
+
+namespace
+{
+
+gem5::EventQueue eventQueue("SPAIBRPTest Queue");
+
+class SPAIBRPTestF : public ::testing::Test
+{
+  protected:
+    std::shared_ptr<gem5::replacement_policy::SPAIB>
+    makePolicy(bool enable_bypass, int bypass_threshold, int dead_threshold,
+               unsigned history_length)
+    {
+        gem5::SPAIBRPParams params;
+        params.eventq_index = 0;
+        params.enable_bypass = enable_bypass;
+        params.bypass_threshold = bypass_threshold;
+        params.dead_threshold = dead_threshold;
+        params.history_length = history_length;
+        return std::make_shared<gem5::replacement_policy::SPAIB>(params);
+    }
+
+    gem5::PacketPtr
+    fakePacket()
+    {
+        return reinterpret_cast<gem5::PacketPtr>(0x1);
+    }
+
+    void
+    tick()
+    {
+        eventQueue.setCurTick(gem5::curTick() + 1);
+    }
+
+    void
+    recordDeadLine(const std::shared_ptr<gem5::replacement_policy::SPAIB>& rp)
+    {
+        auto repl_data = rp->instantiateEntry();
+        const auto pkt = fakePacket();
+        rp->reset(repl_data, pkt);
+        tick();
+        rp->invalidate(repl_data);
+        tick();
+    }
+
+    void
+    recordReusedLine(const std::shared_ptr<gem5::replacement_policy::SPAIB>& rp)
+    {
+        auto repl_data = rp->instantiateEntry();
+        const auto pkt = fakePacket();
+        rp->reset(repl_data, pkt);
+        tick();
+        rp->touch(repl_data, pkt);
+        tick();
+        rp->invalidate(repl_data);
+        tick();
+    }
+
+    void SetUp() override
+    {
+        gem5::curEventQueue(&eventQueue);
+        eventQueue.setCurTick(1);
+    }
+};
+
+TEST_F(SPAIBRPTestF, BypassEnabledAfterDeadStreamingPhase)
+{
+    auto rp = makePolicy(true, 75, 50, 4);
+    const auto pkt = fakePacket();
+
+    for (int i = 0; i < 4; ++i) {
+        recordDeadLine(rp);
+    }
+
+    ASSERT_TRUE(rp->shouldBypass(pkt));
+}
+
+TEST_F(SPAIBRPTestF, BypassClearsAfterReusePhase)
+{
+    auto rp = makePolicy(true, 75, 50, 4);
+    const auto pkt = fakePacket();
+
+    for (int i = 0; i < 4; ++i) {
+        recordDeadLine(rp);
+    }
+    ASSERT_TRUE(rp->shouldBypass(pkt));
+
+    for (int i = 0; i < 4; ++i) {
+        recordReusedLine(rp);
+    }
+
+    ASSERT_FALSE(rp->shouldBypass(pkt));
+}
+
+TEST_F(SPAIBRPTestF, StreamingInsertionMovesNewLineTowardLRU)
+{
+    auto rp = makePolicy(false, 90, 50, 4);
+
+    for (int i = 0; i < 4; ++i) {
+        recordDeadLine(rp);
+    }
+
+    gem5::ReplaceableEntry older_entry;
+    gem5::ReplaceableEntry new_entry;
+    older_entry.replacementData = rp->instantiateEntry();
+    new_entry.replacementData = rp->instantiateEntry();
+
+    const auto pkt = fakePacket();
+
+    rp->reset(older_entry.replacementData, pkt);
+    tick();
+    rp->touch(older_entry.replacementData, pkt);
+    tick();
+
+    rp->reset(new_entry.replacementData, pkt);
+
+    gem5::ReplacementCandidates candidates;
+    candidates.push_back(&older_entry);
+    candidates.push_back(&new_entry);
+
+    ASSERT_EQ(rp->getVictim(candidates), &new_entry);
+}
+
+TEST_F(SPAIBRPTestF, NonStreamingInsertionKeepsNewLineAwayFromLRU)
+{
+    auto rp = makePolicy(false, 90, 75, 4);
+
+    gem5::ReplaceableEntry older_entry;
+    gem5::ReplaceableEntry new_entry;
+    older_entry.replacementData = rp->instantiateEntry();
+    new_entry.replacementData = rp->instantiateEntry();
+
+    const auto pkt = fakePacket();
+
+    rp->reset(older_entry.replacementData, pkt);
+    tick();
+    rp->touch(older_entry.replacementData, pkt);
+    tick();
+
+    rp->reset(new_entry.replacementData, pkt);
+
+    gem5::ReplacementCandidates candidates;
+    candidates.push_back(&older_entry);
+    candidates.push_back(&new_entry);
+
+    ASSERT_EQ(rp->getVictim(candidates), &older_entry);
+}
+
+} // anonymous namespace

--- a/src/mem/cache/tags/base.cc
+++ b/src/mem/cache/tags/base.cc
@@ -127,6 +127,13 @@ BaseTags::insertBlock(const PacketPtr pkt, CacheBlk *blk)
     stats.dataAccesses += 1;
 }
 
+bool
+BaseTags::shouldBypass(const PacketPtr pkt) const
+{
+    (void)pkt;
+    return false;
+}
+
 void
 BaseTags::moveBlock(CacheBlk *src_blk, CacheBlk *dest_blk)
 {

--- a/src/mem/cache/tags/base.hh
+++ b/src/mem/cache/tags/base.hh
@@ -316,6 +316,14 @@ class BaseTags : public ClockedObject
     virtual void insertBlock(const PacketPtr pkt, CacheBlk *blk);
 
     /**
+     * Decide whether a miss fill should bypass allocation in this tag store.
+     *
+     * pkt: Packet corresponding to the fill.
+     * return: True when allocation should be skipped.
+     */
+    virtual bool shouldBypass(const PacketPtr pkt) const;
+
+    /**
      * Move a block's metadata to another location decided by the replacement
      * policy. It behaves as a swap, however, since the destination block
      * should be invalid, the result is a move.

--- a/src/mem/cache/tags/base_set_assoc.hh
+++ b/src/mem/cache/tags/base_set_assoc.hh
@@ -215,6 +215,11 @@ class BaseSetAssoc : public BaseTags
 
     void moveBlock(CacheBlk *src_blk, CacheBlk *dest_blk) override;
 
+    bool shouldBypass(const PacketPtr pkt) const override
+    {
+        return replacementPolicy->shouldBypass(pkt);
+    }
+
     /**
      * Limit the allocation for the cache ways.
      * @param ways The maximum number of ways available for replacement.

--- a/src/mem/cache/tags/sector_tags.hh
+++ b/src/mem/cache/tags/sector_tags.hh
@@ -50,6 +50,7 @@
 #include <vector>
 
 #include "base/statistics.hh"
+#include "mem/cache/replacement_policies/base.hh"
 #include "mem/cache/tags/base.hh"
 #include "mem/cache/tags/sector_blk.hh"
 #include "mem/packet.hh"
@@ -164,6 +165,11 @@ class SectorTags : public BaseTags
     void insertBlock(const PacketPtr pkt, CacheBlk *blk) override;
 
     void moveBlock(CacheBlk *src_blk, CacheBlk *dest_blk) override;
+
+    bool shouldBypass(const PacketPtr pkt) const override
+    {
+        return replacementPolicy->shouldBypass(pkt);
+    }
 
     /**
      * Finds the given address in the cache, do not update replacement data.


### PR DESCRIPTION
This pull request introduces two new adaptive cache replacement policies—SPAIB and SPAIBMPKI—along with their integration into the cache subsystem, support for bypassing cache fills during streaming phases, and comprehensive unit tests. It also adds a mechanism for replacement policies to decide whether to bypass cache allocation, and updates the LSQ to propagate instruction counts for use in MPKI-based policies.

**New adaptive replacement policies and integration:**

* Added the `SPAIB` (Streaming Phase-Aware Insertion and Bypass) and `SPAIBMPKI` (SPAIB with MPKI-based streaming detection) replacement policies, including their C++ implementations (`spaib_rp.cc`, `spaib_mpki_rp.cc`), headers, and Python SimObject definitions. These policies adapt insertion and bypass behavior based on dead-line rates or MPKI, enabling more efficient cache usage during streaming or high-miss phases. [[1]](diffhunk://#diff-d5b82cbc01990315322731ad185c10adce5e285ea6bc48408a102587fa179a7eR1-R142) [[2]](diffhunk://#diff-28db9e2bdf82023ffd552b713f6405fd2c58cd0749f70b8471f739bed250a1aaR1-R66) [[3]](diffhunk://#diff-c1fdeee114b2892859dc2faff896cb2e6f72947fe88522d4a78d28c2bdf9a2fbR1-R105) [[4]](diffhunk://#diff-4f5bda467b16f6c1d2d5dea3b761813db611779082b1a68318fb34cf43c5e723R1-R48) [[5]](diffhunk://#diff-b89872fc0c54ebc7b398206d34a70eea5ec1c75a0345e4765095f53b43b5aeb0R178-R210)
* Integrated the new policies into the build system and test infrastructure by updating the SConscript to include source files, SimObjects, and Google Test cases for both policies. [[1]](diffhunk://#diff-db5b9ebd2a32732fe15059d8750f7feb52241b5fb41c1948d6d3e0c8e51f2baeL34-R34) [[2]](diffhunk://#diff-db5b9ebd2a32732fe15059d8750f7feb52241b5fb41c1948d6d3e0c8e51f2baeR46-R47) [[3]](diffhunk://#diff-db5b9ebd2a32732fe15059d8750f7feb52241b5fb41c1948d6d3e0c8e51f2baeR58-R61)

**Cache allocation and bypass mechanism:**

* Extended the `Base` replacement policy interface with a `shouldBypass(PacketPtr)` method, allowing policies to dynamically decide whether to bypass cache allocation for a given fill. The default implementation returns false for backward compatibility.
* Updated `BaseCache::allocateBlock()` to consult the replacement policy's `shouldBypass()` method, enabling fill bypass when appropriate.

**Support for MPKI-based detection:**

* Modified the LSQ (`LSQ::SingleDataRequest::initiateTranslation()` and `LSQ::SplitDataRequest::initiateTranslation()`) to propagate the instruction count to memory requests, making it available for MPKI-based streaming detection in replacement policies. [[1]](diffhunk://#diff-5b43eba3f0cfcd90760866e874a57633624cf3c7a444156830ea92d99710b30fR933) [[2]](diffhunk://#diff-5b43eba3f0cfcd90760866e874a57633624cf3c7a444156830ea92d99710b30fR970) [[3]](diffhunk://#diff-5b43eba3f0cfcd90760866e874a57633624cf3c7a444156830ea92d99710b30fR1009)

**Testing and validation:**

* Added comprehensive Google Test suites for both `SPAIB` and `SPAIBMPKI` policies, covering bypass activation, streaming insertion, and non-streaming behavior. [[1]](diffhunk://#diff-c26c8b8f28d449bba1c069e27b7878054853158564a0a048a27768b86d4f2a8cR1-R155) [[2]](diffhunk://#diff-e685d245db035c612496a951929ce05de2bd7c17ee58a97da1bffcce36ffd771R1-R130)