### PR TITLE
arch-riscv: raise IllegalInstFault for vlseg/vsseg nf*EMUL>8

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1380,6 +1380,22 @@ def template VlSegConstructor {{
     StaticInstPtr microop;
     uint32_t size_per_elem = width_EEW(_machInst.width) / 8;
 
+    {
+        float vflmul = getVflmul(_machInst.vtype8.vlmul);
+        uint32_t emul = get_emul(width_EEW(_machInst.width),
+                                 getSew(_machInst.vtype8.vsew), vflmul, false);
+        if (emul * NFIELDS > NumVecInternalRegs) {
+            microop = new VectorNopMicroInst(_machInst,
+                std::make_shared<IllegalInstFault>(
+                    "vlseg nf*EMUL > 8: reserved encoding", _machInst));
+            this->microops.push_back(microop);
+            this->microops.front()->setFlag(IsFirstMicroop);
+            this->microops.back()->setFlag(IsLastMicroop);
+            this->flags[IsVector] = true;
+            return;
+        }
+    }
+
     if (micro_vl == 0) {
         microop = new VectorNopMicroInst(_machInst);
         this->microops.push_back(microop);
@@ -1637,6 +1653,22 @@ def template VsSegConstructor {{
     size_t NFIELDS = machInst.nf + 1;
     StaticInstPtr microop;
     uint32_t size_per_elem = width_EEW(_machInst.width) / 8;
+
+    {
+        float vflmul = getVflmul(_machInst.vtype8.vlmul);
+        uint32_t emul = get_emul(width_EEW(_machInst.width),
+                                 getSew(_machInst.vtype8.vsew), vflmul, false);
+        if (emul * NFIELDS > NumVecInternalRegs) {
+            microop = new VectorNopMicroInst(_machInst,
+                std::make_shared<IllegalInstFault>(
+                    "vsseg nf*EMUL > 8: reserved encoding", _machInst));
+            this->microops.push_back(microop);
+            this->microops.front()->setFlag(IsFirstMicroop);
+            this->microops.back()->setFlag(IsLastMicroop);
+            this->flags[IsVector] = true;
+            return;
+        }
+    }
 
     if (micro_vl == 0) {
         microop = new VectorNopMicroInst(_machInst);


### PR DESCRIPTION
Fixes #3054.

### What

Add a legality check in `VlSegConstructor` and `VsSegConstructor`
(`src/arch/riscv/isa/templates/vector_mem.isa`) for the reserved
encoding `nf * EMUL > 8`. When the check fails, a `VectorNopMicroInst`
carrying an `IllegalInstFault` is returned. In FS mode the kernel delivers
`SIGILL` to the offending process and the simulator continues running.

### Why

Without the check, the constructors build more de-interleave micro-ops
than there are internal vector register slots (`NumVecInternalRegs = 8`),
overflowing the rename map and crashing the simulator.

### How to verify

Build with RISC-V ISA and run the SE reproducer in the issue with
`--cpu-type=O3CPU`.

- Without the fix: simulator SIGSEGV in `SimpleRenameMap::rename`.
- With the fix (SE mode): gem5 panics with a clear message:
`panic: Illegal instruction 0x... at pc ...: vlseg nf*EMUL > 8: reserved encoding`
— the fault is raised at the correct point. Note: `IllegalInstFault::invokeSE`
currently panics for all illegal instructions in SE mode; this is a
pre-existing limitation, not introduced by this patch.
- With the fix (FS mode): the kernel trap handler receives the fault and
delivers SIGILL to the offending process; the simulator keeps running.

### Relation to PR #1711

PR #1711 fixed a related `nf * LMUL > 8` check at execute stage.
This fix is at decode stage and uses `nf * EMUL` (not `nf * LMUL`)
to correctly cover widening vlseg/vsseg where `EMUL > LMUL`.