### PR TITLE
stdlib: VIPER GPU cache before connect_things, better names

### DIFF
--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -60,13 +60,33 @@ class BaseViperGPU(SubSystem):
                 "instantiate the gpu memory like gpu_memory = HBM2Stack() "
                 "and **not** like board.gpu_memory = HBM2Stack()"
             )
-        self._memory = gpu_memory
+        self.memory = gpu_memory
 
         # Setup various PCI related parameters
         self._my_id = self.get_gpu_count()
         pci_dev = self.next_pci_dev()
 
         self.device = AMDGPUDevice(pci_func=0, pci_dev=pci_dev)
+
+    def setup_caches(self):
+        # Make the cache hierarchy. This will create an independent RubySystem
+        # class containing only the GPU caches with no network connection to
+        # the CPU cache hierarchy.
+        self.gpu_caches = ViperGPUCacheHierarchy(
+            gpu_memory=self.memory,
+            tcp_size=self._tcp_size,
+            tcp_assoc=self._tcp_assoc,
+            sqc_size=self._sqc_size,
+            sqc_assoc=self._sqc_assoc,
+            scalar_size=self._scalar_size,
+            scalar_assoc=self._scalar_assoc,
+            tcc_size=self._tcc_size,
+            tcc_assoc=self._tcc_assoc,
+            tcc_count=self._tcc_count,
+            cu_per_sqc=self._cu_per_sqc,
+            cache_line_size=self._cache_line_size,
+            shader=self.shader,
+        )
 
     def set_shader(self, shader: ViperShader):
         self.shader = shader
@@ -83,32 +103,11 @@ class BaseViperGPU(SubSystem):
         # Connect all PIO buses
         self.shader.connect_iobus(board.get_io_bus(), board.get_pci_bus())
 
-        # Make the cache hierarchy. This will create an independent RubySystem
-        # class containing only the GPU caches with no network connection to
-        # the CPU cache hierarchy.
-        self.gpu_caches = ViperGPUCacheHierarchy(
-            gpu_memory=self._memory,
-            tcp_size=self._tcp_size,
-            tcp_assoc=self._tcp_assoc,
-            sqc_size=self._sqc_size,
-            sqc_assoc=self._sqc_assoc,
-            scalar_size=self._scalar_size,
-            scalar_assoc=self._scalar_assoc,
-            tcc_size=self._tcc_size,
-            tcc_assoc=self._tcc_assoc,
-            tcc_count=self._tcc_count,
-            cu_per_sqc=self._cu_per_sqc,
-            cache_line_size=self._cache_line_size,
-            shader=self.shader,
-        )
-
-        self.memory = self._memory
-
         # Collect GPU memory controllers created in the GPU cache hierarchy.
         # First assign them as a child to the device so the SimObject unproxy.
         # The device requires the memories parameter to be set as the system
         # pointer required by the AbstractMemory class is set by AMDGPUDevice.
-        self.device.memories = self._memory.get_mem_interfaces()
+        self.device.memories = self.memory.get_mem_interfaces()
 
         self.device.upstream = board.get_pci_host()
 
@@ -160,6 +159,7 @@ class MI210(BaseViperGPU):
             gpu_memory.get_size(),
         )
         self.set_shader(shader)
+        self.setup_caches()
 
         # Setup the SDMA engines depending on device. The MMIO base addresses
         # can be found in the driver code under:
@@ -247,6 +247,7 @@ class MI300X(BaseViperGPU):
             gpu_memory.get_size(),
         )
         self.set_shader(shader)
+        self.setup_caches()
 
         num_sdmas = 16
         sdma_bases = [

--- a/src/python/gem5/prebuilt/viper/gpu_cache_hierarchy.py
+++ b/src/python/gem5/prebuilt/viper/gpu_cache_hierarchy.py
@@ -121,7 +121,10 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
         # There is a single local list of all of the controllers to make it
         # easier to connect everything to the GPU network. This can be
         # customized depending on the topology/network requirements.
-        self._controllers = []
+        self._tcp_controllers = []
+        self._sqc_controllers = []
+        self._scalar_controllers = []
+        self._tcc_controllers = []
         self._directory_controllers = []
         self._dma_controllers = []
         self._mem_ctrls = []
@@ -178,7 +181,7 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
             tcp.WB = False
             tcp.disableL1 = False
 
-            self._controllers.append(tcp)
+            self._tcp_controllers.append(tcp)
 
         # This check ensures there are a same number of CUs with shared SQC
         # and Scalar caches.
@@ -216,7 +219,7 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
             sqc.clk_domain = self.clk_domain
             sqc.recycle_latency = 10
 
-            self._controllers.append(sqc)
+            self._sqc_controllers.append(sqc)
 
         num_scalars = num_sqcs
         for idx in range(num_scalars):
@@ -250,7 +253,7 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
             scalar.clk_domain = self.clk_domain
             scalar.recycle_latency = 10
 
-            self._controllers.append(scalar)
+            self._scalar_controllers.append(scalar)
 
         # Create TCCs (GPU L2 cache)
         for idx in range(tcc_count):
@@ -268,7 +271,7 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
             tcc.clk_domain = self.clk_domain
             tcc.recycle_latency = 10
 
-            self._controllers.append(tcc)
+            self._tcc_controllers.append(tcc)
 
         # Create DMA controllers
         for i, port in enumerate(shader.get_gpu_dma_ports()):
@@ -311,17 +314,27 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
             )
 
         # Number of sequencers = one per TCP, SQC, and Scalar + one per DMA.
-        self.ruby_gpu.num_of_sequencers = len(self._controllers) + len(
-            self._dma_controllers
+        self.ruby_gpu.num_of_sequencers = (
+            len(self._tcp_controllers)
+            + len(self._sqc_controllers)
+            + len(self._scalar_controllers)
+            + len(self._tcc_controllers)
+            + len(self._dma_controllers)
         )
 
-        # Assign the controllers to their parent objects.
-        self.ruby_gpu.controllers = self._controllers
+        # Assign the controllers to their parent objects. Give nice names.
+        self.ruby_gpu.tcp_controllers = self._tcp_controllers
+        self.ruby_gpu.sqc_controllers = self._sqc_controllers
+        self.ruby_gpu.scalar_controllers = self._scalar_controllers
+        self.ruby_gpu.tcc_controllers = self._tcc_controllers
         self.ruby_gpu.directory_controllers = self._directory_controllers
 
         # Connect the controllers using the network topology
         self.ruby_gpu.network.connect(
-            self._controllers
+            self._tcp_controllers
+            + self._sqc_controllers
+            + self._scalar_controllers
+            + self._tcc_controllers
             + self._directory_controllers
             + self._dma_controllers
         )


### PR DESCRIPTION
VIPER's GPU caches are not created until connect_things is called, which prevents users from being able to walk the board hierarchy and set parameters on things that do not have explicit function arguments. Move the creation of the caches earlier so that users can touch any parameter from config scripts without needing to make changes in stdlib and rebuild. To assist with this, the names of TCP, SQC, Scalar, and TCC have been changed from the generic "controllers##" to have a prefix containing the cache type.