### PR TITLE
mem-ruby: Adding missing import Param from TlmController

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmController.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmController.py
@@ -34,6 +34,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.CHIGeneric import CHIGenericController
+from m5.params import Param
 from m5.tlm_chi.port import (
     TlmSinkPort,
     TlmSourcePort,


### PR DESCRIPTION
A recent PR [1] added an ignore_functional Param to the TlmController but forgot to import it from m5.params, therefore breaking CHI-TLM builds

[1]: https://github.com/gem5/gem5/pull/2978

Change-Id: Ibe49c8bd38cc02e9f12893e0e86f0443209378c3