### PR TITLE
cpu: Fix O3 misc-reg commit visibility hazard

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1023,6 +1023,7 @@ Commit::commitInsts()
 
                 // Updates misc. registers.
                 head_inst->updateMiscRegs();
+                iewStage->wakeMiscDependents(head_inst);
 
                 // Check instruction execution if it successfully commits and
                 // is not carrying a fault.

--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1023,7 +1023,6 @@ Commit::commitInsts()
 
                 // Updates misc. registers.
                 head_inst->updateMiscRegs();
-                iewStage->wakeMiscDependents(head_inst);
 
                 // Check instruction execution if it successfully commits and
                 // is not carrying a fault.

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -569,44 +569,41 @@ IEW::unblock(ThreadID tid)
 }
 
 void
-IEW::wakeReadyDependents(const DynInstPtr &inst, int dependents,
-                         bool deferred_misc_only, const char *ready_msg)
+IEW::wakeReadyDependents(ThreadID tid,
+                         const std::vector<PhysRegIdPtr> &ready_regs,
+                         int producers, int dependents, const char *ready_msg)
 {
+    for (const auto dest_reg : ready_regs) {
+        DPRINTF(IEW, ready_msg, dest_reg->index(), dest_reg->className());
+        scoreboard->setReg(dest_reg);
+    }
+
+    if (dependents) {
+        iewStats.producerInst[tid] += producers;
+        iewStats.consumerInst[tid] += dependents;
+    }
+}
+
+void
+IEW::wakeDependents(const DynInstPtr &inst)
+{
+    const int dependents = instQueue.wakeDependents(inst);
+    std::vector<PhysRegIdPtr> ready_regs;
+    ready_regs.reserve(inst->numDestRegs());
+
     for (int i = 0; i < inst->numDestRegs(); i++) {
         const PhysRegIdPtr dest_reg = inst->renamedDestIdx(i);
-        if (dest_reg->isDeferredMiscReg() != deferred_misc_only) {
+        if (dest_reg->isDeferredMiscReg()) {
             continue;
         }
 
         if (dest_reg->getNumPinnedWritesToComplete() == 0) {
-            DPRINTF(IEW, ready_msg, dest_reg->index(), dest_reg->className());
-            scoreboard->setReg(dest_reg);
+            ready_regs.push_back(dest_reg);
         }
     }
 
-    if (dependents) {
-        iewStats.producerInst[inst->threadNumber]++;
-        iewStats.consumerInst[inst->threadNumber] += dependents;
-    }
-}
-
-void
-IEW::wakeDependents(const DynInstPtr& inst)
-{
-    wakeReadyDependents(inst, instQueue.wakeDependents(inst), false,
-                        "Setting Destination Register %i (%s)\n");
-}
-
-void
-IEW::wakeMiscDependents(const DynInstPtr &inst)
-{
-    const auto wake_info = instQueue.wakeMiscDependents(inst);
-    if (!wake_info.hasDeferredMiscDest) {
-        return;
-    }
-
-    wakeReadyDependents(inst, wake_info.dependents, true,
-                        "Setting Destination Register %i (%s) at commit\n");
+    wakeReadyDependents(inst->threadNumber, ready_regs, dependents ? 1 : 0,
+                        dependents, "Setting Destination Register %i (%s)\n");
 }
 
 void
@@ -1524,13 +1521,21 @@ IEW::tick()
         if (fromCommit->commitInfo[tid].doneSeqNum != 0 &&
             !fromCommit->commitInfo[tid].squash &&
             !fromCommit->commitInfo[tid].robSquashing) {
+            const auto deferred_misc_wakeup =
+                instQueue.wakeDeferredMiscDependents(
+                    fromCommit->commitInfo[tid].doneSeqNum, tid);
 
             ldstQueue.commitStores(fromCommit->commitInfo[tid].doneSeqNum,tid);
 
             ldstQueue.commitLoads(fromCommit->commitInfo[tid].doneSeqNum,tid);
 
             updateLSQNextCycle = true;
-            instQueue.commit(fromCommit->commitInfo[tid].doneSeqNum,tid);
+            instQueue.commit(fromCommit->commitInfo[tid].doneSeqNum, tid);
+            wakeReadyDependents(
+                tid, deferred_misc_wakeup.readyRegs,
+                deferred_misc_wakeup.producers,
+                deferred_misc_wakeup.dependents,
+                "Setting Destination Register %i (%s) at commit\n");
         }
 
         if (fromCommit->commitInfo[tid].nonSpecSeqNum != 0) {

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -569,9 +569,44 @@ IEW::unblock(ThreadID tid)
 }
 
 void
+IEW::wakeReadyDependents(const DynInstPtr &inst, int dependents,
+                         bool deferred_misc_only, const char *ready_msg)
+{
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        const PhysRegIdPtr dest_reg = inst->renamedDestIdx(i);
+        if (dest_reg->isDeferredMiscReg() != deferred_misc_only) {
+            continue;
+        }
+
+        if (dest_reg->getNumPinnedWritesToComplete() == 0) {
+            DPRINTF(IEW, ready_msg, dest_reg->index(), dest_reg->className());
+            scoreboard->setReg(dest_reg);
+        }
+    }
+
+    if (dependents) {
+        iewStats.producerInst[inst->threadNumber]++;
+        iewStats.consumerInst[inst->threadNumber] += dependents;
+    }
+}
+
+void
 IEW::wakeDependents(const DynInstPtr& inst)
 {
-    instQueue.wakeDependents(inst);
+    wakeReadyDependents(inst, instQueue.wakeDependents(inst), false,
+                        "Setting Destination Register %i (%s)\n");
+}
+
+void
+IEW::wakeMiscDependents(const DynInstPtr &inst)
+{
+    const auto wake_info = instQueue.wakeMiscDependents(inst);
+    if (!wake_info.hasDeferredMiscDest) {
+        return;
+    }
+
+    wakeReadyDependents(inst, wake_info.dependents, true,
+                        "Setting Destination Register %i (%s) at commit\n");
 }
 
 void
