### PR TITLE
mem-ruby,sim: Remove GPU shadow ROM range

### DIFF
--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -88,9 +88,6 @@ def makeGpuFSSystem(args):
         clock=args.cpu_clock, voltage_domain=system.cpu_voltage_domain
     )
 
-    # Setup VGA ROM region
-    system.shadow_rom_ranges = [AddrRange(0xC0000, size=Addr("128KiB"))]
-
     # Create specified number of CPUs. GPUFS really only needs one.
     system.cpu = [
         TestCPUClass(clk_domain=system.cpu_clk_domain, cpu_id=i)

--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -710,25 +710,10 @@ RubyPort::PioResponsePort::getAddrRanges() const
 }
 
 bool
-RubyPort::MemResponsePort::isShadowRomAddress(Addr addr) const
-{
-    AddrRangeList ranges = owner.system->getShadowRomRanges();
-
-    for (auto it = ranges.begin(); it != ranges.end(); ++it) {
-        if (it->contains(addr)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool
 RubyPort::MemResponsePort::isPhysMemAddress(PacketPtr pkt) const
 {
-    Addr addr = pkt->getAddr();
-    return (owner.system->isMemAddr(addr) && !isShadowRomAddress(addr))
-           || owner.system->isDeviceMemAddr(pkt);
+    return owner.system->isMemAddr(pkt->getAddr()) ||
+           owner.system->isDeviceMemAddr(pkt);
 }
 
 void

--- a/src/mem/ruby/system/RubyPort.hh
+++ b/src/mem/ruby/system/RubyPort.hh
@@ -108,7 +108,6 @@ class RubyPort : public ClockedObject
         void addToRetryList();
 
       private:
-        bool isShadowRomAddress(Addr addr) const;
         bool isPhysMemAddress(PacketPtr pkt) const;
     };
 

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -96,11 +96,6 @@ class System(SimObject):
         "memory.",
     )
 
-    # The ranges backed by a shadowed ROM
-    shadow_rom_ranges = VectorParam.AddrRange(
-        [], "Ranges  backed by a shadowed ROM"
-    )
-
     shared_backstore = Param.String(
         "",
         "backstore's shmem segment filename, "

--- a/src/sim/system.cc
+++ b/src/sim/system.cc
@@ -176,7 +176,6 @@ System::System(const Params &p)
       physmem(name() + ".physmem", p.memories, p.mmap_using_noreserve,
               p.shared_backstore, p.auto_unlink_shared_backstore,
               p.is_sparse_restore),
-      ShadowRomRanges(p.shadow_rom_ranges.begin(), p.shadow_rom_ranges.end()),
       memoryMode(p.mem_mode),
       _cacheLineSize(p.cache_line_size),
       numWorkIds(p.num_work_ids),

--- a/src/sim/system.hh
+++ b/src/sim/system.hh
@@ -379,13 +379,6 @@ class System : public SimObject, public PCEventScope
      */
     memory::AbstractMemory *getDeviceMemory(const PacketPtr& pkt) const;
 
-    /*
-     * Return the list of address ranges backed by a shadowed ROM.
-     *
-     * @return List of address ranges backed by a shadowed ROM
-     */
-    AddrRangeList getShadowRomRanges() const { return ShadowRomRanges; }
-
     /**
      * Get the guest byte order.
      */
@@ -405,8 +398,6 @@ class System : public SimObject, public PCEventScope
     KvmVM *kvmVM = nullptr;
 
     memory::PhysicalMemory physmem;
-
-    AddrRangeList ShadowRomRanges;
 
     enums::MemoryMode memoryMode;
 


### PR DESCRIPTION
This feature is no longer needed and is quite intrusive to the system class. The actual GPU ROM range reading is handled by a `dd` command in full system scripts which writes a VBIOS to the ROM region.

Remove this old feature.