### PR TITLE
cpu: Incorrect eviction in SimpleBTB

### DIFF
--- a/src/cpu/pred/simple_btb.cc
+++ b/src/cpu/pred/simple_btb.cc
@@ -117,10 +117,16 @@ SimpleBTB::update(ThreadID tid, Addr instPC,
 {
     stats.updates[type]++;
 
-    BTBEntry *victim = btb.findVictim({instPC, tid});
+    BTBEntry *entry = btb.findEntry({instPC, tid});
+    if (entry) {
+        btb.accessEntry(entry);
+    } else {
+        // If non-existant make space
+        entry = btb.findVictim({instPC, tid});
+        btb.insertEntry({instPC, tid}, entry);
+    }
 
-    btb.insertEntry({instPC, tid}, victim);
-    victim->update(target, inst);
+    entry->update(target, inst);
 }
 
 


### PR DESCRIPTION
The BTB is updated without checking if the current entry already exists. However, the `findVictim` function will not check if it already exists. This creates duplication.
In some benchmarks, we observed more than 30% increase in misses.