### PR TITLE
arch-arm: Fix ESR ISS2 bit offset

### DIFF
--- a/src/arch/arm/regs/misc_types.hh
+++ b/src/arch/arm/regs/misc_types.hh
@@ -807,7 +807,7 @@ namespace ArmISA
 
         // Data Abort ISS2
         SubBitUnion(data_abort_iss2, 55, 32)
-            Bitfield<5> dirtyBit;
+            Bitfield<37> dirtyBit;
         EndSubBitUnion(data_abort_iss2)
 
         Bitfield<31, 26> ec;


### PR DESCRIPTION
The dirtyBit subBitUnion field was using a relative offset instead of an absolute offset which would lead to incorrect behaviour when set.