### PR TITLE
arch-riscv: Fix incorrect old_vd_idx for OPIVI vector instructions

### DIFF
--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -424,7 +424,7 @@ def format VectorIntWideningFormat(code, category, *flags) {{
     need_elem_idx = mask_cond or code.find("ei") != -1
     is_destructive_fused = iop.op_class == "SimdMultAccOp"
 
-    old_vd_idx = 2
+    old_vd_idx = 2 if category != "OPIVI" else 1
     dest_reg_id = "vecRegClass[_machInst.vd + _microIdx]"
     dest_sew_mul = 2
     src1_reg_id = ""


### PR DESCRIPTION
The widening format was hardcoded to look for the old destination register at index 2. This is correct for OPIVV, but for OPIVI the index should be 1 as there is no vs1 register. This caused the mask register to be incorrectly used as the old VD.