### PR TITLE
mem-ruby: Add new primitives to the TlmGenerator.Transaction class

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -71,7 +71,13 @@ TlmGenerator::Transaction::Assertion::run(Transaction *tran)
 
 TlmGenerator::Transaction::Transaction(ARM::CHI::Payload *pa,
                                        ARM::CHI::Phase &ph)
-    : passed(true), parent(nullptr), _payload(pa), _phase(ph), _start(0)
+    : runCallbacksEvent([this] { runCallbacks(); }, "Transaction runCallback",
+                        false, Event::CPU_Tick_Pri),
+      passed(true),
+      parent(nullptr),
+      _payload(pa),
+      _phase(ph),
+      _start(0)
 {
     _payload->ref();
 }
@@ -135,9 +141,14 @@ TlmGenerator::Transaction::runCallbacks()
         }
         bool wait = (*it)->wait();
 
+        unsigned timeout = (*it)->waitCycles();
+
         it = actions.erase(it);
 
         if (wait) {
+            if (timeout) {
+                parent->scheduleEvaluation(timeout, this);
+            }
             break;
         }
     }
@@ -257,6 +268,10 @@ TlmGenerator::terminate(Transaction *transaction)
 
         // If the transaction has failed, mark the suite as failure
         suiteFailure = suiteFailure || transaction->failed();
+
+        if (!isActive()) {
+            exitSimLoop("TlmGenerator done");
+        }
     } else {
         panic("%u: Can't find transaction id.\n", phase.txn_id);
     }
@@ -302,10 +317,14 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
     } else {
         warn("%u: Transaction untested\n", phase->txn_id);
     }
+}
 
-    if (!isActive()) {
-        exitSimLoop("TlmGenerator done");
-    }
+void
+TlmGenerator::scheduleEvaluation(unsigned cycles, Transaction *transaction)
+{
+    auto &event = transaction->runCallbacksEvent;
+    panic_if(event.scheduled(), "Already scheduled\n");
+    schedule(event, clockEdge(Cycles(cycles)));
 }
 
 bool

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -137,8 +137,16 @@ class TlmGenerator : public ClockedObject
             >;
 
             Action(Callback _cb, bool waiting)
-              : cb(_cb), _wait(waiting)
+                : cb(_cb), _wait(waiting), _waitCycles(0)
             {}
+
+            Action(Callback _cb, unsigned cycles)
+                : cb(_cb), _wait(true), _waitCycles(cycles)
+            {
+                panic_if(cycles == 0,
+                         "waiting time should be bigger than 0\n");
+            }
+
             virtual ~Action() {};
 
             /* A basic action always returns true */
@@ -155,9 +163,19 @@ class TlmGenerator : public ClockedObject
              */
             bool wait() const { return _wait; }
 
+            /**
+             * Returning a value != 0 means we are waiting and
+             */
+            unsigned
+            waitCycles() const
+            {
+                return _waitCycles;
+            }
+
           protected:
             Callback cb;
-            bool _wait;
+            bool _wait = false;
+            unsigned _waitCycles = 0;
         };
 
         /**
@@ -250,6 +268,8 @@ class TlmGenerator : public ClockedObject
          */
         void runCallbacks();
 
+        EventFunctionWrapper runCallbacksEvent;
+
         ARM::CHI::Payload* payload() const { return _payload; }
         ARM::CHI::Phase& phase() { return _phase; }
         Tick
@@ -321,6 +341,8 @@ class TlmGenerator : public ClockedObject
     void inject(Transaction *transaction);
     void send(Transaction *transaction);
     void terminate(Transaction *transaction);
+    void scheduleEvaluation(unsigned cycles, Transaction *transaction);
+
     void recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
     void passFailCheck();
 

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -74,10 +74,16 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
                     cb.attr("__name__").cast<std::string>(),
                     cb.cast<Callback>()));
             })
-        .def("ASSERT",
+        .def("ASSERT_STR",
              [](tlm::chi::TlmGenerator::Transaction &self, std::string name,
                 Callback cb) {
                  self.addCallback(std::make_unique<Assertion>(name, cb));
+             })
+        .def("ASSERT",
+             [](tlm::chi::TlmGenerator::Transaction &self, py::function cb) {
+                 self.addCallback(std::make_unique<Assertion>(
+                     cb.attr("__name__").cast<std::string>(),
+                     cb.cast<Callback>()));
              })
         .def("DO",
              [](tlm::chi::TlmGenerator::Transaction &self, Callback cb) {

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -93,6 +93,11 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
              [](tlm::chi::TlmGenerator::Transaction &self, Callback cb) {
                  self.addCallback(std::make_unique<Action>(cb, true));
              })
+        .def("DO_WAIT_FOR",
+             [](tlm::chi::TlmGenerator::Transaction &self, Callback cb,
+                unsigned cycles) {
+                 self.addCallback(std::make_unique<Action>(cb, cycles));
+             })
         .def("send", &tlm::chi::TlmGenerator::Transaction::send)
         .def_property("phase", &tlm::chi::TlmGenerator::Transaction::phase,
                       &tlm::chi::TlmGenerator::Transaction::phase)


### PR DESCRIPTION
Those are:

* ASSERT_STR => To match EXPECT_STR and allow assertion with no provided string
* DO_WAIT_FOR => Essentially a DO_WAIT with a timeout in cycles passed as an argument