### PR TITLE
arch-vega: Implement several instructions for Triton

### DIFF
--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -7666,8 +7666,7 @@ Decoder::decode_OPU_VOP3__V_ADD_I16(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OPU_VOP3__V_SUB_I16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3__V_SUB_I16(&iFmt->iFmt_VOP3A);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -13632,15 +13632,13 @@ Decoder::decode_OP_VOP3P__V_PK_MAX_F16(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_VOP3P__V_MAD_MIX_F32(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3P__V_MAD_MIX_F32(&iFmt->iFmt_VOP3P);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_VOP3P__V_MAD_MIXLO_F16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3P__V_MAD_MIXLO_F16(&iFmt->iFmt_VOP3P);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -7653,8 +7653,7 @@ Decoder::decode_OPU_VOP3__V_ADD_I32(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OPU_VOP3__V_SUB_I32(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3__V_SUB_I32(&iFmt->iFmt_VOP3A);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -7647,8 +7647,7 @@ Decoder::decode_OPU_VOP3__V_PKNORM_U16_F16(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OPU_VOP3__V_ADD_I32(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3__V_ADD_I32(&iFmt->iFmt_VOP3A);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -7660,8 +7660,7 @@ Decoder::decode_OPU_VOP3__V_SUB_I32(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OPU_VOP3__V_ADD_I16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3__V_ADD_I16(&iFmt->iFmt_VOP3A);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -7674,8 +7674,7 @@ Decoder::decode_OPU_VOP3__V_SUB_I16(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OPU_VOP3__V_PACK_B32_F16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_VOP3__V_PACK_B32_F16(&iFmt->iFmt_VOP3A);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -57127,6 +57127,48 @@ class Inst_VOP3__V_ADD_I16 : public Inst_VOP3A
 
     void execute(GPUDynInstPtr) override;
 }; // Inst_VOP3__V_ADD_I16
+
+class Inst_VOP3__V_SUB_I16 : public Inst_VOP3A
+{
+  public:
+    Inst_VOP3__V_SUB_I16(InFmt_VOP3A *);
+    ~Inst_VOP3__V_SUB_I16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // src_0
+                return 4;
+            case 1: // src_1
+                return 4;
+            case 2: // vdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_VOP3__V_SUB_I16
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -57044,6 +57044,47 @@ class Inst_VOP3__V_ADD_I32 : public Inst_VOP3A
 
     void execute(GPUDynInstPtr) override;
 }; // Inst_VOP3__V_ADD_I32
+class Inst_VOP3__V_PACK_B32_F16 : public Inst_VOP3A
+{
+  public:
+    Inst_VOP3__V_PACK_B32_F16(InFmt_VOP3A *);
+    ~Inst_VOP3__V_PACK_B32_F16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // src_0
+                return 4;
+            case 1: // src_1
+                return 4;
+            case 2: // vdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_VOP3__V_PACK_B32_F16
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -57169,6 +57169,48 @@ class Inst_VOP3__V_SUB_I16 : public Inst_VOP3A
 
     void execute(GPUDynInstPtr) override;
 }; // Inst_VOP3__V_SUB_I16
+
+class Inst_VOP3__V_SUB_I32 : public Inst_VOP3A
+{
+  public:
+    Inst_VOP3__V_SUB_I32(InFmt_VOP3A *);
+    ~Inst_VOP3__V_SUB_I32();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // src_0
+                return 4;
+            case 1: // src_1
+                return 4;
+            case 2: // vdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_VOP3__V_SUB_I32
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -57003,6 +57003,47 @@ class Inst_VOP3P__V_MFMA_LOAD_SCALE : public Inst_VOP3P
 
     void execute(GPUDynInstPtr) override;
 };
+class Inst_VOP3__V_ADD_I32 : public Inst_VOP3A
+{
+  public:
+    Inst_VOP3__V_ADD_I32(InFmt_VOP3A *);
+    ~Inst_VOP3__V_ADD_I32();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // src_0
+                return 4;
+            case 1: // src_1
+                return 4;
+            case 2: // vdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_VOP3__V_ADD_I32
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -57085,6 +57085,48 @@ class Inst_VOP3__V_PACK_B32_F16 : public Inst_VOP3A
 
     void execute(GPUDynInstPtr) override;
 }; // Inst_VOP3__V_PACK_B32_F16
+
+class Inst_VOP3__V_ADD_I16 : public Inst_VOP3A
+{
+  public:
+    Inst_VOP3__V_ADD_I16(InFmt_VOP3A *);
+    ~Inst_VOP3__V_ADD_I16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // src_0
+                return 4;
+            case 1: // src_1
+                return 4;
+            case 2: // vdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_VOP3__V_ADD_I16
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/vop1.cc
+++ b/src/arch/amdgpu/vega/insts/vop1.cc
@@ -441,25 +441,18 @@ Inst_VOP1__V_CVT_F16_F32::~Inst_VOP1__V_CVT_F16_F32()
 void
 Inst_VOP1__V_CVT_F16_F32::execute(GPUDynInstPtr gpuDynInst)
 {
-    Wavefront *wf = gpuDynInst->wavefront();
-    ConstVecOperandF32 src(gpuDynInst, instData.SRC0);
-    VecOperandU32 vdst(gpuDynInst, instData.VDST);
-
-    src.readSrc();
-
-    panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
-    panic_if(isDPPInst(), "DPP not implemented for %s", _opcode);
-
-    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
-        if (wf->execMask(lane)) {
-            float tmp = src[lane];
-            AMDGPU::mxfloat16 out(tmp);
-
-            vdst[lane] = (out.data >> 16);
+    auto opImpl = [](VecOperandU32 &src, VecOperandU32 &vdst, Wavefront *wf) {
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                uint32_t raw_src = src[lane];
+                float tmp = *reinterpret_cast<float *>(&raw_src);
+                AMDGPU::mxfloat16 out(tmp);
+                vdst[lane] = (out.data >> 16);
+            }
         }
-    }
+    };
 
-    vdst.write();
+    vop1Helper<ConstVecOperandU32, VecOperandU32>(gpuDynInst, opImpl);
 } // execute
 // --- Inst_VOP1__V_CVT_F32_F16 class methods ---
 

--- a/src/arch/amdgpu/vega/insts/vop1.cc
+++ b/src/arch/amdgpu/vega/insts/vop1.cc
@@ -485,13 +485,46 @@ Inst_VOP1__V_CVT_F32_F16::execute(GPUDynInstPtr gpuDynInst)
 
     src.readSrc();
 
-    panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
     panic_if(isDPPInst(), "DPP not implemented for %s", _opcode);
 
-    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
-        if (wf->execMask(lane)) {
-            AMDGPU::mxfloat16 tmp(src[lane]);
-            vdst[lane] = float(tmp);
+    if (isSDWAInst()) {
+        VecOperandU32 src0_sdwa(gpuDynInst, extData.iFmt_VOP_SDWA.SRC0);
+        // use copies of original src0, src1, and vdst during selecting
+        VecOperandU32 origSrc0_sdwa(gpuDynInst, extData.iFmt_VOP_SDWA.SRC0);
+        VecOperandF32 origVdst(gpuDynInst, instData.VDST);
+
+        src0_sdwa.read();
+        origSrc0_sdwa.read();
+
+        DPRINTF(
+            VEGA,
+            "Handling V_CVT_F32_F16 SRC SDWA. SRC0: register "
+            "v[%d], DST_SEL: %d, DST_U: %d, CLMP: %d, SRC0_SEL: "
+            "%d, SRC0_SEXT: %d, SRC0_NEG: %d, SRC0_ABS: %d, SRC1_SEL: "
+            "%d, SRC1_SEXT: %d, SRC1_NEG: %d, SRC1_ABS: %d\n",
+            extData.iFmt_VOP_SDWA.SRC0, extData.iFmt_VOP_SDWA.DST_SEL,
+            extData.iFmt_VOP_SDWA.DST_U, extData.iFmt_VOP_SDWA.CLMP,
+            extData.iFmt_VOP_SDWA.SRC0_SEL, extData.iFmt_VOP_SDWA.SRC0_SEXT,
+            extData.iFmt_VOP_SDWA.SRC0_NEG, extData.iFmt_VOP_SDWA.SRC0_ABS,
+            extData.iFmt_VOP_SDWA.SRC1_SEL, extData.iFmt_VOP_SDWA.SRC1_SEXT,
+            extData.iFmt_VOP_SDWA.SRC1_NEG, extData.iFmt_VOP_SDWA.SRC1_ABS);
+
+        processSDWA_src(extData.iFmt_VOP_SDWA, src0_sdwa, origSrc0_sdwa);
+
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                AMDGPU::mxfloat16 tmp(src0_sdwa[lane]);
+                vdst[lane] = float(tmp);
+            }
+        }
+
+        processSDWA_dst(extData.iFmt_VOP_SDWA, vdst, origVdst);
+    } else {
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                AMDGPU::mxfloat16 tmp(src[lane]);
+                vdst[lane] = float(tmp);
+            }
         }
     }
 

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -9815,5 +9815,47 @@ Inst_VOP3__V_PERMLANE32_SWAP_B32::execute(GPUDynInstPtr gpuDynInst)
     src0.write();
     vdst.write();
 } // execute
+// --- Inst_VOP3__V_ADD_I32 class methods ---
+
+Inst_VOP3__V_ADD_I32::Inst_VOP3__V_ADD_I32(InFmt_VOP3A *iFmt)
+    : Inst_VOP3A(iFmt, "v_add_i32", false)
+{
+    setFlag(ALU);
+} // Inst_VOP3__V_ADD_I32
+
+Inst_VOP3__V_ADD_I32::~Inst_VOP3__V_ADD_I32()
+{} // ~Inst_VOP3__V_ADD_I32
+
+// --- description from .arch file ---
+// D.u32 = S0.i32 + S1.i32.
+void
+Inst_VOP3__V_ADD_I32::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandI32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandI32 src1(gpuDynInst, extData.SRC1);
+    VecOperandI32 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    /**
+     * input modifiers are supported by FP operations only
+     */
+    assert(!(instData.ABS & 0x1));
+    assert(!(instData.ABS & 0x2));
+    assert(!(instData.ABS & 0x4));
+    assert(!(extData.NEG & 0x1));
+    assert(!(extData.NEG & 0x2));
+    assert(!(extData.NEG & 0x4));
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            vdst[lane] = src0[lane] + src1[lane];
+        }
+    }
+
+    vdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -9857,5 +9857,84 @@ Inst_VOP3__V_ADD_I32::execute(GPUDynInstPtr gpuDynInst)
 
     vdst.write();
 } // execute
