### PR TITLE
configs,mem-ruby: dumps network route profile

### DIFF
--- a/configs/network/Network.py
+++ b/configs/network/Network.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2016 Georgia Institute of Technology
 # All rights reserved.
 #
@@ -123,7 +135,6 @@ def define_options(parser):
         help="""SimpleNetwork links uses a separate physical
             channel for each virtual network""",
     )
-
     parser.add_argument(
         "--per-vnet-links",
         action="store_true",
@@ -131,6 +142,12 @@ def define_options(parser):
         help="Create one dedicated physical link per vnet between adjacent "
         "routers (HeteroGarnet). Requires XY or TABLE routing. "
         "Default: all vnets share one link per direction.",
+    )
+    parser.add_argument(
+        "--simple-trace-routes",
+        action="store_true",
+        default=False,
+        help="""SimpleNetwork traces latency for all routes""",
     )
 
 
@@ -280,6 +297,7 @@ def init_network(options, network, InterfaceClass):
                 network.number_of_virtual_networks
             )
         network.setup_buffers()
+        network.trace_routes = options.simple_trace_routes
 
     if InterfaceClass != None:
         netifs = [

--- a/src/mem/ruby/network/BasicRouter.hh
+++ b/src/mem/ruby/network/BasicRouter.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2011 Advanced Micro Devices, Inc.
  * All rights reserved.
  *
@@ -51,6 +63,13 @@ class BasicRouter : public ClockedObject
     void init();
 
     void print(std::ostream& out) const;
+
+    uint32_t
+    getID() const
+    {
+        return m_id;
+    }
+
   protected:
     //
     // ID in relation to other routers in the system

--- a/src/mem/ruby/network/MessageBuffer.cc
+++ b/src/mem/ruby/network/MessageBuffer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 ARM Limited
+ * Copyright (c) 2019-2021, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -57,32 +57,41 @@ namespace ruby
 using stl_helpers::operator<<;
 
 MessageBuffer::MessageBuffer(const Params &p)
-    : SimObject(p), m_stall_map_size(0), m_max_size(p.buffer_size),
-    m_max_dequeue_rate(p.max_dequeue_rate), m_dequeues_this_cy(0),
-    m_time_last_time_size_checked(0),
-    m_time_last_time_enqueue(0), m_time_last_time_pop(0),
-    m_last_arrival_time(0), m_last_message_strict_fifo_bypassed(false),
-    m_strict_fifo(p.ordered),
-    m_randomization(p.randomization),
-    m_allow_zero_latency(p.allow_zero_latency),
-    m_routing_priority(p.routing_priority),
-    ADD_STAT(m_not_avail_count, statistics::units::Count::get(),
-             "Number of times this buffer did not have N slots available"),
-    ADD_STAT(m_msg_count, statistics::units::Count::get(),
-             "Number of messages passed the buffer"),
-    ADD_STAT(m_buf_msgs, statistics::units::Rate<
-                statistics::units::Count, statistics::units::Tick>::get(),
-             "Average number of messages in buffer"),
-    ADD_STAT(m_stall_time, statistics::units::Tick::get(),
-             "Total number of ticks messages were stalled in this buffer"),
-    ADD_STAT(m_stall_count, statistics::units::Count::get(),
-             "Number of times messages were stalled"),
-    ADD_STAT(m_avg_stall_time, statistics::units::Rate<
-                statistics::units::Tick, statistics::units::Count>::get(),
-             "Average stall ticks per message"),
-    ADD_STAT(m_occupancy, statistics::units::Rate<
-                statistics::units::Ratio, statistics::units::Tick>::get(),
-             "Average occupancy of buffer capacity")
+    : SimObject(p),
+      m_stall_map_size(0),
+      m_max_size(p.buffer_size),
+      m_max_dequeue_rate(p.max_dequeue_rate),
+      m_dequeues_this_cy(0),
+      m_time_last_time_size_checked(0),
+      m_time_last_time_enqueue(0),
+      m_time_last_time_pop(0),
+      m_last_arrival_time(0),
+      m_last_message_strict_fifo_bypassed(false),
+      m_strict_fifo(p.ordered),
+      m_randomization(p.randomization),
+      m_allow_zero_latency(p.allow_zero_latency),
+      m_routing_priority(p.routing_priority),
+      m_is_inport(false),
+      ADD_STAT(m_not_avail_count, statistics::units::Count::get(),
+               "Number of times this buffer did not have N slots available"),
+      ADD_STAT(m_msg_count, statistics::units::Count::get(),
+               "Number of messages passed the buffer"),
+      ADD_STAT(m_buf_msgs,
+               statistics::units::Rate<statistics::units::Count,
+                                       statistics::units::Tick>::get(),
+               "Average number of messages in buffer"),
+      ADD_STAT(m_stall_time, statistics::units::Tick::get(),
+               "Total number of ticks messages were stalled in this buffer"),
+      ADD_STAT(m_stall_count, statistics::units::Count::get(),
+               "Number of times messages were stalled"),
+      ADD_STAT(m_avg_stall_time,
+               statistics::units::Rate<statistics::units::Tick,
+                                       statistics::units::Count>::get(),
+               "Average stall ticks per message"),
+      ADD_STAT(m_occupancy,
+               statistics::units::Rate<statistics::units::Ratio,
+                                       statistics::units::Tick>::get(),
+               "Average occupancy of buffer capacity")
 {
     m_msg_counter = 0;
     m_consumer = NULL;

--- a/src/mem/ruby/network/MessageBuffer.hh
+++ b/src/mem/ruby/network/MessageBuffer.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 ARM Limited
+ * Copyright (c) 2019-2021, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -103,7 +103,8 @@ class MessageBuffer : public SimObject
     bool areNSlotsAvailable(unsigned int n, Tick curTime);
     int getPriority() { return m_priority_rank; }
     void setPriority(int rank) { m_priority_rank = rank; }
-    void setConsumer(Consumer* consumer)
+    void
+    setConsumer(Consumer *consumer, bool is_inport = false)
     {
         DPRINTF(RubyQueue, "Setting consumer: %s\n", *consumer);
         if (m_consumer != NULL) {
@@ -112,6 +113,7 @@ class MessageBuffer : public SimObject
                   *consumer, *this, *m_consumer);
         }
         m_consumer = consumer;
+        m_is_inport = is_inport;
     }
 
     Consumer* getConsumer() { return m_consumer; }
@@ -195,6 +197,12 @@ class MessageBuffer : public SimObject
     }
 
     int routingPriority() const { return m_routing_priority; }
