### PR TITLE
arch-riscv: Add support for Sv48 and Sv57 virtual memory systems

### DIFF
--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -804,8 +804,11 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                 SATP cur_val = readMiscRegNoEffect(idx);
                 SATP new_val = val;
                 if (new_val.mode != AddrXlateMode::BARE &&
-                    new_val.mode != AddrXlateMode::SV39)
+                    new_val.mode != AddrXlateMode::SV39 &&
+                    new_val.mode != AddrXlateMode::SV48 &&
+                    new_val.mode != AddrXlateMode::SV57) {
                     new_val.mode = cur_val.mode;
+                }
 
                 // TLB flush can be elided here
                 // --- From the RISCV Privileged Spec 20250508, p.129 ---
@@ -825,8 +828,11 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                 SATP cur_val = readMiscRegNoEffect(idx);
                 SATP new_val = val;
                 if (new_val.mode != AddrXlateMode::BARE &&
-                    new_val.mode != AddrXlateMode::SV39)
+                    new_val.mode != AddrXlateMode::SV39 &&
+                    new_val.mode != AddrXlateMode::SV48 &&
+                    new_val.mode != AddrXlateMode::SV57) {
                     new_val.mode = cur_val.mode;
+                }
 
                 setMiscRegNoEffect(idx, new_val);
             }
@@ -868,8 +874,9 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                 SATP new_val = val;
 
                 if (new_val.mode != AddrXlateMode::BARE &&
-                    new_val.mode != AddrXlateMode::SV39)
-                {
+                    new_val.mode != AddrXlateMode::SV39 &&
+                    new_val.mode != AddrXlateMode::SV48 &&
+                    new_val.mode != AddrXlateMode::SV57) {
                     new_val.mode = cur_val.mode;
                 }
 

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -6302,7 +6302,8 @@ decode QUADRANT default Unknown::unknown() {
                                         machInst);
                         }
 
-                        xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                        static_cast<MMU *>(xc->tcBase()->getMMUPtr())->
+                            demapPage(xc->tcBase(), Rs1, Rs2);
                     }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
 
                     0xb: sinval_vvma({{
@@ -6338,7 +6339,8 @@ decode QUADRANT default Unknown::unknown() {
                                         "hfence needs at least S priv",
                                         machInst);
                         }
-                        xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                        static_cast<MMU *>(xc->tcBase()->getMMUPtr())->
+                            demapPage(xc->tcBase(), Rs1, Rs2, false, true);
                         return NoFault;
 
                     }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);
@@ -6432,7 +6434,8 @@ decode QUADRANT default Unknown::unknown() {
                                             "hfence in U or TVM on",
                                             machInst);
                             }
-                            xc->tcBase()->getMMUPtr()->demapPage(Rs1, Rs2);
+                            static_cast<MMU *>(xc->tcBase()->getMMUPtr())->
+                                demapPage(xc->tcBase(), Rs1, Rs2, true);
                             return NoFault;
 
                         }}, IsNonSpeculative, IsSerializeAfter, No_OpClass);

--- a/src/arch/riscv/mmu.hh
+++ b/src/arch/riscv/mmu.hh
@@ -107,6 +107,14 @@ class MMU : public BaseMMU
 
     }
 
+    void
+    demapPage(ThreadContext *tc, Addr vaddr, uint64_t asn,
+              bool is_gvma = false, bool is_vvma = false)
+    {
+        static_cast<TLB *>(itb)->demapPage(tc, vaddr, asn, is_gvma, is_vvma);
+        static_cast<TLB *>(dtb)->demapPage(tc, vaddr, asn, is_gvma, is_vvma);
+    }
+
     PMP *
     getPMP()
     {

--- a/src/arch/riscv/pagetable.cc
+++ b/src/arch/riscv/pagetable.cc
@@ -45,6 +45,7 @@ TlbEntry::serialize(CheckpointOut &cp) const
     SERIALIZE_SCALAR(vaddr);
     SERIALIZE_SCALAR(logBytes);
     SERIALIZE_SCALAR(asid);
+    SERIALIZE_SCALAR(trieKey);
     SERIALIZE_SCALAR(pte);
     SERIALIZE_SCALAR(lruSeq);
 }
@@ -56,6 +57,9 @@ TlbEntry::unserialize(CheckpointIn &cp)
     UNSERIALIZE_SCALAR(vaddr);
     UNSERIALIZE_SCALAR(logBytes);
     UNSERIALIZE_SCALAR(asid);
+    if (!UNSERIALIZE_OPT_SCALAR(trieKey)) {
+        trieKey = 0;
+    }
     UNSERIALIZE_SCALAR(pte);
     UNSERIALIZE_SCALAR(lruSeq);
 }
@@ -74,6 +78,85 @@ getVPNFromVAddr(Addr vaddr, Addr mode)
         return bits(vaddr, 56, 12);
     default:
         panic("Unknown address translation mode %d\n", mode);
