### PR TITLE
dev, gpu-compute: fix C++20 implicit this capture in lambdas

### DIFF
--- a/src/dev/amdgpu/pm4_packet_processor.cc
+++ b/src/dev/amdgpu/pm4_packet_processor.cc
@@ -179,7 +179,7 @@ PM4PacketProcessor::decodeNext(PM4Queue *q)
          */
         PM4Header h{{{0, 0, 0, 0, 0, 0}}};
         auto cb = new DmaVirtCallback<PM4Header>(
-            [=](PM4Header header) { decodeHeader(q, header); }, h);
+            [=, this](PM4Header header) { decodeHeader(q, header); }, h);
         dmaReadVirt(getGARTAddr(q->rptr()), sizeof(uint32_t), cb,
                     &cb->dmaBuffer);
     } else {
@@ -233,7 +233,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
             DPRINTF(PM4PacketProcessor,
                     "PM4 writeData header: %x, count: %d\n", header.ordinal,
                     header.count);
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 writeData(q, (PM4WriteData *)dmaBuffer, header);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4WriteData), cb,
@@ -242,7 +242,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_MAP_QUEUES: {
             dmaBuffer = new PM4MapQueues();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 mapQueues(q, (PM4MapQueues *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapQueues), cb,
@@ -251,7 +251,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_RELEASE_MEM: {
             dmaBuffer = new PM4ReleaseMem();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 releaseMem(q, (PM4ReleaseMem *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4ReleaseMem), cb,
@@ -260,7 +260,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_INDIRECT_BUFFER: {
             dmaBuffer = new PM4IndirectBuf();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 indirectBuffer(q, (PM4IndirectBuf *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4IndirectBuf), cb,
@@ -269,7 +269,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_SWITCH_BUFFER: {
             dmaBuffer = new PM4SwitchBuf();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 switchBuffer(q, (PM4SwitchBuf *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4SwitchBuf), cb,
@@ -278,7 +278,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_SET_UCONFIG_REG: {
             dmaBuffer = new PM4SetUconfigReg();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 setUconfigReg(q, (PM4SetUconfigReg *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4SetUconfigReg), cb,
@@ -287,7 +287,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_WAIT_REG_MEM: {
             dmaBuffer = new PM4WaitRegMem();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 waitRegMem(q, (PM4WaitRegMem *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4WaitRegMem), cb,
@@ -298,16 +298,18 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
                 gpuDevice->getGfxVersion() == GfxVersion::gfx942 ||
                 gpuDevice->getGfxVersion() == GfxVersion::gfx950) {
                 dmaBuffer = new PM4MapProcessV2();
-                cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
-                    mapProcessV2(q, (PM4MapProcessV2 *)dmaBuffer);
-                });
+                cb =
+                    new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+                        mapProcessV2(q, (PM4MapProcessV2 *)dmaBuffer);
+                    });
                 dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcessV2),
                             cb, dmaBuffer);
             } else {
                 dmaBuffer = new PM4MapProcess();
-                cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
-                    mapProcessV1(q, (PM4MapProcess *)dmaBuffer);
-                });
+                cb =
+                    new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+                        mapProcessV1(q, (PM4MapProcess *)dmaBuffer);
+                    });
                 dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4MapProcess), cb,
                             dmaBuffer);
             }
