### PR TITLE
cpu-o3: O3 CPU inter-stage unblock signal causes 1-cycle bubble due to propagation delay

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -100,6 +100,16 @@ class BaseO3CPU(BaseCPU):
     fetchToDecodeDelay = Param.Cycles(1, "Fetch to decode delay")
     decodeWidth = Param.Unsigned(8, "Decode width")
 
+    earlyUnblock = Param.Bool(
+        True,
+        "Signal an upstream stage to unblock as soon as the entries left in "
+        "the skid buffer can keep this stage busy for the block/unblock "
+        "signal round trip, instead of waiting for the skid buffer to drain "
+        "completely. Waiting for a fully drained skid buffer leaves a bubble "
+        "as wide as the round trip. Set to False to restore the legacy "
+        "behaviour.",
+    )
+
     iewToRenameDelay = Param.Cycles(
         1, "Issue/Execute/Writeback to rename delay"
     )

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -97,6 +97,7 @@ Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
       iewToDecodeDelay(params.iewToDecodeDelay),
       commitToDecodeDelay(params.commitToDecodeDelay),
       fetchToDecodeDelay(params.fetchToDecodeDelay),
+      decodeToFetchDelay(params.decodeToFetchDelay),
       decodeWidth(params.decodeWidth),
       numThreads(params.numThreads),
       stats(_cpu)
@@ -302,17 +303,24 @@ Decode::block(ThreadID tid)
 bool
 Decode::unblock(ThreadID tid)
 {
-    // Decode is done unblocking only if the skid buffer is empty.
-    if (skidBuffer[tid].empty()) {
-        DPRINTF(Decode, "[tid:%i] Done unblocking.\n", tid);
+    // Send unblock when skid buffer can be drained within decodeToFetchDelay
+    // cycles. This compensates for signal propagation delay so fetch can
+    // resume without a bubble. Only transition to Running when truly empty.
+    unsigned earlyThreshold = decodeToFetchDelay * decodeWidth;
+    if (skidBuffer[tid].size() <= earlyThreshold) {
         toFetch->decodeUnblock[tid] = true;
         wroteToTimeBuffer = true;
 
-        decodeStatus[tid] = Running;
-        return true;
+        if (skidBuffer[tid].empty()) {
+            DPRINTF(Decode, "[tid:%i] Done unblocking.\n", tid);
+            decodeStatus[tid] = Running;
+            return true;
+        }
+        DPRINTF(Decode,
+                "[tid:%i] Early unblock signal (skid size %u <= "
+                "threshold %u), staying in Unblocking.\n",
+                tid, skidBuffer[tid].size(), earlyThreshold);
     }
-
-    DPRINTF(Decode, "[tid:%i] Currently unblocking.\n", tid);
 
     return false;
 }
@@ -507,7 +515,6 @@ Decode::readStallSignals(ThreadID tid)
     }
 
     if (fromRename->renameUnblock[tid]) {
-        assert(stalls[tid].rename);
         stalls[tid].rename = false;
     }
 }

--- a/src/cpu/o3/decode.cc
+++ b/src/cpu/o3/decode.cc
@@ -97,6 +97,7 @@ Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
       iewToDecodeDelay(params.iewToDecodeDelay),
       commitToDecodeDelay(params.commitToDecodeDelay),
       fetchToDecodeDelay(params.fetchToDecodeDelay),
+      decodeToFetchDelay(params.decodeToFetchDelay),
       decodeWidth(params.decodeWidth),
       numThreads(params.numThreads),
       stats(_cpu)
@@ -106,10 +107,29 @@ Decode::Decode(CPU *_cpu, const BaseO3CPUParams &params)
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              decodeWidth, static_cast<int>(MaxWidth));
 
