### PR TITLE
dev-virtio,configs-arm: Add 9P directory rootfs support

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -83,15 +83,46 @@ class MemBus(SystemXBar):
     default = Self.badaddr_responder.pio
 
 
-def attach_9p(parent):
+def attach_9p(parent, root=None, tag=None):
+    """Attach a VirtIO 9P device to parent.
+
+    Without a root directory, export a scratch directory under the
+    output directory through the diod server. This is the backend used
+    by --vio-9p and is always available.
+
+    With a root directory, export that host directory through the
+    npfs/ufs backend, which is only present when gem5 was built with
+    NPFS_PATH set. Unlike diod, it serializes its state into
+    checkpoints, so a 9P-mounted root filesystem survives a restore.
+
+    A tag of None leaves the device's default mount tag in place.
+    """
     viopci = PciVirtIO()
-    viopci.vio = VirtIO9PDiod()
-    viodir = os.path.realpath(os.path.join(m5.options.outdir, "9p"))
-    viopci.vio.root = os.path.join(viodir, "share")
-    viopci.vio.socketPath = os.path.join(viodir, "socket")
-    os.makedirs(viopci.vio.root, exist_ok=True)
-    if os.path.exists(viopci.vio.socketPath):
-        os.remove(viopci.vio.socketPath)
+
+    if root is None:
+        viodir = os.path.realpath(os.path.join(m5.options.outdir, "9p"))
+        viopci.vio = VirtIO9PDiod()
+        viopci.vio.root = os.path.join(viodir, "share")
+        viopci.vio.socketPath = os.path.join(viodir, "socket")
+        os.makedirs(viopci.vio.root, exist_ok=True)
+        if os.path.exists(viopci.vio.socketPath):
+            os.remove(viopci.vio.socketPath)
+    else:
+        # VirtIO9PUfs is only registered as a SimObject in npfs-enabled
+        # builds, so this check has to precede the first reference to it.
+        if not m5.defines.buildEnv.get("BUILD_9PUFS", False):
+            fatal(
+                "Exporting a host directory through VirtIO 9P requires the "
+                "npfs-backed device, which is not available in this gem5 "
+                "binary. Rebuild gem5 with NPFS_PATH set to the npfs source "
+                "directory."
+            )
+        viopci.vio = VirtIO9PUfs()
+        viopci.vio.root = os.path.realpath(root)
+
+    if tag is not None:
+        viopci.vio.tag = tag
+
     parent.viopci = viopci
     parent.attachPciDevice(viopci)
 

--- a/configs/example/arm/fs_bigLITTLE.py
+++ b/configs/example/arm/fs_bigLITTLE.py
@@ -64,6 +64,7 @@ from devices import (
 )
 
 default_disk = "aarch64-ubuntu-trusty-headless.img"
+default_root = "/dev/vda1"
 
 default_mem_size = "2GiB"
 
