### PR TITLE
 cpu-o3: Release no-access LSQ requests safely

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -835,11 +835,16 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
             // (e.g. re-exec).
             if (fault != NoFault)
                 inst->getFault() = fault;
-        } else if (isLoad) {
+        } else {
             inst->setMemAccPredicate(false);
-            // Commit will have to clean up whatever happened.  Set this
-            // instruction as executed.
-            inst->setExecuted();
+            if (isLoad) {
+                inst->setExecuted();
+            } else {
+                if (inst->sqIdx >= 0) {
+                    thread[tid]->storeQueue[inst->sqIdx].setRequest(nullptr);
+                }
+                request->discard();
+            }
         }
     }
 

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -639,6 +639,17 @@ LSQUnit::executeLoad(const DynInstPtr &inst)
         inst->completeAcc(nullptr);
         iewStage->instToCommit(inst);
         iewStage->activityThisCycle();
+        if (inst->lqIdx >= 0) {
+            LSQRequest *request = loadQueue[inst->lqIdx].request();
+            if (request) {
+                // No packet or translation response will arrive for this
+                // short-circuited access.  Drop the LSQ's request pointer here
+                // after the instruction has completed its execute-stage work,
+                // so the request no longer keeps the DynInst alive.
+                loadQueue[inst->lqIdx].setRequest(nullptr);
+                request->discard();
+            }
+        }
         return NoFault;
     }
 


### PR DESCRIPTION
This change fixes a `DynInst` lifetime leak observed during long O3 x86
boot runs (failed with assert
`DynInst count on board.processor.cores7.core exceeded 1500`). When the MMU
indicates a memory access requires no access (i.e. the access is
short-circuited and no packet is sent), the `LSQ` can retain the
corresponding `LSQRequest` pointer for the `lq`/`sq` entry. Because no
response ever arrives, the normal cleanup path that would release the
`DynInst` is not invoked, allowing the `LSQRequest` to keep the
`DynInstPtr` alive and causing `DynInst` accumulation.

See the short-circuit detection in `LSQ::pushRequest()`:
https://github.com/gem5/gem5/blob/a403abb67942e92b5c51229935ce0fb0fbcc1e6f/src/cpu/o3/lsq.cc#L838-L842

and the load execute handoff in `LSQUnit::executeLoad()`:
https://github.com/gem5/gem5/blob/a403abb67942e92b5c51229935ce0fb0fbcc1e6f/src/cpu/o3/lsq_unit.cc#L636-L642

This commit changes:

- For `store` short-circuited accesses we clear the store queue entry
  (`thread[tid]->storeQueue[inst->sqIdx].setRequest(nullptr)`) and call
  `request->discard()` in `LSQ::pushRequest()`. Stores do not require an
  execute-stage load completion handoff, so they are safe to release
  immediately.

- For `load` short-circuited accesses we retain the `LSQRequest` until
  `LSQUnit::executeLoad()` completes the execute-stage handoff (mark the
  instruction executed, call `completeAcc(nullptr)`, forward the
  instruction to commit, and record activity). After that handoff
  completes we clear the load queue's request pointer
  (`loadQueue[inst->lqIdx].setRequest(nullptr)`) and call
  `request->discard()`. That ensures the `LSQRequest` does not keep the
  `DynInst` alive after the instruction is done.

This works because clearing the LSQ's pointer and discarding the
`LSQRequest` removes the last reference keeping the `DynInst` live.
Immediate discard is safe for stores because there is no later
execute-stage work. Loads require the execute-stage handoff, so
deferring discard until after `LSQUnit::executeLoad()` ensures the
instruction's normal completion path runs first, and then the request is
released.