### PR TITLE
sim: runtime debug flags toggle via SIGRTMIN+1

### DIFF
--- a/src/base/debug.hh
+++ b/src/base/debug.hh
@@ -42,6 +42,7 @@
 #ifndef __BASE_DEBUG_HH__
 #define __BASE_DEBUG_HH__
 
+#include <atomic>
 #include <initializer_list>
 #include <iostream>
 #include <map>
@@ -63,7 +64,10 @@ class Flag
   protected:
     static bool _globalEnable; // whether debug tracings are enabled
 
-    bool _tracing = false; // tracing is enabled and flag is on
+    // Read by every DPRINTF on every thread; atomic to avoid data races
+    // when changeFlag() is called at runtime. Relaxed ordering suffices:
+    // a stale read causes at most one missed or extra debug line.
+    std::atomic<bool> _tracing{false};
 
     const char *_name;
     const char *_desc;
@@ -77,7 +81,11 @@ class Flag
     std::string name() const { return _name; }
     std::string desc() const { return _desc; }
 
-    bool tracing() const { return TRACING_ON && _tracing; }
+    bool
+    tracing() const
+    {
+        return TRACING_ON && _tracing.load(std::memory_order_relaxed);
+    }
 
     virtual void enable() = 0;
     virtual void disable() = 0;
@@ -96,7 +104,11 @@ class SimpleFlag : public Flag
 
     bool _enabled = false; // flag enablement status
 
-    void sync() override { _tracing = _globalEnable && _enabled; }
+    void
+    sync() override
+    {
+        _tracing.store(_globalEnable && _enabled, std::memory_order_relaxed);
+    }
 
   public:
     SimpleFlag(const char *name, const char *desc, bool is_format=false);

--- a/src/sim/SConscript
+++ b/src/sim/SConscript
@@ -62,6 +62,7 @@ SimObject('PowerDomain.py', sim_objects=['PowerDomain'])
 SimObject('SignalPort.py', sim_objects=[])
 
 Source('async.cc')
+Source('debug_ctl.cc')
 Source(
     'backtrace_%s.cc' % env['BACKTRACE_IMPL'],
     tags=['gem5 trace']

--- a/src/sim/async.cc
+++ b/src/sim/async.cc
@@ -36,5 +36,6 @@ volatile bool async_exit = false;
 volatile bool async_io = false;
 volatile bool async_exception = false;
 volatile bool async_hypercall = false;
+volatile bool async_debug_cmd = false;
 
 } // namespace gem5

--- a/src/sim/async.hh
+++ b/src/sim/async.hh
@@ -48,8 +48,8 @@ extern volatile bool async_exit;        ///< Async request to exit simulator.
 extern volatile bool async_io;          ///< Async I/O request (SIGIO).
 extern volatile bool async_exception;   ///< Python exception.
 extern volatile bool async_hypercall;
+extern volatile bool async_debug_cmd; ///< Async debug flag cmd (SIGRTMIN+1).
 //@}
-
 
 } // namespace gem5
 

