### PR TITLE
dev-arm: Default GenericTimerFrame nonSecureAccess to true

### DIFF
--- a/src/dev/arm/generic_timer.cc
+++ b/src/dev/arm/generic_timer.cc
@@ -997,12 +997,15 @@ GenericTimerFrame::GenericTimerFrame(const GenericTimerFrameParams &p)
       timerRange(RangeSize(p.cnt_base, ArmSystem::PageBytes)),
       addrRanges({timerRange}),
       systemCounter(*p.counter),
-      physTimer(csprintf("%s.phys_timer", name()),
-                *this, systemCounter, p.int_phys->get()),
-      virtTimer(csprintf("%s.virt_timer", name()),
-                *this, systemCounter,
+      physTimer(csprintf("%s.phys_timer", name()), *this, systemCounter,
+                p.int_phys->get()),
+      virtTimer(csprintf("%s.virt_timer", name()), *this, systemCounter,
                 p.int_virt->get()),
       accessBits(0x3f),
+      // Default to true: enable non-secure access to simplify bootloader
+      // implementation, which otherwise would need to program CNTNSAR
+      // before booting a non-secure kernel.
+      nonSecureAccess(true),
       system(*dynamic_cast<ArmSystem *>(sys))
 {
     SystemCounter::validateCounterRef(p.counter);


### PR DESCRIPTION
The GenericTimerFrame member nonSecureAccess was implicitly initialized to false.  On systems with Security Extensions enabled this caused validateAccessPerm() to reject every Non-Secure access and timerCtrlRead() to return 0 for all CNTACRn registers.  The Linux kernel's arch_timer_mem_find_best_frame() therefore saw no usable frame and aborted timer initialization with:

    arch_timer: Unable to find a suitable frame in timer @ 0x000000002a810000
    Failed to initialize '/timer@2a810000': -22

On real hardware ARM Trusted Firmware (TF-A) sets CNTNSAR = 0xFF at EL3 before the NS kernel boots, granting Non-Secure access to all timer frames.  gem5 does not model secure firmware, so the post-firmware state must be set at construction time—consistent with accessBits already being initialized to 0x3f in the same constructor.

Initialize nonSecureAccess to true so that Non-Secure kernels can discover and use memory-mapped timer frames without requiring a secure-firmware model.

## Linux timer behavior comparison

### Before the fix (disable NS access)

```console
root@gem5-arm:/# cat /sys/devices/system/clocksource/clocksource0/current_clocksource
jiffies

root@gem5-arm:/# cat /sys/devices/system/clocksource/clocksource0/available_clocksource
jiffies

root@gem5-arm:/# dmesg | grep -iE "timer|clock|sched_clock"
[    0.000000] arch_timer: Unable to find a suitable frame in timer @ 0x000000002a810000
[    0.000000] Failed to initialize '/timer@2a810000': -22
[    0.000000] sched_clock: 64 bits at 250 Hz, resolution 4000000ns, wraps every 9007199254000000ns
[    0.000000] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.004000] PTP clock support registered
[    0.008000] kvm [1]: kvm_arch_timer: uninitialized timecounter
[    0.144000] clk: Disabling unused clocks

root@gem5-arm:/# cat /proc/timer_list  |grep hres
  .hres_active    : 0
  .hres_active    : 0
  .hres_active    : 0
  .hres_active    : 0

```

### After the fix (enable NS access)


```console
root@gem5-arm:/# cat /sys/devices/system/clocksource/clocksource0/current_clocksource
arch_sys_counter

root@gem5-arm:/# cat /sys/devices/system/clocksource/clocksource0/available_clocksource
arch_sys_counter

root@gem5-arm:/# dmesg | grep -iE "timer|clock|sched_clock"
[    0.000000] arch_timer: cp15 and mmio timer(s) running at 25.16MHz (phys/virt).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x5cdd39714, max_idle_ns: 440795202620 ns
[    0.000000] sched_clock: 56 bits at 25MHz, resolution 39ns, wraps every 4398046511084ns
[    0.002736] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.007646] PTP clock support registered
[    0.008167] clocksource: Switched to clocksource arch_sys_counter
[    0.143835] clk: Disabling unused clocks


root@gem5-arm:/# cat /proc/timer_list  |grep hres
 #0: <00000000fdbc0706>, tick_nohz_highres_handler, S:01
  .hres_active    : 1
 #0: <00000000dba2d074>, tick_nohz_highres_handler, S:01
  .hres_active    : 1
 #0: <00000000ce8ad562>, tick_nohz_highres_handler, S:01
  .hres_active    : 1
 #0: <00000000bbe553fa>, tick_nohz_highres_handler, S:01
  .hres_active    : 1

```

### Results

With the `nonSecureAccess=false` wrong setup, the per-CPU timer hardware still fires interrupts for scheduling, so basic operation works — but anything that needs precise timing (benchmarks, performance measurements, network timestamps, clock_gettime()) would be inaccurate.