### PR TITLE
misc: bump gpu-tests timeout to 3 days

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -158,7 +158,7 @@ jobs:
                 test-length: [quick, long, very-long]
         runs-on: [self-hosted, linux, x64]
         container: ghcr.io/gem5/gcn-gpu:latest
-        timeout-minutes: 1440 # 24 hours
+        timeout-minutes: 4320 # 3 days
         needs: get-date
 
         steps:
@@ -181,7 +181,7 @@ jobs:
               id: run-tests
               working-directory: ${{ github.workspace }}/tests
               run: ./main.py run --length=${{ matrix.test-length }} -vvv --gcov=test-only -j $(nproc) --host gcn_gpu --isa=VEGA_X86
-              timeout-minutes: 1410
+              timeout-minutes: 4290
 
             - name: Upload results
               if: always()


### PR DESCRIPTION
Adding `--gcov=test-only` to get code coverage has caused the gpu-tests to take longer than before, and the very-long gpu-tests are timing out as a result. This commit increases the gpu-tests' timeout to 3 days, like the testlib-tests, to avoid timing out.