### PR TITLE
cpu-o3: Fix serializeOnNextInst not cleared on squash in Rename stage

### DIFF
--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -397,7 +397,21 @@ Rename::squash(const InstSeqNum &squash_seq_num, ThreadID tid)
 
             serializeInst[tid] = NULL;
         }
+    } else if (serializeInst[tid] &&
+               serializeInst[tid]->seqNum > squash_seq_num) {
+        // Handle the case where serializeInst points to an instruction
+        // that has been flushed but renameStatus is not SerializeStall.
+        // This can happen if the status changed after the serialize
+        // instruction was set but before squash occurred.
+        DPRINTF(Rename, "[tid:%i] [squash sn:%llu] "
+            "Clearing flushed serializeInst with seqNum %llu\n",
+            tid, squash_seq_num, serializeInst[tid]->seqNum);
+        serializeInst[tid] = NULL;
     }
+
+    // Clear serializeOnNextInst to prevent marking flushed instructions
+    // as serializing after squash
+    serializeOnNextInst[tid] = false;
 
     // Set the status to Squashing.
     renameStatus[tid] = Squashing;

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -403,9 +403,10 @@ Rename::squash(const InstSeqNum &squash_seq_num, ThreadID tid)
         // that has been flushed but renameStatus is not SerializeStall.
         // This can happen if the status changed after the serialize
         // instruction was set but before squash occurred.
-        DPRINTF(Rename, "[tid:%i] [squash sn:%llu] "
-            "Clearing flushed serializeInst with seqNum %llu\n",
-            tid, squash_seq_num, serializeInst[tid]->seqNum);
+        DPRINTF(Rename,
+                "[tid:%i] [squash sn:%llu] "
+                "Clearing flushed serializeInst with seqNum %llu\n",
+                tid, squash_seq_num, serializeInst[tid]->seqNum);
         serializeInst[tid] = NULL;
     }
 


### PR DESCRIPTION
When a SerializeAfter instruction (e.g., RISC-V CSR access) is flushed during squash, serializeOnNextInst[tid] was not being cleared. This could cause the wrong instruction to be marked as SerializeAfter in the new instruction stream after squash.

Scenario:
```
beq x1, x3, correct_path    # Branch instruction

mispredicted_path:
    csrrs x4, mstatus, x0   # SerializeAfter (will be flushed)
    add x5, x6, x7               # Instruction on the mis-pred path
    
correct_path:
    add x14, x1, x2         # Correct path
    # This instruction will be set as SerializeBefore if bug is not fixed
```

The csrr instruction sets serializeOnNextInst[tid]=true, but gets flushed before marking the next instruction. Without clearing this flag during squash, the 'add' instruction in the correct path would be incorrectly marked as SerializeBefore.

Fix: Clear serializeOnNextInst[tid] unconditionally in squash() to prevent stale serialization state from affecting post-squash execution.