### PR TITLE
scons: Raise minimum protoc version to 3.0.0

### DIFF
--- a/src/proto/SConsopts
+++ b/src/proto/SConsopts
@@ -39,8 +39,8 @@ with gem5_scons.Configure(main) as conf:
     except Exception as e:
         warning('While checking protoc version:', str(e))
 
-    # Based on the availability of the compress stream wrappers, require 2.1.0.
-    min_protoc_version = '2.1.0'
+    # The proto files use the 'reserved' keyword, which requires 3.0.0.
+    min_protoc_version = '3.0.0'
 
     # First two words should be "libprotoc x.y.z"
     if len(protoc_version) < 2 or protoc_version[0] != 'libprotoc':


### PR DESCRIPTION
The proto files in src/proto/ use the 'reserved' keyword (e.g., inst.proto), which was introduced in protobuf 3.0. The previous minimum of 2.1.0 allowed protoc 2.x to pass the configure check but then fail during compilation with a confusing parse error:

  inst.proto:98:14: Missing numeric value for enum constant.