### PR TITLE
arch-riscv: fix signed Rs1 offset handling in vslideup/vslidedown causing incorrect window computation

### DIFF
--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -54,6 +54,8 @@ class Checkpoint;
 namespace RiscvISA
 {
 
+static constexpr uint64_t RVV_MAX_VLMAX = 0x10000;
+
 enum PrivilegeMode
 {
     PRV_U = 0,

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5079,7 +5079,8 @@ decode QUADRANT default Unknown::unknown() {
                     }}, OPIVX, SimdAluOp);
                 }
                 0x0e: VectorSlideUpFormat::vslideup_vx({{
-                    int offset = (int)Rs1_vu;
+                    uint64_t raw_offset = Rs1_vu;
+                    int offset = (raw_offset > 0xFFFF) ? 0xFFFF : (int)raw_offset;
                     int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
                     int vdWindowLeft = microVlmax * vdIdx;
                     int vdWindowRight = microVlmax * (vdIdx + 1);
@@ -5122,7 +5123,8 @@ decode QUADRANT default Unknown::unknown() {
                     }
                 }}, OPIVX, SimdMiscOp);
                 0x0f: VectorSlideDownFormat::vslidedown_vx({{
-                    int offset = (int)Rs1_vu;
+                    uint64_t raw_offset = Rs1_vu;
+                    int offset = (raw_offset > 0xFFFF) ? 0xFFFF : (int)raw_offset;
                     int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
                     int offsetWindow = offset % microVlmax;
                     int vdWindowLeft = microVlmax * vdIdx;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -5080,7 +5080,7 @@ decode QUADRANT default Unknown::unknown() {
                 }
                 0x0e: VectorSlideUpFormat::vslideup_vx({{
                     uint64_t raw_offset = Rs1_vu;
-                    int offset = (raw_offset > 0xFFFF) ? 0xFFFF : (int)raw_offset;
+                    int offset = (raw_offset > RVV_MAX_VLMAX) ? (int)RVV_MAX_VLMAX : (int)raw_offset;
                     int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
                     int vdWindowLeft = microVlmax * vdIdx;
                     int vdWindowRight = microVlmax * (vdIdx + 1);
@@ -5124,7 +5124,7 @@ decode QUADRANT default Unknown::unknown() {
                 }}, OPIVX, SimdMiscOp);
                 0x0f: VectorSlideDownFormat::vslidedown_vx({{
                     uint64_t raw_offset = Rs1_vu;
-                    int offset = (raw_offset > 0xFFFF) ? 0xFFFF : (int)raw_offset;
+                    int offset = (raw_offset > RVV_MAX_VLMAX) ? (int)RVV_MAX_VLMAX : (int)raw_offset;
                     int microVlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
                     int offsetWindow = offset % microVlmax;
                     int vdWindowLeft = microVlmax * vdIdx;


### PR DESCRIPTION
The implementation of vslideup.vx and vslidedown.vx incorrectly treated the slide offset (rs1) as a signed integer. By casting Rs1_vu to int, large unsigned values (e.g., 0xffffffff, 0xfffffff8) were interpreted as negative offsets, breaking the internal window calculations.
This resulted in invalid behavior such as reading incorrect elements or modifying vector lanes that should remain unchanged, especially when the offset exceeded VLMAX.
The fix reads Rs1_vu as an unsigned value and clamps it to a safe upper bound before converting to int. This preserves correct semantics for large offsets while avoiding overflow in the existing arithmetic.
With this change, offsets greater than VLMAX are handled correctly, matching the expected RISC-V vector behavior and aligning gem5 with Spike.