--- a/src/sim/debug_ctl.cc
+++ b/src/sim/debug_ctl.cc
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025 Polydoros Petrakis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sim/debug_ctl.hh"
+
+#include <unistd.h>
+
+#include <cctype>
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "base/debug.hh"
+#include "base/logging.hh"
+#include "base/trace.hh"
+#include "sim/eventq.hh"
+
+namespace gem5
+{
+
+/**
+ * Self-deleting event that disables a named debug flag at a future tick.
+ * Scheduled by processDebugCmd() when a +FLAG:Nt duration is given.
+ */
+class DebugFlagOffEvent : public Event
+{
+  public:
+    DebugFlagOffEvent(const std::string &name)
+        : Event(Event::Default_Pri, AutoDelete), flagName(name)
+    {}
+
+    void
+    process() override
+    {
+        if (!debug::changeFlag(flagName.c_str(), false)) {
+            warn("gem5_debug_ctl: auto-disable: unknown flag '%s'\n",
+                 flagName);
+        } else {
+            inform("gem5_debug_ctl: auto-disabled '%s' at tick %lu\n",
+                   flagName.c_str(), curTick());
+        }
+    }
+
+    const char *
+    description() const override
+    {
+        return "DebugFlagOffEvent";
+    }
+
+  private:
+    std::string flagName;
+};
+
+void
+processDebugCmd()
+{
+    std::string path = "/tmp/gem5_debug_" + std::to_string(getpid()) + ".cmd";
+
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        warn("gem5_debug_ctl: cannot open command file '%s'\n", path);
+        return;
+    }
+
+    std::string line;
+    while (std::getline(f, line)) {
+        // Strip inline comments.
+        auto hash = line.find('#');
+        if (hash != std::string::npos) {
+            line = line.substr(0, hash);
+        }
+
+        // Strip trailing whitespace.
+        while (!line.empty() && isspace((unsigned char)line.back())) {
+            line.pop_back();
+        }
+
+        if (line.empty()) {
+            continue;
+        }
+
+        // Handle global trace master toggles.
+        if (line == "trace:on") {
+            trace::enable();
+            inform("gem5_debug_ctl: trace enabled at tick %lu\n", curTick());
+            continue;
+        }
+        if (line == "trace:off") {
+            trace::disable();
+            inform("gem5_debug_ctl: trace disabled at tick %lu\n", curTick());
+            continue;
+        }
+
+        // All remaining commands start with '+' (enable) or '-' (disable).
+        if (line[0] != '+' && line[0] != '-') {
+            warn("gem5_debug_ctl: unrecognised command '%s'\n", line);
+            continue;
+        }
+        bool enable = (line[0] == '+');
+        std::string rest = line.substr(1);
+
+        // Parse optional tick duration suffix: FLAG:Nt
+        Tick duration = 0;
+        std::string flagName = rest;
+        auto colon = rest.find(':');
+        if (colon != std::string::npos) {
+            flagName = rest.substr(0, colon);
+            std::string durStr = rest.substr(colon + 1);
+            if (durStr.size() < 2 || durStr.back() != 't') {
+                warn("gem5_debug_ctl: invalid duration '%s'"
+                     " (expected format: <N>t for ticks)\n",
+                     durStr);
+                continue;
+            } else {
+                try {
+                    duration =
+                        std::stoull(durStr.substr(0, durStr.size() - 1));
+                } catch (const std::exception &e) {
+                    warn("gem5_debug_ctl: invalid duration value"
+                         " '%s': %s\n",
+                         durStr, e.what());
+                    continue;
+                }
+            }
+        }
+
+        if (flagName.empty()) {
+            warn("gem5_debug_ctl: empty flag name in command '%s'\n", line);
+            continue;
+        }
+
+        if (!debug::changeFlag(flagName.c_str(), enable)) {
+            warn("gem5_debug_ctl: unknown debug flag '%s'\n", flagName);
+            continue;
+        }
+
+        inform("gem5_debug_ctl: %s flag '%s' at tick %lu\n",
+               enable ? "enabled" : "disabled", flagName.c_str(), curTick());
+
+        // Schedule auto-disable if a duration was given.
+        if (enable && duration > 0) {
+            auto *ev = new DebugFlagOffEvent(flagName);
+            curEventQueue()->schedule(ev, curTick() + duration);
+            inform("gem5_debug_ctl: will auto-disable '%s' after"
+                   " %lu ticks (at tick %lu)\n",
+                   flagName.c_str(), duration, curTick() + duration);
+        }
+    }
+
+    // Remove the command file so stale commands are not re-processed
+    // if the signal is somehow delivered twice.
+    ::remove(path.c_str());
+}
+
+} // namespace gem5

