### PR TITLE
stdlib: Use atomic_noncaching switching to atomic CPU with Ruby

### DIFF
--- a/src/python/gem5/components/processors/switchable_processor.py
+++ b/src/python/gem5/components/processors/switchable_processor.py
@@ -155,7 +155,9 @@ class SwitchableProcessor(AbstractProcessor):
 
         # Switch the CPUs
         m5.switchCpus(
-            self._board, list(zip(current_core_simobj, to_switch_simobj))
+            self._board,
+            list(zip(current_core_simobj, to_switch_simobj)),
+            is_ruby=self._board.get_cache_hierarchy().is_ruby(),
         )
 
         # Ensure the current processor is updated.

--- a/src/python/m5/simulate.py
+++ b/src/python/m5/simulate.py
@@ -427,7 +427,7 @@ def _changeMemoryMode(system, mode):
         print("System already in target mode. Memory mode unchanged.")
 
 
-def switchCpus(system, cpuList, verbose=True):
+def switchCpus(system, cpuList, verbose=True, is_ruby=False):
     """Switch CPUs in a system.
 
     .. note::
@@ -455,6 +455,8 @@ def switchCpus(system, cpuList, verbose=True):
     new_cpus = [new_cpu for old_cpu, new_cpu in cpuList]
     old_cpu_set = set(old_cpus)
     memory_mode_name = new_cpus[0].memory_mode()
+    if is_ruby and memory_mode_name == "atomic":
+        memory_mode_name = "atomic_noncaching"
     for old_cpu, new_cpu in cpuList:
         if not isinstance(old_cpu, BaseCPU):
             raise TypeError(f"{old_cpu} is not of type BaseCPU")
@@ -470,7 +472,10 @@ def switchCpus(system, cpuList, verbose=True):
             raise RuntimeError(
                 f"New CPU ({old_cpu}) does not support CPU handover."
             )
-        if new_cpu.memory_mode() != memory_mode_name:
+        new_memory_mode = new_cpu.memory_mode()
+        if is_ruby and new_memory_mode == "atomic":
+            new_memory_mode = "atomic_noncaching"
+        if new_memory_mode != memory_mode_name:
             raise RuntimeError(
                 f"{new_cpu} and {new_cpus[0]} require different memory modes."
             )


### PR DESCRIPTION
Atomic CPU with Ruby requires the memory mode to be atomic_noncaching. Currently the m5 python library does not consider this, but stdlib allows for switching to an atomic CPU with a Ruby cache hierarchy.

This commit forces the memory mode to be noncaching if it was atomic and ruby is enabled in the m5 python library. Proposed fix for #3030.