### PR TITLE
misc: Update to use c++20

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -603,13 +603,6 @@ for variant_path in variant_paths:
         with gem5_scons.Configure(env) as conf:
             conf.CheckCxxFlag('-Wno-volatile')
 
-        # Arithmetic operations between differen enums are deprecated.
-        # https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1120r0.html
-        # However, this is common used in code under arch/.
-        # e.g. ArmFault::AddressSizeLL + start_lookup_level
-        env.Append(CXXFLAGS=['-Wno-deprecated-enum-enum-conversion'])
-        env.Append(CXXFLAGS=['-Wno-deprecated-anon-enum-enum-conversion'])
-
         if sys.platform.startswith('freebsd'):
             env.Append(CCFLAGS=['-I/usr/local/include'])
             env.Append(CXXFLAGS=['-I/usr/local/include'])

--- a/SConstruct
+++ b/SConstruct
@@ -594,8 +594,21 @@ for variant_path in variant_paths:
         env.Append(CCFLAGS=['-Wall', '-Wundef', '-Wextra',
                             '-Wno-sign-compare', '-Wno-unused-parameter'])
 
-        # We always compile using C++17
-        env.Append(CXXFLAGS=['-std=c++17'])
+        # We always compile using C++20
+        env.Append(CXXFLAGS=['-std=c++20'])
+        # Left operand of volatile is deprecated in C++20 and then
+        # de-deprecaetd. This skip is a workaround to avoid warning on
+        # intermediate compiler versions. Ref:
+        # https://cplusplus.github.io/CWG/issues/2654.html
+        with gem5_scons.Configure(env) as conf:
+            conf.CheckCxxFlag('-Wno-volatile')
+
+        # Arithmetic operations between differen enums are deprecated.
+        # https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1120r0.html
+        # However, this is common used in code under arch/.
+        # e.g. ArmFault::AddressSizeLL + start_lookup_level
+        env.Append(CXXFLAGS=['-Wno-deprecated-enum-enum-conversion'])
+        env.Append(CXXFLAGS=['-Wno-deprecated-anon-enum-enum-conversion'])
 
         if sys.platform.startswith('freebsd'):
             env.Append(CCFLAGS=['-I/usr/local/include'])
@@ -687,6 +700,9 @@ for variant_path in variant_paths:
                 f'to v{gcc_max_version}.\n'
             )
 
+        # Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
+        if compareVersions(gcc_version, "13") < 0:
+            env.Append(CXXFLAGS=['-Wno-restrict'])
 
         # Add the appropriate Link-Time Optimization (LTO) flags if
         # `--with-lto` is set.

--- a/ext/softfloat/SConscript
+++ b/ext/softfloat/SConscript
@@ -47,6 +47,7 @@ if sf_env['GCC']:
 elif sf_env['CLANG']:
     sf_env.Append(CCFLAGS=['-Wno-unused-variable',
                            '-Wno-unused-label',
+                           '-Wno-implicit-fallthrough',
                            '-Wno-implicit-function-declaration',
                            '-g'])
 

--- a/ext/softfloat/SConscript
+++ b/ext/softfloat/SConscript
@@ -40,14 +40,12 @@ sf_env = env.Clone()
 if sf_env['GCC']:
     sf_env.Append(CCFLAGS=['-Wno-unused-variable',
                            '-Wno-unused-label',
-                           '-Wno-implicit-fallthrough',
                            '-Wno-implicit-function-declaration',
                            '-g'])
 
 elif sf_env['CLANG']:
     sf_env.Append(CCFLAGS=['-Wno-unused-variable',
                            '-Wno-unused-label',
-                           '-Wno-implicit-fallthrough',
                            '-Wno-implicit-function-declaration',
                            '-g'])
 