@@ -315,7 +317,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_UNMAP_QUEUES: {
             dmaBuffer = new PM4UnmapQueues();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 unmapQueues(q, (PM4UnmapQueues *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4UnmapQueues), cb,
@@ -324,7 +326,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_RUN_LIST: {
             dmaBuffer = new PM4RunList();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 runList(q, (PM4RunList *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4RunList), cb,
@@ -333,7 +335,7 @@ PM4PacketProcessor::decodeHeader(PM4Queue *q, PM4Header header)
 
         case IT_QUERY_STATUS: {
             dmaBuffer = new PM4QueryStatus();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 queryStatus(q, (PM4QueryStatus *)dmaBuffer);
             });
             dmaReadVirt(getGARTAddr(q->rptr()), sizeof(PM4QueryStatus), cb,
@@ -380,7 +382,7 @@ PM4PacketProcessor::writeData(PM4Queue *q, PM4WriteData *pkt, PM4Header header)
 
         DPRINTF(PM4PacketProcessor, "Writing %d bytes to %p\n", size, addr);
         auto cb = new DmaVirtCallback<uint32_t>(
-            [=](const uint32_t &) { writeDataDone(q, pkt, addr); });
+            [=, this](const uint32_t &) { writeDataDone(q, pkt, addr); });
         dmaWriteVirt(addr, size, cb, &pkt->data);
 
         if (!pkt->writeConfirm) {
@@ -445,7 +447,7 @@ PM4PacketProcessor::mapQueues(PM4Queue *q, PM4MapQueues *pkt)
 
         QueueDesc *mqd = new QueueDesc();
         memset(mqd, 0, sizeof(QueueDesc));
-        auto cb = new DmaVirtCallback<uint32_t>([=](const uint32_t &) {
+        auto cb = new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {
             processMQD(pkt, q, addr, mqd, gpuDevice->lastVMID());
         });
         dmaReadVirt(addr, sizeof(QueueDesc), cb, mqd);
@@ -456,7 +458,7 @@ PM4PacketProcessor::mapQueues(PM4Queue *q, PM4MapQueues *pkt)
         // For SDMA we read the full MQD, so there is no offset calculation.
         Addr addr = getGARTAddr(pkt->mqdAddr);
 
-        auto cb = new DmaVirtCallback<uint32_t>([=](const uint32_t &) {
+        auto cb = new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {
             processSDMAMQD(pkt, q, addr, sdmaMQD, gpuDevice->lastVMID());
         });
         dmaReadVirt(addr, sizeof(SDMAQueueDesc), cb, sdmaMQD);
@@ -562,7 +564,7 @@ PM4PacketProcessor::releaseMem(PM4Queue *q, PM4ReleaseMem *pkt)
 
     if (pkt->dataSelect == 1) {
         auto cb = new DmaVirtCallback<uint32_t>(
-            [=](const uint32_t &) { releaseMemDone(q, pkt, addr); },
+            [=, this](const uint32_t &) { releaseMemDone(q, pkt, addr); },
             pkt->dataLo);
         dmaWriteVirt(addr, sizeof(uint32_t), cb, &cb->dmaBuffer);
     } else {
@@ -633,7 +635,7 @@ PM4PacketProcessor::unmapAllQueues(bool unmap_static)
                 getGARTAddr(queues[id]->mqdBase() + 96 * sizeof(uint32_t));
             Addr mqd_base = queues[id]->mqdBase();
             auto cb = new DmaVirtCallback<uint32_t>(
-                [=](const uint32_t &) { doneMQDWrite(mqd_base, addr); });
+                [=, this](const uint32_t &) { doneMQDWrite(mqd_base, addr); });
             mqd->base >>= 8;
             dmaWriteVirt(addr, sizeof(QueueDesc), cb, mqd);
             queues.erase(id);
@@ -871,7 +873,8 @@ PM4PacketProcessor::queryStatus(PM4Queue *q, PM4QueryStatus *pkt)
         Addr addr = getGARTAddr(pkt->addr);
         DPRINTF(PM4PacketProcessor, "Using GART addr %lx\n", addr);
         auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint64_t &) { queryStatusDone(q, pkt); }, pkt->data);
+            [=, this](const uint64_t &) { queryStatusDone(q, pkt); },
+            pkt->data);
         dmaWriteVirt(addr, sizeof(uint64_t), cb, &cb->dmaBuffer);
     } else {
         // No other combinations used in amdkfd v9

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -252,7 +252,8 @@ SDMAEngine::unregisterRLCQueue(Addr doorbell, bool unmap_static)
             mqd->rptr = rlc0.globalRptr();
             mqd->wptr = rlc0.getWptr();
 
-            auto cb = new DmaVirtCallback<uint32_t>([=](const uint32_t &) {});
+            auto cb =
+                new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {});
             dmaWriteVirt(rlc0.getMQDAddr(), sizeof(SDMAQueueDesc), cb, mqd);
         } else {
             warn("RLC0 SDMAMQD address invalid\n");
@@ -273,7 +274,8 @@ SDMAEngine::unregisterRLCQueue(Addr doorbell, bool unmap_static)
             mqd->rptr = rlc1.globalRptr();
             mqd->wptr = rlc1.getWptr();
 
-            auto cb = new DmaVirtCallback<uint32_t>([=](const uint32_t &) {});
+            auto cb =
+                new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {});
             dmaWriteVirt(rlc1.getMQDAddr(), sizeof(SDMAQueueDesc), cb, mqd);
         } else {
             warn("RLC1 SDMAMQD address invalid\n");
@@ -372,7 +374,7 @@ SDMAEngine::decodeNext(SDMAQueue *q)
         // The dmaBuffer member of the DmaVirtCallback is passed to the lambda
         // function as header in this case.
         auto cb = new DmaVirtCallback<uint32_t>(
-            [=](const uint32_t &header) { decodeHeader(q, header); });
+            [=, this](const uint32_t &header) { decodeHeader(q, header); });
         dmaReadVirt(q->rptr(), sizeof(uint32_t), cb, &cb->dmaBuffer,
                     sdma_delay);
     } else {
@@ -383,8 +385,8 @@ SDMAEngine::decodeNext(SDMAQueue *q)
         DPRINTF(SDMAEngine, "Writing rptr %#lx back to host addr %#lx\n",
                 q->globalRptr(), q->rptrWbAddr());
         if (q->rptrWbAddr()) {
-            auto cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {},
-                                                    q->globalRptr());
+            auto cb = new DmaVirtCallback<uint64_t>(
+                [=, this](const uint64_t &) {}, q->globalRptr());
             dmaWriteVirt(q->rptrWbAddr(), sizeof(Addr), cb, &cb->dmaBuffer);
         }
         q->processing(false);
