### PR TITLE
misc, util: bump cryptography from 44.0.1 to 46.0.5

### DIFF
--- a/util/gem5-resources-manager/requirements.txt
+++ b/util/gem5-resources-manager/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 colorama==0.4.6
 coverage==7.2.7
-cryptography==44.0.1
+cryptography==46.0.5
 dnspython==2.6.1
 Flask==2.3.2
 idna==3.7


### PR DESCRIPTION
This commit bumps cryptography from 44.0.1 to 46.0.5 in /util/gem5-resources-manager