@@ -1419,23 +1454,7 @@ IEW::writebackInsts()
         // when it's ready to execute the strictly ordered load.
         if (!inst->isSquashed() && inst->isExecuted() &&
                 inst->getFault() == NoFault) {
-            int dependents = instQueue.wakeDependents(inst);
-
-            for (int i = 0; i < inst->numDestRegs(); i++) {
-                // Mark register as ready if not pinned
-                if (inst->renamedDestIdx(i)->
-                        getNumPinnedWritesToComplete() == 0) {
-                    DPRINTF(IEW,"Setting Destination Register %i (%s)\n",
-                            inst->renamedDestIdx(i)->index(),
-                            inst->renamedDestIdx(i)->className());
-                    scoreboard->setReg(inst->renamedDestIdx(i));
-                }
-            }
-
-            if (dependents) {
-                iewStats.producerInst[tid]++;
-                iewStats.consumerInst[tid]+= dependents;
-            }
+            wakeDependents(inst);
             iewStats.writebackCount[tid]++;
         }
     }

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -169,8 +169,11 @@ class IEW
     /** Squashes instructions in IEW for a specific thread. */
     void squash(ThreadID tid);
 
-    /** Wakes all dependents of a completed instruction. */
+    /** Wakes dependents on results that are visible at writeback. */
     void wakeDependents(const DynInstPtr &inst);
+
+    /** Wakes dependents on misc-reg writes once commit makes them visible. */
+    void wakeMiscDependents(const DynInstPtr &inst);
 
     /** Tells memory dependence unit that a memory instruction needs to be
      * rescheduled. It will re-execute once replayMemInst() is called.
@@ -299,6 +302,9 @@ class IEW
   private:
     /** Updates execution stats based on the instruction. */
     void updateExeInstStats(const DynInstPtr &inst);