+
+    bool
+    isInport()
+    {
+        return m_is_inport;
+    }
 
   private:
     void reanalyzeList(std::list<MsgPtr> &, Tick);
@@ -283,6 +291,8 @@ class MessageBuffer : public SimObject
     const bool m_allow_zero_latency;
 
     const int m_routing_priority;
+
+    bool m_is_inport;
 
     int m_input_link_id;
     int m_vnet_id;

--- a/src/mem/ruby/network/RouteProfiler.cc
+++ b/src/mem/ruby/network/RouteProfiler.cc
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/network/RouteProfiler.hh"
+
+#include <cassert>
+#include <numeric>
+
+#include "base/output.hh"
+#include "debug/TraceRoutesDebug.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+void
+RouteProfiler::profFrontEndRdy(Message *msg, BasicRouter *router,
+                               MessageBuffer *src_link, int vnet)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    auto tmp = outstanding_routes.emplace(
+        std::piecewise_construct, std::forward_as_tuple(msg),
+        std::forward_as_tuple(msg, src_link, vnet));
+    OutstandingRoute &entry = tmp.first->second;
+    assert(msg == entry.msg);
+    assert(vnet == entry.vnet);
+    if (bool is_new = tmp.second; is_new) {
+        assert(entry.entries.empty());
+        assert(entry.src_link == src_link);
+    }
+    if (entry.entries.empty() || (entry.entries.back().router != router)) {
+        entry.entries.emplace_back(router, curTick());
+        DPRINTFS(TraceRoutesDebug, router, "Msg %#x entering router vnet=%d\n",
+                 msg, vnet);
+    }
+    assert(entry.entries.back().router == router);
+}
+
+void
+RouteProfiler::profFrontEndRdyClone(Message *msg, BasicRouter *router,
+                                    MessageBuffer *src_link, int vnet,
+                                    Message *clone_from_msg)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    auto tmp = outstanding_routes.emplace(
+        std::piecewise_construct, std::forward_as_tuple(msg),
+        std::forward_as_tuple(msg, src_link, vnet));
+    OutstandingRoute &entry = tmp.first->second;
+    assert(msg == entry.msg);
+    assert(vnet == entry.vnet);
+    assert(tmp.second);
+    assert(entry.entries.empty());
+
+    auto iter = outstanding_routes.find(clone_from_msg);
+    assert(iter != outstanding_routes.end());
+    OutstandingRoute &other = iter->second;
+    assert(entry.vnet == other.vnet);
+    assert(!other.entries.empty());
+    assert(other.entries.back().router == router);
+    entry.src_link = other.src_link;
+    entry.entries = other.entries;
+    DPRINTFS(TraceRoutesDebug, router, "Msg %#x cloned in router vnet=%d\n",
+             msg, vnet);
+}
+
+void
+RouteProfiler::profFrontEndFwd(Message *msg, BasicRouter *router, int vnet)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    auto iter = outstanding_routes.find(msg);
+    assert(iter != outstanding_routes.end());
+    assert(!iter->second.entries.empty());
+    assert(iter->second.msg == msg);
+    assert(vnet == iter->second.vnet);
+    OutstandingRouteEntry &entry = iter->second.entries.back();
+    assert(entry.router == router);
+    entry.frontend_fwd = curTick();
+    entry.backend_rdy = 0;
+}
+
+void
+RouteProfiler::profBackEndRdy(Message *msg, BasicRouter *router, int vnet)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    auto iter = outstanding_routes.find(msg);
+    assert(iter != outstanding_routes.end());
+    assert(!iter->second.entries.empty());
+    assert(iter->second.msg == msg);
+    assert(vnet == iter->second.vnet);
+    OutstandingRouteEntry &entry = iter->second.entries.back();
+    assert(entry.router == router);
+    if (entry.backend_rdy == 0) {
+        entry.backend_rdy = curTick();
+    }
+}
+
+void
+RouteProfiler::profBackEndFwd(Message *msg, BasicRouter *router, int vnet)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    auto iter = outstanding_routes.find(msg);
+    assert(iter != outstanding_routes.end());
+    assert(!iter->second.entries.empty());
+    assert(iter->second.msg == msg);
+    assert(vnet == iter->second.vnet);
+    OutstandingRouteEntry &entry = iter->second.entries.back();
+    assert(entry.router == router);
+    entry.backend_fwd = curTick();
+    DPRINTFS(TraceRoutesDebug, router,
+             "Msg %#x leaving router vnet=%d delay=%d delay_total=%d\n", msg,
+             vnet, entry.backend_fwd - entry.frontend_rdy,
+             entry.backend_fwd - iter->second.entries.front().frontend_rdy);
+}
+
+void
+RouteProfiler::profBackEndFwdExt(Message *msg, BasicRouter *router,
+                                 MessageBuffer *dest_link, int vnet)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    profBackEndFwd(msg, router, vnet);
+    auto iter = outstanding_routes.find(msg);
+    OutstandingRoute &entry = iter->second;
+
+    std::string rs = genRouteString(entry, dest_link);
+
+    Route &route = routes[rs];
+
+    bool was_empty = route.src_link == nullptr;
+    if (was_empty) {
+        route.src_link = entry.src_link;
+        route.dst_link = dest_link;
+        route.vnet = vnet;
+        for (auto e : entry.entries) {
+            route.route.emplace_back();
+            auto &r = route.route.back();
+            r.router = e.router;
+            r.frontend_delay.inc(
+                router->ticksToCycles(e.frontend_fwd - e.frontend_rdy));
+            r.backend_delay.inc(
+                router->ticksToCycles(e.backend_fwd - e.frontend_fwd));
+        }
+    } else {
+        assert(route.src_link == entry.src_link);
+        assert(route.dst_link == dest_link);
+        assert(route.vnet == vnet);
+        assert(route.route.size() == entry.entries.size());
+
+        for (unsigned i = 0; i < entry.entries.size(); ++i) {
+            auto &e = entry.entries[i];
+            auto &r = route.route[i];
+            assert(r.router == e.router);
+            r.frontend_delay.inc(
+                router->ticksToCycles(e.frontend_fwd - e.frontend_rdy));
+            r.backend_delay.inc(
+                router->ticksToCycles(e.backend_fwd - e.frontend_fwd));
+        }
+    }
+    route.total_delay.inc(
+        router->ticksToCycles(entry.entries.back().backend_fwd -
+                              entry.entries.front().frontend_rdy));
+
+    if (debug::TraceRoutesDebug) {
+        std::ostringstream ss;
+        dumpRoute(route, ss);
+        DPRINTF(TraceRoutesDebug, "%s route: %s",
+                was_empty ? "New" : "Updated", ss.str());
+    }
+
+    outstanding_routes.erase(iter);
+}
+
+std::string
+RouteProfiler::genRouteString(OutstandingRoute &route,
+                              MessageBuffer *dest_link)
+{
+    assert(!route.entries.empty());
+    std::stringstream ss;
+    ss << route.vnet << " " << route.src_link->name() << "->";
+    for (auto e : route.entries) {
+        ss << "R" << e.router->getID() << "->";
+    }
+    ss << dest_link->name();
+    return ss.str();
+}
+
+void
+RouteProfiler::dumpRoute(const Route &route, std::ostream &outs) const
+{
+    assert(!route.route.empty());
+    ccprintf(outs, "%.1f %d ", route.total_delay.avg(), route.total_delay.cnt);
+    ccprintf(outs, "vnet%d %s -> ", route.vnet, route.src_link->name());
+    for (auto r : route.route) {
+        ccprintf(outs, "R%d(%.1f,%.1f) -> ", r.router->getID(),
+                 r.frontend_delay.avg(), r.backend_delay.avg());
+    }
+    ccprintf(outs, "%s\n", route.dst_link->name());
+}
+
+void
+RouteProfiler::dumpRoutes()
+{
+    if (routes.empty()) {
+        return;
+    }
+
+    // use set to order map value by badness
+    typedef std::pair<std::string, Route> settype;
+    struct compare
+    {
+        bool
+        operator()(const settype &l, const settype &r) const
+        {
+            if (l.second.badness() != r.second.badness()) {
+                return l.second.badness() > r.second.badness();
+            } else {
+                return l.first > r.first;
+            }
+        }
+    };
+
+    std::set<settype, compare> ordered(routes.begin(), routes.end());
+
+    OutputStream *out =
+        simout.open("interconnect_routes.txt", std::ios_base::out);
+    inform("Dumping all routes to %s\n", out->name());
+    std::ostream &outs = *out->stream();
+
+    for (auto &val : ordered) {
+        dumpRoute(val.second, outs);
+    }
+}
+
+} // namespace ruby
+} // namespace gem5