+// --- Inst_VOP3__V_PACK_B32_F16 class methods ---
+
+Inst_VOP3__V_PACK_B32_F16::Inst_VOP3__V_PACK_B32_F16(InFmt_VOP3A *iFmt)
+    : Inst_VOP3A(iFmt, "v_pack_b32_f16", false)
+{
+    setFlag(ALU);
+} // Inst_VOP3__V_PACK_B32_F16
+
+Inst_VOP3__V_PACK_B32_F16::~Inst_VOP3__V_PACK_B32_F16()
+{} // ~Inst_VOP3__V_PACK_B32_F16
+
+// --- description from .arch file ---
+// D0[31 : 16].f16 = S1.f16;
+// D0[15 : 0].f16 = S0.f16
+void
+Inst_VOP3__V_PACK_B32_F16::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandU32 src1(gpuDynInst, extData.SRC1);
+    VecOperandU32 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    panic_if(isSDWAInst(), "SDWA not supported for %s", _opcode);
+    panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+    panic_if(instData.CLAMP, "CLAMP not supported for %s", _opcode);
+    panic_if(extData.OMOD, "OMOD not supported for %s", _opcode);
+
+    unsigned abs = instData.ABS;
+    unsigned neg = extData.NEG;
+    int opsel = instData.OPSEL;
+
+    // Opsel for dest and src2 not used.
+    assert(!(opsel & 0x8) && !(opsel & 0x4));
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            uint32_t tmp0, tmp1;
+
+            // Select the correct upper or lower 16-bits from sources.
+            if (opsel & 0x1) {
+                tmp0 = bits(src0[lane], 31, 16);
+            } else {
+                tmp0 = bits(src0[lane], 15, 0);
+            }
+
+            if (opsel & 0x2) {
+                tmp1 = bits(src1[lane], 31, 16);
+            } else {
+                tmp1 = bits(src1[lane], 15, 0);
+            }
+
+            // Apply ABS if set by clearing MSb.
+            if (abs & 0x1) {
+                tmp0 &= 0x7fff;
+            }
+            if (abs & 0x2) {
+                tmp1 &= 0x7fff;
+            }
+
+            // Apply NEG if set by setting MSb.
+            if (neg & 0x1) {
+                tmp0 |= 0x8000;
+            }
+            if (neg & 0x2) {
+                tmp1 |= 0x8000;
+            }
+
+            // Place the F16 bits into the destination.
+            vdst[lane] = 0;
+            replaceBits(vdst[lane], 31, 16, tmp1);
+            replaceBits(vdst[lane], 15, 0, tmp0);
+        }
+    }
+
+    vdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -10022,5 +10022,47 @@ Inst_VOP3__V_SUB_I16::execute(GPUDynInstPtr gpuDynInst)
 
     vdst.write();
 } // execute
