### PR TITLE
mem-ruby: Fix old PROTOCOL == 'CHI' check

### DIFF
--- a/src/mem/ruby/protocol/chi/generic/SConscript
+++ b/src/mem/ruby/protocol/chi/generic/SConscript
@@ -37,7 +37,7 @@
 
 Import('*')
 
-if env['CONF']['PROTOCOL'] != 'CHI':
+if not env['CONF']['RUBY_PROTOCOL_CHI']:
     Return()
 
 SimObject('CHIGeneric.py',


### PR DESCRIPTION
After the multi-protocol build we now use RUBY_PROTOCOL_CHI variable as multiple protocols can be compiled at the same time

Change-Id: I8014718ae17f558ee4dbf468c18b435d649c3e0a