--- a/src/mem/ruby/network/RouteProfiler.hh
+++ b/src/mem/ruby/network/RouteProfiler.hh
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_NETWORK_ROUTEPROFILER_HH__
+#define __MEM_RUBY_NETWORK_ROUTEPROFILER_HH__
+
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+#include "mem/ruby/network/BasicLink.hh"
+#include "mem/ruby/network/BasicRouter.hh"
+#include "mem/ruby/network/MessageBuffer.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+class RouteProfiler
+{
+
+  public:
+    RouteProfiler() : m_enabled(false) {}
+
+    // Notifies a message is ready at a router input port
+    void profFrontEndRdy(Message *msg, BasicRouter *router,
+                         MessageBuffer *src_link, int vnet);
+
+    // Notifies ready message was cloned (e.g. on multicast messages)
+    void profFrontEndRdyClone(Message *msg, BasicRouter *router,
+                              MessageBuffer *src_link, int vnet,
+                              Message *clone_from_msg);
+
+    // Notifies a ready message was routed to an output port buffer
+    void profFrontEndFwd(Message *msg, BasicRouter *router, int vnet);
+
+    // Notifies a message is ready at an output port buffer
+    void profBackEndRdy(Message *msg, BasicRouter *router, int vnet);
+
+    // Notifies a ready message was sent through the output link
+    void profBackEndFwd(Message *msg, BasicRouter *router, int vnet);
+
+    // Notifies a ready message was sent through the output link to
+    // its final destination
+    void profBackEndFwdExt(Message *msg, BasicRouter *router,
+                           MessageBuffer *dest_link, int vnet);
+
+    // Dump all routes to file
+    void dumpRoutes();
+
+    // enable disable profiling routes
+    void
+    enable()
+    {
+        m_enabled = true;
+    }
+    void
+    disable()
+    {
+        m_enabled = false;
+    }
+
+  private:
+    bool m_enabled;
+
+    struct OutstandingRouteEntry
+    {
+        BasicRouter *router;
+        Tick frontend_rdy;
+        Tick frontend_fwd;
+        Tick backend_rdy;
+        Tick backend_fwd;
+
+        OutstandingRouteEntry(BasicRouter *_router, Tick _frontend_rdy)
+            : router(_router), frontend_rdy(_frontend_rdy)
+        {}
+    };
+
+    struct OutstandingRoute
+    {
+        Message *msg;
+        MessageBuffer *src_link;
+        int vnet;
+        std::vector<OutstandingRouteEntry> entries;
+
+        OutstandingRoute(Message *_msg, MessageBuffer *_src_link, int _vnet)
+            : msg(_msg), src_link(_src_link), vnet(_vnet)
+        {}
+    };
+
+    struct AvgVal
+    {
+        double acc;
+        uint64_t cnt;
+        AvgVal() : acc(0), cnt(0) {}
+        void
+        inc(double val)
+        {
+            acc += val;
+            cnt += 1;
+        }
+        double
+        avg() const
+        {
+            return acc / cnt;
+        };
+    };
+
+    struct RouteEntry
+    {
+        BasicRouter *router;
+        AvgVal frontend_delay;
+        AvgVal backend_delay;
+    };
+
+    struct Route
+    {
+        int vnet;
+        MessageBuffer *src_link;
+        MessageBuffer *dst_link;
+        AvgVal total_delay;
+        std::vector<RouteEntry> route;
+        Route() : vnet(), src_link(nullptr), dst_link(nullptr) {}
+        double
+        badness() const
+        {
+            return total_delay.avg() / route.size();
+        }
+    };
+
+    std::unordered_map<Message *, OutstandingRoute> outstanding_routes;
+    std::unordered_map<std::string, Route> routes;
+
+    std::string genRouteString(OutstandingRoute &route,
+                               MessageBuffer *dest_link);
+    void dumpRoute(const Route &route, std::ostream &outs) const;
+};
+
+} // namespace ruby
+} // namespace gem5
+
+#endif // __MEM_RUBY_NETWORK_ROUTEPROFILER_HH__

