### PR TITLE
stdlib: Avoid `resource_tracker` spawn from tqdm

### DIFF
--- a/src/python/gem5/utils/progress_bar.py
+++ b/src/python/gem5/utils/progress_bar.py
@@ -48,9 +48,18 @@ class FakeTQDM:
 
 
 try:
+    from threading import RLock
+
     from tqdm.auto import tqdm
+    from tqdm.std import tqdm as std_tqdm
 
     _have_tqdm = True
+
+    # tqdm's default global lock includes a multiprocessing RLock, which may
+    # spawn multiprocessing helper processes. A thread lock is sufficient for
+    # gem5's progress output and avoids launching extra gem5 instances.
+    std_tqdm.set_lock(RLock())
+    tqdm.set_lock(RLock())
 except ImportError:
     tqdm = FakeTQDM()
     _have_tqdm = False

--- a/src/python/gem5/utils/progress_bar.py
+++ b/src/python/gem5/utils/progress_bar.py
@@ -58,8 +58,9 @@ try:
     # tqdm's default global lock includes a multiprocessing RLock, which may
     # spawn multiprocessing helper processes. A thread lock is sufficient for
     # gem5's progress output and avoids launching extra gem5 instances.
-    std_tqdm.set_lock(RLock())
-    tqdm.set_lock(RLock())
+    _tqdm_lock = RLock()
+    std_tqdm.set_lock(_tqdm_lock)
+    tqdm.set_lock(_tqdm_lock)
 except ImportError:
     tqdm = FakeTQDM()
     _have_tqdm = False


### PR DESCRIPTION
When gem5 uses tqdm for resource download/md5 progress, tqdm creates a multiprocessing `RLock` by default. Under gem5, this launches an extra process:

```shell
<gem5.opt> -c 'from multiprocessing.resource_tracker import main;...'
```

This caused duplicate gem5 banner output during normal single-run workloads and made logs noisy/confusing.

This change fixes this by setting tqdm's global lock to a thread-only `RLock` in `src/python/gem5/utils/progress_bar.py`. This preserves progress bar synchronization without creating multiprocessing semaphores, so `resource_tracker` is not started.

The fix applies the lock override to both `tqdm.auto.tqdm` and `tqdm.std.tqdm` to cover the class used at runtime.