### PR TITLE
configs: Add new Simd OpClasses to O3_ARM_v7a_FP

### DIFF
--- a/configs/common/cores/arm/O3_ARM_v7a.py
+++ b/configs/common/cores/arm/O3_ARM_v7a.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Arm Limited
+# Copyright (c) 2025-2026 Arm Limited
 # All rights reserved
 #
 # The license below extends only to copyright in the software and shall
@@ -80,6 +80,9 @@ class O3_ARM_v7a_FP(FUDesc):
         OpDesc(opClass="SimdFloatMultAcc", opLat=5),
         OpDesc(opClass="SimdFloatMatMultAcc", opLat=5),
         OpDesc(opClass="SimdFloatSqrt", opLat=9),
+        OpDesc(opClass="SimdDotProd", opLat=3),
+        OpDesc(opClass="SimdSha3", opLat=2),
+        OpDesc(opClass="SimdCrc", opLat=3),
         OpDesc(opClass="SimdBf16Add", opLat=4),
         OpDesc(opClass="SimdBf16Cmp", opLat=4),
         OpDesc(opClass="SimdBf16Cvt", opLat=3),


### PR DESCRIPTION
Some Simd OpClasses like SimdCrc were introduced by a previous PR [1] and were never added to the old O3_ARM_v7a.py model.

These are:

* SimdDotProd
* SimdSha3
* SimdCrc

The O3_ARM_v7a is what we actually use when running the tests/gem5/fs/linux/arm regressions.

[1]: https://github.com/gem5/gem5/pull/2782

Change-Id: I3e72a2872cf2111f579a0b4b95f4ea1f45f71baa