@@ -209,7 +210,7 @@ def addOptions(parser):
     parser.add_argument(
         "--root",
         type=str,
-        default="/dev/vda1",
+        default=default_root,
         help="Specify the kernel CLI root= argument",
     )
     parser.add_argument(
@@ -322,6 +323,33 @@ def addOptions(parser):
         "--vio-9p", action="store_true", help=Options.vio_9p_help
     )
     parser.add_argument(
+        "--vio-9p-root",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help="Host directory to export through the VirtIO 9P device.",
+    )
+    parser.add_argument(
+        "--vio-9p-tag",
+        type=str,
+        default=None,
+        metavar="TAG",
+        help="VirtIO 9P mount tag. Defaults to /dev/root when a host "
+        "directory is exported, and to the device default otherwise.",
+    )
+    parser.add_argument(
+        "--rootfs-dir",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help=(
+            "Use a host directory as the guest root filesystem via 9P. "
+            "This implies --vio-9p-root DIR and adds rootfstype=9p "
+            "and rootflags=trans=virtio,version=9p2000.L to the "
+            "kernel command line."
+        ),
+    )
+    parser.add_argument(
         "--dtb-gen",
         action="store_true",
         help="Doesn't run simulation, it generates a DTB only",
@@ -332,6 +360,39 @@ def addOptions(parser):
 def build(options):
     m5.ticks.fixGlobalFrequency()
 
+    rootfs_dir = (
+        os.path.realpath(options.rootfs_dir) if options.rootfs_dir else None
+    )
+    vio_9p_root = options.vio_9p_root
+
+    if rootfs_dir:
+        if vio_9p_root is not None:
+            vio_9p_root = os.path.realpath(vio_9p_root)
+            if vio_9p_root != rootfs_dir:
+                m5.util.fatal(
+                    "--rootfs-dir and --vio-9p-root specify different "
+                    "directories"
+                )
+        if not os.path.isdir(rootfs_dir):
+            m5.util.fatal(
+                f"--rootfs-dir must name an existing directory: {rootfs_dir}"
+            )
+        vio_9p_root = rootfs_dir
+    elif vio_9p_root is not None:
+        vio_9p_root = os.path.realpath(vio_9p_root)
+        if not os.path.isdir(vio_9p_root):
+            m5.util.fatal(
+                f"--vio-9p-root must name an existing directory: "
+                f"{vio_9p_root}"
+            )
+
+    # The mount tag doubles as the kernel's root= argument when the guest
+    # root filesystem is served over 9P, so both need the same default.
+    vio_9p_tag = options.vio_9p_tag
+    if vio_9p_tag is None and vio_9p_root is not None:
+        vio_9p_tag = "/dev/root"
+
+    kernel_root = vio_9p_tag if rootfs_dir else options.root
     kernel_cmd = [
         "earlyprintk",
         "earlycon=pl011,0x1c090000",
@@ -340,15 +401,27 @@ def build(options):
         "norandmaps",
         "loglevel=8",
         f"mem={options.mem_size}",
-        f"root={options.root}",
-        "rw",
-        f"init={options.kernel_init}",
-        "vmalloc=768MB",
+        f"root={kernel_root}",
     ]
+    if rootfs_dir:
+        kernel_cmd.extend(
+            ["rootfstype=9p", "rootflags=trans=virtio,version=9p2000.L"]
+        )
+    kernel_cmd.extend(
+        [
+            "rw",
+            f"init={options.kernel_init}",
+            "vmalloc=768MB",
+        ]
+    )
 
     root = Root(full_system=True)
 
-    disks = [default_disk] if len(options.disk) == 0 else options.disk
+    disks = (
+        options.disk
+        if rootfs_dir
+        else ([default_disk] if len(options.disk) == 0 else options.disk)
+    )
     system = createSystem(
         options.caches,
         options.kernel,
@@ -361,6 +434,12 @@ def build(options):
 
     root.system = system
     if options.kernel_cmd:
+        if rootfs_dir:
+            m5.util.warn(
+                "--rootfs-dir attaches the 9P root device, but --kernel-cmd "
+                "overrides the automatic root=, rootfstype=, and rootflags= "
+                "arguments"
+            )
         system.workload.command_line = options.kernel_cmd
     else:
         system.workload.command_line = " ".join(kernel_cmd)
@@ -429,8 +508,8 @@ def build(options):
             sc.sc_time(10000.0 / 100000000.0, sc.sc_time.SC_SEC)
         )
 
-    if options.vio_9p:
-        FSConfig.attach_9p(system.realview, system.iobus)
+    if options.vio_9p or vio_9p_root is not None:
+        FSConfig.attach_9p(system.realview, root=vio_9p_root, tag=vio_9p_tag)
 
     return root
 

--- a/src/dev/virtio/README.md
+++ b/src/dev/virtio/README.md
@@ -1,0 +1,38 @@
+# VirtIO 9P UFS Backend
+
+gem5 can build an optional VirtIO 9P backend backed by npfs/ufs. This backend
+exports a host directory directly to the guest and serializes the npfs state in
+gem5 checkpoints, which allows a 9P-mounted root filesystem to survive
+checkpoint and restore.
+
+Build npfs first, then pass its source directory to SCons:
+
+```sh
+scons -j8 build/ARM/gem5.opt NPFS_PATH=/path/to/npfs
+```
+
+`NPFS_PATH` must point at a tree containing `include/`, `libnpfs/libnpfs.a`,
+and `libufs/libufs.a`. Builds without `NPFS_PATH` still include the existing
+VirtIO 9P proxy classes, but the `VirtIO9PUfs` SimObject is not available.
+
+Only exporting a host directory requires this backend. `--vio-9p` on its own
+still uses the diod server and works in any build.
+
+For ARM full-system boots with `configs/example/arm/fs_bigLITTLE.py`, use a
+host directory as the guest root filesystem with:
+
+```sh
+build/ARM/gem5.opt configs/example/arm/fs_bigLITTLE.py \
+    --kernel /path/to/vmlinux \
+    --bootloader /path/to/boot.arm64 \
+    --bootloader /path/to/boot.arm \
+    --rootfs-dir /path/to/root-directory
+```
+
+`--rootfs-dir` exports the directory through VirtIO 9P, sets the 9P mount tag
+to `/dev/root`, and adds the kernel arguments needed for a 9P root mount:
+`rootfstype=9p` and `rootflags=trans=virtio,version=9p2000.L`.
+
+Use `--vio-9p-root DIR` to export a directory without making it the guest root,
+and `--vio-9p-tag TAG` to override the mount tag. Pass
+`--debug-flags=VIO9PUfs` for verbose output from the embedded npfs/ufs server.

--- a/src/dev/virtio/SConscript
+++ b/src/dev/virtio/SConscript
@@ -37,13 +37,24 @@
 
 Import('*')
 
+sim_9pobjs = ['VirtIO9PBase', 'VirtIO9PProxy', 'VirtIO9PDiod', 'VirtIO9PSocket']
+if env["CONF"]["BUILD_9PUFS"]:
+    npfs_dir = Dir(env["CONF"]["NPFS_PATH"])
+    env.Append(CPPPATH=npfs_dir.Dir('include'))
+    env.Append(LIBPATH=[npfs_dir.Dir('libnpfs'), npfs_dir.Dir('libufs')])
+    env.Append(LIBS=['libufs', 'libnpfs'])
+    sim_9pobjs.append('VirtIO9PUfs')
+    Source('fs9pufs.cc')
+    print("BUILD_9PUFS is set, building with 9P UFS integration\n")
+elif not GetOption("silent"):
+    print("BUILD_9PUFS is not set, building without 9P UFS integration\n")
+
 SimObject('VirtIO.py', sim_objects=[
     'VirtIODeviceBase', 'VirtIODummyDevice', 'PciVirtIO'])
 SimObject('VirtIOConsole.py', sim_objects=['VirtIOConsole'])
 SimObject('VirtIOBlock.py', sim_objects=['VirtIOBlock'])
 SimObject('VirtIORng.py', sim_objects=['VirtIORng'])
-SimObject('VirtIO9P.py', sim_objects=[
-    'VirtIO9PBase', 'VirtIO9PProxy', 'VirtIO9PDiod', 'VirtIO9PSocket'])
+SimObject('VirtIO9P.py', sim_objects=sim_9pobjs)
 
 Source('base.cc')
 Source('pci.cc')
@@ -59,3 +70,5 @@ DebugFlag('VIOConsole', 'VirtIO console device')
 DebugFlag('VIOBlock', 'VirtIO block device')
 DebugFlag('VIO9P', 'General 9p over VirtIO debugging')
 DebugFlag('VIO9PData', 'Dump data in VirtIO 9p connections')
+if env["CONF"]["BUILD_9PUFS"]:
+    DebugFlag('VIO9PUfs', 'Verbose output from the embedded npfs/ufs server')

--- a/src/dev/virtio/SConsopts
+++ b/src/dev/virtio/SConsopts
@@ -1,6 +1,5 @@
 # -*- mode:python -*-
-
-# Copyright (c) 2014,2017 ARM Limited
+# Copyright (c) 2025 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -35,50 +34,30 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects.VirtIO import VirtIODeviceBase
-from m5.params import *
-from m5.proxy import *
+Import('*')
 
+import os
 
-class VirtIO9PBase(VirtIODeviceBase):
-    type = "VirtIO9PBase"
-    abstract = True
-    cxx_header = "dev/virtio/fs9p.hh"
-    cxx_class = "gem5::VirtIO9PBase"
+npfs_vars = Variables()
+npfs_vars.AddVariables(
+    PathVariable(
+        'NPFS_PATH',
+        "npfs source directory containing include/, libnpfs/, and libufs/",
+        '.',
+        PathVariable.PathIsDir,
+    ),
+)
+npfs_vars.Update(main)
 
-    queueSize = Param.Unsigned(32, "Output queue size (pages)")
-    tag = Param.String("gem5", "Mount tag")
+main["CONF"]["BUILD_9PUFS"] = False
 
+npfs_path_ev = os.environ.get("NPFS_PATH", None)
+if npfs_path_ev is not None and npfs_path_ev != ".":
+    print(f"Setting NPFS_PATH from os.environ: {npfs_path_ev}")
+    main["CONF"]["NPFS_PATH"] = npfs_path_ev
+    main["CONF"]["BUILD_9PUFS"] = True
 
-class VirtIO9PProxy(VirtIO9PBase):
-    type = "VirtIO9PProxy"
-    abstract = True
-    cxx_header = "dev/virtio/fs9p.hh"
-    cxx_class = "gem5::VirtIO9PProxy"
-
-
-class VirtIO9PDiod(VirtIO9PProxy):
-    type = "VirtIO9PDiod"
-    cxx_header = "dev/virtio/fs9p.hh"
-    cxx_class = "gem5::VirtIO9PDiod"
-
-    diod = Param.String("diod", "Path to diod, optionally in PATH")
-    root = Param.String("Path to export through diod")
-    socketPath = Param.String("Unused socket to diod")
-
-
-class VirtIO9PSocket(VirtIO9PProxy):
-    type = "VirtIO9PSocket"
-    cxx_header = "dev/virtio/fs9p.hh"
-    cxx_class = "gem5::VirtIO9PSocket"
-
-    server = Param.String("127.0.0.1", "9P server address or host name")
-    port = Param.String("564", "9P server port")
-
-
-class VirtIO9PUfs(VirtIO9PProxy):
-    type = "VirtIO9PUfs"
-    cxx_header = "dev/virtio/fs9pufs.hh"
-    cxx_class = "gem5::VirtIO9PUfs"
-
-    root = Param.String("Host directory to export through npfs/ufs")
+if "NPFS_PATH" in main and main["NPFS_PATH"] != ".":
+    print(f"Setting NPFS_PATH to SCons command line: {main['NPFS_PATH']}")
+    main["CONF"]["NPFS_PATH"] = str(main["NPFS_PATH"])
+    main["CONF"]["BUILD_9PUFS"] = True

--- a/src/dev/virtio/fs9pufs.cc
+++ b/src/dev/virtio/fs9pufs.cc
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2014-2025 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+
+#include "base/callback.hh"
+#include "base/output.hh"
+#include "debug/VIO9P.hh"
+#include "debug/VIO9PData.hh"
+#include "debug/VIO9PUfs.hh"
+#include "params/VirtIO9PBase.hh"
+#include "params/VirtIO9PProxy.hh"
+#include "params/VirtIO9PSocket.hh"
+#include "params/VirtIO9PUfs.hh"
+#include "sim/core.hh"
+#include "sim/system.hh"
+
+#include "dev/virtio/fs9pufs.hh"
+
+namespace gem5
+{
+
+VirtIO9PUfs::VirtIO9PUfs(const Params &params)
+    : VirtIO9PProxy(params),
+      fd_to_ufs(-1),
+      fd_from_ufs(-1),
+      srv(nullptr),
+      conn(nullptr)
+{}
+
+VirtIO9PUfs::~VirtIO9PUfs()
+{}
+
+void
+VirtIO9PUfs::startup()
+{
+    DPRINTF(VIO9P, "VirtIO9PUfs: startup\n");
+    start();
+    dataEvent.reset(new UfsDataEvent(*this, fd_from_ufs, POLLIN));
+    pollQueue.schedule(dataEvent.get());
+}
+
+void
+VirtIO9PUfs::start()
+{
+    const Params &p = dynamic_cast<const Params &>(params());
+
+    if (srv != nullptr) {
+        DPRINTF(VIO9P, "VirtIO9PUfs: already started\n");
+        return;
+    }
+
+    // The last argument is the server's maximum message size; 0 keeps the
+    // npfs default, which the guest then negotiates down.
+    srv = ufs_start(const_cast<char *>(p.root.c_str()),
+                    debug::VIO9PUfs ? 1 : 0, 2, 1, 0);
+    panic_if(srv == nullptr, "Failed to start the 9P server");
+
+    // A server can carry several connections; this device uses one, and
+    // it is that connection, not the server, that holds the 9P state.
+    conn = ufs_connect(srv, &fd_from_ufs, &fd_to_ufs);
+    panic_if(conn == nullptr, "Failed to connect to the 9P server");
+}
+
+ssize_t
+VirtIO9PUfs::read(uint8_t *data, size_t len)
+{
+    assert(fd_from_ufs != -1);
+    const int ret(::read(fd_from_ufs, static_cast<void *>(data), len));
+    return ret < 0 ? -errno : ret;
+}
+
+ssize_t
+VirtIO9PUfs::write(const uint8_t *data, size_t len)
+{
+    assert(fd_to_ufs != -1);
+    const int ret(::write(fd_to_ufs, static_cast<const void *>(data), len));
+    return ret < 0 ? -errno : ret;
+}
+
+void
+VirtIO9PUfs::UfsDataEvent::process(int revent)
+{
+    parent.serverDataReady();
+}
+
+void
+VirtIO9PUfs::terminate()
+{
+    if (fd_to_ufs != -1) {
+        close(fd_to_ufs);
+        fd_to_ufs = -1;
+    }
+    if (fd_from_ufs != -1) {
+        close(fd_from_ufs);
+        fd_from_ufs = -1;
+    }
+}
+
+void
+VirtIO9PUfs::serialize(CheckpointOut &cp) const
+{
+    int datalen;
+    char *data;
+
+    datalen = ufs_checkpoint(conn, reinterpret_cast<void **>(&data));
+    panic_if(datalen < 0, "VirtIO9PUfs: serialize failed");
+
+    SERIALIZE_SCALAR(datalen);
+    SERIALIZE_ARRAY(data, datalen);
+    free(data);
+    VirtIO9PBase::serialize(cp);
+}
+
+void
+VirtIO9PUfs::unserialize(CheckpointIn &cp)
+{
+    int datalen;
+    char *data;
+    char err[256];
+
+    start();
+    UNSERIALIZE_SCALAR(datalen);
+    data = static_cast<char *>(malloc(datalen));
+    UNSERIALIZE_ARRAY(data, datalen);
+    if (ufs_restore(conn, data, datalen, err, sizeof(err)) < 0) {
+        warn("VirtIO9PUfs: restore failed: %s", err);
+    }
+    free(data);
+
+    VirtIO9PBase::unserialize(cp);
+}
+
+} // namespace gem5

--- a/src/dev/virtio/fs9pufs.hh
+++ b/src/dev/virtio/fs9pufs.hh
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2014-2025 ARM Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_VIRTIO_FSUFS_HH__
+#define __DEV_VIRTIO_FSUFS_HH__
+
+#include <map>
+#include <memory>
+#include <string>
+
+extern "C" {
+#include <npfs.h>
+#include <ufs.h>
+}
+
+#include "dev/virtio/fs9p.hh"
+
+namespace gem5
+{
+
+struct VirtIO9PUfsParams;
+
+/**
+ * VirtIO 9p proxy that communicates with the libufs 9p server using
+ * pipes.
+ */
+class VirtIO9PUfs : public VirtIO9PProxy
+{
+  public:
+    typedef VirtIO9PUfsParams Params;
+    VirtIO9PUfs(const Params &params);
+    virtual ~VirtIO9PUfs();
+
+    void startup();
+    void serialize(CheckpointOut &cp) const override;
+    void unserialize(CheckpointIn &cp) override;
+
+  protected:
+    /**
+     * Start the embedded ufs server and setup the communication pipes.
+     */
+    void start();
+
+    ssize_t read(uint8_t *data, size_t len);
+    ssize_t write(const uint8_t *data, size_t len);
+    void terminate();
+
+  private:
+    class UfsDataEvent : public PollEvent
+    {
+      public:
+        UfsDataEvent(VirtIO9PUfs &_parent, int fd, int event)
+            : PollEvent(fd, event), parent(_parent)
+        {}
+
+        virtual ~UfsDataEvent() {}
+
+        void process(int revent);
+
+      private:
+        VirtIO9PUfs &parent;
+    };
+
+    /** fd for data pipe going to ufs (write end) */
+    int fd_to_ufs;
+    /** fd for data pipe coming from ufs (read end) */
+    int fd_from_ufs;
+
+    std::unique_ptr<UfsDataEvent> dataEvent;
+    Npsrv *srv;
+    /** Connection to the embedded server; owns the checkpointed state */
+    Npconn *conn;
+};
+
+} // namespace gem5
+
+#endif // __DEV_VIRTIO_FSUFS_HH__


### PR DESCRIPTION
Adds an optional npfs/ufs-backed VirtIO 9P backend. The backend is enabled at build time by setting NPFS_PATH to an npfs source tree and serializes npfs state into gem5 checkpoints, allowing a 9P-mounted directory filesystem to work across checkpoint and restore.

npfs is available from:

    https://github.com/lionkov/npfs

Updates the ARM fs_bigLITTLE example with --rootfs-dir, --vio-9p-root, --vio-9p-tag, and --vio-9p-debug options. --rootfs-dir exports a host directory through VirtIO 9P, uses /dev/root as the default mount tag, and adds the kernel arguments required to mount the directory as the guest root filesystem.

Documents the optional npfs build flow and rootfs directory usage under src/dev/virtio.