### PR TITLE
stdlib: add default values for cbusy in DMARequestor

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/nodes/dma_requestor.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/dma_requestor.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects import (
+    CBusyTracker,
     ClockDomain,
     RubyCache,
 )
@@ -77,3 +78,6 @@ class DMARequestor(AbstractNode):
         self.number_of_DVM_TBEs = 1  # should not receive any dvm
         self.number_of_DVM_snoop_TBEs = 1  # should not receive any dvm
         self.unify_repl_TBEs = False
+
+        self.cbusy_generator = NULL
+        self.cbusy_tracker = CBusyTracker()


### PR DESCRIPTION
This commit adds default values for `cbusy_generator` and `cbusy_tracker` in DMARequestor. This fixes a test failure in the daily Arm boot tests. Specifically, the test `timing-cpu_2-cores_chi_DualChannelDDR4_2400_arm_boot_test_m5-exit-ALL-x86_64-opt` was failing with the following message:

```
fatal: board.cache_hierarchy.dma_controllers0.cbusy_generator without default or user set value
```