--- a/ext/softfloat/extF80_roundToInt.c
+++ b/ext/softfloat/extF80_roundToInt.c
@@ -96,6 +96,7 @@ extFloat80_t
         switch ( roundingMode ) {
          case softfloat_round_near_even:
             if ( ! (sigA & UINT64_C( 0x7FFFFFFFFFFFFFFF )) ) break;
+            [[fallthrough]];
          case softfloat_round_near_maxMag:
             if ( exp == 0x3FFE ) goto mag1;
             break;

--- a/ext/softfloat/f128_roundToInt.c
+++ b/ext/softfloat/f128_roundToInt.c
@@ -115,6 +115,7 @@ float128_t
             switch ( roundingMode ) {
              case softfloat_round_near_even:
                 if ( ! (fracF128UI64( uiA64 ) | uiA0) ) break;
+                [[fallthrough]];
              case softfloat_round_near_maxMag:
                 if ( exp == 0x3FFE ) uiZ.v64 |= packToF128UI64( 0, 0x3FFF, 0 );
                 break;

--- a/ext/softfloat/f16_roundToInt.c
+++ b/ext/softfloat/f16_roundToInt.c
@@ -63,6 +63,7 @@ float16_t f16_roundToInt( float16_t a, uint_fast8_t roundingMode, bool exact )
         switch ( roundingMode ) {
          case softfloat_round_near_even:
             if ( ! fracF16UI( uiA ) ) break;
+            [[fallthrough]];
          case softfloat_round_near_maxMag:
             if ( exp == 0xE ) uiZ |= packToF16UI( 0, 0xF, 0 );
             break;

--- a/ext/softfloat/f32_roundToInt.c
+++ b/ext/softfloat/f32_roundToInt.c
@@ -63,6 +63,7 @@ float32_t f32_roundToInt( float32_t a, uint_fast8_t roundingMode, bool exact )
         switch ( roundingMode ) {
          case softfloat_round_near_even:
             if ( ! fracF32UI( uiA ) ) break;
+            [[fallthrough]];
          case softfloat_round_near_maxMag:
             if ( exp == 0x7E ) uiZ |= packToF32UI( 0, 0x7F, 0 );
             break;

--- a/ext/softfloat/f64_roundToInt.c
+++ b/ext/softfloat/f64_roundToInt.c
@@ -63,6 +63,7 @@ float64_t f64_roundToInt( float64_t a, uint_fast8_t roundingMode, bool exact )
         switch ( roundingMode ) {
          case softfloat_round_near_even:
             if ( ! fracF64UI( uiA ) ) break;
+            [[fallthrough]];
          case softfloat_round_near_maxMag:
             if ( exp == 0x3FE ) uiZ |= packToF64UI( 0, 0x3FF, 0 );
             break;

--- a/ext/softfloat/fall_reciprocal.c
+++ b/ext/softfloat/fall_reciprocal.c
@@ -106,6 +106,7 @@ float16_t f16_rsqrte7(float16_t in)
     case 0x004: // -subnormal
     case 0x100: // sNaN
         softfloat_exceptionFlags |= softfloat_flag_invalid;
+        [[fallthrough]];
     case 0x200: //qNaN
         uA.ui = defaultNaNF16UI;
         break;
@@ -122,6 +123,7 @@ float16_t f16_rsqrte7(float16_t in)
         break;
     case 0x020: //+ sub
         sub = true;
+        [[fallthrough]];
     default: // +num
         uA.ui = rsqrte7(uA.ui, 5, 10, sub);
         break;
@@ -143,6 +145,7 @@ float32_t f32_rsqrte7(float32_t in)
     case 0x004: // -subnormal
     case 0x100: // sNaN
         softfloat_exceptionFlags |= softfloat_flag_invalid;
+        [[fallthrough]];
     case 0x200: //qNaN
         uA.ui = defaultNaNF32UI;
         break;
@@ -159,6 +162,7 @@ float32_t f32_rsqrte7(float32_t in)
         break;
     case 0x020: //+ sub
         sub = true;
+        [[fallthrough]];
     default: // +num
         uA.ui = rsqrte7(uA.ui, 8, 23, sub);
         break;
@@ -180,6 +184,7 @@ float64_t f64_rsqrte7(float64_t in)
     case 0x004: // -subnormal
     case 0x100: // sNaN
         softfloat_exceptionFlags |= softfloat_flag_invalid;
+        [[fallthrough]];
     case 0x200: //qNaN
         uA.ui = defaultNaNF64UI;
         break;
@@ -196,6 +201,7 @@ float64_t f64_rsqrte7(float64_t in)
         break;
     case 0x020: //+ sub
         sub = true;
+        [[fallthrough]];
     default: // +num
         uA.ui = rsqrte7(uA.ui, 11, 52, sub);
         break;
@@ -287,12 +293,14 @@ float16_t f16_recip7(float16_t in)
         break;
     case 0x100: // sNaN
         softfloat_exceptionFlags |= softfloat_flag_invalid;
+        [[fallthrough]];
     case 0x200: //qNaN
         uA.ui = defaultNaNF16UI;
         break;
     case 0x004: // -subnormal
     case 0x020: //+ sub
         sub = true;
+        [[fallthrough]];
     default: // +- normal
         uA.ui = recip7(uA.ui, 5, 10,
                        softfloat_roundingMode, sub, &round_abnormal);
@@ -330,12 +338,14 @@ float32_t f32_recip7(float32_t in)
         break;
     case 0x100: // sNaN
         softfloat_exceptionFlags |= softfloat_flag_invalid;
+        [[fallthrough]];
     case 0x200: //qNaN
         uA.ui = defaultNaNF32UI;
         break;
     case 0x004: // -subnormal
     case 0x020: //+ sub
         sub = true;
+        [[fallthrough]];
     default: // +- normal
         uA.ui = recip7(uA.ui, 8, 23,
                        softfloat_roundingMode, sub, &round_abnormal);
@@ -373,12 +383,14 @@ float64_t f64_recip7(float64_t in)
         break;
     case 0x100: // sNaN
         softfloat_exceptionFlags |= softfloat_flag_invalid;
+        [[fallthrough]];
     case 0x200: //qNaN
         uA.ui = defaultNaNF64UI;
         break;
     case 0x004: // -subnormal
     case 0x020: //+ sub
         sub = true;
+        [[fallthrough]];
     default: // +- normal
         uA.ui = recip7(uA.ui, 11, 52,
                        softfloat_roundingMode, sub, &round_abnormal);

--- a/src/arch/amdgpu/common/dtype/binary32.hh
+++ b/src/arch/amdgpu/common/dtype/binary32.hh
@@ -42,32 +42,29 @@ namespace AMDGPU
 // this format by default. For now as there do not seem to be any MI300
 // instructions operating directly on the types (i.e., they all cast to FP32
 // first and then perform arithmetic operations).
-typedef union binary32_u
+union binary32
 {
-    enum bitSizes
-    {
-        ebits = 8,
-        mbits = 23,
-        sbits = 1,
-        bias = 127,
+    static constexpr size_t ebits = 8;
+    static constexpr size_t mbits = 23;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t bias = 127;
 
-        inf = 0x7f800000,
-        nan = 0x7f800100,
-        max = 0x7f7fffff
-    };
+    static constexpr uint32_t inf = 0x7f800000;
+    static constexpr uint32_t nan = 0x7f800100;
+    static constexpr uint32_t max = 0x7f7fffff;
 
     uint32_t storage;
     float fp32;
     struct
     {
-        unsigned mant : 23;
-        unsigned exp : 8;
-        unsigned sign : 1;
+        unsigned mant : mbits;
+        unsigned exp : ebits;
+        unsigned sign : sbits;
     };
 
     // To help with stdlib functions with T = float.
     operator float() const { return fp32; }
-} binary32;
+};
 static_assert(sizeof(binary32) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp16_e5m10.hh
+++ b/src/arch/amdgpu/common/dtype/fp16_e5m10.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp16_e5m10_info
 {
-    enum bitSizes
-    {
-        ebits = 5,
-        mbits = 10,
-        sbits = 1,
-        zbits = 16,
-        bias = 15,
+    static constexpr size_t ebits = 5;
+    static constexpr size_t mbits = 10;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 16;
+    static constexpr size_t bias = 15;
 
-        inf = 0x7c000000,
-        nan = 0x7c100000,
-        max = 0x7bff0000
-    };
+    static constexpr uint32_t inf = 0x7c000000;
+    static constexpr uint32_t nan = 0x7c100000;
+    static constexpr uint32_t max = 0x7bff0000;
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp16_e5m10_info;
+};
 static_assert(sizeof(fp16_e5m10_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp16_e8m7.hh
+++ b/src/arch/amdgpu/common/dtype/fp16_e8m7.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp16_e8m7_info
 {
-    enum bitSizes
-    {
-        ebits = 8,
-        mbits = 7,
-        sbits = 1,
-        zbits = 16,
-        bias = 127,
+    static constexpr size_t ebits = 8;
+    static constexpr size_t mbits = 7;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 16;
+    static constexpr size_t bias = 127;
 
-        inf = 0x7f800000,
-        nan = 0x7f810000,
-        max = 0x7f7f0000
-    };
+    static constexpr uint32_t inf = 0x7f800000;
+    static constexpr uint32_t nan = 0x7f810000;
+    static constexpr uint32_t max = 0x7f7f0000;
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp16_e8m7_info;
+};
 static_assert(sizeof(fp16_e8m7_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp4_e2m1.hh
+++ b/src/arch/amdgpu/common/dtype/fp4_e2m1.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp4_e2m1_info
 {
-    enum bitSizes
-    {
-        ebits = 2,
-        mbits = 1,
-        sbits = 1,
-        zbits = 28,
-        bias = 1,
+    static constexpr size_t ebits = 2;
+    static constexpr size_t mbits = 1;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 28;
+    static constexpr size_t bias = 1;
 
-        inf = (0x7 << 28),
-        nan = (0x7 << 28),
-        max = (0x7 << 28)
-    };
+    static constexpr uint32_t inf = (0x7 << 28);
+    static constexpr uint32_t nan = (0x7 << 28);
+    static constexpr uint32_t max = (0x7 << 28);
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp4_e2m1_info;
+};
 static_assert(sizeof(fp4_e2m1_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp6_e2m3.hh
+++ b/src/arch/amdgpu/common/dtype/fp6_e2m3.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp6_e2m3_info
 {
-    enum bitSizes
-    {
-        ebits = 2,
-        mbits = 3,
-        sbits = 1,
-        zbits = 26,
-        bias = 1,
+    static constexpr size_t ebits = 2;
+    static constexpr size_t mbits = 3;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 26;
+    static constexpr size_t bias = 1;
 
-        inf = (0x1f << 26),
-        nan = (0x1f << 26),
-        max = (0x1f << 26)
-    };
+    static constexpr uint32_t inf = (0x1f << 26);
+    static constexpr uint32_t nan = (0x1f << 26);
+    static constexpr uint32_t max = (0x1f << 26);
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp6_e2m3_info;
+};
 static_assert(sizeof(fp6_e2m3_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp6_e3m2.hh
+++ b/src/arch/amdgpu/common/dtype/fp6_e3m2.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp6_e3m2_info
 {
-    enum bitSizes
-    {
-        ebits = 3,
-        mbits = 2,
-        sbits = 1,
-        zbits = 26,
-        bias = 3,
+    static constexpr size_t ebits = 3;
+    static constexpr size_t mbits = 2;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 26;
+    static constexpr size_t bias = 3;
 
-        inf = (0x1f << 26),
-        nan = (0x1f << 26),
-        max = (0x1f << 26)
-    };
+    static constexpr uint32_t inf = (0x1f << 26);
+    static constexpr uint32_t nan = (0x1f << 26);
+    static constexpr uint32_t max = (0x1f << 26);
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp6_e3m2_info;
+};
 static_assert(sizeof(fp6_e3m2_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp8_e4m3.hh
+++ b/src/arch/amdgpu/common/dtype/fp8_e4m3.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp8_e4m3_info
 {
-    enum bitSizes
-    {
-        ebits = 4,
-        mbits = 3,
-        sbits = 1,
-        zbits = 24,
-        bias = 7,
+    static constexpr size_t ebits = 4;
+    static constexpr size_t mbits = 3;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 24;
+    static constexpr size_t bias = 7;
 
-        inf = (0x7f << zbits),
-        nan = (0xff << zbits),
-        max = (0x7f << zbits)
-    };
+    static constexpr uint32_t inf = (0x7f << zbits);
+    static constexpr uint32_t nan = (0xff << zbits);
+    static constexpr uint32_t max = (0x7f << zbits);
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp8_e4m3_info;
+};
 static_assert(sizeof(fp8_e4m3_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/amdgpu/common/dtype/fp8_e5m2.hh
+++ b/src/arch/amdgpu/common/dtype/fp8_e5m2.hh
@@ -40,20 +40,17 @@ namespace gem5
 namespace AMDGPU
 {
 
-typedef union
+union fp8_e5m2_info
 {
-    enum bitSizes
-    {
-        ebits = 5,
-        mbits = 2,
-        sbits = 1,
-        zbits = 24,
-        bias = 15,
+    static constexpr size_t ebits = 5;
+    static constexpr size_t mbits = 2;
+    static constexpr size_t sbits = 1;
+    static constexpr size_t zbits = 24;
+    static constexpr size_t bias = 15;
 
-        inf = (0x7c << zbits),
-        nan = (0xff << zbits),
-        max = (0x7f << zbits)
-    };
+    static constexpr uint32_t inf = (0x7c << zbits);
+    static constexpr uint32_t nan = (0xff << zbits);
+    static constexpr uint32_t max = (0x7f << zbits);
 
     uint32_t storage;
     struct
@@ -63,7 +60,7 @@ typedef union
         unsigned exp : ebits;
         unsigned sign : sbits;
     };
-} fp8_e5m2_info;
+};
 static_assert(sizeof(fp8_e5m2_info) == 4);
 
 } // namespace AMDGPU

--- a/src/arch/arm/faults.cc
+++ b/src/arch/arm/faults.cc
@@ -1823,5 +1823,15 @@ getFaultVAddr(Fault fault, Addr &va)
     }
 }
 
+ArmFault::FaultSource
+llFaultSource(ArmFault::FaultSource baseLL, enums::ArmLookupLevel level)
+{
+    assert(level < 4);
+
+    using U = std::underlying_type_t<ArmFault::FaultSource>;
+    const auto base = static_cast<U>(baseLL);
+    return static_cast<ArmFault::FaultSource>(base + static_cast<U>(level));
+}
+
 } // namespace ArmISA
 } // namespace gem5

--- a/src/arch/arm/faults.hh
+++ b/src/arch/arm/faults.hh
@@ -783,6 +783,9 @@ template<> ArmFault::FaultVals ArmFaultVals<ArmSev>::vals;
  */
 bool getFaultVAddr(Fault fault, Addr &va);
 
+ArmFault::FaultSource llFaultSource(ArmFault::FaultSource baseLL,
+                                    enums::ArmLookupLevel level);
+
 } // namespace ArmISA
 } // namespace gem5
 

--- a/src/arch/arm/isa/insts/mem.isa
+++ b/src/arch/arm/isa/insts/mem.isa
@@ -56,8 +56,11 @@ let {{
 
             # This shouldn't be part of the eaCode, but until the exec templates
             # are converted over it's the easiest place to put it.
+            memFlagsCasted = map(
+                lambda x: f'static_cast<unsigned>({x})', memFlags
+            )
             eaCode += '\n    unsigned memAccessFlags = '
-            eaCode += ('|'.join(memFlags) + ';')
+            eaCode += ('|'.join(memFlagsCasted) + ';')
 
             codeBlobs["ea_code"] = eaCode
 

--- a/src/arch/arm/mmu.cc
+++ b/src/arch/arm/mmu.cc
@@ -40,6 +40,7 @@
 
 #include "arch/arm/mmu.hh"
 
+#include "arch/arm/faults.hh"
 #include "arch/arm/isa.hh"
 #include "arch/arm/mpam.hh"
 #include "arch/arm/reg_abi.hh"
@@ -413,7 +414,7 @@ MMU::checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
         (te->mtype != TlbEntry::MemoryType::Normal)) {
         return std::make_shared<DataAbort>(
             vaddr, te->domain, is_write,
-            ArmFault::PermissionLL + te->lookupLevel,
+            llFaultSource(ArmFault::PermissionLL, te->lookupLevel),
             state.isStage2, tran_method);
     }
 
@@ -455,12 +456,12 @@ MMU::checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
                 // address reported in FAR
                 return std::make_shared<PrefetchAbort>(
                     req->getPC(),
-                    ArmFault::DomainLL + te->lookupLevel,
+                    llFaultSource(ArmFault::DomainLL, te->lookupLevel),
                     state.isStage2, tran_method);
             } else
                 return std::make_shared<DataAbort>(
                     vaddr, te->domain, is_write,
-                    ArmFault::DomainLL + te->lookupLevel,
+                    llFaultSource(ArmFault::DomainLL, te->lookupLevel),
                     state.isStage2, tran_method);
           case 1:
             // Continue with permissions check
@@ -551,7 +552,7 @@ MMU::checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
         // cache line and should not be the address reported in FAR
         return std::make_shared<PrefetchAbort>(
             req->getPC(),
-            ArmFault::PermissionLL + te->lookupLevel,
+            llFaultSource(ArmFault::PermissionLL, te->lookupLevel),
             state.isStage2, tran_method);
     } else if (abt | hapAbt) {
         stats.permsFaults++;
@@ -559,7 +560,7 @@ MMU::checkPermissions(TlbEntry *te, const RequestPtr &req, Mode mode,
                " write:%d\n", ap, is_priv, is_write);
         return std::make_shared<DataAbort>(
             vaddr, te->domain, is_write,
-            ArmFault::PermissionLL + te->lookupLevel,
+            llFaultSource(ArmFault::PermissionLL, te->lookupLevel),
             state.isStage2 | !abt, tran_method);
     }
     return NoFault;
@@ -604,7 +605,7 @@ MMU::checkPermissions64(TlbEntry *te, const RequestPtr &req, Mode mode,
         (te->mtype != TlbEntry::MemoryType::Normal)) {
         return std::make_shared<DataAbort>(
             vaddr_tainted, te->domain, is_write,
-            ArmFault::PermissionLL + te->lookupLevel,
+            llFaultSource(ArmFault::PermissionLL, te->lookupLevel),
             state.isStage2, TranMethod::LpaeTran);
     }
 
@@ -661,7 +662,7 @@ MMU::checkPermissions64(TlbEntry *te, const RequestPtr &req, Mode mode,
             // cache line and should not be the address reported in FAR
             return std::make_shared<PrefetchAbort>(
                 req->getPC(),
-                ArmFault::PermissionLL + te->lookupLevel,
+                llFaultSource(ArmFault::PermissionLL, te->lookupLevel),
                 state.isStage2, TranMethod::LpaeTran);
         } else {
             stats.permsFaults++;
@@ -670,7 +671,7 @@ MMU::checkPermissions64(TlbEntry *te, const RequestPtr &req, Mode mode,
             return std::make_shared<DataAbort>(
                 vaddr_tainted, te->domain,
                 (is_atomic && !grant_read) ? false : is_write,
-                ArmFault::PermissionLL + te->lookupLevel,
+                llFaultSource(ArmFault::PermissionLL, te->lookupLevel),
                 state.isStage2, TranMethod::LpaeTran);
         }
     }

--- a/src/arch/arm/table_walker.cc
+++ b/src/arch/arm/table_walker.cc
@@ -784,14 +784,14 @@ WalkUnit::processWalk(WalkerState *curr_state)
             if (curr_state->isFetch) {
                 return std::make_shared<PrefetchAbort>(
                     curr_state->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             } else {
                 return std::make_shared<DataAbort>(
                     curr_state->vaddr_tainted, DomainType::NoAccess,
                     is_atomic ? false : curr_state->isWrite,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             }
         }
         ttbr = curr_state->tc->readMiscReg(
@@ -804,14 +804,14 @@ WalkUnit::processWalk(WalkerState *curr_state)
             if (curr_state->isFetch) {
                 return std::make_shared<PrefetchAbort>(
                     curr_state->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             } else {
                 return std::make_shared<DataAbort>(
                     curr_state->vaddr_tainted, DomainType::NoAccess,
                     is_atomic ? false : curr_state->isWrite,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             }
         }
         ttbr = ttbr1;
@@ -903,14 +903,16 @@ WalkUnit::processWalkLPAE(WalkerState *curr_state)
                 if (curr_state->isFetch) {
                     return std::make_shared<PrefetchAbort>(
                         curr_state->vaddr_tainted,
-                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                        TranMethod::LpaeTran);
+                        llFaultSource(ArmFault::TranslationLL,
+                                      LookupLevel::L1),
+                        isStage2, TranMethod::LpaeTran);
                 } else {
                     return std::make_shared<DataAbort>(
                         curr_state->vaddr_tainted, DomainType::NoAccess,
                         is_atomic ? false : curr_state->isWrite,
-                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                        TranMethod::LpaeTran);
+                        llFaultSource(ArmFault::TranslationLL,
+                                      LookupLevel::L1),
+                        isStage2, TranMethod::LpaeTran);
                 }
             }
             ttbr = curr_state->tc->readMiscReg(
@@ -927,14 +929,16 @@ WalkUnit::processWalkLPAE(WalkerState *curr_state)
                 if (curr_state->isFetch) {
                     return std::make_shared<PrefetchAbort>(
                         curr_state->vaddr_tainted,
-                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                        TranMethod::LpaeTran);
+                        llFaultSource(ArmFault::TranslationLL,
+                                      LookupLevel::L1),
+                        isStage2, TranMethod::LpaeTran);
                 } else {
                     return std::make_shared<DataAbort>(
                         curr_state->vaddr_tainted, DomainType::NoAccess,
                         is_atomic ? false : curr_state->isWrite,
-                        ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                        TranMethod::LpaeTran);
+                        llFaultSource(ArmFault::TranslationLL,
+                                      LookupLevel::L1),
+                        isStage2, TranMethod::LpaeTran);
                 }
             }
             ttbr = curr_state->tc->readMiscReg(
@@ -950,14 +954,14 @@ WalkUnit::processWalkLPAE(WalkerState *curr_state)
             if (curr_state->isFetch) {
                 return std::make_shared<PrefetchAbort>(
                     curr_state->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::LpaeTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::LpaeTran);
             } else {
                 return std::make_shared<DataAbort>(
                     curr_state->vaddr_tainted, DomainType::NoAccess,
                     is_atomic ? false : curr_state->isWrite,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::LpaeTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::LpaeTran);
             }
         }
     }
@@ -1243,14 +1247,14 @@ WalkUnit::processWalkAArch64(WalkerState *curr_state)
         if (curr_state->isFetch) {
             return std::make_shared<PrefetchAbort>(
                 curr_state->vaddr_tainted,
-                ArmFault::TranslationLL + LookupLevel::L0, isStage2,
-                TranMethod::LpaeTran);
+                llFaultSource(ArmFault::TranslationLL, LookupLevel::L0),
+                isStage2, TranMethod::LpaeTran);
         } else {
             return std::make_shared<DataAbort>(
                 curr_state->vaddr_tainted, DomainType::NoAccess,
                 is_atomic ? false : curr_state->isWrite,
-                ArmFault::TranslationLL + LookupLevel::L0, isStage2,
-                TranMethod::LpaeTran);
+                llFaultSource(ArmFault::TranslationLL, LookupLevel::L0),
+                isStage2, TranMethod::LpaeTran);
         }
     }
 
@@ -1278,14 +1282,14 @@ WalkUnit::processWalkAArch64(WalkerState *curr_state)
         if (curr_state->isFetch) {
             return std::make_shared<PrefetchAbort>(
                 curr_state->vaddr_tainted,
-                ArmFault::AddressSizeLL + start_lookup_level, isStage2,
-                TranMethod::LpaeTran);
+                llFaultSource(ArmFault::AddressSizeLL, start_lookup_level),
+                isStage2, TranMethod::LpaeTran);
         } else {
             return std::make_shared<DataAbort>(
                 curr_state->vaddr_tainted, DomainType::NoAccess,
                 is_atomic ? false : curr_state->isWrite,
-                ArmFault::AddressSizeLL + start_lookup_level, isStage2,
-                TranMethod::LpaeTran);
+                llFaultSource(ArmFault::AddressSizeLL, start_lookup_level),
+                isStage2, TranMethod::LpaeTran);
         }
     }
 