--- a/src/mem/ruby/network/SConscript
+++ b/src/mem/ruby/network/SConscript
@@ -31,6 +31,8 @@ Import('*')
 if not env['CONF']['RUBY']:
     Return()
 
+DebugFlag('TraceRoutesDebug')
+
 SimObject('BasicLink.py', sim_objects=[
     'BasicLink', 'BasicExtLink', 'BasicIntLink'])
 SimObject('BasicRouter.py', sim_objects=['BasicRouter'])
@@ -42,4 +44,5 @@ Source('BasicLink.cc')
 Source('BasicRouter.cc')
 Source('MessageBuffer.cc')
 Source('Network.cc')
+Source('RouteProfiler.cc')
 Source('Topology.cc')

--- a/src/mem/ruby/network/simple/PerfectSwitch.cc
+++ b/src/mem/ruby/network/simple/PerfectSwitch.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 ARM Limited
+ * Copyright (c) 2020-2021, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -201,6 +201,7 @@ PerfectSwitch::operateMessageBuffer(MessageBuffer *buffer, int vnet)
         net_msg_ptr = msg_ptr.get();
         DPRINTF(RubyNetwork, "Message: %s\n", (*net_msg_ptr));
 
+        m_switch->profFrontEndRdy(net_msg_ptr, buffer, vnet);
 
         output_links.clear();
         m_switch->getRoutingUnit().route(*net_msg_ptr, vnet,
@@ -255,11 +256,17 @@ PerfectSwitch::operateMessageBuffer(MessageBuffer *buffer, int vnet)
             if (i > 0) {
                 // create a private copy of the unmodified message
                 msg_ptr = unmodified_msg_ptr->clone();
+
+                m_switch->profFrontEndRdyClone(msg_ptr.get(), buffer, vnet,
+                                               net_msg_ptr);
             }
 
             // Change the internal destination set of the message so it
             // knows which destinations this link is responsible for.
             net_msg_ptr = msg_ptr.get();
+
+            m_switch->profFrontEndFwd(net_msg_ptr, vnet);
+
             net_msg_ptr->getDestination() = output_links[i].m_destinations;
 
             // Enqeue msg

--- a/src/mem/ruby/network/simple/SimpleNetwork.cc
+++ b/src/mem/ruby/network/simple/SimpleNetwork.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Advanced Micro Devices, Inc.
- * Copyright (c) 2019,2021 ARM Limited
+ * Copyright (c) 2019,2021,2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -89,6 +89,12 @@ SimpleNetwork::SimpleNetwork(const Params &p)
     fatal_if((physical_vnets_bandwidth.size() != vnets) &&
              (physical_vnets_bandwidth.size() != 0),
         "physical_vnets_bandwidth must provide BW for all vnets");
+
+    if (p.trace_routes) {
+        routeProfiler.enable();
+        // Register a callback to write the file with all routes
+        registerExitCallback([this]() { dumpRoutes(); });
+    }
 }
 
 void

