### PR TITLE
stdlib: Use VIPERSequencer for GPU SQC/Scalar cache

### DIFF
--- a/src/python/gem5/prebuilt/viper/gpu_cache_hierarchy.py
+++ b/src/python/gem5/prebuilt/viper/gpu_cache_hierarchy.py
@@ -40,6 +40,7 @@ from m5.objects import (
     SrcClockDomain,
     TreePLRURP,
     VIPERCoalescer,
+    VIPERSequencer,
     VoltageDomain,
 )
 
@@ -196,7 +197,7 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
 
             sqc.version = idx
 
-            sqc.sequencer = RubySequencer(
+            sqc.sequencer = VIPERSequencer(
                 version=self.seqCount(),
                 dcache=sqc.L1cache,
                 ruby_system=self.ruby_gpu,
@@ -230,7 +231,7 @@ class ViperGPUCacheHierarchy(AbstractRubyCacheHierarchy):
             # Scalar uses same controller as SQC, so add SQC count
             scalar.version = idx + num_sqcs
 
-            scalar.sequencer = RubySequencer(
+            scalar.sequencer = VIPERSequencer(
                 version=self.seqCount(),
                 dcache=scalar.L1cache,
                 ruby_system=self.ruby_gpu,


### PR DESCRIPTION
The VIPERSequencer handles special reads which are not associated with an address. For example, s_memtime will issue a read request to SQC with no address set. These caches therefore need to use the special VIPER sequencer instead of the standard sequencer.