### PR TITLE
mem-ruby: missing TBE type for setRubySystem code gen

### DIFF
--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -791,6 +791,7 @@ $c_ident::init()
                         "NetDest",
                         "PerfectCacheMemory",
                         "TBETable",
+                        "MN_TBETable",
                     ):
                         code(f"(*{vid}).setRubySystem(m_ruby_system);")
 


### PR DESCRIPTION
Change-Id: Idb6e47d5debd8446aaa6f436a884ba6b1f034844