### PR TITLE
misc: Modifications to weekly tests

### DIFF
--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -154,6 +154,7 @@ jobs:
 
     gpu-tests:
         strategy:
+            fail-fast: false
             matrix:
                 test-length: [quick, long, very-long]
         runs-on: [self-hosted, linux, x64]

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -109,6 +109,7 @@ jobs:
         name: testlib-tests
         strategy:
             fail-fast: false
+            max-parallel: 5
             matrix:
                 test-type: ${{ fromJson(needs.flatten-length-and-testdir-matrices.outputs.test-dirs-matrix-flattened) }}
         runs-on: [self-hosted, linux, x64]


### PR DESCRIPTION
This PR modifies the weekly tests workflow in the following ways:

1. The GPU tests will no longer fail fast, so if one test out of the quick, long, or very-long GPU tests fails, the other two will continue.
2. The TestLib tests in the weekly tests have been limited to only run 5 jobs in parallel. This is to avoid overwhelming the runners or crowding out other tests.