-    // @todo: Make into a parameter
-    skidBufferMax = (fetchToDecodeDelay + 1) *  params.decodeWidth;
+    // The skid buffer has to absorb every instruction fetch can still send
+    // while a block signal is in flight, which spans the whole
+    // fetch -> decode -> fetch round trip. Note that fetch rate limits
+    // itself to decodeWidth instructions per cycle, so that is the relevant
+    // producer bandwidth here.
+    const unsigned round_trip = fetchToDecodeDelay + decodeToFetchDelay;
+    skidBufferMax = (round_trip ? round_trip : 1) * params.decodeWidth;
+    // Fetch's instructions land round_trip cycles after the unblock signal
+    // is sent, so the skid buffer needs to keep decode busy for all but that
+    // last cycle. Anything larger would risk overflowing the skid buffer.
+    earlyUnblockThreshold =
+        params.earlyUnblock
+            ? (round_trip ? round_trip - 1 : 0) * params.decodeWidth
+            : 0;
+
+    fatal_if(earlyUnblockThreshold + params.decodeWidth > skidBufferMax,
+             "decode skid buffer (%u) cannot hold the early unblock "
+             "threshold (%u) plus one cycle of fetch bandwidth (%u)\n",
+             skidBufferMax, earlyUnblockThreshold, params.decodeWidth);
+
     for (int tid = 0; tid < MaxThreads; tid++) {
         stalls[tid] = {false};
+        upstreamStalled[tid] = false;
         decodeStatus[tid] = Idle;
         bdelayDoneSeqNum[tid] = 0;
         squashInst[tid] = nullptr;
@@ -128,6 +148,7 @@ Decode::clearStates(ThreadID tid)
 {
     decodeStatus[tid] = Idle;
     stalls[tid].rename = false;
+    upstreamStalled[tid] = false;
 
     // Clear out any of this thread's instructions being sent to rename.
     for (int i = -cpu->decodeQueue.getPast();
@@ -156,6 +177,7 @@ Decode::resetStage()
         decodeStatus[tid] = Idle;
 
         stalls[tid].rename = false;
+        upstreamStalled[tid] = false;
     }
 }
 
@@ -279,34 +301,55 @@ Decode::block(ThreadID tid)
     // reprocessed when this stage unblocks.
     skidInsert(tid);
 
-    // If the decode status is blocked or unblocking then decode has not yet
-    // signalled fetch to unblock. In that case, there is no need to tell
-    // fetch to block.
-    if (decodeStatus[tid] != Blocked) {
-        // Set the status to Blocked.
-        decodeStatus[tid] = Blocked;
+    const bool status_change = decodeStatus[tid] != Blocked;
 
-        if (toFetch->decodeUnblock[tid]) {
-            toFetch->decodeUnblock[tid] = false;
-        } else {
-            toFetch->decodeBlock[tid] = true;
-            wroteToTimeBuffer = true;
-        }
+    // Set the status to Blocked.
+    decodeStatus[tid] = Blocked;
 
-        return true;
+    // An early unblock may already have been signalled in this same cycle.
+    // Retract it so fetch never observes both signals at once.
+    toFetch->decodeUnblock[tid] = false;
+
+    // Only tell fetch to stall if it does not already believe decode is
+    // blocked. The stage status cannot be used for this test: an early
+    // unblock releases fetch while decode is still Blocked or Unblocking.
+    if (!upstreamStalled[tid]) {
+        toFetch->decodeBlock[tid] = true;
+        upstreamStalled[tid] = true;
+        wroteToTimeBuffer = true;
     }
 
-    return false;
+    return status_change;
 }
 
 bool
 Decode::unblock(ThreadID tid)
 {
+    // A block decision taken earlier in this cycle wins. Fetch must not be
+    // told to resume when decode has just stalled again.
+    if (toFetch->decodeBlock[tid]) {
+        return false;
+    }
+
+    // Release fetch as soon as the entries left in the skid buffer can keep
+    // decode busy until fetch's instructions arrive. Waiting for the skid
+    // buffer to drain completely would leave a bubble as wide as the
+    // block/unblock round trip.
+    if (upstreamStalled[tid] &&
+        skidBuffer[tid].size() <= earlyUnblockThreshold) {
+        DPRINTF(Decode,
+                "[tid:%i] Unblocking fetch, skid buffer size %i is "
+                "within the early unblock threshold %i.\n",
+                tid, skidBuffer[tid].size(), earlyUnblockThreshold);
+
+        toFetch->decodeUnblock[tid] = true;
+        upstreamStalled[tid] = false;
+        wroteToTimeBuffer = true;
+    }
+
     // Decode is done unblocking only if the skid buffer is empty.
     if (skidBuffer[tid].empty()) {
         DPRINTF(Decode, "[tid:%i] Done unblocking.\n", tid);
-        toFetch->decodeUnblock[tid] = true;
-        wroteToTimeBuffer = true;
 
         decodeStatus[tid] = Running;
         return true;
@@ -315,6 +358,25 @@ Decode::unblock(ThreadID tid)
     DPRINTF(Decode, "[tid:%i] Currently unblocking.\n", tid);
 
     return false;
+}
+
+void
+Decode::releaseUpstream(ThreadID tid)
+{
+    if (!upstreamStalled[tid]) {
+        return;
+    }
+
+    if (toFetch->decodeBlock[tid]) {
+        // The block signal raised in this cycle has not been picked up by
+        // fetch yet, so it can simply be retracted.
+        toFetch->decodeBlock[tid] = false;
+    } else {
+        toFetch->decodeUnblock[tid] = true;
+        wroteToTimeBuffer = true;
+    }
+
+    upstreamStalled[tid] = false;
 }
 
 void
@@ -346,10 +408,7 @@ Decode::squash(const DynInstPtr &inst, bool control_miss, ThreadID tid)
     InstSeqNum squash_seq_num = inst->seqNum;
 
     // Might have to tell fetch to unblock.
-    if (decodeStatus[tid] == Blocked ||
-        decodeStatus[tid] == Unblocking) {
-        toFetch->decodeUnblock[tid] = 1;
-    }
+    releaseUpstream(tid);
 
     // Set status to squashing.
     decodeStatus[tid] = Squashing;
@@ -380,21 +439,8 @@ Decode::squash(ThreadID tid)
 {
     DPRINTF(Decode, "[tid:%i] Squashing.\n",tid);
 
-    if (decodeStatus[tid] == Blocked ||
-        decodeStatus[tid] == Unblocking) {
-        if (FullSystem) {
-            toFetch->decodeUnblock[tid] = 1;
-        } else {
-            // In syscall emulation, we can have both a block and a squash due
-            // to a syscall in the same cycle.  This would cause both signals
-            // to be high.  This shouldn't happen in full system.
-            // @todo: Determine if this still happens.
-            if (toFetch->decodeBlock[tid])
-                toFetch->decodeBlock[tid] = 0;
-            else
-                toFetch->decodeUnblock[tid] = 1;
-        }
-    }
+    // The squash empties the skid buffer, so fetch can be released.
+    releaseUpstream(tid);
 
     // Set status to squashing.
     decodeStatus[tid] = Squashing;
@@ -508,6 +554,7 @@ Decode::readStallSignals(ThreadID tid)
 
     if (fromRename->renameUnblock[tid]) {
         assert(stalls[tid].rename);
+        assert(!fromRename->renameBlock[tid]);
         stalls[tid].rename = false;
     }
 }

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -192,6 +192,14 @@ class Decode
      */
     bool unblock(ThreadID tid);
 
+    /** Releases fetch from a stall this stage previously signalled.
+     * If the block signal for this cycle has not been picked up yet it is
+     * simply retracted, otherwise an unblock is sent. Doing nothing when
+     * fetch is already running is what keeps the block/unblock signals
+     * strictly paired.
+     */
+    void releaseUpstream(ThreadID tid);
+
     /** Squashes if there is a PC-relative branch that was predicted
      * incorrectly. Sends squash information back to fetch.
      * @param inst The instruction that was mispredicted.
@@ -260,6 +268,14 @@ class Decode
     /** Tracks which stages are telling decode to stall. */
     Stalls stalls[MaxThreads];
 
+    /** Tracks whether fetch has been told that decode is blocked.
+     * The unblock signal is sent early, while decode is still draining its
+     * skid buffer, so the stage status is no longer a proxy for what fetch
+     * believes. Keeping this explicit is what prevents decode from either
+     * losing a block signal or asserting both signals in the same cycle.
+     */
+    bool upstreamStalled[MaxThreads];
+
     /** Rename to decode delay. */
     Cycles renameToDecodeDelay;
 
@@ -271,6 +287,11 @@ class Decode
 
     /** Fetch to decode delay. */
     Cycles fetchToDecodeDelay;
+
+    /** Decode to fetch delay. Together with fetchToDecodeDelay this forms
+     * the round trip of the block/unblock signals.
+     */
+    Cycles decodeToFetchDelay;
 
     /** The width of decode, in instructions. */
     unsigned decodeWidth;
@@ -286,6 +307,13 @@ class Decode
 
     /** Maximum size of the skid buffer. */
     unsigned skidBufferMax;
+
+    /** Skid buffer occupancy at or below which fetch is signalled to
+     * unblock. Releasing fetch early compensates for the round trip of the
+     * block/unblock signals, so fetch's instructions arrive just as the skid
+     * buffer runs dry instead of one or more cycles later.
+     */
+    unsigned earlyUnblockThreshold;
 
     /** SeqNum of Squashing Branch Delay Instruction (used for MIPS)*/
     Addr bdelayDoneSeqNum[MaxThreads];

--- a/src/cpu/o3/decode.hh
+++ b/src/cpu/o3/decode.hh
@@ -272,6 +272,9 @@ class Decode
     /** Fetch to decode delay. */
     Cycles fetchToDecodeDelay;
 
+    /** Decode to fetch delay (for early unblock calculation). */
+    Cycles decodeToFetchDelay;
+
     /** The width of decode, in instructions. */
     unsigned decodeWidth;
 

--- a/src/cpu/o3/fetch.cc
+++ b/src/cpu/o3/fetch.cc
@@ -924,7 +924,6 @@ Fetch::checkSignalsAndUpdate(ThreadID tid)
     }
 
     if (fromDecode->decodeUnblock[tid]) {
-        assert(stalls[tid].decode);
         assert(!fromDecode->decodeBlock[tid]);
         stalls[tid].decode = false;
     }

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -97,6 +97,7 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       commitToIEWDelay(params.commitToIEWDelay),
       renameToIEWDelay(params.renameToIEWDelay),
       issueToExecuteDelay(params.issueToExecuteDelay),
+      iewToRenameDelay(params.iewToRenameDelay),
       dispatchWidth(params.dispatchWidth),
       issueWidth(params.issueWidth),
       wbNumInst(0),
@@ -558,13 +559,23 @@ IEW::unblock(ThreadID tid)
     DPRINTF(IEW, "[tid:%i] Reading instructions out of the skid "
             "buffer %u.\n",tid, tid);
 
-    // If the skid bufffer is empty, signal back to previous stages to unblock.
-    // Also switch status to running.
-    if (skidBuffer[tid].empty()) {
+    // Send unblock when skid buffer can be drained within iewToRenameDelay
+    // cycles. This compensates for signal propagation delay so rename can
+    // resume without a bubble. Only transition to Running when truly empty.
+    unsigned earlyThreshold = iewToRenameDelay * dispatchWidth;
+    if (skidBuffer[tid].size() <= earlyThreshold) {
         toRename->iewUnblock[tid] = true;
         wroteToTimeBuffer = true;
-        DPRINTF(IEW, "[tid:%i] Done unblocking.\n",tid);
-        dispatchStatus[tid] = Running;
+
+        if (skidBuffer[tid].empty()) {
+            DPRINTF(IEW, "[tid:%i] Done unblocking.\n", tid);
+            dispatchStatus[tid] = Running;
+            return;
+        }
+        DPRINTF(IEW,
+                "[tid:%i] Early unblock signal (skid size %u <= "
+                "threshold %u), staying in Unblocking.\n",
+                tid, skidBuffer[tid].size(), earlyThreshold);
     }
 }
 

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -97,6 +97,7 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
       commitToIEWDelay(params.commitToIEWDelay),
       renameToIEWDelay(params.renameToIEWDelay),
       issueToExecuteDelay(params.issueToExecuteDelay),
+      iewToRenameDelay(params.iewToRenameDelay),
       dispatchWidth(params.dispatchWidth),
       issueWidth(params.issueWidth),
       wbNumInst(0),
@@ -134,11 +135,30 @@ IEW::IEW(CPU *_cpu, const BaseO3CPUParams &params)
     for (ThreadID tid = 0; tid < MaxThreads; tid++) {
         dispatchStatus[tid] = Running;
         fetchRedirect[tid] = false;
+        upstreamStalled[tid] = false;
     }
 
     updateLSQNextCycle = false;
 
-    skidBufferMax = (renameToIEWDelay + 1) * params.renameWidth;
+    // The skid buffer has to absorb every instruction rename can still send
+    // while a block signal is in flight, which spans the whole
+    // rename -> IEW -> rename round trip. Rename is the producer here, so
+    // its width is the relevant bandwidth.
+    const unsigned round_trip = renameToIEWDelay + iewToRenameDelay;
+    skidBufferMax = (round_trip ? round_trip : 1) * params.renameWidth;
+    // Rename's instructions land round_trip cycles after the unblock signal
+    // is sent, so the skid buffer needs to keep dispatch busy for all but
+    // that last cycle. Anything larger would risk overflowing the skid
+    // buffer.
+    earlyUnblockThreshold =
+        params.earlyUnblock
+            ? (round_trip ? round_trip - 1 : 0) * params.renameWidth
+            : 0;
+
+    fatal_if(earlyUnblockThreshold + params.renameWidth > skidBufferMax,
+             "IEW skid buffer (%u) cannot hold the early unblock "
+             "threshold (%u) plus one cycle of rename bandwidth (%u)\n",
+             skidBufferMax, earlyUnblockThreshold, params.renameWidth);
 }
 
 std::string
