### PR TITLE
mem-ruby: Make Payload.byte_enable accessible from python

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
@@ -83,7 +83,8 @@ tlm_chi_pybind(pybind11::module_ &m_internal)
         .def_readwrite("lpid", &Payload::lpid)
         .def_property(
             "ns", [](const Payload &p) { return p.ns; },
-            [](Payload &p, bool val) { p.ns = val; });
+            [](Payload &p, bool val) { p.ns = val; })
+        .def_readwrite("byte_enable", &Payload::byte_enable);
 
     py::class_<Phase>(tlm_chi, "TlmPhase")
         .def(py::init<>())


### PR DESCRIPTION
Change-Id: I48ccf5f69522a660c0c5d1c2a67d19b8b440aa1f