### PR TITLE
mem-ruby: optional RubyPort resp latency

### DIFF
--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013,2020-2021 ARM Limited
+ * Copyright (c) 2012-2013,2020-2021,2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -56,17 +56,22 @@ namespace ruby
 {
 
 RubyPort::RubyPort(const Params &p)
-    : ClockedObject(p), m_ruby_system(p.ruby_system), m_version(p.version),
-      m_controller(NULL), m_mandatory_q_ptr(NULL),
-      m_usingRubyTester(p.using_ruby_tester), system(p.system),
+    : ClockedObject(p),
+      m_ruby_system(p.ruby_system),
+      m_version(p.version),
+      m_controller(NULL),
+      m_mandatory_q_ptr(NULL),
+      m_usingRubyTester(p.using_ruby_tester),
+      system(p.system),
       pioRequestPort(csprintf("%s.pio-request-port", name()), *this),
       pioResponsePort(csprintf("%s.pio-response-port", name()), *this),
       memRequestPort(csprintf("%s.mem-request-port", name()), *this),
       memResponsePort(csprintf("%s-mem-response-port", name()), *this,
-                   p.ruby_system->getAccessBackingStore(), -1,
-                   p.no_retry_on_stall),
+                      p.ruby_system->getAccessBackingStore(), -1,
+                      p.no_retry_on_stall),
       gotAddrRanges(p.port_interrupt_out_port_connection_count),
-      m_isCPUSequencer(p.is_cpu_sequencer)
+      m_isCPUSequencer(p.is_cpu_sequencer),
+      m_responseLatency(p.response_latency)
 {
     assert(m_version != -1);
 
@@ -680,7 +685,8 @@ RubyPort::MemResponsePort::hitCallback(PacketPtr pkt)
         // Send a response in the same cycle. There is no need to delay the
         // response because the response latency is already incurred in the
         // Ruby protocol.
-        schedTimingResp(pkt, curTick());
+        Tick rsp_lat = owner.cyclesToTicks(owner.m_responseLatency);
+        schedTimingResp(pkt, curTick() + rsp_lat);
     } else {
         delete pkt;
     }

--- a/src/mem/ruby/system/RubyPort.hh
+++ b/src/mem/ruby/system/RubyPort.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013,2019,2021 ARM Limited
+ * Copyright (c) 2012-2013,2019,2021,2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -242,6 +242,8 @@ class RubyPort : public ClockedObject
     std::vector<MemResponsePort *> retryList;
 
     bool m_isCPUSequencer;
+
+    const Cycles m_responseLatency;
 };
 
 } // namespace ruby

--- a/src/mem/ruby/system/Sequencer.py
+++ b/src/mem/ruby/system/Sequencer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ARM Limited
+# Copyright (c) 2020,2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -70,6 +70,10 @@ class RubyPort(ClockedObject):
     mem_request_port = RequestPort("Ruby mem request port")
 
     pio_response_port = ResponsePort("Ruby pio response port")
+
+    response_latency = Param.Cycles(
+        0, "Latency for enqueueing response pkts to peer"
+    )
 
     using_ruby_tester = Param.Bool(False, "")
     no_retry_on_stall = Param.Bool(False, "")


### PR DESCRIPTION
Parameter to add latency to response packets scheduled from the RubyPort.

Change-Id: Icad1e5bbd150f785859fc63f481ae4c9c6ad40d7