### PR TITLE
sim: Add current tick to panic output

### DIFF
--- a/src/sim/root.cc
+++ b/src/sim/root.cc
@@ -193,6 +193,16 @@ Root::Root(const RootParams &p, int)
     // having a single global stat group for global stats. Merge that
     // group into the root object here.
     mergeStatGroup(&Root::RootStats::instance);
+
+    // Print the tick if we panic.
+    Logger::getPanic().registerExtraLog([]() {
+        if (Gem5Internal::_curTickPtr) {
+            return csprintf("Panic at tick %llu\n",
+                            (unsigned long long)curTick());
+        } else {
+            return std::string("Panic at tick 0 (no event queue active)\n");
+        }
+    });
 }
 
 void


### PR DESCRIPTION
Register an extra log callback in the Root constructor to print the current simulation tick whenever a panic occurs. This provides useful context for debugging simulation failures without needing to manually add the tick to every panic message.

The callback safely checks if the event queue pointer (`_curTickPtr`) is valid before calling `curTick()` to avoid segmentation faults if a panic occurs before the simulation event queues are fully initialized.