### PR TITLE
cpu: Move setResetAddr to gem5::BaseCPU

### DIFF
--- a/src/arch/arm/fastmodel/iris/cpu.hh
+++ b/src/arch/arm/fastmodel/iris/cpu.hh
@@ -80,12 +80,6 @@ class BaseCPU : public gem5::BaseCPU
     Counter totalInsts() const override;
     Counter totalOps() const override { return totalInsts(); }
 
-    virtual void
-    setResetAddr(Addr addr, bool secure = false)
-    {
-        panic("%s not implemented.", __FUNCTION__);
-    }
-
   protected:
     sc_core::sc_module *evs;
     // Hold casted pointer to *evs.

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -246,6 +246,12 @@ class BaseCPU : public ClockedObject
     // @todo remove me after debugging with legion done
     Tick instCount() { return instCnt; }
 
+    virtual void
+    setResetAddr(Addr addr, bool secure = false)
+    {
+        panic("%s not implemented.", __FUNCTION__);
+    }
+
   protected:
     std::vector<BaseInterrupts*> interrupts;
 


### PR DESCRIPTION
Move setResetAddr to generic CPU model to allow set reset address for non-iris cpu model