### PR TITLE
configs,stdlib: Disable ASLR for GPU

### DIFF
--- a/configs/example/gpufs/mi200.py
+++ b/configs/example/gpufs/mi200.py
@@ -47,6 +47,7 @@ demo_runscript_without_checkpoint = """\
 export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 export HSA_ENABLE_INTERRUPT=0
 export HCC_AMDGPU_TARGET=gfx90a
+echo 0 > /proc/sys/kernel/randomize_va_space
 free -m
 dmesg -n8
 dd if=/root/roms/mi200.rom of=/dev/mem bs=1k seek=768 count=128
@@ -72,6 +73,7 @@ demo_runscript_with_checkpoint = """\
 export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 export HSA_ENABLE_INTERRUPT=0
 export HCC_AMDGPU_TARGET=gfx90a
+echo 0 > /proc/sys/kernel/randomize_va_space
 dmesg -n8
 dd if=/root/roms/mi200.rom of=/dev/mem bs=1k seek=768 count=128
 if [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then

--- a/configs/example/gpufs/mi300.py
+++ b/configs/example/gpufs/mi300.py
@@ -56,6 +56,7 @@ demo_runscript_without_checkpoint = """\
 export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 export HSA_ENABLE_INTERRUPT=0
 export HCC_AMDGPU_TARGET=gfx942
+echo 0 > /proc/sys/kernel/randomize_va_space
 dmesg -n8
 cat /proc/cpuinfo
 dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128
@@ -88,6 +89,7 @@ export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 export HSA_ENABLE_INTERRUPT=0
 export HCC_AMDGPU_TARGET=gfx942
 export HSA_OVERRIDE_GFX_VERSION="9.4.2"
+echo 0 > /proc/sys/kernel/randomize_va_space
 dmesg -n8
 dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128
 if [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -183,6 +183,7 @@ class MI210(BaseViperGPU):
             "export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH\n"
             "export HSA_ENABLE_INTERRUPT=0\n"
             "export HCC_AMDGPU_TARGET=gfx90a\n"
+            "echo 0 > /proc/sys/kernel/randomize_va_space\n"
             f"{debug_commands}\n"
             "dd if=/root/roms/mi200.rom of=/dev/mem bs=1k seek=768 count=128\n"
             "if [ -f /home/gem5/load_amdgpu.sh ]; then\n"
@@ -301,6 +302,7 @@ class MI300X(BaseViperGPU):
             "export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH\n"
             "export HSA_ENABLE_INTERRUPT=0\n"
             "export HCC_AMDGPU_TARGET=gfx942\n"
+            "echo 0 > /proc/sys/kernel/randomize_va_space\n"
             f"{debug_commands}\n"
             "dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128\n"
             # Check if exists (backwards compat with ROCm <7.0)
@@ -364,6 +366,7 @@ class MI355X(MI300X):
             "export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH\n"
             "export HSA_ENABLE_INTERRUPT=0\n"
             "export HCC_AMDGPU_TARGET=gfx950\n"
+            "echo 0 > /proc/sys/kernel/randomize_va_space\n"
             f"{debug_commands}\n"
             "dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128\n"
             "if [ -e /usr/lib/firmware/amdgpu/mi350_discovery ]; then\n"


### PR DESCRIPTION
This change disables address space layout randomization (ASLR) and has two benefits:
 - For debugging, GPU virtual addresses should be the same from run to run which makes greping based on virtual address easier
 - The simulation is more deterministic as units like TLB and page table walker do not vary due to different virtual page numbers each run.