### PR TITLE
mem-ruby: Add python APIs for flushing AbstractController state

### DIFF
--- a/src/mem/ruby/protocol/RubySlicc_Types.sm
+++ b/src/mem/ruby/protocol/RubySlicc_Types.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021,2023-2024 Arm Limited
+ * Copyright (c) 2020-2021,2023-2024,2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -215,6 +215,7 @@ structure (CacheMemory, external = "yes") {
   AbstractCacheEntry allocate(Addr, AbstractCacheEntry, bool);
   void allocateVoid(Addr, AbstractCacheEntry);
   void deallocate(Addr);
+  void flushEntries();
   AbstractCacheEntry lookup(Addr);
   bool isTagPresent(Addr);
   Cycles getTagLatency();

--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Arm Limited
+ * Copyright (c) 2021-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -365,6 +365,14 @@ void notifyCoalesced(Addr addr, RubyRequestType type, RequestPtr req,
       pfProxy.notifyPfHit(req, is_read, data_blk);
     }
   }
+}
+
+void flushController() {
+  // Flush the directory
+  directory.flushEntries();
+
+  // Flush the cache
+  cache.flushEntries();
 }
 
 

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 Arm Limited
+ * Copyright (c) 2021-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -793,6 +793,7 @@ machine(MachineType:Cache, "Cache coherency protocol") :
   structure(PerfectCacheMemory, external = "yes") {
     void allocate(Addr);
     void deallocate(Addr);
+    void flushEntries();
     DirEntry lookup(Addr);
     bool isTagPresent(Addr);
   }

--- a/src/mem/ruby/slicc_interface/AbstractController.hh
+++ b/src/mem/ruby/slicc_interface/AbstractController.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017,2019-2023 ARM Limited
+ * Copyright (c) 2017,2019-2023, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -179,6 +179,16 @@ class AbstractController : public ClockedObject, public Consumer
 
     //! Initialize the message buffers.
     virtual void initNetQueues() = 0;
+
+    //! Flush the internal state of the coherence controller
+    //! (does not write back dirty data and therefore will
+    //! break coherence if used in a normal simulation.
+    //! Supposed to be used for debug/testing purposes only)
+    virtual void
+    flushController()
+    {
+        fatal("flushController not supported in %s", name());
+    }
 
     /** A function used to return the port associated with this bus object. */
     Port &getPort(const std::string &if_name,

--- a/src/mem/ruby/slicc_interface/Controller.py
+++ b/src/mem/ruby/slicc_interface/Controller.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017,2019-2021 ARM Limited
+# Copyright (c) 2017,2019-2021, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -41,6 +41,7 @@ from m5.objects.RubySystem import RubySystem
 from m5.objects.System import System
 from m5.params import *
 from m5.proxy import *
+from m5.util.pybind import PyBindMethod
 
 
 class RubyController(ClockedObject):
@@ -48,6 +49,10 @@ class RubyController(ClockedObject):
     cxx_class = "gem5::ruby::AbstractController"
     cxx_header = "mem/ruby/slicc_interface/AbstractController.hh"
     abstract = True
+
+    cxx_exports = [
+        PyBindMethod("flushController"),
+    ]
 
     version = Param.Int("")
     addr_ranges = VectorParam.AddrRange(

--- a/src/mem/ruby/structures/CacheMemory.cc
+++ b/src/mem/ruby/structures/CacheMemory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 ARM Limited
+ * Copyright (c) 2020-2021, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -353,13 +353,31 @@ CacheMemory::deallocate(Addr address)
 {
     DPRINTF(RubyCache, "deallocating address: %#x\n", address);
     AbstractCacheEntry* entry = lookup(address);
+    deallocate(entry);
+}
+
+void
+CacheMemory::deallocate(AbstractCacheEntry *entry)
+{
     assert(entry != nullptr);
     m_replacementPolicy_ptr->invalidate(entry->replacementData);
     uint32_t cache_set = entry->getSet();
     uint32_t way = entry->getWay();
+    m_tag_index.erase(entry->m_Address);
     delete entry;
     m_cache[cache_set][way] = NULL;
-    m_tag_index.erase(address);
+}
+
+void
+CacheMemory::flushEntries()
+{
+    for (auto &sets : m_cache) {
+        for (auto &entry : sets) {
+            if (entry) {
+                deallocate(entry);
+            }
+        }
+    }
 }
 
 // Returns with the physical address of the conflicting cache line

--- a/src/mem/ruby/structures/CacheMemory.hh
+++ b/src/mem/ruby/structures/CacheMemory.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 ARM Limited
+ * Copyright (c) 2020-2021, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -107,6 +107,13 @@ class CacheMemory : public SimObject
 
     // Explicitly free up this address
     void deallocate(Addr address);
+
+    // Explicitly free up this entry
+    void deallocate(AbstractCacheEntry *entry);
+
+    // Flush all entries within the cache.
+    // Mainly used for debug purposes
+    void flushEntries();
 
     // Returns with the physical address of the conflicting cache line
     Addr cacheProbe(Addr address) const;

--- a/src/mem/ruby/structures/PerfectCacheMemory.hh
+++ b/src/mem/ruby/structures/PerfectCacheMemory.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 ARM Limited
+ * Copyright (c) 2019, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -90,6 +90,9 @@ class PerfectCacheMemory
     void allocate(Addr address);
 
     void deallocate(Addr address);
+
+    // Flush all entries within the cache
+    void flushEntries();
 
     // Returns with the physical address of the conflicting cache line
     Addr cacheProbe(Addr newAddress) const;
@@ -182,6 +185,14 @@ PerfectCacheMemory<ENTRY>::deallocate(Addr address)
     Addr line_addr = makeLineAddress(address, floorLog2(m_block_size));
     [[maybe_unused]] auto num_erased = m_map.erase(line_addr);
     assert(num_erased == 1);
+}
+
+// deallocate entry
+template <class ENTRY>
+inline void
+PerfectCacheMemory<ENTRY>::flushEntries()
+{
+    m_map.clear();
 }
 
 // Returns with the physical address of the conflicting cache line

--- a/src/mem/ruby/structures/RubyCache.py
+++ b/src/mem/ruby/structures/RubyCache.py
@@ -1,3 +1,17 @@
+# -*- mode:python -*-
+
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2009 Advanced Micro Devices, Inc.
 # All rights reserved.
 #
@@ -28,12 +42,17 @@ from m5.objects.ReplacementPolicies import *
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject
+from m5.util.pybind import PyBindMethod
 
 
 class RubyCache(SimObject):
     type = "RubyCache"
     cxx_class = "gem5::ruby::CacheMemory"
     cxx_header = "mem/ruby/structures/CacheMemory.hh"
+
+    cxx_exports = [
+        PyBindMethod("flushEntries"),
+    ]
 
     size = Param.MemorySize("capacity in bytes")
     assoc = Param.Int("")


### PR DESCRIPTION
By exposing the flushing to python, we add a mean for
tearing down the state of the cache (controller). This is very
useful for debug platforms/purposes.

For instance, we could write multiple tests which test
replacement policies for RubyCache. By allowing the cache
to be flushed in between tests, we make sure
tests are properly isolated

This is another step towards making gem5 more testable