@@ -434,9 +436,10 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
             switch (sub_opcode) {
                 case SDMA_SUBOP_COPY_LINEAR: {
                     dmaBuffer = new sdmaCopy();
-                    cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
-                        copy(q, (sdmaCopy *)dmaBuffer);
-                    });
+                    cb = new DmaVirtCallback<uint64_t>(
+                        [=, this](const uint64_t &) {
+                            copy(q, (sdmaCopy *)dmaBuffer);
+                        });
                     dmaReadVirt(q->rptr(), sizeof(sdmaCopy), cb, dmaBuffer,
                                 sdma_delay);
                 } break;
@@ -471,9 +474,10 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
             switch (sub_opcode) {
                 case SDMA_SUBOP_WRITE_LINEAR: {
                     dmaBuffer = new sdmaWrite();
-                    cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
-                        write(q, (sdmaWrite *)dmaBuffer);
-                    });
+                    cb = new DmaVirtCallback<uint64_t>(
+                        [=, this](const uint64_t &) {
+                            write(q, (sdmaWrite *)dmaBuffer);
+                        });
                     dmaReadVirt(q->rptr(), sizeof(sdmaWrite), cb, dmaBuffer,
                                 sdma_delay);
                 } break;
@@ -487,7 +491,7 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         case SDMA_OP_INDIRECT: {
             DPRINTF(SDMAEngine, "SDMA IndirectBuffer packet\n");
             dmaBuffer = new sdmaIndirectBuffer();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 indirectBuffer(q, (sdmaIndirectBuffer *)dmaBuffer, header);
             });
             dmaReadVirt(q->rptr(), sizeof(sdmaIndirectBuffer), cb, dmaBuffer,
@@ -496,16 +500,18 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         case SDMA_OP_FENCE: {
             DPRINTF(SDMAEngine, "SDMA Fence packet\n");
             dmaBuffer = new sdmaFence();
-            cb = new DmaVirtCallback<uint64_t>(
-                [=](const uint64_t &) { fence(q, (sdmaFence *)dmaBuffer); });
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+                fence(q, (sdmaFence *)dmaBuffer);
+            });
             dmaReadVirt(q->rptr(), sizeof(sdmaFence), cb, dmaBuffer,
                         sdma_delay);
         } break;
         case SDMA_OP_TRAP: {
             DPRINTF(SDMAEngine, "SDMA Trap packet\n");
             dmaBuffer = new sdmaTrap();
-            cb = new DmaVirtCallback<uint64_t>(
-                [=](const uint64_t &) { trap(q, (sdmaTrap *)dmaBuffer); });
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+                trap(q, (sdmaTrap *)dmaBuffer);
+            });
             dmaReadVirt(q->rptr(), sizeof(sdmaTrap), cb, dmaBuffer,
                         sdma_delay);
         } break;
@@ -517,7 +523,7 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         case SDMA_OP_POLL_REGMEM: {
             DPRINTF(SDMAEngine, "SDMA PollRegMem packet\n");
             dmaBuffer = new sdmaPollRegMem();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 pollRegMem(q, header, (sdmaPollRegMem *)dmaBuffer);
             });
             dmaReadVirt(q->rptr(), sizeof(sdmaPollRegMem), cb, dmaBuffer,
@@ -544,7 +550,7 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         case SDMA_OP_ATOMIC: {
             DPRINTF(SDMAEngine, "SDMA Atomic packet\n");
             dmaBuffer = new sdmaAtomic();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 atomic(q, header, (sdmaAtomic *)dmaBuffer);
             });
             dmaReadVirt(q->rptr(), sizeof(sdmaAtomic), cb, dmaBuffer,
@@ -553,7 +559,7 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         case SDMA_OP_CONST_FILL: {
             DPRINTF(SDMAEngine, "SDMA Constant fill packet\n");
             dmaBuffer = new sdmaConstFill();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 constFill(q, (sdmaConstFill *)dmaBuffer, header);
             });
             dmaReadVirt(q->rptr(), sizeof(sdmaConstFill), cb, dmaBuffer,
@@ -565,9 +571,10 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
                 case SDMA_SUBOP_PTEPDE_GEN:
                     DPRINTF(SDMAEngine, "SDMA PTEPDE_GEN sub-opcode\n");
                     dmaBuffer = new sdmaPtePde();
-                    cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
-                        ptePde(q, (sdmaPtePde *)dmaBuffer);
-                    });
+                    cb = new DmaVirtCallback<uint64_t>(
+                        [=, this](const uint64_t &) {
+                            ptePde(q, (sdmaPtePde *)dmaBuffer);
+                        });
                     dmaReadVirt(q->rptr(), sizeof(sdmaPtePde), cb, dmaBuffer,
                                 sdma_delay);
                     break;
