### PR TITLE
cpu: Add `AppleVirtCPU` (`KvmCPU` equiv for Apple hosts)

### DIFF
--- a/configs/example/apple_virt_kernel_disk.py
+++ b/configs/example/apple_virt_kernel_disk.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 The Regents of the University of California
+# Copyright (c) 2026 The Regents of The University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,25 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Boot ARM Ubuntu with one AppleVirtCPU in full-system mode.
+"""Boot a local AArch64 kernel and disk image with AppleVirtCPU.
 
-The simulated system's output is written to
+Usage
+-----
+
+```
+scons build/ARM/gem5.opt -j$(sysctl -n hw.ncpu)
+./build/ARM/gem5.opt configs/example/apple_virt_kernel_disk.py \
+    --kernel /path/to/vmlinux.arm64 \
+    --disk-image /path/to/arm64-disk.img \
+    --bootloader /path/to/boot.arm64
+```
+
+The kernel, disk image, and bootloader must be compatible with the
+``VExpress_GEM5_V1`` platform. The simulated terminal is written to
 ``m5out/board.terminal``.
 """
+
+import argparse
 
 from m5.objects import (
     ArmDefaultRelease,
@@ -43,9 +57,30 @@ from gem5.components.memory import DualChannelDDR4_2400
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.isas import ISA
-from gem5.resources.resource import obtain_resource
+from gem5.resources.resource import (
+    BootloaderResource,
+    DiskImageResource,
+    KernelResource,
+)
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires
+
+parser = argparse.ArgumentParser(
+    description="Boot local AArch64 artifacts with AppleVirtCPU."
+)
+parser.add_argument("--kernel", required=True, help="Path to the ARM kernel.")
+parser.add_argument(
+    "--disk-image", required=True, help="Path to the ARM disk image."
+)
+parser.add_argument(
+    "--bootloader", required=True, help="Path to the ARM bootloader."
+)
+parser.add_argument(
+    "--root-partition",
+    default="1",
+    help="Root partition number in the disk image (default: 1).",
+)
+args = parser.parse_args()
 
 requires(isa_required=ISA.ARM, apple_virt_required=True)
 
@@ -69,11 +104,14 @@ board = ArmBoard(
     platform=VExpress_GEM5_V1(),
 )
 
-board.set_workload(
-    obtain_resource(
-        "arm-ubuntu-24.04-boot-with-systemd", resource_version="3.0.0"
-    )
+board.set_kernel_disk_workload(
+    kernel=KernelResource(local_path=args.kernel, architecture=ISA.ARM),
+    disk_image=DiskImageResource(
+        local_path=args.disk_image, root_partition=args.root_partition
+    ),
+    bootloader=BootloaderResource(
+        local_path=args.bootloader, architecture=ISA.ARM
+    ),
 )
 
-simulator = Simulator(board=board)
-simulator.run()
+Simulator(board=board).run()

--- a/configs/example/apple_virt_simple.py
+++ b/configs/example/apple_virt_simple.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,38 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+"""Minimal stdlib example configuration for the Apple virtualization CPU."""
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
+from gem5.components.boards.simple_board import SimpleBoard
+from gem5.components.cachehierarchies.classic.no_cache import NoCache
+from gem5.components.memory import SingleChannelDDR3_1600
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+requires(isa_required=ISA.ARM)
+
+cache_hierarchy = NoCache()
+memory = SingleChannelDDR3_1600(size="512MiB")
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.APPLE_VIRT, isa=ISA.ARM, num_cores=1
+)
+
+board = SimpleBoard(
+    clk_freq="3GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+)
+
+board.set_se_binary_workload(
+    obtain_resource("arm-hello64-static", resource_version="1.0.0")
+)
+
+simulator = Simulator(board=board)
+print("Running AppleVirtCPU stdlib smoke test")
+simulator.run(max_ticks=1_000_000)
+print(f"Exited @ tick {simulator.get_current_tick()}")

--- a/configs/example/apple_virt_simple.py
+++ b/configs/example/apple_virt_simple.py
@@ -24,11 +24,22 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Minimal stdlib example configuration for the Apple virtualization CPU."""
+"""Boot ARM Ubuntu with one AppleVirtCPU in full-system mode.
 
-from gem5.components.boards.simple_board import SimpleBoard
-from gem5.components.cachehierarchies.classic.no_cache import NoCache
-from gem5.components.memory import SingleChannelDDR3_1600
+The simulated system's output is written to
+``m5out/board.terminal``.
+"""
+
+from m5.objects import (
+    ArmDefaultRelease,
+    VExpress_GEM5_V1,
+)
+
+from gem5.components.boards.arm_board import ArmBoard
+from gem5.components.cachehierarchies.classic.private_l1_private_l2_cache_hierarchy import (
+    PrivateL1PrivateL2CacheHierarchy,
+)
+from gem5.components.memory import DualChannelDDR4_2400
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.isas import ISA
@@ -38,24 +49,31 @@ from gem5.utils.requires import requires
 
 requires(isa_required=ISA.ARM)
 
-cache_hierarchy = NoCache()
-memory = SingleChannelDDR3_1600(size="512MiB")
+cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
+    l1d_size="16KiB", l1i_size="16KiB", l2_size="256KiB"
+)
+memory = DualChannelDDR4_2400(size="2GiB")
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.APPLE_VIRT, isa=ISA.ARM, num_cores=1
+    cpu_type=CPUTypes.APPLE_VIRT,
+    isa=ISA.ARM,
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
-board = SimpleBoard(
+board = ArmBoard(
     clk_freq="3GHz",
     processor=processor,
     memory=memory,
     cache_hierarchy=cache_hierarchy,
+    release=ArmDefaultRelease.for_kvm(),
+    platform=VExpress_GEM5_V1(),
 )
 
-board.set_se_binary_workload(
-    obtain_resource("arm-hello64-static", resource_version="1.0.0")
+board.set_workload(
+    obtain_resource(
+        "arm-ubuntu-24.04-boot-with-systemd", resource_version="3.0.0"
+    )
 )
 
 simulator = Simulator(board=board)
-print("Running AppleVirtCPU stdlib smoke test")
-simulator.run(max_ticks=1_000_000)
-print(f"Exited @ tick {simulator.get_current_tick()}")
+simulator.run()

--- a/configs/example/gem5_library/apple_virt_kernel_disk.py
+++ b/configs/example/gem5_library/apple_virt_kernel_disk.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 The Regents of the University of California
+# Copyright (c) 2026 The Regents of The University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Boot ARM Ubuntu with one AppleVirtCPU in full-system mode.
+"""Boot gem5 Resource kernel and disk artifacts with AppleVirtCPU.
 
-The simulated system's output is written to
-``m5out/board.terminal``.
+This example shows the individual kernel, disk-image, and bootloader resource
+interface. The simulated terminal is written to ``m5out/board.terminal``.
 """
 
 from m5.objects import (
@@ -69,10 +69,16 @@ board = ArmBoard(
     platform=VExpress_GEM5_V1(),
 )
 
-board.set_workload(
-    obtain_resource(
-        "arm-ubuntu-24.04-boot-with-systemd", resource_version="3.0.0"
-    )
+board.set_kernel_disk_workload(
+    kernel=obtain_resource(
+        "arm64-linux-kernel-6.8.12", resource_version="1.0.0"
+    ),
+    disk_image=obtain_resource(
+        "arm-ubuntu-24.04-img", resource_version="3.0.0"
+    ),
+    bootloader=obtain_resource(
+        "arm64-bootloader-foundation", resource_version="2.0.0"
+    ),
 )
 
 simulator = Simulator(board=board)

--- a/configs/example/gem5_library/apple_virt_simple.py
+++ b/configs/example/gem5_library/apple_virt_simple.py
@@ -24,25 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Boot a local AArch64 kernel and disk image with AppleVirtCPU.
+"""Boot ARM Ubuntu with one AppleVirtCPU in full-system mode.
 
-Usage
------
-
-```
-scons build/ARM/gem5.opt -j$(sysctl -n hw.ncpu)
-./build/ARM/gem5.opt configs/example/apple_virt_kernel_disk.py \
-    --kernel /path/to/vmlinux.arm64 \
-    --disk-image /path/to/arm64-disk.img \
-    --bootloader /path/to/boot.arm64
-```
-
-The kernel, disk image, and bootloader must be compatible with the
-``VExpress_GEM5_V1`` platform. The simulated terminal is written to
+The simulated system's output is written to
 ``m5out/board.terminal``.
 """
-
-import argparse
 
 from m5.objects import (
     ArmDefaultRelease,
@@ -57,30 +43,9 @@ from gem5.components.memory import DualChannelDDR4_2400
 from gem5.components.processors.cpu_types import CPUTypes
 from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.isas import ISA
-from gem5.resources.resource import (
-    BootloaderResource,
-    DiskImageResource,
-    KernelResource,
-)
+from gem5.resources.resource import obtain_resource
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires
-
-parser = argparse.ArgumentParser(
-    description="Boot local AArch64 artifacts with AppleVirtCPU."
-)
-parser.add_argument("--kernel", required=True, help="Path to the ARM kernel.")
-parser.add_argument(
-    "--disk-image", required=True, help="Path to the ARM disk image."
-)
-parser.add_argument(
-    "--bootloader", required=True, help="Path to the ARM bootloader."
-)
-parser.add_argument(
-    "--root-partition",
-    default="1",
-    help="Root partition number in the disk image (default: 1).",
-)
-args = parser.parse_args()
 
 requires(isa_required=ISA.ARM, apple_virt_required=True)
 
@@ -104,14 +69,11 @@ board = ArmBoard(
     platform=VExpress_GEM5_V1(),
 )
 
-board.set_kernel_disk_workload(
-    kernel=KernelResource(local_path=args.kernel, architecture=ISA.ARM),
-    disk_image=DiskImageResource(
-        local_path=args.disk_image, root_partition=args.root_partition
-    ),
-    bootloader=BootloaderResource(
-        local_path=args.bootloader, architecture=ISA.ARM
-    ),
+board.set_workload(
+    obtain_resource(
+        "arm-ubuntu-24.04-boot-with-systemd", resource_version="3.0.0"
+    )
 )
 
-Simulator(board=board).run()
+simulator = Simulator(board=board)
+simulator.run()

--- a/configs/example/gem5_library/apple_virt_switch.py
+++ b/configs/example/gem5_library/apple_virt_switch.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 The Regents of The University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Boot with AppleVirt, switch to Timing, then switch back to AppleVirt."""
+
+import m5
+from m5.objects import (
+    ArmDefaultRelease,
+    VExpress_GEM5_V1,
+)
+
+from gem5.components.boards.arm_board import ArmBoard
+from gem5.components.cachehierarchies.classic.private_l1_private_l2_cache_hierarchy import (
+    PrivateL1PrivateL2CacheHierarchy,
+)
+from gem5.components.memory import DualChannelDDR4_2400
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_switchable_processor import (
+    SimpleSwitchableProcessor,
+)
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.exit_handler import (
+    AfterBootExitHandler,
+    ExitHandler,
+    ExitHypercall,
+)
+from gem5.simulate.simulator import Simulator
+from gem5.utils.override import overrides
+from gem5.utils.requires import requires
+
+requires(isa_required=ISA.ARM, apple_virt_required=True)
+
+
+class SwitchToTimingHandler(AfterBootExitHandler):
+    @overrides(AfterBootExitHandler)
+    def _process(self, simulator: Simulator) -> None:
+        simulator.switch_processor()
+        print("Switched from AppleVirt to Timing")
+        m5.scheduleTickExitFromCurrent(
+            10_000_000, "Timing takeover interval complete"
+        )
+
+
+class SwitchToAppleVirtHandler(
+    ExitHandler, hypercall=ExitHypercall.SCHEDULED_EXIT
+):
+    @overrides(ExitHandler)
+    def _process(self, simulator: Simulator) -> None:
+        timing_insts = processor.get_total_instructions()
+        if timing_insts <= 0:
+            raise AssertionError(
+                "Timing CPU did not execute instructions after takeover"
+            )
+        print(f"Timing CPU executed {timing_insts} guest instructions")
+        simulator.switch_processor()
+        print("Switched from Timing to AppleVirt")
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return False
+
+
+class SwitchingCompleteHandler(ExitHandler, hypercall_id=101):
+    @overrides(ExitHandler)
+    def _process(self, simulator: Simulator) -> None:
+        print("AppleVirt switching completed successfully")
+
+    @overrides(ExitHandler)
+    def _exit_simulation(self) -> bool:
+        return True
+
+
+cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
+    l1d_size="16KiB", l1i_size="16KiB", l2_size="256KiB"
+)
+memory = DualChannelDDR4_2400(size="2GiB")
+processor = SimpleSwitchableProcessor(
+    starting_core_type=CPUTypes.APPLE_VIRT,
+    switch_core_type=CPUTypes.TIMING,
+    isa=ISA.ARM,
+    num_cores=1,
+    clk_freq="3GHz",
+)
+
+board = ArmBoard(
+    clk_freq="3GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+    release=ArmDefaultRelease.for_kvm(),
+    platform=VExpress_GEM5_V1(),
+)
+workload = obtain_resource(
+    "arm-ubuntu-24.04-boot-with-systemd", resource_version="3.0.0"
+)
+workload.set_parameter(
+    "readfile_contents",
+    "echo 'AppleVirt CPU executed guest code'\n" "gem5-bridge hypercall 101\n",
+)
+board.set_workload(workload)
+
+simulator = Simulator(board=board)
+simulator.run()

--- a/ext/testlib/configuration.py
+++ b/ext/testlib/configuration.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2021 ARM Limited
+# Copyright (c) 2026 The Regents of The University of California
 # All rights reserved
 #
 # The license below extends only to copyright in the software and shall
@@ -406,7 +407,9 @@ def define_post_processors(config):
             try:
                 import platform
 
-                host_machine = platform.machine()
+                host_machine = platform.machine().lower()
+                if host_machine == "arm64":
+                    host_machine = constants.host_arm_tag
                 if host_machine not in constants.supported_hosts:
                     raise ValueError("Invalid host machine")
                 return [[host_machine]]

--- a/src/SConscript
+++ b/src/SConscript
@@ -412,6 +412,28 @@ class SharedLib(TopLevelBase):
 class Executable(TopLevelBase):
     '''Base class for creating an executable from sources.'''
 
+    appleVirtEntitlement = False
+
+    def applyAppleVirtEntitlement(self, env, target):
+        if not self.appleVirtEntitlement or not env['CONF'].get(
+                'USE_APPLE_VIRT', False):
+            return
+
+        entitlement = File(
+            '#src/cpu/apple_virt/apple_virt.entitlements'
+        )
+        env['APPLE_VIRT_CODESIGN'] = env['CONF']['APPLE_VIRT_CODESIGN']
+        env['APPLE_VIRT_ENTITLEMENTS'] = entitlement.abspath
+        env.Depends(target, entitlement)
+        env.AddPostAction(
+            target,
+            MakeAction(
+                '"$APPLE_VIRT_CODESIGN" --force --sign - '
+                '--entitlements "$APPLE_VIRT_ENTITLEMENTS" "$TARGET"',
+                Transform('CODESIGN', 0),
+            ),
+        )
+
     def path(self, env):
         return self.dir.File(self.target + '.${ENV_LABEL}')
 
@@ -430,6 +452,7 @@ class Executable(TopLevelBase):
             env.Append(LIBS=list(lib.source for lib in libs))
 
         executable = env.Program(self.path(env).abspath, objs)[0]
+        self.applyAppleVirtEntitlement(env, executable)
 
         if sys.platform == 'sunos5':
             cmd = 'cp $SOURCE $TARGET; strip $TARGET'
@@ -438,11 +461,14 @@ class Executable(TopLevelBase):
         stripped = env.Command(executable.abspath + '.stripped',
                                executable.abspath,
                                MakeAction(cmd, Transform("STRIP")))[0]
+        self.applyAppleVirtEntitlement(env, stripped)
 
         return [executable, stripped]
 
 class Gem5(Executable):
     '''Base class for the main gem5 executable.'''
+
+    appleVirtEntitlement = True
 
     def declare(self, env):
         objs = self.srcs_to_objs(env, self.sources(env))
@@ -458,6 +484,9 @@ class GTest(Executable):
     '''Create a unit test based on the google test framework.'''
     all = []
     def __init__(self, *srcs_and_filts, **kwargs):
+        self.appleVirtEntitlement = kwargs.pop(
+            'apple_virt_entitlement', False
+        )
         if not kwargs.pop('skip_lib', False):
             srcs_and_filts = srcs_and_filts + (with_tag('gtest lib'),)
         super().__init__(*srcs_and_filts)

--- a/src/arch/arm/apple_virt/ArmAppleVirtCPU.py
+++ b/src/arch/arm/apple_virt/ArmAppleVirtCPU.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+from m5.objects.BaseArmAppleVirtCPU import BaseArmAppleVirtCPU
+from m5.params import *
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+class ArmAppleVirtCPU(BaseArmAppleVirtCPU):
+    type = "ArmAppleVirtCPU"
+    cxx_header = "arch/arm/apple_virt/arm_cpu.hh"
+    cxx_class = "gem5::ArmAppleVirtCPU"

--- a/src/arch/arm/apple_virt/BaseArmAppleVirtCPU.py
+++ b/src/arch/arm/apple_virt/BaseArmAppleVirtCPU.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+from m5.objects.ArmCPU import ArmCPU
+from m5.objects.ArmMMU import ArmMMU
+from m5.objects.BaseAppleVirtCPU import BaseAppleVirtCPU
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+class BaseArmAppleVirtCPU(BaseAppleVirtCPU, ArmCPU):
+    type = "BaseArmAppleVirtCPU"
+    cxx_header = "arch/arm/apple_virt/base_cpu.hh"
+    cxx_class = "gem5::BaseArmAppleVirtCPU"
+    abstract = True
+
+    mmu = ArmMMU()

--- a/src/arch/arm/apple_virt/SConscript
+++ b/src/arch/arm/apple_virt/SConscript
@@ -38,3 +38,5 @@ SimObject('ArmAppleVirtCPU.py', sim_objects=['ArmAppleVirtCPU'],
 
 Source('base_cpu.cc', tags=['arm apple_virt'])
 Source('arm_cpu.cc', tags=['arm apple_virt'])
+
+GTest('exit_decode.test', 'exit_decode.test.cc')

--- a/src/arch/arm/apple_virt/SConscript
+++ b/src/arch/arm/apple_virt/SConscript
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+Import('*')
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
+if env['CONF'].get('APPLE_VIRT_ISA') != 'arm' \
+        or not env['CONF'].get('USE_ARM_ISA', False) \
+        or not env['CONF'].get('USE_APPLE_VIRT', False):
+    Return()
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+SimObject('BaseArmAppleVirtCPU.py', sim_objects=['BaseArmAppleVirtCPU'],
+          tags=['arm apple_virt'])
+SimObject('ArmAppleVirtCPU.py', sim_objects=['ArmAppleVirtCPU'],
+          tags=['arm apple_virt'])
+
+Source('base_cpu.cc', tags=['arm apple_virt'])
+Source('arm_cpu.cc', tags=['arm apple_virt'])

--- a/src/arch/arm/apple_virt/SConscript
+++ b/src/arch/arm/apple_virt/SConscript
@@ -40,3 +40,8 @@ Source('base_cpu.cc', tags=['arm apple_virt'])
 Source('arm_cpu.cc', tags=['arm apple_virt'])
 
 GTest('exit_decode.test', 'exit_decode.test.cc')
+GTest(
+    'hypervisor.test',
+    'hypervisor.test.cc',
+    apple_virt_entitlement=True,
+)

--- a/src/arch/arm/apple_virt/SConsopts
+++ b/src/arch/arm/apple_virt/SConsopts
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
+Import('*')
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+host_isa = None
+try:
+    import platform
+    host_isa = platform.machine()
+except Exception:
+    pass
+
+if host_isa in ('arm64', 'aarch64'):
+    main['CONF']['APPLE_VIRT_ISA'] = 'arm'

--- a/src/arch/arm/apple_virt/arm_cpu.cc
+++ b/src/arch/arm/apple_virt/arm_cpu.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "arch/arm/apple_virt/arm_cpu.hh"
+
+#include "params/ArmAppleVirtCPU.hh"
+
+namespace gem5
+{
+
+ArmAppleVirtCPU::ArmAppleVirtCPU(const ArmAppleVirtCPUParams &params)
+    : BaseArmAppleVirtCPU(params)
+{}
+
+} // namespace gem5

--- a/src/arch/arm/apple_virt/arm_cpu.hh
+++ b/src/arch/arm/apple_virt/arm_cpu.hh
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_ARM_APPLE_VIRT_ARM_CPU_HH__
+#define __ARCH_ARM_APPLE_VIRT_ARM_CPU_HH__
+
+#include "arch/arm/apple_virt/base_cpu.hh"
+
+namespace gem5
+{
+
+struct ArmAppleVirtCPUParams;
+
+class ArmAppleVirtCPU : public BaseArmAppleVirtCPU
+{
+  public:
+    ArmAppleVirtCPU(const ArmAppleVirtCPUParams &params);
+};
+
+} // namespace gem5
+
+#endif

--- a/src/arch/arm/apple_virt/base_cpu.cc
+++ b/src/arch/arm/apple_virt/base_cpu.cc
@@ -28,15 +28,60 @@
 
 #include "arch/arm/apple_virt/base_cpu.hh"
 
+#include <algorithm>
+#include <cstring>
+
+#include "arch/arm/apple_virt/exit_decode.hh"
+#include "arch/arm/interrupts.hh"
+#include "arch/arm/pcstate.hh"
+#include "arch/arm/regs/cc.hh"
 #include "arch/arm/regs/int.hh"
 #include "arch/arm/regs/misc.hh"
 #include "arch/arm/regs/misc_types.hh"
+#include "arch/arm/regs/vec.hh"
+#include "arch/arm/utility.hh"
+#include "base/bitfield.hh"
 #include "cpu/thread_context.hh"
 #include "debug/AppleVirtRun.hh"
 #include "params/BaseArmAppleVirtCPU.hh"
 
 namespace gem5
 {
+
+namespace
+{
+
+struct SysRegMap
+{
+    hv_sys_reg_t hv;
+    ArmISA::MiscRegIndex gem5;
+    bool effectful = false;
+};
+
+const SysRegMap sysRegMap[] = {
+    {HV_SYS_REG_SCTLR_EL1, ArmISA::MISCREG_SCTLR_EL1},
+    {HV_SYS_REG_CPACR_EL1, ArmISA::MISCREG_CPACR_EL1},
+    {HV_SYS_REG_TTBR0_EL1, ArmISA::MISCREG_TTBR0_EL1},
+    {HV_SYS_REG_TTBR1_EL1, ArmISA::MISCREG_TTBR1_EL1},
+    {HV_SYS_REG_TCR_EL1, ArmISA::MISCREG_TCR_EL1},
+    {HV_SYS_REG_SPSR_EL1, ArmISA::MISCREG_SPSR_EL1},
+    {HV_SYS_REG_ELR_EL1, ArmISA::MISCREG_ELR_EL1},
+    {HV_SYS_REG_AFSR0_EL1, ArmISA::MISCREG_AFSR0_EL1},
+    {HV_SYS_REG_AFSR1_EL1, ArmISA::MISCREG_AFSR1_EL1},
+    {HV_SYS_REG_ESR_EL1, ArmISA::MISCREG_ESR_EL1},
+    {HV_SYS_REG_FAR_EL1, ArmISA::MISCREG_FAR_EL1},
+    {HV_SYS_REG_PAR_EL1, ArmISA::MISCREG_PAR_EL1},
+    {HV_SYS_REG_MAIR_EL1, ArmISA::MISCREG_MAIR_EL1},
+    {HV_SYS_REG_AMAIR_EL1, ArmISA::MISCREG_AMAIR_EL1},
+    {HV_SYS_REG_VBAR_EL1, ArmISA::MISCREG_VBAR_EL1},
+    {HV_SYS_REG_CONTEXTIDR_EL1, ArmISA::MISCREG_CONTEXTIDR_EL1},
+    {HV_SYS_REG_TPIDR_EL1, ArmISA::MISCREG_TPIDR_EL1},
+    {HV_SYS_REG_TPIDR_EL0, ArmISA::MISCREG_TPIDR_EL0},
+    {HV_SYS_REG_TPIDRRO_EL0, ArmISA::MISCREG_TPIDRRO_EL0},
+    {HV_SYS_REG_CNTKCTL_EL1, ArmISA::MISCREG_CNTKCTL_EL1, true},
+};
+
+} // anonymous namespace
 
 BaseArmAppleVirtCPU::BaseArmAppleVirtCPU(
     const BaseArmAppleVirtCPUParams &params)
@@ -55,29 +100,67 @@ BaseArmAppleVirtCPU::syncThreadToHV()
     ThreadContext *tc = threadContext;
     fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
 
+    fatal_if(!ArmISA::inAArch64(tc),
+             "AppleVirtCPU supports AArch64 guest state only");
     ArmISA::CPSR pstate(tc->readMiscRegNoEffect(ArmISA::MISCREG_CPSR));
-
-    if (pstate.width) {
-        warn_once("AppleVirtCPU forcing AArch64 guest state for HVF run");
-        pstate.width = 0;
-        pstate.el = 0;
-        pstate.sp = 0;
-        pstate.t = 0;
-    }
+    fatal_if(pstate.el > 1,
+             "AppleVirtCPU supports guest exception levels EL0 and EL1");
+    pstate.nz = tc->getReg(ArmISA::cc_reg::Nz);
+    pstate.c = tc->getReg(ArmISA::cc_reg::C);
+    pstate.v = tc->getReg(ArmISA::cc_reg::V);
 
     hv_return_t hv_err =
         hv_vcpu_set_reg(hvVCPU, HV_REG_CPSR, static_cast<RegVal>(pstate));
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to set HVF PSTATE register (err=%d)", hv_err);
 
-    const RegVal sp = tc->getReg(ArmISA::int_reg::Spx);
-    hv_err = hv_vcpu_set_sys_reg(hvVCPU, HV_SYS_REG_SP_EL0, sp);
+    hv_err = hv_vcpu_set_sys_reg(
+        hvVCPU, HV_SYS_REG_SP_EL0,
+        tc->getReg(ArmISA::intRegClass[ArmISA::int_reg::Sp0]));
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to set HVF SP_EL0 register (err=%d)", hv_err);
 
-    hv_err = hv_vcpu_set_sys_reg(hvVCPU, HV_SYS_REG_SP_EL1, sp);
+    hv_err = hv_vcpu_set_sys_reg(
+        hvVCPU, HV_SYS_REG_SP_EL1,
+        tc->getReg(ArmISA::intRegClass[ArmISA::int_reg::Sp1]));
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to set HVF SP_EL1 register (err=%d)", hv_err);
+
+    for (const auto &mapping : sysRegMap) {
+        RegVal value;
+        if (mapping.effectful) {
+            EventQueue::ScopedMigration migrate(vm->eventQueue());
+            value = tc->readMiscReg(mapping.gem5);
+        } else {
+            value = tc->readMiscRegNoEffect(mapping.gem5);
+        }
+        hv_err = hv_vcpu_set_sys_reg(hvVCPU, mapping.hv, value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to set HVF system register %#x (err=%d)", mapping.hv,
+                 hv_err);
+    }
+
+    for (int idx = 0; idx < ArmISA::NumVecV8ArchRegs; ++idx) {
+        ArmISA::VecRegContainer container;
+        tc->getReg(ArmISA::vecRegClass[idx], &container);
+        hv_simd_fp_uchar16_t value{};
+        const auto bytes = container.as<uint8_t>();
+        std::memcpy(&value, bytes, sizeof(value));
+        hv_err = hv_vcpu_set_simd_fp_reg(
+            hvVCPU, static_cast<hv_simd_fp_reg_t>(HV_SIMD_FP_REG_Q0 + idx),
+            value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to set HVF Q%d register (err=%d)", idx, hv_err);
+    }
+
+    hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_FPCR,
+                             tc->readMiscRegNoEffect(ArmISA::MISCREG_FPCR));
+    fatal_if(hv_err != HV_SUCCESS, "Failed to set HVF FPCR register (err=%d)",
+             hv_err);
+    hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_FPSR,
+                             tc->readMiscRegNoEffect(ArmISA::MISCREG_FPSR));
+    fatal_if(hv_err != HV_SUCCESS, "Failed to set HVF FPSR register (err=%d)",
+             hv_err);
 }
 
 void
@@ -92,13 +175,196 @@ BaseArmAppleVirtCPU::syncHVToThread()
     hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_CPSR, &pstate);
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to read HVF PSTATE register (err=%d)", hv_err);
-    tc->setMiscRegNoEffect(ArmISA::MISCREG_CPSR, pstate);
+    const ArmISA::CPSR cpsr(pstate);
+    tc->setMiscRegNoEffect(ArmISA::MISCREG_CPSR, cpsr);
+    tc->setReg(ArmISA::cc_reg::Nz, cpsr.nz);
+    tc->setReg(ArmISA::cc_reg::C, cpsr.c);
+    tc->setReg(ArmISA::cc_reg::V, cpsr.v);
 
     RegVal sp = 0;
     hv_err = hv_vcpu_get_sys_reg(hvVCPU, HV_SYS_REG_SP_EL0, &sp);
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to read HVF SP_EL0 register (err=%d)", hv_err);
-    tc->setReg(ArmISA::int_reg::Spx, sp);
+    tc->setReg(ArmISA::intRegClass[ArmISA::int_reg::Sp0], sp);
+
+    hv_err = hv_vcpu_get_sys_reg(hvVCPU, HV_SYS_REG_SP_EL1, &sp);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to read HVF SP_EL1 register (err=%d)", hv_err);
+    tc->setReg(ArmISA::intRegClass[ArmISA::int_reg::Sp1], sp);
+
+    for (const auto &mapping : sysRegMap) {
+        RegVal value = 0;
+        hv_err = hv_vcpu_get_sys_reg(hvVCPU, mapping.hv, &value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to read HVF system register %#x (err=%d)", mapping.hv,
+                 hv_err);
+        if (mapping.effectful) {
+            EventQueue::ScopedMigration migrate(vm->eventQueue());
+            tc->setMiscReg(mapping.gem5, value);
+        } else {
+            tc->setMiscRegNoEffect(mapping.gem5, value);
+        }
+    }
+
+    for (int idx = 0; idx < ArmISA::NumVecV8ArchRegs; ++idx) {
+        hv_simd_fp_uchar16_t value{};
+        hv_err = hv_vcpu_get_simd_fp_reg(
+            hvVCPU, static_cast<hv_simd_fp_reg_t>(HV_SIMD_FP_REG_Q0 + idx),
+            &value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to read HVF Q%d register (err=%d)", idx, hv_err);
+        auto *container = static_cast<ArmISA::VecRegContainer *>(
+            tc->getWritableReg(ArmISA::vecRegClass[idx]));
+        auto bytes = container->as<uint8_t>();
+        std::memcpy(bytes, &value, sizeof(value));
+    }
+
+    RegVal value = 0;
+    hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_FPCR, &value);
+    fatal_if(hv_err != HV_SUCCESS, "Failed to read HVF FPCR register (err=%d)",
+             hv_err);
+    tc->setMiscRegNoEffect(ArmISA::MISCREG_FPCR, value);
+    hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_FPSR, &value);
+    fatal_if(hv_err != HV_SUCCESS, "Failed to read HVF FPSR register (err=%d)",
+             hv_err);
+    tc->setMiscRegNoEffect(ArmISA::MISCREG_FPSR, value);
+
+    ArmISA::PCState pc = tc->pcState().as<ArmISA::PCState>();
+    pc.aarch64(true);
+    pc.nextAArch64(true);
+    pc.thumb(false);
+    pc.nextThumb(false);
+    tc->pcState(pc);
+}
+
+void
+BaseArmAppleVirtCPU::updateInterrupts()
+{
+    auto *interrupt = static_cast<ArmISA::Interrupts *>(interrupts[0]);
+    const bool irq = interrupt->checkRaw(ArmISA::INT_IRQ);
+    const bool fiq = interrupt->checkRaw(ArmISA::INT_FIQ);
+
+    hv_return_t hv_err =
+        hv_vcpu_set_pending_interrupt(hvVCPU, HV_INTERRUPT_TYPE_IRQ, irq);
+    fatal_if(hv_err != HV_SUCCESS, "Failed to update HVF IRQ state (err=%d)",
+             hv_err);
+    hv_err = hv_vcpu_set_pending_interrupt(hvVCPU, HV_INTERRUPT_TYPE_FIQ, fiq);
+    fatal_if(hv_err != HV_SUCCESS, "Failed to update HVF FIQ state (err=%d)",
+             hv_err);
+}
+
+Tick
+BaseArmAppleVirtCPU::handleException(const hv_vcpu_exit_exception_t &exception)
+{
+    const auto decoded = ArmISA::AppleVirt::decodeExit(exception.syndrome);
+    using ArmISA::AppleVirt::ExitKind;
+
+    DPRINTF(AppleVirtRun,
+            "exception PC=%#x ESR=%#llx EC=%#x ISS=%#x FAR=%#llx "
+            "IPA=%#llx\n",
+            threadContext->pcState().instAddr(),
+            static_cast<unsigned long long>(exception.syndrome), decoded.ec,
+            decoded.iss,
+            static_cast<unsigned long long>(exception.virtual_address),
+            static_cast<unsigned long long>(exception.physical_address));
+
+    if (decoded.kind == ExitKind::Wfi || decoded.kind == ExitKind::Wfe) {
+        advancePC();
+        return 0;
+    }
+
+    if (decoded.kind == ExitKind::SystemRegister) {
+        const auto &sys_reg = decoded.systemRegister;
+        const ArmISA::MiscRegIndex misc_reg = ArmISA::decodeAArch64SysReg(
+            sys_reg.op0, sys_reg.op1, sys_reg.crn, sys_reg.crm, sys_reg.op2);
+        fatal_if(misc_reg == ArmISA::MISCREG_UNKNOWN ||
+                     misc_reg == ArmISA::MISCREG_IMPDEF_UNIMPL,
+                 "Unsupported AppleVirtCPU system register access: "
+                 "S%u_%u_C%u_C%u_%u ESR=%#llx",
+                 sys_reg.op0, sys_reg.op1, sys_reg.crn, sys_reg.crm,
+                 sys_reg.op2,
+                 static_cast<unsigned long long>(exception.syndrome));
+
+        if (sys_reg.read) {
+            const RegVal value = threadContext->readMiscReg(misc_reg);
+            if (sys_reg.targetRegister != 31) {
+                threadContext->setReg(
+                    ArmISA::int_reg::x(sys_reg.targetRegister), value);
+                const hv_return_t hv_err = hv_vcpu_set_reg(
+                    hvVCPU,
+                    static_cast<hv_reg_t>(HV_REG_X0 + sys_reg.targetRegister),
+                    value);
+                fatal_if(hv_err != HV_SUCCESS,
+                         "Failed to complete AppleVirtCPU system register "
+                         "read (err=%d)",
+                         hv_err);
+            }
+        } else {
+            const RegVal value =
+                sys_reg.targetRegister == 31
+                    ? 0
+                    : threadContext->getReg(
+                          ArmISA::int_reg::x(sys_reg.targetRegister));
+            threadContext->setMiscReg(misc_reg, value);
+        }
+
+        advancePC();
+        return 0;
+    }
+
+    if (decoded.kind != ExitKind::DataAbort) {
+        fatal("Unsupported AppleVirtCPU exception: ESR=%#llx EC=%#x "
+              "ISS=%#x FAR=%#llx IPA=%#llx",
+              static_cast<unsigned long long>(exception.syndrome), decoded.ec,
+              decoded.iss,
+              static_cast<unsigned long long>(exception.virtual_address),
+              static_cast<unsigned long long>(exception.physical_address));
+    }
+
+    const auto &abort = decoded.dataAbort;
+    fatal_if(!abort.valid || abort.s1ptw || abort.cacheMaintenance,
+             "Unsupported AppleVirtCPU data abort: ESR=%#llx FAR=%#llx "
+             "IPA=%#llx",
+             static_cast<unsigned long long>(exception.syndrome),
+             static_cast<unsigned long long>(exception.virtual_address),
+             static_cast<unsigned long long>(exception.physical_address));
+
+    RegVal value = 0;
+    if (abort.write && abort.targetRegister != 31) {
+        value =
+            threadContext->getReg(ArmISA::int_reg::x(abort.targetRegister));
+    }
+
+    const Tick delay = doMMIOAccess(exception.physical_address, &value,
+                                    abort.size, abort.write);
+
+    if (!abort.write && abort.targetRegister != 31) {
+        const unsigned bits = abort.size * 8;
+        value &= mask(bits);
+        if (abort.signExtend) {
+            const RegVal sign_bit = RegVal(1) << (bits - 1);
+            value = (value ^ sign_bit) - sign_bit;
+        }
+        if (!abort.sf) {
+            value = static_cast<uint32_t>(value);
+        }
+        threadContext->setReg(ArmISA::int_reg::x(abort.targetRegister), value);
+        hv_return_t hv_err = hv_vcpu_set_reg(
+            hvVCPU, static_cast<hv_reg_t>(HV_REG_X0 + abort.targetRegister),
+            value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to complete AppleVirtCPU MMIO read (err=%d)", hv_err);
+    }
+
+    advancePC();
+    return delay;
+}
+
+void
+BaseArmAppleVirtCPU::handleVTimerActivated()
+{
+    fatal("AppleVirtCPU does not support the architectural virtual timer; "
+          "use a gem5-simulated timer");
 }
 
 } // namespace gem5

