### PR TITLE
mem: addd SimpleMemory latency based on norm dist 

### DIFF
--- a/src/base/random.hh
+++ b/src/base/random.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 ARM Limited
+ * Copyright (c) 2014, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -214,6 +214,28 @@ class Random
         // + 1 to handle cases where min == max
         T r = gen() % (max - min + 1) + min;
         return r;
+    }
+
+    /**
+     * @ingroup api_base_utils
+     */
+    template <typename T>
+    typename std::enable_if_t<std::is_integral_v<T>, T>
+    random_norm(T avg, T stdev)
+    {
+        std::normal_distribution<double> dist((double)avg, (double)stdev);
+        return (T)std::llround(dist(gen));
+    }
+
+    /**
+     * @ingroup api_base_utils
+     */
+    template <typename T>
+    typename std::enable_if_t<std::is_floating_point_v<T>, T>
+    random_norm(T avg, T stdev)
+    {
+        std::normal_distribution<T> dist(avg, stdev);
+        return dist(gen);
     }
 };
 

--- a/src/mem/SConscript
+++ b/src/mem/SConscript
@@ -60,7 +60,8 @@ SimObject('ExternalMaster.py', sim_objects=['ExternalMaster'])
 SimObject('ExternalSlave.py', sim_objects=['ExternalSlave'])
 SimObject('CfiMemory.py', sim_objects=['CfiMemory'])
 SimObject('SharedMemoryServer.py', sim_objects=['SharedMemoryServer'])
-SimObject('SimpleMemory.py', sim_objects=['SimpleMemory'])
+SimObject('SimpleMemory.py', sim_objects=['SimpleMemory'],
+        enums=['LatencyDistribution'])
 SimObject('XBar.py', sim_objects=[
     'BaseXBar', 'NoncoherentXBar', 'CoherentXBar', 'SnoopFilter'])
 SimObject('HMCController.py', sim_objects=['HMCController'])

--- a/src/mem/SimpleMemory.py
+++ b/src/mem/SimpleMemory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2013, 2021 Arm Limited
+# Copyright (c) 2012-2013, 2021, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -40,6 +40,19 @@ from m5.objects.AbstractMemory import *
 from m5.params import *
 
 
+class LatencyDistribution(ScopedEnum):
+    vals = [
+        # Uniform distribution between [0, latency_dist_param] which
+        # gets added to the latency Param
+        "Uniform",
+        # Normal distribution norm(latency, latency_dist_param)
+        # latency_dist_param is the standard deviation.
+        # Distribution gets clipped after 3 * stdev from the mean
+        "Normal",
+        "None",
+    ]
+
+
 class SimpleMemory(AbstractMemory):
     type = "SimpleMemory"
     cxx_header = "mem/simple_mem.hh"
@@ -47,7 +60,14 @@ class SimpleMemory(AbstractMemory):
 
     port = ResponsePort("This port sends responses and receives requests")
     latency = Param.Latency("30ns", "Request to response latency")