+// --- Inst_VOP3__V_SUB_I32 class methods ---
+
+Inst_VOP3__V_SUB_I32::Inst_VOP3__V_SUB_I32(InFmt_VOP3A *iFmt)
+    : Inst_VOP3A(iFmt, "v_sub_i32", false)
+{
+    setFlag(ALU);
+} // Inst_VOP3__V_SUB_I32
+
+Inst_VOP3__V_SUB_I32::~Inst_VOP3__V_SUB_I32()
+{} // ~Inst_VOP3__V_SUB_I32
+
+// --- description from .arch file ---
+// D.i32 = S0.i32 - S1.i32.
+void
+Inst_VOP3__V_SUB_I32::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandI32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandI32 src1(gpuDynInst, extData.SRC1);
+    VecOperandI32 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    /**
+     * input modifiers are supported by FP operations only
+     */
+    assert(!(instData.ABS & 0x1));
+    assert(!(instData.ABS & 0x2));
+    assert(!(instData.ABS & 0x4));
+    assert(!(extData.NEG & 0x1));
+    assert(!(extData.NEG & 0x2));
+    assert(!(extData.NEG & 0x4));
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            vdst[lane] = src0[lane] - src1[lane];
+        }
+    }
+
+    vdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -9979,5 +9979,48 @@ Inst_VOP3__V_ADD_I16::execute(GPUDynInstPtr gpuDynInst)
 
     vdst.write();
 } // execute