--- a/src/arch/arm/apple_virt/base_cpu.cc
+++ b/src/arch/arm/apple_virt/base_cpu.cc
@@ -101,7 +101,9 @@ BaseArmAppleVirtCPU::BaseArmAppleVirtCPU(
 
 void
 BaseArmAppleVirtCPU::startup()
-{ BaseAppleVirtCPU::startup(); }
+{
+    BaseAppleVirtCPU::startup();
+}
 
 void
 BaseArmAppleVirtCPU::syncThreadToHV()

--- a/src/arch/arm/apple_virt/base_cpu.cc
+++ b/src/arch/arm/apple_virt/base_cpu.cc
@@ -312,14 +312,15 @@ BaseArmAppleVirtCPU::handleException(const hv_vcpu_exit_exception_t &exception)
     const auto decoded = ArmISA::AppleVirt::decodeExit(exception.syndrome);
     using ArmISA::AppleVirt::ExitKind;
 
-    DPRINTF(AppleVirtRun,
-            "exception PC=%#x ESR=%#llx EC=%#x ISS=%#x FAR=%#llx "
-            "IPA=%#llx\n",
-            threadContext->pcState().instAddr(),
-            static_cast<unsigned long long>(exception.syndrome), decoded.ec,
-            decoded.iss,
-            static_cast<unsigned long long>(exception.virtual_address),
-            static_cast<unsigned long long>(exception.physical_address));
+    DPRINTF(
+        AppleVirtRun,
+        "exception PC=%#llx ESR=%#llx EC=%#x ISS=%#x FAR=%#llx "
+        "IPA=%#llx\n",
+        static_cast<unsigned long long>(threadContext->pcState().instAddr()),
+        static_cast<unsigned long long>(exception.syndrome), decoded.ec,
+        decoded.iss,
+        static_cast<unsigned long long>(exception.virtual_address),
+        static_cast<unsigned long long>(exception.physical_address));
 
     if (decoded.kind == ExitKind::Wfi || decoded.kind == ExitKind::Wfe) {
         advancePC();

--- a/src/arch/arm/apple_virt/base_cpu.cc
+++ b/src/arch/arm/apple_virt/base_cpu.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "arch/arm/apple_virt/base_cpu.hh"
+
+#include "arch/arm/regs/int.hh"
+#include "arch/arm/regs/misc.hh"
+#include "arch/arm/regs/misc_types.hh"
+#include "cpu/thread_context.hh"
+#include "debug/AppleVirtRun.hh"
+#include "params/BaseArmAppleVirtCPU.hh"
+
+namespace gem5
+{
+
+BaseArmAppleVirtCPU::BaseArmAppleVirtCPU(
+    const BaseArmAppleVirtCPUParams &params)
+    : BaseAppleVirtCPU(params)
+{}
+
+void
+BaseArmAppleVirtCPU::startup()
+{ BaseAppleVirtCPU::startup(); }
+
+void
+BaseArmAppleVirtCPU::syncThreadToHV()
+{
+    BaseAppleVirtCPU::syncThreadToHV();
+
+    ThreadContext *tc = threadContext;
+    fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
+
+    ArmISA::CPSR pstate(tc->readMiscRegNoEffect(ArmISA::MISCREG_CPSR));
+
+    if (pstate.width) {
+        warn_once("AppleVirtCPU forcing AArch64 guest state for HVF run");
+        pstate.width = 0;
+        pstate.el = 0;
+        pstate.sp = 0;
+        pstate.t = 0;
+    }
+
+    hv_return_t hv_err =
+        hv_vcpu_set_reg(hvVCPU, HV_REG_CPSR, static_cast<RegVal>(pstate));
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to set HVF PSTATE register (err=%d)", hv_err);
+
+    const RegVal sp = tc->getReg(ArmISA::int_reg::Spx);
+    hv_err = hv_vcpu_set_sys_reg(hvVCPU, HV_SYS_REG_SP_EL0, sp);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to set HVF SP_EL0 register (err=%d)", hv_err);
+
+    hv_err = hv_vcpu_set_sys_reg(hvVCPU, HV_SYS_REG_SP_EL1, sp);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to set HVF SP_EL1 register (err=%d)", hv_err);
+}
+
+void
+BaseArmAppleVirtCPU::syncHVToThread()
+{
+    BaseAppleVirtCPU::syncHVToThread();
+
+    ThreadContext *tc = threadContext;
+    fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
+
+    RegVal pstate = 0;
+    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_CPSR, &pstate);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to read HVF PSTATE register (err=%d)", hv_err);
+    tc->setMiscRegNoEffect(ArmISA::MISCREG_CPSR, pstate);
+
+    RegVal sp = 0;
+    hv_err = hv_vcpu_get_sys_reg(hvVCPU, HV_SYS_REG_SP_EL0, &sp);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to read HVF SP_EL0 register (err=%d)", hv_err);
+    tc->setReg(ArmISA::int_reg::Spx, sp);
+}
+
+} // namespace gem5

--- a/src/arch/arm/apple_virt/base_cpu.cc
+++ b/src/arch/arm/apple_virt/base_cpu.cc
@@ -64,6 +64,16 @@ const SysRegMap sysRegMap[] = {
     {HV_SYS_REG_TTBR0_EL1, ArmISA::MISCREG_TTBR0_EL1},
     {HV_SYS_REG_TTBR1_EL1, ArmISA::MISCREG_TTBR1_EL1},
     {HV_SYS_REG_TCR_EL1, ArmISA::MISCREG_TCR_EL1},
+    {HV_SYS_REG_APIAKEYLO_EL1, ArmISA::MISCREG_APIAKeyLo_EL1},
+    {HV_SYS_REG_APIAKEYHI_EL1, ArmISA::MISCREG_APIAKeyHi_EL1},
+    {HV_SYS_REG_APIBKEYLO_EL1, ArmISA::MISCREG_APIBKeyLo_EL1},
+    {HV_SYS_REG_APIBKEYHI_EL1, ArmISA::MISCREG_APIBKeyHi_EL1},
+    {HV_SYS_REG_APDAKEYLO_EL1, ArmISA::MISCREG_APDAKeyLo_EL1},
+    {HV_SYS_REG_APDAKEYHI_EL1, ArmISA::MISCREG_APDAKeyHi_EL1},
+    {HV_SYS_REG_APDBKEYLO_EL1, ArmISA::MISCREG_APDBKeyLo_EL1},
+    {HV_SYS_REG_APDBKEYHI_EL1, ArmISA::MISCREG_APDBKeyHi_EL1},
+    {HV_SYS_REG_APGAKEYLO_EL1, ArmISA::MISCREG_APGAKeyLo_EL1},
+    {HV_SYS_REG_APGAKEYHI_EL1, ArmISA::MISCREG_APGAKeyHi_EL1},
     {HV_SYS_REG_SPSR_EL1, ArmISA::MISCREG_SPSR_EL1},
     {HV_SYS_REG_ELR_EL1, ArmISA::MISCREG_ELR_EL1},
     {HV_SYS_REG_AFSR0_EL1, ArmISA::MISCREG_AFSR0_EL1},
@@ -76,6 +86,7 @@ const SysRegMap sysRegMap[] = {
     {HV_SYS_REG_VBAR_EL1, ArmISA::MISCREG_VBAR_EL1},
     {HV_SYS_REG_CONTEXTIDR_EL1, ArmISA::MISCREG_CONTEXTIDR_EL1},
     {HV_SYS_REG_TPIDR_EL1, ArmISA::MISCREG_TPIDR_EL1},
+    {HV_SYS_REG_CSSELR_EL1, ArmISA::MISCREG_CSSELR_EL1},
     {HV_SYS_REG_TPIDR_EL0, ArmISA::MISCREG_TPIDR_EL0},
     {HV_SYS_REG_TPIDRRO_EL0, ArmISA::MISCREG_TPIDRRO_EL0},
     {HV_SYS_REG_CNTKCTL_EL1, ArmISA::MISCREG_CNTKCTL_EL1, true},
@@ -95,10 +106,22 @@ BaseArmAppleVirtCPU::startup()
 void
 BaseArmAppleVirtCPU::syncThreadToHV()
 {
-    BaseAppleVirtCPU::syncThreadToHV();
-
     ThreadContext *tc = threadContext;
     fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
+
+    const auto pc = tc->pcState().instAddr();
+    hv_return_t hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_PC, pc);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to set HVF PC register (pc=%#llx err=%d)",
+             static_cast<unsigned long long>(pc), hv_err);
+
+    for (int idx = 0; idx < 31; ++idx) {
+        const hv_reg_t hv_reg = static_cast<hv_reg_t>(HV_REG_X0 + idx);
+        hv_err = hv_vcpu_set_reg(hvVCPU, hv_reg,
+                                 tc->getReg(ArmISA::int_reg::x(idx)));
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to set HVF X%d register (err=%d)", idx, hv_err);
+    }
 
     fatal_if(!ArmISA::inAArch64(tc),
              "AppleVirtCPU supports AArch64 guest state only");
@@ -109,8 +132,7 @@ BaseArmAppleVirtCPU::syncThreadToHV()
     pstate.c = tc->getReg(ArmISA::cc_reg::C);
     pstate.v = tc->getReg(ArmISA::cc_reg::V);
 
-    hv_return_t hv_err =
-        hv_vcpu_set_reg(hvVCPU, HV_REG_CPSR, static_cast<RegVal>(pstate));
+    hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_CPSR, static_cast<RegVal>(pstate));
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to set HVF PSTATE register (err=%d)", hv_err);
 
@@ -166,13 +188,26 @@ BaseArmAppleVirtCPU::syncThreadToHV()
 void
 BaseArmAppleVirtCPU::syncHVToThread()
 {
-    BaseAppleVirtCPU::syncHVToThread();
-
     ThreadContext *tc = threadContext;
     fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
 
+    RegVal pc = 0;
+    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_PC, &pc);
+    fatal_if(hv_err != HV_SUCCESS, "Failed to read HVF PC register (err=%d)",
+             hv_err);
+    tc->pcState(static_cast<Addr>(pc));
+
+    for (int idx = 0; idx < 31; ++idx) {
+        const hv_reg_t hv_reg = static_cast<hv_reg_t>(HV_REG_X0 + idx);
+        RegVal value = 0;
+        hv_err = hv_vcpu_get_reg(hvVCPU, hv_reg, &value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to read HVF X%d register (err=%d)", idx, hv_err);
+        tc->setReg(ArmISA::int_reg::x(idx), value);
+    }
+
     RegVal pstate = 0;
-    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_CPSR, &pstate);
+    hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_CPSR, &pstate);
     fatal_if(hv_err != HV_SUCCESS,
              "Failed to read HVF PSTATE register (err=%d)", hv_err);
     const ArmISA::CPSR cpsr(pstate);
@@ -229,12 +264,28 @@ BaseArmAppleVirtCPU::syncHVToThread()
              hv_err);
     tc->setMiscRegNoEffect(ArmISA::MISCREG_FPSR, value);
 
