### PR TITLE
arch-x86: Fix CVTSI2SS REX.W source width

### DIFF
--- a/src/arch/x86/isa/decoder/two_byte_opcodes.isa
+++ b/src/arch/x86/isa/decoder/two_byte_opcodes.isa
@@ -328,7 +328,7 @@
                 }
                 // repe (0xF3)
                 0x4: decode OPCODE_OP_BOTTOM3 {
-                    0x2: CVTSI2SS(Vd,Ed);
+                    0x2: CVTSI2SS(Vd,Edp);
                     0x4: CVTTSS2SI(Gd,Wd);
                     0x5: CVTSS2SI(Gd,Wd);
                     default: UD2();


### PR DESCRIPTION
## Summary

Fix the x86 decoding of `CVTSI2SS` when used with a `REX.W` prefix.

The decoder currently uses `Ed` for the source operand, which forces the source width to 32 bits even in the `REX.W` form. This causes values with bit 31 set to be interpreted as signed 32-bit integers instead of signed 64-bit integers.

Replace `Ed` with `Edp` so the source operand width follows the instruction encoding:

- no `REX.W`: `r/m32`
- with `REX.W`: `r/m64`

## Reproducer

```cpp
uint64_t a = 4018585650ull;
float f = (float)a;
printf("a=%lu f=%f\n", a, f);
```

Before:

> a=4018585650 f=-276381632.000000

After:

> a=4018585650 f=4018585600.000000