+// --- Inst_VOP3__V_SUB_I16 class methods ---
+
+Inst_VOP3__V_SUB_I16::Inst_VOP3__V_SUB_I16(InFmt_VOP3A *iFmt)
+    : Inst_VOP3A(iFmt, "v_sub_i16", false)
+{
+    setFlag(ALU);
+} // Inst_VOP3__V_SUB_I16
+
+Inst_VOP3__V_SUB_I16::~Inst_VOP3__V_SUB_I16()
+{} // ~Inst_VOP3__V_SUB_I16
+
+// --- description from .arch file ---
+// D.i16 = S0.i16 - S1.i16.
+// Supports saturation (unsigned 16-bit integer domain).
+void
+Inst_VOP3__V_SUB_I16::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandI16 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandI16 src1(gpuDynInst, extData.SRC1);
+    VecOperandI16 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    /**
+     * input modifiers are supported by FP operations only
+     */
+    assert(!(instData.ABS & 0x1));
+    assert(!(instData.ABS & 0x2));
+    assert(!(instData.ABS & 0x4));
+    assert(!(extData.NEG & 0x1));
+    assert(!(extData.NEG & 0x2));
+    assert(!(extData.NEG & 0x4));
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            vdst[lane] = src0[lane] - src1[lane];
+        }
+    }
+
+    vdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3.cc
+++ b/src/arch/amdgpu/vega/insts/vop3.cc
@@ -9936,5 +9936,48 @@ Inst_VOP3__V_PACK_B32_F16::execute(GPUDynInstPtr gpuDynInst)
 
     vdst.write();
 } // execute