@@ -328,6 +348,8 @@ IEW::clearStates(ThreadID tid)
         time_struct.iewBlock[tid] = false;
         time_struct.iewUnblock[tid] = false;
     }
+
+    upstreamStalled[tid] = false;
 }
 
 void
@@ -440,6 +462,11 @@ IEW::takeOverFrom()
     for (ThreadID tid = 0; tid < numThreads; tid++) {
         dispatchStatus[tid] = Running;
         fetchRedirect[tid] = false;
+        // Rename drops its stall latch in its own takeOverFrom, so the record
+        // of having stalled it has to go as well. Keeping it would make
+        // block() believe rename is already stalled and silently swallow the
+        // first block signal after the switch.
+        upstreamStalled[tid] = false;
     }
 
     updateLSQNextCycle = false;
@@ -539,9 +566,16 @@ IEW::block(ThreadID tid)
 {
     DPRINTF(IEW, "[tid:%i] Blocking.\n", tid);
 
-    if (dispatchStatus[tid] != Blocked &&
-        dispatchStatus[tid] != Unblocking) {
+    // An early unblock may already have been signalled in this same cycle.
+    // Retract it so rename never observes both signals at once.
+    toRename->iewUnblock[tid] = false;
+
+    // Only tell rename to stall if it does not already believe dispatch is
+    // blocked. The stage status cannot be used for this test: an early
+    // unblock releases rename while dispatch is still Blocked or Unblocking.
+    if (!upstreamStalled[tid]) {
         toRename->iewBlock[tid] = true;
+        upstreamStalled[tid] = true;
         wroteToTimeBuffer = true;
     }
 
@@ -558,14 +592,52 @@ IEW::unblock(ThreadID tid)
     DPRINTF(IEW, "[tid:%i] Reading instructions out of the skid "
             "buffer %u.\n",tid, tid);
 
-    // If the skid bufffer is empty, signal back to previous stages to unblock.
-    // Also switch status to running.
-    if (skidBuffer[tid].empty()) {
+    // A block decision taken earlier in this cycle wins. Rename must not be
+    // told to resume when dispatch has just stalled again.
+    if (toRename->iewBlock[tid]) {
+        return;
+    }
+
+    // Release rename as soon as the entries left in the skid buffer can keep
+    // dispatch busy until rename's instructions arrive. Waiting for the skid
+    // buffer to drain completely would leave a bubble as wide as the
+    // block/unblock round trip.
+    if (upstreamStalled[tid] &&
+        skidBuffer[tid].size() <= earlyUnblockThreshold) {
+        DPRINTF(IEW,
+                "[tid:%i] Unblocking rename, skid buffer size %u is "
+                "within the early unblock threshold %u.\n",
+                tid, skidBuffer[tid].size(), earlyUnblockThreshold);
+
         toRename->iewUnblock[tid] = true;
+        upstreamStalled[tid] = false;
         wroteToTimeBuffer = true;
+    }
+
+    // Dispatch is done unblocking only if the skid buffer is empty.
+    if (skidBuffer[tid].empty()) {
         DPRINTF(IEW, "[tid:%i] Done unblocking.\n",tid);
         dispatchStatus[tid] = Running;
     }
+}
+
+void
+IEW::releaseUpstream(ThreadID tid)
+{
+    if (!upstreamStalled[tid]) {
+        return;
+    }
+
+    if (toRename->iewBlock[tid]) {
+        // The block signal raised in this cycle has not been picked up by
+        // rename yet, so it can simply be retracted.
+        toRename->iewBlock[tid] = false;
+    } else {
+        toRename->iewUnblock[tid] = true;
+        wroteToTimeBuffer = true;
+    }
+
+    upstreamStalled[tid] = false;
 }
 
 void
@@ -775,11 +847,8 @@ IEW::checkSignalsAndUpdate(ThreadID tid)
     if (fromCommit->commitInfo[tid].squash) {
         squash(tid);
 
-        if (dispatchStatus[tid] == Blocked ||
-            dispatchStatus[tid] == Unblocking) {
-            toRename->iewUnblock[tid] = true;
-            wroteToTimeBuffer = true;
-        }
+        // The squash empties the skid buffer, so rename can be released.
+        releaseUpstream(tid);
 
         dispatchStatus[tid] = Squashing;
         fetchRedirect[tid] = false;

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -262,6 +262,14 @@ class IEW
      */
     void unblock(ThreadID tid);
 
+    /** Releases rename from a stall this stage previously signalled.
+     * If the block signal for this cycle has not been picked up yet it is
+     * simply retracted, otherwise an unblock is sent. Doing nothing when
+     * rename is already running is what keeps the block/unblock signals
+     * strictly paired.
+     */
+    void releaseUpstream(ThreadID tid);
+
     /** Determines proper actions to take given Dispatch's status. */
     void dispatch(ThreadID tid);
 
@@ -392,6 +400,26 @@ class IEW
      * scheduled, and sent to a FU for execution.
      */
     Cycles issueToExecuteDelay;
+
+    /** IEW to rename delay. Together with renameToIEWDelay this forms the
+     * round trip of the block/unblock signals.
+     */
+    Cycles iewToRenameDelay;
+
+    /** Tracks whether rename has been told that dispatch is blocked.
+     * The unblock signal is sent early, while dispatch is still draining its
+     * skid buffer, so the stage status is no longer a proxy for what rename
+     * believes. Keeping this explicit is what prevents IEW from either
+     * losing a block signal or asserting both signals in the same cycle.
+     */
+    bool upstreamStalled[MaxThreads];
+
+    /** Skid buffer occupancy at or below which rename is signalled to
+     * unblock. Releasing rename early compensates for the round trip of the
+     * block/unblock signals, so rename's instructions arrive just as the
+     * skid buffer runs dry instead of one or more cycles later.
+     */
+    unsigned earlyUnblockThreshold;
 
     /** Width of dispatch, in instructions. */
     unsigned dispatchWidth;

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -390,6 +390,9 @@ class IEW
      */
     Cycles issueToExecuteDelay;
 
+    /** IEW to rename delay (for early unblock calculation). */
+    Cycles iewToRenameDelay;
+
     /** Width of dispatch, in instructions. */
     unsigned dispatchWidth;
 

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -84,6 +84,7 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
       iewToRenameDelay(params.iewToRenameDelay),
       decodeToRenameDelay(params.decodeToRenameDelay),
       commitToRenameDelay(params.commitToRenameDelay),
+      renameToDecodeDelay(params.renameToDecodeDelay),
       renameWidth(params.renameWidth),
       numThreads(params.numThreads),
       stats(_cpu)
@@ -930,16 +931,25 @@ Rename::unblock(ThreadID tid)
 {
     DPRINTF(Rename, "[tid:%i] Trying to unblock.\n", tid);
 
-    // Rename is done unblocking if the skid buffer is empty.
-    if (skidBuffer[tid].empty() && renameStatus[tid] != SerializeStall) {
-
-        DPRINTF(Rename, "[tid:%i] Done unblocking.\n", tid);
+    // Send unblock when skid buffer can be drained within renameToDecodeDelay
+    // cycles. This compensates for signal propagation delay so decode can
+    // resume without a bubble. Only transition to Running when truly empty.
+    unsigned earlyThreshold = renameToDecodeDelay * renameWidth;
+    if (skidBuffer[tid].size() <= earlyThreshold &&
+        renameStatus[tid] != SerializeStall) {
 
         toDecode->renameUnblock[tid] = true;
         wroteToTimeBuffer = true;
 
-        renameStatus[tid] = Running;
-        return true;
+        if (skidBuffer[tid].empty()) {
+            DPRINTF(Rename, "[tid:%i] Done unblocking.\n", tid);
+            renameStatus[tid] = Running;
+            return true;
+        }
+        DPRINTF(Rename,
+                "[tid:%i] Early unblock signal (skid size %u <= "
+                "threshold %u), staying in Unblocking.\n",
+                tid, skidBuffer[tid].size(), earlyThreshold);
     }
 
     return false;
@@ -1285,7 +1295,6 @@ Rename::readStallSignals(ThreadID tid)
     }
 
     if (fromIEW->iewUnblock[tid]) {
-        assert(stalls[tid].iew);
         stalls[tid].iew = false;
     }
 }

--- a/src/cpu/o3/rename.cc
+++ b/src/cpu/o3/rename.cc
@@ -84,6 +84,7 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
       iewToRenameDelay(params.iewToRenameDelay),
       decodeToRenameDelay(params.decodeToRenameDelay),
       commitToRenameDelay(params.commitToRenameDelay),
+      renameToDecodeDelay(params.renameToDecodeDelay),
       renameWidth(params.renameWidth),
       numThreads(params.numThreads),
       stats(_cpu)
@@ -93,8 +94,26 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
              "\tincrease MaxWidth in src/cpu/o3/limits.hh\n",
              renameWidth, static_cast<int>(MaxWidth));
 
-    // @todo: Make into a parameter.
-    skidBufferMax = (decodeToRenameDelay + 1) * params.decodeWidth;
+    // The skid buffer has to absorb every instruction decode can still send
+    // while a block signal is in flight, which spans the whole
+    // decode -> rename -> decode round trip. Decode is the producer here, so
+    // its width is the relevant bandwidth.
+    const unsigned round_trip = static_cast<unsigned>(decodeToRenameDelay) +
+                                static_cast<unsigned>(renameToDecodeDelay);
+    skidBufferMax = (round_trip ? round_trip : 1) * params.decodeWidth;
+    // Decode's instructions land round_trip cycles after the unblock signal
+    // is sent, so the skid buffer needs to keep rename busy for all but that
+    // last cycle. Anything larger would risk overflowing the skid buffer.
+    earlyUnblockThreshold =
+        params.earlyUnblock
+            ? (round_trip ? round_trip - 1 : 0) * params.decodeWidth
+            : 0;
+
+    fatal_if(earlyUnblockThreshold + params.decodeWidth > skidBufferMax,
+             "rename skid buffer (%u) cannot hold the early unblock "
+             "threshold (%u) plus one cycle of decode bandwidth (%u)\n",
+             skidBufferMax, earlyUnblockThreshold, params.decodeWidth);
+
     for (uint32_t tid = 0; tid < MaxThreads; tid++) {
         renameStatus[tid] = Idle;
         renameMap[tid] = nullptr;
@@ -104,6 +123,7 @@ Rename::Rename(CPU *_cpu, const BaseO3CPUParams &params)
         freeEntries[tid] = {0, 0, 0, 0};
         emptyROB[tid] = true;
         stalls[tid] = {false, false};
+        upstreamStalled[tid] = false;
         serializeInst[tid] = nullptr;
         serializeOnNextInst[tid] = false;
     }
@@ -256,6 +276,7 @@ Rename::clearStates(ThreadID tid)
     emptyROB[tid] = true;
 
     stalls[tid].iew = false;
+    upstreamStalled[tid] = false;
     serializeInst[tid] = NULL;
 
     instsInProgress[tid] = 0;
@@ -301,6 +322,7 @@ Rename::resetStage()
         emptyROB[tid] = true;
 
         stalls[tid].iew = false;
+        upstreamStalled[tid] = false;
         serializeInst[tid] = NULL;
 
         instsInProgress[tid] = 0;
@@ -379,7 +401,8 @@ Rename::squash(const InstSeqNum &squash_seq_num, ThreadID tid)
     // cycle and there should be space to hold everything due to the squash.
     if (renameStatus[tid] == Blocked ||
         renameStatus[tid] == Unblocking) {
-        toDecode->renameUnblock[tid] = 1;
+        // The squash empties the skid buffer, so decode can be released.
+        releaseUpstream(tid);
 
         resumeSerialize = false;
         serializeInst[tid] = NULL;
@@ -392,7 +415,10 @@ Rename::squash(const InstSeqNum &squash_seq_num, ThreadID tid)
             assert(serializeInst[tid]);
         } else {
             resumeSerialize = false;
-            toDecode->renameUnblock[tid] = 1;
+
+            // The serializing instruction survived the squash, so rename
+            // stops stalling on it and decode has to be released.
+            releaseUpstream(tid);
 
             serializeInst[tid] = NULL;
         }
@@ -894,23 +920,26 @@ Rename::block(ThreadID tid)
     // reprocessed when this stage unblocks.
     skidInsert(tid);
 
-    // Only signal backwards to block if the previous stages do not think
-    // rename is already blocked. While Unblocking, decode already believes
-    // rename is stalled (skid drain); do not re-assert renameBlock.
-    if (renameStatus[tid] != Blocked) {
-        if (renameStatus[tid] != Unblocking) {
-            toDecode->renameBlock[tid] = true;
-            toDecode->renameUnblock[tid] = false;
-            wroteToTimeBuffer = true;
-        }
+    // An early unblock may already have been signalled in this same cycle.
+    // Retract it so decode never observes both signals at once.
+    toDecode->renameUnblock[tid] = false;
 
-        // Rename can not go from SerializeStall to Blocked, otherwise
-        // it would not know to complete the serialize stall.
-        if (renameStatus[tid] != SerializeStall) {
-            // Set status to Blocked.
-            renameStatus[tid] = Blocked;
-            return true;
-        }
+    // Only signal backwards to block if decode does not already believe
+    // rename is blocked. The stage status cannot be used for this test: an
+    // early unblock releases decode while rename is still Blocked or
+    // Unblocking.
+    if (!upstreamStalled[tid]) {
+        toDecode->renameBlock[tid] = true;
+        upstreamStalled[tid] = true;
+        wroteToTimeBuffer = true;
+    }
+
+    // Rename can not go from SerializeStall to Blocked, otherwise
+    // it would not know to complete the serialize stall.
+    if (renameStatus[tid] != SerializeStall && renameStatus[tid] != Blocked) {
+        // Set status to Blocked.
+        renameStatus[tid] = Blocked;
+        return true;
     }
 
     return false;
@@ -921,19 +950,55 @@ Rename::unblock(ThreadID tid)
 {
     DPRINTF(Rename, "[tid:%i] Trying to unblock.\n", tid);
 
-    // Rename is done unblocking if the skid buffer is empty.
-    if (skidBuffer[tid].empty() && renameStatus[tid] != SerializeStall) {
+    // A block decision taken earlier in this cycle wins. Decode must not be
+    // told to resume when rename has just stalled again.
+    if (toDecode->renameBlock[tid]) {
+        return false;
+    }
 
-        DPRINTF(Rename, "[tid:%i] Done unblocking.\n", tid);
+    // Release decode as soon as the entries left in the skid buffer can keep
+    // rename busy until decode's instructions arrive. A serialize stall has
+    // no bound on its duration, so no early release is possible there.
+    if (upstreamStalled[tid] && renameStatus[tid] != SerializeStall &&
+        skidBuffer[tid].size() <= earlyUnblockThreshold) {
+        DPRINTF(Rename,
+                "[tid:%i] Unblocking decode, skid buffer size %i is "
+                "within the early unblock threshold %i.\n",
+                tid, skidBuffer[tid].size(), earlyUnblockThreshold);
 
         toDecode->renameUnblock[tid] = true;
+        upstreamStalled[tid] = false;
         wroteToTimeBuffer = true;
+    }
+
+    // Rename is done unblocking if the skid buffer is empty.
+    if (skidBuffer[tid].empty() && renameStatus[tid] != SerializeStall) {
+        DPRINTF(Rename, "[tid:%i] Done unblocking.\n", tid);
 
         renameStatus[tid] = Running;
         return true;
     }
 
     return false;
+}
+
+void
+Rename::releaseUpstream(ThreadID tid)
+{
+    if (!upstreamStalled[tid]) {
+        return;
+    }
+
+    if (toDecode->renameBlock[tid]) {
+        // The block signal raised in this cycle has not been picked up by
+        // decode yet, so it can simply be retracted.
+        toDecode->renameBlock[tid] = false;
+    } else {
+        toDecode->renameUnblock[tid] = true;
+        wroteToTimeBuffer = true;
+    }
+
+    upstreamStalled[tid] = false;
 }
 
 void
@@ -1277,6 +1342,7 @@ Rename::readStallSignals(ThreadID tid)
 
     if (fromIEW->iewUnblock[tid]) {
         assert(stalls[tid].iew);
+        assert(!fromIEW->iewBlock[tid]);
         stalls[tid].iew = false;
     }
 }

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -243,6 +243,14 @@ class Rename
      */
     bool unblock(ThreadID tid);
 
+    /** Releases decode from a stall this stage previously signalled.
+     * If the block signal for this cycle has not been picked up yet it is
+     * simply retracted, otherwise an unblock is sent. Doing nothing when
+     * decode is already running is what keeps the block/unblock signals
+     * strictly paired.
+     */
+    void releaseUpstream(ThreadID tid);
+
     /** Executes actual squash, removing squashed instructions. */
     void doSquash(const InstSeqNum &squash_seq_num, ThreadID tid);
 
@@ -424,6 +432,14 @@ class Rename
     /** Tracks which stages are telling decode to stall. */
     Stalls stalls[MaxThreads];
 
+    /** Tracks whether decode has been told that rename is blocked.
+     * The unblock signal is sent early, while rename is still draining its
+     * skid buffer, so the stage status is no longer a proxy for what decode
+     * believes. Keeping this explicit is what prevents rename from either
+     * losing a block signal or asserting both signals in the same cycle.
+     */
+    bool upstreamStalled[MaxThreads];
+
     /** The serialize instruction that rename has stalled on. */
     DynInstPtr serializeInst[MaxThreads];
 
@@ -440,6 +456,12 @@ class Rename
 
     /** Delay between commit and rename, in ticks. */
     unsigned commitToRenameDelay;
+
+    /** Delay between rename and decode, in ticks. Together with
+     * decodeToRenameDelay this forms the round trip of the block/unblock
+     * signals.
+     */
+    Cycles renameToDecodeDelay;
 
     /** Rename width, in instructions. */
     unsigned renameWidth;
@@ -461,6 +483,13 @@ class Rename
 
     /** The maximum skid buffer size. */
     unsigned skidBufferMax;
+
+    /** Skid buffer occupancy at or below which decode is signalled to
+     * unblock. Releasing decode early compensates for the round trip of the
+     * block/unblock signals, so decode's instructions arrive just as the
+     * skid buffer runs dry instead of one or more cycles later.
+     */
+    unsigned earlyUnblockThreshold;
 
     /** Enum to record the source of a structure full stall.  Can come from
      * either ROB, IQ, LSQ, and it is priortized in that order.

--- a/src/cpu/o3/rename.hh
+++ b/src/cpu/o3/rename.hh
@@ -441,6 +441,9 @@ class Rename
     /** Delay between commit and rename, in ticks. */
     unsigned commitToRenameDelay;
 
+    /** Rename to decode delay (for early unblock calculation). */
+    Cycles renameToDecodeDelay;
+
     /** Rename width, in instructions. */
     unsigned renameWidth;
 


### PR DESCRIPTION
Fixes #3190 

When a downstream stage (decode/rename/IEW) blocks the upstream stage, it previously only sent the unblock signal after its skid buffer was completely drained. Due to signal propagation delay (e.g., decodeToFetchDelay), this caused a 1-cycle bubble before the upstream stage could resume sending instructions.

Fix: send unblock early when skidBuffer.size() <= stageDelay * stageWidth, i.e., when the remaining entries can be consumed during the signal propagation time. The stage only transitions to Running state when the skid buffer is truly empty, maintaining correctness.

Applied uniformly to decode->fetch, rename->decode, and IEW->rename paths. Remove stale assertions that assumed unblock is only received once.