### PR TITLE
mem-ruby: Add support for RespSepData in TLM controller

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -231,7 +231,15 @@ CacheController::ReadTransaction::handle(const CHIResponseMsg *msg)
 {
     /// TODO: remove this, DBID is not sent
     phase.dbid = msg->m_dbid;
-    return Transaction::handle(msg);
+    const bool finished = Transaction::handle(msg);
+
+    // Read transactions complete on DAT beats, not on RespSepData.
+    // If we terminate here, the following DAT can no longer be matched.
+    if (phase.rsp_opcode == ARM::CHI::RSP_OPCODE_RESP_SEP_DATA) {
+        return false;
+    }
+
+    return finished;
 }
 
 bool

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -316,6 +316,8 @@ rspOpcode(RspOpcode opc, Resp resp)
 {
     switch(opc) {
       case RSP_OPCODE_COMP_ACK: return CHIResponseType_CompAck;
+      case RSP_OPCODE_RESP_SEP_DATA:
+          return CHIResponseType_RespSepData;
       case RSP_OPCODE_SNP_RESP:
         switch (resp) {
           case RESP_I: return CHIResponseType_SnpResp_I;
@@ -384,6 +386,8 @@ rspOpcode(CHIResponseType rsp)
         return RSP_OPCODE_COMP_DBID_RESP;
       case CHIResponseType_DBIDResp:
           return RSP_OPCODE_DBID_RESP;
+      case CHIResponseType_RespSepData:
+          return RSP_OPCODE_RESP_SEP_DATA;
       case CHIResponseType_RetryAck:
         return RSP_OPCODE_RETRY_ACK;
       default:
@@ -468,6 +472,8 @@ rspResp(CHIResponseType rsp)
         case CHIResponseType_CompDBIDResp:
             return RESP_I;
         case CHIResponseType_DBIDResp:
+            return RESP_I;
+        case CHIResponseType_RespSepData:
             return RESP_I;
         case CHIResponseType_RetryAck:
             // Just setup to zero


### PR DESCRIPTION
This was exposed when we turn enable_DMT_early_dealloc on

Change-Id: I2675a30a20a4cbcdc12a72f1dbb739aa5c3a0831
Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>