### PR TITLE
arch-riscv: Fix incorrect accumulator type in widening floating-point reduction micro-op

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1971,7 +1971,7 @@ Fault
 
     auto reduce_loop =
         [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vu tmp_val = (microIdx == 0) ? Vs1[0]:Vd[0];
+            vwu tmp_val = (microIdx == 0) ? Vs1[0] : Vd[0];
             for (uint32_t i = 0; i < this->microVl; i++) {
                 uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
                     this->microIdx;


### PR DESCRIPTION
The VectorReduceFloatWideningMicroExecute template declared the reduction accumulator as vu (the narrow element type, fp16 in the SEW=16 case) instead of vwu (the widened type, fp32). This caused the intermediate accumulator to be silently truncated to 16 bits on every iteration, producing incorrect results for all vfwredosum.vs and vfwredusum.vs instructions.
The initial accumulator value read from vs1[0] was also affected: since tmp_val was typed vu, the fp32 value from vs1 was truncated immediately on assignment before any arithmetic was performed.

Fix proposed:
Change the accumulator declaration from vu to vwu so that the full widened precision is preserved throughout the reduction loop, matching the RISC-V V specification which mandates that the accumulator operates at 2*SEW precision.

Before:
vu tmp_val = (microIdx == 0) ? Vs1[0] : Vd[0];

After:
vwu tmp_val = (microIdx == 0) ? Vs1[0] : Vd[0];