+// --- Inst_VOP3__V_ADD_I16 class methods ---
+
+Inst_VOP3__V_ADD_I16::Inst_VOP3__V_ADD_I16(InFmt_VOP3A *iFmt)
+    : Inst_VOP3A(iFmt, "v_add_i16", false)
+{
+    setFlag(ALU);
+} // Inst_VOP3__V_ADD_I16
+
+Inst_VOP3__V_ADD_I16::~Inst_VOP3__V_ADD_I16()
+{} // ~Inst_VOP3__V_ADD_I16
+
+// --- description from .arch file ---
+// D.i16 = S0.i16 + S1.i16.
+// Supports saturation (unsigned 16-bit integer domain).
+void
+Inst_VOP3__V_ADD_I16::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandI16 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandI16 src1(gpuDynInst, extData.SRC1);
+    VecOperandI16 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    /**
+     * input modifiers are supported by FP operations only
+     */
+    assert(!(instData.ABS & 0x1));
+    assert(!(instData.ABS & 0x2));
+    assert(!(instData.ABS & 0x4));
+    assert(!(extData.NEG & 0x1));
+    assert(!(extData.NEG & 0x2));
+    assert(!(extData.NEG & 0x4));
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            vdst[lane] = src0[lane] + src1[lane];
+        }
+    }
+
+    vdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3_cmp.cc
+++ b/src/arch/amdgpu/vega/insts/vop3_cmp.cc
@@ -701,7 +701,38 @@ Inst_VOP3__V_CMP_O_F16::~Inst_VOP3__V_CMP_O_F16()
 void
 Inst_VOP3__V_CMP_O_F16::execute(GPUDynInstPtr gpuDynInst)
 {
-    panicUnimplemented();
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandU32 src1(gpuDynInst, extData.SRC1);
+    ScalarOperandU64 sdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
+    panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+
+    // Modifiers (abs, neg, etc.) should not impact anything as this is
+    // just a NaN check, so they are ignored here.
+    int opsel = instData.OPSEL;
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            uint16_t S0 = opsel & 0x1 ? uint16_t(bits(src0[lane], 31, 16))
+                                      : uint16_t(bits(src0[lane], 15, 0));
+            uint16_t S1 = opsel & 0x2 ? uint16_t(bits(src1[lane], 31, 16))
+                                      : uint16_t(bits(src1[lane], 15, 0));
+
+            // NaN is max exponent + non-zero mantissa.
+            uint16_t expMask = 0x7C00;
+            uint16_t manMask = 0x03FF;
+            bool isS0NaN = (S0 & expMask) == expMask && (S0 & manMask) != 0;
+            bool isS1NaN = (S1 & expMask) == expMask && (S1 & manMask) != 0;
+            sdst.setBit(lane, (!isS0NaN && !isS1NaN) ? 1 : 0);
+        }
+    }
+
+    sdst.write();
 } // execute
 // --- Inst_VOP3__V_CMP_U_F16 class methods ---
 

--- a/src/arch/amdgpu/vega/insts/vop3_cmp.cc
+++ b/src/arch/amdgpu/vega/insts/vop3_cmp.cc
@@ -606,7 +606,47 @@ Inst_VOP3__V_CMP_EQ_F16::~Inst_VOP3__V_CMP_EQ_F16()
 void
 Inst_VOP3__V_CMP_EQ_F16::execute(GPUDynInstPtr gpuDynInst)
 {
-    panicUnimplemented();
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU16 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandU16 src1(gpuDynInst, extData.SRC1);
+    ScalarOperandU64 sdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+    sdst.read();
+
+    unsigned opsel = instData.OPSEL;
+    unsigned do_abs = instData.ABS;
+    unsigned do_neg = extData.NEG;
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            uint32_t i0 = opsel & 0x1 ? bits(src0[lane], 31, 16)
+                                      : bits(src0[lane], 15, 0);
+            uint32_t i1 = opsel & 0x2 ? bits(src1[lane], 31, 16)
+                                      : bits(src1[lane], 15, 0);
+
+            AMDGPU::mxfloat16 s0(i0);
+            AMDGPU::mxfloat16 s1(i1);
+
+            if ((do_abs & 1) && (s0 < 0.0f)) {
+                s0 = -s0;
+            }
+            if ((do_abs & 2) && (s1 < 0.0f)) {
+                s1 = -s1;
+            }
+            if (do_neg & 1) {
+                s0 = -s0;
+            }
+            if (do_neg & 2) {
+                s1 = -s1;
+            }
+
+            sdst.setBit(lane, (float(s0) == float(s1)) ? 1 : 0);
+        }
+    }
+
+    sdst.write();
 } // execute
 // --- Inst_VOP3__V_CMP_LE_F16 class methods ---
 

--- a/src/arch/amdgpu/vega/insts/vop3p.cc
+++ b/src/arch/amdgpu/vega/insts/vop3p.cc
@@ -1033,5 +1033,220 @@ Inst_VOP3P__V_MFMA_LOAD_SCALE::execute(GPUDynInstPtr gpuDynInst)
     }
 }
 
