### PR TITLE
cpu, cpu-o3: fix ElasticTrace probe type mismatch

### DIFF
--- a/src/cpu/o3/probe/elastic_trace.cc
+++ b/src/cpu/o3/probe/elastic_trace.cc
@@ -128,17 +128,17 @@ ElasticTrace::regEtraceListeners()
     // each probe point.
     connectListener<ProbeListenerArg<ElasticTrace, RequestPtr>>(
         this, "FetchRequest", &ElasticTrace::fetchReqTrace);
-    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstPtr>>(
         this, "Execute", &ElasticTrace::recordExecTick);
-    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstPtr>>(
         this, "ToCommit", &ElasticTrace::recordToCommTick);
-    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstPtr>>(
         this, "Rename", &ElasticTrace::updateRegDep);
     connectListener<ProbeListenerArg<ElasticTrace, SeqNumRegPair>>(
         this, "SquashInRename", &ElasticTrace::removeRegDepMapEntry);
-    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstPtr>>(
         this, "Squash", &ElasticTrace::addSquashedInst);
-    connectListener<ProbeListenerArg<ElasticTrace, DynInstConstPtr>>(
+    connectListener<ProbeListenerArg<ElasticTrace, DynInstPtr>>(
         this, "Commit", &ElasticTrace::addCommittedInst);
     allProbesReg = true;
 }
@@ -166,7 +166,7 @@ ElasticTrace::fetchReqTrace(const RequestPtr &req)
 }
 
 void
-ElasticTrace::recordExecTick(const DynInstConstPtr& dyn_inst)
+ElasticTrace::recordExecTick(const DynInstPtr &dyn_inst)
 {
 
     // In a corner case, a retired instruction is propagated backward to the
@@ -203,7 +203,7 @@ ElasticTrace::recordExecTick(const DynInstConstPtr& dyn_inst)
 }
 
 void
-ElasticTrace::recordToCommTick(const DynInstConstPtr& dyn_inst)
+ElasticTrace::recordToCommTick(const DynInstPtr &dyn_inst)
 {
     // If tracing has just been enabled then the instruction at this stage of
     // execution is far enough that we cannot gather info about its past like
@@ -224,7 +224,7 @@ ElasticTrace::recordToCommTick(const DynInstConstPtr& dyn_inst)
 }
 
 void
