### PR TITLE
mem-ruby: Implementation of CHI Cbusy

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 Arm Limited
+# Copyright (c) 2021-2024, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -257,6 +257,8 @@ class CHI_L1Controller(Base_CHI_Cache_Controller):
         self.cache = cache
         self.prefetcher = prefetcher
         self.use_prefetcher = prefetcher != NULL
+        self.cbusy_generator = NULL
+        self.cbusy_tracker = CBusyTracker()
         self.send_evictions = True
         self.is_HN = False
         self.enable_DMT = False
@@ -295,6 +297,8 @@ class CHI_L2Controller(Base_CHI_Cache_Controller):
         self.cache = cache
         self.prefetcher = prefetcher
         self.use_prefetcher = prefetcher != NULL
+        self.cbusy_generator = CBusy()
+        self.cbusy_tracker = CBusyTracker()
         self.allow_SD = True
         self.is_HN = False
         self.enable_DMT = False
@@ -357,6 +361,8 @@ class CHI_HNFController(Base_CHI_Cache_Controller):
         self.number_of_DVM_TBEs = 1  # should not receive any dvm
         self.number_of_DVM_snoop_TBEs = 1  # should not receive any dvm
         self.unify_repl_TBEs = False
+        self.cbusy_generator = CBusy()
+        self.cbusy_tracker = CBusyTracker()
 
 
 class CHI_MNController(CHI_MiscNode_Controller):
@@ -409,6 +415,8 @@ class CHI_DMAController(Base_CHI_Cache_Controller):
 
         self.prefetcher = NULL
         self.use_prefetcher = False
+        self.cbusy_generator = NULL
+        self.cbusy_tracker = CBusyTracker()
         self.cache = DummyCache()
         self.sequencer.dcache = NULL
         # All allocations are false
@@ -745,6 +753,7 @@ class CHI_SNF_Base(CHI_Node):
             requestToMemory=MemCtrlMessageBuffer(),
             reqRdy=TriggerMessageBuffer(),
             transitions_per_cycle=1024,
+            cbusy_generator=SnfCBusy(),
         )
 
         # The Memory_Controller implementation deallocates the TBE for

--- a/src/mem/packet.hh
+++ b/src/mem/packet.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2019, 2021 ARM Limited
+ * Copyright (c) 2012-2019, 2021, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -583,6 +583,20 @@ class Packet : public Printable, public Extensible<Packet>
         return t;
     }
 
+    /**
+     * Value indicating the average occupancy of downstream objects that
+     * handled the request which produced this response packet.
+     * -1 = indicates completerBusy not set or not available.
+     * it is implementation defined how this score gets interpreted
+     * An example could be:
+     *
+     * 0 = occupancy < 50%
+     * 1 = 50%-75%
+     * 2 = 75%-90%
+     * 3 = >90%
+     */
+    int8_t completerBusy;
+
     /// Return the string name of the cmd field (for debugging and
     /// tracing).
     const std::string &cmdString() const { return cmd.toString(); }
@@ -875,13 +889,21 @@ class Packet : public Printable, public Extensible<Packet>
      * not be valid. The command must be supplied.
      */
     Packet(const RequestPtr &_req, MemCmd _cmd)