-    ArmISA::PCState pc = tc->pcState().as<ArmISA::PCState>();
-    pc.aarch64(true);
-    pc.nextAArch64(true);
-    pc.thumb(false);
-    pc.nextThumb(false);
-    tc->pcState(pc);
+    ArmISA::PCState pc_state = tc->pcState().as<ArmISA::PCState>();
+    pc_state.aarch64(true);
+    pc_state.nextAArch64(true);
+    pc_state.thumb(false);
+    pc_state.nextThumb(false);
+    tc->pcState(pc_state);
+}
+
+void
+BaseArmAppleVirtCPU::advancePC()
+{
+    uint64_t pc = 0;
+    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_PC, &pc);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to read HVF PC while completing an exit (err=%d)",
+             hv_err);
+    pc += sizeof(uint32_t);
+    hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_PC, pc);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to advance HVF PC while completing an exit (err=%d)",
+             hv_err);
+    threadContext->pcState(static_cast<Addr>(pc));
 }
 
 void

--- a/src/arch/arm/apple_virt/base_cpu.hh
+++ b/src/arch/arm/apple_virt/base_cpu.hh
@@ -51,6 +51,9 @@ class BaseArmAppleVirtCPU : public BaseAppleVirtCPU
   protected:
     void syncThreadToHV() override;
     void syncHVToThread() override;
+    void updateInterrupts() override;
+    Tick handleException(const hv_vcpu_exit_exception_t &exception) override;
+    void handleVTimerActivated() override;
 };
 
 } // namespace gem5

--- a/src/arch/arm/apple_virt/base_cpu.hh
+++ b/src/arch/arm/apple_virt/base_cpu.hh
@@ -49,6 +49,7 @@ class BaseArmAppleVirtCPU : public BaseAppleVirtCPU
     void startup() override;
 
   protected:
+    void advancePC() override;
     void syncThreadToHV() override;
     void syncHVToThread() override;
     void updateInterrupts() override;

--- a/src/arch/arm/apple_virt/base_cpu.hh
+++ b/src/arch/arm/apple_virt/base_cpu.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Apple virtualization backend for Arm CPUs.
+ */
+
+#ifndef __ARCH_ARM_APPLE_VIRT_BASE_CPU_HH__
+#define __ARCH_ARM_APPLE_VIRT_BASE_CPU_HH__
+
+#include "cpu/apple_virt/base.hh"
+
+namespace gem5
+{
+
+struct BaseArmAppleVirtCPUParams;
+
+class BaseArmAppleVirtCPU : public BaseAppleVirtCPU
+{
+  public:
+    BaseArmAppleVirtCPU(const BaseArmAppleVirtCPUParams &params);
+    ~BaseArmAppleVirtCPU() override = default;
+
+    void startup() override;
+
+  protected:
+    void syncThreadToHV() override;
+    void syncHVToThread() override;
+};
+
+} // namespace gem5
+
+#endif

--- a/src/arch/arm/apple_virt/exit_decode.hh
+++ b/src/arch/arm/apple_virt/exit_decode.hh
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_ARM_APPLE_VIRT_EXIT_DECODE_HH__
+#define __ARCH_ARM_APPLE_VIRT_EXIT_DECODE_HH__
+
+#include <cstdint>
+
+namespace gem5
+{
+namespace ArmISA
+{
+namespace AppleVirt
+{
+
+enum class ExitKind
+{
+    Unsupported,
+    DataAbort,
+    SystemRegister,
+    Wfi,
+    Wfe,
+};
+
+struct SystemRegisterSyndrome
+{
+    uint8_t op0 = 0;
+    uint8_t op1 = 0;
+    uint8_t crn = 0;
+    uint8_t crm = 0;
+    uint8_t op2 = 0;
+    uint8_t targetRegister = 0;
+    bool read = false;
+};
+
+struct DataAbortSyndrome
+{
+    /** The instruction syndrome fields are valid (ESR_EL2.ISV). */
+    bool valid = false;
+    bool write = false;
+    /** Access size in bytes, or zero when valid is false. */
+    uint8_t size = 0;
+    bool signExtend = false;
+    /** Architectural integer register number, or zero when invalid. */
+    uint8_t targetRegister = 0;
+    bool sf = false;
+    bool acquireRelease = false;
+    bool cacheMaintenance = false;
+    bool s1ptw = false;
+};
+
+struct DecodedExit
+{
+    ExitKind kind = ExitKind::Unsupported;
+    uint8_t ec = 0;
+    uint32_t iss = 0;
+    DataAbortSyndrome dataAbort;
+    SystemRegisterSyndrome systemRegister;
+};
+
+/** Decode the architecture-defined fields of an AArch64 ESR value. */
+constexpr DecodedExit
+decodeExit(uint64_t esr)
+{
+    constexpr uint8_t trappedWfxEc = 0x01;
+    constexpr uint8_t trappedSystemRegisterEc = 0x18;
+    constexpr uint8_t dataAbortLowerElEc = 0x24;
+    constexpr uint8_t dataAbortSameElEc = 0x25;
+    constexpr uint32_t issMask = (1U << 25) - 1;
+
+    DecodedExit exit;
+    exit.ec = (esr >> 26) & 0x3f;
+    exit.iss = esr & issMask;
+
+    if (exit.ec == trappedWfxEc) {
+        const uint8_t trapped_instruction = exit.iss & 0x3;
+        if (trapped_instruction == 0) {
+            exit.kind = ExitKind::Wfi;
+        } else if (trapped_instruction == 1) {
+            exit.kind = ExitKind::Wfe;
+        }
+        return exit;
+    }
+
+    if (exit.ec == trappedSystemRegisterEc) {
+        exit.kind = ExitKind::SystemRegister;
+        auto &sys_reg = exit.systemRegister;
+        sys_reg.op0 = (exit.iss >> 20) & 0x3;
+        sys_reg.op1 = (exit.iss >> 14) & 0x7;
+        sys_reg.crn = (exit.iss >> 10) & 0xf;
+        sys_reg.crm = (exit.iss >> 1) & 0xf;
+        sys_reg.op2 = (exit.iss >> 17) & 0x7;
+        sys_reg.targetRegister = (exit.iss >> 5) & 0x1f;
+        sys_reg.read = exit.iss & 0x1;
+        return exit;
+    }
+
+    if (exit.ec != dataAbortLowerElEc && exit.ec != dataAbortSameElEc) {
+        return exit;
+    }
+
+    exit.kind = ExitKind::DataAbort;
+    auto &abort = exit.dataAbort;
+    abort.valid = (exit.iss >> 24) & 0x1;
+    abort.write = (exit.iss >> 6) & 0x1;
+    abort.cacheMaintenance = (exit.iss >> 8) & 0x1;
+    abort.s1ptw = (exit.iss >> 7) & 0x1;
+
+    if (abort.valid) {
+        const uint8_t sas = (exit.iss >> 22) & 0x3;
+        abort.size = 1U << sas;
+        abort.signExtend = (exit.iss >> 21) & 0x1;
+        abort.targetRegister = (exit.iss >> 16) & 0x1f;
+        abort.sf = (exit.iss >> 15) & 0x1;
+        abort.acquireRelease = (exit.iss >> 14) & 0x1;
+    }
+
+    return exit;
+}
+
+} // namespace AppleVirt
+} // namespace ArmISA
+} // namespace gem5
+
+#endif // __ARCH_ARM_APPLE_VIRT_EXIT_DECODE_HH__

