### PR TITLE
mem: Add enable_backdoor param to BaseXBar

### DIFF
--- a/src/mem/XBar.py
+++ b/src/mem/XBar.py
@@ -93,6 +93,11 @@ class BaseXBar(ClockedObject):
     use_default_range = Param.Bool(
         False, "Perform address mapping for the default port"
     )
+    enable_backdoor = Param.Bool(
+        True,
+        "If true, allow receiving and forwarding of backdoor requests. "
+        "If false, the XBar will send packets without a backdoor.",
+    )
 
 
 class NoncoherentXBar(BaseXBar):

--- a/src/mem/coherent_xbar.cc
+++ b/src/mem/coherent_xbar.cc
@@ -815,9 +815,10 @@ CoherentXBar::recvAtomicBackdoor(PacketPtr pkt, PortID cpu_side_port_id,
 
             // forward the request to the appropriate destination
             auto mem_side_port = memSidePorts[mem_side_port_id];
-            response_latency = backdoor ?
-                mem_side_port->sendAtomicBackdoor(pkt, *backdoor) :
-                mem_side_port->sendAtomic(pkt);
+            response_latency =
+                (enableBackdoor && backdoor)
+                    ? mem_side_port->sendAtomicBackdoor(pkt, *backdoor)
+                    : mem_side_port->sendAtomic(pkt);
         } else {
             // if it does not need a response we sink the packet above
             assert(pkt->needsResponse());

--- a/src/mem/noncoherent_xbar.cc
+++ b/src/mem/noncoherent_xbar.cc
@@ -264,9 +264,10 @@ NoncoherentXBar::recvAtomicBackdoor(PacketPtr pkt, PortID cpu_side_port_id,
 
     // forward the request to the appropriate destination
     auto mem_side_port = memSidePorts[mem_side_port_id];
-    Tick response_latency = backdoor ?
-        mem_side_port->sendAtomicBackdoor(pkt, *backdoor) :
-        mem_side_port->sendAtomic(pkt);
+    Tick response_latency =
+        (enableBackdoor && backdoor)
+            ? mem_side_port->sendAtomicBackdoor(pkt, *backdoor)
+            : mem_side_port->sendAtomic(pkt);
 
     // add the response data
     if (pkt->isResponse()) {

--- a/src/mem/xbar.cc
+++ b/src/mem/xbar.cc
@@ -65,9 +65,12 @@ BaseXBar::BaseXBar(const BaseXBarParams &p)
       headerLatency(p.header_latency),
       width(p.width),
       gotAddrRanges(p.port_default_connection_count +
-                          p.port_mem_side_ports_connection_count, false),
-      gotAllAddrRanges(false), defaultPortID(InvalidPortID),
+                        p.port_mem_side_ports_connection_count,
+                    false),
+      gotAllAddrRanges(false),
+      defaultPortID(InvalidPortID),
       useDefaultRange(p.use_default_range),
+      enableBackdoor(p.enable_backdoor),
 
       ADD_STAT(transDist, statistics::units::Count::get(),
                "Transaction distribution"),

--- a/src/mem/xbar.hh
+++ b/src/mem/xbar.hh
@@ -395,6 +395,10 @@ class BaseXBar : public ClockedObject
        addresses not handled by another port to default device. */
     const bool useDefaultRange;
 
+    /** If true, allow receiving and forwarding of backdoor requests.
+        If false, the XBar will send packets without a backdoor. */
+    const bool enableBackdoor;
+
     BaseXBar(const BaseXBarParams &p);
 
     /**


### PR DESCRIPTION
If the enable_backdoor is ture, the XBar will send packet to mem_side_ports with backdoor. Otherwise, send packet without backdoor

Change-Id: I48e2ae353a72adaa81fd10f45b0475b2490952e3