### PR TITLE
arch-riscv: fix srcRegIdxArr overflow in VPinVdMicroInst corrupting destination register

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -808,7 +808,7 @@ class VCpyVsMicroInst : public VectorArithMicroInst
 class VPinVdMicroInst : public VectorArithMicroInst
 {
     private:
-        RegId srcRegIdxArr[2];
+        RegId srcRegIdxArr[3];
         RegId destRegIdxArr[1];
         const bool isSlideupVx;
         const bool isReduction;


### PR DESCRIPTION
The implementation of VPinVdMicroInst incorrectly defined the source register array with insufficient capacity. When used in vslideup.vx with masking enabled, the micro-op registers three source operands (undisturbed vd, rs1, and v0), but the array was only sized for two.
This caused a buffer overflow that overwrote destRegIdxArr[0] with the v0 register identifier, effectively redirecting writes to the mask register instead of the intended destination vector register.
As a result, instructions like vslideup.vx could corrupt v0, diverging from the expected behavior where the mask register remains unchanged.
Expanding srcRegIdxArr to hold three entries fixes the overflow and ensures the destination register is preserved correctly across all micro-ops.