--- a/src/arch/arm/apple_virt/exit_decode.test.cc
+++ b/src/arch/arm/apple_virt/exit_decode.test.cc
@@ -43,7 +43,9 @@ namespace
 
 constexpr uint64_t
 makeEsr(uint8_t ec, uint32_t iss)
-{ return (static_cast<uint64_t>(ec) << 26) | (iss & 0x1ffffff); }
+{
+    return (static_cast<uint64_t>(ec) << 26) | (iss & 0x1ffffff);
+}
 
 TEST(AppleVirtExitDecode, DecodesWfiAndWfe)
 {

--- a/src/arch/arm/apple_virt/exit_decode.test.cc
+++ b/src/arch/arm/apple_virt/exit_decode.test.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "arch/arm/apple_virt/exit_decode.hh"
+
+namespace gem5
+{
+namespace ArmISA
+{
+namespace AppleVirt
+{
+namespace
+{
+
+constexpr uint64_t
+makeEsr(uint8_t ec, uint32_t iss)
+{ return (static_cast<uint64_t>(ec) << 26) | (iss & 0x1ffffff); }
+
+TEST(AppleVirtExitDecode, DecodesWfiAndWfe)
+{
+    EXPECT_EQ(decodeExit(makeEsr(0x01, 0)).kind, ExitKind::Wfi);
+    EXPECT_EQ(decodeExit(makeEsr(0x01, 1)).kind, ExitKind::Wfe);
+}
+
+TEST(AppleVirtExitDecode, RejectsUnsupportedExceptionClassesAndWfxTypes)
+{
+    const auto unknown = decodeExit(makeEsr(0x00, 0x12345));
+    EXPECT_EQ(unknown.kind, ExitKind::Unsupported);
+    EXPECT_EQ(unknown.ec, 0x00);
+    EXPECT_EQ(unknown.iss, 0x12345);
+
+    EXPECT_EQ(decodeExit(makeEsr(0x01, 2)).kind, ExitKind::Unsupported);
+    EXPECT_EQ(decodeExit(makeEsr(0x01, 3)).kind, ExitKind::Unsupported);
+}
+
+TEST(AppleVirtExitDecode, DecodesSystemRegisterAccess)
+{
+    constexpr uint32_t iss = (2U << 20) | (4U << 17) | (3U << 14) |
+                             (9U << 10) | (17U << 5) | (12U << 1) | 1U;
+    const auto exit = decodeExit(makeEsr(0x18, iss));
+
+    EXPECT_EQ(exit.kind, ExitKind::SystemRegister);
+    EXPECT_EQ(exit.systemRegister.op0, 2);
+    EXPECT_EQ(exit.systemRegister.op1, 3);
+    EXPECT_EQ(exit.systemRegister.crn, 9);
+    EXPECT_EQ(exit.systemRegister.crm, 12);
+    EXPECT_EQ(exit.systemRegister.op2, 4);
+    EXPECT_EQ(exit.systemRegister.targetRegister, 17);
+    EXPECT_TRUE(exit.systemRegister.read);
+}
+
+TEST(AppleVirtExitDecode, DecodesValidDataAbortRead)
+{
+    constexpr uint32_t iss = (1U << 24) | (2U << 22) | (1U << 21) |
+                             (13U << 16) | (1U << 15) | (1U << 14);
+    const auto exit = decodeExit(makeEsr(0x24, iss));
+
+    EXPECT_EQ(exit.kind, ExitKind::DataAbort);
+    EXPECT_EQ(exit.ec, 0x24);
+    EXPECT_EQ(exit.iss, iss);
+    EXPECT_TRUE(exit.dataAbort.valid);
+    EXPECT_FALSE(exit.dataAbort.write);
+    EXPECT_EQ(exit.dataAbort.size, 4);
+    EXPECT_TRUE(exit.dataAbort.signExtend);
+    EXPECT_EQ(exit.dataAbort.targetRegister, 13);
+    EXPECT_TRUE(exit.dataAbort.sf);
+    EXPECT_TRUE(exit.dataAbort.acquireRelease);
+    EXPECT_FALSE(exit.dataAbort.cacheMaintenance);
+    EXPECT_FALSE(exit.dataAbort.s1ptw);
+}
+
+TEST(AppleVirtExitDecode, DecodesValidDataAbortWrite)
+{
+    constexpr uint32_t iss =
+        (1U << 24) | (3U << 22) | (31U << 16) | (1U << 8) | (1U << 6);
+    const auto exit = decodeExit(makeEsr(0x25, iss));
+
+    EXPECT_EQ(exit.kind, ExitKind::DataAbort);
+    EXPECT_TRUE(exit.dataAbort.valid);
+    EXPECT_TRUE(exit.dataAbort.write);
+    EXPECT_EQ(exit.dataAbort.size, 8);
+    EXPECT_FALSE(exit.dataAbort.signExtend);
+    EXPECT_EQ(exit.dataAbort.targetRegister, 31);
+    EXPECT_FALSE(exit.dataAbort.sf);
+    EXPECT_FALSE(exit.dataAbort.acquireRelease);
+    EXPECT_TRUE(exit.dataAbort.cacheMaintenance);
+    EXPECT_FALSE(exit.dataAbort.s1ptw);
+}
+
+TEST(AppleVirtExitDecode, KeepsIndependentFieldsForInvalidSyndrome)
+{
+    constexpr uint32_t iss = (3U << 22) | (1U << 21) | (17U << 16) |
+                             (1U << 15) | (1U << 14) | (1U << 8) | (1U << 7) |
+                             (1U << 6);
+    const auto exit = decodeExit(makeEsr(0x24, iss));
+
+    EXPECT_EQ(exit.kind, ExitKind::DataAbort);
+    EXPECT_FALSE(exit.dataAbort.valid);
+    EXPECT_TRUE(exit.dataAbort.write);
+    EXPECT_EQ(exit.dataAbort.size, 0);
+    EXPECT_FALSE(exit.dataAbort.signExtend);
+    EXPECT_EQ(exit.dataAbort.targetRegister, 0);
+    EXPECT_FALSE(exit.dataAbort.sf);
+    EXPECT_FALSE(exit.dataAbort.acquireRelease);
+    EXPECT_TRUE(exit.dataAbort.cacheMaintenance);
+    EXPECT_TRUE(exit.dataAbort.s1ptw);
+}
+
+} // anonymous namespace
+} // namespace AppleVirt
+} // namespace ArmISA
+} // namespace gem5

--- a/src/arch/arm/apple_virt/hypervisor.test.cc
+++ b/src/arch/arm/apple_virt/hypervisor.test.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Hypervisor/hv.h>
+#include <Hypervisor/hv_vcpu.h>
+#include <Hypervisor/hv_vm.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdint>
+
+namespace
+{
+
+class HypervisorTest : public testing::Test
+{
+  protected:
+    void
+    SetUp() override
+    {
+        ASSERT_EQ(hv_vm_create(nullptr), HV_SUCCESS);
+        vmCreated = true;
+    }
+
+    void
+    TearDown() override
+    {
+        if (vcpuCreated) {
+            EXPECT_EQ(hv_vcpu_destroy(vcpu), HV_SUCCESS);
+        }
+        if (memoryMapped) {
+            EXPECT_EQ(hv_vm_unmap(GuestAddress, pageSize), HV_SUCCESS);
+        }
+        if (hostPage != MAP_FAILED) {
+            EXPECT_EQ(munmap(hostPage, pageSize), 0);
+        }
+        if (vmCreated) {
+            EXPECT_EQ(hv_vm_destroy(), HV_SUCCESS);
+        }
+    }
+
+    void
+    mapGuestPage()
+    {
+        pageSize = sysconf(_SC_PAGESIZE);
+        ASSERT_GT(pageSize, 0);
+        hostPage = mmap(nullptr, pageSize, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANON, -1, 0);
+        ASSERT_NE(hostPage, MAP_FAILED);
+        ASSERT_EQ(hv_vm_map(hostPage, GuestAddress, pageSize,
+                            HV_MEMORY_READ | HV_MEMORY_EXEC),
+                  HV_SUCCESS);
+        memoryMapped = true;
+    }
+
+    void
+    createVCPU()
+    {
+        ASSERT_EQ(hv_vcpu_create(&vcpu, &exit, nullptr), HV_SUCCESS);
+        vcpuCreated = true;
+    }
+
+    static constexpr hv_ipa_t GuestAddress = 0x100000;
+    bool vmCreated = false;
+    bool memoryMapped = false;
+    bool vcpuCreated = false;
+    long pageSize = 0;
+    void *hostPage = MAP_FAILED;
+    hv_vcpu_t vcpu = 0;
+    hv_vcpu_exit_t *exit = nullptr;
+};
+
+TEST_F(HypervisorTest, CreatesVCPUAndSynchronizesRegisters)
+{
+    createVCPU();
+
+    constexpr uint64_t value = 0x123456789abcdef0;
+    ASSERT_EQ(hv_vcpu_set_reg(vcpu, HV_REG_X0, value), HV_SUCCESS);
+
+    uint64_t observed = 0;
+    ASSERT_EQ(hv_vcpu_get_reg(vcpu, HV_REG_X0, &observed), HV_SUCCESS);
+    EXPECT_EQ(observed, value);
+}
+
+TEST_F(HypervisorTest, SynchronizesPointerAuthenticationKeys)
+{
+    createVCPU();
+
+    constexpr std::array keys = {
+        HV_SYS_REG_APIAKEYLO_EL1, HV_SYS_REG_APIAKEYHI_EL1,
+        HV_SYS_REG_APIBKEYLO_EL1, HV_SYS_REG_APIBKEYHI_EL1,
+        HV_SYS_REG_APDAKEYLO_EL1, HV_SYS_REG_APDAKEYHI_EL1,
+        HV_SYS_REG_APDBKEYLO_EL1, HV_SYS_REG_APDBKEYHI_EL1,
+        HV_SYS_REG_APGAKEYLO_EL1, HV_SYS_REG_APGAKEYHI_EL1,
+    };
+
+    constexpr uint64_t value = 0x123456789abcdef0;
+    for (const auto key : keys) {
+        ASSERT_EQ(hv_vcpu_set_sys_reg(vcpu, key, value), HV_SUCCESS);
+        uint64_t observed = 0;
+        ASSERT_EQ(hv_vcpu_get_sys_reg(vcpu, key, &observed), HV_SUCCESS);
+        EXPECT_EQ(observed, value);
+    }
+}
+
+TEST_F(HypervisorTest, SynchronizesCacheSelector)
+{
+    createVCPU();
+
+    constexpr uint64_t value = 2;
+    ASSERT_EQ(hv_vcpu_set_sys_reg(vcpu, HV_SYS_REG_CSSELR_EL1, value),
+              HV_SUCCESS);
+
+    uint64_t observed = 0;
+    ASSERT_EQ(hv_vcpu_get_sys_reg(vcpu, HV_SYS_REG_CSSELR_EL1, &observed),
+              HV_SUCCESS);
+    EXPECT_EQ(observed, value);
+}
+
+TEST_F(HypervisorTest, ExecutesGuestCodeAndReportsExit)
+{
+    mapGuestPage();
+    createVCPU();
+
+    // HVC #0. Hypervisor.framework runs the instruction at EL1 and reports
+    // the resulting HVC64 exception to the host.
+    constexpr uint32_t hvc = 0xd4000002;
+    *static_cast<uint32_t *>(hostPage) = hvc;
+
+    ASSERT_EQ(hv_vcpu_set_reg(vcpu, HV_REG_PC, GuestAddress), HV_SUCCESS);
+    ASSERT_EQ(hv_vcpu_set_reg(vcpu, HV_REG_CPSR, 0x3c5), HV_SUCCESS);
+    ASSERT_EQ(hv_vcpu_run(vcpu), HV_SUCCESS);
+
+    ASSERT_NE(exit, nullptr);
+    EXPECT_EQ(exit->reason, HV_EXIT_REASON_EXCEPTION);
+    EXPECT_EQ(exit->exception.syndrome >> 26, 0x16);
+}
+
+} // anonymous namespace

--- a/src/cpu/apple_virt/AppleVirtVM.py
+++ b/src/cpu/apple_virt/AppleVirtVM.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+from m5.params import *
+from m5.SimObject import SimObject
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+class AppleVirtVM(SimObject):
+    type = "AppleVirtVM"
+    cxx_header = "cpu/apple_virt/vm.hh"
+    cxx_class = "gem5::AppleVirtVM"

--- a/src/cpu/apple_virt/BaseAppleVirtCPU.py
+++ b/src/cpu/apple_virt/BaseAppleVirtCPU.py
@@ -42,7 +42,7 @@ class BaseAppleVirtCPU(BaseCPU):
 
     @classmethod
     def support_take_over(cls):
-        return False
+        return True
 
     host_run_time_us = Param.Unsigned(
         1000, "Maximum host microseconds spent in one HVF entry"

--- a/src/cpu/apple_virt/BaseAppleVirtCPU.py
+++ b/src/cpu/apple_virt/BaseAppleVirtCPU.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+from m5.objects.AppleVirtVM import AppleVirtVM
+from m5.objects.BaseCPU import BaseCPU
+from m5.params import *
+from m5.proxy import *
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+class BaseAppleVirtCPU(BaseCPU):
+    type = "BaseAppleVirtCPU"
+    cxx_header = "cpu/apple_virt/base.hh"
+    cxx_class = "gem5::BaseAppleVirtCPU"
+    abstract = True
+
+    run_period = Param.Cycles(1, "Scheduling quantum between HVF entries")
+
+    vm = Param.AppleVirtVM(Parent.any, "Shared Apple virtual machine instance")

--- a/src/cpu/apple_virt/BaseAppleVirtCPU.py
+++ b/src/cpu/apple_virt/BaseAppleVirtCPU.py
@@ -36,6 +36,16 @@ class BaseAppleVirtCPU(BaseCPU):
     cxx_class = "gem5::BaseAppleVirtCPU"
     abstract = True
 
-    run_period = Param.Cycles(1, "Scheduling quantum between HVF entries")
+    @classmethod
+    def memory_mode(cls):
+        return "atomic_noncaching"
+
+    @classmethod
+    def support_take_over(cls):
+        return False
+
+    host_run_time_us = Param.Unsigned(
+        1000, "Maximum host microseconds spent in one HVF entry"
+    )
 
     vm = Param.AppleVirtVM(Parent.any, "Shared Apple virtual machine instance")

--- a/src/cpu/apple_virt/Kconfig
+++ b/src/cpu/apple_virt/Kconfig
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+config HAVE_APPLE_VIRT
+    bool "Host supports Apple Hypervisor framework"
+    default "$(HAVE_APPLE_VIRT)"
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
+config APPLE_VIRT_ISA
+    string
+    default "$(APPLE_VIRT_ISA)"
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
+config USE_APPLE_VIRT
+    bool "Enable Apple Hypervisor backend"
+    depends on APPLE_VIRT_ISA != "" && HAVE_APPLE_VIRT
     default y

--- a/src/cpu/apple_virt/Kconfig
+++ b/src/cpu/apple_virt/Kconfig
@@ -34,5 +34,5 @@ config APPLE_VIRT_ISA
 
 config USE_APPLE_VIRT
     bool "Enable Apple Hypervisor backend"
-    depends on APPLE_VIRT_ISA != "" && HAVE_APPLE_VIRT
+    depends on APPLE_VIRT_ISA = "arm" && HAVE_APPLE_VIRT && USE_ARM_ISA
     default y

--- a/src/cpu/apple_virt/SConscript
+++ b/src/cpu/apple_virt/SConscript
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,33 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+Import('*')
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
+if not env['CONF'].get('USE_APPLE_VIRT', False):
+    Return()
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+env.Append(LINKFLAGS=['-framework', 'Hypervisor'])
+
+env.TagImplies('apple_virt', 'gem5 lib')
+env.TagImplies(env.subst('${CONF["APPLE_VIRT_ISA"]} apple_virt'),
+               env.subst('${CONF["APPLE_VIRT_ISA"]} isa'))
+
+SimObject('AppleVirtVM.py', sim_objects=['AppleVirtVM'], tags=['apple_virt'])
+SimObject(
+    'BaseAppleVirtCPU.py',
+    sim_objects=['BaseAppleVirtCPU'],
+    tags=['apple_virt'],
+)
+
+Source('vm.cc', tags=['apple_virt'])
+Source('base.cc', tags=['apple_virt'])
+
+DebugFlag(
+    'AppleVirt',
+    'Apple virtualization backend diagnostics',
+    tags=['apple_virt'],
+)
+DebugFlag('AppleVirtRun', 'HVF run-loop tracing', tags=['apple_virt'])
+
+CompoundFlag('AppleVirtAll', ['AppleVirt', 'AppleVirtRun'],
+             'All Apple virtualization debug flags', tags=['apple_virt'])

--- a/src/cpu/apple_virt/SConsopts
+++ b/src/cpu/apple_virt/SConsopts
@@ -26,20 +26,53 @@
 
 Import('*')
 
+import sys
+
 from gem5_scons import warning
 
 import gem5_scons
 
 main['CONF'].setdefault('APPLE_VIRT_ISA', '')
 
+
+def check_hypervisor_framework(conf, code):
+    previous_linkflags = list(conf.env['LINKFLAGS'])
+    try:
+        conf.env.Append(LINKFLAGS=['-framework', 'Hypervisor'])
+        return conf.TryLink(code, '.cc')
+    finally:
+        conf.env['LINKFLAGS'] = previous_linkflags
+
+
 with gem5_scons.Configure(main) as conf:
     main['CONF']['HAVE_APPLE_VIRT'] = False
+    main['CONF']['APPLE_VIRT_CODESIGN'] = ''
 
-    if not conf.CheckHeader('Hypervisor/hv.h', '<>'):
-        warning("Info: Compatible header file <Hypervisor/hv.h> not found, "
-                "disabling Apple virtualization support.")
+    link_test = r'''
+#include <Hypervisor/hv_vm.h>
+
+int
+main()
+{
+    auto create_vm = &hv_vm_create;
+    (void)create_vm;
+    return 0;
+}
+'''
+
+    if sys.platform != 'darwin':
+        warning("Apple virtualization is only available on macOS; disabling "
+                "support")
+    elif not check_hypervisor_framework(conf, link_test):
+        warning("Cannot compile and link against Hypervisor.framework; "
+                "disabling Apple virtualization support")
+    elif not main.Detect('codesign'):
+        warning("Cannot find codesign, which is required to apply the Apple "
+                "hypervisor entitlement; disabling Apple virtualization "
+                "support")
     else:
         main['CONF']['HAVE_APPLE_VIRT'] = True
+        main['CONF']['APPLE_VIRT_CODESIGN'] = main.Detect('codesign')
 
 
 def create_use_apple_virt_var():

--- a/src/cpu/apple_virt/SConsopts
+++ b/src/cpu/apple_virt/SConsopts
@@ -45,9 +45,8 @@ with gem5_scons.Configure(main) as conf:
 def create_use_apple_virt_var():
     # Kconfig computes USE_APPLE_VIRT from HAVE_APPLE_VIRT and
     # APPLE_VIRT_ISA. Leave the value unset here so Kconfig can
-    # auto-enable it (matching KVM behavior) when host and ISA
-    # support
-    # are available.
+    # auto-enable it (matching KVM behavior) when host and ISA support are
+    # available.
     have_host = main['CONF']['HAVE_APPLE_VIRT']
     have_isa = main['CONF']['APPLE_VIRT_ISA']
     if not (have_host and have_isa):

--- a/src/cpu/apple_virt/SConsopts
+++ b/src/cpu/apple_virt/SConsopts
@@ -1,4 +1,5 @@
-# Copyright 2023 Google LLC
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,14 +24,35 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config HAVE_CAPSTONE
-    def_bool $(HAVE_CAPSTONE)
+Import('*')
 
-rsource "kvm/Kconfig"
-rsource "apple_virt/Kconfig"
+from gem5_scons import warning
 
-config USE_CAPSTONE
-    depends on HAVE_CAPSTONE
-    depends on USE_ARM_ISA
-    bool "Use CapstoneDisassembler"
-    default y
+import gem5_scons
+
+main['CONF'].setdefault('APPLE_VIRT_ISA', '')
+
+with gem5_scons.Configure(main) as conf:
+    main['CONF']['HAVE_APPLE_VIRT'] = False
+
+    if not conf.CheckHeader('Hypervisor/hv.h', '<>'):
+        warning("Info: Compatible header file <Hypervisor/hv.h> not found, "
+                "disabling Apple virtualization support.")
+    else:
+        main['CONF']['HAVE_APPLE_VIRT'] = True
+
+
+def create_use_apple_virt_var():
+    # Kconfig computes USE_APPLE_VIRT from HAVE_APPLE_VIRT and
+    # APPLE_VIRT_ISA. Leave the value unset here so Kconfig can
+    # auto-enable it (matching KVM behavior) when host and ISA
+    # support
+    # are available.
+    have_host = main['CONF']['HAVE_APPLE_VIRT']
+    have_isa = main['CONF']['APPLE_VIRT_ISA']
+    if not (have_host and have_isa):
+        warning("Cannot enable Apple virtualization, host or ISA support "
+                "is unavailable")
+
+
+AfterSConsopts(create_use_apple_virt_var)

--- a/src/cpu/apple_virt/apple_virt.entitlements
+++ b/src/cpu/apple_virt/apple_virt.entitlements
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.hypervisor</key>
+  <true/>
+</dict>
+</plist>

--- a/src/cpu/apple_virt/base.cc
+++ b/src/cpu/apple_virt/base.cc
@@ -33,7 +33,6 @@
 #include <algorithm>
 #include <cassert>
 
-#include "arch/arm/regs/int.hh"
 #include "arch/generic/mmu.hh"
 #include "base/logging.hh"
 #include "cpu/base.hh"
@@ -209,6 +208,22 @@ BaseAppleVirtCPU::drainResume()
         status = Status::Running;
         schedule(runEvent, clockEdge(Cycles(0)));
     }
+}
+
+void
+BaseAppleVirtCPU::serializeThread(CheckpointOut &cp, ThreadID tid) const
+{
+    assert(tid == 0);
+    assert(status == Status::Idle);
+    thread->serialize(cp);
+}
+
+void
+BaseAppleVirtCPU::unserializeThread(CheckpointIn &cp, ThreadID tid)
+{
+    assert(tid == 0);
+    assert(status == Status::Idle);
+    thread->unserialize(cp);
 }
 
 void