@@ -1855,14 +1859,14 @@ WalkUnit::doL1Descriptor(WalkerState *curr_state)
             if (curr_state->isFetch) {
                 curr_state->fault = std::make_shared<PrefetchAbort>(
                     curr_state->vaddr_tainted,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             } else {
                 curr_state->fault = std::make_shared<DataAbort>(
                     curr_state->vaddr_tainted, DomainType::NoAccess,
                     is_atomic ? false : curr_state->isWrite,
-                    ArmFault::TranslationLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::TranslationLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             }
             return;
         case L1Descriptor::Section:
@@ -1876,8 +1880,8 @@ WalkUnit::doL1Descriptor(WalkerState *curr_state)
                 curr_state->fault = std::make_shared<DataAbort>(
                     curr_state->vaddr_tainted, curr_state->l1Desc.domain(),
                     is_atomic ? false : curr_state->isWrite,
-                    ArmFault::AccessFlagLL + LookupLevel::L1, isStage2,
-                    TranMethod::VmsaTran);
+                    llFaultSource(ArmFault::AccessFlagLL, LookupLevel::L1),
+                    isStage2, TranMethod::VmsaTran);
             }
             if (curr_state->l1Desc.supersection()) {
                 panic("Haven't implemented supersections\n");
@@ -1922,13 +1926,14 @@ WalkUnit::generateLongDescFault(WalkerState *curr_state,
 {
     if (curr_state->isFetch) {
         return std::make_shared<PrefetchAbort>(
-            curr_state->vaddr_tainted, src + curr_state->longDesc.lookupLevel,
-            isStage2, TranMethod::LpaeTran);
+            curr_state->vaddr_tainted,
+            llFaultSource(src, curr_state->longDesc.lookupLevel), isStage2,
+            TranMethod::LpaeTran);
     } else {
         return std::make_shared<DataAbort>(
             curr_state->vaddr_tainted, DomainType::NoAccess,
             curr_state->req->isAtomic() ? false : curr_state->isWrite,
-            src + curr_state->longDesc.lookupLevel, isStage2,
+            llFaultSource(src, curr_state->longDesc.lookupLevel), isStage2,
             TranMethod::LpaeTran);
     }
 }
@@ -1977,8 +1982,8 @@ WalkUnit::doLongDescriptor(WalkerState *curr_state)
             DPRINTF(PageTableWalker,
                     "L%d descriptor Invalid, causing fault type %d\n",
                     curr_state->longDesc.lookupLevel,
-                    ArmFault::TranslationLL +
-                        curr_state->longDesc.lookupLevel);
+                    llFaultSource(ArmFault::TranslationLL,
+                                  curr_state->longDesc.lookupLevel));
 
             curr_state->fault =
                 generateLongDescFault(curr_state, ArmFault::TranslationLL);
