### PR TITLE
misc: use std::size_t as size_type

### DIFF
--- a/src/base/stats/types.hh
+++ b/src/base/stats/types.hh
@@ -29,6 +29,7 @@
 #ifndef __BASE_STATS_TYPES_HH__
 #define __BASE_STATS_TYPES_HH__
 
+#include <cstddef>
 #include <limits>
 #include <map>
 #include <vector>

--- a/src/base/stats/types.hh
+++ b/src/base/stats/types.hh
@@ -56,7 +56,7 @@ typedef double Result;
 /** vector of results. */
 typedef std::vector<Result> VResult;
 
-typedef unsigned int size_type;
+typedef std::size_t size_type;
 typedef unsigned int off_type;
 
 enum DistType { Deviation, Dist, Hist };


### PR DESCRIPTION
This aligns with most STL behavior and also fix the mysterious `__builtin_memcpy` warning.

If we use g++-15 to compile `gem5.opt` on current `develop` branch there will be errors complaining `__builtin_memcpy` ( have out-of-bounds, e.g.:
```text
scons build/ALL/gem5.opt -j16
...
In file included from /usr/include/c++/15/vector:67,
                 from src/cpu/pred/tage_base.hh:52,
                 from src/cpu/pred/tage_base.cc:39:
In function ‘constexpr std::__enable_if_t<((bool)std::__is_bitwise_relocatable<_Tp>::value), _Tp*> std::__relocate_a_1(_Tp*, _Tp*, _Tp*, allocator<_T2>&) [with _Tp = gem5::statistics::StatStor*; _Up = gem5::statistics::StatStor*]’,
    inlined from ‘constexpr _ForwardIterator std::__relocate_a(_InputIterator, _InputIterator, _ForwardIterator, _Allocator&) [with _InputIterator = gem5::statistics::StatStor**; _ForwardIterator = gem5::statistics::StatStor**; _Allocator = allocator<gem5::statistics::StatStor*>]’ at /usr/include/c++/15/bits/stl_uninitialized.h:1359:33,
    inlined from ‘static constexpr std::vector<_Tp, _Alloc>::pointer std::vector<_Tp, _Alloc>::_S_relocate(pointer, pointer, pointer, _Tp_alloc_type&) [with _Tp = gem5::statistics::StatStor*; _Alloc = std::allocator<gem5::statistics::StatStor*>]’ at /usr/include/c++/15/bits/stl_vector.h:539:26,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::reserve(size_type) [with _Tp = gem5::statistics::StatStor*; _Alloc = std::allocator<gem5::statistics::StatStor*>]’ at /usr/include/c++/15/bits/vector.tcc:80:19,
    inlined from ‘void gem5::statistics::VectorBase<Derived, Stor>::doInit(gem5::statistics::size_type) [with Derived = gem5::statistics::Vector; Stor = gem5::statistics::StatStor]’ at src/base/statistics.hh:959:24:
/usr/include/c++/15/bits/stl_uninitialized.h:1343:27: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ forming offset [34359738360, 34359738367] is out of the bounds [0, 34359738360] [-Werror=array-bounds=]
 1343 |           __builtin_memcpy(__result, __first, __count * sizeof(_Tp));
      |           ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [SO Param] m5.objects.MESI_Three_Level_HTM_DMA_Controller, MESI_Three_Level_HTM_DMA_Controller -> ALL/params/MESI_Three_Level_HTM_DMA_Controller.hh
In file included from /usr/include/c++/15/memory:71,
                 from src/mem/cache/compressors/dictionary_compressor.hh:49,
                 from src/mem/cache/compressors/base_dictionary_compressor.cc:34:
In function ‘constexpr std::__enable_if_t<((bool)std::__is_bitwise_relocatable<_Tp>::value), _Tp*> std::__relocate_a_1(_Tp*, _Tp*, _Tp*, allocator<_T2>&) [with _Tp = gem5::statistics::StatStor*; _Up = gem5::statistics::StatStor*]’,
    inlined from ‘constexpr _ForwardIterator std::__relocate_a(_InputIterator, _InputIterator, _ForwardIterator, _Allocator&) [with _InputIterator = gem5::statistics::StatStor**; _ForwardIterator = gem5::statistics::StatStor**; _Allocator = allocator<gem5::statistics::StatStor*>]’ at /usr/include/c++/15/bits/stl_uninitialized.h:1359:33,
    inlined from ‘static constexpr std::vector<_Tp, _Alloc>::pointer std::vector<_Tp, _Alloc>::_S_relocate(pointer, pointer, pointer, _Tp_alloc_type&) [with _Tp = gem5::statistics::StatStor*; _Alloc = std::allocator<gem5::statistics::StatStor*>]’ at /usr/include/c++/15/bits/stl_vector.h:539:26,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::reserve(size_type) [with _Tp = gem5::statistics::StatStor*; _Alloc = std::allocator<gem5::statistics::StatStor*>]’ at /usr/include/c++/15/bits/vector.tcc:80:19,
    inlined from ‘void gem5::statistics::VectorBase<Derived, Stor>::doInit(gem5::statistics::size_type) [with Derived = gem5::statistics::Vector; Stor = gem5::statistics::StatStor]’ at src/base/statistics.hh:959:24,
    inlined from ‘Derived& gem5::statistics::VectorBase<Derived, Stor>::init(gem5::statistics::size_type) [with Derived = gem5::statistics::Vector; Stor = gem5::statistics::StatStor]’ at src/base/statistics.hh:1044:20,
    inlined from ‘virtual void gem5::compression::BaseDictionaryCompressor::DictionaryStats::regStats()’ at src/mem/cache/compressors/base_dictionary_compressor.cc:63:18:
/usr/include/c++/15/bits/stl_uninitialized.h:1343:27: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ forming offset [34359738360, 34359738367] is out of the bounds [0, 34359738360] [-Werror=array-bounds=]
 1343 |           __builtin_memcpy(__result, __first, __count * sizeof(_Tp));
      |           ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [     CXX] ALL/python/_m5/param_PerfectCompressor.cc -> .o
 [     CXX] src/mem/cache/compressors/perfect.cc -> ALL/mem/cache/compressors/perfect.o
```

I can't explain why but this PR eliminates that error too.