+void
+Inst_VOP3P__V_MAD_MIXLO_F16::execute(GPUDynInstPtr gpuDynInst)
+{
+    // Multiply two inputs and add a third input where the inputs
+    // are a mix of half-precision float and single-precision
+    // float values. Convert the result to a half-precision float.
+    // Store the result into the low bits of a vector register.
+    // Size and location of the three inputs are controlled by
+    // { OPSEL_HI[i], OPSEL[i] }: 0=src[31:0], 1=src[31:0],
+    // 2=src[15:0], 3=src[31:16]. For MIX opcodes the NEG_HI
+    // instruction field acts as an absolute-value modifier
+    // for the three inputs.
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandU32 src1(gpuDynInst, extData.SRC1);
+    ConstVecOperandU32 src2(gpuDynInst, extData.SRC2);
+    VecOperandU16 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+    src2.readSrc();
+
+    int opsel = instData.OPSEL;
+    int opsel_hi = extData.OPSEL_HI | (instData.OPSEL_HI2 << 2);
+    int neg_hi = instData.NEG_HI;
+
+    ArmISA::FPSCR fpscr;
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            float s0, s1, s2;
+
+            // Fill in s0.
+            if (opsel_hi & 0x1) {
+                uint16_t tmp0;
+
+                if (opsel & 0x1) {
+                    tmp0 = bits(src0[lane], 31, 16);
+                } else {
+                    tmp0 = bits(src0[lane], 15, 0);
+                }
+
+                uint32_t conv = ArmISA::fplibConvert<uint16_t, uint32_t>(
+                    tmp0, ArmISA::FPRounding_TIEEVEN, fpscr);
+                s0 = *reinterpret_cast<float *>(&conv);
+            } else {
+                uint32_t tmp0 = src0[lane];
+                s0 = *reinterpret_cast<float *>(&tmp0);
+            }
+
+            if (neg_hi & 0x1) {
+                s0 = std::fabs(s0);
+            }
+
+            // Fill in s1.
+            if (opsel_hi & 0x2) {
+                uint16_t tmp1;
+
+                if (opsel & 0x2) {
+                    tmp1 = bits(src1[lane], 31, 16);
+                } else {
+                    tmp1 = bits(src1[lane], 15, 0);
+                }
+
+                uint32_t conv = ArmISA::fplibConvert<uint16_t, uint32_t>(
+                    tmp1, ArmISA::FPRounding_TIEEVEN, fpscr);
+                s1 = *reinterpret_cast<float *>(&conv);
+            } else {
+                uint32_t tmp1 = src1[lane];
+                s1 = *reinterpret_cast<float *>(&tmp1);
+            }
+
+            if (neg_hi & 0x2) {
+                s1 = std::fabs(s1);
+            }
+
+            // Fill in s2.
+            if (opsel_hi & 0x4) {
+                uint16_t tmp2;
+
+                if (opsel & 0x4) {
+                    tmp2 = bits(src2[lane], 31, 16);
+                } else {
+                    tmp2 = bits(src2[lane], 15, 0);
+                }
+
+                uint32_t conv = ArmISA::fplibConvert<uint16_t, uint32_t>(
+                    tmp2, ArmISA::FPRounding_TIEEVEN, fpscr);
+                s2 = *reinterpret_cast<float *>(&conv);
+            } else {
+                uint32_t tmp2 = src2[lane];
+                s2 = *reinterpret_cast<float *>(&tmp2);
+            }
+
+            if (neg_hi & 0x4) {
+                s2 = std::fabs(s2);
+            }
+
+            float result = std::fma(s0, s1, s2);
+            uint32_t tmpv = *reinterpret_cast<uint32_t *>(&result);
+
+            vdst[lane] = ArmISA::fplibConvert<uint32_t, uint16_t>(
+                tmpv, ArmISA::FPRounding_TIEEVEN, fpscr);
+        }
+    }
+
+    vdst.write();
+}
+
+void
+Inst_VOP3P__V_MAD_MIX_F32::execute(GPUDynInstPtr gpuDynInst)
+{
+    // Multiply two inputs and add a third input where the inputs
+    // are a mix of half-precision float and single-precision
+    // float values. The result is stored as a single-precision
+    // float into the destination vector register. Size and location
+    // of the three inputs are controlled by
+    // { OPSEL_HI[i], OPSEL[i] }: 0=src[31:0], 1=src[31:0],
+    // 2=src[15:0], 3=src[31:16]. For MIX opcodes the NEG_HI
+    // instruction field acts as an absolute-value modifier
+    // for the three inputs.
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU32 src0(gpuDynInst, extData.SRC0);
+    ConstVecOperandU32 src1(gpuDynInst, extData.SRC1);
+    ConstVecOperandU32 src2(gpuDynInst, extData.SRC2);
+    VecOperandF32 vdst(gpuDynInst, instData.VDST);
+
+    src0.readSrc();
+    src1.readSrc();
+    src2.readSrc();
+
+    int opsel = instData.OPSEL;
+    int opsel_hi = extData.OPSEL_HI | (instData.OPSEL_HI2 << 2);
+    int neg_hi = instData.NEG_HI;
+
+    ArmISA::FPSCR fpscr;
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            float s0, s1, s2;
+
+            // Fill in s0.
+            if (opsel_hi & 0x1) {
+                uint16_t tmp0;
+
+                if (opsel & 0x1) {
+                    tmp0 = bits(src0[lane], 31, 16);
+                } else {
+                    tmp0 = bits(src0[lane], 15, 0);
+                }
+
+                uint32_t conv = ArmISA::fplibConvert<uint16_t, uint32_t>(
+                    tmp0, ArmISA::FPRounding_TIEEVEN, fpscr);
+                s0 = *reinterpret_cast<float *>(&conv);
+            } else {
+                uint32_t tmp0 = src0[lane];
+                s0 = *reinterpret_cast<float *>(&tmp0);
+            }
+
+            if (neg_hi & 0x1) {
+                s0 = std::fabs(s0);
+            }
+
+            // Fill in s1.
+            if (opsel_hi & 0x2) {
+                uint16_t tmp1;
+
+                if (opsel & 0x2) {
+                    tmp1 = bits(src1[lane], 31, 16);
+                } else {
+                    tmp1 = bits(src1[lane], 15, 0);
+                }
+
+                uint32_t conv = ArmISA::fplibConvert<uint16_t, uint32_t>(
+                    tmp1, ArmISA::FPRounding_TIEEVEN, fpscr);
+                s1 = *reinterpret_cast<float *>(&conv);
+            } else {
+                uint32_t tmp1 = src1[lane];
+                s1 = *reinterpret_cast<float *>(&tmp1);
+            }
+
+            if (neg_hi & 0x2) {
+                s1 = std::fabs(s1);
+            }
+
+            // Fill in s2.
+            if (opsel_hi & 0x4) {
+                uint16_t tmp2;
+
+                if (opsel & 0x4) {
+                    tmp2 = bits(src2[lane], 31, 16);
+                } else {
+                    tmp2 = bits(src2[lane], 15, 0);
+                }
+
+                uint32_t conv = ArmISA::fplibConvert<uint16_t, uint32_t>(
+                    tmp2, ArmISA::FPRounding_TIEEVEN, fpscr);
+                s2 = *reinterpret_cast<float *>(&conv);
+            } else {
+                uint32_t tmp2 = src2[lane];
+                s2 = *reinterpret_cast<float *>(&tmp2);
+            }
+
+            if (neg_hi & 0x4) {
+                s2 = std::fabs(s2);
+            }
+
+            float result = std::fma(s0, s1, s2);
+            vdst[lane] = result;
+        }
+    }
+
+    vdst.write();
+}
+
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/vop3p.cc
+++ b/src/arch/amdgpu/vega/insts/vop3p.cc
@@ -728,10 +728,10 @@ Inst_VOP3P__V_PK_FMA_F32::execute(GPUDynInstPtr gpuDynInst)
             if (neg & 1) {
                 s0lf = -s0lf;
             }