-    latency_var = Param.Latency("0ns", "Request to response latency variance")
+    latency_dist = Param.LatencyDistribution(
+        "None", "Latency distribution of SimpleMemory"
+    )
+    latency_dist_param = Param.Latency(
+        "0ns",
+        "Request to response latency variance. It is interpreted "
+        "as standard deviation for normal distribution",
+    )
     # The memory bandwidth limit default is set to 12.8GiB/s which is
     # representative of a x64 DDR3-1600 channel.
     bandwidth = Param.MemoryBandwidth(

--- a/src/mem/SimpleMemory.py
+++ b/src/mem/SimpleMemory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2013, 2021 Arm Limited
+# Copyright (c) 2012-2013, 2021, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -47,7 +47,9 @@ class SimpleMemory(AbstractMemory):
 
     port = ResponsePort("This port sends responses and receives requests")
     latency = Param.Latency("30ns", "Request to response latency")
+    # use either one or the other, stdev used a normal distribution
     latency_var = Param.Latency("0ns", "Request to response latency variance")
+    latency_stdev = Param.Latency("0ns", "Request to response latency stdev")
     # The memory bandwidth limit default is set to 12.8GiB/s which is
     # representative of a x64 DDR3-1600 channel.
     bandwidth = Param.MemoryBandwidth(

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2015 ARM Limited
+ * Copyright (c) 2010-2013, 2015, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -43,6 +43,7 @@
 #include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/Drain.hh"
+#include "debug/MemoryAccess.hh"
 
 namespace gem5
 {
@@ -50,14 +51,26 @@ namespace gem5
 namespace memory
 {
 
-SimpleMemory::SimpleMemory(const SimpleMemoryParams &p) :
-    AbstractMemory(p),
-    port(name() + ".port", *this), latency(p.latency),
-    latency_var(p.latency_var), bandwidth(p.bandwidth), isBusy(false),
-    retryReq(false), retryResp(false),
-    releaseEvent([this]{ release(); }, name()),
-    dequeueEvent([this]{ dequeue(); }, name())
+SimpleMemory::SimpleMemory(const SimpleMemoryParams &p)
+    : AbstractMemory(p),
+      port(name() + ".port", *this),
+      latency(p.latency),
+      latencyDist(p.latency_dist),
+      latencyDistParam(p.latency_dist_param),
+      bandwidth(p.bandwidth),
+      isBusy(false),
+      retryReq(false),
+      retryResp(false),
+      releaseEvent([this] { release(); }, name()),
+      dequeueEvent([this] { dequeue(); }, name())
 {
+    if (latencyDist == LatencyDistribution::None) {
+        fatal_if(latencyDistParam != 0,
+                 "Setting latency_dist_param when latency_dist = None\n");
+    } else {
+        fatal_if(latencyDistParam == 0,
+                 "Not setting latency_dist_param when latency_dist != None\n");
+    }
 }
 
 void
@@ -236,8 +249,26 @@ SimpleMemory::dequeue()
 Tick
 SimpleMemory::getLatency() const
 {
-    return latency +
-        (latency_var ? rng->random<Tick>(0, latency_var) : 0);
+    Tick lat = 0;
+    switch (latencyDist) {
+        case LatencyDistribution::None:
+            lat = latency;
+            break;
+        case LatencyDistribution::Uniform:
+            lat = latency + rng->random<Tick>(0, latencyDistParam);
+            break;
+        case LatencyDistribution::Normal:
+            lat = rng->random_norm(latency, latencyDistParam);
+            lat = std::min(lat, latency + (latencyDistParam * 3));
+            lat = std::max(lat, latency - (latencyDistParam * 3));
+            break;
+        default:
+            /** We should never get here */
+            lat = latency;
+            break;
+    }
+    DPRINTF(MemoryAccess, "Generated latency = %d\n", lat);
+    return lat;
 }
 
 void

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013, 2015 ARM Limited
+ * Copyright (c) 2010-2013, 2015, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -43,6 +43,7 @@
 #include "base/random.hh"
 #include "base/trace.hh"
 #include "debug/Drain.hh"
+#include "debug/MemoryAccess.hh"
 
 namespace gem5
 {
@@ -50,13 +51,19 @@ namespace gem5
 namespace memory
 {
 
-SimpleMemory::SimpleMemory(const SimpleMemoryParams &p) :
-    AbstractMemory(p),
-    port(name() + ".port", *this), latency(p.latency),
-    latency_var(p.latency_var), bandwidth(p.bandwidth), isBusy(false),
-    retryReq(false), retryResp(false),
-    releaseEvent([this]{ release(); }, name()),
-    dequeueEvent([this]{ dequeue(); }, name())
+SimpleMemory::SimpleMemory(const SimpleMemoryParams &p)
+    : AbstractMemory(p),
+      port(name() + ".port", *this),
+      latency(p.latency),
+      latency_var(p.latency_var),
+      latency_stdev(p.latency_stdev),
+      latency_stdev_max(p.latency + (p.latency_stdev * 3)),
+      bandwidth(p.bandwidth),
+      isBusy(false),
+      retryReq(false),
+      retryResp(false),
+      releaseEvent([this] { release(); }, name()),
+      dequeueEvent([this] { dequeue(); }, name())
 {
 }
 
@@ -236,8 +243,15 @@ SimpleMemory::dequeue()
 Tick
 SimpleMemory::getLatency() const
 {
-    return latency +
-        (latency_var ? rng->random<Tick>(0, latency_var) : 0);
+    if (latency_stdev) {
+        Tick lat = std::min(rng->random_norm(latency, latency_stdev),
+                            latency_stdev_max);
+        DPRINTF(MemoryAccess, "Generated latency norm(%d, %d) = %d\n", latency,
+                latency_stdev, lat);
+        return lat;
+    } else {
+        return latency + (latency_var ? rng->random<Tick>(0, latency_var) : 0);
+    }
 }
 
 void

--- a/src/mem/simple_mem.hh
+++ b/src/mem/simple_mem.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013 ARM Limited
+ * Copyright (c) 2012-2013, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -49,6 +49,7 @@
 #include <list>
 
 #include "base/random.hh"
+#include "enums/LatencyDistribution.hh"
 #include "mem/abstract_mem.hh"
 #include "mem/port.hh"
 #include "params/SimpleMemory.hh"
@@ -117,7 +118,8 @@ class SimpleMemory : public AbstractMemory
     /**
      * Fudge factor added to the latency.
      */
-    const Tick latency_var;
+    const LatencyDistribution latencyDist;
+    const Tick latencyDistParam;
 
     /**
      * Internal (unbounded) storage to mimic the delay caused by the

--- a/src/mem/simple_mem.hh
+++ b/src/mem/simple_mem.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2013 ARM Limited
+ * Copyright (c) 2012-2013, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -118,6 +118,8 @@ class SimpleMemory : public AbstractMemory
      * Fudge factor added to the latency.
      */
     const Tick latency_var;
+    const Tick latency_stdev;
+    const Tick latency_stdev_max;
 
     /**
      * Internal (unbounded) storage to mimic the delay caused by the

--- a/src/python/gem5/components/memory/simple.py
+++ b/src/python/gem5/components/memory/simple.py
@@ -80,7 +80,9 @@ class SingleChannelSimpleMemory(AbstractMemorySystem):
         super().__init__()
 
         self.module = SimpleMemory(
-            latency=latency, latency_var=latency_var, bandwidth=bandwidth
+            latency=latency,
+            latency_dist_param=latency_var,
+            bandwidth=bandwidth,
         )
         self._size = toMemorySize(size)
 

--- a/tests/gem5/memory/simple-run.py
+++ b/tests/gem5/memory/simple-run.py
@@ -63,7 +63,7 @@ class MyMem(SimpleMemory):
     if args.latency:
         latency = args.latency
     if args.latency_var:
-        latency_var = args.latency_var
+        latency_dist_param = args.latency_var
 
 
 # system simulated


### PR DESCRIPTION
If latency_stdev is set, latency_var is ignored, and the latency for
each accesss is computed using a normal distribution with avg=latancy
and stdev=latency_stdev.