### PR TITLE
mem-garnet: complete HeteroGarnet per-vnet dedicated links for XY routing

### DIFF
--- a/configs/network/Network.py
+++ b/configs/network/Network.py
@@ -124,6 +124,15 @@ def define_options(parser):
             channel for each virtual network""",
     )
 
+    parser.add_argument(
+        "--per-vnet-links",
+        action="store_true",
+        default=False,
+        help="Create one dedicated physical link per vnet between adjacent "
+        "routers (HeteroGarnet). Requires XY or TABLE routing. "
+        "Default: all vnets share one link per direction.",
+    )
+
 
 def create_network(options, ruby):
     # Allow legacy users to use garnet through garnet2.0 option

--- a/configs/topologies/Mesh_XY.py
+++ b/configs/topologies/Mesh_XY.py
@@ -119,81 +119,101 @@ class Mesh_XY(SimpleTopology):
         # Create the mesh links.
         int_links = []
 
+        # --per-vnet-links: create one dedicated link per vnet per direction.
+        # Default (off): one shared link per direction (supported_vnets=[]).
+        per_vnet = getattr(options, "per_vnet_links", False)
+        num_vnets = network.number_of_virtual_networks
+        vnets = list(range(num_vnets)) if per_vnet else [None]
+
+        if per_vnet:
+            print(
+                f"Mesh_XY: per_vnet_links enabled, "
+                f"{num_vnets} links per direction per router pair"
+            )
+
         # East output to West input links (weight = 1)
-        for row in range(num_rows):
-            for col in range(num_columns):
-                if col + 1 < num_columns:
-                    east_out = col + (row * num_columns)
-                    west_in = (col + 1) + (row * num_columns)
-                    int_links.append(
-                        IntLink(
-                            link_id=link_count,
-                            src_node=routers[east_out],
-                            dst_node=routers[west_in],
-                            src_outport="East",
-                            dst_inport="West",
-                            latency=link_latency,
-                            weight=1,
+        for v in vnets:
+            for row in range(num_rows):
+                for col in range(num_columns):
+                    if col + 1 < num_columns:
+                        east_out = col + (row * num_columns)
+                        west_in = (col + 1) + (row * num_columns)
+                        int_links.append(
+                            IntLink(
+                                link_id=link_count,
+                                src_node=routers[east_out],
+                                dst_node=routers[west_in],
+                                src_outport="East",
+                                dst_inport="West",
+                                latency=link_latency,
+                                weight=1,
+                                supported_vnets=[v] if v is not None else [],
+                            )
                         )
-                    )
-                    link_count += 1
+                        link_count += 1
 
         # West output to East input links (weight = 1)
-        for row in range(num_rows):
-            for col in range(num_columns):
-                if col + 1 < num_columns:
-                    east_in = col + (row * num_columns)
-                    west_out = (col + 1) + (row * num_columns)
-                    int_links.append(
-                        IntLink(
-                            link_id=link_count,
-                            src_node=routers[west_out],
-                            dst_node=routers[east_in],
-                            src_outport="West",
-                            dst_inport="East",
-                            latency=link_latency,
-                            weight=1,
+        for v in vnets:
+            for row in range(num_rows):
+                for col in range(num_columns):
+                    if col + 1 < num_columns:
+                        east_in = col + (row * num_columns)
+                        west_out = (col + 1) + (row * num_columns)
+                        int_links.append(
+                            IntLink(
+                                link_id=link_count,
+                                src_node=routers[west_out],
+                                dst_node=routers[east_in],
+                                src_outport="West",
+                                dst_inport="East",
+                                latency=link_latency,
+                                weight=1,
+                                supported_vnets=[v] if v is not None else [],
+                            )
                         )
-                    )
-                    link_count += 1
+                        link_count += 1
 
         # North output to South input links (weight = 2)
-        for col in range(num_columns):
-            for row in range(num_rows):
-                if row + 1 < num_rows:
-                    north_out = col + (row * num_columns)
-                    south_in = col + ((row + 1) * num_columns)
-                    int_links.append(
-                        IntLink(
-                            link_id=link_count,
-                            src_node=routers[north_out],
-                            dst_node=routers[south_in],
-                            src_outport="North",
-                            dst_inport="South",
-                            latency=link_latency,
-                            weight=2,
+        for v in vnets:
+            for col in range(num_columns):
+                for row in range(num_rows):
+                    if row + 1 < num_rows:
+                        north_out = col + (row * num_columns)
+                        south_in = col + ((row + 1) * num_columns)
+                        int_links.append(
+                            IntLink(
+                                link_id=link_count,
+                                src_node=routers[north_out],
+                                dst_node=routers[south_in],
+                                src_outport="North",
+                                dst_inport="South",
+                                latency=link_latency,
+                                weight=2,
+                                supported_vnets=[v] if v is not None else [],
+                            )
                         )
-                    )
-                    link_count += 1
+                        link_count += 1
 
         # South output to North input links (weight = 2)
-        for col in range(num_columns):
-            for row in range(num_rows):
-                if row + 1 < num_rows:
-                    north_in = col + (row * num_columns)
-                    south_out = col + ((row + 1) * num_columns)
-                    int_links.append(
-                        IntLink(
-                            link_id=link_count,
-                            src_node=routers[south_out],
-                            dst_node=routers[north_in],
-                            src_outport="South",
-                            dst_inport="North",
-                            latency=link_latency,
-                            weight=2,
+        for v in vnets:
+            for col in range(num_columns):
+                for row in range(num_rows):
+                    if row + 1 < num_rows:
+                        north_in = col + (row * num_columns)
+                        south_out = col + ((row + 1) * num_columns)
+                        int_links.append(
+                            IntLink(
+                                link_id=link_count,
+                                src_node=routers[south_out],
+                                dst_node=routers[north_in],
+                                src_outport="South",
+                                dst_inport="North",
+                                latency=link_latency,
+                                weight=2,
+                                supported_vnets=[v] if v is not None else [],
+                            )
                         )
-                    )
-                    link_count += 1
+                        link_count += 1
 
         network.int_links = int_links
 

--- a/src/mem/ruby/network/garnet/NetworkLink.cc
+++ b/src/mem/ruby/network/garnet/NetworkLink.cc
@@ -61,6 +61,20 @@ NetworkLink::NetworkLink(const Params &p)
 }
 
 void
+NetworkLink::regStats()
+{
+    ClockedObject::regStats();
+
+    m_flits_per_vnet.name(name() + ".flits_per_vnet")
+        .desc("Number of flits transmitted per virtual network")
+        .flags(statistics::nozero | statistics::total)
+        .init(m_virt_nets);
+    for (int v = 0; v < (int)m_virt_nets; v++) {
+        m_flits_per_vnet.subname(v, "vnet-" + std::to_string(v));
+    }
+}
+
+void
 NetworkLink::setLinkConsumer(Consumer *consumer)
 {
     link_consumer = consumer;
@@ -102,6 +116,7 @@ NetworkLink::wakeup()
         link_consumer->scheduleEventAbsolute(clockEdge(m_latency));
         m_link_utilized++;
         m_vc_load[t_flit->get_vc()]++;
+        m_flits_per_vnet[t_flit->get_vnet()]++;
     }
 
     if (!link_srcQueue->isEmpty()) {
@@ -115,7 +130,9 @@ NetworkLink::resetStats()
     for (int i = 0; i < m_vc_load.size(); i++) {
         m_vc_load[i] = 0;
     }
-
+    for (int v = 0; v < (int)m_virt_nets; v++) {
+        m_flits_per_vnet[v] = 0;
+    }
     m_link_utilized = 0;
 }
 

--- a/src/mem/ruby/network/garnet/NetworkLink.hh
+++ b/src/mem/ruby/network/garnet/NetworkLink.hh
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <vector>
 
+#include "base/statistics.hh"
 #include "mem/ruby/common/Consumer.hh"
 #include "mem/ruby/network/garnet/CommonTypes.hh"
 #include "mem/ruby/network/garnet/flitBuffer.hh"
@@ -65,10 +66,17 @@ class NetworkLink : public ClockedObject, public Consumer
     virtual void setVcsPerVnet(uint32_t consumerVcs);
     void setType(link_type type) { m_type = type; }
     link_type getType() { return m_type; }
-    void print(std::ostream& out) const {}
+    void
+    print(std::ostream &out) const override
+    {}
     int get_id() const { return m_id; }
-    flitBuffer *getBuffer() { return &linkBuffer;}
-    virtual void wakeup();
+    flitBuffer *
+    getBuffer()
+    {
+        return &linkBuffer;
+    }
+    void wakeup() override;
+    void regStats() override;
 
     unsigned int getLinkUtilization() const { return m_link_utilized; }
     const std::vector<unsigned int> & getVcLoad() const { return m_vc_load; }
@@ -83,7 +91,7 @@ class NetworkLink : public ClockedObject, public Consumer
 
     bool functionalRead(Packet *pkt, WriteMask &mask);
     uint32_t functionalWrite(Packet *);
-    void resetStats();
+    void resetStats() override;
 
     std::vector<int> mVnets;
     uint32_t bitWidth;
@@ -98,6 +106,8 @@ class NetworkLink : public ClockedObject, public Consumer
     // Statistical variables
     unsigned int m_link_utilized;
     std::vector<unsigned int> m_vc_load;
+    // Per-vnet flit counter: suppressed by nozero when zero (feature off).
+    statistics::Vector m_flits_per_vnet;
 
   protected:
     uint32_t m_virt_nets;

--- a/src/mem/ruby/network/garnet/Router.cc
+++ b/src/mem/ruby/network/garnet/Router.cc
@@ -143,7 +143,7 @@ Router::addOutPort(PortDirection outport_dirn,
 
     routingUnit.addRoute(routing_table_entry);
     routingUnit.addWeight(link_weight);
-    routingUnit.addOutDirection(outport_dirn, port_num);
+    routingUnit.addOutDirection(outport_dirn, port_num, out_link->mVnets);
 }
 
 PortDirection

--- a/src/mem/ruby/network/garnet/RoutingUnit.cc
+++ b/src/mem/ruby/network/garnet/RoutingUnit.cc
@@ -153,10 +153,37 @@ RoutingUnit::addInDirection(PortDirection inport_dirn, int inport_idx)
 }
 
 void
-RoutingUnit::addOutDirection(PortDirection outport_dirn, int outport_idx)
+RoutingUnit::addOutDirection(PortDirection outport_dirn, int outport_idx,
+                             const std::vector<int> &supported_vnets)
 {
-    m_outports_dirn2idx[outport_dirn] = outport_idx;
-    m_outports_idx2dirn[outport_idx]  = outport_dirn;
+    if (m_outports_dirn2idx.empty()) {
+        m_outports_dirn2idx.resize(m_router->get_num_vnets());
+    }
+
+    if (supported_vnets.empty()) {
+        // Shared link: register this port for all vnets
+        for (int v = 0; v < (int)m_outports_dirn2idx.size(); v++) {
+            m_outports_dirn2idx[v][outport_dirn] = outport_idx;
+            DPRINTF(RubyNetwork,
+                    "Router %d: addOutDirection vnet=%d"
+                    " dirn=%s port=%d\n",
+                    m_router->get_id(), v, outport_dirn, outport_idx);
+        }
+    } else {
+        // Dedicated link: register only for the specified vnets
+        for (int v : supported_vnets) {
+            fatal_if(
+                v < 0 || v >= (int)m_outports_dirn2idx.size(),
+                "Router %d: supported_vnets entry %d out of range [0,%d)\n",
+                m_router->get_id(), v, (int)m_outports_dirn2idx.size());
+            m_outports_dirn2idx[v][outport_dirn] = outport_idx;
+            DPRINTF(RubyNetwork,
+                    "Router %d: addOutDirection vnet=%d"
+                    " dirn=%s port=%d\n",
+                    m_router->get_id(), v, outport_dirn, outport_idx);
+        }
+    }
+    m_outports_idx2dirn[outport_idx] = outport_dirn;
 }
 
 // outportCompute() is called by the InputUnit
@@ -257,7 +284,14 @@ RoutingUnit::outportComputeXY(RouteInfo route,
         panic("x_hops == y_hops == 0");
     }
 
-    return m_outports_dirn2idx[outport_dirn];
+    fatal_if(route.vnet < 0 || route.vnet >= (int)m_outports_dirn2idx.size(),
+             "Router %d: vnet %d out of range [0,%d) in outportComputeXY\n",
+             m_router->get_id(), route.vnet, (int)m_outports_dirn2idx.size());
+    fatal_if(m_outports_dirn2idx[route.vnet].count(outport_dirn) == 0,
+             "Router %d: no outport for vnet %d dirn %s - "
+             "topology misconfiguration\n",
+             m_router->get_id(), route.vnet, outport_dirn);
+    return m_outports_dirn2idx[route.vnet][outport_dirn];
 }
 
 // Template for implementing custom routing algorithm

--- a/src/mem/ruby/network/garnet/RoutingUnit.hh
+++ b/src/mem/ruby/network/garnet/RoutingUnit.hh
@@ -66,7 +66,8 @@ class RoutingUnit
 
     // Topology-specific direction based routing
     void addInDirection(PortDirection inport_dirn, int inport);
-    void addOutDirection(PortDirection outport_dirn, int outport);
+    void addOutDirection(PortDirection outport_dirn, int outport,
+                         const std::vector<int> &supported_vnets = {});
 
     // Routing for Mesh
     int outportComputeXY(RouteInfo route,
@@ -94,7 +95,9 @@ class RoutingUnit
     std::map<PortDirection, int> m_inports_dirn2idx;
     std::map<int, PortDirection> m_inports_idx2dirn;
     std::map<int, PortDirection> m_outports_idx2dirn;
-    std::map<PortDirection, int> m_outports_dirn2idx;
+    // Per-vnet direction-to-port map (HeteroGarnet: each vnet may have its own
+    // dedicated outport per direction). Resized lazily in addOutDirection.
+    std::vector<std::map<PortDirection, int>> m_outports_dirn2idx;
 };
 
 } // namespace garnet

--- a/tests/gem5/memory/test.py
+++ b/tests/gem5/memory/test.py
@@ -72,6 +72,21 @@ gem5_verify_config(
 
 null_tests = [
     ("garnet_synth_traffic", None, ["--sim-cycles", "5000000"]),
+    (
+        "garnet_synth_traffic-per-vnet-links",
+        "garnet_synth_traffic",
+        [
+            "--sim-cycles",
+            "5000000",
+            "--network=garnet",
+            "--topology=Mesh_XY",
+            "--num-cpus=4",
+            "--num-dirs=4",
+            "--mesh-rows=2",
+            "--routing-algorithm=1",
+            "--per-vnet-links",
+        ],
+    ),
     ("memcheck", None, ["--maxtick", "2000000000", "--prefetchers"]),
     (
         "ruby_mem_test-garnet",


### PR DESCRIPTION
Completes XY routing support for HeteroGarnet per-vnet dedicated links and adds a `--per-vnet-links` flag to `Mesh_XY.py`. Scope is `Mesh_XY` topology and XY routing; TABLE routing and other topologies are unaffected. The `supported_vnets` field on `IntLink`/`NetworkLink` already exists in upstream Garnet; this patch wires it through to the routing layer.

This models heterogeneous link topologies found in commercial interconnects
(e.g. ARM CMN), where different traffic classes use dedicated physical channels
to improve inter-vnet bandwidth isolation and reduce head-of-line blocking.

**Backward compatible:** with `--per-vnet-links` absent (default), all links
have empty `mVnets`, `addOutDirection` writes the same port to all vnet slots,
and `outportComputeXY` returns the same port for any vnet — identical to the
original flat map behavior. Zero behavioral change for existing users.

Changes:
- `RoutingUnit`: change `m_outports_dirn2idx` from a flat map to a
`vector<map<PortDirection,int>>` indexed by vnet. `addOutDirection` resizes
lazily and registers each vnet/direction/port mapping. `outportComputeXY`
indexes by `route.vnet` with explicit bounds and direction guards.
- `Router::addOutPort`: pass `out_link->mVnets` to `addOutDirection`.
- `NetworkLink`: add `statistics::Vector m_flits_per_vnet` (flags: `nozero |
total`) via `regStats()` override. Provides per-link per-vnet flit counts
and `::total` for utilization (`::total / ruby_cycles`).
- `configs/network/Network.py`: add `--per-vnet-links` CLI flag.
- `configs/topologies/Mesh_XY.py`: add outer vnet loop over all four link
directions when `--per-vnet-links` is set.
- `tests/gem5/memory/test.py`: add `garnet_synth_traffic-per-vnet-links`
regression test.

Tested with `Garnet_standalone` on a 4x4 `Mesh_XY`:
- XY and TABLE routing: performance parity between ON and OFF at low injection
rate; throughput and latency improvement in tested stress profiles
(uniform_random, transpose); neutral in tornado
- Vnet isolation confirmed via per-link `flits_per_vnet` stats: with
`--per-vnet-links` ON each internal link carries traffic for exactly one
vnet; with feature OFF links carry mixed vnet traffic
- gem5 CI: `garnet_synth_traffic`, `ruby_mem_test-garnet`, and new
`garnet_synth_traffic-per-vnet-links` pass