@@ -605,7 +612,7 @@ SDMAEngine::decodeHeader(SDMAQueue *q, uint32_t header)
         case SDMA_OP_SRBM_WRITE: {
             DPRINTF(SDMAEngine, "SDMA SRBMWrite packet\n");
             dmaBuffer = new sdmaSRBMWrite();
-            cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+            cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
                 srbmWrite(q, header, (sdmaSRBMWrite *)dmaBuffer);
             });
             dmaReadVirt(q->rptr(), sizeof(sdmaSRBMWrite), cb, dmaBuffer,
@@ -639,7 +646,7 @@ SDMAEngine::write(SDMAQueue *q, sdmaWrite *pkt)
     // first we have to read needed data from the SDMA queue
     uint32_t *dmaBuffer = new uint32_t[pkt->count];
     auto cb = new DmaVirtCallback<uint64_t>(
-        [=](const uint64_t &) { writeReadData(q, pkt, dmaBuffer); });
+        [=, this](const uint64_t &) { writeReadData(q, pkt, dmaBuffer); });
     dmaReadVirt(q->rptr(), sizeof(uint32_t) * pkt->count, cb,
                 (void *)dmaBuffer, sdma_delay);
 }
@@ -664,7 +671,7 @@ SDMAEngine::writeReadData(SDMAQueue *q, sdmaWrite *pkt, uint32_t *dmaBuffer)
                  "SDMA write to GART not implemented");
 
         auto cb = new EventFunctionWrapper(
-            [=] { writeDone(q, pkt, dmaBuffer); }, name());
+            [=, this] { writeDone(q, pkt, dmaBuffer); }, name());
         gpuDevice->getMemMgr()->writeRequest(mmhub_addr, (uint8_t *)dmaBuffer,
                                              bufferSize, 0, cb);
     } else {
@@ -672,7 +679,7 @@ SDMAEngine::writeReadData(SDMAQueue *q, sdmaWrite *pkt, uint32_t *dmaBuffer)
             pkt->dest = getGARTAddr(pkt->dest);
         }
         auto cb = new DmaVirtCallback<uint32_t>(
-            [=](const uint64_t &) { writeDone(q, pkt, dmaBuffer); });
+            [=, this](const uint64_t &) { writeDone(q, pkt, dmaBuffer); });
         dmaWriteVirt(pkt->dest, bufferSize, cb, (void *)dmaBuffer);
     }
 }
@@ -684,8 +691,8 @@ SDMAEngine::writeDone(SDMAQueue *q, sdmaWrite *pkt, uint32_t *dmaBuffer)
     DPRINTF(SDMAEngine, "Write packet completed to %p, %d dwords\n", pkt->dest,
             pkt->count);
 
-    auto cleanup_cb =
-        new EventFunctionWrapper([=] { writeCleanup(dmaBuffer); }, name());
+    auto cleanup_cb = new EventFunctionWrapper(
+        [=, this] { writeCleanup(dmaBuffer); }, name());
 
     auto system_ptr = gpuDevice->CP()->system();
     if (!system_ptr->isAtomicMode()) {
@@ -730,7 +737,7 @@ SDMAEngine::copy(SDMAQueue *q, sdmaCopy *pkt)
     if (device_addr) {
         DPRINTF(SDMAEngine, "Copying from device address %#lx\n", device_addr);
         auto cb = new EventFunctionWrapper(
-            [=] { copyReadData(q, pkt, dmaBuffer); }, name());
+            [=, this] { copyReadData(q, pkt, dmaBuffer); }, name());
 
         // Copy the minimum page size at a time in case the physical addresses
         // are not contiguous.
@@ -750,7 +757,7 @@ SDMAEngine::copy(SDMAQueue *q, sdmaCopy *pkt)
         }
     } else {
         auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint64_t &) { copyReadData(q, pkt, dmaBuffer); });
+            [=, this](const uint64_t &) { copyReadData(q, pkt, dmaBuffer); });
         dmaReadVirt(pkt->source, pkt->count, cb, (void *)dmaBuffer,
                     sdma_delay);
     }
@@ -777,7 +784,7 @@ SDMAEngine::copyReadData(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer)
     if (device_addr) {
         DPRINTF(SDMAEngine, "Copying to device address %#lx\n", device_addr);
         auto cb = new EventFunctionWrapper(
-            [=] { copyDone(q, pkt, dmaBuffer); }, name());
+            [=, this] { copyDone(q, pkt, dmaBuffer); }, name());
 
         // Copy the minimum page size at a time in case the physical addresses
         // are not contiguous.
