### PR TITLE
arch-x86: add MPK support

### DIFF
--- a/src/arch/x86/X86ISA.py
+++ b/src/arch/x86/X86ISA.py
@@ -73,7 +73,7 @@ class X86ISA(BaseISA):
     #     https://sandpile.org/x86/cpuid.htm
     # 0000_0001h
     FamilyModelStepping = VectorParam.UInt32(
-        [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x00000209],
+        [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x0C000209],
         "type/family/model/stepping and feature flags",
     )
     # 0000_0004h
@@ -83,17 +83,59 @@ class X86ISA(BaseISA):
     )
     # 0000_0007h
     ExtendedFeatures = VectorParam.UInt32(
-        [0x00000000, 0x01800001, 0x00000000, 0x00000000], "feature flags"
+        [0x00004000, 0x01800001, 0x00000000, 0x00000018], "feature flags"
     )
     # 0000_000Dh - This uses ECX index, so the last entry must be all zeros
     ExtendedState = VectorParam.UInt32(
         [
+            ##0
+            0x00000203,
+            0x00000248,
+            0x00000000,
+            0x00000248,
+            ##1
             0x00000000,
             0x00000000,
             0x00000000,
             0x00000000,
+            ##2
             0x00000000,
             0x00000000,
+            0x00000000,
+            0x00000000,
+            ##3
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            ##4
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            ##5
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            ##6
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            ##7
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            ##8
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            0x00000000,
+            ##9
+            0x00000008,
+            0x00000240,
             0x00000000,
             0x00000000,
         ],

--- a/src/arch/x86/X86ISA.py
+++ b/src/arch/x86/X86ISA.py
@@ -73,7 +73,7 @@ class X86ISA(BaseISA):
     #     https://sandpile.org/x86/cpuid.htm
     # 0000_0001h
     FamilyModelStepping = VectorParam.UInt32(
-        [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x0C000209],
+        [0x00020F51, 0x00000805, 0xEFDBFBFF, 0x04000209],
         "type/family/model/stepping and feature flags",
     )
     # 0000_0004h

--- a/src/arch/x86/cpuid.cc
+++ b/src/arch/x86/cpuid.cc
@@ -124,6 +124,22 @@ X86CPUID::doCpuid(ThreadContext * tc, uint32_t function, uint32_t index,
     auto &cap_vec = capabilities[function];
     result = CpuidResult(cap_vec[cap_offset + 0], cap_vec[cap_offset + 1],
                          cap_vec[cap_offset + 2], cap_vec[cap_offset + 3]);
+
+    // For CPUID function 1, we need to check the value of CR4.OSXSAVE
+    // to determine whether to set the OSXSAVE bit in the returned value
+    if (function == 1) {
+        CR4 cr4 = tc->readMiscRegNoEffect(misc_reg::Cr4);
+        if (cr4.osxsave) {
+            result =
+                CpuidResult(cap_vec[cap_offset + 0], cap_vec[cap_offset + 1],
+                            cap_vec[cap_offset + 2], 0x0C000209);
+        } else {
+            result =
+                CpuidResult(cap_vec[cap_offset + 0], cap_vec[cap_offset + 1],
+                            cap_vec[cap_offset + 2], 0x04000209);
+        }
+    }
+
     DPRINTF(X86, "CPUID function %x returning (%x, %x, %x, %x)\n",
             function, result.rax, result.rbx, result.rdx, result.rcx);
 

--- a/src/arch/x86/isa/decoder/two_byte_opcodes.isa
+++ b/src/arch/x86/isa/decoder/two_byte_opcodes.isa
@@ -95,8 +95,8 @@
                 }
                 0x2: decode MODRM_MOD {
                     0x3: decode MODRM_RM {
-                        0x0: xgetbv();
-                        0x1: xsetbv();
+                        0x0: Inst::XGETBV();
+                        0x1: Inst::XGETBV();
                     }
                     default: decode MODE_SUBMODE {
                         0x0: Cpl0Inst::LGDT(M);
@@ -137,6 +137,8 @@
                     0x3: decode MODRM_RM {
                         0x0: BasicOperate::SERIALIZE({{/*Nothing*/}},
                                                          IsSerializeAfter);
+                        0x6: Inst::RDPKRU();
+                        0x7: Inst::WRPKRU();
                         }
                     }
                 0x6: Inst::LMSW(Ew);
@@ -767,8 +769,16 @@
                     }
                     0x2: Inst::LDMXCSR(Md);
                     0x3: Inst::STMXCSR(Md);
-                    0x4: xsave();
-                    0x5: xrstor();
+                    0x4: decode OPSIZE {
+                         4: Inst::XSAVE(M);
+                         8: Inst::XSAVE64(M);
+                         default: xsave();
+                    }
+                    0x5: decode OPSIZE {
+                          4: Inst::XRSTOR(M);
+                          8: Inst::XRSTOR64(M);
+                          default: xrstor();
+                    }
                     0x6: decode LEGACY_DECODEVAL {
                         0x0: Inst::UD2();
                         0x1: Inst::CLWB(Mb);

--- a/src/arch/x86/isa/insts/simd128/integer/save_and_restore_state/save_and_restore_state.py
+++ b/src/arch/x86/isa/insts/simd128/integer/save_and_restore_state/save_and_restore_state.py
@@ -158,6 +158,59 @@ fxrstor64Template = """
     wrval ctrlRegIdx("misc_reg::Foseg"), t2
 """ + fxrstorCommonTemplate
 
+
+xrstor32Template = fxrstor32Template + """
+        ld t1, seg, %(mode)s, "DISPLACEMENT + 512", dataSize=8
+        ld t1, seg, %(mode)s, "DISPLACEMENT + 512 + 64", dataSize=4
+        wrval ctrlRegIdx("misc_reg::Pkru"), t1
+    """
+
+
+xrstor64Template = fxrstor64Template + """
+        ld t1, seg, %(mode)s, "DISPLACEMENT + 512 + 64", dataSize=4
+        wrval ctrlRegIdx("misc_reg::Pkru"), t1
+    """
+
+
+xsave64Template = (
+    # Legacy region
+    fxsave64Template
+    +
+    # Xsave header
+    """
+        #XSTATE_BV
+        rdval t1, ctrlRegIdx("misc_reg::Xcr0")
+        st t1, seg, %(mode)s, "DISPLACEMENT + 512", dataSize=8
+        #XCOMP_BV not supported, so 0
+        limm t2, 0, dataSize=8
+        st t2, seg, %(mode)s, "DISPLACEMENT + 512 + 8", dataSize=8
+        # PKRU, TODO use CPUID for this
+        rdval t1, ctrlRegIdx("misc_reg::Pkru")
+        st t1, seg, %(mode)s, "DISPLACEMENT + 512 + 64", dataSize=8
+
+    """
+)
+
+xsave32Template = (
+    fxsave32Template
+    +
+    # Xsave header
+    """
+        #XSTATE_BV
+        #XSTATE_BV
+        rdval t1, ctrlRegIdx("misc_reg::Xcr0")
+        st t1, seg, %(mode)s, "DISPLACEMENT + 512", dataSize=8
+        #XCOMP_BV not supported, so 0
+        limm t2, 0, dataSize=8
+        st t2, seg, %(mode)s, "DISPLACEMENT + 512 + 8", dataSize=8
+        # PKRU, TODO use CPUID for this
+        rdval t1, ctrlRegIdx("misc_reg::Pkru")
+        st t1, seg, %(mode)s, "DISPLACEMENT + 512 + 64", dataSize=8
+
+    """
+)
+
+
 microcode = (
     """
 def macroop FXSAVE_M {
@@ -211,5 +264,61 @@ def macroop FXRSTOR64_P {
     + fxrstor64Template % {"mode": "riprel"}
     + """
 };
+
+
+def macroop XSAVE_M {
+
+"""
+    + xsave32Template % {"mode": "sib"}
+    + """
+};
+
+
+def macroop XSAVE_P {
+    rdip t7
+"""
+    + xsave32Template % {"mode": "riprel"}
+    + """
+};
+
+def macroop XSAVE64_M {
+"""
+    + xsave64Template % {"mode": "sib"}
+    + """
+};
+
+def macroop XSAVE64_P {
+    rdip t7
+"""
+    + xsave64Template % {"mode": "riprel"}
+    + """
+};
+
+def macroop XRSTOR_M {
+"""
+    + xrstor32Template % {"mode": "sib"}
+    + """
+};
+
+def macroop XRSTOR_P {
+    rdip t7
+"""
+    + xrstor32Template % {"mode": "riprel"}
+    + """
+};
+
+def macroop XRSTOR64_M {
+"""
+    + xrstor64Template % {"mode": "sib"}
+    + """
+};
+
+def macroop XRSTOR64_P {
+    rdip t7
+"""
+    + xrstor64Template % {"mode": "riprel"}
+    + """
+};
+
 """
 )

--- a/src/arch/x86/isa/insts/system/control_registers.py
+++ b/src/arch/x86/isa/insts/system/control_registers.py
@@ -81,4 +81,27 @@ def macroop SMSW_P {
     rdip t7, dataSize=asz
     st t1, seg, riprel, disp, dataSize=2
 };
+
+def macroop RDPKRU
+{
+    rdpkru rax
+};
+
+def macroop WRPKRU
+{
+    .serialize_before
+    wrpkru rax
+    .serialize_after
+};
+
+def macroop XGETBV
+{
+    xgetbv rax
+};
+
+def macroop XSETBV
+{
+    xsetbv rax
+};
+
 """

--- a/src/arch/x86/isa/microops/regop.isa
+++ b/src/arch/x86/isa/microops/regop.isa
@@ -1415,7 +1415,8 @@ let {{
                         CR4 cr4 = newVal;
                         // Fault if any unknown bits are set. Also,
                         // PAE can't be disabled in long mode.
-                        if (bits(newVal, 63, 17) ||
+                        if (bits(newVal, 63, 23) ||
+                            bits(newVal, 21, 19) ||
                             bits(newVal, 15, 11) ||
                                 (machInst.mode.mode == LongMode && !cr4.pae))
                             fault = std::make_shared<GeneralProtection>(0);
@@ -1748,4 +1749,80 @@ let {{
             }
             cfofBits = cfofBits & ~(X86ISA::OFBit | X86ISA::CFBit);
         '''
+
+    class Rdpkru(RdRegOp):
+        code = '''
+            CR4 cr4 = CR4Op;
+            if (!cr4.pke) {
+                fault = std::make_shared<InvalidOpcode>();
+            }
+            if (Rcx == 0) {
+                DestReg = PkruOp;
+                Rdx = 0;
+            } else {
+                fault = std::make_shared<GenericISA::M5PanicFault>(
+                        "Segment not present.\\n");
+            }
+        '''
+
+    class Wrpkru(RdRegOp):
+        code = '''
+            CR4 cr4 = CR4Op;
+            if (!cr4.pke) {
+                fault = std::make_shared<InvalidOpcode>();
+            }
+            if (Rcx == 0 && Rdx == 0) {
+                PkruOp = Rax;
+            } else {
+                fault = std::make_shared<GenericISA::M5PanicFault>(
+                        "Segment not present.\\n");
+            }
+        '''
+
+    class Xgetbv(RdRegOp):
+        code = '''
+        CR4 cr4 = CR4Op;
+
+        if (Rcx != 0) {
+            fault = std::make_shared<GeneralProtection>(0);
+        }
+
+        if (!cr4.osxsave) {
+            fault = std::make_shared<InvalidOpcode>();
+        }
+        Rax = Xcr0Op;
+
+        '''
+
+
+
+
+    class Xsetbv(RdRegOp):
+        code = '''
+        HandyM5Reg m5reg = M5Reg;
+        uint64_t edx = Rdx & 0xFFFFFFFFULL;
+        uint64_t eax = Rax & 0xFFFFFFFFULL;
+        CR4 cr4 = CR4Op;
+        if (m5reg.cpl != 0) {
+            fault = std::make_shared<GeneralProtection>(0);
+        }
+        if (Rcx != 0) {
+            fault = std::make_shared<GeneralProtection>(0);
+        }
+        if (bits(eax,0) == 0) {
+            fault = std::make_shared<GeneralProtection>(0);
+        }
+        if (bits(eax,2) == 1 && bits(eax,1) == 0) {
+            fault = std::make_shared<GeneralProtection>(0);
+        }
+        if (!cr4.osxsave) {
+            fault = std::make_shared<InvalidOpcode>();
+        }
+
+        uint64_t edx_eax = (edx << 32) | eax;
+        Xcr0Op = edx_eax
+
+        '''
+
+
 }};

--- a/src/arch/x86/isa/operands.isa
+++ b/src/arch/x86/isa/operands.isa
@@ -260,5 +260,7 @@ def operands {{
         'MiscRegSrc1':   ControlReg('src1', 211),
         'TscOp':         ControlReg('X86ISA::misc_reg::Tsc', 212),
         'M5Reg':         SquashCReg('X86ISA::misc_reg::M5Reg', 213),
+        'PkruOp':        ControlReg('X86ISA::misc_reg::Pkru', 214),
+        'Xcr0Op':        ControlReg('X86ISA::misc_reg::Xcr0', 215),
         'Mem':           MemOp('uqw', None, (None, 'IsLoad', 'IsStore'), 300)
 }};

--- a/src/arch/x86/pagetable.cc
+++ b/src/arch/x86/pagetable.cc
@@ -51,7 +51,7 @@ namespace X86ISA
 TlbEntry::TlbEntry()
     : paddr(0), vaddr(0), logBytes(0), writable(0),
       user(true), uncacheable(0), global(false), patBit(0),
-      noExec(false), lruSeq(0)
+      noExec(false), lruSeq(0), memoryKey(0)
 {
 }
 
@@ -59,7 +59,7 @@ TlbEntry::TlbEntry(Addr asn, Addr _vaddr, Addr _paddr,
                    bool uncacheable, bool read_only) :
     paddr(_paddr), vaddr(_vaddr), logBytes(PageShift), writable(!read_only),
     user(true), uncacheable(uncacheable), global(false), patBit(0),
-    noExec(false), lruSeq(0)
+    noExec(false), lruSeq(0), memoryKey(0)
 {}
 
 void
@@ -75,6 +75,7 @@ TlbEntry::serialize(CheckpointOut &cp) const
     SERIALIZE_SCALAR(patBit);
     SERIALIZE_SCALAR(noExec);
     SERIALIZE_SCALAR(lruSeq);
+    SERIALIZE_SCALAR(memoryKey);
 }
 
 void
@@ -90,6 +91,7 @@ TlbEntry::unserialize(CheckpointIn &cp)
     UNSERIALIZE_SCALAR(patBit);
     UNSERIALIZE_SCALAR(noExec);
     UNSERIALIZE_SCALAR(lruSeq);
+    UNSERIALIZE_SCALAR(memoryKey);
 }
 
 } // namespace X86ISA

--- a/src/arch/x86/pagetable.cc
+++ b/src/arch/x86/pagetable.cc
@@ -49,17 +49,33 @@ namespace X86ISA
 {
 
 TlbEntry::TlbEntry()
-    : paddr(0), vaddr(0), logBytes(0), writable(0),
-      user(true), uncacheable(0), global(false), patBit(0),
-      noExec(false), lruSeq(0), memoryKey(0)
+    : paddr(0),
+      vaddr(0),
+      logBytes(0),
+      writable(0),
+      user(true),
+      uncacheable(0),
+      global(false),
+      patBit(0),
+      noExec(false),
+      lruSeq(0),
+      memoryKey(0)
 {
 }
 
-TlbEntry::TlbEntry(Addr asn, Addr _vaddr, Addr _paddr,
-                   bool uncacheable, bool read_only) :
-    paddr(_paddr), vaddr(_vaddr), logBytes(PageShift), writable(!read_only),
-    user(true), uncacheable(uncacheable), global(false), patBit(0),
-    noExec(false), lruSeq(0), memoryKey(0)
+TlbEntry::TlbEntry(Addr asn, Addr _vaddr, Addr _paddr, bool uncacheable,
+                   bool read_only)
+    : paddr(_paddr),
+      vaddr(_vaddr),
+      logBytes(PageShift),
+      writable(!read_only),
+      user(true),
+      uncacheable(uncacheable),
+      global(false),
+      patBit(0),
+      noExec(false),
+      lruSeq(0),
+      memoryKey(0)
 {}
 
 void

--- a/src/arch/x86/pagetable.hh
+++ b/src/arch/x86/pagetable.hh
@@ -90,6 +90,9 @@ namespace X86ISA
         bool noExec;
         // A sequence number to keep track of LRU.
         uint64_t lruSeq;
+        // Four bit value used to index the PKRU register to check
+        // memory protection (only enabled if bit 22 in Cr4 is set)
+        uint8_t memoryKey;
 
         TlbEntryTrie::Handle trieHandle;
 
@@ -138,6 +141,7 @@ namespace X86ISA
     // point in the future.
     BitUnion64(PageTableEntry)
         Bitfield<63> nx;
+        Bitfield<62, 59> mpk;
         Bitfield<51, 12> base;
         Bitfield<11, 9> avl;
         Bitfield<8> g;

--- a/src/arch/x86/pagetable_walker.cc
+++ b/src/arch/x86/pagetable_walker.cc
@@ -312,6 +312,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = pte.w;
         entry.user = pte.u;
+        entry.memoryKey = pte.mpk;
         if (badNX || !pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -327,6 +328,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = entry.writable && pte.w;
         entry.user = entry.user && pte.u;
+        entry.memoryKey = pte.mpk;
         if (badNX || !pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -340,6 +342,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = entry.writable && pte.w;
         entry.user = entry.user && pte.u;
+        entry.memoryKey = pte.mpk;
         if (badNX || !pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -369,6 +372,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = entry.writable && pte.w;
         entry.user = entry.user && pte.u;
+        entry.memoryKey = pte.mpk;
         if (badNX || !pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -399,6 +403,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = pte.w;
         entry.user = pte.u;
+        entry.memoryKey = pte.mpk;
         if (badNX || !pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -429,6 +434,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = entry.writable && pte.w;
         entry.user = entry.user && pte.u;
+        entry.memoryKey = pte.mpk;
         if (badNX || !pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -448,6 +454,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = pte.w;
         entry.user = pte.u;
+        entry.memoryKey = pte.mpk;
         if (!pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -477,6 +484,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = pte.w;
         entry.user = pte.u;
+        entry.memoryKey = pte.mpk;
         if (!pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);
@@ -493,6 +501,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
         pte.a = 1;
         entry.writable = pte.w;
         entry.user = pte.u;
+        entry.memoryKey = pte.mpk;
         if (!pte.p) {
             doEndWalk = true;
             fault = pageFault(pte.p);

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -378,7 +378,7 @@ X86_64Process::initState()
 
             CR4 cr4 = 0;
             //Turn on pae.
-            cr4.pke = 0; // Disable MPK
+            cr4.pke = 0;     // Disable MPK
             cr4.osxsave = 0; // Disable XSAVE and Proc Extended States
             cr4.osxmmexcpt = 0; // Operating System Unmasked Exception
             cr4.osfxsr = 1; // Operating System FXSave/FSRSTOR Support

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -378,6 +378,7 @@ X86_64Process::initState()
 
             CR4 cr4 = 0;
             //Turn on pae.
+            cr4.pke = 0; // Disable MPK
             cr4.osxsave = 0; // Disable XSAVE and Proc Extended States
             cr4.osxmmexcpt = 0; // Operating System Unmasked Exception
             cr4.osfxsr = 1; // Operating System FXSave/FSRSTOR Support
@@ -408,6 +409,18 @@ X86_64Process::initState()
 
             tc->setMiscReg(misc_reg::IdtrBase, IDTVirtAddr);
             tc->setMiscReg(misc_reg::IdtrLimit, 0xffff);
+
+            XCR0 xcr0 = 0;
+            xcr0.x87 = 1; // Must always be 1
+            xcr0.sse = 0;
+            xcr0.avx = 0;
+            xcr0.bndreg = 0;
+            xcr0.bndsrc = 0;
+            xcr0.opmask = 0;
+            xcr0.zmm_hi256 = 0;
+            xcr0.hi16_zmm = 0;
+            xcr0.pkru = 0;
+            tc->setMiscReg(misc_reg::Xcr0, xcr0);
 
             /* enabling syscall and sysret */
             RegVal star = ((RegVal)sret << 48) | ((RegVal)scall << 32);
@@ -632,6 +645,18 @@ X86_64Process::initState()
             cr4.pcide = 1;
             cr4.fsgsbase = 1; // Enable FSGSBASE instructions
             tc->setMiscReg(misc_reg::Cr4, cr4);
+
+            XCR0 xcr0 = 0;
+            xcr0.x87 = 1; // Must always be 1
+            xcr0.sse = 0;
+            xcr0.avx = 0;
+            xcr0.bndreg = 0;
+            xcr0.bndsrc = 0;
+            xcr0.opmask = 0;
+            xcr0.zmm_hi256 = 0;
+            xcr0.hi16_zmm = 0;
+            xcr0.pkru = 0;
+            tc->setMiscReg(misc_reg::Xcr0, xcr0);
         }
     }
 }

--- a/src/arch/x86/regs/misc.hh
+++ b/src/arch/x86/regs/misc.hh
@@ -144,7 +144,7 @@ enum : RegIndex
     // Flags register
     Rflags = DrBase + NumDRegs,
 
-    //Register to keep handy values like the CPU mode in.
+    // Register to keep handy values like the CPU mode in.
     M5Reg,
 
     /*
@@ -398,7 +398,7 @@ enum : RegIndex
     Fooff,
     Fop,
 
-    //XXX Add "Model-Specific Registers"
+    // XXX Add "Model-Specific Registers"
 
     ApicBase,
 
@@ -639,7 +639,7 @@ BitUnion64(CR3)
 EndBitUnion(CR3)
 
 BitUnion64(CR4)
-    Bitfield<22> pke; // Enable Memory Protection Keys
+    Bitfield<22> pke;     // Enable Memory Protection Keys
     Bitfield<18> osxsave; // Enable XSAVE and Proc Extended States
     Bitfield<17> pcide; // PCID Enable
     Bitfield<16> fsgsbase; // Enable RDFSBASE, RDGSBASE, WRFSBASE,
@@ -1090,27 +1090,26 @@ BitUnion64(LocalApicBase)
     Bitfield<8> bsp;
 EndBitUnion(LocalApicBase)
 
-
 /**
  * Protection Key Register (User)
  */
 BitUnion64(PKRU)
-    Bitfield<31,30> mpk15;
-    Bitfield<29,28> mpk14;
-    Bitfield<27,26> mpk13;
-    Bitfield<25,24> mpk12;
-    Bitfield<23,22> mpk11;
-    Bitfield<21,20> mpk10;
-    Bitfield<19,18> mpk9;
-    Bitfield<17,16> mpk8;
-    Bitfield<15,14> mpk7;
-    Bitfield<13,12> mpk6;
-    Bitfield<11,10> mpk5;
-    Bitfield<9,8> mpk4;
-    Bitfield<7,6> mpk3;
-    Bitfield<5,4> mpk2;
-    Bitfield<3,2> mpk1;
-    Bitfield<1,0> mpk0;
+    Bitfield<31, 30> mpk15;
+    Bitfield<29, 28> mpk14;
+    Bitfield<27, 26> mpk13;
+    Bitfield<25, 24> mpk12;
+    Bitfield<23, 22> mpk11;
+    Bitfield<21, 20> mpk10;
+    Bitfield<19, 18> mpk9;
+    Bitfield<17, 16> mpk8;
+    Bitfield<15, 14> mpk7;
+    Bitfield<13, 12> mpk6;
+    Bitfield<11, 10> mpk5;
+    Bitfield<9, 8> mpk4;
+    Bitfield<7, 6> mpk3;
+    Bitfield<5, 4> mpk2;
+    Bitfield<3, 2> mpk1;
+    Bitfield<1, 0> mpk0;
 EndBitUnion(PKRU)
 
 } // namespace X86ISA

--- a/src/arch/x86/regs/misc.hh
+++ b/src/arch/x86/regs/misc.hh
@@ -405,6 +405,8 @@ enum : RegIndex
     // "Fake" MSRs for internally implemented devices
     PciConfigAddress,
 
+    Pkru,
+
     XcrBase,
     Xcr0 = XcrBase,
 
@@ -637,6 +639,7 @@ BitUnion64(CR3)
 EndBitUnion(CR3)
 
 BitUnion64(CR4)
+    Bitfield<22> pke; // Enable Memory Protection Keys
     Bitfield<18> osxsave; // Enable XSAVE and Proc Extended States
     Bitfield<17> pcide; // PCID Enable
     Bitfield<16> fsgsbase; // Enable RDFSBASE, RDGSBASE, WRFSBASE,
@@ -1086,6 +1089,29 @@ BitUnion64(LocalApicBase)
     Bitfield<11> enable;
     Bitfield<8> bsp;
 EndBitUnion(LocalApicBase)
+
+
+/**
+ * Protection Key Register (User)
+ */
+BitUnion64(PKRU)
+    Bitfield<31,30> mpk15;
+    Bitfield<29,28> mpk14;
+    Bitfield<27,26> mpk13;
+    Bitfield<25,24> mpk12;
+    Bitfield<23,22> mpk11;
+    Bitfield<21,20> mpk10;
+    Bitfield<19,18> mpk9;
+    Bitfield<17,16> mpk8;
+    Bitfield<15,14> mpk7;
+    Bitfield<13,12> mpk6;
+    Bitfield<11,10> mpk5;
+    Bitfield<9,8> mpk4;
+    Bitfield<7,6> mpk3;
+    Bitfield<5,4> mpk2;
+    Bitfield<3,2> mpk1;
+    Bitfield<1,0> mpk0;
+EndBitUnion(PKRU)
 
 } // namespace X86ISA
 } // namespace gem5

--- a/src/arch/x86/tlb.cc
+++ b/src/arch/x86/tlb.cc
@@ -489,29 +489,30 @@ TLB::translate(const RequestPtr &req,
             bool inUser = m5Reg.cpl == 3 && !(flags & CPL0FlagBit);
 
             if (cr4.pke) {
-                //Memory protection keys enabled
+                // Memory protection keys enabled
                 PKRU pkru = tc->readMiscRegNoEffect(misc_reg::Pkru);
 
                 uint8_t key = entry->memoryKey & 0xF;
-                auto permission = bits(pkru, 2 * key + 1,
-                                          2 * key);
+                auto permission = bits(pkru, 2 * key + 1, 2 * key);
 
                 bool accessDisable = bits(permission, 0);
                 bool writeDisable = bits(permission, 1);
                 if (accessDisable) {
 
-                    DPRINTF(TLB, "MPK Illegal access to "
-                                 "address %#x.\n", vaddr);
+                    DPRINTF(TLB,
+                            "MPK Illegal access to "
+                            "address %#x.\n",
+                            vaddr);
 
-                    return std::make_shared<PageFault>(vaddr, true,
-                                                       mode, inUser,
-                                                       false);
+                    return std::make_shared<PageFault>(vaddr, true, mode,
+                                                       inUser, false);
                 } else if (writeDisable && mode == BaseMMU::Write) {
-                    DPRINTF(TLB, "MPK Illegal write to"
-                                 " address %#x.\n", vaddr);
-                    return std::make_shared<PageFault>(vaddr, true,
-                                                       mode, inUser,
-                                                       false);
+                    DPRINTF(TLB,
+                            "MPK Illegal write to"
+                            " address %#x.\n",
+                            vaddr);
+                    return std::make_shared<PageFault>(vaddr, true, mode,
+                                                       inUser, false);
                 }
             }
 

--- a/src/arch/x86/tlb.cc
+++ b/src/arch/x86/tlb.cc
@@ -500,15 +500,15 @@ TLB::translate(const RequestPtr &req,
                 bool writeDisable = bits(permission, 1);
                 if (accessDisable) {
 
-                    DPRINTF(TLB, "MPK Illegal access to
-                        address %#x.\n", vaddr);
+                    DPRINTF(TLB, "MPK Illegal access to "
+                                 "address %#x.\n", vaddr);
 
                     return std::make_shared<PageFault>(vaddr, true,
                                                        mode, inUser,
                                                        false);
                 } else if (writeDisable && mode == BaseMMU::Write) {
-                    DPRINTF(TLB, "MPK Illegal write to
-                        address %#x.\n", vaddr);
+                    DPRINTF(TLB, "MPK Illegal write to"
+                                 " address %#x.\n", vaddr);
                     return std::make_shared<PageFault>(vaddr, true,
                                                        mode, inUser,
                                                        false);

--- a/src/arch/x86/tlb.cc
+++ b/src/arch/x86/tlb.cc
@@ -485,8 +485,37 @@ TLB::translate(const RequestPtr &req,
 
             DPRINTF(TLB, "Entry found with paddr %#x, "
                     "doing protection checks.\n", entry->paddr);
-            // Do paging protection checks.
+
             bool inUser = m5Reg.cpl == 3 && !(flags & CPL0FlagBit);
+
+            if (cr4.pke) {
+                //Memory protection keys enabled
+                PKRU pkru = tc->readMiscRegNoEffect(misc_reg::Pkru);
+
+                uint8_t key = entry->memoryKey & 0xF;
+                auto permission = bits(pkru, 2 * key + 1,
+                                          2 * key);
+
+                bool accessDisable = bits(permission, 0);
+                bool writeDisable = bits(permission, 1);
+                if (accessDisable) {
+
+                    DPRINTF(TLB, "MPK Illegal access to
+                        address %#x.\n", vaddr);
+
+                    return std::make_shared<PageFault>(vaddr, true,
+                                                       mode, inUser,
+                                                       false);
+                } else if (writeDisable && mode == BaseMMU::Write) {
+                    DPRINTF(TLB, "MPK Illegal write to
+                        address %#x.\n", vaddr);
+                    return std::make_shared<PageFault>(vaddr, true,
+                                                       mode, inUser,
+                                                       false);
+                }
+            }
+
+            // Do paging protection checks.
             CR0 cr0 = tc->readMiscRegNoEffect(misc_reg::Cr0);
             bool badWrite = (!entry->writable && (inUser || cr0.wp));
             if ((inUser && !entry->user) ||

--- a/util/cpt_upgraders/x86-add-mpk.py
+++ b/util/cpt_upgraders/x86-add-mpk.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+def upgrader(cpt):
+    """
+    Update the checkpoint to include the PKRU register if X86 checkpoint.
+    The value is set to the default of 0 (no restrictions).
+    Additionally, add the memoryKey entry to the TLB checkpoints.
+    Default MPK 0.
+    """
+
+    import re
+
+    print("Hello")
+    for sec in cpt.sections():
+        if re.search(r"\.isa$", sec):
+            print("Match")
+            if cpt.get(sec, "isaName") == "x86":
+                regVals = cpt.get(sec, "regVal")
+                regVals = f"{regVals} 0"
+                cpt.set(sec, "regVal", regVals)
+            else:
+                print("not x86 ISA")
+                return
+
+    for sec in cpt.sections():
+        if re.search(r".*\.mmu\.(dtb|itb)\.Entry\d+$", sec):
+            cpt.set(sec, "memoryKey", "0")


### PR DESCRIPTION
Hello together,

I unfortunately messed up my commit history in my original PR #3005 so I try to do a clean version.

I added preliminary support for Intel MPK for one of my projects and thought it could be of use for the community if I polish it a bit.

The main features are the (wr/rd)pkru instructions, the pkru csr and the enforcement in the TLB.
Additionally, the PKRU register needs to be stored using xsave across context switches.
I am unsure about some modifications in the CPUID response in X86ISA.py.
Some bits, e.g., OSXSAVE depend on the status of other registers (Cr4 in this case) https://www.felixcloutier.com/x86/cpuid.
Also, the modifications in save_and_restore_state.py are preliminary as the xsave/xrstore instructions should store based on XCr0.

I'd appreciate suggestions for how I could improve my PR and look forward to the feedback!

I worked on the failing tests in the meantime.
Some tests will always fail since the checkpoints provided in the gem5 resources do not have memory keys for the dtb entries and no value for the PKRU CSR.
Another issue has been resolved by checking the cr4.osxsave bit before providing the cpuid response.