--- a/src/mem/ruby/network/simple/SimpleNetwork.hh
+++ b/src/mem/ruby/network/simple/SimpleNetwork.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021,2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -46,6 +46,7 @@
 #include <vector>
 
 #include "mem/ruby/network/Network.hh"
+#include "mem/ruby/network/RouteProfiler.hh"
 #include "params/SimpleNetwork.hh"
 
 namespace gem5
@@ -123,6 +124,15 @@ class SimpleNetwork : public Network
         std::vector<statistics::Formula *> m_msg_counts;
         std::vector<statistics::Formula *> m_msg_bytes;
     } networkStats;
+
+  public:
+    RouteProfiler routeProfiler;
+
+    void
+    dumpRoutes()
+    {
+        routeProfiler.dumpRoutes();
+    }
 };
 
 inline std::ostream&

--- a/src/mem/ruby/network/simple/SimpleNetwork.py
+++ b/src/mem/ruby/network/simple/SimpleNetwork.py
@@ -56,6 +56,7 @@ class SimpleNetwork(RubyNetwork):
                                 routers; 0 indicates infinite buffering",
     )
     endpoint_bandwidth = Param.Int(1000, "bandwidth adjustment factor")
+    trace_routes = Param.Bool(False, "Generate trace with all used routes")
 
     physical_vnets_channels = VectorParam.Int(
         [],

--- a/src/mem/ruby/network/simple/Switch.cc
+++ b/src/mem/ruby/network/simple/Switch.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Inria
- * Copyright (c) 2019,2021 ARM Limited
+ * Copyright (c) 2019,2021,2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -220,6 +220,44 @@ Switch::SwitchStats::regStats()
     }
 
     statistics::Group::regStats();
