### PR TITLE
cpu-o3: Fix stall when instruction has no capable FU

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -207,6 +207,12 @@ IQUnit::numFreeEntries(const DynInstPtr &inst) const
     }
 }
 
+bool
+IQUnit::isCapable(OpClass op_class) const
+{
+    return _fuPool->isCapable(op_class);
+}
+
 InstructionQueue::FUCompletion::FUCompletion(const DynInstPtr &_inst,
                                              FUPool *fu_pool, int fu_idx,
                                              InstructionQueue *iq_ptr)
@@ -616,10 +622,23 @@ InstructionQueue::numFreeEntries(ThreadID tid)
 unsigned
 InstructionQueue::numFreeEntries(const DynInstPtr &inst)
 {
+    bool any_capable = false;
     unsigned free_entries = 0;
     for (auto iq : iqs) {
-        free_entries += iq->numFreeEntries(inst);
+        if (iq->isCapable(inst->opClass())) {
+            any_capable = true;
+            free_entries += iq->numFreeEntries(inst);
+        }
     }
+
+    if (any_capable) {
+        return free_entries;
+    }
+
+    for (auto iq : iqs) {
+        free_entries += iq->numFreeEntries(inst->threadNumber);
+    }
+
     return free_entries;
 }
 
@@ -672,13 +691,26 @@ InstructionQueue::hasReadyInsts()
 IQUnit *
 InstructionQueue::findIQ(const DynInstPtr &inst)
 {
+    bool any_capable = false;
     for (auto iq : iqs) {
-        // If the IQ can store the selected instruction,
-        // return the IQ as valid
-        if (iq->numFreeEntries(inst) > 0) {
+        if (iq->isCapable(inst->opClass())) {
+            any_capable = true;
+            if (iq->numFreeEntries(inst) > 0) {
+                return iq;
+            }
+        }
+    }
+
+    if (any_capable) {
+        return nullptr;
+    }
+
+    for (auto iq : iqs) {
+        if (iq->numFreeEntries(inst->threadNumber) > 0) {
             return iq;
         }
     }
+
     return nullptr;
 }
 

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -132,6 +132,8 @@ class IQUnit : public SimObject
         return _fuPool;
     }
 
+    bool isCapable(OpClass op_class) const;
+
   private:
     /** IQ sharing policy for SMT. */
     SMTQueuePolicy iqPolicy;


### PR DESCRIPTION
When an instruction cannot be executed by any Functional Unit (FU) in any Instruction Queue (IQ) unit, the numFreeEntries method would return 0, causing the pipeline to stall indefinitely at the dispatch stage.

This patch modifies findIQ and numFreeEntries to fallback to any IQ that has space if no IQ is capable of executing the instruction. This allows the instruction to be dispatched, reach the commit stage, and trigger the intended panic for missing FU capability.