-        :  cmd(_cmd), id((PacketId)_req.get()), req(_req),
-           data(nullptr), addr(0), _isSecure(false), size(0),
-           _qosValue(0),
-           htmReturnReason(HtmCacheFailure::NO_FAIL),
-           htmTransactionUid(0),
-           headerDelay(0), snoopDelay(0),
-           payloadDelay(0), senderState(NULL)
+        : cmd(_cmd),
+          id((PacketId)_req.get()),
+          req(_req),
+          data(nullptr),
+          addr(0),
+          _isSecure(false),
+          size(0),
+          _qosValue(0),
+          htmReturnReason(HtmCacheFailure::NO_FAIL),
+          htmTransactionUid(0),
+          headerDelay(0),
+          snoopDelay(0),
+          payloadDelay(0),
+          senderState(NULL),
+          completerBusy(-1)
     {
         flags.clear();
         if (req->hasPaddr()) {
@@ -916,13 +938,20 @@ class Packet : public Printable, public Extensible<Packet>
      * req.  this allows for overriding the size/addr of the req.
      */
     Packet(const RequestPtr &_req, MemCmd _cmd, int _blkSize, PacketId _id = 0)
-        :  cmd(_cmd), id(_id ? _id : (PacketId)_req.get()), req(_req),
-           data(nullptr), addr(0), _isSecure(false),
-           _qosValue(0),
-           htmReturnReason(HtmCacheFailure::NO_FAIL),
-           htmTransactionUid(0),
-           headerDelay(0),
-           snoopDelay(0), payloadDelay(0), senderState(NULL)
+        : cmd(_cmd),
+          id(_id ? _id : (PacketId)_req.get()),
+          req(_req),
+          data(nullptr),
+          addr(0),
+          _isSecure(false),
+          _qosValue(0),
+          htmReturnReason(HtmCacheFailure::NO_FAIL),
+          htmTransactionUid(0),
+          headerDelay(0),
+          snoopDelay(0),
+          payloadDelay(0),
+          senderState(NULL),
+          completerBusy(-1)
     {
         flags.clear();
         if (req->hasPaddr()) {
@@ -942,18 +971,23 @@ class Packet : public Printable, public Extensible<Packet>
      * packet should allocate its own data.
      */
     Packet(const PacketPtr pkt, bool clear_flags, bool alloc_data)
-        :  Extensible<Packet>(*pkt),
-           cmd(pkt->cmd), id(pkt->id), req(pkt->req),
-           data(nullptr),
-           addr(pkt->addr), _isSecure(pkt->_isSecure), size(pkt->size),
-           bytesValid(pkt->bytesValid),
-           _qosValue(pkt->qosValue()),
-           htmReturnReason(HtmCacheFailure::NO_FAIL),
-           htmTransactionUid(0),
-           headerDelay(pkt->headerDelay),
-           snoopDelay(0),
-           payloadDelay(pkt->payloadDelay),
-           senderState(pkt->senderState)
+        : Extensible<Packet>(*pkt),
+          cmd(pkt->cmd),
+          id(pkt->id),
+          req(pkt->req),
+          data(nullptr),
+          addr(pkt->addr),
+          _isSecure(pkt->_isSecure),
+          size(pkt->size),
+          bytesValid(pkt->bytesValid),
+          _qosValue(pkt->qosValue()),
+          htmReturnReason(HtmCacheFailure::NO_FAIL),
+          htmTransactionUid(0),
+          headerDelay(pkt->headerDelay),
+          snoopDelay(0),
+          payloadDelay(pkt->payloadDelay),
+          senderState(pkt->senderState),
+          completerBusy(-1)
     {
         if (!clear_flags)
             flags.set(pkt->flags & COPY_FLAGS);

--- a/src/mem/ruby/SConscript
+++ b/src/mem/ruby/SConscript
@@ -1,6 +1,6 @@
 # -*- mode:python -*-
 
-# Copyright (c) 2021,2023 Arm Limited
+# Copyright (c) 2021,2023,2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -92,6 +92,7 @@ def MakeInclude(source):
     env.Command(target, source, include_action)
 
 MakeInclude('slicc_interface/AbstractCacheEntry.hh')
+MakeInclude('slicc_interface/AbstractController.hh')
 MakeInclude('slicc_interface/Message.hh')
 MakeInclude('slicc_interface/RubyRequest.hh')
 
@@ -111,6 +112,8 @@ MakeInclude('structures/CacheMemory.hh')
 MakeInclude('structures/DirectoryMemory.hh')
 MakeInclude('structures/PerfectCacheMemory.hh')
 MakeInclude('structures/PersistentTable.hh')
+MakeInclude('structures/BackpressureGen.hh')
+MakeInclude('structures/BackpressureTracker.hh')
 MakeInclude('structures/RubyPrefetcher.hh')
 MakeInclude('structures/RubyPrefetcherProxy.hh')
 MakeInclude('structures/TBEStorage.hh')

--- a/src/mem/ruby/protocol/RubySlicc_Exports.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Exports.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021,2023,2025 Arm Limited
+ * Copyright (c) 2020-2021,2023,2025-2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -55,6 +55,8 @@ external_type(Tick, primitive="yes", default="0");
 external_type(RequestPtr, primitive="yes", default="nullptr");
 external_type(RequestorID, primitive="yes");
 external_type(prefetch::Base, primitive="yes");
+external_type(AbstractController, primitive="yes");
+external_type(Message, primitive="yes");
 
 structure(WriteMask, external="yes", desc="...") {
   void clear();

--- a/src/mem/ruby/protocol/RubySlicc_Types.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Types.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021,2023-2024 Arm Limited
+ * Copyright (c) 2020-2021,2023-2024,2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -55,6 +55,7 @@ structure(MessageBuffer, buffer="yes", inport="yes", outport="yes",
   // in debug traces dumped by the protocol.
   bool areNSlotsAvailable(int n, Tick curTime);
   int getSize(Tick curTime);
+  Tick oldestMsgStallTicks(Tick current_time);
 }
 
 external_type(Scalar, primitive="yes");
@@ -278,4 +279,14 @@ structure(RubyPrefetcherProxy, external = "yes") {
     // SLICC controller must define its own regProbePoints and call
     // this for every RubyPrefetcherProxy object present
     void regProbePoints();
+}
+structure (BackpressureGen, external = "yes") {
+    int generate(AbstractController * controller, Message msg);
+}
+
+// Helper class for tracking responder occupancy
+structure(BackpressureTracker, external ="yes") {
+    void update(MachineID, int);
+    void updateDMT(MachineID, int);
+    int report();
 }

--- a/src/mem/ruby/protocol/RubySlicc_Types.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Types.sm
@@ -131,19 +131,24 @@ structure (Sequencer, external = "yes") {
   void readCallback(Addr, DataBlock, bool, MachineType);
   void readCallback(Addr, DataBlock, bool, MachineType,
                     Cycles, Cycles, Cycles);
+  void readCallbackCBusy(Addr, DataBlock, bool, int);
 
   void writeCallback(Addr, DataBlock);
   void writeCallback(Addr, DataBlock, bool);
   void writeCallback(Addr, DataBlock, bool, MachineType);
   void writeCallback(Addr, DataBlock, bool, MachineType,
                      Cycles, Cycles, Cycles);
+  void writeCallbackCBusy(Addr, DataBlock, bool, int);
+
   void writeUniqueCallback(Addr, DataBlock);
+  void writeUniqueCallbackCBusy(Addr, DataBlock, int);
 
   void atomicCallback(Addr, DataBlock);
   void atomicCallback(Addr, DataBlock, bool);
   void atomicCallback(Addr, DataBlock, bool, MachineType);
   void atomicCallback(Addr, DataBlock, bool, MachineType,
                       Cycles, Cycles, Cycles);
+  void atomicCallbackCBusy(Addr, DataBlock, bool, int);
 
 
   void unaddressedCallback(Addr, RubyRequestType);

--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Arm Limited
+ * Copyright (c) 2021-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -2232,6 +2232,76 @@ action(Receive_RespSepData, desc="") {
   }
 }
 
+
+action(UpdateBPTracker_FromRespSepData, desc="") {
+  peek(rspInPort, CHIResponseMsg) {
+    // consistency check
+    assert(tbe.pendReqDest.count() == 1);
+    assert(in_msg.responder == tbe.pendReqDest.smallestElement());
+    assert(in_msg.cbusy >= 0);
+    cbusy_tracker.update(in_msg.responder, in_msg.cbusy);
+  }
+}
+
+action(UpdateBPTracker_FromDataSepResp, desc="") {
+  // Only update once all data is received
+  if (tbe.expected_req_resp.hasReceivedData()) {
+    peek(datInPort, CHIDataMsg) {
+      assert(in_msg.cbusy >= 0);
+      cbusy_tracker.updateDMT(in_msg.responder, in_msg.cbusy);
+    }
+  }
+}
+
+action(UpdateBPTracker_FromCompData, desc="") {
+  // Only update once all data is received
+  if (tbe.expected_req_resp.hasReceivedData()) {
+    peek(datInPort, CHIDataMsg) {
+      assert(tbe.pendReqDest.count() == 1);
+      MachineID orig_responder := tbe.pendReqDest.smallestElement();
+      if (in_msg.cbusy >= 0) {
+        // response came from downstream
+        if (in_msg.responder == orig_responder) {
+          cbusy_tracker.update(in_msg.responder, in_msg.cbusy);
+        } else {
+          // was a DMT response
+          cbusy_tracker.updateDMT(in_msg.responder, in_msg.cbusy);
+          // NOTE: When responder is a upstream cache (DCT on), cbusy is not set
+        }
+      }
+    }
+  }
+}
+
+action(UpdateBPTracker_FromDatalessResp, desc="") {
+  // Only update once all data is received
+  peek(rspInPort, CHIResponseMsg) {
+    // consistency check
+    assert(tbe.pendReqDest.count() == 1);
+    assert(in_msg.responder == tbe.pendReqDest.smallestElement());
+    assert(in_msg.cbusy >= 0);
+    cbusy_tracker.update(in_msg.responder, in_msg.cbusy);
+  }
+}
+
+action(UpdateBPTracker_FromRetryAck, desc="") {
+  // Only update once all data is received
+  peek(rspInPort, CHIResponseMsg) {
+    // consistency check
+    assert(in_msg.cbusy >= 0);
+    cbusy_tracker.update(in_msg.responder, in_msg.cbusy);
+  }
+}
+
+action(UpdateBPTracker_FromPCrdGrant, desc="") {
+  // Only update once all data is received
+  peek(rspInPort, CHIResponseMsg) {
+    // consistency check
+    assert(in_msg.cbusy >= 0);
+    cbusy_tracker.update(in_msg.responder, in_msg.cbusy);
+  }
+}
+
 action(Receive_ReadReceipt, desc="") {
   assert(is_valid(tbe));
   assert(tbe.expected_req_resp.hasExpected());
@@ -2835,6 +2905,7 @@ action(Send_CompData, desc="") {
                             (tbe.snd_msgType == CHIDataType:CompData_SD_PD);
 
   tbe.snd_destination := tbe.requestor;
+  tbe.snd_cbusy := true;
   setupPendingSend(tbe);
   printTBEState(tbe);
 }
@@ -2875,6 +2946,7 @@ action(Send_WBData, desc="") {
     }
   }
   tbe.snd_destination := mapAddressToDownstreamMachine(tbe.addr);
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -2965,6 +3037,7 @@ action(Send_SnpRespData, desc="") {
   }
 
   tbe.snd_destination := tbe.requestor;
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -2983,6 +3056,7 @@ action(Send_CompData_SnpUniqueFwd, desc="") {
   tbe.actions.pushFront(Event:SendSnpFwdedResp);
 
   tbe.snd_destination := tbe.fwdRequestor;
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -3005,6 +3079,7 @@ action(Send_CompData_SnpSharedFwd, desc="") {
   }
 
   tbe.snd_destination := tbe.fwdRequestor;
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -3022,6 +3097,7 @@ action(Send_CompData_SnpNSDFwd, desc="") {
   }
 
   tbe.snd_destination := tbe.fwdRequestor;
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -3033,6 +3109,7 @@ action(Send_CompData_SnpOnceFwd, desc="") {
   tbe.actions.pushFront(Event:SendSnpFwdedResp);
 
   tbe.snd_destination := tbe.fwdRequestor;
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -3066,6 +3143,7 @@ action(Send_SnpRespDataFwded, desc="") {
   }
 
   tbe.snd_destination := tbe.requestor;
+  tbe.snd_cbusy := false;
   setupPendingSend(tbe);
 }
 
@@ -3148,8 +3226,10 @@ action(Send_Data, desc="") {
     out_msg.bitMask.setMask(offset, range);
 
     out_msg.responder := machineID;
-
     out_msg.Destination.add(tbe.snd_destination);
+    if (tbe.snd_cbusy) {
+      out_msg.cbusy := getCurrCBusy(out_msg);
+    }
   }
 
   // send next chunk (if any) next cycle
@@ -3165,6 +3245,7 @@ action(Send_RespSepData, desc="") {
     out_msg.Destination.add(tbe.requestor);
     out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3186,6 +3267,7 @@ action(Send_CompI, desc="") {
     out_msg.Destination.add(tbe.requestor);
     out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3198,6 +3280,7 @@ action(Send_CompUC, desc="") {
     out_msg.Destination.add(tbe.requestor);
     out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3213,6 +3296,7 @@ action(Send_CompUC_Stale, desc="") {
     // We don't know if this is a stale clean unique or a bug, so flag the
     // reponse so the requestor can make further checks
     out_msg.stale := true;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3225,6 +3309,7 @@ action(Send_CompUD_PD, desc="") {
     out_msg.Destination.add(tbe.requestor);
     out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3251,6 +3336,7 @@ action(Send_CompI_Stale, desc="") {
     // We don't know if this is a stale writeback or a bug, so flag the
     // reponse so the requestor can make further checks
     out_msg.stale := true;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3263,6 +3349,7 @@ action(Send_CompDBIDResp, desc="") {
     out_msg.Destination.add(tbe.requestor);
     out_msg.txnId := tbe.txnId;
     out_msg.dbid := tbe.txnId;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3278,6 +3365,7 @@ action(Send_CompDBIDResp_Stale, desc="") {
     // We don't know if this is a stale writeback or a bug, so flag the
     // reponse so the requestor can make further checks
     out_msg.stale := true;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3290,6 +3378,7 @@ action(Send_DBIDResp, desc="") {
     out_msg.Destination.add(tbe.requestor);
     out_msg.dbid := tbe.txnId;
     out_msg.txnId := tbe.txnId;
+    out_msg.cbusy := getCurrCBusy(out_msg);
   }
 }
 
@@ -3358,6 +3447,7 @@ action(Send_RetryAck, desc="") {
       out_msg.Destination.add(in_msg.retryDest);
       out_msg.txnId := in_msg.txnId;
       out_msg.lpid := in_msg.lpid;
+      out_msg.cbusy := getCurrCBusy(out_msg);
     }
   }
 }
@@ -3371,6 +3461,7 @@ action(Send_PCrdGrant, desc="") {
       out_msg.responder := machineID;
       out_msg.Destination.add(in_msg.retryDest);
       out_msg.lpid := in_msg.lpid;
+      out_msg.cbusy := getCurrCBusy(out_msg);
     }
   }
 }
@@ -3709,12 +3800,12 @@ action(Callback_Miss, desc="") {
 
   } else if (tbe.dataValid && (tbe.reqType == CHIRequestType:Load)) {
     DPRINTF(RubySlicc, "Read data %s\n", tbe.dataBlk);
-    sequencer.readCallback(tbe.addr, tbe.dataBlk, true);
+    sequencer.readCallbackCBusy(tbe.addr, tbe.dataBlk, true, cbusy_tracker.report());
 
   } else if (tbe.dataValid && ((tbe.reqType == CHIRequestType:Store) ||
                                (tbe.reqType == CHIRequestType:StoreLine))) {
     DPRINTF(RubySlicc, "Write before %s\n", tbe.dataBlk);
-    sequencer.writeCallback(tbe.addr, tbe.dataBlk, true);
+    sequencer.writeCallbackCBusy(tbe.addr, tbe.dataBlk, true, cbusy_tracker.report());
     DPRINTF(RubySlicc, "Write after %s\n", tbe.dataBlk);
     tbe.dataDirty := true;
 
@@ -3789,7 +3880,7 @@ action(Callback_WriteUnique, desc="") {
   assert((tbe.reqType == CHIRequestType:StoreLine) ||
          (tbe.reqType == CHIRequestType:Store));
   assert(tbe.dataValid == false);
-  sequencer.writeUniqueCallback(tbe.addr, tbe.dataBlk);
+  sequencer.writeUniqueCallbackCBusy(tbe.addr, tbe.dataBlk, cbusy_tracker.report());
   DPRINTF(RubySlicc, "WriteUnique data %s\n", tbe.dataBlk);
   // set mask; note data is never considered valid
   assert(tbe.dataBlkValid.isEmpty());

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Arm Limited
+ * Copyright (c) 2021-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -765,6 +765,30 @@ void processRetryQueue() {
       out_msg.lpid := e.lpid;
     }
   }
+}
+
+public int tbeSize() {
+  return storTBEs.size();
+}
+
+public int tbeReserved() {
+  return storTBEs.reserved();
+}
+
+public int tbeCapacity() {
+  return storTBEs.capacity();
+}
+
+public bool hasRetryQueueEntries() {
+  return !retryQueue.empty();
+}
+
+int getCurrCBusy(CHIDataMsg message) {
+  return cbusy_generator.generate(this, message);
+}
+
+int getCurrCBusy(CHIResponseMsg message) {
+  return cbusy_generator.generate(this, message);
 }
 
 void printResources() {

--- a/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-transitions.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Arm Limited
+ * Copyright (c) 2021-2024, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -1456,12 +1456,14 @@ transition(BUSY_BLKD,
 
 transition({BUSY_BLKD,BUSY_INTR}, RespSepData, BUSY_BLKD) {
   Receive_RespSepData;
+  UpdateBPTracker_FromRespSepData;
   Pop_RespInQueue;
   ProcessNextState;
 }
 
 transition({BUSY_BLKD,BUSY_INTR}, DataSepResp_UC, BUSY_BLKD) {
   Receive_ReqDataResp;
+  UpdateBPTracker_FromDataSepResp;
   UpdateDataState_FromReqDataResp;
   Callback_Miss;
   Profile_OutgoingEnd_DataResp;
@@ -1474,6 +1476,7 @@ transition({BUSY_BLKD,BUSY_INTR},
             BUSY_BLKD) {
   Receive_RespSepDataFromCompData;
   Receive_ReqDataResp;
+  UpdateBPTracker_FromCompData;
   UpdateDataState_FromReqDataResp;
   Callback_Miss;
   Profile_OutgoingEnd_DataResp;
@@ -1483,6 +1486,7 @@ transition({BUSY_BLKD,BUSY_INTR},
 
 transition(BUSY_INTR, ReadReceipt, BUSY_BLKD) {
   Receive_ReadReceipt;
+  UpdateBPTracker_FromDatalessResp;
   Pop_RespInQueue;
   ProcessNextState;
 }
@@ -1491,12 +1495,14 @@ transition(BUSY_INTR, ReadReceipt, BUSY_BLKD) {
 
 transition(BUSY_INTR, {RetryAck, RetryAck_PoC}) {
   Receive_RetryAck;
+  UpdateBPTracker_FromRetryAck;
   Pop_RespInQueue;
   ProcessNextState;
 }
 
 transition(BUSY_INTR, {PCrdGrant, PCrdGrant_PoC}) {
   Receive_PCrdGrant;
+  UpdateBPTracker_FromPCrdGrant;
   Pop_RespInQueue;
   ProcessNextState;
 }
@@ -1507,12 +1513,14 @@ transition(BUSY_INTR, {PCrdGrant, PCrdGrant_PoC}) {
 
 transition(BUSY_BLKD, RetryAck_PoC) {
   Receive_RetryAck;
+  UpdateBPTracker_FromRetryAck;
   Pop_RespInQueue;
   ProcessNextState;
 }
 
 transition(BUSY_BLKD, PCrdGrant_PoC) {
   Receive_PCrdGrant;
+  UpdateBPTracker_FromPCrdGrant;
   Pop_RespInQueue;
   ProcessNextState;
 }
@@ -1521,12 +1529,14 @@ transition(BUSY_BLKD, PCrdGrant_PoC) {
 // BUSY_BLKD and BUSY_INTR
 transition({BUSY_INTR,BUSY_BLKD}, {RetryAck_Hazard, RetryAck_PoC_Hazard}) {
   Receive_RetryAck_Hazard;
+  UpdateBPTracker_FromRetryAck;
   Pop_RespInQueue;
   ProcessNextState;
 }
 
 transition({BUSY_INTR,BUSY_BLKD}, {PCrdGrant_Hazard, PCrdGrant_PoC_Hazard}) {
   Receive_PCrdGrant_Hazard;
+  UpdateBPTracker_FromPCrdGrant;
   Pop_RespInQueue;
   ProcessNextState;
 }
@@ -1566,6 +1576,7 @@ transition(BUSY_BLKD,
 // waiting for WB or evict ack
 transition(BUSY_INTR, Comp_I, BUSY_BLKD) {
   Receive_ReqResp;
+  UpdateBPTracker_FromDatalessResp;
   Profile_OutgoingEnd_DatalessResp;
   Pop_RespInQueue;
   ProcessNextState;
@@ -1575,6 +1586,7 @@ transition(BUSY_INTR, Comp_I, BUSY_BLKD) {
 transition(BUSY_INTR, Comp_UC, BUSY_BLKD) {
   Receive_ReqResp;
   UpdateDataState_FromCUResp;
+  UpdateBPTracker_FromDatalessResp;
   Profile_OutgoingEnd_DatalessResp;
   Pop_RespInQueue;
   ProcessNextState;
@@ -1584,6 +1596,7 @@ transition(BUSY_INTR, Comp_UC, BUSY_BLKD) {
 transition(BUSY_INTR, CompDBIDResp, BUSY_BLKD) {
   Receive_ReqResp;
   Receive_ReqResp_CopyDBID;
+  UpdateBPTracker_FromDatalessResp;
   Profile_OutgoingEnd_DatalessResp;
   Pop_RespInQueue;
   ProcessNextState;
@@ -1599,6 +1612,7 @@ transition({BUSY_INTR,BUSY_BLKD}, DBIDResp, BUSY_BLKD) {
 }
 transition(BUSY_BLKD, Comp) {
   Receive_ReqResp_WUComp;
+  UpdateBPTracker_FromDatalessResp;
   Profile_OutgoingEnd_DatalessResp;
   Pop_RespInQueue;
   ProcessNextState;

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Arm Limited
+ * Copyright (c) 2021-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -114,6 +114,12 @@ machine(MachineType:Cache, "Cache coherency protocol") :
   // Width of the data channel. Data transfer are split in multiple messages
   // at the protocol level when this is less than the cache line size.
   int data_channel_size;
+
+  // Maps local resource usage to outgoing CBusy values.
+  BackpressureGen * cbusy_generator, default="NULL";
+
+  // Tracks responder-reported CBusy values for downstream throttling.
+  BackpressureTracker * cbusy_tracker, default="NULL";
 
   // Set when this is used as the home node and point of coherency of the
   // system. Must be false for every other cache level.
@@ -732,6 +738,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
     bool snd_pendEv,            desc="Is there a pending tx event ?";
     WriteMask snd_pendBytes,    desc="Which bytes are pending transmission";
     CHIDataType snd_msgType,    desc="Type of message being sent";
+    bool snd_cbusy,             desc="Include CBusy in the sent msg";
     MachineID snd_destination,  desc="Data destination";
 
     // Tracks how to update the directory when receiving a CompAck

--- a/src/mem/ruby/protocol/chi/CHI-mem.sm
+++ b/src/mem/ruby/protocol/chi/CHI-mem.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 Arm Limited
+ * Copyright (c) 2021-2023, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -45,6 +45,7 @@ machine(MachineType:Memory, "Memory controller interface") :
   Cycles to_memory_controller_latency := 1;
 
   int data_channel_size;
+  BackpressureGen * cbusy_generator, default="NULL";
 
   // Interface to the network
   // Note vnet_type is used by Garnet only. "response" type is assumed to
@@ -326,6 +327,30 @@ machine(MachineType:Memory, "Memory controller interface") :
   // Helper functions
   ////////////////////////////////////////////////////////////////////////////
 
+  public int tbeSize() {
+    return storTBEs.size();
+  }
+
+  public int tbeReserved() {
+    return storTBEs.reserved();
+  }
+
+  public int tbeCapacity() {
+    return storTBEs.capacity();
+  }
+
+  public bool hasRetryQueueEntries() {
+    return !retryQueue.empty();
+  }
+
+  int getCurrCBusy(CHIResponseMsg message) {
+    return cbusy_generator.generate(this, message);
+  }
+
+  int getCurrCBusy(CHIDataMsg message) {
+    return cbusy_generator.generate(this, message);
+  }
+
   void printResources() {
     DPRINTF(RubySlicc, "Resources(avail/max): TBEs=%d/%d\n",
                   storTBEs.size(), storTBEs.capacity());
@@ -540,6 +565,7 @@ machine(MachineType:Memory, "Memory controller interface") :
       out_msg.type := CHIResponseType:ReadReceipt;
       out_msg.responder := machineID;
       out_msg.Destination.add(tbe.requestor);
+      out_msg.cbusy := getCurrCBusy(out_msg);
     }
     // also send different type of data when ready
     tbe.useDataSepResp := true;
@@ -552,6 +578,7 @@ machine(MachineType:Memory, "Memory controller interface") :
       out_msg.type := CHIResponseType:CompDBIDResp;
       out_msg.responder := machineID;
       out_msg.Destination.add(tbe.requestor);
+      out_msg.cbusy := getCurrCBusy(out_msg);
     }
   }
 
@@ -620,7 +647,10 @@ machine(MachineType:Memory, "Memory controller interface") :
       out_msg.dataBlk := tbe.dataBlk;
       // Called in order for the whole block so use rxtxBytes as offset
       out_msg.bitMask.setMask(tbe.rxtxBytes, data_channel_size);
+
+      out_msg.responder := machineID;
       out_msg.Destination.add(tbe.destination);
+      out_msg.cbusy := getCurrCBusy(out_msg);
     }
 
     //DPRINTF(RubySlicc, "rxtxBytes=%d\n", tbe.rxtxBytes);
@@ -689,6 +719,7 @@ machine(MachineType:Memory, "Memory controller interface") :
         out_msg.type := CHIResponseType:RetryAck;
         out_msg.responder := machineID;
         out_msg.Destination.add(in_msg.retryDest);
+        out_msg.cbusy := getCurrCBusy(out_msg);
       }
     }
   }
@@ -700,6 +731,7 @@ machine(MachineType:Memory, "Memory controller interface") :
         out_msg.type := CHIResponseType:PCrdGrant;
         out_msg.responder := machineID;
         out_msg.Destination.add(in_msg.retryDest);
+        out_msg.cbusy := getCurrCBusy(out_msg);
       }
     }
   }

--- a/src/mem/ruby/protocol/chi/CHI-msg.sm
+++ b/src/mem/ruby/protocol/chi/CHI-msg.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023-2025 Arm Limited
+ * Copyright (c) 2021, 2023-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -168,12 +168,15 @@ structure(CHIResponseMsg, desc="", interface="Message") {
   CHIResponseType type, desc="Response type";
   MachineID responder,  desc="Responder ID";
   NetDest Destination,  desc="Response destination";
-  bool stale,           desc="Response to a stale request";
   bool usesTxnId,       desc="True if using a Transaction ID", default="false";
   Addr txnId,           desc="Transaction ID", default="0";
   Addr dbid,            desc="Data Buffer ID", default="0";
   uint8_t lpid,         desc="Logical processor ID, used in conjunction with responder field", default="0";
+
+  int cbusy, default="-1", desc="CBusy value of the responder";
+
   //NOTE: not in CHI and for debuging only
+  bool stale,           desc="Response to a stale request";
 
   MessageSizeType MessageSize, default="MessageSizeType_Control";
 
@@ -223,6 +226,8 @@ structure(CHIDataMsg, desc="", interface="Message") {
   WriteMask bitMask,    desc="Which bytes in the data block are valid";
   bool usesTxnId,       desc="True if using a Transaction ID", default="false";
   Addr txnId,           desc="Transaction ID", default="0";
+
+  int cbusy, default="-1", desc="CBusy value of the responder";
 
   MessageSizeType MessageSize, default="MessageSizeType_Data";
 

--- a/src/mem/ruby/protocol/chi/generic/CBusy.cc
+++ b/src/mem/ruby/protocol/chi/generic/CBusy.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/generic/CBusy.hh"
+
+#include "mem/ruby/protocol/CHI/Cache_Controller.hh"
+#include "mem/ruby/protocol/CHI/Memory_Controller.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+namespace CHI
+{
+
+BaseCBusy::BaseCBusy(const Params &p)
+    : BackpressureGen(p),
+      threshold0(p.threshold_0),
+      threshold1(p.threshold_1),
+      threshold2(p.threshold_2)
+{}
+
+int
+CBusy::generate(AbstractController *ctrl, const Message &msg) const
+{
+    return generateFromTbeOccupancy<CHI::Cache_Controller>(ctrl);
+}
+
+CBusyTracker::CBusyTracker(const Params &p)
+    : BackpressureTracker(p), stats(this)
+{}
+
+void
+CBusyTracker::update(const MachineID &mach_id, int cbusy)
+{
+    entries.updateCBusy(mach_id, cbusy);
+    stats.avgCBusy = entries.avgCBusy();
+}
+
+void
+CBusyTracker::updateDMT(const MachineID &mach_id, int cbusy)
+{
+    dmtEntries.updateCBusy(mach_id, cbusy);
+    stats.avgCBusyDMT = dmtEntries.avgCBusy();
+}
+
+void
+CBusyTracker::print(std::ostream &out) const
+{
+    out << "AvgCBusy=" << entries.avgCBusy() << "/" << dmtEntries.avgCBusy();
+}
+
+void
+CBusyTracker::CBusyTrackerHelper::updateCBusy(const MachineID &mach_id,
+                                              int cbusy)
+{
+    auto aux = cbusyEntries.insert(std::make_pair(mach_id, 0));
+    int &curr_cbusy = aux.first->second;
+    assert(curr_cbusy <= cbusySum);
+    cbusySum -= curr_cbusy;
+    cbusySum += cbusy;
+    curr_cbusy = cbusy;
+}
+
+int
+CBusyTracker::CBusyTrackerHelper::avgCBusy() const
+{
+    return (cbusyEntries.size() != 0)
+               ? (cbusySum + (cbusyEntries.size() / 2)) / cbusyEntries.size()
+               : 0;
+}
+
+int
+CBusyTracker::CBusyTrackerHelper::maxCBusy() const
+{
+    int max = 0;
+    for (const auto &e : cbusyEntries) {
+        if (e.second > max) {
+            max = e.second;
+        }
+    }
+    return max;
+}
+
+CBusyTracker::CBusyTrackerStats::CBusyTrackerStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(avgCBusy, "Avg CBusy value on request responses"),
+      ADD_STAT(avgCBusyDMT, "Avg CBusy value on DMT request responses")
+{}
+
+int
+SnfCBusy::generate(AbstractController *ctrl, const Message &msg) const
+{
+    return generateFromTbeOccupancy<CHI::Memory_Controller>(ctrl);
+}
+
+} // namespace CHI
+} // namespace ruby
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/generic/CBusy.hh
+++ b/src/mem/ruby/protocol/chi/generic/CBusy.hh
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_GENERIC_CBUSY_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_GENERIC_CBUSY_HH__
+
+#include <unordered_map>
+
+#include "base/statistics.hh"
+#include "mem/ruby/common/MachineID.hh"
+#include "mem/ruby/structures/BackpressureGen.hh"
+#include "mem/ruby/structures/BackpressureTracker.hh"
+#include "params/BaseCBusy.hh"
+#include "params/CBusyTracker.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+namespace CHI
+{
+
+/**
+ * Base class for CHI CBusy generators.
+ *
+ * Subclasses map controller state to a protocol CBusy level using
+ * configurable occupancy thresholds.
+ */
+class BaseCBusy : public BackpressureGen
+{
+  public:
+    PARAMS(BaseCBusy);
+
+    /** Construct a CBusy generator with configured threshold levels. */
+    BaseCBusy(const Params &p);
+
+  protected:
+    /** Lower bound for CBusy level 1. */
+    const unsigned threshold0;
+    /** Lower bound for CBusy level 2. */
+    const unsigned threshold1;
+    /** Lower bound for CBusy level 3. */
+    const unsigned threshold2;
+};
+
+/**
+ * Common CBusy generator base for controllers exposing TBE occupancy APIs.
+ * The TBE occupancy determines the CBusy value
+ */
+class TbeCBusy : public BaseCBusy
+{
+  public:
+    TbeCBusy(const BaseCBusyParams &p) : BaseCBusy(p) {}
+
+  protected:
+    template <typename Controller>
+    int
+    generateFromTbeOccupancy(AbstractController *ctrl) const
+    {
+        auto chi_ctrl = dynamic_cast<Controller *>(ctrl);
+        assert(chi_ctrl);
+
+        auto tbe_used = chi_ctrl->tbeSize() + chi_ctrl->tbeReserved();
+        auto tbe_capacity = chi_ctrl->tbeCapacity();
+        auto occupancy = (100 * tbe_used) / tbe_capacity;
+
+        // TBE occupancy thresholds for setting CBusy:
+        // 0 = occupancy < 50%; 1 = 50%-75%; 2 = 75%-90%; 3 = >90%
+        if (occupancy < threshold0) {
+            return 0;
+        } else if (occupancy < threshold1) {
+            return 1;
+        } else if (occupancy < threshold2) {
+            return 2;
+        } else {
+            return 3;
+        }
+    }
+};
+
+/**
+ * Cache-side CBusy generator.
+ *
+ * Generates levels 0..3 based only on TBE occupancy.
+ */
+class CBusy : public TbeCBusy
+{
+  public:
+    CBusy(const BaseCBusyParams &p) : TbeCBusy(p) {}
+
+    /** Compute CBusy from cache controller occupancy. */
+    int generate(AbstractController *ctrl,
+                 const Message &message) const override;
+};
+
+/**
+ * Memory-side CBusy generator.
+ *
+ * Generates levels 0..3 based only on TBE occupancy.
+ */
+class SnfCBusy : public TbeCBusy
+{
+  public:
+    SnfCBusy(const BaseCBusyParams &p) : TbeCBusy(p) {}
+
+    /** Compute CBusy from memory controller occupancy. */
+    int generate(AbstractController *ctrl,
+                 const Message &message) const override;
+};
+
+/**
+ * CHI BackpressureTracker implementation based on observed response CBusy.
+ *
+ * Tracking algorithm:
+ * - Keep one entry per responder with its latest observed CBusy value.
+ * - Maintain a running sum of those latest values.
+ * - On update for responder R, subtract R's previous value from the sum,
+ *   store the new value, then add the new value to the sum.
+ *
+ * This makes each update O(1) and allows efficient aggregate reporting:
+ * max uses the per-responder map, while average uses the running sum.
+ */
+class CBusyTracker : public BackpressureTracker
+{
+  private:
+    class CBusyTrackerHelper
+    {
+      public:
+        /**
+         * Latest observed CBusy per responder.
+         * Each responder contributes exactly one value to cbusySum.
+         */
+        std::unordered_map<MachineID, int> cbusyEntries;
+        /**
+         * Running sum of the current values in cbusyEntries.
+         * On update, we subtract the responder's previous value and add the
+         * new one, so this remains the sum across all responders.
+         */
+        int cbusySum;
+
+        CBusyTrackerHelper() : cbusySum(0) {}
+
+        void updateCBusy(const MachineID &mach_id, int cbusy);
+        int avgCBusy() const;
+        int maxCBusy() const;
+    };
+
+    CBusyTrackerHelper entries;
+    CBusyTrackerHelper dmtEntries;
+
+    struct CBusyTrackerStats : public statistics::Group
+    {
+        CBusyTrackerStats(statistics::Group *parent);
+
+        statistics::Average avgCBusy;
+        statistics::Average avgCBusyDMT;
+    } stats;
+
+  public:
+    PARAMS(CBusyTracker);
+    CBusyTracker(const Params &p);
+
+    void update(const MachineID &mach_id, int cbusy) override;
+    void updateDMT(const MachineID &mach_id, int cbusy) override;
+    int
+    report() override
+    {
+        return entries.maxCBusy();
+    }
+    void print(std::ostream &out) const override;
+};
+
+} // namespace CHI
+} // namespace ruby
+} // namespace gem5
+
+#endif // __MEM_RUBY_PROTOCOL_CHI_GENERIC_CBUSY_HH__

--- a/src/mem/ruby/protocol/chi/generic/CBusy.py
+++ b/src/mem/ruby/protocol/chi/generic/CBusy.py
@@ -1,6 +1,4 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2023, 2026 Arm Limited
+# Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -35,19 +33,39 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from m5.objects.BackpressureGen import BackpressureGen
+from m5.objects.BackpressureTracker import BackpressureTracker
+from m5.params import *
 
-if not env['CONF']['RUBY_PROTOCOL_CHI']:
-    Return()
 
-SimObject('CHIGeneric.py', sim_objects=['CHIGenericController'])
-SimObject(
-    'CBusy.py',
-    sim_objects=['BaseCBusy', 'CBusy', 'SnfCBusy', 'CBusyTracker']
-)
+class BaseCBusy(BackpressureGen):
+    type = "BaseCBusy"
+    cxx_header = "mem/ruby/protocol/chi/generic/CBusy.hh"
+    cxx_class = "gem5::ruby::CHI::BaseCBusy"
+    abstract = True
 
-DebugFlag('RubyCHIGeneric')
-DebugFlag('RubyCHIGenericVerbose')
+    # 0 = Less than 50% full
+    # 1 = Greater than 50% full
+    # 2 = Greater than 75% full
+    # 3 = Greater than 90% full
+    threshold_0 = Param.Unsigned(50, "Threshold for cbusy level 0")
+    threshold_1 = Param.Unsigned(75, "Threshold for cbusy level 1")
+    threshold_2 = Param.Unsigned(90, "Threshold for cbusy level 2")
 
-Source('CHIGenericController.cc')
-Source('CBusy.cc')
+
+class CBusy(BaseCBusy):
+    type = "CBusy"
+    cxx_header = "mem/ruby/protocol/chi/generic/CBusy.hh"
+    cxx_class = "gem5::ruby::CHI::CBusy"
+
+
+class SnfCBusy(BaseCBusy):
+    type = "SnfCBusy"
+    cxx_header = "mem/ruby/protocol/chi/generic/CBusy.hh"
+    cxx_class = "gem5::ruby::CHI::SnfCBusy"
+
+
+class CBusyTracker(BackpressureTracker):
+    type = "CBusyTracker"
+    cxx_header = "mem/ruby/protocol/chi/generic/CBusy.hh"
+    cxx_class = "gem5::ruby::CHI::CBusyTracker"

--- a/src/mem/ruby/protocol/chi/generic/CHIGenericController.cc
+++ b/src/mem/ruby/protocol/chi/generic/CHIGenericController.cc
@@ -59,15 +59,19 @@ namespace ruby
 using namespace CHI;
 
 CHIGenericController::CHIGenericController(const Params &p)
-  : AbstractController(p),
-    reqOut(p.reqOut), snpOut(p.snpOut),
-    rspOut(p.rspOut), datOut(p.datOut),
-    reqIn(p.reqIn), snpIn(p.snpIn),
-    rspIn(p.rspIn), datIn(p.datIn),
-    cacheLineSize(p.ruby_system->getBlockSizeBytes()),
-    cacheLineBits(floorLog2(cacheLineSize)),
-    dataChannelSize(p.data_channel_size),
-    dataMsgsPerLine(cacheLineSize / p.data_channel_size)
+    : AbstractController(p),
+      reqOut(p.reqOut),
+      snpOut(p.snpOut),
+      rspOut(p.rspOut),
+      datOut(p.datOut),
+      reqIn(p.reqIn),
+      snpIn(p.snpIn),
+      rspIn(p.rspIn),
+      datIn(p.datIn),
+      cacheLineSize(p.ruby_system->getBlockSizeBytes()),
+      cacheLineBits(floorLog2(cacheLineSize)),
+      dataChannelSize(p.data_channel_size),
+      dataMsgsPerLine(cacheLineSize / p.data_channel_size)
 {
     m_machineID.type = MachineType_Cache;
     m_machineID.num = m_version;

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -187,6 +187,7 @@ CacheController::Transaction::handle(const CHIResponseMsg *msg)
     phase.rsp_opcode = opcode;
     phase.resp = ruby_to_tlm::rspResp(msg->m_type);
     phase.txn_id = msg->m_txnId;
+    phase.c_busy = msg->m_cbusy;
 
     controller->bw(payload, &phase);
     return opcode != ARM::CHI::RSP_OPCODE_RETRY_ACK;
@@ -208,6 +209,7 @@ CacheController::ReadTransaction::handle(const CHIDataMsg *msg)
     phase.resp = ruby_to_tlm::datResp(msg->m_type);
     phase.txn_id = msg->m_txnId;
     phase.data_id = dataId(msg->m_addr + msg->m_bitMask.firstBitSet(true));
+    phase.c_busy = msg->m_cbusy;
 
     // This is a hack, we should fix it on the ruby side
     if (forward(msg)) {

--- a/src/mem/ruby/slicc_interface/RubySlicc_Util.hh
+++ b/src/mem/ruby/slicc_interface/RubySlicc_Util.hh
@@ -69,6 +69,12 @@ inline Cycles zero_time() { return Cycles(0); }
 
 inline Cycles intToCycles(int c) { return Cycles(c); }
 
+inline int
+cyclesToInt(Cycles c)
+{
+    return (int)c;
+}
+
 inline Tick intToTick(int c) { return c; }
 
 inline NodeID

--- a/src/mem/ruby/structures/BackpressureGen.cc
+++ b/src/mem/ruby/structures/BackpressureGen.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023,2026 Arm Limited
+ * Copyright (c) 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -10,9 +10,6 @@
  * terms below provided that you ensure that this notice is replicated
  * unmodified and in its entirety in all distributions of the software,
  * modified or unmodified, in source code or in binary form.
- *
- * Copyright (c) 1999-2005 Mark D. Hill and David A. Wood
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,28 +35,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Miscallaneous Functions
+#include "mem/ruby/structures/BackpressureGen.hh"
 
-void error(std::string msg);
-void assert(bool condition);
-Cycles zero_time();
-Cycles intToCycles(int c);
-int cyclesToInt(Cycles c);
-Tick intToTick(int c);
-NodeID intToID(int nodenum);
-int IDToInt(NodeID id);
-int addressToInt(Addr addr);
-Addr intToAddress(int addr);
-int addressOffset(Addr addr, Addr base);
-int max_tokens();
-Addr makeLineAddress(Addr addr);
-Addr makeLineAddress(Addr addr, int cacheLineBits);
-int getOffset(Addr addr);
-int mod(int val, int mod);
-Addr bitSelect(Addr addr, int small, int big);
-Addr maskLowOrderBits(Addr addr, int number);
-Addr makeNextStrideAddress(Addr addr, int stride);
-structure(BoolVec, external="yes") {
-}
-int countBoolVec(BoolVec bVec);
-RequestorID getRequestorID(RequestPtr req);
+#include "mem/ruby/slicc_interface/AbstractController.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+BackpressureGen::BackpressureGen(const Params &p) : SimObject(p)
+{}
+
+} // namespace ruby
+} // namespace gem5

--- a/src/mem/ruby/structures/BackpressureGen.hh
+++ b/src/mem/ruby/structures/BackpressureGen.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023,2026 Arm Limited
+ * Copyright (c) 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -10,9 +10,6 @@
  * terms below provided that you ensure that this notice is replicated
  * unmodified and in its entirety in all distributions of the software,
  * modified or unmodified, in source code or in binary form.
- *
- * Copyright (c) 1999-2005 Mark D. Hill and David A. Wood
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,28 +35,32 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Miscallaneous Functions
+#ifndef __MEM_RUBY_STRUCTURES_BACKPRESSURE_GEN_HH__
+#define __MEM_RUBY_STRUCTURES_BACKPRESSURE_GEN_HH__
 
-void error(std::string msg);
-void assert(bool condition);
-Cycles zero_time();
-Cycles intToCycles(int c);
-int cyclesToInt(Cycles c);
-Tick intToTick(int c);
-NodeID intToID(int nodenum);
-int IDToInt(NodeID id);
-int addressToInt(Addr addr);
-Addr intToAddress(int addr);
-int addressOffset(Addr addr, Addr base);
-int max_tokens();
-Addr makeLineAddress(Addr addr);
-Addr makeLineAddress(Addr addr, int cacheLineBits);
-int getOffset(Addr addr);
-int mod(int val, int mod);
-Addr bitSelect(Addr addr, int small, int big);
-Addr maskLowOrderBits(Addr addr, int number);
-Addr makeNextStrideAddress(Addr addr, int stride);
-structure(BoolVec, external="yes") {
-}
-int countBoolVec(BoolVec bVec);
-RequestorID getRequestorID(RequestPtr req);
+#include "params/BackpressureGen.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+class AbstractController;
+class Message;
+
+class BackpressureGen : public SimObject
+{
+  public:
+    PARAMS(BackpressureGen);
+    BackpressureGen(const Params &p);
+
+    virtual int generate(AbstractController *ctrl,
+                         const Message &msg) const = 0;
+};
+
+} // namespace ruby
+} // namespace gem5
+
+#endif // __MEM_RUBY_STRUCTURES_BACKPRESSURE_GEN_HH__

--- a/src/mem/ruby/structures/BackpressureGen.py
+++ b/src/mem/ruby/structures/BackpressureGen.py
@@ -1,6 +1,4 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2023, 2026 Arm Limited
+# Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -35,19 +33,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from m5.params import *
+from m5.SimObject import SimObject
 
-if not env['CONF']['RUBY_PROTOCOL_CHI']:
-    Return()
 
-SimObject('CHIGeneric.py', sim_objects=['CHIGenericController'])
-SimObject(
-    'CBusy.py',
-    sim_objects=['BaseCBusy', 'CBusy', 'SnfCBusy', 'CBusyTracker']
-)
-
-DebugFlag('RubyCHIGeneric')
-DebugFlag('RubyCHIGenericVerbose')
-
-Source('CHIGenericController.cc')
-Source('CBusy.cc')
+class BackpressureGen(SimObject):
+    type = "BackpressureGen"
+    cxx_header = "mem/ruby/structures/BackpressureGen.hh"
+    cxx_class = "gem5::ruby::BackpressureGen"
+    abstract = True

--- a/src/mem/ruby/structures/BackpressureTracker.cc
+++ b/src/mem/ruby/structures/BackpressureTracker.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023,2026 Arm Limited
+ * Copyright (c) 2021, 2026 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -10,9 +10,6 @@
  * terms below provided that you ensure that this notice is replicated
  * unmodified and in its entirety in all distributions of the software,
  * modified or unmodified, in source code or in binary form.
- *
- * Copyright (c) 1999-2005 Mark D. Hill and David A. Wood
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,28 +35,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Miscallaneous Functions
+#include "mem/ruby/structures/BackpressureTracker.hh"
 
-void error(std::string msg);
-void assert(bool condition);
-Cycles zero_time();
-Cycles intToCycles(int c);
-int cyclesToInt(Cycles c);
-Tick intToTick(int c);
-NodeID intToID(int nodenum);
-int IDToInt(NodeID id);
-int addressToInt(Addr addr);
-Addr intToAddress(int addr);
-int addressOffset(Addr addr, Addr base);
-int max_tokens();
-Addr makeLineAddress(Addr addr);
-Addr makeLineAddress(Addr addr, int cacheLineBits);
-int getOffset(Addr addr);
-int mod(int val, int mod);
-Addr bitSelect(Addr addr, int small, int big);
-Addr maskLowOrderBits(Addr addr, int number);
-Addr makeNextStrideAddress(Addr addr, int stride);
-structure(BoolVec, external="yes") {
-}
-int countBoolVec(BoolVec bVec);
-RequestorID getRequestorID(RequestPtr req);
+namespace gem5
+{
+
+namespace ruby
+{
+
+BackpressureTracker::BackpressureTracker(const Params &p) : SimObject(p)
+{}
+
+} // namespace ruby
+} // namespace gem5

--- a/src/mem/ruby/structures/BackpressureTracker.hh
+++ b/src/mem/ruby/structures/BackpressureTracker.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021,2023,2026 Arm Limited
+ * Copyright (c) 2021, 2026 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -10,9 +10,6 @@
  * terms below provided that you ensure that this notice is replicated
  * unmodified and in its entirety in all distributions of the software,
  * modified or unmodified, in source code or in binary form.
- *
- * Copyright (c) 1999-2005 Mark D. Hill and David A. Wood
- * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,28 +35,66 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Miscallaneous Functions
+#ifndef __MEM_RUBY_STRUCTURES_BACKPRESSURETRACKER_HH__
+#define __MEM_RUBY_STRUCTURES_BACKPRESSURETRACKER_HH__
 
-void error(std::string msg);
-void assert(bool condition);
-Cycles zero_time();
-Cycles intToCycles(int c);
-int cyclesToInt(Cycles c);
-Tick intToTick(int c);
-NodeID intToID(int nodenum);
-int IDToInt(NodeID id);
-int addressToInt(Addr addr);
-Addr intToAddress(int addr);
-int addressOffset(Addr addr, Addr base);
-int max_tokens();
-Addr makeLineAddress(Addr addr);
-Addr makeLineAddress(Addr addr, int cacheLineBits);
-int getOffset(Addr addr);
-int mod(int val, int mod);
-Addr bitSelect(Addr addr, int small, int big);
-Addr maskLowOrderBits(Addr addr, int number);
-Addr makeNextStrideAddress(Addr addr, int stride);
-structure(BoolVec, external="yes") {
+#include <iostream>
+
+#include "mem/ruby/common/MachineID.hh"
+#include "params/BackpressureTracker.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+// Tracks responder-side backpressure information for downstream requests.
+class BackpressureTracker : public SimObject
+{
+  public:
+    PARAMS(BackpressureTracker);
+
+    /** Construct a tracker with simulator-owned configuration parameters. */
+    BackpressureTracker(const Params &p);
+
+    /**
+     * Record the latest backpressure level observed for a responder.
+     *
+     * @param mach_id Responder identifier associated with the observation.
+     * @param cbusy Backpressure level reported by that responder.
+     */
+    virtual void update(const MachineID &mach_id, int cbusy) = 0;
+
+    /**
+     * Record the latest backpressure level for responses observed on an
+     * alternate transfer path.
+     *
+     * @param mach_id Responder identifier associated with the observation.
+     * @param cbusy Backpressure level reported by that responder.
+     */
+    virtual void updateDMT(const MachineID &mach_id, int cbusy) = 0;
+
+    /**
+     * Return a summarized backpressure level across tracked responders.
+     *
+     * The exact aggregation policy is implementation-defined.
+     */
+    virtual int report() = 0;
+
+    /** Print a human-readable summary of the tracked backpressure state. */
+    virtual void print(std::ostream &out) const = 0;
+};
+
+inline std::ostream &
+operator<<(std::ostream &out, const BackpressureTracker &obj)
+{
+    obj.print(out);
+    return out;
 }
-int countBoolVec(BoolVec bVec);
-RequestorID getRequestorID(RequestPtr req);
+
+} // namespace ruby
+} // namespace gem5
+
+#endif // __MEM_RUBY_STRUCTURES_BACKPRESSURETRACKER_HH__

--- a/src/mem/ruby/structures/BackpressureTracker.py
+++ b/src/mem/ruby/structures/BackpressureTracker.py
@@ -1,6 +1,4 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2023, 2026 Arm Limited
+# Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -35,19 +33,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from m5.SimObject import SimObject
 
-if not env['CONF']['RUBY_PROTOCOL_CHI']:
-    Return()
 
-SimObject('CHIGeneric.py', sim_objects=['CHIGenericController'])
-SimObject(
-    'CBusy.py',
-    sim_objects=['BaseCBusy', 'CBusy', 'SnfCBusy', 'CBusyTracker']
-)
-
-DebugFlag('RubyCHIGeneric')
-DebugFlag('RubyCHIGenericVerbose')
-
-Source('CHIGenericController.cc')
-Source('CBusy.cc')
+class BackpressureTracker(SimObject):
+    type = "BackpressureTracker"
+    cxx_header = "mem/ruby/structures/BackpressureTracker.hh"
+    cxx_class = "gem5::ruby::BackpressureTracker"
+    abstract = True

--- a/src/mem/ruby/structures/SConscript
+++ b/src/mem/ruby/structures/SConscript
@@ -43,6 +43,8 @@ Import('*')
 if not env['CONF']['RUBY']:
     Return()
 
+SimObject('BackpressureGen.py', sim_objects=['BackpressureGen'])
+SimObject('BackpressureTracker.py', sim_objects=['BackpressureTracker'])
 SimObject('RubyCache.py', sim_objects=['RubyCache'])
 SimObject('DirectoryMemory.py', sim_objects=['RubyDirectoryMemory'])
 SimObject('RubyPrefetcher.py', sim_objects=['RubyPrefetcher'])
@@ -57,6 +59,8 @@ Source('RubyPrefetcherProxy.cc')
 Source('TimerTable.cc')
 Source('BankedArray.cc')
 Source('ALUFreeListArray.cc')
+Source('BackpressureGen.cc')
+Source('BackpressureTracker.cc')
 Source('TBEStorage.cc')
 if env['CONF']['RUBY_PROTOCOL_CHI']:
     Source('MN_TBETable.cc')

--- a/src/mem/ruby/system/Sequencer.cc
+++ b/src/mem/ruby/system/Sequencer.cc
@@ -463,12 +463,13 @@ Sequencer::writeCallbackScFail(Addr address, DataBlock& data)
 }
 
 void
-Sequencer::writeCallback(Addr address, DataBlock& data,
-                         const bool externalHit, const MachineType mach,
-                         const Cycles initialRequestTime,
-                         const Cycles forwardRequestTime,
-                         const Cycles firstResponseTime,
-                         const bool noCoales)
+Sequencer::writeCallbackCBusy(Addr address, DataBlock &data,
+                              const bool externalHit, const int cBusy,
+                              const MachineType mach,
+                              const Cycles initialRequestTime,
+                              const Cycles forwardRequestTime,
+                              const Cycles firstResponseTime,
+                              const bool noCoales)
 {
     //
     // Free the whole list as we assume we have had the exclusive access
@@ -545,7 +546,7 @@ Sequencer::writeCallback(Addr address, DataBlock& data,
             }
 
             markRemoved();
-            hitCallback(&seq_req, data, success, mach, externalHit,
+            hitCallback(&seq_req, data, success, mach, externalHit, cBusy,
                         initialRequestTime, forwardRequestTime,
                         firstResponseTime, !ruby_request);
             ruby_request = false;
@@ -553,7 +554,7 @@ Sequencer::writeCallback(Addr address, DataBlock& data,
             // handle read request
             assert(!ruby_request);
             markRemoved();
-            hitCallback(&seq_req, data, true, mach, externalHit,
+            hitCallback(&seq_req, data, true, mach, externalHit, cBusy,
                         initialRequestTime, forwardRequestTime,
                         firstResponseTime, !ruby_request);
         }
@@ -594,11 +595,11 @@ Sequencer::processReadCallback(SequencerRequest &seq_req,
 }
 
 void
-Sequencer::readCallback(Addr address, DataBlock& data,
-                        bool externalHit, const MachineType mach,
-                        Cycles initialRequestTime,
-                        Cycles forwardRequestTime,
-                        Cycles firstResponseTime)
+Sequencer::readCallbackCBusy(Addr address, DataBlock &data, bool externalHit,
+                             const int cBusy, const MachineType mach,
+                             Cycles initialRequestTime,
+                             Cycles forwardRequestTime,
+                             Cycles firstResponseTime)
 {
     //
     // Free up read requests until we hit the first Write request
@@ -625,9 +626,9 @@ Sequencer::readCallback(Addr address, DataBlock& data,
                               firstResponseTime);
         }
         markRemoved();
-        hitCallback(&seq_req, data, true, mach, externalHit,
-                    initialRequestTime, forwardRequestTime,
-                    firstResponseTime, !ruby_request);
+        hitCallback(&seq_req, data, true, mach, externalHit, cBusy,
+                    initialRequestTime, forwardRequestTime, firstResponseTime,
+                    !ruby_request);
         ruby_request = false;
         seq_req_list.pop_front();
     }
@@ -639,11 +640,12 @@ Sequencer::readCallback(Addr address, DataBlock& data,
 }
 
 void
-Sequencer::atomicCallback(Addr address, DataBlock& data,
-                         const bool externalHit, const MachineType mach,
-                         const Cycles initialRequestTime,
-                         const Cycles forwardRequestTime,
-                         const Cycles firstResponseTime)
+Sequencer::atomicCallbackCBusy(Addr address, DataBlock &data,
+                               const bool externalHit, const int cBusy,
+                               const MachineType mach,
+                               const Cycles initialRequestTime,
+                               const Cycles forwardRequestTime,
+                               const Cycles firstResponseTime)
 {
     //
     // Free the first request (an atomic operation) from the list.
@@ -682,9 +684,9 @@ Sequencer::atomicCallback(Addr address, DataBlock& data,
 
         markRemoved();
         ruby_request = false;
-        hitCallback(&seq_req, data, true, mach, externalHit,
-                    initialRequestTime, forwardRequestTime,
-                    firstResponseTime, false);
+        hitCallback(&seq_req, data, true, mach, externalHit, cBusy,
+                    initialRequestTime, forwardRequestTime, firstResponseTime,
+                    false);
         seq_req_list.pop_front();
     }
 
@@ -695,9 +697,9 @@ Sequencer::atomicCallback(Addr address, DataBlock& data,
 }
 
 void
-Sequencer::hitCallback(SequencerRequest* srequest, DataBlock& data,
-                       bool llscSuccess,
-                       const MachineType mach, const bool externalHit,
+Sequencer::hitCallback(SequencerRequest *srequest, DataBlock &data,
+                       bool llscSuccess, const MachineType mach,
+                       const bool externalHit, const int cBusy,
                        const Cycles initialRequestTime,
                        const Cycles forwardRequestTime,
                        const Cycles firstResponseTime,
@@ -803,6 +805,7 @@ Sequencer::hitCallback(SequencerRequest* srequest, DataBlock& data,
         delete pkt;
         m_ruby_system->m_cache_recorder->enqueueNextFlushRequest();
     } else {
+        pkt->completerBusy = cBusy;
         ruby_hit_callback(pkt);
     }
 

--- a/src/mem/ruby/system/Sequencer.hh
+++ b/src/mem/ruby/system/Sequencer.hh
@@ -101,37 +101,84 @@ class Sequencer : public RubyPort
     void resetStats() override;
     void collateStats();
 
-    void writeCallback(Addr address,
-                       DataBlock& data,
-                       const bool externalHit = false,
-                       const MachineType mach = MachineType_NUM,
-                       const Cycles initialRequestTime = Cycles(0),
-                       const Cycles forwardRequestTime = Cycles(0),
-                       const Cycles firstResponseTime = Cycles(0),
-                       const bool noCoales = false);
+    void writeCallbackCBusy(Addr address, DataBlock &data,
+                            const bool externalHit = false,
+                            const int cBusy = -1,
+                            const MachineType mach = MachineType_NUM,
+                            const Cycles initialRequestTime = Cycles(0),
+                            const Cycles forwardRequestTime = Cycles(0),
+                            const Cycles firstResponseTime = Cycles(0),
+                            const bool noCoales = false);
+
+    void
+    writeCallback(Addr address, DataBlock &data,
+                  const bool externalHit = false,
+                  const MachineType mach = MachineType_NUM,
+                  const Cycles initialRequestTime = Cycles(0),
+                  const Cycles forwardRequestTime = Cycles(0),
+                  const Cycles firstResponseTime = Cycles(0),
+                  const bool noCoales = false)
+    {
+        writeCallbackCBusy(address, data, externalHit, -1, mach,
+                           initialRequestTime, forwardRequestTime,
+                           firstResponseTime, noCoales);
+    }
 
     // Write callback that prevents coalescing
     void writeUniqueCallback(Addr address, DataBlock& data)
     {
-        writeCallback(address, data, true, MachineType_NUM, Cycles(0),
-                      Cycles(0), Cycles(0), true);
+        writeCallbackCBusy(address, data, true, -1, MachineType_NUM, Cycles(0),
+                           Cycles(0), Cycles(0), true);
     }
 
-    void readCallback(Addr address,
-                      DataBlock& data,
-                      const bool externalHit = false,
-                      const MachineType mach = MachineType_NUM,
-                      const Cycles initialRequestTime = Cycles(0),
-                      const Cycles forwardRequestTime = Cycles(0),
-                      const Cycles firstResponseTime = Cycles(0));
+    void
+    writeUniqueCallbackCBusy(Addr address, DataBlock &data,
+                             const int cBusy = -1)
+    {
+        writeCallbackCBusy(address, data, true, cBusy, MachineType_NUM,
+                           Cycles(0), Cycles(0), Cycles(0), true);
+    }
 
-    void atomicCallback(Addr address,
-                        DataBlock& data,
-                        const bool externalHit = false,
-                        const MachineType mach = MachineType_NUM,
-                        const Cycles initialRequestTime = Cycles(0),
-                        const Cycles forwardRequestTime = Cycles(0),
-                        const Cycles firstResponseTime = Cycles(0));
+    void readCallbackCBusy(Addr address, DataBlock &data,
+                           const bool externalHit = false,
+                           const int cBusy = -1,
+                           const MachineType mach = MachineType_NUM,
+                           const Cycles initialRequestTime = Cycles(0),
+                           const Cycles forwardRequestTime = Cycles(0),
+                           const Cycles firstResponseTime = Cycles(0));
+
+    void
+    readCallback(Addr address, DataBlock &data, const bool externalHit = false,
+                 const MachineType mach = MachineType_NUM,
+                 const Cycles initialRequestTime = Cycles(0),
+                 const Cycles forwardRequestTime = Cycles(0),
+                 const Cycles firstResponseTime = Cycles(0))
+    {
+        readCallbackCBusy(address, data, externalHit, -1, mach,
+                          initialRequestTime, forwardRequestTime,
+                          firstResponseTime);
+    }
+
+    void atomicCallbackCBusy(Addr address, DataBlock &data,
+                             const bool externalHit = false,
+                             const int cBusy = -1,
+                             const MachineType mach = MachineType_NUM,
+                             const Cycles initialRequestTime = Cycles(0),
+                             const Cycles forwardRequestTime = Cycles(0),
+                             const Cycles firstResponseTime = Cycles(0));
+
+    void
+    atomicCallback(Addr address, DataBlock &data,
+                   const bool externalHit = false,
+                   const MachineType mach = MachineType_NUM,
+                   const Cycles initialRequestTime = Cycles(0),
+                   const Cycles forwardRequestTime = Cycles(0),
+                   const Cycles firstResponseTime = Cycles(0))
+    {
+        atomicCallbackCBusy(address, data, externalHit, -1, mach,
+                            initialRequestTime, forwardRequestTime,
+                            firstResponseTime);
+    }
 
     void unaddressedCallback(Addr unaddressedReqId,
                              RubyRequestType requestType,
@@ -211,9 +258,10 @@ class Sequencer : public RubyPort
 
   protected:
     void issueRequest(PacketPtr pkt, RubyRequestType type);
-    virtual void hitCallback(SequencerRequest* srequest, DataBlock& data,
-                             bool llscSuccess,
-                             const MachineType mach, const bool externalHit,
+
+    virtual void hitCallback(SequencerRequest *srequest, DataBlock &data,
+                             bool llscSuccess, const MachineType mach,
+                             const bool externalHit, const int cBusy,
                              const Cycles initialRequestTime,
                              const Cycles forwardRequestTime,
                              const Cycles firstResponseTime,

--- a/src/mem/ruby/system/VIPERSequencer.cc
+++ b/src/mem/ruby/system/VIPERSequencer.cc
@@ -53,18 +53,19 @@ VIPERSequencer::~VIPERSequencer()
 }
 
 void
-VIPERSequencer::hitCallback(SequencerRequest* srequest, DataBlock& data,
-                            bool llscSuccess,
-                            const MachineType mach, const bool externalHit,
+VIPERSequencer::hitCallback(SequencerRequest *srequest, DataBlock &data,
+                            bool llscSuccess, const MachineType mach,
+                            const bool externalHit, const int cBusy,
                             const Cycles initialRequestTime,
                             const Cycles forwardRequestTime,
                             const Cycles firstResponseTime,
                             const bool was_coalesced)
 {
     if (srequest->m_type != RubyRequestType_hasNoAddr) {
-        return Sequencer::hitCallback(
-            srequest, data, llscSuccess, mach, externalHit, initialRequestTime,
-            forwardRequestTime, firstResponseTime, was_coalesced);
+        return Sequencer::hitCallback(srequest, data, llscSuccess, mach,
+                                      externalHit, cBusy, initialRequestTime,
+                                      forwardRequestTime, firstResponseTime,
+                                      was_coalesced);
     }
 
     PacketPtr pkt = srequest->pkt;

--- a/src/mem/ruby/system/VIPERSequencer.hh
+++ b/src/mem/ruby/system/VIPERSequencer.hh
@@ -51,13 +51,12 @@ class VIPERSequencer : public Sequencer
     ~VIPERSequencer();
 
   private:
-    void hitCallback(SequencerRequest* srequest, DataBlock& data,
-                     bool llscSuccess,
-                     const MachineType mach, const bool externalHit,
+    void hitCallback(SequencerRequest *srequest, DataBlock &data,
+                     bool llscSuccess, const MachineType mach,
+                     const bool externalHit, const int cBusy,
                      const Cycles initialRequestTime,
                      const Cycles forwardRequestTime,
-                     const Cycles firstResponseTime,
-                     const bool was_coalesced);
+                     const Cycles firstResponseTime, const bool was_coalesced);
 
     bool processReadCallback(SequencerRequest &seq_req,
                              DataBlock& data,

--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -64,6 +64,8 @@ python_class_map = {
     "DMASequencer": "DMASequencer",
     "RubyPrefetcher": "RubyPrefetcher",
     "prefetch::Base": "BasePrefetcher",
+    "BackpressureGen": "BackpressureGen",
+    "BackpressureTracker": "BackpressureTracker",
     "Cycles": "Cycles",
     "Addr": "Addr",
 }

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 Arm Limited
+# Copyright (c) 2021-2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -40,6 +40,8 @@ import math
 from typing import List
 
 from m5.objects import (
+    CBusy,
+    CBusyTracker,
     ClockDomain,
     RubyCache,
     RubyNetwork,
@@ -149,3 +151,6 @@ class SimpleDirectory(BaseDirectory):
         self.number_of_DVM_TBEs = 1  # should not receive any dvm
         self.number_of_DVM_snoop_TBEs = 1  # should not receive any dvm
         self.unify_repl_TBEs = False
+
+        self.cbusy_generator = CBusy()
+        self.cbusy_tracker = CBusyTracker()

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/l1_cache.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/l1_cache.py
@@ -37,6 +37,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects import (
+    CBusyTracker,
     ClockDomain,
     RubyCache,
     RubyNetwork,
@@ -70,6 +71,8 @@ class L1CacheController(AbstractNode):
         self.send_evictions = requires_send_evicts
         self.use_prefetcher = False
         self.prefetcher = NULL
+        self.cbusy_generator = NULL
+        self.cbusy_tracker = CBusyTracker()
 
         # Only applies to home nodes
         self.is_HN = False

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/l2_cache.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/l2_cache.py
@@ -37,6 +37,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects import (
+    CBusy,
+    CBusyTracker,
     ClockDomain,
     RubyCache,
     RubyNetwork,
@@ -85,6 +87,8 @@ class L2CacheController(AbstractNode):
         self.send_evictions = False
         self.use_prefetcher = False
         self.prefetcher = NULL
+        self.cbusy_generator = CBusy()
+        self.cbusy_tracker = CBusyTracker()
 
         # Only applies to home nodes
         self.is_HN = False

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/memory_controller.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/memory_controller.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2021 The Regents of the University of California
 # All Rights Reserved.
 #
@@ -30,6 +42,7 @@ from m5.objects import (
     CHI_Memory_Controller,
     MessageBuffer,
     RubyNetwork,
+    SnfCBusy,
 )
 from m5.params import (
     AddrRange,
@@ -70,6 +83,7 @@ class MemoryController(CHI_Memory_Controller):
         self.addr_ranges = ranges
         self.memory_out_port = port
         self.data_channel_size = 32
+        self.cbusy_generator = SnfCBusy()
 
         self.connectQueues(network)
 


### PR DESCRIPTION
This PR implements the Completer Busy field in CHI. According to the CHI spec:

```
The Completer Busy indication is a mechanism for the Completer of a transaction to indicate its current level of
activity. This signaling provides additional information to a Requester on how aggressive it can be in generating
speculative activity to improve performance
```

The patch implements CBusy generation by defining a generic BackpressureGen class and providing a
CBusy generator implementation which matches the example contained in the CHI spec.
This uses the fullness of TBETables as a proxy for fullness.
More specifically:

     * cbusy:0 = occupancy < 50%
     * cbusy:1 = 50%-75%
     * cbusy:2 = 75%-90%
     * cbusy:3 = >90%

It has to be noted this PR does not consume the received CBusy value to curb aggressiveness of speculative activity. This will be provided by a future PR.

Also because of the following CHI spec suggestion:
```
It is IMPLEMENTATION DEFINED how a CBusy indication is set by the Completer and how it should be interpreted
by a Requester. However, it is recommended that implementations consider mechanisms to avoid a few busy
Completers among many skewing the results.
```

We add a BackpressureTracker class in addition the BackpressureGen, which is responsible on aggregating results to provide the aforementioned stability and avoid skewing results