### PR TITLE
python: Fix unhashable SimObjectVector bug in SimObject find_all()

### DIFF
--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -1106,7 +1106,12 @@ class SimObject(metaclass=MetaSimObject):
             if issubclass(pdesc.ptype, ptype):
                 match_obj = self._values[pname]
                 if not isproxy(match_obj) and not isNullPointer(match_obj):
-                    all[match_obj] = True
+                    if isSimObjectVector(match_obj):
+                        for item in match_obj:
+                            if not isNullPointer(item):
+                                all[item] = True
+                    else:
+                        all[match_obj] = True
         # Also make sure to sort the keys based on the objects' path to
         # ensure that the order is the same on all hosts
         return sorted(all.keys(), key=lambda o: o.path()), True


### PR DESCRIPTION
When executing m5.instantiate(), gem5 traverses the simulation tree using find_all() to discover objects of specific types (e.g., AbstractMemory). During this traversal, the function checks if a parameter's inner type (pdesc.ptype) matches the target search type.

When a VectorParam is used (e.g., VectorParam.AbstractMemory), pdesc.ptype matches the target type, but its runtime value is a SimObjectVector container. In original implementation, find_all() erroneously used this container directly as a dictionary key. Since SimObjectVector lacks a __hash__ method, this caused a crash: TypeError: unhashable type: 'SimObjectVector'

This patch modifies find_all() to unpack SimObjectVector values and add their individual SimObjects to the deduplication dictionary, resolving the crash while preserving type safety.