### PR TITLE
arch-x86: Fix decoding of REX prefixes in invalid positions

### DIFF
--- a/src/arch/x86/decoder.cc
+++ b/src/arch/x86/decoder.cc
@@ -152,10 +152,12 @@ Decoder::doPrefixState(uint8_t nextByte)
       case OperandSizeOverride:
         DPRINTF(Decoder, "Found operand size override prefix.\n");
         emi.legacy.op = true;
+        emi.rex = 0;
         break;
       case AddressSizeOverride:
         DPRINTF(Decoder, "Found address size override prefix.\n");
         emi.legacy.addr = true;
+        emi.rex = 0;
         break;
         // Segment override prefixes
       case CSOverride:
@@ -163,6 +165,10 @@ Decoder::doPrefixState(uint8_t nextByte)
       case ESOverride:
       case SSOverride:
           if (emi.mode.submode == SixtyFourBitMode) {
+              // Even though these are ignored in 64-bit mode,
+              // placing these after a REX prefix still renders
+              // the REX invalid.
+              emi.rex = 0;
               break;
           }
           [[fallthrough]];
@@ -170,18 +176,22 @@ Decoder::doPrefixState(uint8_t nextByte)
       case GSOverride:
           DPRINTF(Decoder, "Found segment override.\n");
           emi.legacy.seg = prefix;
+          emi.rex = 0;
           break;
       case Lock:
         DPRINTF(Decoder, "Found lock prefix.\n");
         emi.legacy.lock = true;
+        emi.rex = 0;
         break;
       case Rep:
         DPRINTF(Decoder, "Found rep prefix.\n");
         emi.legacy.rep = true;
+        emi.rex = 0;
         break;
       case Repne:
         DPRINTF(Decoder, "Found repne prefix.\n");
         emi.legacy.repne = true;
+        emi.rex = 0;
         break;
       case RexPrefix:
         DPRINTF(Decoder, "Found Rex prefix %#x.\n", nextByte);

--- a/src/arch/x86/decoder.cc
+++ b/src/arch/x86/decoder.cc
@@ -199,13 +199,35 @@ Decoder::doPrefixState(uint8_t nextByte)
         break;
       case Vex2Prefix:
         DPRINTF(Decoder, "Found VEX two-byte prefix %#x.\n", nextByte);
-        emi.vex.present = 1;
-        nextState = Vex2Of2State;
+        if (emi.rex != 0) {
+            // This is an invalid combination that should cause an undefined
+            // instruction exception.
+            // Pretend this was an undefined instruction so the main decoder
+            // will behave correctly, and stop trying to interpret bytes.
+            instDone = true;
+            nextState = ResetState;
+            emi.opcode.type = TwoByteOpcode;
+            emi.opcode.op = 0x0B;
+        } else {
+            emi.vex.present = 1;
+            nextState = Vex2Of2State;
+        }
         break;
       case Vex3Prefix:
         DPRINTF(Decoder, "Found VEX three-byte prefix %#x.\n", nextByte);
-        emi.vex.present = 1;
-        nextState = Vex2Of3State;
+        if (emi.rex != 0) {
+            // This is an invalid combination that should cause an undefined
+            // instruction exception.
+            // Pretend this was an undefined instruction so the main decoder
+            // will behave correctly, and stop trying to interpret bytes.
+            instDone = true;
+            nextState = ResetState;
+            emi.opcode.type = TwoByteOpcode;
+            emi.opcode.op = 0x0B;
+        } else {
+            emi.vex.present = 1;
+            nextState = Vex2Of3State;
+        }
         break;
       case 0:
         nextState = OneByteOpcodeState;


### PR DESCRIPTION
In x86-64, REX prefixes in invalid positions should be ignored, according to the Intel manual, Section 2.1.1:

> Only one REX prefix is allowed per instruction. If used, the REX
> prefix byte must immediately precede the opcode byte or the escape
> opcode byte (0FH). [..] *Other placements are ignored.*

This change ensures that other placements of the REX prefix are actually ignored, by resetting the `emi.rex` field to 0 any time a non-REX prefix is encountered.

This fixes #2962.

I have tested this change with the test program in #2962 and a full-system X86 boot.