### PR TITLE
mem-ruby: Extend slicc to ease interaction with SimObjects

### DIFF
--- a/src/mem/slicc/ast/FuncDeclAST.py
+++ b/src/mem/slicc/ast/FuncDeclAST.py
@@ -1,3 +1,16 @@
+# -*- mode:python -*-
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
 # Copyright (c) 2009 The Hewlett-Packard Development Company
 # All rights reserved.
@@ -33,13 +46,26 @@ from slicc.symbols import (
 
 
 class FuncDeclAST(DeclAST):
-    def __init__(self, slicc, return_type, ident, formals, pairs, statements):
+    def __init__(
+        self,
+        slicc,
+        return_type,
+        ident,
+        formals,
+        pairs,
+        statements,
+        is_public=False,
+    ):
         super().__init__(slicc, pairs)
 
         self.return_type = return_type
         self.ident = ident
         self.formals = formals
         self.statements = statements
+        self.is_public = is_public
+
+        if self.is_public:
+            self["public"] = "yes"
 
     def __repr__(self):
         return f"[FuncDecl: {self.ident}]"

--- a/src/mem/slicc/ast/ThisExprAST.py
+++ b/src/mem/slicc/ast/ThisExprAST.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2026 Arm Limited
+# Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -9,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2009 The Hewlett-Packard Development Company
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -36,52 +33,20 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# actual ASTs
-from slicc.ast.ActionDeclAST import *
-from slicc.ast.AssignStatementAST import *
-from slicc.ast.AST import *
-from slicc.ast.CheckAllocateStatementAST import *
-from slicc.ast.CheckNextCycleAST import *
-from slicc.ast.CheckProbeStatementAST import *
-from slicc.ast.DeclAST import *
-from slicc.ast.DeclListAST import *
-from slicc.ast.DeferEnqueueingStatementAST import *
-from slicc.ast.EnqueueStatementAST import *
-from slicc.ast.EnumDeclAST import *
-from slicc.ast.EnumExprAST import *
-from slicc.ast.ExprAST import *
-from slicc.ast.ExprStatementAST import *
-from slicc.ast.FormalParamAST import *
-from slicc.ast.FuncCallExprAST import *
-from slicc.ast.FuncDeclAST import *
-from slicc.ast.IfStatementAST import *
-from slicc.ast.InPortDeclAST import *
-from slicc.ast.IsValidPtrExprAST import *
-from slicc.ast.LiteralExprAST import *
-from slicc.ast.LocalVariableAST import *
-from slicc.ast.MachineAST import *
-from slicc.ast.MemberExprAST import *
-from slicc.ast.MethodCallExprAST import *
-from slicc.ast.NewExprAST import *
-from slicc.ast.ObjDeclAST import *
-from slicc.ast.OodAST import *
-from slicc.ast.OperatorExprAST import *
-from slicc.ast.OutPortDeclAST import *
-from slicc.ast.PairAST import *
-from slicc.ast.PairListAST import *
-from slicc.ast.PeekStatementAST import *
-from slicc.ast.ReturnStatementAST import *
-from slicc.ast.StallAndWaitStatementAST import *
-from slicc.ast.StateDeclAST import *
-from slicc.ast.StatementAST import *
-from slicc.ast.StatementListAST import *
-from slicc.ast.StaticCastAST import *
-from slicc.ast.ThisExprAST import *
-from slicc.ast.TransitionDeclAST import *
-from slicc.ast.TypeAST import *
-from slicc.ast.TypeDeclAST import *
-from slicc.ast.TypeFieldAST import *
-from slicc.ast.TypeFieldEnumAST import *
-from slicc.ast.TypeFieldStateAST import *
-from slicc.ast.VarExprAST import *
-from slicc.ast.WakeupPortStatementAST import *
+from slicc.ast.ExprAST import ExprAST
+from slicc.symbols import Type
+
+
+class ThisExprAST(ExprAST):
+    def __init__(self, slicc):
+        super().__init__(slicc)
+
+    def __repr__(self):
+        return "[This:]"
+
+    def generate(self, code, **kwargs):
+        code += "this"
+        type = self.symtab.find("AbstractController", Type)
+        if type is None:
+            self.error("Internal: missing external type 'AbstractController'")
+        return type

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020,2021 ARM Limited
+# Copyright (c) 2020,2021,2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -174,6 +174,7 @@ class SLICC(Grammar):
         "new": "NEW",
         "OOD": "OOD",
         "defer_enqueueing": "DEFER_ENQUEUEING",
+        "public": "PUBLIC",
     }
 
     literals = ":[]{}(),="
@@ -464,12 +465,22 @@ class SLICC(Grammar):
     def p_func_decl__0(self, p):
         """func_decl :  void ident '(' params ')' pairs SEMI
         | type ident '(' params ')' pairs SEMI"""
