### PR TITLE
tests: fix failing gem5/memory daily test

### DIFF
--- a/tests/gem5/memory/simple-run.py
+++ b/tests/gem5/memory/simple-run.py
@@ -41,7 +41,8 @@ from m5.objects import *
 parser = argparse.ArgumentParser(description="Simple memory tester")
 parser.add_argument("--bandwidth", default=None)
 parser.add_argument("--latency", default=None)
-parser.add_argument("--latency_var", default=None)
+parser.add_argument("--latency_dist", default=None)
+parser.add_argument("--latency_dist_param", default=None)
 
 args = parser.parse_args()
 
@@ -62,8 +63,10 @@ class MyMem(SimpleMemory):
         bandwidth = args.bandwidth
     if args.latency:
         latency = args.latency
-    if args.latency_var:
-        latency_dist_param = args.latency_var
+    if args.latency_dist:
+        latency_dist = args.latency_dist
+    if args.latency_dist_param:
+        latency_dist_param = args.latency_dist_param
 
 
 # system simulated

--- a/tests/gem5/memory/test.py
+++ b/tests/gem5/memory/test.py
@@ -45,7 +45,7 @@ simple_mem_params = [
     ("low-latency", {"latency": "1ns"}),
     ("high-latency", {"latency": "1us"}),
     ("low-bandwidth", {"bandwidth": "1MiB/s"}),
-    ("high-var", {"latency_var": "100ns"}),
+    ("high-var", {"latency_dist": "Uniform", "latency_dist_param": "100ns"}),
 ]
 
 


### PR DESCRIPTION
After https://github.com/gem5/gem5/pull/3088 was merged, the `simple_mem_high-var-NULL-x86_64-opt` test started failing due to some parameters not being set correctly. This commit fixes that test failure, and also renames the `--latency-var` argument in `tests/gem5/memory/simple-run.py` to `--latency_dist_param`.