--- a/src/sim/debug_ctl.hh
+++ b/src/sim/debug_ctl.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008 The Hewlett-Packard Development Company
+ * Copyright (c) 2025 Polydoros Petrakis
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,38 +26,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SIM_INIT_SIGNALS_HH__
-#define __SIM_INIT_SIGNALS_HH__
-
-#include <csignal>
-#include <string>
+#ifndef __SIM_DEBUG_CTL_HH__
+#define __SIM_DEBUG_CTL_HH__
 
 namespace gem5
 {
 
-void dumpStatsHandler(int sigtype);
-void dumprstStatsHandler(int sigtype);
-void exitNowHandler(int sigtype);
-void abortHandler(int sigtype);
-void initSignals();
-
-// separate out sigint handler so that we can restore the python one
-void initSigInt();
-void initSigCont();
-// SIGRTMIN is reserved for KVM (KVM_KICK_SIGNAL); this installs on SIGRTMIN+1.
-// No-op on platforms without real-time signals (e.g. macOS).
-#ifdef SIGRTMIN
-void initSigRTMin();
-#else
-inline void
-initSigRTMin()
-{}
-#endif
-std::string extractStringFromJSON(std::string &full_str, std::string start_str,
-                                  std::string end_str, size_t &search_start);
-void processExternalSignal(void);
-void restoreSigInt();
+/**
+ * Process debug flag commands from /tmp/gem5_debug_<pid>.cmd.
+ *
+ * Called from doSimLoop() when async_debug_cmd is set (triggered by
+ * SIGRTMIN+1). The command file is written by util/gem5_debug_ctl.sh.
+ *
+ * Command file format (one command per line, # comments supported):
+ *   +FLAG           enable flag (stays on until explicitly disabled)
+ *   +FLAG:Nt        enable flag, auto-disable after N ticks
+ *   -FLAG           disable flag immediately
+ *   trace:on        global trace master enable
+ *   trace:off       global trace master disable
+ *
+ * The file is deleted after processing. Unknown flag names produce a
+ * warning but do not abort processing of remaining commands.
+ */
+void processDebugCmd();
 
 } // namespace gem5
 
-#endif // __SIM_INIT_SIGNALS_HH__
+#endif // __SIM_DEBUG_CTL_HH__

--- a/src/sim/init_signals.cc
+++ b/src/sim/init_signals.cc
@@ -483,5 +483,21 @@ void restoreSigInt()
     sigaction(SIGINT, &old_int_sa, NULL);
 }
 
+#ifdef SIGRTMIN
+static void
+debugCmdHandler(int sigtype)
+{
+    async_event = true;
+    async_debug_cmd = true;
+    getEventQueue(0)->wakeup();
+}
+
+// SIGRTMIN is reserved for KVM (KVM_KICK_SIGNAL). Use SIGRTMIN+1.
+void
+initSigRTMin()
+{
+    installSignalHandler(SIGRTMIN + 1, debugCmdHandler);
+}
+#endif // SIGRTMIN
 
 } // namespace gem5

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -51,6 +51,7 @@
 #include "base/types.hh"
 #include "debug/EnteringEventQueue.hh"
 #include "sim/async.hh"
+#include "sim/debug_ctl.hh"
 #include "sim/eventq.hh"
 #include "sim/init_signals.hh"
 #include "sim/sim_events.hh"
@@ -194,6 +195,7 @@ simulate(Tick num_cycles)
     // Note: This should be done before initializing the threads
     initSigInt();
     initSigCont();
+    initSigRTMin();
 
     if (global_exit_event)//cleaning last global exit event
         global_exit_event->clean();
@@ -333,6 +335,10 @@ doSimLoop(EventQueue *eventq)
             if (async_hypercall) {
                 async_hypercall = false;
                 processExternalSignal();
+            }
+            if (async_debug_cmd) {
+                async_debug_cmd = false;
+                processDebugCmd();
             }
         }
 