@@ -2117,14 +2122,14 @@ WalkUnit::doL2Descriptor(WalkerState *curr_state)
         if (curr_state->isFetch) {
             curr_state->fault = std::make_shared<PrefetchAbort>(
                 curr_state->vaddr_tainted,
-                ArmFault::TranslationLL + LookupLevel::L2, isStage2,
-                TranMethod::VmsaTran);
+                llFaultSource(ArmFault::TranslationLL, LookupLevel::L2),
+                isStage2, TranMethod::VmsaTran);
         } else {
             curr_state->fault = std::make_shared<DataAbort>(
                 curr_state->vaddr_tainted, curr_state->l1Desc.domain(),
                 is_atomic ? false : curr_state->isWrite,
-                ArmFault::TranslationLL + LookupLevel::L2, isStage2,
-                TranMethod::VmsaTran);
+                llFaultSource(ArmFault::TranslationLL, LookupLevel::L2),
+                isStage2, TranMethod::VmsaTran);
         }
         return;
     }
@@ -2140,7 +2145,7 @@ WalkUnit::doL2Descriptor(WalkerState *curr_state)
         curr_state->fault = std::make_shared<DataAbort>(
             curr_state->vaddr_tainted, DomainType::NoAccess,
             is_atomic ? false : curr_state->isWrite,
-            ArmFault::AccessFlagLL + LookupLevel::L2, isStage2,
+            llFaultSource(ArmFault::AccessFlagLL, LookupLevel::L2), isStage2,
             TranMethod::VmsaTran);
     }
 

