### PR TITLE
arch-riscv: Add RELEASE flag to all CBO instructions

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -1373,7 +1373,7 @@ decode QUADRANT default Unknown::unknown() {
                                 // on menvcfg (01 and 11 respectively)
                                 Mem = 0;
                             }
-                        }}, mem_flags = [INVALIDATE, DST_POC]);
+                        }}, mem_flags=[INVALIDATE, DST_POC, RELEASE]);
                             // mem_flags might need a conditional to add CLEAN
                             // in certain cases; unsure of syntax for that
 
@@ -1393,7 +1393,7 @@ decode QUADRANT default Unknown::unknown() {
                             } else {
                                 Mem = 0;
                             }
-                        }}, mem_flags=[CLEAN, DST_POC]);
+                        }}, mem_flags=[CLEAN, DST_POC, RELEASE]);
                         0x2: cbo_flush({{
                             SENVCFG senvcfg = xc->readMiscReg(MISCREG_SENVCFG);
                             auto pm = (PrivilegeMode)xc->readMiscReg(
@@ -1410,7 +1410,7 @@ decode QUADRANT default Unknown::unknown() {
                             } else {
                                 Mem = 0;
                             }
-                        }}, mem_flags=[CLEAN, INVALIDATE, DST_POC]);
+                        }}, mem_flags=[CLEAN, INVALIDATE, DST_POC, RELEASE]);
                         0x4: cbo_zero({{
                             SENVCFG senvcfg = xc->readMiscReg(MISCREG_SENVCFG);
                             auto pm = (PrivilegeMode)xc->readMiscReg(
@@ -1426,7 +1426,7 @@ decode QUADRANT default Unknown::unknown() {
                             } else {
                                 Mem = 0;
                             }
-                        }}, mem_flags=[CACHE_BLOCK_ZERO]);
+                        }}, mem_flags=[CACHE_BLOCK_ZERO, RELEASE]);
                     }
                 }
             }


### PR DESCRIPTION
Add Request::RELEASE flag to all four RISC-V Zicbom extension cache block operation instructions (cbo.inval, cbo.clean, cbo.flush, and cbo.zero) to ensure proper store queue ordering and prevent cache race conditions.

Cache maintenance operations must execute after all prior memory accesses complete to ensure correctness:
For cbo.clean and cbo.flush, without the RELEASE flag, when prior store instructions experience cache misses, the cache does not immediately allocate dirty cache lines. **As a result, the WriteClean operation would have no effect since there are no dirty lines to clean**. 
The RELEASE flag ensures all pending store operations complete before the cache maintenance instruction executes. Similarly, the RELEASE flag has been added to cbo.inval and cbo.zero to prevent race conditions between these cache maintenance operations and pending store queue entries.