### PR TITLE
ext: Zero-init `ext/softfloat` `commonNaN` macros

### DIFF
--- a/ext/softfloat/specialize.h
+++ b/ext/softfloat/specialize.h
@@ -111,7 +111,11 @@ struct commonNaN { char _unused; };
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f16UIToCommonNaN( uiA, zPtr ) if ( ! ((uiA) & 0x0200) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f16UIToCommonNaN( uiA, zPtr ) \
+    do { \
+        if ( ! ((uiA) & 0x0200) ) softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 16-bit floating-point
@@ -146,7 +150,11 @@ uint_fast16_t
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f32UIToCommonNaN( uiA, zPtr ) if ( ! ((uiA) & 0x00400000) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f32UIToCommonNaN( uiA, zPtr ) \
+    do { \
+        if ( ! ((uiA) & 0x00400000) ) softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 32-bit floating-point
@@ -181,7 +189,11 @@ uint_fast32_t
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f64UIToCommonNaN( uiA, zPtr ) if ( ! ((uiA) & UINT64_C( 0x0008000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f64UIToCommonNaN( uiA, zPtr ) \
+    do { \
+        if ( ! ((uiA) & UINT64_C( 0x0008000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 64-bit floating-point
@@ -226,8 +238,12 @@ uint_fast64_t
 | location pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid
 | exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_extF80UIToCommonNaN( uiA64, uiA0, zPtr ) if ( ! ((uiA0) & UINT64_C( 0x4000000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
-
+#define softfloat_extF80UIToCommonNaN( uiA64, uiA0, zPtr ) \
+    do { \
+        if ( ! ((uiA0) & UINT64_C( 0x4000000000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into an 80-bit extended
 | floating-point NaN, and returns the bit pattern of this value as an unsigned
@@ -284,7 +300,12 @@ struct uint128
 | pointed to by `zPtr'.  If the NaN is a signaling NaN, the invalid exception
 | is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_f128UIToCommonNaN( uiA64, uiA0, zPtr ) if ( ! ((uiA64) & UINT64_C( 0x0000800000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f128UIToCommonNaN( uiA64, uiA0, zPtr ) \
+    do { \
+        if ( ! ((uiA64) & UINT64_C( 0x0000800000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 128-bit floating-point
@@ -333,7 +354,12 @@ struct uint128
 | common NaN at the location pointed to by `zPtr'.  If the NaN is a signaling
 | NaN, the invalid exception is raised.
 *----------------------------------------------------------------------------*/
-#define softfloat_extF80MToCommonNaN( aSPtr, zPtr ) if ( ! ((aSPtr)->signif & UINT64_C( 0x4000000000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_extF80MToCommonNaN( aSPtr, zPtr ) \
+    do { \
+        if ( ! ((aSPtr)->signif & UINT64_C( 0x4000000000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into an 80-bit extended
@@ -384,7 +410,12 @@ void
 | four 32-bit elements that concatenate in the platform's normal endian order
 | to form a 128-bit floating-point value.
 *----------------------------------------------------------------------------*/
-#define softfloat_f128MToCommonNaN( aWPtr, zPtr ) if ( ! ((aWPtr)[indexWordHi( 4 )] & UINT64_C( 0x0000800000000000 )) ) softfloat_raiseFlags( softfloat_flag_invalid )
+#define softfloat_f128MToCommonNaN( aWPtr, zPtr ) \
+    do { \
+        if ( ! ((aWPtr)[indexWordHi( 4 )] & UINT64_C( 0x0000800000000000 )) ) \
+            softfloat_raiseFlags( softfloat_flag_invalid ); \
+        *(zPtr) = (struct commonNaN){ 0 }; \
+    } while (0)
 
 /*----------------------------------------------------------------------------
 | Converts the common NaN pointed to by `aPtr' into a 128-bit floating-point


### PR DESCRIPTION
Clang 21 added `-Wuninitialized-const-pointer` (and we build with `-Werror`). With `SOFTFLOAT_FAST_INT64` the various `*ToCommonNaN` macros never write to the destination struct, so the new check fires:

```
ext/softfloat/extF80_to_f128.c:64:45: error: variable 'commonNaN' is
uninitialized when passed as a const pointer argument here
[-Werror,-Wuninitialized-const-pointer]
 64 | uiZ = softfloat_commonNaNToF128UI( &commonNaN );
    |                                       ^~~~~~~~~
```

See the source here:
https://github.com/gem5/gem5/blob/7a2b0e413d06c5ce7097104abef3b1d9eaabca91/ext/softfloat/extF80_to_f128.c#L64.

The lastest version of softfloat does not fix this error (The project hasn't been updated in 2 years with most of remaining unaltered for the last 9 years). Therefore I have opted to modifiying the code in `ext/softfloat`.

Thechange alters the macro which creates the struct to zero the `commonNan`. This change alters ever `*ToCommonNaN` macro to zero-initialise the struct. This preserves behaviour while satisfying clang 21.