@@ -406,83 +421,6 @@ BaseAppleVirtCPU::doMMIOAccess(Addr paddr, void *data, unsigned size,
     Tick delay = dataPort.sendAtomic(packet);
     delete packet;
     return delay;
-}
-
-void
-BaseAppleVirtCPU::advancePC()
-{
-    uint64_t pc = 0;
-    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_PC, &pc);
-    fatal_if(hv_err != HV_SUCCESS,
-             "Failed to read HVF PC while completing an exit (err=%d)",
-             hv_err);
-    pc += 4;
-    hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_PC, pc);
-    fatal_if(hv_err != HV_SUCCESS,
-             "Failed to advance HVF PC while completing an exit (err=%d)",
-             hv_err);
-    threadContext->pcState(static_cast<Addr>(pc));
-}
-
-Tick
-BaseAppleVirtCPU::handleException(const hv_vcpu_exit_exception_t &exception)
-{
-    fatal("Unhandled AppleVirtCPU exception: syndrome=%#llx far=%#llx "
-          "ipa=%#llx",
-          static_cast<unsigned long long>(exception.syndrome),
-          static_cast<unsigned long long>(exception.virtual_address),
-          static_cast<unsigned long long>(exception.physical_address));
-}
-
-void
-BaseAppleVirtCPU::handleVTimerActivated()
-{ fatal("AppleVirtCPU does not implement the architectural virtual timer"); }
-
-void
-BaseAppleVirtCPU::syncThreadToHV()
-{
-    ThreadContext *tc = threadContext;
-    fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
-
-    const auto pc = tc->pcState().instAddr();
-    hv_return_t hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_PC, pc);
-    fatal_if(hv_err != HV_SUCCESS,
-             "Failed to set HVF PC register (pc=%#llx err=%d)",
-             static_cast<unsigned long long>(pc), hv_err);
-
-    for (int idx = 0; idx < 31; ++idx) {
-        hv_reg_t hv_reg = static_cast<hv_reg_t>(HV_REG_X0 + idx);
-        hv_err = hv_vcpu_set_reg(hvVCPU, hv_reg,
-                                 tc->getReg(ArmISA::int_reg::x(idx)));
-        fatal_if(hv_err != HV_SUCCESS,
-                 "Failed to set HVF X%d register (err=%d)", idx, hv_err);
-    }
-
-    // TODO: sync SP once an HVF mapping is confirmed.
-}
-
-void
-BaseAppleVirtCPU::syncHVToThread()
-{
-    ThreadContext *tc = threadContext;
-    fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
-
-    RegVal pc = 0;
-    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_PC, &pc);
-    fatal_if(hv_err != HV_SUCCESS, "Failed to read HVF PC register (err=%d)",
-             hv_err);
-    tc->pcState(static_cast<Addr>(pc));
-
-    for (int idx = 0; idx < 31; ++idx) {
-        hv_reg_t hv_reg = static_cast<hv_reg_t>(HV_REG_X0 + idx);
-        RegVal value = 0;
-        hv_err = hv_vcpu_get_reg(hvVCPU, hv_reg, &value);
-        fatal_if(hv_err != HV_SUCCESS,
-                 "Failed to read HVF X%d register (err=%d)", idx, hv_err);
-        tc->setReg(ArmISA::int_reg::x(idx), value);
-    }
-
-    // TODO: sync SP once an HVF mapping is confirmed.
 }
 
 } // namespace gem5

--- a/src/cpu/apple_virt/base.cc
+++ b/src/cpu/apple_virt/base.cc
@@ -30,13 +30,19 @@
 
 #include <Hypervisor/hv_vcpu.h>
 
+#include <algorithm>
+#include <cassert>
+
 #include "arch/arm/regs/int.hh"
+#include "arch/generic/mmu.hh"
 #include "base/logging.hh"
 #include "cpu/base.hh"
 #include "cpu/simple_thread.hh"
 #include "cpu/thread_context.hh"
 #include "debug/AppleVirtRun.hh"
 #include "params/BaseAppleVirtCPU.hh"
+#include "sim/core.hh"
+#include "sim/faults.hh"
 #include "sim/full_system.hh"
 #include "sim/process.hh"
 #include "sim/system.hh"
@@ -62,24 +68,22 @@ BaseAppleVirtCPU::BaseAppleVirtCPU(const BaseAppleVirtCPUParams &params)
       threadContext(nullptr),
       hvVCPU(static_cast<hv_vcpu_t>(~0U)),
       hvExit(nullptr),
+      status(Status::Idle),
       hvReady(false),
       runEvent([this]() { runOnce(); }, name() + ".run"),
-      runPeriod(params.run_period),
+      hostRunTime(params.host_run_time_us),
       dataPort(name() + ".dcache_port"),
-      instPort(name() + ".icache_port")
+      instPort(name() + ".icache_port"),
+      watchdogStop(false),
+      watchdogArmed(false),
+      watchdogGeneration(0)
 {
     fatal_if(!vm, "BaseAppleVirtCPU requires an AppleVirtVM instance");
+    fatal_if(!FullSystem,
+             "AppleVirtCPU currently supports full-system mode only");
 
-    if (FullSystem) {
-        thread = new SimpleThread(this, 0, params.system, params.mmu,
-                                  params.isa[0], params.decoder[0]);
-    } else {
-        fatal_if(params.workload.empty(),
-                 "AppleVirtCPU requires exactly one SE workload");
-        thread =
-            new SimpleThread(this, 0, params.system, params.workload[0],
-                             params.mmu, params.isa[0], params.decoder[0]);
-    }
+    thread = new SimpleThread(this, 0, params.system, params.mmu,
+                              params.isa[0], params.decoder[0]);
 
     thread->setStatus(ThreadContext::Halted);
     threadContext = thread->getTC();
@@ -88,13 +92,8 @@ BaseAppleVirtCPU::BaseAppleVirtCPU(const BaseAppleVirtCPUParams &params)
 
 BaseAppleVirtCPU::~BaseAppleVirtCPU()
 {
-    if (hvReady) {
-        hv_return_t hv_err = hv_vcpu_destroy(hvVCPU);
-        if (hv_err != HV_SUCCESS) {
-            warn("hv_vcpu_destroy failed (err=%d)", hv_err);
-        }
-    }
-
+    stopWatchdog();
+    destroyVCPU();
     delete thread;
 }
 
@@ -105,6 +104,9 @@ BaseAppleVirtCPU::init()
 
     fatal_if(numThreads != 1,
              "AppleVirtCPU currently supports only a single thread");
+    fatal_if(!thread->comInstEventQueue.empty(),
+             "AppleVirtCPU does not support instruction-count events");
+    verifyMemoryMode();
 }
 
 void
@@ -112,7 +114,15 @@ BaseAppleVirtCPU::startup()
 {
     BaseCPU::startup();
     vm->ensureInitialized(*system);
-    schedule(runEvent, clockEdge(runPeriod));
+    createVCPU();
+    startWatchdog();
+
+    if (thread->status() == ThreadContext::Active) {
+        status = Status::Running;
+        if (!runEvent.scheduled()) {
+            schedule(runEvent, clockEdge(Cycles(0)));
+        }
+    }
 }
 
 void
@@ -122,42 +132,311 @@ BaseAppleVirtCPU::wakeup(ThreadID tid)
         return;
     }
 
+    if (hvReady) {
+        hv_vcpu_t vcpu = hvVCPU;
+        hv_vcpus_exit(&vcpu, 1);
+    }
+
+    if (thread->status() == ThreadContext::Suspended) {
+        thread->activate();
+    }
+}
+
+void
+BaseAppleVirtCPU::activateContext(ThreadID thread_num)
+{
+    assert(thread_num == 0);
+    if (status == Status::Running) {
+        return;
+    }
+
+    status = Status::Running;
     if (!runEvent.scheduled()) {
         schedule(runEvent, clockEdge(Cycles(0)));
     }
 }
 
 void
-BaseAppleVirtCPU::runOnce()
+BaseAppleVirtCPU::suspendContext(ThreadID thread_num)
 {
-    if (!hvReady) {
-        hv_return_t hv_err = hv_vcpu_create(&hvVCPU, &hvExit, nullptr);
-        fatal_if(hv_err != HV_SUCCESS,
-                 "hv_vcpu_create failed for AppleVirtCPU (err=%d)", hv_err);
-        hvReady = true;
+    assert(thread_num == 0);
+    if (runEvent.scheduled()) {
+        deschedule(runEvent);
+    }
+    status = Status::Idle;
+}
+
+void
+BaseAppleVirtCPU::haltContext(ThreadID thread_num)
+{
+    suspendContext(thread_num);
+    updateCycleCounters(BaseCPU::CPU_STATE_SLEEP);
+}
+
+ThreadContext *
+BaseAppleVirtCPU::getContext(int tid)
+{
+    assert(tid == 0);
+    if (hvReady && std::this_thread::get_id() == ownerThread) {
+        syncHVToThread();
+    }
+    return threadContext;
+}
+
+DrainState
+BaseAppleVirtCPU::drain()
+{
+    if (runEvent.scheduled()) {
+        deschedule(runEvent);
+    }
+    status = Status::Idle;
+    if (hvReady && std::this_thread::get_id() == ownerThread) {
+        syncHVToThread();
+    }
+    return DrainState::Drained;
+}
+
+void
+BaseAppleVirtCPU::drainResume()
+{
+    assert(!runEvent.scheduled());
+    if (switchedOut()) {
+        return;
     }
 
-    syncThreadToHV();
+    verifyMemoryMode();
+    if (thread->status() == ThreadContext::Active) {
+        status = Status::Running;
+        schedule(runEvent, clockEdge(Cycles(0)));
+    }
+}
 
+void
+BaseAppleVirtCPU::verifyMemoryMode() const
+{
+    fatal_if(!system->bypassCaches(),
+             "AppleVirtCPU requires atomic non-caching memory mode");
+}
+
+void
+BaseAppleVirtCPU::createVCPU()
+{
+    assert(!hvReady);
+    ownerThread = std::this_thread::get_id();
+    vm->registerCPU();
+
+    hv_return_t hv_err = hv_vcpu_create(&hvVCPU, &hvExit, nullptr);
+    fatal_if(hv_err != HV_SUCCESS,
+             "hv_vcpu_create failed for AppleVirtCPU (err=%d)", hv_err);
+    hvReady = true;
+}
+
+void
+BaseAppleVirtCPU::destroyVCPU()
+{
+    if (!hvReady) {
+        return;
+    }
+
+    fatal_if(std::this_thread::get_id() != ownerThread,
+             "AppleVirtCPU vCPU must be destroyed by its owner thread");
+    hv_return_t hv_err = hv_vcpu_destroy(hvVCPU);
+    warn_if(hv_err != HV_SUCCESS, "hv_vcpu_destroy failed (err=%d)", hv_err);
+    if (hv_err == HV_SUCCESS) {
+        hvReady = false;
+        vm->unregisterCPU();
+    }
+}
+
+void
+BaseAppleVirtCPU::runOnce()
+{
+    assert(status == Status::Running);
+    fatal_if(std::this_thread::get_id() != ownerThread,
+             "AppleVirtCPU must run on the thread which created its vCPU");
+    fatal_if(!thread->comInstEventQueue.empty(),
+             "AppleVirtCPU does not support instruction-count events");
+
+    syncThreadToHV();
+    updateInterrupts();
+    armWatchdog();
+
+    const auto host_start = std::chrono::steady_clock::now();
     hv_return_t hv_err = hv_vcpu_run(hvVCPU);
+    const auto host_end = std::chrono::steady_clock::now();
+    disarmWatchdog();
     fatal_if(hv_err != HV_SUCCESS,
              "hv_vcpu_run failed for AppleVirtCPU (err=%d)", hv_err);
 
-    if (hvExit) {
-        DPRINTF(AppleVirtRun, "vCPU exited with reason %u\n", hvExit->reason);
-        if (hvExit->reason == HV_EXIT_REASON_EXCEPTION) {
-            warn("AppleVirtCPU exception exit: syndrome=%#x far=%#llx",
-                 hvExit->exception.syndrome,
-                 static_cast<unsigned long long>(
-                     hvExit->exception.virtual_address));
-            return;
-        }
+    syncHVToThread();
+    fatal_if(!hvExit, "AppleVirtCPU run completed without exit information");
+
+    DPRINTF(AppleVirtRun, "vCPU exited with reason %u\n", hvExit->reason);
+    Tick delay = 0;
+    switch (hvExit->reason) {
+        case HV_EXIT_REASON_CANCELED:
+            break;
+        case HV_EXIT_REASON_EXCEPTION:
+            delay = handleException(hvExit->exception);
+            break;
+        case HV_EXIT_REASON_VTIMER_ACTIVATED:
+            handleVTimerActivated();
+            break;
+        case HV_EXIT_REASON_UNKNOWN:
+        default:
+            fatal("AppleVirtCPU exited for an unknown reason");
     }
 
-    syncHVToThread();
-
-    schedule(runEvent, clockEdge(runPeriod));
+    if (status == Status::Running) {
+        const auto host_ns =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(host_end -
+                                                                 host_start)
+                .count();
+        const Tick execution_delay =
+            std::max<Tick>(1, host_ns * sim_clock::as_int::ns);
+        baseStats.numCycles += ticksToCycles(execution_delay);
+        Cycles next_cycles = ticksToCycles(execution_delay + delay);
+        next_cycles = std::max(next_cycles, Cycles(1));
+        schedule(runEvent, clockEdge(next_cycles));
+    }
 }
+
+void
+BaseAppleVirtCPU::startWatchdog()
+{
+    watchdogThread = std::thread([this]() { watchdogLoop(); });
+}
+
+void
+BaseAppleVirtCPU::stopWatchdog()
+{
+    if (!watchdogThread.joinable()) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(watchdogMutex);
+        watchdogStop = true;
+        watchdogArmed = false;
+        ++watchdogGeneration;
+    }
+    watchdogCV.notify_all();
+    watchdogThread.join();
+}
+
+void
+BaseAppleVirtCPU::armWatchdog()
+{
+    {
+        std::lock_guard<std::mutex> lock(watchdogMutex);
+        watchdogArmed = true;
+        ++watchdogGeneration;
+    }
+    watchdogCV.notify_all();
+}
+
+void
+BaseAppleVirtCPU::disarmWatchdog()
+{
+    {
+        std::lock_guard<std::mutex> lock(watchdogMutex);
+        watchdogArmed = false;
+        ++watchdogGeneration;
+    }
+    watchdogCV.notify_all();
+}
+
+void
+BaseAppleVirtCPU::watchdogLoop()
+{
+    std::unique_lock<std::mutex> lock(watchdogMutex);
+    while (!watchdogStop) {
+        watchdogCV.wait(lock,
+                        [this]() { return watchdogStop || watchdogArmed; });
+        if (watchdogStop) {
+            break;
+        }
+
+        const uint64_t generation = watchdogGeneration;
+        if (watchdogCV.wait_for(lock, hostRunTime, [this, generation]() {
+                return watchdogStop || !watchdogArmed ||
+                       watchdogGeneration != generation;
+            })) {
+            continue;
+        }
+
+        hv_vcpu_t vcpu = hvVCPU;
+        watchdogArmed = false;
+        lock.unlock();
+        hv_return_t hv_err = hv_vcpus_exit(&vcpu, 1);
+        warn_if(hv_err != HV_SUCCESS,
+                "hv_vcpus_exit failed in AppleVirtCPU watchdog (err=%d)",
+                hv_err);
+        lock.lock();
+    }
+}
+
+Tick
+BaseAppleVirtCPU::doMMIOAccess(Addr paddr, void *data, unsigned size,
+                               bool write)
+{
+    RequestPtr request = std::make_shared<Request>(
+        paddr, size, Request::UNCACHEABLE, dataRequestorId());
+    request->setContext(threadContext->contextId());
+
+    const BaseMMU::Mode mode = write ? BaseMMU::Write : BaseMMU::Read;
+    Fault fault = threadContext->getMMUPtr()->finalizePhysical(
+        request, threadContext, mode);
+    if (fault != NoFault) {
+        warn("Finalizing AppleVirtCPU MMIO failed: %s", fault->name());
+    }
+
+    PacketPtr packet =
+        new Packet(request, write ? MemCmd::WriteReq : MemCmd::ReadReq);
+    packet->dataStatic(data);
+
+    if (request->isLocalAccess()) {
+        const Cycles local_delay =
+            request->localAccessor(threadContext, packet);
+        delete packet;
+        return clockPeriod() * local_delay;
+    }
+
+    EventQueue::ScopedMigration migrate(vm->eventQueue());
+    Tick delay = dataPort.sendAtomic(packet);
+    delete packet;
+    return delay;
+}
+
+void
+BaseAppleVirtCPU::advancePC()
+{
+    uint64_t pc = 0;
+    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_PC, &pc);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to read HVF PC while completing an exit (err=%d)",
+             hv_err);
+    pc += 4;
+    hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_PC, pc);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to advance HVF PC while completing an exit (err=%d)",
+             hv_err);
+    threadContext->pcState(static_cast<Addr>(pc));
+}
+
+Tick
+BaseAppleVirtCPU::handleException(const hv_vcpu_exit_exception_t &exception)
+{
+    fatal("Unhandled AppleVirtCPU exception: syndrome=%#llx far=%#llx "
+          "ipa=%#llx",
+          static_cast<unsigned long long>(exception.syndrome),
+          static_cast<unsigned long long>(exception.virtual_address),
+          static_cast<unsigned long long>(exception.physical_address));
+}
+
+void
+BaseAppleVirtCPU::handleVTimerActivated()
+{ fatal("AppleVirtCPU does not implement the architectural virtual timer"); }
 
 void
 BaseAppleVirtCPU::syncThreadToHV()