-            if (neg & 1) {
+            if (neg & 2) {
                 s1lf = -s1lf;
             }
-            if (neg & 1) {
+            if (neg & 4) {
                 s2lf = -s2lf;
             }
 
@@ -751,10 +751,10 @@ Inst_VOP3P__V_PK_FMA_F32::execute(GPUDynInstPtr gpuDynInst)
             if (neg_hi & 1) {
                 s0hf = -s0hf;
             }
-            if (neg_hi & 1) {
+            if (neg_hi & 2) {
                 s1hf = -s1hf;
             }
-            if (neg_hi & 1) {
+            if (neg_hi & 4) {
                 s2hf = -s2hf;
             }
 

--- a/src/arch/amdgpu/vega/insts/vop3p.hh
+++ b/src/arch/amdgpu/vega/insts/vop3p.hh
@@ -464,6 +464,26 @@ class Inst_VOP3P__V_ACCVGPR_WRITE : public Inst_VOP3P__1OP
 
     void execute(GPUDynInstPtr gpuDynInst) override;
 };
+
+class Inst_VOP3P__V_MAD_MIXLO_F16 : public Inst_VOP3P__3OP_X16
+{
+  public:
+    Inst_VOP3P__V_MAD_MIXLO_F16(InFmt_VOP3P *iFmt)
+        : Inst_VOP3P__3OP_X16(iFmt, "v_mad_mixlo_f16")
+    {}
+
+    void execute(GPUDynInstPtr gpuDynInst) override;
+};
+
+class Inst_VOP3P__V_MAD_MIX_F32 : public Inst_VOP3P__3OP_X16
+{
+  public:
+    Inst_VOP3P__V_MAD_MIX_F32(InFmt_VOP3P *iFmt)
+        : Inst_VOP3P__3OP_X16(iFmt, "v_mad_mix_f32")
+    {}
+
+    void execute(GPUDynInstPtr gpuDynInst) override;
+};
 } // namespace VegaISA
 } // namespace gem5
 

--- a/src/arch/amdgpu/vega/insts/vopc.cc
+++ b/src/arch/amdgpu/vega/insts/vopc.cc
@@ -710,7 +710,32 @@ Inst_VOPC__V_CMP_O_F16::~Inst_VOPC__V_CMP_O_F16()
 void
 Inst_VOPC__V_CMP_O_F16::execute(GPUDynInstPtr gpuDynInst)
 {
-    panicUnimplemented();
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU16 src0(gpuDynInst, instData.SRC0);
+    ConstVecOperandU16 src1(gpuDynInst, instData.VSRC1);
+    ScalarOperandU64 vcc(gpuDynInst, REG_VCC_LO);
+
+    src0.readSrc();
+    src1.readSrc();
+
+    panic_if(isSDWAInst(), "SDWA not implemented for %s", _opcode);
+    panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (wf->execMask(lane)) {
+            uint16_t S0 = src0[lane];
+            uint16_t S1 = src1[lane];
+
+            // NaN is max exponent + non-zero mantissa.
+            uint16_t expMask = 0x7C00;
+            uint16_t manMask = 0x03FF;
+            bool isS0NaN = (S0 & expMask) == expMask && (S0 & manMask) != 0;
+            bool isS1NaN = (S1 & expMask) == expMask && (S1 & manMask) != 0;
+            vcc.setBit(lane, (!isS0NaN && !isS1NaN) ? 1 : 0);
+        }
+    }
+
+    vcc.write();
 } // execute
 // --- Inst_VOPC__V_CMP_U_F16 class methods ---
 

