### PR TITLE
arch-riscv: Fix some vslideup instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5048,6 +5048,8 @@ decode QUADRANT default Unknown::unknown() {
                     bool copyAll = vs3WindowLeft >= vdWindowLeft
                         && vs3WindowLeft < vdWindowRight;
 
+                    COPY_OLD_VD(oldDstIdx);
+
                     if (copyAll) {
                         int backLen = vdWindowRight - vs3WindowLeft;
                         int frontLen = microVlmax - backLen;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5048,7 +5048,9 @@ decode QUADRANT default Unknown::unknown() {
                     bool copyAll = vs3WindowLeft >= vdWindowLeft
                         && vs3WindowLeft < vdWindowRight;
 
-                    COPY_OLD_VD(oldDstIdx);
+                    RiscvISA::vreg_t old_vd;
+                    xc->getRegOperand(this, oldDstIdx, &old_vd);
+                    tmp_d0 = old_vd;
 
                     if (copyAll) {
                         int backLen = vdWindowRight - vs3WindowLeft;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5410,13 +5410,13 @@ decode QUADRANT default Unknown::unknown() {
                         int frontLen = microVlmax - backLen;
                         int vdOffset = 0;
                         for (int i = 0; vdOffset < frontLen
-                            && vdOffset < microVl; vdOffset++) {
+                            && vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs3_vu[i];

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1603,7 +1603,8 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
 
     dest_set_src_reg_idx = ""
     # No dest reg pin: Bypass tail/mask policy to copy unchanged elements
-    if "slideup" in name or "slide1up" in name:
+    slideup_insts = ["vslideup_vx", "vslideup_vi"]
+    if name in slideup_insts:
         dest_set_src_reg_idx = f"oldDstIdx = {num_src_regs};\n"
         dest_set_src_reg_idx += setSrcWrapper(dest_reg_id)
     elif name not in ["vslidedown_vx"]:

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -1603,10 +1603,10 @@ def VectorSlideBase(name, Name, category, code, flags, macro_construtor,
 
     dest_set_src_reg_idx = ""
     # No dest reg pin: Bypass tail/mask policy to copy unchanged elements
-    if name == "vslideup_vi":
+    if "slideup" in name or "slide1up" in name:
         dest_set_src_reg_idx = f"oldDstIdx = {num_src_regs};\n"
         dest_set_src_reg_idx += setSrcWrapper(dest_reg_id)
-    elif name not in ["vslideup_vx", "vslidedown_vx"]:
+    elif name not in ["vslidedown_vx"]:
         dest_set_src_reg_idx = tailMaskCondSetSrcWrapper(
             setSrcWrapper(dest_reg_id)
         )


### PR DESCRIPTION
This PR fixes two bugs in the RVV `vslideup` instructions:

1. Follow-up to #2625. The `vfslide1up_vf` instruction was missing the `i++` increment in the loop.
2. The `vslideup_vx` instruction did not preserve the old `vd`. This patch fixes it and ensures that all `vslideup` related instructions correctly preserve the old `vd`.