### PR TITLE
arch-x86: x87 FPU movfp/lfpimm micro-ops use wrong dataSize

### DIFF
--- a/src/arch/x86/isa/insts/x87/data_transfer_and_conversion/convert_and_load_or_store_integer.py
+++ b/src/arch/x86/isa/insts/x87/data_transfer_and_conversion/convert_and_load_or_store_integer.py
@@ -39,14 +39,14 @@ microcode = """
 # fild common case
 def macroop FILD_M {
     ldifp87 ufp1, seg, sib, disp
-    movfp st(-1), ufp1, spm=-1
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 # fild with RIP-relative addressing
 def macroop FILD_P {
     rdip t7
     ldifp87 ufp1, seg, riprel, disp
-    movfp st(-1), ufp1, spm=-1
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 # FIST

--- a/src/arch/x86/isa/insts/x87/data_transfer_and_conversion/exchange.py
+++ b/src/arch/x86/isa/insts/x87/data_transfer_and_conversion/exchange.py
@@ -36,8 +36,8 @@
 microcode = """
 def macroop FXCH_R
 {
-    movfp ufp1, sti
-    movfp sti, st(0)
-    movfp st(0), ufp1
+    movfp ufp1, sti, dataSize=8
+    movfp sti, st(0), dataSize=8
+    movfp st(0), ufp1, dataSize=8
 };
 """

--- a/src/arch/x86/isa/insts/x87/data_transfer_and_conversion/load_or_store_floating_point.py
+++ b/src/arch/x86/isa/insts/x87/data_transfer_and_conversion/load_or_store_floating_point.py
@@ -36,17 +36,17 @@
 microcode = """
 def macroop FLD_M {
     ldfp87 ufp1, seg, sib, disp
-    movfp st(-1), ufp1, spm=-1
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLD_P {
     rdip t7
     ldfp87 ufp1, seg, riprel, disp
-    movfp st(-1), ufp1, spm=-1
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLD_R {
-    movfp st(-1), sti, spm=-1
+    movfp st(-1), sti, spm=-1, dataSize=8
 };
 
 def macroop FLD80_M {
@@ -63,7 +63,7 @@ def macroop FLD80_P {
 };
 
 def macroop FST_R {
-    movfp sti, st(0)
+    movfp sti, st(0), dataSize=8
 };
 
 def macroop FST_M {
@@ -76,17 +76,17 @@ def macroop FST_P {
 };
 
 def macroop FSTP_R {
-    movfp sti, st(0), spm=1
+    movfp sti, st(0), spm=1, dataSize=8
 };
 
 def macroop FSTP_M {
-    movfp ufp1, st(0)
+    movfp ufp1, st(0), dataSize=8
     stfp87 ufp1, seg, sib, disp
     pop87
 };
 
 def macroop FSTP_P {
-    movfp ufp1, st(0)
+    movfp ufp1, st(0), dataSize=8
     rdip t7
     stfp87 ufp1, seg, riprel, disp
     pop87

--- a/src/arch/x86/isa/insts/x87/load_constants/load_0_1_or_pi.py
+++ b/src/arch/x86/isa/insts/x87/load_constants/load_0_1_or_pi.py
@@ -37,18 +37,18 @@
 microcode = """
 
 def macroop FLDZ {
-    lfpimm ufp1, 0.0
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 0.0, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLD1 {
-    lfpimm ufp1, 1.0
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 1.0, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLDPI {
-    lfpimm ufp1, 3.14159265359
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 3.14159265359, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 """

--- a/src/arch/x86/isa/insts/x87/load_constants/load_logarithm.py
+++ b/src/arch/x86/isa/insts/x87/load_constants/load_logarithm.py
@@ -37,23 +37,23 @@
 microcode = """
 
 def macroop FLDL2E {
-    lfpimm ufp1, 1.44269504089
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 1.44269504089, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLDL2T {
-    lfpimm ufp1, 3.32192809489
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 3.32192809489, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLDLG2 {
-    lfpimm ufp1, 0.30102999566
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 0.30102999566, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 def macroop FLDLN2 {
-    lfpimm ufp1, 0.69314718056
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 0.69314718056, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 """

--- a/src/arch/x86/isa/insts/x87/transcendental_functions/trigonometric_functions.py
+++ b/src/arch/x86/isa/insts/x87/transcendental_functions/trigonometric_functions.py
@@ -46,14 +46,14 @@ def macroop FCOS {
 def macroop FSINCOS {
     sinfp ufp1, st(0)
     cosfp ufp2, st(0)
-    movfp st(0), ufp1
-    movfp st(-1), ufp2, spm=-1
+    movfp st(0), ufp1, dataSize=8
+    movfp st(-1), ufp2, spm=-1, dataSize=8
 };
 
 def macroop FPTAN {
     tanfp st(0), st(0)
-    lfpimm ufp1, 1
-    movfp st(-1), ufp1, spm=-1
+    lfpimm ufp1, 1, dataSize=8
+    movfp st(-1), ufp1, spm=-1, dataSize=8
 };
 
 # FPATAN


### PR DESCRIPTION
x87 FPU macroop definitions (constant loads, register loads/stores, exchanges, trig functions) do not specify `dataSize=8` for their `movfp` and `lfpimm` micro-ops. These micro-ops inherit `env.dataSize`, which defaults to 4 (32-bit operand size) in 64-bit mode for x87 instructions. When `dataSize=4`, the `movfp` micro-op does a 32-bit partial write (read-modify-write preserving the upper 32 bits of the destination), which silently drops the upper 32 bits of the source value.

This means instructions like `FLD1`, `FLDPI`, `FLD`, `FST`, `FXCH`, etc. produce incorrect results on any CPU model that goes through `SimpleThread::setReg` for register writes (AtomicSimpleCPU, TimingSimpleCPU, MinorCPU).


Test to reproduce:
```asm
global _start
section .text
_start:
    finit
    fld1                    ; push 1.0
    sub rsp, 16
    fstp qword [rsp]        ; pop st(0) to [rsp]
    mov rax, [rsp]          ; rax = the double value
    add rsp, 16
    ; rax should be 0x3FF0000000000000
    ; compare with expected
    mov rbx, 0x3FF0000000000000
    cmp rax, rbx
    jne .fail
    ; pass: exit 0
    mov eax, 60
    xor edi, edi
    syscall
.fail:
    ; fail: exit 1
    mov eax, 60
    mov edi, 1
    syscall
```


----------

Kinda related to https://github.com/gem5/gem5/pull/2779