--- a/src/arch/amdgpu/vega/insts/vopc.cc
+++ b/src/arch/amdgpu/vega/insts/vopc.cc
@@ -30,6 +30,7 @@
  */
 
 #include "arch/amdgpu/vega/insts/instructions.hh"
+#include "arch/arm/insts/fplib.hh"
 
 namespace gem5
 {
@@ -615,7 +616,34 @@ Inst_VOPC__V_CMP_EQ_F16::~Inst_VOPC__V_CMP_EQ_F16()
 void
 Inst_VOPC__V_CMP_EQ_F16::execute(GPUDynInstPtr gpuDynInst)
 {
-    panicUnimplemented();
+    Wavefront *wf = gpuDynInst->wavefront();
+    ConstVecOperandU32 src0(gpuDynInst, instData.SRC0);
+    ConstVecOperandU32 src1(gpuDynInst, instData.VSRC1);
+    ScalarOperandU64 vcc(gpuDynInst, REG_VCC_LO);
+
+    src0.readSrc();
+    src1.read();
+
+    auto cmpImpl = [](uint32_t a, uint32_t b) {
+        uint16_t a_fp16 = uint16_t(a & 0xFFFF);
+        uint16_t b_fp16 = uint16_t(b & 0xFFFF);
+        ArmISA::FPSCR fpscr;
+        return int(fplibCompareEQ(a_fp16, b_fp16, fpscr));
+    };
+
+    if (isSDWAInst()) {
+        sdwabHelper<uint32_t>(gpuDynInst, cmpImpl);
+    } else if (isDPPInst()) {
+        panic_if(isDPPInst(), "DPP not supported for %s", _opcode);
+    } else {
+        for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+            if (wf->execMask(lane)) {
+                vcc.setBit(lane, cmpImpl(src0[lane], src1[lane]));
+            }
+        }
+
+        vcc.write();
+    }
 } // execute
 // --- Inst_VOPC__V_CMP_LE_F16 class methods ---
 


### PR DESCRIPTION
Adding a bunch of instructions that triton likes to use. We now have advanced instructions like the ability to add and subtract signed numbers. Tested with single instruction tests found here: https://github.com/abmerop/gem5-resources/tree/inst-tests/src/gpu/instruction-tests. 