### PR TITLE
cpu-o3: Early retire prefetches after issuing memory requests

### DIFF
--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -1044,9 +1044,14 @@ LSQRequest::LSQRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad)
       _amo_op(nullptr)
 {
     flags.set(Flag::IsLoad, isLoad);
+    // A prefetch has no destination register, so keep it off the load
+    // writeback path. HTM prefetches are excluded: their response may
+    // signal a transaction abort handled in completeDataAccess().
     flags.set(Flag::WriteBackToRegister,
               _inst->isStoreConditional() || _inst->isAtomic() ||
-              _inst->isLoad());
+                  (_inst->isLoad() &&
+                   !((_inst->isDataPrefetch() || _inst->isInstPrefetch()) &&
+                     !_inst->inHtmTransactionalState())));
     flags.set(Flag::IsAtomic, _inst->isAtomic());
     install();
 }
@@ -1071,9 +1076,12 @@ LSQRequest::LSQRequest(LSQUnit *port, const DynInstPtr &inst, bool isLoad,
       _hasStaleTranslation(stale_translation)
 {
     flags.set(Flag::IsLoad, isLoad);
+    // See the comment on WriteBackToRegister in the constructor above.
     flags.set(Flag::WriteBackToRegister,
               _inst->isStoreConditional() || _inst->isAtomic() ||
-              _inst->isLoad());
+                  (_inst->isLoad() &&
+                   !((_inst->isDataPrefetch() || _inst->isInstPrefetch()) &&
+                     !_inst->inHtmTransactionalState())));
     flags.set(Flag::IsAtomic, _inst->isAtomic());
     install();
 }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -675,6 +675,27 @@ LSQUnit::executeLoad(const DynInstPtr &inst)
         iewStage->instToCommit(inst);
         iewStage->activityThisCycle();
     } else {
+        // A prefetch has no destination register and no architectural
+        // side effects, so retirement need not wait for the response;
+        // commit it as soon as the request has been sent. A late
+        // response is dropped like a squashed one (recvTimingResp bails
+        // out on isReleased(), LSQ::recvTimingResp still cleans up).
+        // Prefetches in an HTM transaction are excluded: their response
+        // may signal a transaction abort, which is only raised from
+        // completeDataAccess().
+        if ((inst->isDataPrefetch() || inst->isInstPrefetch()) &&
+            inst->savedRequest && inst->savedRequest->isSent() &&
+            !inst->inHtmTransactionalState()) {
+            DPRINTF(LSQUnit,
+                    "Prefetch [sn:%lli] retired early after the "
+                    "request was sent\n",
+                    inst->seqNum);
+            inst->setExecuted();
+            iewStage->instToCommit(inst);
+            iewStage->activityThisCycle();
+            return NoFault;
+        }
+
         if (inst->effAddrValid()) {
             auto it = inst->lqIt;
             ++it;


### PR DESCRIPTION
Fixes #3132

Correction to the original issue
The original issue said prefetches occupy LQ/ROB entries for the full memory latency. That was measured on v25.0.0.1 and is no longer accurate on develop — both memory systems already ACK a software prefetch early:

Classic: Cache::handleTimingReqMiss replies with dummy data and continues the fill asynchronously.
Ruby: RubyPort::MemResponsePort::recvTimingReq schedules a response at curTick() once makeRequest() returns Issued. Added in d446055f5e (#2311), after v25.0 — which is why my original testing saw the full-latency behaviour.
So this PR is not about eliminating DRAM-miss occupancy.

What it actually fixes
In the O3 LSQ a prefetch is still modelled as an ordinary load for retirement: WriteBackToRegister is set, so it cannot be marked executed until a response runs through completeDataAccess() and the load writeback path.

Semantically wrong — a prefetch has no destination register and no architectural side effects, so retirement should not depend on the response.
Structurally wrong — correctness relies on each memory system implementing its own early-ACK workaround (plus the matching teardown in Sequencer::insertRequest/readCallback and Cache::serviceMSHRTargets). Any path without that hack (NoncoherentCache, or a CPU wired straight to a memory controller) still stalls the prefetch for the full latency.
Fix
Two changes that must go together:

LSQRequest no longer sets WriteBackToRegister for data/instruction prefetches, so SoftPFResp skips load writeback.
LSQUnit::executeLoad sets executed and pushes to commit once savedRequest->isSent().
Change 1 alone would deadlock the prefetch; change 2 alone leaves a pointless writeback.

A response arriving post-commit is handled like a squash: LSQUnit::recvTimingResp bails out on isReleased(), LSQ::recvTimingResp still calls packetReplied(). Skipping completeDataAccess() is safe since !needWBToRegister().

HTM prefetches keep WriteBackToRegister and are excluded from early retire, because a cache-signalled transaction abort is only raised from completeDataAccess().

Expected impact
Where the ACK already returns within ~1 cycle, the effect is small: commit 1–2 cycles earlier, end-to-end IPC essentially unchanged (thanks @aphlta for measuring this). LQ pressure when the request cannot be sent at all is unaffected, since early retire requires isSent().

The value is a correct prefetch retirement model in the CPU, and correct behaviour on memory systems without an early-ACK workaround — not a performance win.