### PR TITLE
arch-riscv: Fix segfault in masked vector strided loads

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1932,6 +1932,7 @@ def template VlElementMicroConstructor {{
     if (_has_rs2) {
         setSrcRegIdx(_numSrcRegs++, intRegClass[_machInst.rs2]);
     }
+    SET_VM_SRC();
     this->flags[IsLoad] = true;
 }
 


### PR DESCRIPTION
VlElementMicroConstructor did not register v0 as a source operand when vm=0, despite execute() calling getRegOperand(this, _numSrcRegs-1) to read the mask. This out-of-bounds access caused a segfault.
Affected instructions: vlse8.v, vlse16.v, vlse32.v, vlse64.v and all vlsseg* variants when used with a mask (vm=0).
Fix is one line: add SET_VM_SRC() at the end of the constructor, matching the pattern already used in VlSegMicroConstructor and VleMicroConstructor.