@@ -799,7 +806,7 @@ SDMAEngine::copyReadData(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer)
     } else {
         DPRINTF(SDMAEngine, "Copying to host address %#lx\n", pkt->dest);
         auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint64_t &) { copyDone(q, pkt, dmaBuffer); });
+            [=, this](const uint64_t &) { copyDone(q, pkt, dmaBuffer); });
         dmaWriteVirt(pkt->dest, pkt->count, cb, (void *)dmaBuffer);
     }
 
@@ -825,8 +832,8 @@ SDMAEngine::copyDone(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer)
     DPRINTF(SDMAEngine, "Copy completed to %p, %d dwords\n", pkt->dest,
             pkt->count);
 
-    auto cleanup_cb =
-        new EventFunctionWrapper([=] { copyCleanup(dmaBuffer); }, name());
+    auto cleanup_cb = new EventFunctionWrapper(
+        [=, this] { copyCleanup(dmaBuffer); }, name());
 
     auto system_ptr = gpuDevice->CP()->system();
     if (!system_ptr->isAtomicMode()) {
@@ -879,7 +886,7 @@ SDMAEngine::fence(SDMAQueue *q, sdmaFence *pkt)
 
     // Writing the data from the fence packet to the destination address.
     auto cb = new DmaVirtCallback<uint32_t>(
-        [=](const uint32_t &) { fenceDone(q, pkt); }, pkt->data);
+        [=, this](const uint32_t &) { fenceDone(q, pkt); }, pkt->data);
     dmaWriteVirt(pkt->dest, sizeof(pkt->data), cb, &cb->dmaBuffer);
 }
 
@@ -995,8 +1002,8 @@ SDMAEngine::pollRegMem(SDMAQueue *q, uint32_t header, sdmaPollRegMem *pkt)
     if (prm_header.mode == 1) {
         // polling on a memory location
         if (prm_header.op == 0) {
-            auto cb =
-                new DmaVirtCallback<uint32_t>([=](const uint32_t &dma_buffer) {
+            auto cb = new DmaVirtCallback<uint32_t>(
+                [=, this](const uint32_t &dma_buffer) {
                     pollRegMemRead(q, header, pkt, dma_buffer, 0);
                 });
             dmaReadVirt(pkt->address, sizeof(uint32_t), cb,
@@ -1035,8 +1042,8 @@ SDMAEngine::pollRegMemRead(SDMAQueue *q, uint32_t header, sdmaPollRegMem *pkt,
         DPRINTF(SDMAEngine, "SDMA polling mem addr %p, val %d ref %d.\n",
                 pkt->address, dma_buffer, pkt->ref);
 
-        auto cb =
-            new DmaVirtCallback<uint32_t>([=](const uint32_t &dma_buffer) {
+        auto cb = new DmaVirtCallback<uint32_t>(
+            [=, this](const uint32_t &dma_buffer) {
                 pollRegMemRead(q, header, pkt, dma_buffer, count + 1);
             });
         dmaReadVirt(pkt->address, sizeof(uint32_t), cb, (void *)&cb->dmaBuffer,
@@ -1106,7 +1113,7 @@ SDMAEngine::ptePde(SDMAQueue *q, sdmaPtePde *pkt)
                  "SDMA write to GART not implemented");
 
         auto cb = new EventFunctionWrapper(
-            [=] { ptePdeDone(q, pkt, dmaBuffer); }, name());
+            [=, this] { ptePdeDone(q, pkt, dmaBuffer); }, name());
         gpuDevice->getMemMgr()->writeRequest(mmhub_addr, (uint8_t *)dmaBuffer,
                                              sizeof(uint64_t) * pkt->count, 0,
                                              cb);
@@ -1115,7 +1122,7 @@ SDMAEngine::ptePde(SDMAQueue *q, sdmaPtePde *pkt)
             pkt->dest = getGARTAddr(pkt->dest);
         }
         auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint64_t &) { ptePdeDone(q, pkt, dmaBuffer); });
+            [=, this](const uint64_t &) { ptePdeDone(q, pkt, dmaBuffer); });
         dmaWriteVirt(pkt->dest, sizeof(uint64_t) * pkt->count, cb,
                      (void *)dmaBuffer);
     }
@@ -1128,8 +1135,8 @@ SDMAEngine::ptePdeDone(SDMAQueue *q, sdmaPtePde *pkt, uint64_t *dmaBuffer)
     DPRINTF(SDMAEngine, "PtePde packet completed to %p, %d 2dwords\n",
             pkt->dest, pkt->count);
 
-    auto cleanup_cb =
-        new EventFunctionWrapper([=] { ptePdeCleanup(dmaBuffer); }, name());
+    auto cleanup_cb = new EventFunctionWrapper(
+        [=, this] { ptePdeCleanup(dmaBuffer); }, name());
 
     auto system_ptr = gpuDevice->CP()->system();
     if (!system_ptr->isAtomicMode()) {
@@ -1166,8 +1173,9 @@ SDMAEngine::atomic(SDMAQueue *q, uint32_t header, sdmaAtomic *pkt)
 
     // Read the data at pkt->addr
     uint64_t *dmaBuffer = new uint64_t;
-    auto cb = new DmaVirtCallback<uint64_t>(
-        [=](const uint64_t &) { atomicData(q, header, pkt, dmaBuffer); });
+    auto cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+        atomicData(q, header, pkt, dmaBuffer);
+    });
     dmaReadVirt(pkt->addr, sizeof(uint64_t), cb, (void *)dmaBuffer,
                 sdma_delay);
 }