--- a/src/cpu/apple_virt/base.cc
+++ b/src/cpu/apple_virt/base.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/apple_virt/base.hh"
+
+#include <Hypervisor/hv_vcpu.h>
+
+#include "arch/arm/regs/int.hh"
+#include "base/logging.hh"
+#include "cpu/base.hh"
+#include "cpu/simple_thread.hh"
+#include "cpu/thread_context.hh"
+#include "debug/AppleVirtRun.hh"
+#include "params/BaseAppleVirtCPU.hh"
+#include "sim/full_system.hh"
+#include "sim/process.hh"
+#include "sim/system.hh"
+
+namespace gem5
+{
+
+bool
+BaseAppleVirtCPU::AppleVirtCPUPort::recvTimingResp(PacketPtr)
+{
+    panic("%s does not support timing responses", name());
+    return false;
+}
+
+void
+BaseAppleVirtCPU::AppleVirtCPUPort::recvReqRetry()
+{ panic("%s does not support request retries", name()); }
+
+BaseAppleVirtCPU::BaseAppleVirtCPU(const BaseAppleVirtCPUParams &params)
+    : BaseCPU(params),
+      vm(params.vm),
+      thread(nullptr),
+      threadContext(nullptr),
+      hvVCPU(static_cast<hv_vcpu_t>(~0U)),
+      hvExit(nullptr),
+      hvReady(false),
+      runEvent([this]() { runOnce(); }, name() + ".run"),
+      runPeriod(params.run_period),
+      dataPort(name() + ".dcache_port"),
+      instPort(name() + ".icache_port")
+{
+    fatal_if(!vm, "BaseAppleVirtCPU requires an AppleVirtVM instance");
+
+    if (FullSystem) {
+        thread = new SimpleThread(this, 0, params.system, params.mmu,
+                                  params.isa[0], params.decoder[0]);
+    } else {
+        fatal_if(params.workload.empty(),
+                 "AppleVirtCPU requires exactly one SE workload");
+        thread =
+            new SimpleThread(this, 0, params.system, params.workload[0],
+                             params.mmu, params.isa[0], params.decoder[0]);
+    }
+
+    thread->setStatus(ThreadContext::Halted);
+    threadContext = thread->getTC();
+    threadContexts.push_back(threadContext);
+}
+
+BaseAppleVirtCPU::~BaseAppleVirtCPU()
+{
+    if (hvReady) {
+        hv_return_t hv_err = hv_vcpu_destroy(hvVCPU);
+        if (hv_err != HV_SUCCESS) {
+            warn("hv_vcpu_destroy failed (err=%d)", hv_err);
+        }
+    }
+
+    delete thread;
+}
+
+void
+BaseAppleVirtCPU::init()
+{
+    BaseCPU::init();
+
+    fatal_if(numThreads != 1,
+             "AppleVirtCPU currently supports only a single thread");
+}
+
+void
+BaseAppleVirtCPU::startup()
+{
+    BaseCPU::startup();
+    vm->ensureInitialized(*system);
+    schedule(runEvent, clockEdge(runPeriod));
+}
+
+void
+BaseAppleVirtCPU::wakeup(ThreadID tid)
+{
+    if (tid != 0) {
+        return;
+    }
+
+    if (!runEvent.scheduled()) {
+        schedule(runEvent, clockEdge(Cycles(0)));
+    }
+}
+
+void
+BaseAppleVirtCPU::runOnce()
+{
+    if (!hvReady) {
+        hv_return_t hv_err = hv_vcpu_create(&hvVCPU, &hvExit, nullptr);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "hv_vcpu_create failed for AppleVirtCPU (err=%d)", hv_err);
+        hvReady = true;
+    }
+
+    syncThreadToHV();
+
+    hv_return_t hv_err = hv_vcpu_run(hvVCPU);
+    fatal_if(hv_err != HV_SUCCESS,
+             "hv_vcpu_run failed for AppleVirtCPU (err=%d)", hv_err);
+
+    if (hvExit) {
+        DPRINTF(AppleVirtRun, "vCPU exited with reason %u\n", hvExit->reason);
+        if (hvExit->reason == HV_EXIT_REASON_EXCEPTION) {
+            warn("AppleVirtCPU exception exit: syndrome=%#x far=%#llx",
+                 hvExit->exception.syndrome,
+                 static_cast<unsigned long long>(
+                     hvExit->exception.virtual_address));
+            return;
+        }
+    }
+
+    syncHVToThread();
+
+    schedule(runEvent, clockEdge(runPeriod));
+}
+
+void
+BaseAppleVirtCPU::syncThreadToHV()
+{
+    ThreadContext *tc = threadContext;
+    fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
+
+    const auto pc = tc->pcState().instAddr();
+    hv_return_t hv_err = hv_vcpu_set_reg(hvVCPU, HV_REG_PC, pc);
+    fatal_if(hv_err != HV_SUCCESS,
+             "Failed to set HVF PC register (pc=%#llx err=%d)",
+             static_cast<unsigned long long>(pc), hv_err);
+
+    for (int idx = 0; idx < 31; ++idx) {
+        hv_reg_t hv_reg = static_cast<hv_reg_t>(HV_REG_X0 + idx);
+        hv_err = hv_vcpu_set_reg(hvVCPU, hv_reg,
+                                 tc->getReg(ArmISA::int_reg::x(idx)));
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to set HVF X%d register (err=%d)", idx, hv_err);
+    }
+
+    // TODO: sync SP once an HVF mapping is confirmed.
+}
+
+void
+BaseAppleVirtCPU::syncHVToThread()
+{
+    ThreadContext *tc = threadContext;
+    fatal_if(!tc, "AppleVirtCPU has no thread context to sync");
+
+    RegVal pc = 0;
+    hv_return_t hv_err = hv_vcpu_get_reg(hvVCPU, HV_REG_PC, &pc);
+    fatal_if(hv_err != HV_SUCCESS, "Failed to read HVF PC register (err=%d)",
+             hv_err);
+    tc->pcState(static_cast<Addr>(pc));
+
+    for (int idx = 0; idx < 31; ++idx) {
+        hv_reg_t hv_reg = static_cast<hv_reg_t>(HV_REG_X0 + idx);
+        RegVal value = 0;
+        hv_err = hv_vcpu_get_reg(hvVCPU, hv_reg, &value);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "Failed to read HVF X%d register (err=%d)", idx, hv_err);
+        tc->setReg(ArmISA::int_reg::x(idx), value);
+    }
+
+    // TODO: sync SP once an HVF mapping is confirmed.
+}
+
+} // namespace gem5

--- a/src/cpu/apple_virt/base.cc
+++ b/src/cpu/apple_virt/base.cc
@@ -213,6 +213,33 @@ BaseAppleVirtCPU::drainResume()
 }
 
 void
