### PR TITLE
gpu-compute: Emulate copy aligned BLIT kernels

### DIFF
--- a/configs/example/gpufs/runfs.py
+++ b/configs/example/gpufs/runfs.py
@@ -229,6 +229,14 @@ def addRunFSOptions(parser):
         help="Frequency in exec cycles of GPU progress prints",
     )
 
+    parser.add_argument(
+        "--emulate-blit-kernels",
+        default=False,
+        action="store_true",
+        help="Emulate blit kernels as functional copies instead of running"
+        "GPU kernel. Intended to improve simulation performance.",
+    )
+
 
 def runGpuFSSystem(args):
     """

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -125,6 +125,7 @@ def makeGpuFSSystem(args):
         dispatcher=dispatcher,
         walker=cp_pt_walker,
         target_non_blit_kernel_id=target_kernel,
+        emulate_blits=args.emulate_blit_kernels,
     )
     shader.dispatcher = dispatcher
     shader.gpu_cmd_proc = gpu_cmd_proc

--- a/src/gpu-compute/GPU.py
+++ b/src/gpu-compute/GPU.py
@@ -380,6 +380,7 @@ class GPUCommandProcessor(DmaVirtDevice):
         0,
         "Skip kernels until reaching this kernel (counting only non-blit kernels)",
     )
+    emulate_blits = Param.Bool(False, "Emulate detected BLIT kernels")
 
 
 class StorageClassType(Enum):

--- a/src/gpu-compute/SConscript
+++ b/src/gpu-compute/SConscript
@@ -43,6 +43,7 @@ SimObject('GPU.py', sim_objects=[
 SimObject('GPUStaticInstFlags.py', enums=['GPUStaticInstFlags'])
 SimObject('LdsState.py', sim_objects=['LdsState'])
 
+Source('blit_emulation.cc')
 Source('comm.cc')
 Source('compute_unit.cc')
 Source('dispatcher.cc')

--- a/src/gpu-compute/blit_emulation.cc
+++ b/src/gpu-compute/blit_emulation.cc
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gpu-compute/blit_emulation.hh"
+
+#include "arch/amdgpu/vega/pagetable_walker.hh"
+#include "dev/amdgpu/amdgpu_device.hh"
+#include "gpu-compute/gpu_command_processor.hh"
+#include "gpu-compute/hsa_queue_entry.hh"
+#include "mem/abstract_mem.hh"
+
+namespace gem5
+{
+
+static constexpr int blitFillKernargCount = 8;
+static constexpr int blitCopyMisalignedKernargCount = 13;
+
+void
+GPUCommandProcessor::readBlitKernargs(HSAQueueEntry *task)
+{
+    /**
+     * In full system mode, the page table entry may point to a system
+     * page or a device page. System pages use the proxy as normal, but
+     * a device page needs to be read from device memory. Check what type
+     * it is here.
+     */
+    bool is_system_page = true;
+    Addr phys_addr = task->kernargAddr();
+
+    /**
+     * Full system currently only supports running on single VMID (one
+     * virtual memory space), i.e., one application running on GPU at a
+     * time. Because of this, for now we know the VMID is always 1. Later
+     * the VMID would have to be passed on to the command processor.
+     */
+    int vmid = 1;
+    unsigned tmp_bytes;
+    walker->startFunctional(gpuDevice->getVM().getPageTableBase(vmid),
+                            phys_addr, tmp_bytes, BaseMMU::Mode::Read,
+                            is_system_page);
+
+    DPRINTF(GPUCommandProc, "Blit kernarg data is in %s memory\n",
+            is_system_page ? "host" : "device");
+
+    /* Copy the max amount -- Unused kernargs *should* be zeros. */
+    unsigned kernarg_size = maxBlitKernargs * sizeof(uint32_t);
+    uint32_t *blit_kernargs = new uint32_t[kernarg_size];
+
+    if (is_system_page) {
+        auto cb = new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {
+            processBlitKernargs(task, blit_kernargs);
+        });
+
+        dmaReadVirt(task->kernargAddr(), kernarg_size, cb, blit_kernargs);
+    } else {
+        // Read from GPU memory manager one cache line at a time to prevent
+        // rare cases where the preload data spans two memory pages.
+        constexpr unsigned alignment_granularity = 64;
+        ChunkGenerator gen(task->kernargAddr(), kernarg_size,
+                           alignment_granularity);
+
+        for (; !gen.done(); gen.next()) {
+            Addr chunk_addr = gen.addr();
+            int vmid = 1;
+            unsigned dummy;
+            walker->startFunctional(gpuDevice->getVM().getPageTableBase(vmid),
+                                    chunk_addr, dummy, BaseMMU::Mode::Read,
+                                    is_system_page);
+
+            Request::Flags flags = Request::PHYSICAL;
+            RequestPtr request =
+                std::make_shared<Request>(chunk_addr, alignment_granularity,
+                                          flags, walker->getDevRequestor());
+
+            PacketPtr readPkt = new Packet(request, MemCmd::ReadReq);
+            readPkt->dataStatic(blit_kernargs + gen.complete());
+
+            assert(system()->getDeviceMemory(readPkt) != nullptr);
+            system()->getDeviceMemory(readPkt)->access(readPkt);
+            delete readPkt;
+        }
+
+        processBlitKernargs(task, blit_kernargs);
+    }
+}
+
+void
+GPUCommandProcessor::processBlitKernargs(HSAQueueEntry *task, uint32_t *args)
+{
+    if (debug::GPUCommandProc) {
+        for (int i = 0; i < maxBlitKernargs; ++i) {
+            DPRINTF(GPUCommandProc, "Blit kernarg[%d] = %#x\n", i, args[i]);
+        }
+    }
+
+    // There are 3 types of blit kernels: Copy Aligned, Copy Misaligned, and
+    // Fill. Typically we see Copy Aligned so implement that first. If we
+    // see the other types then we should run the blit kernel. Copy Misaligned
+    // has 13 SGPRs and Fill has 8 SGPRs. We use the first kernarg that is
+    // zero to detect the type.
+    if (args[blitFillKernargCount] == 0) {
+        DPRINTF(GPUCommandProc, "Fill blit detected -- Skipping emulation\n");
+
+        delete[] args;
+        if (task->akc()->kernarg_preload_spec_length == 0) {
+            initABI(task);
+        } else {
+            readPreload(task);
+        }
+
+        return;
+    } else if (args[blitCopyMisalignedKernargCount] == 0) {
+        DPRINTF(GPUCommandProc, "Copy Misaligned blit detected -- Skipping "
+                                "emulation\n");
+
+        delete[] args;
+        if (task->akc()->kernarg_preload_spec_length == 0) {
+            initABI(task);
+        } else {
+            readPreload(task);
+        }
+
+        return;
+    } else {
+        DPRINTF(GPUCommandProc,
+                "Emulating Copy Aligned blit kernel %i "
+                "(Task ID: %i)\n",
+                dynamic_task_id - non_blit_kernel_id, dynamic_task_id);
+
+        copyAligned(task, args);
+    }
+}
+
+void
+GPUCommandProcessor::completeBlit(HSAQueueEntry *task)
+{
+    // Notify the HSA PP that this kernel is complete
+    hsaPacketProc().finishPkt(task->dispPktPtr(), task->queueId());
+    assert(task->completionSignal());
+
+    DPRINTF(GPUCommandProc,
+            "Blit emulation complete with completion "
+            "signal! Addr: %d\n",
+            task->completionSignal());
+
+    sendCompletionSignal(task->completionSignal());
+}
+
+void
+GPUCommandProcessor::blitRead(BlitCopyDesc *desc, HSAQueueEntry *task)
+{
+    DPRINTF(GPUCommandProc, "Read src data for blit phase %d\n", desc->phase);
+
+    if (desc->size[desc->phase] == 0) {
+        desc->phase++;
+        if (desc->phase == desc->numPhases) {
+            DPRINTF(GPUCommandProc, "No blit copy data, completing\n");
+            delete desc;
+            completeBlit(task);
+        } else {
+            DPRINTF(GPUCommandProc, "No blit copy data, next phase\n");
+            blitRead(desc, task);
+        }
+
+        return;
+    }
+
+    auto buf_size = desc->size[desc->phase];
+    uint8_t *buf = new uint8_t[buf_size];
+
+    auto cb = new DmaVirtCallback<uint32_t>(
+        [=, this](const uint32_t &) { blitWrite(desc, task, buf); });
+    dmaReadVirt(desc->srcStart[desc->phase], buf_size, cb, buf);
+}
+
+void
+GPUCommandProcessor::blitWrite(BlitCopyDesc *desc, HSAQueueEntry *task,
+                               uint8_t *buf)
+{
+    DPRINTF(GPUCommandProc, "Write dest data for blit phase %d\n",
+            desc->phase);
+
+    auto buf_size = desc->size[desc->phase];
+
+    bool is_system_page = false;
+    Addr base_addr = desc->dstStart[desc->phase];
+    int vmid = 1;
+    unsigned tmp_bytes;
+
+    // Since this is functional anyways, it is unclear if writing pages at a
+    // time is more efficient. Run with this now as it's easier to implement.
+    for (int i = 0; i < buf_size; ++i) {
+        Addr phys_addr = base_addr + i;
+        walker->startFunctional(gpuDevice->getVM().getPageTableBase(vmid),
+                                phys_addr, tmp_bytes, BaseMMU::Mode::Read,
+                                is_system_page);
+        assert(!is_system_page);
+
+        Request::Flags flags = Request::PHYSICAL;
+        RequestPtr request = std::make_shared<Request>(
+            phys_addr, 1, flags, walker->getDevRequestor());
+
+        PacketPtr writePkt = new Packet(request, MemCmd::WriteReq);
+        writePkt->dataStatic(buf + i);
+
+        assert(system()->getDeviceMemory(writePkt) != nullptr);
+        system()->getDeviceMemory(writePkt)->access(writePkt);
+        delete writePkt;
+    }
+
+    blitAck(desc, task, buf);
+}
+
+void
+GPUCommandProcessor::blitAck(BlitCopyDesc *desc, HSAQueueEntry *task,
+                             uint8_t *buf)
+{
+    DPRINTF(GPUCommandProc, "Write complete for blit phase %d\n", desc->phase);
+
+    delete[] buf;
+
+    desc->phase++;
+    if (desc->phase == desc->numPhases) {
+        delete desc;
+        completeBlit(task);
+    } else {
+        blitRead(desc, task);
+    }
+}
+
+void
+GPUCommandProcessor::copyAligned(HSAQueueEntry *task, uint32_t *args)
+{
+    // See https://github.com/ROCm/rocm-systems/blob/rocm-7.2.4/projects/
+    //        rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+    //
+    // Kernel argument buffer:
+    //   [DW  0, 1]  Phase 1 src start address
+    //   [DW  2, 3]  Phase 1 dst start address
+    //   [DW  4, 5]  Phase 2 src start address
+    //   [DW  6, 7]  Phase 2 dst start address
+    //   [DW  8, 9]  Phase 3 src start address
+    //   [DW 10,11]  Phase 3 dst start address
+    //   [DW 12,13]  Phase 4 src start address
+    //   [DW 14,15]  Phase 4 dst start address
+    //   [DW 16,17]  Phase 4 src end address
+    //   [DW 18,19]  Phase 4 dst end address
+    //   [DW 20   ]  Total number of workitems
+    Addr *as_addr = reinterpret_cast<Addr *>(args);
+
+    Addr p1_src_start = as_addr[0];
+    Addr p1_dst_start = as_addr[1];
+    Addr p2_src_start = as_addr[2];
+    Addr p2_dst_start = as_addr[3];
+    Addr p3_src_start = as_addr[4];
+    Addr p3_dst_start = as_addr[5];
+    Addr p4_src_start = as_addr[6];
+    Addr p4_dst_start = as_addr[7];
+    Addr p4_src_end = as_addr[8];
+
+    assert(p2_src_start >= p1_src_start);
+    assert(p3_src_start >= p2_src_start);
+    assert(p4_src_start >= p3_src_start);
+    assert(p4_src_end >= p4_src_start);
+
+    BlitCopyDesc *copyDesc = new BlitCopyDesc();
+
+    // Insert backwards so `phase` variable can be used to end blit emulation.
+    copyDesc->dstStart[0] = p1_dst_start;
+    copyDesc->srcStart[0] = p1_src_start;
+    copyDesc->dstStart[1] = p2_dst_start;
+    copyDesc->srcStart[1] = p2_src_start;
+    copyDesc->dstStart[2] = p3_dst_start;
+    copyDesc->srcStart[2] = p3_src_start;
+    copyDesc->dstStart[3] = p4_dst_start;
+    copyDesc->srcStart[3] = p4_src_start;
+
+    copyDesc->size[0] = p2_src_start - p1_src_start;
+    copyDesc->size[1] = p3_src_start - p2_src_start;
+    copyDesc->size[2] = p4_src_start - p3_src_start;
+    copyDesc->size[3] = p4_src_end - p4_src_start;
+
+    copyDesc->phase = 0;
+    copyDesc->numPhases = 4;
+
+    blitRead(copyDesc, task);
+}
+
+} // namespace gem5

--- a/src/gpu-compute/blit_emulation.hh
+++ b/src/gpu-compute/blit_emulation.hh
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GPU_COMPUTE_BLIT_EMULATION_HH__
+#define __GPU_COMPUTE_BLIT_EMULATION_HH__
+
+#include "base/types.hh"
+
+namespace gem5
+{
+
+// Number of kernel arguments in dword counts.
+constexpr int copyAlignedKernargs = 21;
+constexpr int copyMisalignedKernargs = 13;
+constexpr int fillKernargs = 8;
+constexpr int maxBlitKernargs = copyAlignedKernargs;
+
+// Max of 4 phases.
+typedef struct
+{
+    Addr dstStart[4];
+    Addr srcStart[4];
+    Addr size[4];
+    int phase;
+    int numPhases;
+} BlitCopyDesc;
+
+} // namespace gem5
+
+#endif // __GPU_COMPUTE_BLIT_EMULATION_HH__

--- a/src/gpu-compute/dispatcher.hh
+++ b/src/gpu-compute/dispatcher.hh
@@ -80,6 +80,11 @@ class GPUDispatcher : public SimObject
     void scheduleDispatch();
     void dispatch(HSAQueueEntry *task);
     HSAQueueEntry *hsaTask(int disp_id);
+    bool
+    hasKernelExitEvents() const
+    {
+        return kernelExitEvents;
+    }
 
   private:
     Shader *shader;

--- a/src/gpu-compute/gpu_command_processor.cc
+++ b/src/gpu-compute/gpu_command_processor.cc
@@ -63,7 +63,8 @@ GPUCommandProcessor::GPUCommandProcessor(const Params &p)
       _driver(nullptr),
       walker(p.walker),
       hsaPP(p.hsapp),
-      target_non_blit_kernel_id(p.target_non_blit_kernel_id)
+      target_non_blit_kernel_id(p.target_non_blit_kernel_id),
+      emulateBlitKernels(p.emulate_blits)
 {
     assert(hsaPP);
     hsaPP->setDevice(this);
@@ -141,7 +142,7 @@ GPUCommandProcessor::completeTimingRead(int dispType)
                                      dispatchData.host_pkt_addr);
                 break;
             case ComputeUnit::SQCPort::SenderState::DISPATCH_PRELOAD_ARG:
-                initPreload(dispatchData.akc, dispatchData.task);
+                initPreload(dispatchData.task);
                 break;
         }
     }
@@ -368,6 +369,23 @@ GPUCommandProcessor::dispatchKernelObject(AMDKernelCode *akc, void *raw_pkt,
     Tick start_ts = curTick() / sim_clock::as_int::ns;
     dispatchStartTime.insert({disp_pkt->completion_signal, start_ts});
 
+    if (is_blit_kernel && emulateBlitKernels) {
+        DPRINTF(GPUCommandProc, "Emulating blit kernel (Task ID: %i)\n",
+                dynamic_task_id);
+
+        // DMA the kernargs
+        readBlitKernargs(task);
+
+        // This allows debug-at and exit-at GPU task options to work
+        if (dispatcher.hasKernelExitEvents()) {
+            exitSimLoop("GPU Blit Kernel Completed");
+        }
+
+        ++dynamic_task_id;
+
+        return;
+    }
+
     // Potentially skip a non-blit kernel
     if (!is_blit_kernel && (non_blit_kernel_id < target_non_blit_kernel_id)) {
         DPRINTF(GPUCommandProc, "Skipping non-blit kernel %i (Task ID: %i)\n",
@@ -420,7 +438,7 @@ GPUCommandProcessor::dispatchKernelObject(AMDKernelCode *akc, void *raw_pkt,
 
         delete akc;
     } else {
-        readPreload(akc, task);
+        readPreload(task);
     }
 
     ++dynamic_task_id;
@@ -742,13 +760,14 @@ GPUCommandProcessor::signalWakeupEvent(uint32_t event_id)
 }
 
 void
-GPUCommandProcessor::readPreload(AMDKernelCode *akc, HSAQueueEntry *task)
+GPUCommandProcessor::readPreload(HSAQueueEntry *task)
 {
     _hsa_dispatch_packet_t *disp_pkt =
         (_hsa_dispatch_packet_t *)task->dispPktPtr();
 
     // Data preloaded is copied from the kernarg segment. Preloading starts at
     // the dword offset specified by kernarg_preload_spec_offset.
+    AMDKernelCode *akc = task->akc();
     Addr preload_addr =
         (Addr)disp_pkt->kernarg_address + akc->kernarg_preload_spec_offset * 4;
 
@@ -792,7 +811,7 @@ GPUCommandProcessor::readPreload(AMDKernelCode *akc, HSAQueueEntry *task)
         warn("Preload kernarg from host untested!\n");
 
         auto cb = new DmaVirtCallback<uint32_t>(
-            [=, this](const uint32_t &) { initPreload(akc, task); });
+            [=, this](const uint32_t &) { initPreload(task); });
 
         dmaReadVirt(preload_addr,
                     sizeof(uint32_t) * akc->kernarg_preload_spec_length, cb,
@@ -835,9 +854,10 @@ GPUCommandProcessor::readPreload(AMDKernelCode *akc, HSAQueueEntry *task)
 }
 
 void
-GPUCommandProcessor::initPreload(AMDKernelCode *akc, HSAQueueEntry *task)
+GPUCommandProcessor::initPreload(HSAQueueEntry *task)
 {
     // Fill in SGPRs
+    AMDKernelCode *akc = task->akc();
     int num_sgprs = akc->kernarg_preload_spec_length;
 
     task->preloadLength(num_sgprs);

--- a/src/gpu-compute/gpu_command_processor.hh
+++ b/src/gpu-compute/gpu_command_processor.hh
@@ -54,6 +54,7 @@
 #include "dev/dma_virt_device.hh"
 #include "dev/hsa/hsa_packet_processor.hh"
 #include "dev/hsa/hsa_signal.hh"
+#include "gpu-compute/blit_emulation.hh"
 #include "gpu-compute/dispatcher.hh"
 #include "gpu-compute/gpu_compute_driver.hh"
 #include "gpu-compute/hsa_queue_entry.hh"
@@ -339,8 +340,20 @@ class GPUCommandProcessor : public DmaVirtDevice
         }
     }
 
-    void readPreload(AMDKernelCode *akc, HSAQueueEntry *task);
-    void initPreload(AMDKernelCode *akc, HSAQueueEntry *task);
+    /* Methods for blit kernel emulation. */
+    bool emulateBlitKernels = false;
+
+    void readBlitKernargs(HSAQueueEntry *task);
+    void processBlitKernargs(HSAQueueEntry *task, uint32_t *args);
+    void completeBlit(HSAQueueEntry *task);
+    void copyAligned(HSAQueueEntry *task, uint32_t *args);
+
+    void blitRead(BlitCopyDesc *desc, HSAQueueEntry *task);
+    void blitWrite(BlitCopyDesc *desc, HSAQueueEntry *task, uint8_t *buf);
+    void blitAck(BlitCopyDesc *desc, HSAQueueEntry *task, uint8_t *buf);
+
+    void readPreload(HSAQueueEntry *task);
+    void initPreload(HSAQueueEntry *task);
 };
 
 } // namespace gem5

--- a/src/gpu-compute/hsa_queue_entry.hh
+++ b/src/gpu-compute/hsa_queue_entry.hh
@@ -141,6 +141,8 @@ class HSAQueueEntry
         // Granularity 4. Value 0-63. 0 - accum-offset = 4,
         // 1 - accum-offset = 8, ..., 63 - accum-offset = 256.
         _accumOffset = (akc->accum_offset + 1) * 4;
+
+        _akc = akc;
     }
 
     const GfxVersion &
@@ -452,6 +454,25 @@ class HSAQueueEntry
         return &(_preloadArgs[0]);
     }
 
+    void
+    setEmulated()
+    {
+        _wasEmulated = true;
+    }
+
+    bool
+    wasEmulated() const
+    {
+        return _wasEmulated;
+    }
+
+    AMDKernelCode *
+    akc() const
+    {
+        assert(_akc != nullptr);
+        return _akc;
+    }
+
   private:
     void
     parseKernelCode(AMDKernelCode *akc)
@@ -549,6 +570,12 @@ class HSAQueueEntry
     // max amount. It is of dword type to easily access during wave start.
     unsigned _preloadLength = 0;
     uint32_t _preloadArgs[KernargPreloadPktSize / sizeof(uint32_t)];
+
+    // Set if the task was emulated instead of simulated (e.g., BLIT kernel).
+    // We keep a copy of the akc pointer in case emulated needs to back out
+    // due to an unsupported kernel type.
+    bool _wasEmulated = false;
+    AMDKernelCode *_akc;
 };
 
 } // namespace gem5


### PR DESCRIPTION
Detect and emulate blit kernels. Currently only supports the Copy Aligned BLIT kernel. Unaligned copy and Fill BLIT kernels have not been regularly observed in practice, so in those cases the kernels are simulated.

This is intended as a performance improvement. Ranges from nice simulation reduction (static apps) to massive improvements (apps using hipModuleLoad for example). Note that this does NOT do timing stores to device memory which will cause problems for writeback cache configurations. Since the default is write-through this is left for future work. Device writes also happen one byte at a time. The improvement could be slightly better writing pages at a time.

This can be turned on using the --emulate-blit-kernels command line argument for classic GPUFS configs (configs in configs/) or enabled in stdlib by setting emulate_blits = True in each GPUCommandProcessor.