@@ -1193,8 +1201,9 @@ SDMAEngine::atomicData(SDMAQueue *q, uint32_t header, sdmaAtomic *pkt,
         // Reuse the dmaBuffer allocated
         *dmaBuffer = dst_data + src_data;
 
-        auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint64_t &) { atomicDone(q, header, pkt, dmaBuffer); });
+        auto cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+            atomicDone(q, header, pkt, dmaBuffer);
+        });
         dmaWriteVirt(pkt->addr, sizeof(uint64_t), cb, (void *)dmaBuffer);
     } else {
         panic("Unsupported SDMA atomic opcode: %d\n", at_header.opcode);
@@ -1240,7 +1249,7 @@ SDMAEngine::constFill(SDMAQueue *q, sdmaConstFill *pkt, uint32_t header)
                 fill_bytes, pkt->srcData, pkt->addr);
 
         auto cb = new EventFunctionWrapper(
-            [=] { constFillDone(q, pkt, fill_data); }, name());
+            [=, this] { constFillDone(q, pkt, fill_data); }, name());
 
         // Copy the minimum page size at a time in case the physical addresses
         // are not contiguous.
@@ -1263,7 +1272,7 @@ SDMAEngine::constFill(SDMAQueue *q, sdmaConstFill *pkt, uint32_t header)
                 fill_bytes, pkt->srcData, pkt->addr);
 
         auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint64_t &) { constFillDone(q, pkt, fill_data); });
+            [=, this](const uint64_t &) { constFillDone(q, pkt, fill_data); });
         dmaWriteVirt(pkt->addr, fill_bytes, cb, (void *)fill_data);
     }
 }

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -252,8 +252,7 @@ SDMAEngine::unregisterRLCQueue(Addr doorbell, bool unmap_static)
             mqd->rptr = rlc0.globalRptr();
             mqd->wptr = rlc0.getWptr();
 
-            auto cb =
-                new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {});
+            auto cb = new DmaVirtCallback<uint32_t>([](const uint32_t &) {});
             dmaWriteVirt(rlc0.getMQDAddr(), sizeof(SDMAQueueDesc), cb, mqd);
         } else {
             warn("RLC0 SDMAMQD address invalid\n");
@@ -274,8 +273,7 @@ SDMAEngine::unregisterRLCQueue(Addr doorbell, bool unmap_static)
             mqd->rptr = rlc1.globalRptr();
             mqd->wptr = rlc1.getWptr();
 
-            auto cb =
-                new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {});
+            auto cb = new DmaVirtCallback<uint32_t>([](const uint32_t &) {});
             dmaWriteVirt(rlc1.getMQDAddr(), sizeof(SDMAQueueDesc), cb, mqd);
         } else {
             warn("RLC1 SDMAMQD address invalid\n");
@@ -385,8 +383,8 @@ SDMAEngine::decodeNext(SDMAQueue *q)
         DPRINTF(SDMAEngine, "Writing rptr %#lx back to host addr %#lx\n",
                 q->globalRptr(), q->rptrWbAddr());
         if (q->rptrWbAddr()) {
-            auto cb = new DmaVirtCallback<uint64_t>(
-                [=, this](const uint64_t &) {}, q->globalRptr());
+            auto cb = new DmaVirtCallback<uint64_t>([](const uint64_t &) {},
+                                                    q->globalRptr());
             dmaWriteVirt(q->rptrWbAddr(), sizeof(Addr), cb, &cb->dmaBuffer);
         }
         q->processing(false);

--- a/src/dev/hsa/hsa_packet_processor.cc
+++ b/src/dev/hsa/hsa_packet_processor.cc
@@ -210,7 +210,8 @@ HSAPacketProcessor::updateReadIndex(int pid, uint32_t rl_idx)
     AQLRingBuffer *aqlbuf = regdQList[rl_idx]->qCntxt.aqlBuf;
     HSAQueueDescriptor *qDesc = regdQList[rl_idx]->qCntxt.qDesc;
     auto cb = new DmaVirtCallback<uint64_t>(
-        [=](const uint32_t &dma_data) { this->updateReadDispIdDma(); }, 0);
+        [=, this](const uint32_t &dma_data) { this->updateReadDispIdDma(); },
+        0);
 
     DPRINTF(HSAPacketProcessor, "%s: read-pointer offset [0x%x]\n",
             __FUNCTION__, aqlbuf->rdIdx());