+BaseAppleVirtCPU::switchOut()
+{
+    BaseCPU::switchOut();
+
+    // CPU switching drains the system before switching out a core. The
+    // AppleVirt run event must therefore be descheduled and the host vCPU
+    // state must already be reflected in the gem5 ThreadContext.
+    assert(!runEvent.scheduled());
+    assert(status == Status::Idle);
+}
+
+void
+BaseAppleVirtCPU::takeOverFrom(BaseCPU *cpu)
+{
+    BaseCPU::takeOverFrom(cpu);
+
+    // The vCPU is created during startup even when this CPU starts switched
+    // out. Push the newly copied ThreadContext into Hypervisor.framework now
+    // so the first run begins from the exact takeover state.
+    assert(!runEvent.scheduled());
+    assert(status == Status::Idle);
+    assert(hvReady);
+    assert(threadContexts.size() == 1);
+    syncThreadToHV();
+}
+
+void
 BaseAppleVirtCPU::serializeThread(CheckpointOut &cp, ThreadID tid) const
 {
     assert(tid == 0);

--- a/src/cpu/apple_virt/base.cc
+++ b/src/cpu/apple_virt/base.cc
@@ -58,7 +58,9 @@ BaseAppleVirtCPU::AppleVirtCPUPort::recvTimingResp(PacketPtr)
 
 void
 BaseAppleVirtCPU::AppleVirtCPUPort::recvReqRetry()
-{ panic("%s does not support request retries", name()); }
+{
+    panic("%s does not support request retries", name());
+}
 
 BaseAppleVirtCPU::BaseAppleVirtCPU(const BaseAppleVirtCPUParams &params)
     : BaseCPU(params),

--- a/src/cpu/apple_virt/base.hh
+++ b/src/cpu/apple_virt/base.hh
@@ -67,6 +67,8 @@ class BaseAppleVirtCPU : public BaseCPU
     void startup() override;
     DrainState drain() override;
     void drainResume() override;
+    void switchOut() override;
+    void takeOverFrom(BaseCPU *cpu) override;
     void serializeThread(CheckpointOut &cp, ThreadID tid) const override;
     void unserializeThread(CheckpointIn &cp, ThreadID tid) override;
     void verifyMemoryMode() const override;

--- a/src/cpu/apple_virt/base.hh
+++ b/src/cpu/apple_virt/base.hh
@@ -73,14 +73,20 @@ class BaseAppleVirtCPU : public BaseCPU
 
     Port &
     getDataPort() override
-    { return dataPort; }
+    {
+        return dataPort;
+    }
     Port &
     getInstPort() override
-    { return instPort; }
+    {
+        return instPort;
+    }
     void wakeup(ThreadID tid = 0) override;
     bool
     wakeupOnInterrupt(ThreadID tid) const override
-    { return true; }
+    {
+        return true;
+    }
     void activateContext(ThreadID thread_num) override;
     void suspendContext(ThreadID thread_num) override;
     void haltContext(ThreadID thread_num) override;
@@ -89,10 +95,14 @@ class BaseAppleVirtCPU : public BaseCPU
 
     Counter
     totalInsts() const override
-    { return 0; }
+    {
+        return 0;
+    }
     Counter
     totalOps() const override
-    { return 0; }
+    {
+        return 0;
+    }
 
   protected:
     /** Shared virtual machine front-end. */

--- a/src/cpu/apple_virt/base.hh
+++ b/src/cpu/apple_virt/base.hh
@@ -31,7 +31,11 @@
 
 #include <Hypervisor/hv_vcpu.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <thread>
 
 #include "cpu/apple_virt/vm.hh"
 #include "cpu/base.hh"
@@ -45,10 +49,13 @@ namespace gem5
 struct BaseAppleVirtCPUParams;
 
 /**
- * Skeleton CPU model that will eventually offload execution to the Apple
- * Hypervisor framework.  At the moment it only allocates the shared VM and
- * prepares per-CPU bookkeeping; the run loop will be fleshed out as the
- * backend implementation matures.
+ * Base class for CPUs accelerated by Apple's Hypervisor framework.
+ *
+ * The initial implementation intentionally supports one full-system CPU in
+ * atomic non-caching mode. A host-side watchdog bounds each blocking
+ * hv_vcpu_run() call so gem5's event queue continues to make progress.
+ * Hypervisor.framework does not expose a retired-instruction counter, so
+ * instruction-count events and instruction statistics are unsupported.
  */
 class BaseAppleVirtCPU : public BaseCPU
 {
@@ -58,6 +65,9 @@ class BaseAppleVirtCPU : public BaseCPU
 
     void init() override;
     void startup() override;
+    DrainState drain() override;
+    void drainResume() override;
+    void verifyMemoryMode() const override;
 
     Port &
     getDataPort() override
@@ -66,10 +76,14 @@ class BaseAppleVirtCPU : public BaseCPU
     getInstPort() override
     { return instPort; }
     void wakeup(ThreadID tid = 0) override;
+    bool
+    wakeupOnInterrupt(ThreadID tid) const override
+    { return true; }
+    void activateContext(ThreadID thread_num) override;
+    void suspendContext(ThreadID thread_num) override;
+    void haltContext(ThreadID thread_num) override;
 
-    ThreadContext *
-    getContext(int tid) override
-    { return threadContext; }
+    ThreadContext *getContext(int tid) override;
 
     Counter
     totalInsts() const override
@@ -92,6 +106,14 @@ class BaseAppleVirtCPU : public BaseCPU
     hv_vcpu_t hvVCPU;
     hv_vcpu_exit_t *hvExit;
 
+    enum class Status
+    {
+        Idle,
+        Running,
+    };
+
+    Status status;
+
     class AppleVirtCPUPort : public RequestPort
     {
       public:
@@ -105,14 +127,38 @@ class BaseAppleVirtCPU : public BaseCPU
 
     bool hvReady;
     EventFunctionWrapper runEvent;
-    Cycles runPeriod;
+    std::chrono::microseconds hostRunTime;
 
     AppleVirtCPUPort dataPort;
     AppleVirtCPUPort instPort;
 
     void runOnce();
+    void createVCPU();
+    void destroyVCPU();
+    void startWatchdog();
+    void stopWatchdog();
+    void armWatchdog();
+    void disarmWatchdog();
+    void watchdogLoop();
+
+    Tick doMMIOAccess(Addr paddr, void *data, unsigned size, bool write);
+    void advancePC();
+
     virtual void syncThreadToHV();
     virtual void syncHVToThread();
+    virtual void
+    updateInterrupts()
+    {}
+    virtual Tick handleException(const hv_vcpu_exit_exception_t &exception);
+    virtual void handleVTimerActivated();
+
+    std::thread::id ownerThread;
+    std::thread watchdogThread;
+    std::mutex watchdogMutex;
+    std::condition_variable watchdogCV;
+    bool watchdogStop;
+    bool watchdogArmed;
+    uint64_t watchdogGeneration;
 };
 
 } // namespace gem5

--- a/src/cpu/apple_virt/base.hh
+++ b/src/cpu/apple_virt/base.hh
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_APPLE_VIRT_BASE_HH__
+#define __CPU_APPLE_VIRT_BASE_HH__
+
+#include <Hypervisor/hv_vcpu.h>
+
+#include <memory>
+
+#include "cpu/apple_virt/vm.hh"
+#include "cpu/base.hh"
+#include "cpu/simple_thread.hh"
+#include "mem/port.hh"
+#include "sim/eventq.hh"
+
+namespace gem5
+{
+
+struct BaseAppleVirtCPUParams;
+
+/**
+ * Skeleton CPU model that will eventually offload execution to the Apple
+ * Hypervisor framework.  At the moment it only allocates the shared VM and
+ * prepares per-CPU bookkeeping; the run loop will be fleshed out as the
+ * backend implementation matures.
+ */
+class BaseAppleVirtCPU : public BaseCPU
+{
+  public:
+    BaseAppleVirtCPU(const BaseAppleVirtCPUParams &params);
+    ~BaseAppleVirtCPU() override;
+
+    void init() override;
+    void startup() override;
+
+    Port &
+    getDataPort() override
+    { return dataPort; }
+    Port &
+    getInstPort() override
+    { return instPort; }
+    void wakeup(ThreadID tid = 0) override;
+
+    ThreadContext *
+    getContext(int tid) override
+    { return threadContext; }
+
+    Counter
+    totalInsts() const override
+    { return 0; }
+    Counter
+    totalOps() const override
+    { return 0; }
+
+  protected:
+    /** Shared virtual machine front-end. */
+    AppleVirtVM *vm;
+
+    /** Cached gem5 thread representation. */
+    SimpleThread *thread;
+
+    /** ThreadContext view to expose to the rest of gem5. */
+    ThreadContext *threadContext;
+
+    /** HVF handle for this vCPU. */
+    hv_vcpu_t hvVCPU;
+    hv_vcpu_exit_t *hvExit;
+
+    class AppleVirtCPUPort : public RequestPort
+    {
+      public:
+        explicit AppleVirtCPUPort(const std::string &name) : RequestPort(name)
+        {}
+
+      protected:
+        bool recvTimingResp(PacketPtr pkt) override;
+        void recvReqRetry() override;
+    };
+
+    bool hvReady;
+    EventFunctionWrapper runEvent;
+    Cycles runPeriod;
+
+    AppleVirtCPUPort dataPort;
+    AppleVirtCPUPort instPort;
+
+    void runOnce();
+    virtual void syncThreadToHV();
+    virtual void syncHVToThread();
+};
+
+} // namespace gem5
+
+#endif

--- a/src/cpu/apple_virt/base.hh
+++ b/src/cpu/apple_virt/base.hh
@@ -67,6 +67,8 @@ class BaseAppleVirtCPU : public BaseCPU
     void startup() override;
     DrainState drain() override;
     void drainResume() override;
+    void serializeThread(CheckpointOut &cp, ThreadID tid) const override;
+    void unserializeThread(CheckpointIn &cp, ThreadID tid) override;
     void verifyMemoryMode() const override;
 
     Port &
@@ -142,15 +144,14 @@ class BaseAppleVirtCPU : public BaseCPU
     void watchdogLoop();
 
     Tick doMMIOAccess(Addr paddr, void *data, unsigned size, bool write);
-    void advancePC();
 
-    virtual void syncThreadToHV();
-    virtual void syncHVToThread();
-    virtual void
-    updateInterrupts()
-    {}
-    virtual Tick handleException(const hv_vcpu_exit_exception_t &exception);
-    virtual void handleVTimerActivated();
+    virtual void advancePC() = 0;
+    virtual void syncThreadToHV() = 0;
+    virtual void syncHVToThread() = 0;
+    virtual void updateInterrupts() = 0;
+    virtual Tick
+    handleException(const hv_vcpu_exit_exception_t &exception) = 0;
+    virtual void handleVTimerActivated() = 0;
 
     std::thread::id ownerThread;
     std::thread watchdogThread;

--- a/src/cpu/apple_virt/vm.cc
+++ b/src/cpu/apple_virt/vm.cc
@@ -31,6 +31,11 @@
 #include <Hypervisor/hv_types.h>
 #include <Hypervisor/hv_vm.h>
 
+#include <unistd.h>
+
+#include <cassert>
+#include <cstdint>
+
 #include "base/logging.hh"
 #include "mem/physical.hh"
 #include "params/AppleVirtVM.hh"
@@ -40,17 +45,40 @@ namespace gem5
 {
 
 AppleVirtVM::AppleVirtVM(const AppleVirtVMParams &params)
-    : SimObject(params), initialized(false)
-{}
+    : SimObject(params),
+      initialized(false),
+      activeCPUs(0),
+      hostPageSize(sysconf(_SC_PAGESIZE))
+{
+    fatal_if(hostPageSize <= 0,
+             "AppleVirtVM could not determine the host page size");
+}
 
 AppleVirtVM::~AppleVirtVM()
 {
     if (initialized) {
+        warn_if(activeCPUs != 0,
+                "Destroying AppleVirtVM while %u vCPU(s) remain", activeCPUs);
         hv_return_t hv_err = hv_vm_destroy();
         if (hv_err != HV_SUCCESS) {
             warn("hv_vm_destroy failed (%d)", hv_err);
         }
     }
+}
+
+void
+AppleVirtVM::registerCPU()
+{
+    fatal_if(activeCPUs != 0,
+             "AppleVirtVM currently supports exactly one vCPU");
+    ++activeCPUs;
+}
+
+void
+AppleVirtVM::unregisterCPU()
+{
+    assert(activeCPUs == 1);
+    --activeCPUs;
 }
 
 void
@@ -80,7 +108,18 @@ AppleVirtVM::mapSystemMemory(System &system)
         }
 
         const AddrRange &range = entry.range;
+        fatal_if(range.interleaved(),
+                 "AppleVirtVM cannot map interleaved range %s",
+                 range.to_string());
         const uint64_t size = range.size();
+        const auto host_addr = reinterpret_cast<uintptr_t>(entry.pmem);
+        fatal_if(host_addr % hostPageSize != 0 ||
+                     range.start() % hostPageSize != 0 ||
+                     size % hostPageSize != 0,
+                 "AppleVirtVM mapping [%#llx, %#llx) is not aligned to "
+                 "the %ld-byte host page size",
+                 static_cast<unsigned long long>(range.start()),
+                 static_cast<unsigned long long>(range.end()), hostPageSize);
         hv_return_t hv_err =
             hv_vm_map(static_cast<void *>(entry.pmem), range.start(), size,
                       HV_MEMORY_READ | HV_MEMORY_WRITE | HV_MEMORY_EXEC);

--- a/src/cpu/apple_virt/vm.cc
+++ b/src/cpu/apple_virt/vm.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/apple_virt/vm.hh"
+
+#include <Hypervisor/hv_types.h>
+#include <Hypervisor/hv_vm.h>
+
+#include "base/logging.hh"
+#include "mem/physical.hh"
+#include "params/AppleVirtVM.hh"
+#include "sim/system.hh"
+
+namespace gem5
+{
+
+AppleVirtVM::AppleVirtVM(const AppleVirtVMParams &params)
+    : SimObject(params), initialized(false)
+{}
+
+AppleVirtVM::~AppleVirtVM()
+{
+    if (initialized) {
+        hv_return_t hv_err = hv_vm_destroy();
+        if (hv_err != HV_SUCCESS) {
+            warn("hv_vm_destroy failed (%d)", hv_err);
+        }
+    }
+}
+
+void
+AppleVirtVM::ensureInitialized(System &system)
+{
+    if (initialized) {
+        return;
+    }
+
+    hv_return_t hv_err = hv_vm_create(nullptr);
+    fatal_if(hv_err != HV_SUCCESS,
+             "hv_vm_create failed while bringing up AppleVirt VM (err=%d)",
+             hv_err);
+
+    mapSystemMemory(system);
+    initialized = true;
+}
+
+void
+AppleVirtVM::mapSystemMemory(System &system)
+{
+    auto &phys_mem = system.getPhysMem();
+    const auto backing = phys_mem.getBackingStore();
+    for (const auto &entry : backing) {
+        if (!entry.kvmMap || !entry.pmem) {
+            continue;
+        }
+
+        const AddrRange &range = entry.range;
+        const uint64_t size = range.size();
+        hv_return_t hv_err =
+            hv_vm_map(static_cast<void *>(entry.pmem), range.start(), size,
+                      HV_MEMORY_READ | HV_MEMORY_WRITE | HV_MEMORY_EXEC);
+        fatal_if(hv_err != HV_SUCCESS,
+                 "hv_vm_map failed for range [%#llx, %#llx) (err=%d)",
+                 static_cast<unsigned long long>(range.start()),
+                 static_cast<unsigned long long>(range.end()), hv_err);
+    }
+}
+
+} // namespace gem5

--- a/src/cpu/apple_virt/vm.hh
+++ b/src/cpu/apple_virt/vm.hh
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 The Regents of The University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_APPLE_VIRT_VM_HH__
+#define __CPU_APPLE_VIRT_VM_HH__
+
+#include <Hypervisor/hv.h>
+#include <Hypervisor/hv_vm.h>
+
+#include "base/addr_range.hh"
+#include "params/AppleVirtVM.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5
+{
+
+class System;
+
+/**
+ * Thin wrapper around the Apple Hypervisor (HVF) virtual machine APIs. It is
+ * responsible for creating the VM instance that all AppleVirt CPUs share and
+ * for mapping the gem5 backing store into the guest physical address space.
+ */
+class AppleVirtVM : public SimObject
+{
+  public:
+    AppleVirtVM(const AppleVirtVMParams &params);
+    ~AppleVirtVM() override;
+
+    /** Map the system backing store into the guest address space. */
+    void mapSystemMemory(System &system);
+
+    /** Ensure the VM is initialised before any CPU touches it. */
+    void ensureInitialized(System &system);
+
+  private:
+    bool initialized;
+};
+
+} // namespace gem5
+
+#endif

--- a/src/cpu/apple_virt/vm.hh
+++ b/src/cpu/apple_virt/vm.hh
@@ -58,8 +58,16 @@ class AppleVirtVM : public SimObject
     /** Ensure the VM is initialised before any CPU touches it. */
     void ensureInitialized(System &system);
 
+    /** Register the single vCPU supported by the initial backend. */
+    void registerCPU();
+
+    /** Record that the vCPU has been destroyed. */
+    void unregisterCPU();
+
   private:
     bool initialized;
+    unsigned activeCPUs;
+    long hostPageSize;
 };
 
 } // namespace gem5

--- a/src/dev/arm/GenericTimer.py
+++ b/src/dev/arm/GenericTimer.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2009-2020, 2022 Arm Limited
+# Copyright (c) 2026 The Regents of The University of California
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -118,8 +119,14 @@ class GenericTimer(SimObject):
     # Another real world bootloader might be changing the CNTFRQ register
     # value, so this initial value will be discarded
     cntfrq = Param.UInt64(0x1800000, "Value for the CNTFRQ timer register")
+    generate_system_interface = Param.Bool(
+        True, "Generate the architectural timer system interface in the DTB"
+    )
 
     def generateDeviceTree(self, state):
