### PR TITLE
cpu: Use value-initialization for TimeBuffer entries

### DIFF
--- a/src/cpu/minor/pipe_data.hh
+++ b/src/cpu/minor/pipe_data.hh
@@ -200,7 +200,7 @@ class ForwardLineData /* : public ReportIF, public BubbleIF */
     std::unique_ptr<PCStateBase> pc;
 
     /** Address of this line of data */
-    Addr fetchAddr;
+    Addr fetchAddr = 0;
 
     /** Explicit line width, don't rely on data.size */
     unsigned int lineWidth = 0;

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -30,6 +30,7 @@
 #define __BASE_TIMEBUF_HH__
 
 #include <cassert>
+#include <type_traits>
 #include <vector>
 
 namespace gem5
@@ -140,6 +141,8 @@ class TimeBuffer
         : past(p), future(f), size(past + future + 1),
           data(new char[size * sizeof(T)]), index(size), base(0)
     {
+        static_assert(std::is_default_constructible_v<T>,
+                      "T must be default constructible.");
         assert(past >= 0 && future >= 0);
         char *ptr = data;
         for (unsigned i = 0; i < size; i++) {

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -30,7 +30,6 @@
 #define __BASE_TIMEBUF_HH__
 
 #include <cassert>
-#include <cstring>
 #include <vector>
 
 namespace gem5
@@ -145,8 +144,7 @@ class TimeBuffer
         char *ptr = data;
         for (unsigned i = 0; i < size; i++) {
             index[i] = ptr;
-            std::memset(ptr, 0, sizeof(T));
-            new (ptr) T;
+            new (ptr) T();
             ptr += sizeof(T);
         }
 
@@ -185,8 +183,7 @@ class TimeBuffer
         if (ptr >= (int)size)
             ptr -= size;
         (reinterpret_cast<T *>(index[ptr]))->~T();
-        std::memset(index[ptr], 0, sizeof(T));
-        new (index[ptr]) T;
+        new (index[ptr]) T();
     }
 
   protected:


### PR DESCRIPTION
Replace the memset-plus-placement-new pattern with `new (ptr) T()`. This avoids relying on all-bits-zero as a valid initial state for arbitrary `T` and uses the language-defined initialization semantics instead.

`fetchAddr` in `ForwardLineData` was dependent on the zeroing behavior. Given this was not an explicit contract of `TimeBuffer`, this change explicitly zero's `fetchAddr` in default construction to avoid undefined behavior.