### PR TITLE
configs: Add Read generator for separate DATA/RSP responses

### DIFF
--- a/configs/example/chi_tlm/lib/chi.py
+++ b/configs/example/chi_tlm/lib/chi.py
@@ -60,12 +60,18 @@ def phase_gen(txn_id, req):
     return phase
 
 
-def channel_check(transaction):
-    return expect_equal(transaction.phase.channel, Channel.DAT)
+def channel_check_gen(exp):
+    def channel_check(transaction):
+        return expect_equal(transaction.phase.channel, exp)
+
+    return channel_check
 
 
-def opcode_check(transaction):
-    return expect_equal(transaction.phase.opcode, DatOpcode.COMP_DATA)
+def opcode_check_gen(exp):
+    def opcode_check(transaction):
+        return expect_equal(transaction.phase.opcode, exp)
+
+    return opcode_check
 
 
 def cacheline_check(resp):
@@ -110,13 +116,13 @@ def checked_read(generator, address, txn_id, req, resp):
     phase = phase_gen(txn_id, req=req)
 
     tran = generator.inject(payload, phase)
-    tran.EXPECT(channel_check)
-    tran.EXPECT(opcode_check)
+    tran.EXPECT(channel_check_gen(Channel.DAT))
+    tran.EXPECT(opcode_check_gen(DatOpcode.COMP_DATA))
     tran.EXPECT(cacheline_check(resp))
     tran.EXPECT(data_id_check_gen(0))
     tran.DO_WAIT(wait_data)
-    tran.EXPECT(channel_check)
-    tran.EXPECT(opcode_check)
+    tran.EXPECT(channel_check_gen(Channel.DAT))
+    tran.EXPECT(opcode_check_gen(DatOpcode.COMP_DATA))
     tran.EXPECT(cacheline_check(resp))
     tran.EXPECT(data_id_check_gen(2))
     tran.DO(do_comp_ack)

--- a/configs/example/chi_tlm/lib/chi.py
+++ b/configs/example/chi_tlm/lib/chi.py
@@ -130,6 +130,31 @@ def checked_read(generator, address, txn_id, req, resp):
     return tran
 
 
+def checked_read_separate_data_resp(
+    generator, address, txn_id, req, expected_resp
+):
+    payload = payload_gen(address)
+    phase = phase_gen(txn_id, req=req)
+
+    tran = generator.inject(payload, phase)
+    tran.EXPECT(channel_check_gen(Channel.RSP))
+    tran.EXPECT(opcode_check_gen(RspOpcode.RESP_SEP_DATA))
+    tran.EXPECT(cacheline_check(Resp.RESP_I))
+    tran.DO_WAIT(wait_data)
+    tran.EXPECT(channel_check_gen(Channel.DAT))
+    tran.EXPECT(opcode_check_gen(DatOpcode.DATA_SEP_RESP))
+    tran.EXPECT(cacheline_check(expected_resp))
+    tran.EXPECT(data_id_check_gen(0))
+    tran.DO_WAIT(wait_data)
+    tran.EXPECT(channel_check_gen(Channel.DAT))
+    tran.EXPECT(opcode_check_gen(DatOpcode.DATA_SEP_RESP))
+    tran.EXPECT(cacheline_check(expected_resp))
+    tran.EXPECT(data_id_check_gen(2))
+    tran.DO(do_comp_ack)
+
+    return tran
+
+
 def read_shared(generator, address, txn_id, resp):
     return checked_read(
         generator, address, txn_id, ReqOpcode.READ_SHARED, resp


### PR DESCRIPTION
This covers the case for a Read operation with separate
DATA and RSP responses.

This in gem5 is exposed by setting:

    enable_DMT_early_dealloc = True