### PR TITLE
arch-arm, mem-ruby: Allow MPAM setting in chi::tlm library

### DIFF
--- a/src/arch/arm/mpam.cc
+++ b/src/arch/arm/mpam.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -61,37 +61,37 @@ PartitionFieldExtension::clone() const
 uint64_t
 PartitionFieldExtension::getPartitionID() const
 {
-    return this->_partitionID;
+    return bundle._partitionID;
 }
 
 uint64_t
 PartitionFieldExtension::getPartitionMonitoringID() const
 {
-    return this->_partitionMonitoringID;
+    return bundle._partitionMonitoringID;
 }
 
 bool
 PartitionFieldExtension::getMpamNS() const
 {
-    return this->_ns;
+    return bundle._ns;
 }
 
 void
 PartitionFieldExtension::setPartitionID(uint64_t id)
 {
-    this->_partitionID = id;
+    bundle._partitionID = id;
 }
 
 void
 PartitionFieldExtension::setPartitionMonitoringID(uint64_t id)
 {
-    this->_partitionMonitoringID = id;
+    bundle._partitionMonitoringID = id;
 }
 
 void
 PartitionFieldExtension::setMpamNS(bool ns)
 {
-    this->_ns = ns;
+    bundle._ns = ns;
 }
 
 

--- a/src/arch/arm/mpam.hh
+++ b/src/arch/arm/mpam.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -48,6 +48,13 @@ namespace gem5::ArmISA::mpam
 const uint64_t DEFAULT_PARTITION_ID = 0;
 const uint64_t DEFAULT_PARTITION_MONITORING_ID = 0;
 
+struct MpamBundle
+{
+    uint64_t _partitionID = DEFAULT_PARTITION_ID;
+    uint64_t _partitionMonitoringID = DEFAULT_PARTITION_MONITORING_ID;
+    bool _ns = true;
+};
+
 class PartitionFieldExtension : public Extension<Request,
                                                  PartitionFieldExtension>
 {
@@ -93,9 +100,7 @@ class PartitionFieldExtension : public Extension<Request,
     void setMpamNS(bool ns);
 
   private:
-    uint64_t _partitionID = DEFAULT_PARTITION_ID;
-    uint64_t _partitionMonitoringID = DEFAULT_PARTITION_MONITORING_ID;
-    bool _ns = true;
+    MpamBundle bundle;
 };
 
 /** Partition ID data type */

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -64,18 +64,26 @@ void
 tlm_chi_pybind(pybind11::module_ &m_internal)
 {
     auto tlm_chi = m_internal.def_submodule("tlm_chi");
+
+    using Mpam = decltype(Payload::mpam);
+    py::class_<Mpam>(tlm_chi, "Mpam")
+        .def(py::init<>())
+        .def_readwrite("mpam_ns", &Mpam::mpam_ns)
+        .def_readwrite("part_id", &Mpam::part_id)
+        .def_readwrite("perf_mon_group", &Mpam::perf_mon_group);
+
     py::class_<Payload, std::unique_ptr<Payload, PayloadDeleter<Payload>>>(
         tlm_chi, "TlmPayload")
         .def(py::init(&Payload::new_payload))
         .def_readwrite("address", &Payload::address)
-        .def_property("size",
-            [] (const Payload &p) { return p.size; },
-            [] (Payload &p, SizeEnum val) { p.size = val; })
+        .def_readwrite("mpam", &Payload::mpam)
+        .def_property(
+            "size", [](const Payload &p) { return p.size; },
+            [](Payload &p, SizeEnum val) { p.size = val; })
         .def_readwrite("lpid", &Payload::lpid)
-        .def_property("ns",
-            [] (const Payload &p) { return p.ns; },
-            [] (Payload &p, bool val) { p.ns = val; })
-        ;
+        .def_property(
+            "ns", [](const Payload &p) { return p.ns; },
+            [](Payload &p, bool val) { p.ns = val; });
 
     py::class_<Phase>(tlm_chi, "TlmPhase")
         .def(py::init<>())

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -479,6 +479,16 @@ rspResp(CHIResponseType rsp)
 
 }
 
+::gem5::ArmISA::mpam::MpamBundle
+getMpam(const Payload &payload)
+{
+    ::gem5::ArmISA::mpam::MpamBundle bundle;
+    bundle._ns = payload.mpam.mpam_ns;
+    bundle._partitionID = payload.mpam.part_id;
+    bundle._partitionMonitoringID = payload.mpam.perf_mon_group;
+    return bundle;
+}
+
 Addr
 transactionSize(Size sz)
 {

--- a/src/mem/ruby/protocol/chi/tlm/utils.hh
+++ b/src/mem/ruby/protocol/chi/tlm/utils.hh
@@ -40,6 +40,7 @@
 
 #include <ARM/TLM/arm_chi.h>
 
+#include "arch/arm/mpam.hh"
 #include "base/types.hh"
 #include "mem/ruby/protocol/CHI/CHIDataType.hh"
 #include "mem/ruby/protocol/CHI/CHIRequestType.hh"
@@ -70,6 +71,8 @@ ARM::CHI::Resp datResp(ruby::CHI::CHIDataType dat);
 ARM::CHI::Resp rspResp(ruby::CHI::CHIResponseType rsp);
 
 }
+
+::gem5::ArmISA::mpam::MpamBundle getMpam(const ARM::CHI::Payload &payload);
 
 Addr transactionSize(ARM::CHI::Size sz);
 


### PR DESCRIPTION
With this PR we enable the following:

* Allow to configure the MPAM field in the ARM::CHI::Payload from python
* Provide a conversion helper to translate between the ARM::CHI::Mpam data type to the gem5::MpamBundle data type