### PR TITLE
cpu-o3: add LeastLoaded IQ insertion policy

### DIFF
--- a/configs/common/cores/arm/neoverse_v2.py
+++ b/configs/common/cores/arm/neoverse_v2.py
@@ -319,6 +319,7 @@ class NeoverseV2(ArmO3CPU):
 
     # The Neoverse Scheduler
     # Configured according to https://chipsandcheese.com/p/arms-neoverse-v2-in-awss-graviton-4
+    iqInsertionPolicy = "LeastLoaded"
     instQueues = [
         Neoverse_V2_IQ0(),
         Neoverse_V2_IQ1(),

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -185,6 +185,9 @@ class BaseO3CPU(BaseCPU):
     # most ISAs don't use condition-code regs, so default is 0
     numPhysCCRegs = Param.Unsigned(0, "Number of physical cc registers")
     instQueues = VectorParam.IQUnit(IQUnit(), "Vector of IQs")
+    iqInsertionPolicy = Param.IQInsertionPolicy(
+        "FirstMatch", "Policy for inserting instructions to IQs"
+    )
     numROBEntries = Param.Unsigned(192, "Number of reorder buffer entries")
 
     smtNumFetchingThreads = Param.Unsigned(1, "SMT Number of Fetching Threads")

--- a/src/cpu/o3/IQUnit.py
+++ b/src/cpu/o3/IQUnit.py
@@ -43,6 +43,10 @@ from m5.proxy import Parent
 from m5.SimObject import SimObject
 
 
+class IQInsertionPolicy(ScopedEnum):
+    vals = ["FirstMatch", "LeastLoaded"]
+
+
 class IQUnit(SimObject):
     type = "IQUnit"
     cxx_class = "gem5::o3::IQUnit"

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -46,7 +46,8 @@ if env['CONF']['BUILD_ISA']:
     SimObject('FUPool.py', sim_objects=['FUPool'])
     SimObject('FuncUnitConfig.py', sim_objects=[])
     SimObject('BaseO3CPU.py', sim_objects=['BaseO3CPU'])
-    SimObject('IQUnit.py', sim_objects=['IQUnit'])
+    SimObject('IQUnit.py', sim_objects=['IQUnit'],
+        enums=['IQInsertionPolicy'])
     SimObject('SMT.py',
         enums=['SMTFetchPolicy', 'SMTQueuePolicy', 'CommitPolicy'])
 

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -248,6 +248,7 @@ InstructionQueue::InstructionQueue(CPU *cpu_ptr, IEW *iew_ptr,
     : cpu(cpu_ptr),
       iewStage(iew_ptr),
       iqs(params.instQueues),
+      insertionPolicy(params.iqInsertionPolicy),
       numThreads(params.numThreads),
       totalWidth(params.issueWidth),
       commitToIEWDelay(params.commitToIEWDelay),
@@ -692,13 +693,43 @@ IQUnit *
 InstructionQueue::findIQ(const DynInstPtr &inst)
 {
     bool any_capable = false;
-    for (auto iq : iqs) {
-        if (iq->isCapable(inst->opClass())) {
-            any_capable = true;
-            if (iq->numFreeEntries(inst) > 0) {
-                return iq;
+    if (insertionPolicy == IQInsertionPolicy::LeastLoaded) {
+        // LeastLoaded insertion policy
+        // Find the least loaded IQ to insert
+
+        IQUnit *best_iq = nullptr;
+        unsigned best_load = 0;
+
+        for (auto iq : iqs) {
+            if (iq->isCapable(inst->opClass())) {
+                any_capable = true;
+                if (iq->numFreeEntries(inst) > 0) {
+                    unsigned load = iq->numEntries() - iq->numFreeEntries();
+                    if (!best_iq || load < best_load) {
+                        best_iq = iq;
+                        best_load = load;
+                    }
+                }
             }
         }
+
+        if (best_iq) {
+            return best_iq;
+        }
+    } else if (insertionPolicy == IQInsertionPolicy::FirstMatch) {
+        // FirstMatch insertion policy (default)
+        // Find the first non-full IQ to insert
+
+        for (auto iq : iqs) {
+            if (iq->isCapable(inst->opClass())) {
+                any_capable = true;
+                if (iq->numFreeEntries(inst) > 0) {
+                    return iq;
+                }
+            }
+        }
+    } else {
+        fatal("Unknown IQ insertion policy %d\n", (int)insertionPolicy);
     }
 
     if (any_capable) {

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -58,6 +58,7 @@
 #include "cpu/o3/store_set.hh"
 #include "cpu/op_class.hh"
 #include "cpu/timebuf.hh"
+#include "enums/IQInsertionPolicy.hh"
 #include "enums/SMTQueuePolicy.hh"
 #include "sim/eventq.hh"
 
@@ -394,6 +395,9 @@ class InstructionQueue
 
     /** List of Instruction Queues */
     std::vector<IQUnit *> iqs;
+
+    /** Insertion policy for routing instructions to IQs */
+    IQInsertionPolicy insertionPolicy;
 
     /** The memory dependence unit, which tracks/predicts memory dependences
      *  between instructions.


### PR DESCRIPTION
For early CPU models with a unified IQ, the existing behavior works fine. However, newer models like Neoverse-V2 have multiple IQs for the same OpClass (e.g. IntAlu appears in 4 IQs). With the previous FirstMatch behavior (which this commit names), some FUs can be underutilized because they wait for another IQ to fill up first. For example, if IQ0 and IQ1 both have ALU slots, the ALU in IQ1 may only be utilized after IQ0 is full.

This commit adds a LeastLoaded insertion policy that distributes instructions evenly across IQs, and names the previous behavior FirstMatch. On a microbenchmark, this improves IPC from 3.72 to 4.00, matching the theoretical ceiling determined by the number of FUs.