@@ -572,7 +573,7 @@ HSAPacketProcessor::getCommandsFromHost(int pid, uint32_t rl_idx)
 
         void *aql_buf = aqlRingBuffer->ptr(dma_start_ix);
         auto cb = new DmaVirtCallback<uint64_t>(
-            [=](const uint32_t &dma_data) {
+            [=, this](const uint32_t &dma_data) {
                 this->cmdQueueCmdDma(this, pid, true, dma_start_ix, num_2_xfer,
                                      series_ctx, aql_buf);
             },

--- a/src/dev/lupio/lupio_tmr.cc
+++ b/src/dev/lupio/lupio_tmr.cc
@@ -54,10 +54,7 @@ LupioTMR::LupioTMR(const Params &params) :
 
     for (int cpu = 0; cpu < nThread; cpu++) {
         timers[cpu].tmrEvent = new EventFunctionWrapper(
-            [=]{
-                lupioTMRCallback(cpu);
-            }, name()+"done"
-        );
+            [=, this] { lupioTMRCallback(cpu); }, name() + "done");
     }
 
     DPRINTF(LupioTMR, "LupioTMR initalized\n");

--- a/src/gpu-compute/gpu_command_processor.cc
+++ b/src/gpu-compute/gpu_command_processor.cc
@@ -259,7 +259,7 @@ GPUCommandProcessor::submitDispatchPkt(void *raw_pkt, uint32_t queue_id,
                     "sending system DMA read for kernel_object\n");
 
             auto dma_callback =
-                new DmaVirtCallback<uint32_t>([=](const uint32_t &) {
+                new DmaVirtCallback<uint32_t>([=, this](const uint32_t &) {
                     dispatchKernelObject(akc, raw_pkt, queue_id,
                                          host_pkt_addr);
                 });
@@ -461,7 +461,7 @@ GPUCommandProcessor::updateHsaSignalAsync(Addr signal_handle, int64_t diff)
 {
     Addr mailbox_addr = getHsaSignalMailboxAddr(signal_handle);
     uint64_t *mailboxValue = new uint64_t;
-    auto cb2 = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+    auto cb2 = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
         updateHsaMailboxData(signal_handle, mailboxValue);
     });
     dmaReadVirt(mailbox_addr, sizeof(uint64_t), cb2, (void *)mailboxValue);
@@ -480,7 +480,7 @@ GPUCommandProcessor::updateHsaMailboxData(Addr signal_handle,
         // This is an interruptible signal. Now, read the
         // event ID and directly communicate with the driver
         // about that event notification.
-        auto cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+        auto cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
             updateHsaEventData(signal_handle, mailbox_value);
         });
         dmaReadVirt(event_addr, sizeof(uint64_t), cb, (void *)mailbox_value);
@@ -492,7 +492,7 @@ GPUCommandProcessor::updateHsaMailboxData(Addr signal_handle,
         amd_event_t *event_ts = new amd_event_t;
         event_ts->start_ts = dispatchStartTime[signal_handle];
         event_ts->end_ts = curTick() / sim_clock::as_int::ns;
-        auto cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+        auto cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
             updateHsaEventTs(signal_handle, event_ts);
         });
         dmaWriteVirt(ts_addr, sizeof(amd_event_t), cb, (void *)event_ts);
@@ -514,7 +514,7 @@ GPUCommandProcessor::updateHsaEventData(Addr signal_handle,
     DPRINTF(GPUCommandProc, "updateHsaEventData read %ld\n", *event_value);
     // Write *event_value to the mailbox to clear the event
     auto cb = new DmaVirtCallback<uint64_t>(
-        [=](const uint64_t &) { updateHsaSignalDone(event_value); },
+        [=, this](const uint64_t &) { updateHsaSignalDone(event_value); },
         *event_value);
     dmaWriteVirt(mailbox_addr, sizeof(uint64_t), cb, &cb->dmaBuffer, 0);
 
@@ -523,8 +523,9 @@ GPUCommandProcessor::updateHsaEventData(Addr signal_handle,
     amd_event_t *event_ts = new amd_event_t;
     event_ts->start_ts = dispatchStartTime[signal_handle];
     event_ts->end_ts = curTick() / sim_clock::as_int::ns;
-    auto cb2 = new DmaVirtCallback<uint64_t>(
-        [=](const uint64_t &) { updateHsaEventTs(signal_handle, event_ts); });
+    auto cb2 = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
+        updateHsaEventTs(signal_handle, event_ts);
+    });
     dmaWriteVirt(ts_addr, sizeof(amd_event_t), cb2, (void *)event_ts);
     DPRINTF(GPUCommandProc, "updateHsaEventData reading timestamp addr %lx\n",
             ts_addr);