+}
+
+void
+Switch::profFrontEndRdy(Message *msg, MessageBuffer *src_link, int vnet)
+{
+    m_network_ptr->routeProfiler.profFrontEndRdy(msg, this, src_link, vnet);
+}
+
+void
+Switch::profFrontEndRdyClone(Message *msg, MessageBuffer *src_link, int vnet,
+                             Message *clone_from_msg)
+{
+    m_network_ptr->routeProfiler.profFrontEndRdyClone(msg, this, src_link,
+                                                      vnet, clone_from_msg);
+}
+
+void
+Switch::profFrontEndFwd(Message *msg, int vnet)
+{
+    m_network_ptr->routeProfiler.profFrontEndFwd(msg, this, vnet);
+}
+
+void
+Switch::profBackEndRdy(Message *msg, int vnet)
+{
+    m_network_ptr->routeProfiler.profBackEndRdy(msg, this, vnet);
+}
+
+void
+Switch::profBackEndFwd(Message *msg, int vnet)
+{
+    m_network_ptr->routeProfiler.profBackEndFwd(msg, this, vnet);
+}
+
+void
+Switch::profBackEndFwdExt(Message *msg, MessageBuffer *dest_link, int vnet)
+{
+    m_network_ptr->routeProfiler.profBackEndFwdExt(msg, this, dest_link, vnet);
 }
 
 } // namespace ruby

