### PR TITLE
cpu-o3: assign CPU-scoped name to PhysRegFile

### DIFF
--- a/src/cpu/o3/cpu.cc
+++ b/src/cpu/o3/cpu.cc
@@ -88,7 +88,7 @@ CPU::CPU(const BaseO3CPUParams &params)
       iew(this, params),
       commit(this, params),
 
-      regFile(params.numPhysIntRegs, params.numPhysFloatRegs,
+      regFile(this, params.numPhysIntRegs, params.numPhysFloatRegs,
               params.numPhysVecRegs, params.numPhysVecPredRegs,
               params.numPhysMatRegs, params.numPhysCCRegs,
               params.isa[0]->regClasses()),

--- a/src/cpu/o3/regfile.cc
+++ b/src/cpu/o3/regfile.cc
@@ -40,7 +40,7 @@
  */
 
 #include "cpu/o3/regfile.hh"
-
+#include "cpu/o3/cpu.hh"
 #include "cpu/o3/free_list.hh"
 
 namespace gem5
@@ -49,14 +49,15 @@ namespace gem5
 namespace o3
 {
 
-PhysRegFile::PhysRegFile(unsigned _numPhysicalIntRegs,
+PhysRegFile::PhysRegFile(CPU *_cpu, unsigned _numPhysicalIntRegs,
                          unsigned _numPhysicalFloatRegs,
                          unsigned _numPhysicalVecRegs,
                          unsigned _numPhysicalVecPredRegs,
                          unsigned _numPhysicalMatRegs,
                          unsigned _numPhysicalCCRegs,
                          const BaseISA::RegClasses &reg_classes)
-    : intRegFile(*reg_classes.at(IntRegClass), _numPhysicalIntRegs),
+    : cpu(_cpu),
+      intRegFile(*reg_classes.at(IntRegClass), _numPhysicalIntRegs),
       floatRegFile(*reg_classes.at(FloatRegClass), _numPhysicalFloatRegs),
       vectorRegFile(*reg_classes.at(VecRegClass), _numPhysicalVecRegs),
       vectorElemRegFile(*reg_classes.at(VecElemClass),
@@ -140,6 +141,11 @@ PhysRegFile::PhysRegFile(unsigned _numPhysicalIntRegs,
     }
 }
 
+std::string
+PhysRegFile::name() const
+{
+    return cpu->name() + ".regfile";
+}
 
 void
 PhysRegFile::initFreeList(UnifiedFreeList *freeList)

--- a/src/cpu/o3/regfile.hh
+++ b/src/cpu/o3/regfile.hh
@@ -58,6 +58,7 @@ namespace o3
 {
 
 class UnifiedFreeList;
+class CPU;
 
 /**
  * Simple physical register file class.
@@ -71,6 +72,9 @@ class PhysRegFile
     using IdRange = std::pair<PhysIds::iterator,
                               PhysIds::iterator>;
   private:
+    /** CPU pointer. */
+    CPU *cpu;
+
     /** Integer register file. */
     RegFile intRegFile;
     std::vector<PhysRegId> intRegIds;
@@ -145,13 +149,14 @@ class PhysRegFile
      * Constructs a physical register file with the specified amount of
      * integer and floating point registers.
      */
-    PhysRegFile(unsigned _numPhysicalIntRegs,
-                unsigned _numPhysicalFloatRegs,
-                unsigned _numPhysicalVecRegs,
-                unsigned _numPhysicalVecPredRegs,
-                unsigned _numPhysicalMatRegs,
+    PhysRegFile(CPU *_cpu, unsigned _numPhysicalIntRegs,
+                unsigned _numPhysicalFloatRegs, unsigned _numPhysicalVecRegs,
+                unsigned _numPhysicalVecPredRegs, unsigned _numPhysicalMatRegs,
                 unsigned _numPhysicalCCRegs,
                 const BaseISA::RegClasses &classes);
+
+    /** Returns the name of the physical register file. */
+    std::string name() const;
 
     /**
      * Destructor to free resources


### PR DESCRIPTION
Store a CPU pointer in PhysRegFile and override name() to return "<cpu>.regfile" so that register file DPRINTF messages carry a per-CPU prefix instead of the generic "global" tag.

Before: global: RegFile: Setting int register ...
After:  system.cpu2.regfile: RegFile: Setting int register ...