+
+    void wakeReadyDependents(const DynInstPtr &inst, int dependents,
+                             bool deferred_misc_only, const char *ready_msg);
 
     /** Pointer to main time buffer used for backwards communication. */
     TimeBuffer<TimeStruct> *timeBuffer;

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -172,9 +172,6 @@ class IEW
     /** Wakes dependents on results that are visible at writeback. */
     void wakeDependents(const DynInstPtr &inst);
 
-    /** Wakes dependents on misc-reg writes once commit makes them visible. */
-    void wakeMiscDependents(const DynInstPtr &inst);
-
     /** Tells memory dependence unit that a memory instruction needs to be
      * rescheduled. It will re-execute once replayMemInst() is called.
      */
@@ -303,8 +300,10 @@ class IEW
     /** Updates execution stats based on the instruction. */
     void updateExeInstStats(const DynInstPtr &inst);
 
-    void wakeReadyDependents(const DynInstPtr &inst, int dependents,
-                             bool deferred_misc_only, const char *ready_msg);
+    void wakeReadyDependents(ThreadID tid,
+                             const std::vector<PhysRegIdPtr> &ready_regs,
+                             int producers, int dependents,
+                             const char *ready_msg);
 
     /** Pointer to main time buffer used for backwards communication. */
     TimeBuffer<TimeStruct> *timeBuffer;

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1122,19 +1122,55 @@ InstructionQueue::scheduleNonSpec(const InstSeqNum &inst)
     nonSpecInsts.erase(inst_it);
 }
 
+InstructionQueue::DeferredMiscWakeupInfo
+InstructionQueue::wakeDeferredMiscDependents(const InstSeqNum &inst,
+                                             ThreadID tid)
+{
+    DPRINTF(IQ, "[tid:%i] Waking deferred misc dependents through [sn:%llu]\n",
+            tid, inst);
+
+    DeferredMiscWakeupInfo wakeup_info;
+    const ListIt commit_end = firstUncommitted(inst, tid);
+
+    for (ListIt iq_it = instList[tid].begin(); iq_it != commit_end; ++iq_it) {
+        const DynInstPtr committed_inst = *iq_it;
+        const auto wake_info = wakeMiscDependents(committed_inst);
+
+        if (wake_info.hasDeferredMiscDest) {
+            wakeup_info.readyRegs.insert(wakeup_info.readyRegs.end(),
+                                         wake_info.readyRegs.begin(),
+                                         wake_info.readyRegs.end());
+            wakeup_info.dependents += wake_info.dependents;
+
+            if (wake_info.dependents) {
+                ++wakeup_info.producers;
+            }
+        }
+    }
+
+    return wakeup_info;
+}
+
 void
 InstructionQueue::commit(const InstSeqNum &inst, ThreadID tid)
 {
     DPRINTF(IQ, "[tid:%i] Committing instructions older than [sn:%llu]\n",
             tid,inst);
 
+    instList[tid].erase(instList[tid].begin(), firstUncommitted(inst, tid));
+}
+
+InstructionQueue::ListIt
+InstructionQueue::firstUncommitted(const InstSeqNum &inst, ThreadID tid)
+{
     ListIt iq_it = instList[tid].begin();
 
     while (iq_it != instList[tid].end() &&
            (*iq_it)->seqNum <= inst) {
         ++iq_it;
-        instList[tid].pop_front();
     }
+
+    return iq_it;
 }
 
 int
@@ -1150,8 +1186,24 @@ InstructionQueue::wakeMiscDependents(const DynInstPtr &completed_inst)
         return WakeDependentsInfo();
     }
 
