### PR TITLE
arch/riscv: Fix srcRegIdxArr buffer overflow in VlSegDeIntrlvMicroInst

### DIFF
--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -713,7 +713,7 @@ class VlSegMicroInst : public VectorMicroInst
 class VlSegDeIntrlvMicroInst : public VectorArithMicroInst
 {
   private:
-    RegId srcRegIdxArr[NumVecInternalRegs];
+    RegId srcRegIdxArr[NumVecInternalRegs + 2];
     RegId destRegIdxArr[1];
     uint32_t numSrcs;
     uint32_t numMicroops;


### PR DESCRIPTION
The constructor of VlSegDeIntrlvMicroInst registers up to 10 source registers (8 fields + oldDst + v0), but srcRegIdxArr was sized to NumVecInternalRegs (8). With vlseg8.v and vm=0 this overflows the array, corrupting stack memory and causing a segfault when execute() calls getRegOperand(this, vmsrcIdx).
Fix: srcRegIdxArr[NumVecInternalRegs + 2] in vector.hh.