### PR TITLE
misc: Bump requests from 2.32.4 to 2.33.0

### DIFF
--- a/ext/pybind11/docs/requirements.txt
+++ b/ext/pybind11/docs/requirements.txt
@@ -23,8 +23,6 @@ idna==3.7
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.7.0
-    # via sphinx
 jinja2==3.1.6
     # via
     #   myst-parser
@@ -49,7 +47,7 @@ pygments==2.17.2
     #   sphinx
 pyyaml==6.0.2
     # via myst-parser
-requests==2.32.4
+requests==2.33.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
@@ -87,5 +85,3 @@ sphinxcontrib-svg2pdfconverter==1.2.2
     # via -r requirements.in
 urllib3==2.6.3
     # via requests
-zipp==3.23.0
-    # via importlib-metadata

--- a/util/gem5-resources-manager/requirements.txt
+++ b/util/gem5-resources-manager/requirements.txt
@@ -22,7 +22,7 @@ pycparser==2.21
 pymongo==4.6.3
 pyrsistent==0.19.3
 python-dotenv==1.0.0
-requests==2.32.4
+requests==2.33.0
 sentinels==1.0.0
 urllib3==2.6.3
 Werkzeug==3.1.5


### PR DESCRIPTION
This bumps requests from 2.32.4 to 2.33.0 in ext/pybind11/docs and util/gem5-resources-manager. It also removes importlib-metadata and zipp from ext/pybind11/docs, to match the changes in https://github.com/gem5/gem5/pull/3035/changes.