### PR TITLE
misc: Fix weekly test workflow so it runs long, very-long tests

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -52,7 +52,7 @@ jobs:
             test-dirs-matrix-very-long: ${{ steps.dir-matrix.outputs.test-dirs-matrix-very-long }}
         steps:
             - uses: actions/checkout@v4
-            - name: Get directories for testlib-very-long
+            - name: Get directories for testlib-${{ matrix.type }}
               working-directory: ${{ github.workspace }}/tests
               id: dir-matrix
               run: |
@@ -142,7 +142,7 @@ jobs:
               if: always()
               uses: actions/upload-artifact@v4
               with:
-                  name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-very-long-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
+                  name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-${{ matrix.test-type.length }}-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
                       }}-status-${{ steps.run-tests.outcome }}-output
                   path: tests/testing-results
 

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -88,9 +88,11 @@ jobs:
             - id: flatten-matrix
               run: |
                   echo '${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-quick }}'
-                  primary='["quick"]'
+                  primary='["quick", "long", "very-long"]'
                   secondary='{
-                      "quick": ${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-quick }}
+                      "quick": ${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-quick }},
+                      "long": ${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-long }},
+                      "very-long": ${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-very-long }}
                   }'
 
                   flat_matrix=$(echo $secondary | jq -c '[

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -85,9 +85,9 @@ jobs:
             test-dirs-matrix-flattened: ${{ steps.flatten-matrix.outputs.matrix }}
         needs: [get-date, get-testlib-dirs]
         steps:
-            - id: flatten-matrix
+            - name: Flatten matrix into length and testdir pairs
+              id: flatten-matrix
               run: |
-                  echo '${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-quick }}'
                   primary='["quick", "long", "very-long"]'
                   secondary='{
                       "quick": ${{ needs.get-testlib-dirs.outputs.test-dirs-matrix-quick }},


### PR DESCRIPTION
This PR fixes the weekly tests so they run the `long` and `very-long` tests. Previously, the weekly tests were modified in an attempt to run the `quick`, `long`, and `very-long` tests. However, the `long` and `very-long` tests were commented out/removed for testing, and were not properly added back in.
This PR fixes this issue.

It also fixes the name that the artifacts are uploaded to, and makes some cosmetic changes.