### PR TITLE
configs,mem-ruby: extend CHI for SimpleNetwork

### DIFF
--- a/configs/ruby/CHI.py
+++ b/configs/ruby/CHI.py
@@ -93,6 +93,8 @@ def create_system(
 
     # NoC params
     params = chi_defs.NoC_Params
+    params.network = options.network
+    params.topology = options.topology
     # Node types
     CHI_RNF = chi_defs.CHI_RNF
     CHI_HNF = chi_defs.CHI_HNF
@@ -228,18 +230,13 @@ def create_system(
     for hnf in ruby_system.hnf:
         hnf.setDownstream(mem_dests)
 
-    # Setup data message size for all controllers
-    for cntrl in all_cntrls:
-        cntrl.data_channel_size = params.data_width
+    # Configure network
+    params = chi_defs.setup_network_parameters(ruby_system, params)
 
-    # Network configurations
-    # virtual networks: 0=request, 1=snoop, 2=response, 3=data
-    ruby_system.network.number_of_virtual_networks = 4
-
-    ruby_system.network.control_msg_size = params.cntrl_msg_size
-    ruby_system.network.data_msg_size = params.data_width
-    if options.network == "simple":
-        ruby_system.network.buffer_size = params.router_buffer_size
+    # setup_network_parameters sets the channel parameter so reset this option
+    if options.simple_physical_channels:
+        print("WARNING: CHI ignores --simple-physical-channels")
+        options.simple_physical_channels = False
 
     # Incorporate the params into options so it's propagated to
     # makeTopology and create_topology the parent scripts

--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -103,14 +103,25 @@ class NoC_Params:
     """
     Default parameters for the interconnect. The value of data_width is
     also used to set the data_channel_size for all CHI controllers.
-    (see configs/ruby/CHI.py)
+    (see CHINode::connectController in this file)
     """
 
+    network = "simple"
+    topology = "CustomMesh"
     router_link_latency = 1
     node_link_latency = 1
-    router_latency = 1
+    router_ext_latency = 1
+    router_int_latency = 1
     router_buffer_size = 4
     cntrl_msg_size = 8
+    req_int_channels = 1
+    snp_int_channels = 1
+    dat_int_channels = 1
+    rsp_int_channels = 1
+    req_ext_channels = 1
+    snp_ext_channels = 1
+    dat_ext_channels = 1
+    rsp_ext_channels = 1
     data_width = 32
     # Map of (src,dst) -> weight,latency (cycles)
     # Customizes the weight and latency for the link between the routers src
@@ -119,6 +130,52 @@ class NoC_Params:
     # (dst,src) are present.
     # A new link is created if no src->dst link exists.
     custom_links = {}
+
+
+def setup_network_parameters(ruby_system, noc_params):
+    """
+    Configures the parameters of Ruby's network object for CHI according
+    to the provided configuration file
+    """
+    network = ruby_system.network
+
+    # virtual networks: 0=request, 1=snoop, 2=response, 3=data
+    network.number_of_virtual_networks = 4
+    ruby_system.number_of_virtual_networks = 4
+
+    # Message sizes
+    network.control_msg_size = noc_params.cntrl_msg_size
+    network.data_msg_size = noc_params.data_width
+
+    # Link bandwidth.
+    ctrl_link_width = noc_params.cntrl_msg_size
+    data_link_width = noc_params.cntrl_msg_size + noc_params.data_width
+    req_channels = noc_params.req_int_channels
+    snp_channels = noc_params.snp_int_channels
+    rsp_channels = noc_params.rsp_int_channels
+    dat_channels = noc_params.dat_int_channels
+
+    if noc_params.network == "garnet":
+        # later passed on to Garnet's init functions
+        noc_params.link_width_bits = data_link_width * 8
+    else:
+        # Router port buffer (per vnet)
+        network.buffer_size = noc_params.router_buffer_size
+
+        # Use separate physical channels per vnet in simple network
+        network.physical_vnets_channels = [
+            req_channels,
+            snp_channels,
+            rsp_channels,
+            dat_channels,
+        ]
+        network.physical_vnets_bandwidth = [
+            ctrl_link_width,
+            ctrl_link_width,
+            ctrl_link_width,
+            data_link_width,
+        ]
+    return noc_params
 
 
 class CHI_Node(SubSystem):
@@ -139,10 +196,29 @@ class CHI_Node(SubSystem):
         If 'num_nodes_per_router' is left undefined, we circulate around
         'router_list' until all nodes are mapped.
         See 'distributeNodes' in configs/topologies/CustomMesh.py
+
+        The inbound/outbound link latency define the latency to send/receive
+        messages from/to the network router.
+        These latencies do not map 1:1 to send vs. receive timing on the
+        Ruby external link. `outbound_link_latency` is used when messages
+        are enqueued in the *.sm files, and is therefore applied to the
+        SLICC controller message latencies: request_latency,
+        response_latency, snoop_latency, and data_latency.
+        `inbound_link_latency` is used by CustomMesh.py to set the Ruby
+        external-link latency for the controller/router connection. Ruby
+        external links are bi-directional, so this link latency applies in
+        both controller->router and router->controller directions, not just
+        traffic incoming to the controller. Both default to the global
+        NoC_Params.node_link_latency.
         """
 
         num_nodes_per_router = None
         router_list = None
+
+        inbound_link_latency = NoC_Params.node_link_latency
+        outbound_link_latency = NoC_Params.node_link_latency
+
+        gbl_noc_params = NoC_Params
 
     def __init__(self, ruby_system):
         super().__init__()
@@ -195,6 +271,56 @@ class CHI_Node(SubSystem):
         cntrl.rspIn.in_port = self._network.out_port
         cntrl.snpIn.in_port = self._network.out_port
         cntrl.datIn.in_port = self._network.out_port
+
+        # Adjust node params for the provided interconnect configuration
+        node_params = self.NoC_Params
+        gbl_params = node_params.gbl_noc_params
+        req_channels = gbl_params.req_ext_channels
+        snp_channels = gbl_params.snp_ext_channels
+        rsp_channels = gbl_params.rsp_ext_channels
+        dat_channels = gbl_params.dat_ext_channels
+
+        # Set the data message size
+        cntrl.data_channel_size = NoC_Params.data_width
+
+        # Enforces the number of channels or ports between
+        # the node and the router by limiting the number of
+        # messages that can be consumed in a cycle
+        cntrl.reqIn.max_dequeue_rate = req_channels
+        cntrl.snpIn.max_dequeue_rate = snp_channels
+        cntrl.reqOut.max_dequeue_rate = req_channels
+        cntrl.snpOut.max_dequeue_rate = snp_channels
+        cntrl.rspIn.max_dequeue_rate = rsp_channels
+        cntrl.datIn.max_dequeue_rate = dat_channels
+        cntrl.rspOut.max_dequeue_rate = rsp_channels
+        cntrl.datOut.max_dequeue_rate = dat_channels
+
+        # The latency for outbound messages to the network is defined by
+        # these parameters when enqueueing messages in the SLICC code
+        cntrl.request_latency = node_params.outbound_link_latency
+        cntrl.response_latency = node_params.outbound_link_latency
+        cntrl.snoop_latency = node_params.outbound_link_latency
+        cntrl.data_latency = node_params.outbound_link_latency
+
+        # if using SimpleNetwork + physical_vnets option, also fine tuned
+        # the buffers size to properly create contention and network stalls.
+        # Sizes are set similarly to src/mem/ruby/network/simple/SimpleLink.py
+        # NOTE: this has not been properly tested with garnet so buffer sizes
+        # remain unlimited in those configs. Also see setup_network_parameters
+        if gbl_params.network == "simple":
+            latency = node_params.inbound_link_latency
+            cntrl.reqIn.buffer_size = req_channels * (latency + 1)
+            cntrl.snpIn.buffer_size = snp_channels * (latency + 1)
+            cntrl.rspIn.buffer_size = rsp_channels * (latency + 1)
+            cntrl.datIn.buffer_size = dat_channels * (latency + 1)
+            # Memory_Controller currently assumes no resource stall in the
+            # output ports so only set the sizes for Cache_Controllers
+            if isinstance(cntrl, Cache_Controller):
+                latency = node_params.outbound_link_latency
+                cntrl.reqOut.buffer_size = req_channels * (latency + 1)
+                cntrl.snpOut.buffer_size = snp_channels * (latency + 1)
+                cntrl.rspOut.buffer_size = rsp_channels * (latency + 1)
+                cntrl.datOut.buffer_size = dat_channels * (latency + 1)
 
 
 class TriggerMessageBuffer(MessageBuffer):
@@ -689,6 +815,9 @@ class CHI_HNF(CHI_Node):
             parent.cntrl = self._cntrl
 
         self.connectController(self._cntrl)
+
+    def connectController(self, cntrl):
+        CHI_Node.connectController(self, cntrl)
 
     def getAllControllers(self):
         return [self._cntrl]

--- a/configs/topologies/CustomMesh.py
+++ b/configs/topologies/CustomMesh.py
@@ -141,15 +141,20 @@ class CustomMesh(SimpleTopology):
     # distributeNodes
     # --------------------------------------------------------------------------
 
-    def _createRNFRouter(self, mesh_router):
+    def _createRNFRouter(self, noc_params, mesh_router):
         # Create a zero-latency router bridging node controllers
         # and the mesh router
-        node_router = self._Router(
-            router_id=len(self._routers), latency=self.node_router_latency
-        )
+        node_router = self._Router(router_id=len(self._routers))
         node_router._row = mesh_router._row
         node_router._col = mesh_router._col
         node_router._main = False
+
+        if hasattr(node_router, "int_routing_latency"):
+            node_router.int_routing_latency = self.node_router_latency
+            node_router.ext_routing_latency = self.node_router_latency
+        else:
+            node_router.latency = self.node_router_latency
+
         self._routers.append(node_router)
 
         # connect node_router <-> mesh router
@@ -158,7 +163,7 @@ class CustomMesh(SimpleTopology):
                 link_id=self._link_count,
                 src_node=node_router,
                 dst_node=mesh_router,
-                latency=self._router_link_latency,
+                latency=noc_params.node_link_latency,
             )
         )
         self._link_count += 1
@@ -168,19 +173,19 @@ class CustomMesh(SimpleTopology):
                 link_id=self._link_count,
                 src_node=mesh_router,
                 dst_node=node_router,
-                latency=self._router_link_latency,
+                latency=noc_params.node_link_latency,
             )
         )
         self._link_count += 1
 
         return node_router
 
-    def distributeNodes(self, node_placement_config, node_list):
+    def distributeNodes(self, noc_params, node_params, node_list):
         if len(node_list) == 0:
             return
 
-        num_nodes_per_router = node_placement_config.num_nodes_per_router
-        router_idx_list = node_placement_config.router_list
+        num_nodes_per_router = node_params.num_nodes_per_router
+        router_idx_list = node_params.router_list
 
         if num_nodes_per_router:
             # evenly distribute nodes to all listed routers
@@ -196,7 +201,7 @@ class CustomMesh(SimpleTopology):
                 # and the mesh router
                 # for non-RNF nodes, node router is mesh router
                 if isinstance(node, CHI.CHI_RNF):
-                    router = self._createRNFRouter(router)
+                    router = self._createRNFRouter(noc_params, router)
 
                 # connect all ctrls in the node to node_router
                 ctrls = node.getNetworkSideControllers()
@@ -206,9 +211,10 @@ class CustomMesh(SimpleTopology):
                             link_id=self._link_count,
                             ext_node=c,
                             int_node=router,
-                            latency=self._node_link_latency,
+                            latency=node_params.inbound_link_latency,
                         )
                     )
+                    # See CHI_config.py for outbound_link_latency
                     self._link_count += 1
                     c._row = router._row
                     c._col = router._col
@@ -221,7 +227,7 @@ class CustomMesh(SimpleTopology):
                 router = self._routers[ridx]
 
                 if isinstance(node, CHI.CHI_RNF):
-                    router = self._createRNFRouter(router)
+                    router = self._createRNFRouter(noc_params, router)
                 ctrls = node.getNetworkSideControllers()
                 for c in ctrls:
                     self._ext_links.append(
@@ -229,7 +235,7 @@ class CustomMesh(SimpleTopology):
                             link_id=self._link_count,
                             ext_node=c,
                             int_node=router,
-                            latency=self._node_link_latency,
+                            latency=node_params.inbound_link_latency,
                         )
                     )
                     self._link_count += 1
@@ -253,13 +259,6 @@ class CustomMesh(SimpleTopology):
         self._Router = Router
 
         self.node_router_latency = 1 if options.network == "garnet" else 0
-        if hasattr(options, "router_link_latency"):
-            self._router_link_latency = options.router_link_latency
-            self._node_link_latency = options.node_link_latency
-        else:
-            print("WARNING: router/node link latencies not provided")
-            self._router_link_latency = options.link_latency
-            self._node_link_latency = options.link_latency
         self._custom_links = options.custom_links
 
         # classify nodes into different types
@@ -313,10 +312,18 @@ class CustomMesh(SimpleTopology):
                 )
 
         # Create all mesh routers
-        self._routers = [
-            Router(router_id=i, latency=options.router_latency)
-            for i in range(num_mesh_routers)
-        ]
+        self._routers = [Router(router_id=i) for i in range(num_mesh_routers)]
+        # Set up latency
+        if hasattr(self._routers[0], "int_routing_latency"):
+            for router in self._routers:
+                router.int_routing_latency = options.router_int_latency
+                router.ext_routing_latency = options.router_ext_latency
+        else:
+            print("WARNING: router does not support int/ext routing latencies")
+            for router in self._routers:
+                router.latency = max(
+                    options.router_int_latency, options.router_ext_latency
+                )
 
         # Assign helpers later needed by generate_dot
         for row in range(num_rows):
@@ -344,23 +351,23 @@ class CustomMesh(SimpleTopology):
         self._makeCustomMesh()
 
         # Place CHI_RNF on the mesh
-        self.distributeNodes(rnf_params, rnf_nodes)
+        self.distributeNodes(options, rnf_params, rnf_nodes)
 
         # Place CHI_HNF on the mesh
-        self.distributeNodes(hnf_params, hnf_nodes)
+        self.distributeNodes(options, hnf_params, hnf_nodes)
 
         # Place CHI_MN on the mesh
-        self.distributeNodes(mn_params, mn_nodes)
+        self.distributeNodes(options, mn_params, mn_nodes)
 
         # Place CHI_SNF_MainMem on the mesh
-        self.distributeNodes(mem_params, mem_nodes)
+        self.distributeNodes(options, mem_params, mem_nodes)
 
         # Place all IO mem nodes on the mesh
-        self.distributeNodes(io_mem_params, io_mem_nodes)
+        self.distributeNodes(options, io_mem_params, io_mem_nodes)
 
         # Place all IO request nodes on the mesh
-        self.distributeNodes(rni_dma_params, rni_dma_nodes)
-        self.distributeNodes(rni_io_params, rni_io_nodes)
+        self.distributeNodes(options, rni_dma_params, rni_dma_nodes)
+        self.distributeNodes(options, rni_io_params, rni_io_nodes)
 
         # Set up
         network.int_links = self._int_links

--- a/src/mem/ruby/protocol/chi/CHI-mem.sm
+++ b/src/mem/ruby/protocol/chi/CHI-mem.sm
@@ -42,6 +42,8 @@ machine(MachineType:Memory, "Memory controller interface") :
   // cycle to the response enqueue latency as default
   Cycles response_latency := 2;
   Cycles data_latency := 1;
+  Cycles request_latency := 1; // Not used, but required by CHI_config.py
+  Cycles snoop_latency := 1; // Not used, but required by CHI_config.py
   Cycles to_memory_controller_latency := 1;
 
   int data_channel_size;


### PR DESCRIPTION
CHI configuration files support options for creating a more detailed configuration using SimpleNetwork.

This means:

* Configuring int/ext latency separately via router_int/ext_latency
* Configuring the max_dequeue_rate for all channels via individual parameters (e.g. req_ext_channels)
* Configuring the inbound/outbound_link_latency

The inbound/outbound link latency define the latency to send/receive messages from/to the network router. Notice the outbound latency is defined when the messages are enqueued at the *.sm files, so outbound_link_latency is used to set these parameters in the SLICC controllers: request_latency, response_latency, snoop_latency, and data_latency. inbound_link_latency is used by CustomMesh.py to set the incoming link latency. Both default to the global NoC_Params.node_link_latency

Change-Id: Id2ebb5ef862e25153ebb3f3d9cd4d67e61d82732