+        if not self.generate_system_interface:
+            return
+
         node = FdtNode("timer")
 
         node.appendCompatible(

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -231,8 +231,11 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         if hasattr(self.realview.gic, "cpu_addr"):
             self.gic_cpu_addr = self.realview.gic.cpu_addr
 
-        # For KVM cpus, we need to simulate the GIC.
-        if any(core.is_kvm_core() for core in self.processor.get_cores()):
+        # Hardware-virtualized CPUs need gem5 to simulate the GIC.
+        if any(
+            core.is_kvm_core() or core.is_apple_virt_core()
+            for core in self.processor.get_cores()
+        ):
             # The following is taken from
             # `tests/fs/linux/arm/configs/arm_generic.py`:
             # Arm KVM regressions will use a simulated GIC. This means that in
@@ -240,7 +243,8 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
             # generic timer from the DTB and we need to inform the MuxingKvmGic
             # class to use the gem5 GIC instead of relying on the host one
             GenericTimer.generateDeviceTree = SimObject.generateDeviceTree
-            self.realview.gic.simulate_gic = True
+            if hasattr(self.realview.gic, "simulate_gic"):
+                self.realview.gic.simulate_gic = True
 
         # IO devices has to setup before incorporating the caches in the case
         # of ruby caches. Otherwise the DMA controllers are incorrectly

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -54,7 +54,6 @@ from m5.objects import (
     BadAddr,
     Bridge,
     CowDiskImage,
-    GenericTimer,
     IOXBar,
     PciHost,
     PciVirtIO,
@@ -242,7 +241,7 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
             # order to work we need to remove the system interface of the
             # generic timer from the DTB and we need to inform the MuxingKvmGic
             # class to use the gem5 GIC instead of relying on the host one
-            GenericTimer.generateDeviceTree = SimObject.generateDeviceTree
+            self.realview.generic_timer.generate_system_interface = False
             if hasattr(self.realview.gic, "simulate_gic"):
                 self.realview.gic.simulate_gic = True
 

--- a/src/python/gem5/components/processors/abstract_core.py
+++ b/src/python/gem5/components/processors/abstract_core.py
@@ -75,6 +75,10 @@ class AbstractCore(SubSystem):
         """
         raise NotImplementedError
 
+    def is_apple_virt_core(self) -> bool:
+        """Return whether this core uses Apple's Hypervisor framework."""
+        return False
+
     @abstractmethod
     def connect_icache(self, port: Port) -> None:
         """

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -120,6 +120,17 @@ class BaseCPUCore(AbstractCore):
             # can't be a KVM core.
             return False
 
+    @overrides(AbstractCore)
+    def is_apple_virt_core(self) -> bool:
+        try:
+            from m5.objects import BaseAppleVirtCPU
+
+            return isinstance(self.core, BaseAppleVirtCPU)
+        except ImportError:
+            # If BaseAppleVirtCPU is not importable, Apple virtualization was
+            # not compiled into this binary.
+            return False
+
     def get_isa(self) -> ISA:
         return self._isa
 
@@ -137,14 +148,10 @@ class BaseCPUCore(AbstractCore):
 
     @overrides(AbstractCore)
     def set_workload(self, process: Process) -> None:
-        try:
-            from m5.objects import BaseAppleVirtCPU
-
-            if isinstance(self.core, BaseAppleVirtCPU):
-                self.core.workload = [process]
-                return
-        except ImportError:
-            pass
+        if self.is_apple_virt_core():
+            raise NotImplementedError(
+                "AppleVirtCPU only supports full-system workloads"
+            )
 
         self.core.workload = process
 

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -137,6 +137,15 @@ class BaseCPUCore(AbstractCore):
 
     @overrides(AbstractCore)
     def set_workload(self, process: Process) -> None:
+        try:
+            from m5.objects import BaseAppleVirtCPU
+
+            if isinstance(self.core, BaseAppleVirtCPU):
+                self.core.workload = [process]
+                return
+        except ImportError:
+            pass
+
         self.core.workload = process
 
     @overrides(AbstractCore)

--- a/src/python/gem5/components/processors/base_cpu_processor.py
+++ b/src/python/gem5/components/processors/base_cpu_processor.py
@@ -52,6 +52,7 @@ from m5.objects import (
 )
 from m5.util import warn
 
+from ...isas import ISA
 from ...utils.override import overrides
 from ..boards.abstract_board import AbstractBoard
 from ..boards.mem_mode import MemMode
@@ -95,20 +96,15 @@ class BaseCPUProcessor(AbstractProcessor):
             self.kvm_vm = KvmVM()
 
         if self._any_apple_virt_core():
-            from m5.objects import AppleVirtVM
-
-            self.apple_virt_vm = AppleVirtVM()
+            if len(self.get_cores()) != 1:
+                raise ValueError(
+                    "AppleVirtCPU currently supports exactly one core"
+                )
+            if self.get_isa() != ISA.ARM:
+                raise ValueError("AppleVirtCPU only supports the ARM ISA")
 
     def _any_apple_virt_core(self) -> bool:
-        try:
-            from m5.objects import BaseAppleVirtCPU
-
-            return any(
-                isinstance(core.get_simobject(), BaseAppleVirtCPU)
-                for core in self.get_cores()
-            )
-        except ImportError:
-            return False
+        return any(core.is_apple_virt_core() for core in self.get_cores())
 
     @overrides(AbstractProcessor)
     def incorporate_processor(self, board: AbstractBoard) -> None:
@@ -122,12 +118,16 @@ class BaseCPUProcessor(AbstractProcessor):
                 core.get_simobject().eventq_index = i + 1
             board.set_mem_mode(MemMode.ATOMIC_NONCACHING)
         elif self._any_apple_virt_core():
-            for i, core in enumerate(self.cores):
+            if not board.is_fullsystem():
+                raise ValueError(
+                    "AppleVirtCPU only supports full-system simulation"
+                )
+            from m5.objects import AppleVirtVM
+
+            board.apple_virt_vm = AppleVirtVM()
+            for core in self.cores:
                 simobj = core.get_simobject()
-                simobj.vm = self.apple_virt_vm
-                for obj in simobj.descendants():
-                    obj.eventq_index = 0
-                simobj.eventq_index = i + 1
+                simobj.vm = board.apple_virt_vm
             board.set_mem_mode(MemMode.ATOMIC_NONCACHING)
         elif isinstance(
             self.cores[0].get_simobject(),
@@ -153,9 +153,6 @@ class BaseCPUProcessor(AbstractProcessor):
 
     def _pre_instantiate(self, root: Root) -> None:
         super()._pre_instantiate(root)
-        if (
-            any(core.is_kvm_core() for core in self.get_cores())
-            or self._any_apple_virt_core()
-        ):
+        if any(core.is_kvm_core() for core in self.get_cores()):
             m5.ticks.fixGlobalFrequency()
             root.sim_quantum = m5.ticks.fromSeconds(0.001)

--- a/src/python/gem5/components/processors/base_cpu_processor.py
+++ b/src/python/gem5/components/processors/base_cpu_processor.py
@@ -94,6 +94,22 @@ class BaseCPUProcessor(AbstractProcessor):
 
             self.kvm_vm = KvmVM()
 
+        if self._any_apple_virt_core():
+            from m5.objects import AppleVirtVM
+
+            self.apple_virt_vm = AppleVirtVM()
+
+    def _any_apple_virt_core(self) -> bool:
+        try:
+            from m5.objects import BaseAppleVirtCPU
+
+            return any(
+                isinstance(core.get_simobject(), BaseAppleVirtCPU)
+                for core in self.get_cores()
+            )
+        except ImportError:
+            return False
+
     @overrides(AbstractProcessor)
     def incorporate_processor(self, board: AbstractBoard) -> None:
         if any(core.is_kvm_core() for core in self.get_cores()):
@@ -104,6 +120,14 @@ class BaseCPUProcessor(AbstractProcessor):
                 for obj in core.get_simobject().descendants():
                     obj.eventq_index = 0
                 core.get_simobject().eventq_index = i + 1
+            board.set_mem_mode(MemMode.ATOMIC_NONCACHING)
+        elif self._any_apple_virt_core():
+            for i, core in enumerate(self.cores):
+                simobj = core.get_simobject()
+                simobj.vm = self.apple_virt_vm
+                for obj in simobj.descendants():
+                    obj.eventq_index = 0
+                simobj.eventq_index = i + 1
             board.set_mem_mode(MemMode.ATOMIC_NONCACHING)
         elif isinstance(
             self.cores[0].get_simobject(),
@@ -129,6 +153,9 @@ class BaseCPUProcessor(AbstractProcessor):
 
     def _pre_instantiate(self, root: Root) -> None:
         super()._pre_instantiate(root)
-        if any(core.is_kvm_core() for core in self.get_cores()):
+        if (
+            any(core.is_kvm_core() for core in self.get_cores())
+            or self._any_apple_virt_core()
+        ):
             m5.ticks.fixGlobalFrequency()
             root.sim_quantum = m5.ticks.fromSeconds(0.001)

--- a/src/python/gem5/components/processors/cpu_types.py
+++ b/src/python/gem5/components/processors/cpu_types.py
@@ -34,6 +34,7 @@ from ..boards.mem_mode import MemMode
 class CPUTypes(Enum):
     ATOMIC = "atomic"
     KVM = "kvm"
+    APPLE_VIRT = "apple_virt"
     O3 = "o3"
     TIMING = "timing"
     MINOR = "minor"
@@ -84,6 +85,7 @@ def get_mem_mode(input: CPUTypes) -> MemMode:
         CPUTypes.O3: MemMode.TIMING,
         CPUTypes.MINOR: MemMode.TIMING,
         CPUTypes.KVM: MemMode.ATOMIC_NONCACHING,
+        CPUTypes.APPLE_VIRT: MemMode.ATOMIC_NONCACHING,
         CPUTypes.ATOMIC: MemMode.ATOMIC,
     }
 

--- a/src/python/gem5/components/processors/simple_core.py
+++ b/src/python/gem5/components/processors/simple_core.py
@@ -82,6 +82,7 @@ class SimpleCore(BaseCPUCore):
             CPUTypes.O3: "O3CPU",
             CPUTypes.TIMING: "TimingSimpleCPU",
             CPUTypes.KVM: "KvmCPU",
+            CPUTypes.APPLE_VIRT: "AppleVirtCPU",
             CPUTypes.MINOR: "MinorCPU",
         }
 
@@ -98,9 +99,9 @@ class SimpleCore(BaseCPUCore):
                 "`AbstractCore.cpu_simobject_factory._cpu_types_string_map`"
             )
 
-        if cpu_type == CPUTypes.KVM:
-            # For some reason, the KVM CPU is under "m5.objects" not the
-            # "m5.objects.{ISA}CPU".
+        if cpu_type in (CPUTypes.KVM, CPUTypes.APPLE_VIRT):
+            # For some reason, the KVM and Apple virt CPUs are under
+            # "m5.objects" not the "m5.objects.{ISA}CPU".
             module_str = f"m5.objects"
         else:
             module_str = f"m5.objects.{_isa_string_map[isa]}CPU"
@@ -109,7 +110,13 @@ class SimpleCore(BaseCPUCore):
         # : ArmKvmCPU and ArmV8KvmCPU for 32 bit (Armv7l) and 64 bit (Armv8)
         # respectively.
 
-        if (
+        if cpu_type == CPUTypes.APPLE_VIRT:
+            if isa != ISA.ARM:
+                raise NotImplementedError(
+                    "AppleVirtCPU is currently only supported for ARM ISA"
+                )
+            cpu_class_str = "ArmAppleVirtCPU"
+        elif (
             isa.name == "ARM"
             and cpu_type == CPUTypes.KVM
             and platform.architecture()[0] == "64bit"
@@ -150,9 +157,14 @@ class SimpleCore(BaseCPUCore):
         :param core_id: The id of the core to be returned.
         """
 
-        core = cls.cpu_class_factory(cpu_type=cpu_type, isa=isa)(
-            cpu_id=core_id
-        )
+        cpu_class = cls.cpu_class_factory(cpu_type=cpu_type, isa=isa)
+
+        if cpu_type == CPUTypes.APPLE_VIRT:
+            from m5.objects import AppleVirtVM
+
+            core = cpu_class(cpu_id=core_id, vm=AppleVirtVM())
+        else:
+            core = cpu_class(cpu_id=core_id)
 
         # RISC-V KVM vector state is host-dependent. Use the latest profile
         # without the V extension by default; callers may select RVA23S64 when

--- a/src/python/gem5/components/processors/simple_core.py
+++ b/src/python/gem5/components/processors/simple_core.py
@@ -67,6 +67,8 @@ class SimpleCore(BaseCPUCore):
 
         assert isa is not None
         requires(isa_required=isa)
+        if cpu_type == CPUTypes.APPLE_VIRT:
+            requires(apple_virt_required=True)
 
         _isa_string_map = {
             ISA.X86: "X86",
@@ -134,7 +136,7 @@ class SimpleCore(BaseCPUCore):
             to_return_cls = getattr(
                 importlib.import_module(module_str), cpu_class_str
             )
-        except ImportError:
+        except (AttributeError, ImportError):
             raise Exception(
                 f"Cannot find CPU type '{cpu_type.name}' for '{isa.name}' "
                 "ISA. Please ensure you have compiled the correct version of "

--- a/src/python/gem5/components/processors/simple_core.py
+++ b/src/python/gem5/components/processors/simple_core.py
@@ -157,14 +157,9 @@ class SimpleCore(BaseCPUCore):
         :param core_id: The id of the core to be returned.
         """
 
-        cpu_class = cls.cpu_class_factory(cpu_type=cpu_type, isa=isa)
-
-        if cpu_type == CPUTypes.APPLE_VIRT:
-            from m5.objects import AppleVirtVM
-
-            core = cpu_class(cpu_id=core_id, vm=AppleVirtVM())
-        else:
-            core = cpu_class(cpu_id=core_id)
+        core = cls.cpu_class_factory(cpu_type=cpu_type, isa=isa)(
+            cpu_id=core_id
+        )
 
         # RISC-V KVM vector state is host-dependent. Use the latest profile
         # without the V extension by default; callers may select RVA23S64 when

--- a/src/python/gem5/components/processors/switchable_processor.py
+++ b/src/python/gem5/components/processors/switchable_processor.py
@@ -33,6 +33,7 @@ from typing import (
 import m5
 from m5.objects import Root
 
+from ...isas import ISA
 from ...utils.override import *
 from ..boards.abstract_board import AbstractBoard
 from .abstract_core import AbstractCore
@@ -90,16 +91,32 @@ class SwitchableProcessor(AbstractProcessor):
         self._prepare_kvm = any(
             core.is_kvm_core() for core in self._all_cores()
         )
-
-        if any(core.is_apple_virt_core() for core in self._all_cores()):
-            raise NotImplementedError(
-                "AppleVirtCPU does not support CPU switching"
+        apple_virt_cores = [
+            core for core in self._all_cores() if core.is_apple_virt_core()
+        ]
+        self._prepare_apple_virt = bool(apple_virt_cores)
+        if len(apple_virt_cores) > 1:
+            raise ValueError(
+                "AppleVirtCPU currently supports exactly one core"
             )
+        if self._prepare_apple_virt and self.get_isa() != ISA.ARM:
+            raise ValueError("AppleVirtCPU only supports the ARM ISA")
+        if self._prepare_apple_virt and not any(
+            core.is_apple_virt_core() for core in self._current_cores
+        ):
+            raise ValueError("AppleVirtCPU must be in the starting core set")
 
         if self._prepare_kvm:
             from m5.objects import KvmVM
 
             self.kvm_vm = KvmVM()
+
+        if self._prepare_apple_virt:
+            from m5.objects import AppleVirtVM
+
+            self.apple_virt_vm = AppleVirtVM()
+            for core in apple_virt_cores:
+                core.get_simobject().vm = self.apple_virt_vm
 
     @overrides(AbstractProcessor)
     def incorporate_processor(self, board: AbstractBoard) -> None:
@@ -108,6 +125,11 @@ class SwitchableProcessor(AbstractProcessor):
         # argument. We therefore need to store the board when incorporating the
         # procsesor
         self._board = board
+
+        if self._prepare_apple_virt and not board.is_fullsystem():
+            raise ValueError(
+                "AppleVirtCPU only supports full-system simulation"
+            )
 
         if self._prepare_kvm:
             # To get the KVM CPUs to run on different host CPUs

--- a/src/python/gem5/components/processors/switchable_processor.py
+++ b/src/python/gem5/components/processors/switchable_processor.py
@@ -91,6 +91,11 @@ class SwitchableProcessor(AbstractProcessor):
             core.is_kvm_core() for core in self._all_cores()
         )
 
+        if any(core.is_apple_virt_core() for core in self._all_cores()):
+            raise NotImplementedError(
+                "AppleVirtCPU does not support CPU switching"
+            )
+
         if self._prepare_kvm:
             from m5.objects import KvmVM
 

--- a/src/python/gem5/utils/requires.py
+++ b/src/python/gem5/utils/requires.py
@@ -28,6 +28,8 @@ import inspect
 import os
 from typing import Optional
 
+from m5.defines import buildEnv
+
 from ..coherence_protocol import CoherenceProtocol
 from ..isas import ISA
 from ..runtime import (
@@ -58,16 +60,19 @@ def requires(
     isa_required: Optional[ISA] = None,
     coherence_protocol_required: Optional[CoherenceProtocol] = None,
     kvm_required: bool = False,
+    apple_virt_required: bool = False,
 ) -> None:
     """
-    Ensures the ISA/Coherence protocol/KVM requirements are met. An exception
-    will be raise if they are not.
+    Ensures the ISA/coherence protocol/host virtualization requirements are
+    met. An exception will be raised if they are not.
 
     :param isa_required: The ISA(s) gem5 must be compiled to.
     :param coherence_protocol_required: The coherence protocol gem5 must be
                                         compiled to.
     :param kvm_required: The host system must have the Kernel-based Virtual
                          Machine available.
+    :param apple_virt_required: The gem5 binary must include Apple
+                                virtualization support.
     :raises Exception: Raises an exception if the required ISA or coherence
                        protocol do not match that of the current gem5 binary.
     """
@@ -120,5 +125,13 @@ def requires(
         raise Exception(
             _get_exception_str(
                 msg="KVM is required but is unavailable on this system"
+            )
+        )
+
+    if apple_virt_required and not buildEnv.get("USE_APPLE_VIRT", False):
+        raise Exception(
+            _get_exception_str(
+                msg="Apple virtualization is required but is unavailable in "
+                "this gem5 binary"
             )
         )

--- a/tests/gem5/example_configs/arm/test_gem5_library_examples.py
+++ b/tests/gem5/example_configs/arm/test_gem5_library_examples.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 The Regents of the University of California
+# Copyright (c) 2021-2026 The Regents of the University of California
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import platform
 import re
+import shutil
+import subprocess
+import sys
 
 from testlib import (
     config,
@@ -39,6 +43,26 @@ hello_verifier = verifier.MatchRegex(re.compile(r"Hello world!"))
 save_checkpoint_verifier = verifier.MatchRegex(
     re.compile(r"Done taking a checkpoint")
 )
+
+
+def supports_apple_virt():
+    if (
+        sys.platform != "darwin"
+        or platform.machine().lower() not in ("arm64", "aarch64")
+        or shutil.which("codesign") is None
+    ):
+        return False
+
+    try:
+        return (
+            subprocess.check_output(
+                ("sysctl", "-n", "kern.hv_support"), text=True
+            ).strip()
+            == "1"
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return False
+
 
 gem5_verify_config(
     name="test-gem5-library-example-arm-hello",
@@ -70,3 +94,23 @@ gem5_verify_config(
     valid_hosts=constants.supported_hosts,
     length=constants.long_tag,
 )
+
+
+if supports_apple_virt():
+    for example in ("apple_virt_simple", "apple_virt_kernel_disk"):
+        gem5_verify_config(
+            name=f"test-gem5-library-example-{example.replace('_', '-')}",
+            fixtures=(),
+            verifiers=(),
+            config=joinpath(
+                config.base_dir,
+                "configs",
+                "example",
+                "gem5_library",
+                f"{example}.py",
+            ),
+            config_args=[],
+            valid_isas=(constants.all_compiled_tag,),
+            valid_hosts=(constants.host_arm_tag,),
+            length=constants.quick_tag,
+        )

--- a/tests/gem5/example_configs/arm/test_gem5_library_examples.py
+++ b/tests/gem5/example_configs/arm/test_gem5_library_examples.py
@@ -114,3 +114,24 @@ if supports_apple_virt():
             valid_hosts=(constants.host_arm_tag,),
             length=constants.quick_tag,
         )
+
+    gem5_verify_config(
+        name="test-gem5-library-example-apple-virt-switch",
+        fixtures=(),
+        verifiers=(
+            verifier.MatchRegex(
+                re.compile("AppleVirt switching completed successfully")
+            ),
+        ),
+        config=joinpath(
+            config.base_dir,
+            "configs",
+            "example",
+            "gem5_library",
+            "apple_virt_switch.py",
+        ),
+        config_args=[],
+        valid_isas=(constants.all_compiled_tag,),
+        valid_hosts=(constants.host_arm_tag,),
+        length=constants.quick_tag,
+    )


### PR DESCRIPTION
## Summary

This adds `AppleVirtCPU`, an AArch64 full-system CPU backend accelerated by
Apple's Hypervisor.framework. It fills the same host-acceleration role as
`KvmCPU` on Apple Silicon while gem5 continues to model the platform, memory,
devices, interrupts, and simulation event queue.

The implementation includes:

- an `AppleVirtVM` that maps gem5's physical memory into the Apple hypervisor;
- an `ArmAppleVirtCPU` that synchronizes general-purpose, system, SIMD/FP,
  pointer-authentication, and checkpoint-relevant architectural state;
- exception handling for system-register traps, WFI/WFE, HVC, and MMIO data
  aborts;
- a watchdog that bounds each host `hv_vcpu_run()` call so gem5 events continue
  to make progress;
- IRQ/FIQ delivery through the gem5-modeled Arm GIC;
- stdlib support through `CPUTypes.APPLE_VIRT`, `SimpleProcessor`,
  `SimpleSwitchableProcessor`, `ArmBoard`, and
  `requires(apple_virt_required=True)`;
- CPU takeover support for switching from AppleVirt to a simulated CPU and
  back; and
- checkpoint serialization through the synchronized gem5 thread state.

## Build integration

SCons now detects support automatically. On an Apple Silicon macOS host it
performs a compile-and-link probe for Hypervisor.framework, verifies that
`codesign` is available, enables the Arm AppleVirt backend, and links the
framework.

The normal and stripped gem5 executables are then signed automatically with
the bundled `com.apple.security.hypervisor` entitlement. The host integration
test receives the same entitlement; unrelated test executables do not. No
manual signing step is required.

Non-Apple hosts and non-Arm builds leave `USE_APPLE_VIRT` disabled.

## Examples

The stdlib examples under `configs/example/gem5_library/` cover normal boot,
explicitly pinned resources, and CPU switching.

Boot the gem5 Resources Ubuntu 24.04 workload:

```sh
scons build/ARM/gem5.opt -j$(sysctl -n hw.ncpu)
build/ARM/gem5.opt \
    configs/example/gem5_library/apple_virt_simple.py
```

Boot explicitly selected, pinned gem5 Resource kernel, disk-image, and
bootloader artifacts:

```sh
build/ARM/gem5.opt \
    configs/example/gem5_library/apple_virt_kernel_disk.py
```

Boot with AppleVirt, switch to a Timing CPU, then switch back:

```sh
build/ARM/gem5.opt \
    configs/example/gem5_library/apple_virt_switch.py
```

These examples use the stdlib `ArmBoard` and processor interfaces and require
no user-supplied artifact paths.

## Tests and validation

TestLib registers the examples as quick tests only on compatible Apple Silicon
hosts. Compatibility detection checks macOS, an Arm64 host, hardware
hypervisor support, and `codesign`. TestLib also normalizes macOS's `arm64`
machine name to its `aarch64` host tag, so plain `./main.py` discovery
selects the tests on supported Macs. Incompatible hosts do not register the
suites.

Validation performed on an Apple Silicon host:

- Built signed `build/ARM/gem5.opt` and `build/ALL/gem5.opt` binaries and
  verified both with `codesign --verify`.
- Passed 4 host Hypervisor.framework tests covering VM/vCPU creation, register
  synchronization, all pointer-authentication keys, `CSSELR_EL1`, guest code
  execution, and exception reporting.
- Passed 6 AppleVirt exception-decoder unit tests.
- Booted the stdlib Ubuntu 24.04 example to `multi-user.target`, completed the
  automatic login, ran the gem5 bridge script, and exited normally.
- Passed the focused quick TestLib switching suite. It switches
  AppleVirt-to-Timing-to-AppleVirt, verifies that Timing retires guest
  instructions, and then observes an AppleVirt-executed guest hypercall.
- Confirmed the suites are discovered for the default Apple Silicon host and
  are absent for an `x86_64` host selection.
- Confirmed an X86 build configuration does not select AppleVirt.
- Passed the gem5 pre-commit hooks and `git diff --check`.

## Current scope

This initial backend intentionally supports one AArch64 full-system vCPU in
atomic non-caching mode. CPU switching is supported when AppleVirt is the
starting core; configuring AppleVirt only as a later switch target is deferred
until boards can prepare all switchable cores consistently. SE mode,
instruction-count events and instruction statistics, EL2/EL3 guest execution,
and the Hypervisor.framework architectural virtual-timer exit are not
supported. `ArmBoard` omits the architectural timer system interface from the
guest DTB for AppleVirt and uses gem5's modeled timer path instead.