@@ -541,7 +542,7 @@ GPUCommandProcessor::updateHsaEventTs(Addr signal_handle, amd_event_t *ts)
     int64_t diff = -1;
 
     uint64_t *signalValue = new uint64_t;
-    auto cb = new DmaVirtCallback<uint64_t>([=](const uint64_t &) {
+    auto cb = new DmaVirtCallback<uint64_t>([=, this](const uint64_t &) {
         updateHsaSignalData(value_addr, diff, signalValue);
     });
     dmaReadVirt(value_addr, sizeof(uint64_t), cb, (void *)signalValue);
@@ -558,7 +559,7 @@ GPUCommandProcessor::updateHsaSignalData(Addr value_addr, int64_t diff,
             *prev_value, *prev_value + diff);
     *prev_value += diff;
     auto cb = new DmaVirtCallback<uint64_t>(
-        [=](const uint64_t &) { updateHsaSignalDone(prev_value); });
+        [=, this](const uint64_t &) { updateHsaSignalDone(prev_value); });
     dmaWriteVirt(value_addr, sizeof(uint64_t), cb, (void *)prev_value);
 }
 
@@ -791,7 +792,7 @@ GPUCommandProcessor::readPreload(AMDKernelCode *akc, HSAQueueEntry *task)
         warn("Preload kernarg from host untested!\n");
 
         auto cb = new DmaVirtCallback<uint32_t>(
-            [=](const uint32_t &) { initPreload(akc, task); });
+            [=, this](const uint32_t &) { initPreload(akc, task); });
 
         dmaReadVirt(preload_addr,
                     sizeof(uint32_t) * akc->kernarg_preload_spec_length, cb,
@@ -860,7 +861,7 @@ void
 GPUCommandProcessor::initABI(HSAQueueEntry *task)
 {
     auto cb = new DmaVirtCallback<uint32_t>(
-        [=](const uint32_t &readDispIdOffset) {
+        [=, this](const uint32_t &readDispIdOffset) {
             ReadDispIdOffsetDmaEvent(task, readDispIdOffset);
         },
         0);

--- a/src/gpu-compute/gpu_command_processor.hh
+++ b/src/gpu-compute/gpu_command_processor.hh
@@ -222,8 +222,8 @@ class GPUCommandProcessor : public DmaVirtDevice
          * DMA a copy of the MQD into the task. some fields of
          * the MQD will be used to initialize register state in VI
          */
-        auto *mqdDmaEvent =
-            new DmaVirtCallback<int>([=](const int &) { MQDDmaEvent(task); });
+        auto *mqdDmaEvent = new DmaVirtCallback<int>(
+            [=, this](const int &) { MQDDmaEvent(task); });
 
         dmaReadVirt(task->hostAMDQueueAddr, sizeof(_amd_queue_t), mqdDmaEvent,
                     &task->amdQueue);
@@ -274,7 +274,7 @@ class GPUCommandProcessor : public DmaVirtDevice
                     task->privMemPerItem());
 
             updateHsaSignal(task->amdQueue.queue_inactive_signal.handle, 1,
-                            [=](const uint64_t &dma_buffer) {
+                            [=, this](const uint64_t &dma_buffer) {
                                 WaitScratchDmaEvent(task, dma_buffer);
                             });
 
@@ -308,7 +308,7 @@ class GPUCommandProcessor : public DmaVirtDevice
              * since other MQD entries won't change since we last read them.
              */
             auto cb = new DmaVirtCallback<int>(
-                [=](const int &) { MQDDmaEvent(task); });
+                [=, this](const int &) { MQDDmaEvent(task); });
 
             dmaReadVirt(task->hostAMDQueueAddr, sizeof(_amd_queue_t), cb,
                         &task->amdQueue);
@@ -323,8 +323,8 @@ class GPUCommandProcessor : public DmaVirtDevice
                     "Polling queue inactive signal at "
                     "%p.\n",
                     value_addr);
-            auto cb =
-                new DmaVirtCallback<uint64_t>([=](const uint64_t &dma_buffer) {
+            auto cb = new DmaVirtCallback<uint64_t>(
+                [=, this](const uint64_t &dma_buffer) {
                     WaitScratchDmaEvent(task, dma_buffer);
                 });
 


### PR DESCRIPTION
After C++20 change, capturing 'this' implicitly via '[=]' is deprecated. Added explicit 'this' to lambda capture lists to fix the resulting - Wdeprecated warnings.