### PR TITLE
mem-ruby: prefetch wrapper fixes read hit/fill

### DIFF
--- a/src/mem/ruby/structures/RubyPrefetcherProxy.cc
+++ b/src/mem/ruby/structures/RubyPrefetcherProxy.cc
@@ -165,8 +165,8 @@ RubyPrefetcherProxy::notifyPfHit(const RequestPtr& req, bool is_read,
 {
     assert(ppHit);
     assert(req);
-    Packet pkt(req, is_read ? Packet::makeReadCmd(req) :
-                              Packet::makeWriteCmd(req));
+    Packet pkt(req, is_read ? Packet::makeReadCmd(req).responseCommand()
+                            : Packet::makeWriteCmd(req));
     // NOTE: for now we only communicate physical address with prefetchers
     pkt.dataStaticConst<uint8_t>(data_blk.getData(getOffset(req->getPaddr()),
                                   pkt.getSize()));
@@ -198,9 +198,8 @@ RubyPrefetcherProxy::notifyPfFill(const RequestPtr& req,
 {
     assert(ppFill);
     assert(req);
-    Packet pkt(req, Packet::makeReadCmd(req));
-    if (from_pf)
-        pkt.cmd = Packet::Command::HardPFReq;
+    Packet pkt(req, from_pf ? MemCmd::HardPFResp
+                            : Packet::makeReadCmd(req).responseCommand());
     // NOTE: for now we only communicate physical address with prefetchers
     pkt.dataStaticConst<uint8_t>(data_blk.getData(getOffset(req->getPaddr()),
                                   pkt.getSize()));


### PR DESCRIPTION
Probes for a read hit and cache fill create a response packet so its HasData property is set and the pkt data is readable by prefetchers.

Change-Id: I34483923e4a02009bfa9d3c2d735e3f4ee4fca37