--- a/util/gem5_debug_ctl.sh
+++ b/util/gem5_debug_ctl.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Polydoros Petrakis
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# gem5_debug_ctl.sh — runtime debug flag control for a running gem5 process.
+#
+# gem5 registers a SIGRTMIN+1 handler at simulation start. This script writes
+# a command file to /tmp/gem5_debug_<pid>.cmd and sends SIGRTMIN+1 to trigger
+# processing. Commands are executed in the main event loop, so they take effect
+# at the next sim tick after delivery (no mid-instruction races).
+#
+# Usage:
+#   gem5_debug_ctl.sh <pid> <cmd> [<cmd> ...]
+#
+# Commands:
+#   +FLAG           Enable flag (stays on until explicitly disabled)
+#   +FLAG:Nt        Enable flag, auto-disable after N ticks
+#   -FLAG           Disable flag immediately
+#   trace:on        Global trace master enable  (all enabled flags emit output)
+#   trace:off       Global trace master disable (flags unchanged, output silent)
+#
+# Examples (<PID> e.g. 12345):
+#   gem5_debug_ctl.sh <PID> +Rename
+#   gem5_debug_ctl.sh <PID> +O3CPU:100000t
+#   gem5_debug_ctl.sh <PID> -Fetch trace:off
+#   gem5_debug_ctl.sh <PID> +Rename:100000t +Fetch:100000t trace:on
+#
+# To list available flag names:
+#   <gem5_binary> --debug-help 2>&1 | grep -i <keyword>
+#
+# Confirmation lines (gem5_debug_ctl: ...) appear in the sim's stdout/log.
+
+set -euo pipefail
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/{ /^[^#]/d; s/^# \{0,1\}//p }' "$0"
+    exit 1
+}
+
+if [[ $# -lt 2 ]]; then
+    usage
+fi
+
+PID="$1"
+shift
+
+# Verify the target is a running gem5 process.
+if ! kill -0 "${PID}" 2>/dev/null; then
+    echo "Error: no process with PID ${PID}" >&2
+    exit 1
+fi
+if ! ps -p "${PID}" -o comm= 2>/dev/null | grep -q 'gem5'; then
+    echo "Warning: PID ${PID} does not appear to be a gem5 process" >&2
+fi
+
+CMD_FILE="/tmp/gem5_debug_${PID}.cmd"
+
+# Write commands one per line (overwrite any leftover file from a prior run).
+printf '%s\n' "$@" > "${CMD_FILE}"
+
+# SIGRTMIN+1 is used to avoid SIGRTMIN which is reserved for KVM.
+kill -RTMIN+1 "${PID}"
+
+echo "Sent ${#} command(s) to gem5 PID ${PID}." \
+     "Check the sim log for 'gem5_debug_ctl:' confirmation lines."


### PR DESCRIPTION
Follows up on discussion #1598.

## Summary

This patch adds the ability to enable and disable gem5 debug flags in a
running simulation without restarting it.

gem5 installs a handler on `SIGRTMIN+1` at simulation start. A companion
shell script (`util/gem5_debug_ctl.sh`) writes commands to a temporary file
and sends the signal. Commands are processed on the main event loop at the
next sim tick after delivery — no mid-instruction races.

Supported commands:

| Command        | Effect                                          |
|----------------|-------------------------------------------------|
| `+FLAG`        | Enable flag                                     |
| `+FLAG:Nt`     | Enable flag, auto-disable after N ticks         |
| `-FLAG`        | Disable flag                                    |
| `trace:on`     | Global output enable (individual flags unchanged)  |
| `trace:off`    | Global output silence (individual flags unchanged) |

Example usage:

```bash
# Enable Rename for 100000 ticks on a running sim (PID e.g. 12345)
util/gem5_debug_ctl.sh <PID> +Rename:100000t

# Enable multiple flags at once for a bounded window, with output enabled
util/gem5_debug_ctl.sh <PID> +Fetch:100000t +Rename:100000t +IEW:100000t trace:on

# Disable Fetch and silence all output
util/gem5_debug_ctl.sh <PID> -Fetch trace:off
```

Confirmation lines (`gem5_debug_ctl: ...`) appear in the sim's stdout/log.

## Design notes

- `SIGRTMIN+1` is used to avoid `SIGRTMIN` which is reserved for KVM
  (`KVM_KICK_SIGNAL`).
- The signal handler follows the existing gem5 async pattern: sets
  `async_event` + `async_debug_cmd`, wakes the primary event queue, returns
  immediately. All file I/O and flag changes happen on the main thread.
- `Flag::_tracing` is changed from `bool` to `std::atomic<bool>` (relaxed
  ordering) to eliminate the data race that arises when `changeFlag()` is
  called while other host threads are executing `DPRINTF`.
- Auto-disable is implemented as a self-deleting `Event` (`AutoDelete`)
  scheduled at `curTick() + duration`.

---

*This implementation was developed with AI assistance.*