### PR TITLE
arch-riscv: fix incorrect Rs1 write position in v/vfslide1down.vx when vl < VMAX

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5552,11 +5552,13 @@ decode QUADRANT default Unknown::unknown() {
                             }
                         }
                     }
-                    if (lastUop) {
-                        if (this->vm || elem_mask(v0,
-                            vdWindowLeft + microVl - 1)) {
-                            auto fd = ftype_freg<et>(freg(Fs1_bits));
-                            Vd_vu[microVl - 1] = fd.v;
+                    if (machInst.vl > 0 && vdWindowLeft <= (int)(machInst.vl - 1) && (int)(machInst.vl - 1) < vdWindowRight) {
+                        int posInMicro = (int)(machInst.vl - 1) - vdWindowLeft;
+                        if (posInMicro < microVl) {
+                            if (this->vm || elem_mask(v0, (int)(machInst.vl - 1))) {
+                                auto fd = ftype_freg<et>(freg(Fs1_bits));
+                                Vd_vu[posInMicro] = fd.v;
+                            }
                         }
                     }
                 }}, OPFVF, SimdMiscOp);
@@ -5903,10 +5905,13 @@ decode QUADRANT default Unknown::unknown() {
                             }
                         }
                     }
-                    if (lastUop) {
-                        if (this->vm || elem_mask(v0,
-                            vdWindowLeft + microVl - 1)) {
-                            Vd_vu[microVl - 1] = Rs1_vu;
+                    if (machInst.vl > 0 && vdWindowLeft <= (int)(machInst.vl - 1)
+                        && (int)(machInst.vl - 1) < vdWindowRight) {
+                        int posInMicro = (int)(machInst.vl - 1) - vdWindowLeft;
+                        if (posInMicro < microVl) {
+                            if (this->vm || elem_mask(v0, (int)(machInst.vl - 1))) {
+                                Vd_vu[posInMicro] = Rs1_vu;
+                            }
                         }
                     }
                 }}, OPIVX, SimdMiscOp);

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5552,12 +5552,15 @@ decode QUADRANT default Unknown::unknown() {
                             }
                         }
                     }
-                    if (machInst.vl > 0 && vdWindowLeft <= (int)(machInst.vl - 1) && (int)(machInst.vl - 1) < vdWindowRight) {
-                        int posInMicro = (int)(machInst.vl - 1) - vdWindowLeft;
-                        if (posInMicro < microVl) {
-                            if (this->vm || elem_mask(v0, (int)(machInst.vl - 1))) {
-                                auto fd = ftype_freg<et>(freg(Fs1_bits));
-                                Vd_vu[posInMicro] = fd.v;
+                    if (machInst.vl > 0) {
+                        const int lastElem = (int)machInst.vl - 1;
+                        if (vdWindowLeft <= lastElem && lastElem < vdWindowRight) {
+                            int posInMicro = lastElem - vdWindowLeft;
+                            if (posInMicro < microVl) {
+                                if (this->vm || elem_mask(v0, lastElem)) {
+                                    auto fd = ftype_freg<et>(freg(Fs1_bits));
+                                    Vd_vu[posInMicro] = fd.v;
+                                }
                             }
                         }
                     }
@@ -5905,12 +5908,14 @@ decode QUADRANT default Unknown::unknown() {
                             }
                         }
                     }
-                    if (machInst.vl > 0 && vdWindowLeft <= (int)(machInst.vl - 1)
-                        && (int)(machInst.vl - 1) < vdWindowRight) {
-                        int posInMicro = (int)(machInst.vl - 1) - vdWindowLeft;
-                        if (posInMicro < microVl) {
-                            if (this->vm || elem_mask(v0, (int)(machInst.vl - 1))) {
-                                Vd_vu[posInMicro] = Rs1_vu;
+                    if (machInst.vl > 0) {
+                        const int lastElem = (int)machInst.vl - 1;
+                        if (vdWindowLeft <= lastElem && lastElem < vdWindowRight) {
+                            int posInMicro = lastElem - vdWindowLeft;
+                            if (posInMicro < microVl) {
+                                if (this->vm || elem_mask(v0, lastElem)) {
+                                    Vd_vu[posInMicro] = Rs1_vu;
+                                }
                             }
                         }
                     }

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5552,16 +5552,11 @@ decode QUADRANT default Unknown::unknown() {
                             }
                         }
                     }
-                    if (machInst.vl > 0) {
-                        const int lastElem = (int)machInst.vl - 1;
-                        if (vdWindowLeft <= lastElem && lastElem < vdWindowRight) {
-                            int posInMicro = lastElem - vdWindowLeft;
-                            if (posInMicro < microVl) {
-                                if (this->vm || elem_mask(v0, lastElem)) {
-                                    auto fd = ftype_freg<et>(freg(Fs1_bits));
-                                    Vd_vu[posInMicro] = fd.v;
-                                }
-                            }
+                    if (isLastMicroop()) {
+                        if (this->vm || elem_mask(v0,
+                            vdWindowLeft + microVl - 1)) {
+                            auto fd = ftype_freg<et>(freg(Fs1_bits));
+                            Vd_vu[microVl - 1] = fd.v;
                         }
                     }
                 }}, OPFVF, SimdMiscOp);
@@ -5908,15 +5903,10 @@ decode QUADRANT default Unknown::unknown() {
                             }
                         }
                     }
