### PR TITLE
scons: Support for GCC 15.2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -683,7 +683,7 @@ for variant_path in variant_paths:
 
     if env['GCC']:
         gcc_min_version = "11"
-        gcc_max_version = "14.2"
+        gcc_max_version = "15.2"
         gcc_version = env['CXXVERSION']
         if compareVersions(gcc_version, gcc_min_version) < 0 or \
               compareVersions(gcc_version, gcc_max_version) > 0:


### PR DESCRIPTION
**SConstruct**: Bumped `gcc_max_version` to `15.2` to enable GCC 15 support.