### PR TITLE
sim/power: initialize intermediate thermal nodes to ambient temp

### DIFF
--- a/src/sim/power/thermal_model.cc
+++ b/src/sim/power/thermal_model.cc
@@ -205,6 +205,23 @@ ThermalModel::startup()
     for (unsigned i = 0; i < eq_nodes.size(); i++)
         eq_nodes[i]->id = i;
 
+    // Initialize intermediate nodes (not ThermalDomain or ThermalReference)
+    // to the ambient reference temperature. Without this, these nodes retain
+    // the 0 K (absolute zero) default from ThermalNode's constructor.
+    // ThermalCapacitor::getEquation() uses n->temp as T_prev in the Backward
+    // Euler discretization; a 0 K intermediate node acts as an absolute-zero
+    // heat sink in the first solver step, causing physically impossible
+    // junction cooling (observed: die temp drops from 25 C to ~12 C despite
+    // positive power input in a 2-node Cauer RC network).
+    if (!references.empty()) {
+        const Temperature ambient = references[0]->_temperature;
+        for (auto *n : eq_nodes) {
+            if (n->temp.toKelvin() < 1.0) {
+                n->temp = ambient;
+            }
+        }
+    }
+
     // Schedule first thermal update
     schedule(stepEvent, curTick() + sim_clock::as_int::s * _step);
 }


### PR DESCRIPTION
ThermalModel::startup() initializes only ThermalDomain and ThermalReference nodes. Intermediate structural nodes (e.g. node_pkg in a 2-node Cauer RC network) retain the 0 K (absolute zero) default from ThermalNode's constructor. ThermalCapacitor::getEquation() uses n->temp as T_prev in the Backward Euler discretization; a 0 K intermediate node acts as an absolute-zero heat sink in the first solver step, causing physically impossible junction cooling.

Observed symptom: die temperature drops 25 C -> 12.34 C under ~3 W positive CPU power in a 2-node Cauer RC network, with the die temperature falling below ambient instead of rising toward steady-state.

Fix: after building eq_nodes in startup(), initialize any node whose temperature is below 1 K (i.e. the uninitialized 0 K constructor default) to the first ThermalReference temperature (ambient). Domain nodes are already initialized before eq_nodes is built and are unaffected by this check.

Independent verification: a Backward Euler Python solver with identical Cauer 2-node RC parameters reproduces the anomalous 12.29 C result (gem5 observed: 12.34 C, deviation: 0.05 C). With correct 298 K initialization the die temperature reaches 25.03 C as physics requires.

Reproduction dataset, verification script, and full analysis: https://github.com/rtester1111-tech/arm-thermal-research

Change-Id: Id3ce31fa614b438f38ddc0d08319e73d001b5cfa