### PR TITLE
sim: Expose ClockedObject cyclesToTick/ticksToCycles to python

### DIFF
--- a/src/sim/ClockedObject.py
+++ b/src/sim/ClockedObject.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012, 2015-2017, 2019-2020 ARM Limited
+# Copyright (c) 2012, 2015-2017, 2019-2020, 2026 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -37,6 +37,7 @@ from m5.objects.PowerState import PowerState
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject
+from m5.util.pybind import PyBindMethod
 
 
 class ClockedObject(SimObject):
@@ -44,6 +45,11 @@ class ClockedObject(SimObject):
     abstract = True
     cxx_header = "sim/clocked_object.hh"
     cxx_class = "gem5::ClockedObject"
+
+    cxx_exports = [
+        PyBindMethod("ticksToCycles"),
+        PyBindMethod("cyclesToTicks"),
+    ]
 
     # The clock domain this clocked object belongs to, inheriting the
     # parent's clock domain by default


### PR DESCRIPTION
By exposing these two methods we are able to work with cycles from within a python script.

For example, if a gem5 config is keeping track of execution time it will inevitably do so with ticks.
While ticks are the universal measure for time in gem5, it is not straightforward for a user to extract numbers which are closer to the simulated hardware

Change-Id: I180aab9520375374784f85f65c3f32c51e548bf3

Reviewed-by: Andreas Sandberg <andreas.sandberg@arm.com>