### PR TITLE
arch-riscv: Fix element indexing in vfslide1up_vf micro-ops

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5461,13 +5461,13 @@ decode QUADRANT default Unknown::unknown() {
                         int frontLen = microVlmax - backLen;
                         int vdOffset = 0;
                         for (int i = 0; vdOffset < frontLen
-                            && vdOffset < microVl; vdOffset++) {
+                            && vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs2_vu[i + backLen];
                             }
                         }
-                        for (int i = 0; vdOffset < microVl; vdOffset++) {
+                        for (int i = 0; vdOffset < microVl; vdOffset++, i++) {
                             if (this->vm || elem_mask(v0,
                                 vdOffset + vdWindowLeft)) {
                                 Vd_vu[vdOffset] = Vs3_vu[i];


### PR DESCRIPTION
The implementation of vfslide1up_vf in the copyAll block contained a logic error where the source index i was declared but never incremented. This caused the instruction to incorrectly repeat a single element from the source registers across all destination positions within a micro-op, instead of streaming through the register.

By adding i++ to the increment section of both loops, the source index now correctly advances alongside the destination offset. This ensures that the elements are shifted properly according to the vslide1up specification, maintaining data integrity across the entire vector length.