-ElasticTrace::updateRegDep(const DynInstConstPtr& dyn_inst)
+ElasticTrace::updateRegDep(const DynInstPtr &dyn_inst)
 {
     // Get the sequence number of the instruction
     InstSeqNum seq_num = dyn_inst->seqNum;
@@ -293,15 +293,15 @@ ElasticTrace::updateRegDep(const DynInstConstPtr& dyn_inst)
 void
 ElasticTrace::removeRegDepMapEntry(const SeqNumRegPair &inst_reg_pair)
 {
-    DPRINTFR(ElasticTrace, "Remove Map entry for Reg %i\n",
-            inst_reg_pair.second);
-    auto itr_regdep_map = physRegDepMap.find(inst_reg_pair.second);
+    RegIndex reg_idx = inst_reg_pair.second->index();
+    DPRINTFR(ElasticTrace, "Remove Map entry for Reg %i\n", reg_idx);
+    auto itr_regdep_map = physRegDepMap.find(reg_idx);
     if (itr_regdep_map != physRegDepMap.end())
         physRegDepMap.erase(itr_regdep_map);
 }
 
 void
-ElasticTrace::addSquashedInst(const DynInstConstPtr& head_inst)
+ElasticTrace::addSquashedInst(const DynInstPtr &head_inst)
 {
     // If the squashed instruction was squashed before being processed by
     // execute stage then it will not be in the temporary store. In this case
@@ -329,7 +329,7 @@ ElasticTrace::addSquashedInst(const DynInstConstPtr& head_inst)
 }
 
 void
-ElasticTrace::addCommittedInst(const DynInstConstPtr& head_inst)
+ElasticTrace::addCommittedInst(const DynInstPtr &head_inst)
 {
     DPRINTFR(ElasticTrace, "Attempt to add committed inst [sn:%lli]\n",
                 head_inst->seqNum);
@@ -388,8 +388,8 @@ ElasticTrace::addCommittedInst(const DynInstConstPtr& head_inst)
 }
 
 void
-ElasticTrace::addDepTraceRecord(const DynInstConstPtr& head_inst,
-                                InstExecInfo* exec_info_ptr, bool commit)
+ElasticTrace::addDepTraceRecord(const DynInstPtr &head_inst,
+                                InstExecInfo *exec_info_ptr, bool commit)
 {
     // Create a record to assign dynamic intruction related fields.
     TraceInfo* new_record = new TraceInfo;
@@ -650,7 +650,7 @@ ElasticTrace::hasCompCompleted(TraceInfo* past_record,
 }
 
 void
-ElasticTrace::clearTempStoreUntil(const DynInstConstPtr& head_inst)
+ElasticTrace::clearTempStoreUntil(const DynInstPtr &head_inst)
 {
     // Clear from temp store starting with the execution info object
     // corresponding the head_inst and continue clearing by decrementing the

--- a/src/cpu/o3/probe/elastic_trace.hh
+++ b/src/cpu/o3/probe/elastic_trace.hh
@@ -94,7 +94,7 @@ class ElasticTrace : public ProbeListenerObject
 {
 
   public:
-    typedef typename std::pair<InstSeqNum, RegIndex> SeqNumRegPair;
+    typedef typename std::pair<InstSeqNum, PhysRegIdPtr> SeqNumRegPair;
 
     /** Trace record types corresponding to instruction node types */
     typedef ProtoMessage::InstDepRecord::RecordType RecordType;
@@ -133,7 +133,7 @@ class ElasticTrace : public ProbeListenerObject
      *
      * @param dyn_inst pointer to dynamic instruction in flight
      */
-    void recordExecTick(const DynInstConstPtr& dyn_inst);
+    void recordExecTick(const DynInstPtr &dyn_inst);
 
     /**
      * Populate the timestamp field in an InstExecInfo object for an
@@ -142,7 +142,7 @@ class ElasticTrace : public ProbeListenerObject
      *
      * @param dyn_inst pointer to dynamic instruction in flight
      */
-    void recordToCommTick(const DynInstConstPtr& dyn_inst);
+    void recordToCommTick(const DynInstPtr &dyn_inst);
 
     /**
      * Record a Read After Write physical register dependency if there has
@@ -153,7 +153,7 @@ class ElasticTrace : public ProbeListenerObject
      *
      * @param dyn_inst pointer to dynamic instruction in flight
      */
-    void updateRegDep(const DynInstConstPtr& dyn_inst);
+    void updateRegDep(const DynInstPtr &dyn_inst);
 
     /**
      * When an instruction gets squashed the destination register mapped to it
@@ -170,14 +170,14 @@ class ElasticTrace : public ProbeListenerObject
      *
      * @param head_inst pointer to dynamic instruction to be squashed
      */
-    void addSquashedInst(const DynInstConstPtr& head_inst);
+    void addSquashedInst(const DynInstPtr &head_inst);
 
     /**
      * Add an instruction that is at the head of the ROB and is committed.
      *
      * @param head_inst pointer to dynamic instruction to be committed
      */
-    void addCommittedInst(const DynInstConstPtr& head_inst);
+    void addCommittedInst(const DynInstPtr &head_inst);
 
     /** Event to trigger registering this listener for all probe points. */
     EventFunctionWrapper regEtraceListenersEvent;
@@ -381,8 +381,8 @@ class ElasticTrace : public ProbeListenerObject
      * @param exec_info_ptr Pointer to InstExecInfo for that instruction
      * @param commit        True if instruction is committed, false if squashed
      */
-    void addDepTraceRecord(const DynInstConstPtr& head_inst,
-                           InstExecInfo* exec_info_ptr, bool commit);
+    void addDepTraceRecord(const DynInstPtr &head_inst,
+                           InstExecInfo *exec_info_ptr, bool commit);
 
     /**
      * Clear entries in the temporary store of execution info objects to free
@@ -390,7 +390,7 @@ class ElasticTrace : public ProbeListenerObject
      *
      * @param head_inst pointer to dynamic instruction
      */
-    void clearTempStoreUntil(const DynInstConstPtr& head_inst);
+    void clearTempStoreUntil(const DynInstPtr &head_inst);
 
     /**
      * Calculate the computational delay between an instruction and a


### PR DESCRIPTION
Fixes #3166 

This commit fixes a panic that occurs when using the ElasticTrace probe.
The types used at the probe points differed from the types used to register listeners in ElasticTrace.
See issue for details.