-        p[0] = ast.FuncDeclAST(self, p[1], p[2], p[4], p[6], None)
+        p[0] = ast.FuncDeclAST(self, p[1], p[2], p[4], p[6], None, False)
 
     def p_func_decl__1(self, p):
         """func_decl :  void ident '(' types ')' pairs SEMI
         | type ident '(' types ')' pairs SEMI"""
-        p[0] = ast.FuncDeclAST(self, p[1], p[2], p[4], p[6], None)
+        p[0] = ast.FuncDeclAST(self, p[1], p[2], p[4], p[6], None, False)
+
+    def p_func_decl__public_0(self, p):
+        """func_decl :  PUBLIC void ident '(' params ')' pairs SEMI
+        | PUBLIC type ident '(' params ')' pairs SEMI"""
+        p[0] = ast.FuncDeclAST(self, p[2], p[3], p[5], p[7], None, True)
+
+    def p_func_decl__public_1(self, p):
+        """func_decl :  PUBLIC void ident '(' types ')' pairs SEMI
+        | PUBLIC type ident '(' types ')' pairs SEMI"""
+        p[0] = ast.FuncDeclAST(self, p[2], p[3], p[5], p[7], None, True)
 
     def p_decl__func_def(self, p):
         "decl : func_def"
@@ -478,7 +489,12 @@ class SLICC(Grammar):
     def p_func_def__0(self, p):
         """func_def : void ident '(' params ')' pairs statements
         | type ident '(' params ')' pairs statements"""
-        p[0] = ast.FuncDeclAST(self, p[1], p[2], p[4], p[6], p[7])
+        p[0] = ast.FuncDeclAST(self, p[1], p[2], p[4], p[6], p[7], False)
+
+    def p_func_def__public_0(self, p):
+        """func_def : PUBLIC void ident '(' params ')' pairs statements
+        | PUBLIC type ident '(' params ')' pairs statements"""
+        p[0] = ast.FuncDeclAST(self, p[2], p[3], p[5], p[7], p[8], True)
 
     # Enum fields
     def p_type_enums__list(self, p):

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -175,6 +175,7 @@ class SLICC(Grammar):
         "OOD": "OOD",
         "defer_enqueueing": "DEFER_ENQUEUEING",
         "public": "PUBLIC",
+        "this": "THIS",
     }
 
     literals = ":[]{}(),="
@@ -790,6 +791,10 @@ class SLICC(Grammar):
     def p_expr__new(self, p):
         "aexpr : NEW type"
         p[0] = ast.NewExprAST(self, p[2])
+
+    def p_expr__this(self, p):
+        "aexpr : THIS"
+        p[0] = ast.ThisExprAST(self)
 
     def p_expr__null(self, p):
         "aexpr : OOD"

--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021,2023 ARM Limited
+# Copyright (c) 2019-2021,2023,2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -419,6 +419,27 @@ class $c_ident : public AbstractController
     bool isPossible(${ident}_State state, ${ident}_Event event);
     uint64_t getTransitionCount(${ident}_State state, ${ident}_Event event);
 
+""")
+
+        public_funcs = []
+        private_funcs = []
+        for func in self.functions:
+            if "public" in func and str(func["public"]).lower() == "yes":
+                public_funcs.append(func)
+            else:
+                private_funcs.append(func)
+
+        if public_funcs:
+            code("""
+    // Public helper functions
+""")
+            for func in public_funcs:
+                proto = func.prototype
+                if proto:
+                    code("    $proto")
+
+        code("""
+
 private:
 """)
 
@@ -479,7 +500,7 @@ std::vector<std::vector<statistics::Vector *> > transVec;
 // Internal functions
 """)
 
-        for func in self.functions:
+        for func in private_funcs:
             proto = func.prototype
             if proto:
                 code("$proto")


### PR DESCRIPTION
One of the biggest shortcomings of slicc is the difficulty in integrating SimObjects within the language.
SimObjects are the building blocks of gem5 and allow modularity and specialization at the same time.

It would be nice if we could offload some of the non protocol logic (outside of coherence handling) from slicc
files to C++ files.
While we can already integrate SimObjects with the slicc Cache_Controller, there is no way for the SimObject to
gain access to its internal state.

This is mainly cause the autogenerated methods (examples are in CHI-cache-funcs.sm) are defined as private within
the controller. They are in fact meant to be internal methods only.

With this patch we add the 2 following improvements:

1) We extend the language with the "PUBLIC" keyword, which describes a method as being part of the public interface.

So if I have the following method:
```

int tbeSize() {
    return storTBEs.size()
}

// autogenerated file:
class Cache_Controller
{
  private:
    int tbeSize();
};

```
Marking it as public will transform the code as follows

```
public int tbeSize() {
    return storTBEs.size()
}

// autogenerated file:
class Cache_Controller
{
  public:
    int tbeSize();
  private:
    [..]
};
```

2) To be able to use the aforementioned public methods, a SimObject needs to get hold of a pointer of the
Coherence_Controller. To do so, we define the "this" keyword, so that a parent controller can pass its
pointer to the child SimObject