### PR TITLE
mem-cache: Fixed extractTags not registered in CompressedTags

### DIFF
--- a/src/mem/cache/tags/compressed_tags.cc
+++ b/src/mem/cache/tags/compressed_tags.cc
@@ -105,12 +105,18 @@ CompressedTags::tagsInit()
             // Set its index and sector offset
             blk->setSectorOffset(k);
 
+            // Register TagExtractor for SubBlk
+            blk->registerTagExtractor(genTagExtractor(indexingPolicy));
+
             // Update block index
             ++blk_index;
         }
 
         // Link block to indexing policy
         indexingPolicy->setEntry(superblock, superblock_index);
+
+        // Register TagExtractor for SecBlk
+        superblock->registerTagExtractor(genTagExtractor(indexingPolicy));
     }
 }
 


### PR DESCRIPTION
This commit fixes an issue where when using CompressedTags extractTags method was not registered. This resulted in an assertion fail. Github issue: #3168