-                    if (machInst.vl > 0) {
-                        const int lastElem = (int)machInst.vl - 1;
-                        if (vdWindowLeft <= lastElem && lastElem < vdWindowRight) {
-                            int posInMicro = lastElem - vdWindowLeft;
-                            if (posInMicro < microVl) {
-                                if (this->vm || elem_mask(v0, lastElem)) {
-                                    Vd_vu[posInMicro] = Rs1_vu;
-                                }
-                            }
+                    if (isLastMicroop()) {
+                        if (this->vm || elem_mask(v0,
+                            vdWindowLeft + microVl - 1)) {
+                            Vd_vu[microVl - 1] = Rs1_vu;
                         }
                     }
                 }}, OPIVX, SimdMiscOp);

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2433,7 +2433,7 @@ template<typename ElemType>
 
             microop = new %(class_name)sMicro<ElemType>(
                 _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
-                _vlen, true, j == (std::max(i - 1, 0) - 1), false, false);
+                _vlen, true, j == (std::max(i - 1, 0) - 1), false);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
         }
@@ -2558,7 +2558,7 @@ template<typename ElemType>
 
             microop = new %(class_name)sMicro<ElemType>(
                 _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
-                _vlen, false, j >= (num_microops - 2), false, overlap);
+                _vlen, false, j >= (num_microops - 2), overlap);
             microop->setDelayedCommit();
             this->microops.push_back(microop);
         }
@@ -2618,8 +2618,7 @@ template<typename ElemType>
             if (copyFrontFromVs2 || copyFrontFromVs3 || needZeroTail) {
                 microop = new %(class_name)sMicro<ElemType>(
                     _machInst, micro_vl, micro_idx++, i, vs2Idx, vs3Idx, _elen,
-                    _vlen, false, lastUopForVd,
-                    i == (num_microops - 1) || micro_vl < micro_vlmax);
+                    _vlen, false, lastUopForVd);
                 microop->setDelayedCommit();
                 this->microops.push_back(microop);
                 break;
@@ -2647,13 +2646,12 @@ private:
     RegId destRegIdxArr[1];
     bool vm;
     bool lastUopForVd;
-    bool lastUop;
     bool slideUp;
 public:
     %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
         uint32_t _microIdx, uint32_t _vdIdx, uint32_t _vs2Idx,
         uint32_t _vs3Idx, uint32_t _elen, uint32_t _vlen, bool _slideUp,
-        bool _lastUopForVd, bool _lastUop=false, bool _copyVs = false);
+        bool _lastUopForVd, bool _copyVs = false);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -2666,11 +2664,10 @@ template<typename ElemType>
 %(class_name)s<ElemType>::%(class_name)s(ExtMachInst _machInst,
         uint32_t _microVl, uint32_t _microIdx, uint32_t _vdIdx,
         uint32_t _vs2Idx, uint32_t _vs3Idx, uint32_t _elen, uint32_t _vlen,
-        bool _slideUp, bool _lastUopForVd, bool _lastUop, bool _copyVs)
+        bool _slideUp, bool _lastUopForVd, bool _copyVs)
     : %(base_class)s("%(mnemonic)s", _machInst, %(op_class)s, _microVl,
         _microIdx, _vdIdx, _vs2Idx, _vs3Idx, _elen, _vlen),
       lastUopForVd(_lastUopForVd),
-      lastUop(_lastUop),
       slideUp(_slideUp)
 {
     this->vm = _machInst.vm;


### PR DESCRIPTION
The implementation of vslide1down.vx/vfslide1down.vf incorrectly relied on lastUop to write the final active element (vl - 1). This assumption only holds when vl == VLMAX, where the last element naturally falls within the final micro-op. When vl < VLMAX, the element vl - 1 may belong to an earlier micro-op, causing the write to be skipped entirely.
By replacing the lastUop check with a condition that detects whether vl - 1 lies within the current micro-op window, the write is performed in the correct micro-op regardless of vl. This ensures the final element is always written to the proper position in Vd_vu.
This fix corrects the behavior for all vl values and ensures consistency across both integer and floating-point variants of the instruction.