--- a/src/mem/ruby/network/simple/Switch.hh
+++ b/src/mem/ruby/network/simple/Switch.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021,2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -144,6 +144,14 @@ class Switch : public BasicRouter
         std::vector<statistics::Formula *> m_msg_counts;
         std::vector<statistics::Formula *> m_msg_bytes;
     } switchStats;
+
+    void profFrontEndRdy(Message *msg, MessageBuffer *src_link, int vnet);
+    void profFrontEndRdyClone(Message *msg, MessageBuffer *src_link, int vnet,
+                              Message *clone_from_msg);
+    void profFrontEndFwd(Message *msg, int vnet);
+    void profBackEndRdy(Message *msg, int vnet);
+    void profBackEndFwd(Message *msg, int vnet);
+    void profBackEndFwdExt(Message *msg, MessageBuffer *dest_link, int vnet);
 };
 
 inline std::ostream&

--- a/src/mem/ruby/network/simple/Throttle.cc
+++ b/src/mem/ruby/network/simple/Throttle.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021,2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -180,6 +180,10 @@ Throttle::operateVnet(int vnet, int channel, int &total_bw_remaining,
     int bw_remaining = m_physical_vnets ?
                 getLinkBandwidth(vnet) : total_bw_remaining;
 
+    if (in->isReady(current_time)) {
+        m_switch->profBackEndRdy(in->peekMsgPtr().get(), vnet);
+    }
+
     auto hasPendingWork = [&]{ return in->isReady(current_time) ||
                                       units_remaining > 0; };
     while ((bw_remaining > 0) && hasPendingWork() &&
@@ -204,6 +208,18 @@ Throttle::operateVnet(int vnet, int channel, int &total_bw_remaining,
                          m_switch->cyclesToTicks(m_link_latency),
                          m_ruby_system->getRandomization(),
                          m_ruby_system->getWarmupEnabled());
+
+            if (out->isInport()) {
+                m_switch->profBackEndFwdExt(net_msg_ptr, out, vnet);
+            } else {
+                m_switch->profBackEndFwd(net_msg_ptr, vnet);
+            }
+
+            // Could still have more ready but won't execute because no more
+            // BW or output port blocked
+            if (in->isReady(current_time)) {
+                m_switch->profBackEndRdy(in->peekMsgPtr().get(), vnet);
+            }
 
             // Count the message
             (*(throttleStats.

--- a/src/mem/ruby/structures/TimerTable.hh
+++ b/src/mem/ruby/structures/TimerTable.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
  * All rights reserved.
  *
@@ -55,7 +67,7 @@ class TimerTable
     }
 
     void
-    setConsumer(Consumer* consumer_ptr)
+    setConsumer(Consumer *consumer_ptr, bool is_inport = false)
     {
         assert(m_consumer_ptr == NULL);
         m_consumer_ptr = consumer_ptr;

--- a/src/mem/ruby/structures/WireBuffer.hh
+++ b/src/mem/ruby/structures/WireBuffer.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2010 Advanced Micro Devices, Inc.
  * All rights reserved.
  *
@@ -70,7 +82,8 @@ class WireBuffer : public SimObject
 
     void wakeup();
 
-    void setConsumer(Consumer* consumer_ptr)
+    void
+    setConsumer(Consumer *consumer_ptr, bool is_inport = false)
     {
         m_consumer_ptr = consumer_ptr;
     }

--- a/src/mem/slicc/symbols/StateMachine.py
+++ b/src/mem/slicc/symbols/StateMachine.py
@@ -829,7 +829,7 @@ $c_ident::init()
         code()
         for port in self.in_ports:
             # Set the queue consumers
-            code("${{port.code}}.setConsumer(this);")
+            code("${{port.code}}.setConsumer(this, true);")
 
         # Initialize the transition profiling
         code()


### PR DESCRIPTION
if trace_routes parameter is set when using SimpleNetwork, each unique route used in the network is tracked and dumped in a text file at the end of the simulation in the format:

delay_cy msg_cnt vnet src_port -> r0 -> .. -> rn -> dest_port

delay_cy is the average delay of the route. For each router the average internal delays are also included. The dumped routes are ordered by: delay_cy / #hops

The TraceRoutesDebug debug flag can also be use to print additional routing information.

JIRA: https://gem5.atlassian.net/browse/GEM5-920

Change-Id: I15ac24ef28d28cf8e141522704bc47be0712b2c1