+    }
+}
+
+Addr
+getVAddrBits(Addr mode)
+{
+    switch (mode) {
+        case BARE:
+            return BARE_VADDR_BITS;
+        case SV39:
+            return SV39_VADDR_BITS;
+        case SV48:
+            return SV48_VADDR_BITS;
+        case SV57:
+            return SV57_VADDR_BITS;
+        default:
+            panic("Unknown address translation mode %d\n", mode);
+    }
+}
+
+Addr
+getLevels(Addr mode)
+{
+    switch (mode) {
+        case SV39:
+            return SV39_LEVELS;
+        case SV48:
+            return SV48_LEVELS;
+        case SV57:
+            return SV57_LEVELS;
+        default:
+            panic("Unknown address translation mode %d\n", mode);
+    }
+}
+
+Addr
+getLevelBits(Addr mode)
+{
+    switch (mode) {
+        case SV39:
+            return SV39_LEVEL_BITS;
+        case SV48:
+            return SV48_LEVEL_BITS;
+        case SV57:
+            return SV57_LEVEL_BITS;
+        default:
+            panic("Unknown address translation mode %d\n", mode);
+    }
+}
+
+Addr
+getWidenedBits(Addr mode)
+{
+    switch (mode) {
+        case SV39:
+            return SV39X4_WIDENED_BITS;
+        case SV48:
+            return SV48X4_WIDENED_BITS;
+        case SV57:
+            return SV57X4_WIDENED_BITS;
+        default:
+            panic("Unknown address translation mode %d\n", mode);
+    }
+}
+
+Addr
+getSextVAddr(Addr vaddr, Addr mode)
+{
+    switch (mode) {
+        case BARE:
+            return Addr(sext<BARE_VADDR_BITS>(vaddr));
+        case SV39:
+            return Addr(sext<SV39_VADDR_BITS>(vaddr));
+        case SV48:
+            return Addr(sext<SV48_VADDR_BITS>(vaddr));
+        case SV57:
+            return Addr(sext<SV57_VADDR_BITS>(vaddr));
+        default:
+            panic("Unknown address translation mode %d\n", mode);
     }
 }
 

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -40,7 +40,8 @@
 namespace gem5
 {
 
-namespace RiscvISA {
+namespace RiscvISA
+{
 
 BitUnion64(SATP)
     Bitfield<63, 60> mode;
@@ -56,18 +57,46 @@ enum AddrXlateMode
     SV57 = 10,
 };
 
+// BARE
+const Addr BARE_VADDR_BITS = 64;
+
 // Sv39 paging
 const Addr SV39_XLEN = 64;
-const Addr SV39_VADDR_BITS  = 39;
+const Addr SV39_VADDR_BITS = 39;
 const Addr SV39_LEVELS = 3;
-const Addr SV39_LEVEL_BITS  = 9;
+const Addr SV39_LEVEL_BITS = 9;
 const Addr SV39X4_WIDENED_BITS = 2;
 
-BitUnion64(PTESv39)
+// Sv48 paging
+const Addr SV48_XLEN = 64;
+const Addr SV48_VADDR_BITS = 48;
+const Addr SV48_LEVELS = 4;
+const Addr SV48_LEVEL_BITS = 9;
+const Addr SV48X4_WIDENED_BITS = 2;
+
+// Sv57 paging
+const Addr SV57_XLEN = 64;
+const Addr SV57_VADDR_BITS = 57;
+const Addr SV57_LEVELS = 5;
+const Addr SV57_LEVEL_BITS = 9;
+const Addr SV57X4_WIDENED_BITS = 2;
+
+BitUnion64(PTE)
     Bitfield<63> n;
     Bitfield<62, 54> reserved;
     Bitfield<53, 10> ppn;
-    Bitfield<53, 28> ppn2;
+    SubBitUnion(PTESv39, 53, 28)
+        Bitfield<53, 28> ppn2;
+    EndSubBitUnion(PTESv39)
+    SubBitUnion(PTESv48, 53, 28)
+        Bitfield<53, 37> ppn3;
+        Bitfield<36, 28> ppn2;
+    EndSubBitUnion(PTESv48)
+    SubBitUnion(PTESv57, 53, 28)
+        Bitfield<53, 46> ppn4;
+        Bitfield<45, 37> ppn3;
+        Bitfield<36, 28> ppn2;
+    EndSubBitUnion(PTESv57)
     Bitfield<27, 19> ppn1;
     Bitfield<18, 10> ppn0;
     Bitfield<7> d;
@@ -79,7 +108,7 @@ BitUnion64(PTESv39)
     Bitfield<2> w;
     Bitfield<1> r;
     Bitfield<0> v;
-EndBitUnion(PTESv39)
+EndBitUnion(PTE)
 
 /**
  * Remove the page offset and the upper bits that are
@@ -87,6 +116,11 @@ EndBitUnion(PTESv39)
  * Note that this must assume the smallest page size
  */
 Addr getVPNFromVAddr(Addr vaddr, Addr mode);
+Addr getVAddrBits(Addr mode);
+Addr getLevels(Addr mode);
+Addr getLevelBits(Addr mode);
+Addr getWidenedBits(Addr mode);
+Addr getSextVAddr(Addr vaddr, Addr mode);
 
 struct TlbEntry;
 typedef Trie<Addr, TlbEntry> TlbEntryTrie;
@@ -103,9 +137,12 @@ struct TlbEntry : public Serializable
 
     uint16_t asid;
 
-    PTESv39 pte;
+    // The trieKey is for checkpoint.
+    Addr trieKey;
 
-    PTESv39 gpte;
+    PTE pte;
+
+    PTE gpte;
 
     TlbEntryTrie::Handle trieHandle;
 
@@ -113,18 +150,20 @@ struct TlbEntry : public Serializable
     uint64_t lruSeq;
 
     TlbEntry()
-        : paddr(0), vaddr(0), logBytes(0), pte(), gpte(), lruSeq(0)
+        : paddr(0), vaddr(0), logBytes(0), trieKey(0), pte(), gpte(), lruSeq(0)
     {}
 
     // Return the page size in bytes
-    Addr size() const
+    Addr
+    size() const
     {
         return (static_cast<Addr>(1) << logBytes);
     }
 
-    void reset()
+    void
+    reset()
     {
-        paddr = vaddr = logBytes = pte = gpte = lruSeq = 0;
+        paddr = vaddr = logBytes = trieKey = pte = gpte = lruSeq = 0;
     }
 
     void serialize(CheckpointOut &cp) const override;

--- a/src/arch/riscv/pagetable.hh
+++ b/src/arch/riscv/pagetable.hh
@@ -40,7 +40,8 @@
 namespace gem5
 {
 
-namespace RiscvISA {
+namespace RiscvISA
+{
 
 BitUnion64(SATP)
     Bitfield<63, 60> mode;
@@ -56,18 +57,46 @@ enum AddrXlateMode
     SV57 = 10,
 };
 
+// BARE
+const Addr BARE_VADDR_BITS = 64;
+
 // Sv39 paging
 const Addr SV39_XLEN = 64;
-const Addr SV39_VADDR_BITS  = 39;
+const Addr SV39_VADDR_BITS = 39;
 const Addr SV39_LEVELS = 3;
-const Addr SV39_LEVEL_BITS  = 9;
+const Addr SV39_LEVEL_BITS = 9;
 const Addr SV39X4_WIDENED_BITS = 2;
 
-BitUnion64(PTESv39)
+// Sv48 paging
+const Addr SV48_XLEN = 64;
+const Addr SV48_VADDR_BITS = 48;
+const Addr SV48_LEVELS = 4;
+const Addr SV48_LEVEL_BITS = 9;
+const Addr SV48X4_WIDENED_BITS = 2;
+
+// Sv57 paging
+const Addr SV57_XLEN = 64;
+const Addr SV57_VADDR_BITS = 57;
+const Addr SV57_LEVELS = 5;
+const Addr SV57_LEVEL_BITS = 9;
+const Addr SV57X4_WIDENED_BITS = 2;
+
+BitUnion64(PTE)
     Bitfield<63> n;
     Bitfield<62, 54> reserved;
     Bitfield<53, 10> ppn;
-    Bitfield<53, 28> ppn2;
+    SubBitUnion(PTESv39, 53, 10)
+        Bitfield<53, 28> ppn2;
+    EndSubBitUnion(PTESv39)
+    SubBitUnion(PTESv48, 53, 10)
+        Bitfield<53, 37> ppn3;
+        Bitfield<36, 28> ppn2;
+    EndSubBitUnion(PTESv48)
+    SubBitUnion(PTESv57, 53, 10)
+        Bitfield<53, 46> ppn4;
+        Bitfield<45, 37> ppn3;
+        Bitfield<36, 28> ppn2;
+    EndSubBitUnion(PTESv57)
     Bitfield<27, 19> ppn1;
     Bitfield<18, 10> ppn0;
     Bitfield<7> d;
@@ -79,7 +108,7 @@ BitUnion64(PTESv39)
     Bitfield<2> w;
     Bitfield<1> r;
     Bitfield<0> v;
-EndBitUnion(PTESv39)
+EndBitUnion(PTE)
 
 /**
  * Remove the page offset and the upper bits that are
@@ -87,6 +116,11 @@ EndBitUnion(PTESv39)
  * Note that this must assume the smallest page size
  */
 Addr getVPNFromVAddr(Addr vaddr, Addr mode);
+Addr getVAddrBits(Addr mode);
+Addr getLevels(Addr mode);
+Addr getLevelBits(Addr mode);
+Addr getWidenedBits(Addr mode);
+Addr getSextVAddr(Addr vaddr, Addr mode);
 
 struct TlbEntry;
 typedef Trie<Addr, TlbEntry> TlbEntryTrie;
@@ -103,9 +137,12 @@ struct TlbEntry : public Serializable
 
     uint16_t asid;
 
-    PTESv39 pte;
+    // The trieKey is for checkpoint.
+    Addr trieKey;
 
-    PTESv39 gpte;
+    PTE pte;
+
+    PTE gpte;
 
     TlbEntryTrie::Handle trieHandle;
 
@@ -113,18 +150,20 @@ struct TlbEntry : public Serializable
     uint64_t lruSeq;
 
     TlbEntry()
-        : paddr(0), vaddr(0), logBytes(0), pte(), gpte(), lruSeq(0)
+        : paddr(0), vaddr(0), logBytes(0), trieKey(0), pte(), gpte(), lruSeq(0)
     {}
 
     // Return the page size in bytes
-    Addr size() const
+    Addr
+    size() const
     {
         return (static_cast<Addr>(1) << logBytes);
     }
 
-    void reset()
+    void
+    reset()
     {
-        paddr = vaddr = logBytes = pte = gpte = lruSeq = 0;
+        paddr = vaddr = logBytes = trieKey = pte = gpte = lruSeq = 0;
     }
 
     void serialize(CheckpointOut &cp) const override;

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -240,7 +240,8 @@ Walker::startWalkWrapper()
     WalkerState *currState = currStates.front();
 
     // check if we get a tlb hit to skip the walk
-    Addr vaddr = Addr(sext<SV39_VADDR_BITS>(currState->req->getVaddr()));
+    Addr vaddr =
+        getSextVAddr(currState->req->getVaddr(), currState->satp.mode);
     Addr vpn = getVPNFromVAddr(vaddr, currState->satp.mode);
     TlbEntry *e = tlb->lookup(vpn, currState->satp.asid, currState->mode,
                               true);
@@ -280,7 +281,8 @@ Walker::startWalkWrapper()
         // check the next translation request, if it exists
         if (currStates.size()) {
             currState = currStates.front();
-            vaddr = Addr(sext<SV39_VADDR_BITS>(currState->req->getVaddr()));
+            vaddr =
+                getSextVAddr(currState->req->getVaddr(), currState->satp.mode);
             Addr vpn = getVPNFromVAddr(vaddr, currState->satp.mode);
             e = tlb->lookup(vpn, currState->satp.asid, currState->mode,
                             true);
@@ -330,9 +332,8 @@ Walker::WalkerState::walkGStage(Addr guest_paddr, Addr& host_paddr)
     gstate = Translate;
     nextgState = Ready;
 
-
-    const int maxgpabits = SV39_LEVELS * SV39_LEVEL_BITS +
-                    SV39X4_WIDENED_BITS + PageShift;
+    const int maxgpabits = getLevels(hgatp.mode) * getLevelBits(hgatp.mode) +
+                           getWidenedBits(hgatp.mode) + PageShift;
     Addr maxgpa = mask(maxgpabits);
 
     // If there is a bit beyond maxgpa, throw pf
@@ -348,8 +349,8 @@ Walker::WalkerState::walkGStage(Addr guest_paddr, Addr& host_paddr)
     }
 
     Addr pte_addr = setupWalk(guest_paddr);
-    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTESv39));
-    glevel = SV39_LEVELS - 1;
+    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
+    glevel = getLevels(hgatp.mode) - 1;
 
     // TODO THE TIMING PATH IS UNTESTED
     if (timing) {
@@ -381,7 +382,7 @@ Walker::WalkerState::walkGStage(Addr guest_paddr, Addr& host_paddr)
         // which is discarded after.
         Addr ppn = walkType == GstageOnly ? entry.paddr : gresult.paddr;
         Addr vpn = guest_paddr >> PageShift;
-        Addr vpn_bits = vpn & mask(glevel * SV39_LEVEL_BITS);
+        Addr vpn_bits = vpn & mask(glevel * getLevelBits(hgatp.mode));
 
         // Update gresult
         gresult.paddr = (ppn | vpn_bits);
@@ -437,19 +438,18 @@ Walker::WalkerState::walkOneStage(Addr vaddr)
 
     // Make sure MSBS are the same
     // riscv-privileged-20211203 page 84
-    auto mask_for_msbs = mask(64 - SV39_VADDR_BITS);
-    auto msbs = bits(vaddr, 63, SV39_VADDR_BITS);
+    auto mask_for_msbs = mask(64 - getVAddrBits(satp.mode));
+    auto msbs = bits(vaddr, 63, getVAddrBits(satp.mode));
     if (msbs != 0 && msbs != mask_for_msbs) {
         return pageFault();
     }
 
     Addr pte_addr = setupWalk(vaddr);
-    level = SV39_LEVELS - 1;
+    level = getLevels(satp.mode) - 1;
     // Create physical request for first_pte_addr
     // This is a host physical address
     // In two-stage this gets discarded?
-    read = createReqPacket(pte_addr,
-            MemCmd::ReadReq, sizeof(PTESv39));
+    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
 
     if (timing)
     {
@@ -502,21 +502,18 @@ Walker::WalkerState::walkTwoStage(Addr vaddr)
 
     // Make sure MSBS are the same
     // riscv-privileged-20211203 page 84
-    auto mask_for_msbs = mask(64 - SV39_VADDR_BITS);
-    auto msbs = bits(vaddr, 63, SV39_VADDR_BITS);
+    auto mask_for_msbs = mask(64 - getVAddrBits(satp.mode));
+    auto msbs = bits(vaddr, 63, getVAddrBits(satp.mode));
     if (msbs != 0 && msbs != mask_for_msbs) {
         return pageFault();
     }
 
     Addr pte_addr = setupWalk(vaddr);
-    level = SV39_LEVELS - 1;
+    level = getLevels(satp.mode) - 1;
     // Create physical request for first_pte_addr
     // This is a host physical address
     // In two-stage this gets discarded?
-    read = createReqPacket(pte_addr,
-            MemCmd::ReadReq, sizeof(PTESv39));
-
-
+    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
 
     if (timing)
     {
@@ -544,8 +541,7 @@ Walker::WalkerState::walkTwoStage(Addr vaddr)
         pte_addr = host_paddr;
 
         // Create the physmem packet to be sent
-        read = createReqPacket(pte_addr,
-            MemCmd::ReadReq, sizeof(PTESv39));
+        read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
 
         // G-stage done go back to first_stage logic
         curstage = FIRST_STAGE;
@@ -609,9 +605,10 @@ Walker::WalkerState::walkTwoStage(Addr vaddr)
 Fault
 Walker::WalkerState::guestToHostPage(Addr vaddr)
 {
-    Addr gpa = (((entry.paddr) |
-    ((vaddr >> PageShift) & mask(level*SV39_LEVEL_BITS)))
-    << PageShift) | (vaddr & mask(PageShift));
+    Addr gpa = (((entry.paddr) | ((vaddr >> PageShift) &
+                                  mask(level * getLevelBits(satp.mode))))
+                << PageShift) |
+               (vaddr & mask(PageShift));
 
     Addr host_page_address;
     Fault fault = walkGStage(gpa, host_page_address);
@@ -623,7 +620,7 @@ Walker::WalkerState::guestToHostPage(Addr vaddr)
     // gpn (vaddr) -> ppn (paddr) translation is already
     // in gresult, host_page_address is not needed here
     // TLB stores ppn and pte
-    // entry.logBytes = PageShift + (level * SV39_LEVEL_BITS);
+    // entry.logBytes = PageShift + (level * getLevelBits(satp.mode));
     entry.logBytes = PageShift;
     entry.paddr = gresult.paddr;
     entry.vaddr &= ~((1 << entry.logBytes) - 1);
@@ -652,10 +649,9 @@ Walker::WalkerState::startFunctional(Addr &addr, unsigned &logBytes)
     return fault;
 }
 
-
 Fault
-Walker::WalkerState::checkPTEPermissions(
-    PTESv39 pte, WalkFlags& stepWalkFlags, int level)
+Walker::WalkerState::checkPTEPermissions(PTE pte, WalkFlags &stepWalkFlags,
+                                         int level)
 {
     // If valid bit is off OR
     // the page is writable but not readable, throw pf
@@ -682,9 +678,11 @@ Walker::WalkerState::checkPTEPermissions(
         if (level >= 1 && pte.ppn0 != 0)
         {
             return pageFault();
-        }
-        else if (level == 2 && pte.ppn1 != 0)
-        {
+        } else if (level >= 2 && pte.ppn1 != 0) {
+            return pageFault();
+        } else if (level >= 3 && pte.PTESv48.ppn2 != 0) {
+            return pageFault();
+        } else if (level >= 4 && pte.PTESv57.ppn3 != 0) {
             return pageFault();
         }
 
@@ -716,7 +714,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
 
     Fault fault = NoFault;
     write = NULL;
-    PTESv39 pte = read->getLE<uint64_t>();
+    PTE pte = read->getLE<uint64_t>();
     Addr nextRead = 0;
 
     // walk flags are initialized to false
@@ -773,16 +771,17 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         pte.ppn & ~mask(NapotShift) :
                         pte.ppn;
 
-                    entry.logBytes = (pte.n) ?
-                        PageShift + NapotShift :
-                        PageShift + (level * SV39_LEVEL_BITS);
+                    entry.logBytes =
+                        (pte.n)
+                            ? PageShift + NapotShift
+                            : PageShift + (level * getLevelBits(satp.mode));
 
                     // Only truncate the address in non-two stage walks
                     // The truncation for two-stage is done in
                     // walkTwoStage()
                     if (walkType != TwoStage) {
-                        entry.logBytes = PageShift +
-                                        (level * SV39_LEVEL_BITS);
+                        entry.logBytes =
+                            PageShift + (level * getLevelBits(satp.mode));
                         entry.vaddr &= ~((1 << entry.logBytes) - 1);
                     }
 
@@ -822,8 +821,8 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                 fault = pageFault();
             }
             else {
-                shift = (PageShift + SV39_LEVEL_BITS * level);
-                idx = (entry.vaddr >> shift) & mask(SV39_LEVEL_BITS);
+                shift = (PageShift + getLevelBits(satp.mode) * level);
+                idx = (entry.vaddr >> shift) & mask(getLevelBits(satp.mode));
                 nextRead = (pte.ppn << PageShift) + (idx * sizeof(pte));
                 nextState = Translate;
             }
@@ -885,7 +884,7 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
 
     Fault fault = NoFault;
     write = NULL;
-    PTESv39 pte = read->getLE<uint64_t>();
+    PTE pte = read->getLE<uint64_t>();
     Addr nextRead = 0;
 
     // walk flags are initialized to false
@@ -942,9 +941,10 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                         pte.ppn & ~mask(NapotShift) :
                         pte.ppn;
 
-                    entry.logBytes = (pte.n) ?
-                        PageShift + NapotShift :
-                        PageShift + (glevel * SV39_LEVEL_BITS);
+                    entry.logBytes =
+                        (pte.n)
+                            ? PageShift + NapotShift
+                            : PageShift + (glevel * getLevelBits(hgatp.mode));
 
                     entry.vaddr &= ~((1 << entry.logBytes) - 1);
 
@@ -959,8 +959,8 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                         stepWalkFlags.doTLBInsert = true;
                 }
                 else {
-                    gresult.logBytes = PageShift +
-                                    (glevel * SV39_LEVEL_BITS);
+                    gresult.logBytes =
+                        PageShift + (glevel * getLevelBits(hgatp.mode));
                     gresult.paddr = pte.ppn;
                     gresult.vaddr &= ~((1 << entry.logBytes) - 1);
                     gresult.pte = pte;
@@ -992,8 +992,9 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                 fault = pageFault();
             }
             else {
-                shift = (PageShift + SV39_LEVEL_BITS * glevel);
-                idx = (gresult.vaddr >> shift) & mask(SV39_LEVEL_BITS);
+                shift = (PageShift + getLevelBits(hgatp.mode) * glevel);
+                idx =
+                    (gresult.vaddr >> shift) & mask(getLevelBits(hgatp.mode));
                 nextRead = (pte.ppn << PageShift) + (idx * sizeof(pte));
                 nextgState = Translate;
             }
@@ -1067,19 +1068,20 @@ Walker::WalkerState::setupWalk(Addr vaddr)
     Addr pte_addr;
 
     if (curstage == FIRST_STAGE) {
-        //vaddr = Addr(sext<SV39_VADDR_BITS>(vaddr));
-        shift = PageShift + SV39_LEVEL_BITS * 2;
-        idx = (vaddr >> shift) & mask(SV39_LEVEL_BITS);
-        pte_addr = (satp.ppn << PageShift) + (idx * sizeof(PTESv39));
+        // vaddr = getSextVAddr(vaddr, satp.mode);
+        shift =
+            PageShift + getLevelBits(satp.mode) * (getLevels(satp.mode) - 1);
+        idx = (vaddr >> shift) & mask(getLevelBits(satp.mode));
+        pte_addr = (satp.ppn << PageShift) + (idx * sizeof(PTE));
 
         // original vaddress for first-stage is in entry.vaddr already
     }
     else if (curstage == GSTAGE) {
-        shift = PageShift + SV39_LEVEL_BITS * 2;
-        idx = (vaddr >> shift) &
-            mask(SV39_LEVEL_BITS + SV39X4_WIDENED_BITS); // widened
-        pte_addr = ((hgatp.ppn << PageShift) & ~mask(2)) +
-                    (idx * sizeof(PTESv39));
+        shift =
+            PageShift + getLevelBits(hgatp.mode) * (getLevels(hgatp.mode) - 1);
+        idx = (vaddr >> shift) & mask(getLevelBits(hgatp.mode) +
+                                      getWidenedBits(hgatp.mode)); // widened
+        pte_addr = ((hgatp.ppn << PageShift) & ~mask(2)) + (idx * sizeof(PTE));
 
         gresult.vaddr = vaddr; // store original address for g-stage
     }
@@ -1136,8 +1138,7 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
              * permissions violations, so we'll need the return value as
              * well.
              */
-            Addr vaddr = req->getVaddr();
-            vaddr = Addr(sext<SV39_VADDR_BITS>(vaddr));
+            Addr vaddr = getSextVAddr(req->getVaddr(), satp.mode);
             Addr paddr = walker->tlb->hiddenTranslateWithTLB(vaddr, satp.asid,
                                                              satp.mode, mode);
 

--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -240,7 +240,8 @@ Walker::startWalkWrapper()
     WalkerState *currState = currStates.front();
 
     // check if we get a tlb hit to skip the walk
-    Addr vaddr = Addr(sext<SV39_VADDR_BITS>(currState->req->getVaddr()));
+    Addr vaddr =
+        getSextVAddr(currState->req->getVaddr(), currState->satp.mode);
     Addr vpn = getVPNFromVAddr(vaddr, currState->satp.mode);
     TlbEntry *e = tlb->lookup(vpn, currState->satp.asid, currState->mode,
                               true);
@@ -280,7 +281,8 @@ Walker::startWalkWrapper()
         // check the next translation request, if it exists
         if (currStates.size()) {
             currState = currStates.front();
-            vaddr = Addr(sext<SV39_VADDR_BITS>(currState->req->getVaddr()));
+            vaddr =
+                getSextVAddr(currState->req->getVaddr(), currState->satp.mode);
             Addr vpn = getVPNFromVAddr(vaddr, currState->satp.mode);
             e = tlb->lookup(vpn, currState->satp.asid, currState->mode,
                             true);
@@ -330,9 +332,8 @@ Walker::WalkerState::walkGStage(Addr guest_paddr, Addr& host_paddr)
     gstate = Translate;
     nextgState = Ready;
 
-
-    const int maxgpabits = SV39_LEVELS * SV39_LEVEL_BITS +
-                    SV39X4_WIDENED_BITS + PageShift;
+    const int maxgpabits = getLevels(hgatp.mode) * getLevelBits(hgatp.mode) +
+                           getWidenedBits(hgatp.mode) + PageShift;
     Addr maxgpa = mask(maxgpabits);
 
     // If there is a bit beyond maxgpa, throw pf
@@ -348,8 +349,8 @@ Walker::WalkerState::walkGStage(Addr guest_paddr, Addr& host_paddr)
     }
 
     Addr pte_addr = setupWalk(guest_paddr);
-    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTESv39));
-    glevel = SV39_LEVELS - 1;
+    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
+    glevel = getLevels(hgatp.mode) - 1;
 
     // TODO THE TIMING PATH IS UNTESTED
     if (timing) {
@@ -381,7 +382,7 @@ Walker::WalkerState::walkGStage(Addr guest_paddr, Addr& host_paddr)
         // which is discarded after.
         Addr ppn = walkType == GstageOnly ? entry.paddr : gresult.paddr;
         Addr vpn = guest_paddr >> PageShift;
-        Addr vpn_bits = vpn & mask(glevel * SV39_LEVEL_BITS);
+        Addr vpn_bits = vpn & mask(glevel * getLevelBits(hgatp.mode));
 
         // Update gresult
         gresult.paddr = (ppn | vpn_bits);
@@ -437,19 +438,18 @@ Walker::WalkerState::walkOneStage(Addr vaddr)
 
     // Make sure MSBS are the same
     // riscv-privileged-20211203 page 84
-    auto mask_for_msbs = mask(64 - SV39_VADDR_BITS);
-    auto msbs = bits(vaddr, 63, SV39_VADDR_BITS);
+    auto mask_for_msbs = mask(64 - getVAddrBits(satp.mode));
+    auto msbs = bits(vaddr, 63, getVAddrBits(satp.mode));
     if (msbs != 0 && msbs != mask_for_msbs) {
         return pageFault();
     }
 
     Addr pte_addr = setupWalk(vaddr);
-    level = SV39_LEVELS - 1;
+    level = getLevels(satp.mode) - 1;
     // Create physical request for first_pte_addr
     // This is a host physical address
     // In two-stage this gets discarded?
-    read = createReqPacket(pte_addr,
-            MemCmd::ReadReq, sizeof(PTESv39));
+    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
 
     if (timing)
     {
@@ -502,21 +502,18 @@ Walker::WalkerState::walkTwoStage(Addr vaddr)
 
     // Make sure MSBS are the same
     // riscv-privileged-20211203 page 84
-    auto mask_for_msbs = mask(64 - SV39_VADDR_BITS);
-    auto msbs = bits(vaddr, 63, SV39_VADDR_BITS);
+    auto mask_for_msbs = mask(64 - getVAddrBits(satp.mode));
+    auto msbs = bits(vaddr, 63, getVAddrBits(satp.mode));
     if (msbs != 0 && msbs != mask_for_msbs) {
         return pageFault();
     }
 
     Addr pte_addr = setupWalk(vaddr);
-    level = SV39_LEVELS - 1;
+    level = getLevels(satp.mode) - 1;
     // Create physical request for first_pte_addr
     // This is a host physical address
     // In two-stage this gets discarded?
-    read = createReqPacket(pte_addr,
-            MemCmd::ReadReq, sizeof(PTESv39));
-
-
+    read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
 
     if (timing)
     {
@@ -544,8 +541,7 @@ Walker::WalkerState::walkTwoStage(Addr vaddr)
         pte_addr = host_paddr;
 
         // Create the physmem packet to be sent
-        read = createReqPacket(pte_addr,
-            MemCmd::ReadReq, sizeof(PTESv39));
+        read = createReqPacket(pte_addr, MemCmd::ReadReq, sizeof(PTE));
 
         // G-stage done go back to first_stage logic
         curstage = FIRST_STAGE;
@@ -609,9 +605,10 @@ Walker::WalkerState::walkTwoStage(Addr vaddr)
 Fault
 Walker::WalkerState::guestToHostPage(Addr vaddr)
 {
-    Addr gpa = (((entry.paddr) |
-    ((vaddr >> PageShift) & mask(level*SV39_LEVEL_BITS)))
-    << PageShift) | (vaddr & mask(PageShift));
+    Addr gpa = (((entry.paddr) | ((vaddr >> PageShift) &
+                                  mask(level * getLevelBits(satp.mode))))
+                << PageShift) |
+               (vaddr & mask(PageShift));
 
     Addr host_page_address;
     Fault fault = walkGStage(gpa, host_page_address);
@@ -623,7 +620,7 @@ Walker::WalkerState::guestToHostPage(Addr vaddr)
     // gpn (vaddr) -> ppn (paddr) translation is already
     // in gresult, host_page_address is not needed here
     // TLB stores ppn and pte
-    // entry.logBytes = PageShift + (level * SV39_LEVEL_BITS);
+    // entry.logBytes = PageShift + (level * getLevelBits(satp.mode));
     entry.logBytes = PageShift;
     entry.paddr = gresult.paddr;
     entry.vaddr &= ~((1 << entry.logBytes) - 1);
@@ -652,10 +649,9 @@ Walker::WalkerState::startFunctional(Addr &addr, unsigned &logBytes)
     return fault;
 }
 
-
 Fault
-Walker::WalkerState::checkPTEPermissions(
-    PTESv39 pte, WalkFlags& stepWalkFlags, int level)
+Walker::WalkerState::checkPTEPermissions(PTE pte, WalkFlags &stepWalkFlags,
+                                         int level)
 {
     // If valid bit is off OR
     // the page is writable but not readable, throw pf
@@ -682,9 +678,11 @@ Walker::WalkerState::checkPTEPermissions(
         if (level >= 1 && pte.ppn0 != 0)
         {
             return pageFault();
-        }
-        else if (level == 2 && pte.ppn1 != 0)
-        {
+        } else if (level >= 2 && pte.ppn1 != 0) {
+            return pageFault();
+        } else if (level >= 3 && pte.PTESv48.ppn2 != 0) {
+            return pageFault();
+        } else if (level >= 4 && pte.PTESv57.ppn3 != 0) {
             return pageFault();
         }
 
@@ -716,7 +714,7 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
 
     Fault fault = NoFault;
     write = NULL;
-    PTESv39 pte = read->getLE<uint64_t>();
+    PTE pte = read->getLE<uint64_t>();
     Addr nextRead = 0;
 
     // walk flags are initialized to false
@@ -773,16 +771,17 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                         pte.ppn & ~mask(NapotShift) :
                         pte.ppn;
 
-                    entry.logBytes = (pte.n) ?
-                        PageShift + NapotShift :
-                        PageShift + (level * SV39_LEVEL_BITS);
+                    entry.logBytes =
+                        (pte.n)
+                            ? PageShift + NapotShift
+                            : PageShift + (level * getLevelBits(satp.mode));
 
                     // Only truncate the address in non-two stage walks
                     // The truncation for two-stage is done in
                     // walkTwoStage()
                     if (walkType != TwoStage) {
-                        entry.logBytes = PageShift +
-                                        (level * SV39_LEVEL_BITS);
+                        entry.logBytes =
+                            PageShift + (level * getLevelBits(satp.mode));
                         entry.vaddr &= ~((1 << entry.logBytes) - 1);
                     }
 
@@ -822,8 +821,8 @@ Walker::WalkerState::stepWalk(PacketPtr &write)
                 fault = pageFault();
             }
             else {
-                shift = (PageShift + SV39_LEVEL_BITS * level);
-                idx = (entry.vaddr >> shift) & mask(SV39_LEVEL_BITS);
+                shift = (PageShift + getLevelBits(satp.mode) * level);
+                idx = (entry.vaddr >> shift) & mask(getLevelBits(satp.mode));
                 nextRead = (pte.ppn << PageShift) + (idx * sizeof(pte));
                 nextState = Translate;
             }
@@ -885,7 +884,7 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
 
     Fault fault = NoFault;
     write = NULL;
-    PTESv39 pte = read->getLE<uint64_t>();
+    PTE pte = read->getLE<uint64_t>();
     Addr nextRead = 0;
 
     // walk flags are initialized to false
@@ -942,9 +941,10 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                         pte.ppn & ~mask(NapotShift) :
                         pte.ppn;
 
-                    entry.logBytes = (pte.n) ?
-                        PageShift + NapotShift :
-                        PageShift + (glevel * SV39_LEVEL_BITS);
+                    entry.logBytes =
+                        (pte.n)
+                            ? PageShift + NapotShift
+                            : PageShift + (glevel * getLevelBits(hgatp.mode));
 
                     entry.vaddr &= ~((1 << entry.logBytes) - 1);
 
@@ -959,8 +959,8 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                         stepWalkFlags.doTLBInsert = true;
                 }
                 else {
-                    gresult.logBytes = PageShift +
-                                    (glevel * SV39_LEVEL_BITS);
+                    gresult.logBytes =
+                        PageShift + (glevel * getLevelBits(hgatp.mode));
                     gresult.paddr = pte.ppn;
                     gresult.vaddr &= ~((1 << entry.logBytes) - 1);
                     gresult.pte = pte;
@@ -992,8 +992,9 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                 fault = pageFault();
             }
             else {
-                shift = (PageShift + SV39_LEVEL_BITS * glevel);
-                idx = (gresult.vaddr >> shift) & mask(SV39_LEVEL_BITS);
+                shift = (PageShift + getLevelBits(hgatp.mode) * glevel);
+                idx =
+                    (gresult.vaddr >> shift) & mask(getLevelBits(hgatp.mode));
                 nextRead = (pte.ppn << PageShift) + (idx * sizeof(pte));
                 nextgState = Translate;
             }
@@ -1030,7 +1031,7 @@ Walker::WalkerState::stepWalkGStage(PacketPtr &write)
                 // for GstageOnly walks. Two stage walks insert
                 // in walkTwoStage.
                 assert(walkType == GstageOnly);
-                Addr vpn = getVPNFromVAddr(entry.vaddr, satp.mode);
+                Addr vpn = getVPNFromVAddr(entry.vaddr, hgatp.mode);
                 walker->tlb->insert(vpn, entry);
             }
         }
@@ -1067,19 +1068,20 @@ Walker::WalkerState::setupWalk(Addr vaddr)
     Addr pte_addr;
 
     if (curstage == FIRST_STAGE) {
-        //vaddr = Addr(sext<SV39_VADDR_BITS>(vaddr));
-        shift = PageShift + SV39_LEVEL_BITS * 2;
-        idx = (vaddr >> shift) & mask(SV39_LEVEL_BITS);
-        pte_addr = (satp.ppn << PageShift) + (idx * sizeof(PTESv39));
+        // vaddr = getSextVAddr(vaddr, satp.mode);
+        shift =
+            PageShift + getLevelBits(satp.mode) * (getLevels(satp.mode) - 1);
+        idx = (vaddr >> shift) & mask(getLevelBits(satp.mode));
+        pte_addr = (satp.ppn << PageShift) + (idx * sizeof(PTE));
 
         // original vaddress for first-stage is in entry.vaddr already
     }
     else if (curstage == GSTAGE) {
-        shift = PageShift + SV39_LEVEL_BITS * 2;
-        idx = (vaddr >> shift) &
-            mask(SV39_LEVEL_BITS + SV39X4_WIDENED_BITS); // widened
-        pte_addr = ((hgatp.ppn << PageShift) & ~mask(2)) +
-                    (idx * sizeof(PTESv39));
+        shift =
+            PageShift + getLevelBits(hgatp.mode) * (getLevels(hgatp.mode) - 1);
+        idx = (vaddr >> shift) & mask(getLevelBits(hgatp.mode) +
+                                      getWidenedBits(hgatp.mode)); // widened
+        pte_addr = ((hgatp.ppn << PageShift) & ~mask(2)) + (idx * sizeof(PTE));
 
         gresult.vaddr = vaddr; // store original address for g-stage
     }
@@ -1136,8 +1138,7 @@ Walker::WalkerState::recvPacket(PacketPtr pkt)
              * permissions violations, so we'll need the return value as
              * well.
              */
-            Addr vaddr = req->getVaddr();
-            vaddr = Addr(sext<SV39_VADDR_BITS>(vaddr));
+            Addr vaddr = getSextVAddr(req->getVaddr(), satp.mode);
             Addr paddr = walker->tlb->hiddenTranslateWithTLB(vaddr, satp.asid,
                                                              satp.mode, mode);
 

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -165,8 +165,8 @@ namespace RiscvISA
             std::string name() const {return walker->name();}
 
           private:
-            Fault checkPTEPermissions(
-              PTESv39 pte, WalkFlags& stepWalkFlags, int level);
+            Fault checkPTEPermissions(PTE pte, WalkFlags &stepWalkFlags,
+                                      int level);
             Addr setupWalk(Addr vaddr);
             Fault stepWalk(PacketPtr &write);
             Fault stepWalkGStage(PacketPtr &write);

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -176,6 +176,7 @@ TLB::insert(Addr vpn, const TlbEntry &entry)
 
     Addr key = buildKey(vpn, entry.asid);
     *newEntry = entry;
+    newEntry->trieKey = key;
     newEntry->lruSeq = nextSeq();
     newEntry->trieHandle = trie.insert(
         key, TlbEntryTrie::MaxBits - entry.logBytes + PageShift, newEntry
@@ -185,6 +186,15 @@ TLB::insert(Addr vpn, const TlbEntry &entry)
 
 void
 TLB::demapPage(Addr vaddr, uint64_t asid)
+{
+    warn("TLB::demapPage without ThreadContext is not fully supported for "
+         "RISC-V. Flushing all.\n");
+    flushAll();
+}
+
+void
+TLB::demapPage(ThreadContext *tc, Addr vaddr, uint64_t asid, bool is_gvma,
+               bool is_vvma)
 {
     // Note: vaddr is Reg[rs1] and asid is Reg[rs2]
     // The definition of this instruction is
@@ -205,8 +215,15 @@ TLB::demapPage(Addr vaddr, uint64_t asid)
         flushAll();
     } else {
         if (vaddr != 0 && asid != 0) {
-            // TODO: When supporting other address translation modes, fix this
-            Addr vpn = getVPNFromVAddr(vaddr, AddrXlateMode::SV39);
+            bool is_virt = tc->readMiscReg(MISCREG_VIRT) == 1;
+            RegIndex satp_reg = MISCREG_SATP;
+            if (is_gvma) {
+                satp_reg = MISCREG_HGATP;
+            } else if (is_vvma || is_virt) {
+                satp_reg = MISCREG_VSATP;
+            }
+            SATP satp = tc->readMiscReg(satp_reg);
+            Addr vpn = getVPNFromVAddr(vaddr, satp.mode);
             TlbEntry *entry = lookup(vpn, asid, BaseMMU::Read, true);
             if (entry) {
                 remove(entry - tlb.data());
@@ -249,8 +266,9 @@ TLB::remove(size_t idx)
 }
 
 Fault
-TLB::checkPermissions(ThreadContext* tc, MemAccessInfo mem_access, Addr vaddr,
-            BaseMMU::Mode mode, PTESv39 pte, Addr gvaddr, XlateStage stage)
+TLB::checkPermissions(ThreadContext *tc, MemAccessInfo mem_access, Addr vaddr,
+                      BaseMMU::Mode mode, PTE pte, Addr gvaddr,
+                      XlateStage stage)
 {
     MISA misa = tc->readMiscReg(MISCREG_ISA);
     STATUS status = tc->readMiscReg(MISCREG_STATUS);
@@ -721,10 +739,15 @@ TLB::unserialize(CheckpointIn &cp)
         freeList.pop_front();
 
         newEntry->unserializeSection(cp, csprintf("Entry%d", x));
-        // TODO: When supporting other addressing modes fix this
-        Addr vpn = getVPNFromVAddr(newEntry->vaddr, AddrXlateMode::SV39);
-        Addr key = buildKey(vpn, newEntry->asid);
-        newEntry->trieHandle = trie.insert(key,
+
+        // Backward compatibility for the checkpoints without trieKey.
+        if (newEntry->trieKey == 0) {
+            Addr vpn = getVPNFromVAddr(newEntry->vaddr, AddrXlateMode::SV39);
+            newEntry->trieKey = buildKey(vpn, newEntry->asid);
+        }
+
+        newEntry->trieHandle = trie.insert(
+            newEntry->trieKey,
             TlbEntryTrie::MaxBits - newEntry->logBytes + PageShift, newEntry);
     }
 }

--- a/src/arch/riscv/tlb.hh
+++ b/src/arch/riscv/tlb.hh
@@ -135,11 +135,13 @@ class TLB : public BaseTLB
     TlbEntry *insert(Addr vpn, const TlbEntry &entry);
     void flushAll() override;
     void demapPage(Addr vaddr, uint64_t asn) override;
+    void demapPage(ThreadContext *tc, Addr vaddr, uint64_t asn,
+                   bool is_gvma = false, bool is_vvma = false);
 
-    Fault checkPermissions(ThreadContext* tc, MemAccessInfo mem_access,
-                            Addr vaddr, BaseMMU::Mode mode, PTESv39 pte,
-                            Addr gvaddr = 0x0,
-                            XlateStage stage = XlateStage::FIRST_STAGE);
+    Fault checkPermissions(ThreadContext *tc, MemAccessInfo mem_access,
+                           Addr vaddr, BaseMMU::Mode mode, PTE pte,
+                           Addr gvaddr = 0x0,
+                           XlateStage stage = XlateStage::FIRST_STAGE);
 
     Fault createPagefault(Addr vaddr, BaseMMU::Mode mode, Addr gvaddr = 0x0,
                           bool gpf = false, bool virt = false);


### PR DESCRIPTION
This commit extends the RISC-V page table walker and TLB to support the Sv48 and Sv57 address translation modes.

Key changes include:
 - Generalizing the `PTESv39` struct into a `PTE` bitunion with sub-bitfields for Sv39, Sv48, and Sv57.
 - Adding helper functions (e.g., `getLevels`, `getLevelBits`, `getVAddrBits`) to dynamically query translation mode properties rather than relying on hardcoded Sv39 constants.
 - Modifying `demapPage` to take a `ThreadContext*`, allowing it to read the appropriate `satp` and virtualization registers to determine the correct translation mode when flushing the TLB.
 - Adding a `key` field to `TlbEntry` for checkpoint serialization. This avoids address translation mode dependency issues and ensures backward compatibility when restoring older checkpoints.

---

Sorry that the RISC-V hypervisor is not tested. I might need to learn how to run the hypervisor tests…

---

I tested the patch with `xv6-riscv` and `linux kernel`.
We can boot the xv6-riscv and linux kernel with SV39, SV48, SV57.

```
git clone git@github.com:TommyWu-fdgkhdkgh/gem5-verify-vm.git
cd gem5-verify-vm

make buildroot/gem5/build
make linux/gem5/build
make opensbi/gem5/build
make xv6-riscv/clone
make gem5/clone
make gem5/build

# run xv6-riscv, SV39, atomic CPU
make xv6-riscv/build/SV39
./gem5/build/RISCV/gem5.opt ./run_xv6.py --kernel-type=xv6-riscv --cpu-type=atomic

# run xv6-riscv, SV48, minor CPU
make xv6-riscv/build/SV48
./gem5/build/RISCV/gem5.opt ./run_xv6.py --kernel-type=xv6-riscv --cpu-type=minor

# run xv6-riscv, SV57, o3 CPU
make xv6-riscv/build/SV57
./gem5/build/RISCV/gem5.opt ./run_xv6.py --kernel-type=xv6-riscv --cpu-type=o3

# run linux kernel, SV39, atomic CPU
./gem5/build/RISCV/gem5.opt ./run_xv6.py --kernel-type=linux --vm-mode=sv39 --cpu-type=atomic

# run linux kernel, SV48, minor CPU
./gem5/build/RISCV/gem5.opt ./run_xv6.py --kernel-type=linux --vm-mode=sv48 --cpu-type=minor

# run linux kernel, SV57, o3 CPU
./gem5/build/RISCV/gem5.opt ./run_xv6.py --kernel-type=linux --vm-mode=sv57 --cpu-type=o3
```