-    return WakeDependentsInfo(
+    WakeDependentsInfo wake_info(
         wakeSelectedDependents(completed_inst, true, false), true);
+
+    for (int dest_reg_idx = 0; dest_reg_idx < completed_inst->numDestRegs();
+         dest_reg_idx++) {
+        const PhysRegIdPtr dest_reg =
+            completed_inst->renamedDestIdx(dest_reg_idx);
+
+        if (!dest_reg->isDeferredMiscReg()) {
+            continue;
+        }
+
+        if (dest_reg->getNumPinnedWritesToComplete() == 0) {
+            wake_info.readyRegs.push_back(dest_reg);
+        }
+    }
+
+    return wake_info;
 }
 
 int

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -81,6 +81,24 @@ namespace gem5
 namespace o3
 {
 
+namespace
+{
+
+bool
+hasDeferredMiscDest(const DynInstPtr &inst)
+{
+    for (int dest_reg_idx = 0; dest_reg_idx < inst->numDestRegs();
+         dest_reg_idx++) {
+        if (inst->renamedDestIdx(dest_reg_idx)->isDeferredMiscReg()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // anonymous namespace
+
 IQUnit::IQUnit(const IQUnitParams &params)
     : SimObject(params),
       iqPolicy(params.smtIQPolicy),
@@ -1122,6 +1140,25 @@ InstructionQueue::commit(const InstSeqNum &inst, ThreadID tid)
 int
 InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
 {
+    return wakeSelectedDependents(completed_inst, false, true);
+}
+
+InstructionQueue::WakeDependentsInfo
+InstructionQueue::wakeMiscDependents(const DynInstPtr &completed_inst)
+{
+    if (!hasDeferredMiscDest(completed_inst)) {
+        return WakeDependentsInfo();
+    }
+
+    return WakeDependentsInfo(
+        wakeSelectedDependents(completed_inst, true, false), true);
+}
+
+int
+InstructionQueue::wakeSelectedDependents(const DynInstPtr &completed_inst,
+                                         bool deferred_misc_only,
+                                         bool process_mem_inst)
+{
     int dependents = 0;
 
     // The instruction queue here takes care of both floating and int ops
@@ -1143,18 +1180,20 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
     // instruction if it is a memory instruction.  Also complete the memory
     // instruction at this point since we know it executed without issues.
     ThreadID tid = completed_inst->threadNumber;
-    if (completed_inst->isMemRef()) {
-        memDepUnit[tid].completeInst(completed_inst);
+    if (process_mem_inst) {
+        if (completed_inst->isMemRef()) {
+            memDepUnit[tid].completeInst(completed_inst);
 
-        DPRINTF(IQ, "Completing mem instruction PC: %s [sn:%llu]\n",
-            completed_inst->pcState(), completed_inst->seqNum);
+            DPRINTF(IQ, "Completing mem instruction PC: %s [sn:%llu]\n",
+                    completed_inst->pcState(), completed_inst->seqNum);
 
-        completed_inst->clearInIQ();
-        completed_inst->memOpDone(true);
-    } else if (completed_inst->isReadBarrier() ||
-               completed_inst->isWriteBarrier()) {
-        // Completes a non mem ref barrier
-        memDepUnit[tid].completeInst(completed_inst);
+            completed_inst->clearInIQ();
+            completed_inst->memOpDone(true);
+        } else if (completed_inst->isReadBarrier() ||
+                   completed_inst->isWriteBarrier()) {
+            // Completes a non mem ref barrier
+            memDepUnit[tid].completeInst(completed_inst);
+        }
     }
 
     for (int dest_reg_idx = 0;
@@ -1163,6 +1202,10 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
     {
         PhysRegIdPtr dest_reg =
             completed_inst->renamedDestIdx(dest_reg_idx);
+
+        if (dest_reg->isDeferredMiscReg() != deferred_misc_only) {
+            continue;
+        }
 
         // Special case of uniq or control registers.  They are not
         // handled by the IQ and thus have no dependency graph entry.

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -183,6 +183,16 @@ class InstructionQueue
     // Typedef of iterator through the list of instructions.
     typedef typename std::list<DynInstPtr>::iterator ListIt;
 
+    struct WakeDependentsInfo
+    {
+        WakeDependentsInfo(int deps = 0, bool has_deferred_misc_dest = false)
+            : dependents(deps), hasDeferredMiscDest(has_deferred_misc_dest)
+        {}
+
+        int dependents;
+        bool hasDeferredMiscDest;
+    };
+
     /** FU completion event class. */
     class FUCompletion : public Event
     {
@@ -333,6 +343,9 @@ class InstructionQueue
     /** Wakes all dependents of a completed instruction. */
     int wakeDependents(const DynInstPtr &completed_inst);
 
+    /** Wakes dependents on misc regs that only become visible at commit. */
+    WakeDependentsInfo wakeMiscDependents(const DynInstPtr &completed_inst);
+
     /** Adds a ready memory instruction to the ready list. */
     void addReadyMemInst(const DynInstPtr &ready_inst);
 
@@ -378,6 +391,10 @@ class InstructionQueue
   private:
     /** Does the actual squashing. */
     void doSquash(ThreadID tid);
+
+    /** Wakes either deferred misc-reg dependents or all others. */
+    int wakeSelectedDependents(const DynInstPtr &completed_inst,
+                               bool deferred_misc_only, bool process_mem_inst);
 
     /////////////////////////
     // Various pointers

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -57,6 +57,7 @@
 #include "cpu/o3/mem_dep_unit.hh"
 #include "cpu/o3/store_set.hh"
 #include "cpu/op_class.hh"
+#include "cpu/reg_class.hh"
 #include "cpu/timebuf.hh"
 #include "enums/SMTQueuePolicy.hh"
 #include "sim/eventq.hh"
@@ -191,6 +192,14 @@ class InstructionQueue
 
         int dependents;
         bool hasDeferredMiscDest;
+        std::vector<PhysRegIdPtr> readyRegs;
+    };
+
+    struct DeferredMiscWakeupInfo
+    {
+        std::vector<PhysRegIdPtr> readyRegs;
+        unsigned producers = 0;
+        int dependents = 0;
     };
 
     /** FU completion event class. */
@@ -333,6 +342,13 @@ class InstructionQueue
 
     /** Schedules a single specific non-speculative instruction. */
     void scheduleNonSpec(const InstSeqNum &inst);
+
+    /**
+     * Wakes misc-reg dependents for instructions that become architecturally
+     * visible once commit reaches IEW.
+     */
+    DeferredMiscWakeupInfo wakeDeferredMiscDependents(const InstSeqNum &inst,
+                                                      ThreadID tid = 0);
 
     /**
      * Commits all instructions up to and including the given sequence number,
@@ -550,6 +566,9 @@ class InstructionQueue
      *  the scoreboard that exists in the rename map.
      */
     std::vector<bool> regScoreboard;
+
+    /** Returns the first IQ entry that is newer than the committed seq num. */
+    ListIt firstUncommitted(const InstSeqNum &inst, ThreadID tid);
 
     /** Adds an instruction to the dependency graph, as a consumer. */
     bool addToDependents(const DynInstPtr &new_inst);

--- a/src/cpu/reg_class.hh
+++ b/src/cpu/reg_class.hh
@@ -490,6 +490,12 @@ class PhysRegId : private RegId
         return regClass().isSerializing(regClass()[index()]);
     }
 
+    bool
+    isDeferredMiscReg() const
+    {
+        return classValue() == MiscRegClass && !isAlwaysReady();
+    }
+
     /** Flat index accessor */
     const RegIndex& flatIndex() const { return flatIdx; }
 


### PR DESCRIPTION
#3157 

[AI assisted]

Many code are formatted by clang-format. So what I tried are listed here:
1. commit.cc after update the MiscRegs wake Misc Dependents
2. iew.hh and iew.cc. add heler function to distinguish the MiscReg which can be deferred and set the scoreboard
3. inst_queue.cc. similar as iew