--- a/src/arch/mips/utility.cc
+++ b/src/arch/mips/utility.cc
@@ -132,11 +132,11 @@ uint32_t
 genInvalidVector(uint32_t fcsr_bits)
 {
     //Set FCSR invalid in "flag" field
-    int invalid_offset = Invalid + Flag_Field;
+    int invalid_offset = (int)Invalid + (int)Flag_Field;
     fcsr_bits = fcsr_bits | (1 << invalid_offset);
 
     //Set FCSR invalid in "cause" flag
-    int cause_offset = Invalid + Cause_Field;
+    int cause_offset = (int)Invalid + (int)Cause_Field;
     fcsr_bits = fcsr_bits | (1 << cause_offset);
 
     return fcsr_bits;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2068,7 +2068,7 @@ decode QUADRANT default Unknown::unknown() {
             0x2: decode AMOFUNCT {
                 0x2: LoadReserved::lr_w({{
                     Rd_sd = Mem_sw;
-                }}, mem_flags=[LLSC, 'ARCH_BITS & XlateFlags::LR']);
+                }}, mem_flags=[LLSC], xlate_flags=['LR']);
                 0x3: StoreCond::sc_w({{
                     Mem_uw = Rs2_uw;
                 }}, {{
@@ -2174,7 +2174,7 @@ decode QUADRANT default Unknown::unknown() {
                 0x1: decode AMOFUNCT {
                     0x2: LoadReserved::lr_d({{
                         Rd_sd = Mem_sd;
-                    }}, mem_flags=[LLSC, 'ARCH_BITS & XlateFlags::LR']);
+                    }}, mem_flags=[LLSC], xlate_flags=['LR']);
                     0x3: StoreCond::sc_d({{
                         Mem = Rs2;
                     }}, {{
@@ -6481,76 +6481,48 @@ decode QUADRANT default Unknown::unknown() {
                 0x30: decode RS2 {
                     0x0: HyperLoad::hlv_b({{
                         Rd_sd = Mem_sb;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                     0x1: HyperLoad::hlv_bu({{
                         Rd = Mem_ub;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                 }
                 0x31: HyperStore::hsv_b({{
                     Mem_ub = Rs2_ub;
-                }}, mem_flags=[
-                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                ]);
+                }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                 0x32: decode RS2 {
                     0x0: HyperLoad::hlv_h({{
                         Rd_sd = Mem_sh;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                     0x1: HyperLoad::hlv_hu({{
                         Rd = Mem_uh;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                     0x3: HyperLoad::hlvx_hu({{
                         Rd = Mem_uh;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT',
-                        'ARCH_BITS & XlateFlags::HLVX'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT', 'HLVX']);
                 }
                 0x33: HyperStore::hsv_h({{
                         Mem_uh = Rs2_uh
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                 0x34: decode RS2 {
                     0x0: HyperLoad::hlv_w({{
                         Rd_sd = Mem_sw;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                     0x1: HyperLoad::hlv_wu({{
                         Rd = Mem_uw;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                     0x3: HyperLoad::hlvx_wu({{
                         Rd = Mem_uw;
-                    }}, mem_flags=[
-                        'ARCH_BITS & XlateFlags::FORCE_VIRT',
-                        'ARCH_BITS & XlateFlags::HLVX'
-                    ]);
+                    }}, mem_flags=[], xlate_flags=['FORCE_VIRT', 'HLVX']);
                 }
                 0x35: HyperStore::hsv_w({{
                     Mem_uw = Rs2_uw;
-                }}, mem_flags=[
-                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                ]);
+                }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                 0x36: HyperLoad::hlv_d({{
                     Rd_sd = Mem_sd;
-                }}, mem_flags=[
-                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                ]);
+                }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
                 0x37: HyperStore::hsv_d({{
                     Mem_ud = Rs2_ud;
-                }}, mem_flags=[
-                    'ARCH_BITS & XlateFlags::FORCE_VIRT'
-                ]);
+                }}, mem_flags=[], xlate_flags=['FORCE_VIRT']);
 
             }
         }

--- a/src/arch/riscv/isa/formats/amo.isa
+++ b/src/arch/riscv/isa/formats/amo.isa
@@ -429,7 +429,8 @@ def template AtomicMemOpRMWCompleteAcc {{
 // LR/SC/AMO decode formats
 
 def format LoadReserved(memacc_code, postacc_code={{ }},
-        ea_code={{EA = rvSext(Rs1);}}, mem_flags=[], inst_flags=[]) {{
+        ea_code={{EA = rvSext(Rs1);}}, mem_flags=[], inst_flags=[],
+        xlate_flags=[]) {{
     macro_ea_code = ''
     macro_inst_flags = []
     macro_iop = InstObjParams(name, Name, 'LoadReserved', macro_ea_code,
@@ -442,13 +443,23 @@ def format LoadReserved(memacc_code, postacc_code={{ }},
 
     mem_flags = makeList(mem_flags)
     inst_flags = makeList(inst_flags)
+    xlate_flags = makeList(xlate_flags)
     iop = InstObjParams(name, Name, 'LoadReservedMicro',
         {'ea_code': ea_code, 'memacc_code': memacc_code,
         'postacc_code': postacc_code}, inst_flags)
-    mem_flags = ['(Request::%s)' % flag for flag in mem_flags]
+    mem_flags = [
+        'static_cast<Request::FlagsType>(Request::%s)' % flag
+        for flag in mem_flags
+    ]
     align_flag = getAlignFlag(iop)
     if align_flag:
-        mem_flags.append(align_flag)
+        mem_flags.append('static_cast<Request::FlagsType>(%s)' % align_flag)
+    if xlate_flags:
+        xlate_flags_casted = [
+            ('(static_cast<Request::FlagsType>(Request::ARCH_BITS) & '
+             'static_cast<Request::FlagsType>(XlateFlags::%s))') % flag
+            for flag in xlate_flags]
+        mem_flags.extend(xlate_flags_casted)
     iop.constructor += '\n\tmemAccessFlags = memAccessFlags | ' + \
         '|'.join(mem_flags) + ';'
 

--- a/src/arch/riscv/isa/formats/mem.isa
+++ b/src/arch/riscv/isa/formats/mem.isa
@@ -84,20 +84,30 @@ def getAlignFlag(iop):
 
 def LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
         inst_flags, base_class, postacc_code='', decode_template=BasicDecode,
-        exec_template_base=''):
+        exec_template_base='', xlate_flags=None):
     # Make sure flags are in lists (convert to lists if not).
     mem_flags = makeList(mem_flags)
     inst_flags = makeList(inst_flags)
+    xlate_flags = makeList(xlate_flags)
 
     iop = InstObjParams(name, Name, base_class,
         {'offset_code': offset_code, 'ea_code': ea_code,
          'memacc_code': memacc_code, 'postacc_code': postacc_code },
         inst_flags)
 
-    mem_flags = [ '(Request::%s)' % flag for flag in mem_flags ]
+    mem_flags = [
+        'static_cast<Request::FlagsType>(Request::%s)' % flag
+        for flag in mem_flags
+    ]
     align_flag = getAlignFlag(iop)
     if align_flag:
-        mem_flags.append(align_flag)
+        mem_flags.append('static_cast<Request::FlagsType>(%s)' % align_flag)
+    if xlate_flags:
+        xlate_flags_casted = [
+            ('(static_cast<Request::FlagsType>(Request::ARCH_BITS) & '
+             'static_cast<Request::FlagsType>(XlateFlags::%s))') % flag
+            for flag in xlate_flags]
+        mem_flags.extend(xlate_flags_casted)
     if mem_flags:
         s = '\n\tmemAccessFlags = ' + '|'.join(mem_flags) + ';'
         iop.constructor += s
@@ -572,16 +582,18 @@ def format CBMOp(memacc_code, ea_code={{EA = rvSext(Rs1);}},
 
 def format HyperLoad(memacc_code, ea_code = {{EA = rvZext(Rs1 + offset);}},
         offset_code={{offset = 0;}},
-        mem_flags=[], inst_flags=[]) {{
+        mem_flags=[], inst_flags=[], xlate_flags=[]) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
-        inst_flags, 'Load', exec_template_base='HyperLoad')
+        inst_flags, 'Load', exec_template_base='HyperLoad',
+        xlate_flags=xlate_flags)
 }};
 
 def format HyperStore(memacc_code, ea_code={{EA = rvZext(Rs1 + offset);}},
         offset_code={{offset = 0;}},
-        mem_flags=[], inst_flags=[]) {{
+        mem_flags=[], inst_flags=[], xlate_flags=[]) {{
     (header_output, decoder_output, decode_block, exec_output) = \
         LoadStoreBase(name, Name, offset_code, ea_code, memacc_code, mem_flags,
-        inst_flags, 'Store', exec_template_base='HyperStore')
+        inst_flags, 'Store', exec_template_base='HyperStore',
+        xlate_flags=xlate_flags)
 }};

--- a/src/cpu/minor/dyn_inst.hh
+++ b/src/cpu/minor/dyn_inst.hh
@@ -123,7 +123,7 @@ class InstId
   public:
     /* Equal if the thread and last set sequence number matches */
     bool
-    operator== (const InstId &rhs)
+    operator==(const InstId &rhs) const
     {
         /* If any of fetch and exec sequence number are not set
          *  they need to be 0, so a straight comparison is still

--- a/src/dev/arm/css/scmi_protocols.cc
+++ b/src/dev/arm/css/scmi_protocols.cc
@@ -267,8 +267,7 @@ BaseProtocol::discoverAgent(Message &msg)
 
         agent_size = agent_name.length();
 
-        strncpy((char *)&payload.name,
-                agent_name.c_str(), agent_size);
+        strncpy((char *)&payload.name, agent_name.c_str(), agent_size + 1);
 
         payload.status = SUCCESS;
         // header + status + payload


### PR DESCRIPTION
GCC will soon enable C++20 as default [ref](https://gcc.gnu.org/projects/cxx-status.html) and some style guide (e.g. the Google one [ref](https://google.github.io/styleguide/cppguide.html)) suggest using C++20 already.

This is a trial of enabling it in gem5. Would like to check if this makes sense or any concern.

Tested locally with clang-14 and GCC-12