### PR TITLE
base, mem: Add new Request::DEBUG to GDB read/write request

### DIFF
--- a/src/base/remote_gdb.cc
+++ b/src/base/remote_gdb.cc
@@ -815,8 +815,9 @@ BaseRemoteGDB::processCommands(GDBSignal sig)
 bool
 BaseRemoteGDB::readBlob(Addr vaddr, size_t size, char *data)
 {
-    TranslatingPortProxy fs_proxy(tc);
-    SETranslatingPortProxy se_proxy(tc);
+    TranslatingPortProxy fs_proxy(tc, Request::DEBUG);
+    SETranslatingPortProxy se_proxy(tc, SETranslatingPortProxy::NextPage,
+                                    Request::DEBUG);
     PortProxy &virt_proxy = FullSystem ? fs_proxy : se_proxy;
 
     virt_proxy.readBlob(vaddr, data, size);
@@ -826,8 +827,9 @@ BaseRemoteGDB::readBlob(Addr vaddr, size_t size, char *data)
 bool
 BaseRemoteGDB::writeBlob(Addr vaddr, size_t size, const char *data)
 {
-    TranslatingPortProxy fs_proxy(tc);
-    SETranslatingPortProxy se_proxy(tc);
+    TranslatingPortProxy fs_proxy(tc, Request::DEBUG);
+    SETranslatingPortProxy se_proxy(tc, SETranslatingPortProxy::NextPage,
+                                    Request::DEBUG);
     PortProxy &virt_proxy = FullSystem ? fs_proxy : se_proxy;
 
     virt_proxy.writeBlob(vaddr, data, size);

--- a/src/mem/port_proxy.hh
+++ b/src/mem/port_proxy.hh
@@ -71,7 +71,8 @@ class ThreadContext;
 
 /**
  * This object is a proxy for a port or other object which implements the
- * functional response protocol, to be used for debug accesses.
+ * functional response protocol, to be used for debug accesses or loading
+ * binaries.
  *
  * This proxy object is used when non structural entities
  * (e.g. thread contexts, object file loaders) need access to the

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -262,6 +262,11 @@ class Request : public Extensible<Request>
         /** TLBI_EXT_SYNC_COMP seems to be the largest value
             of FlagsType, so HAS_NO_ADDR's value is that << 1 */
         HAS_NO_ADDR                = 0x0001000000000000,
+
+        /**
+         * The request is debug access from debug model (gdb, etc)?
+         */
+        DEBUG                      = 0x0002000000000000,
         // clang-format on
     };
     static const FlagsType STORE_NO_DATA = CACHE_BLOCK_ZERO |
@@ -1094,6 +1099,12 @@ class Request : public Extensible<Request>
     isAcquirePC() const
     {
         return _cacheCoherenceFlags.isSet(ACQUIRE_PC);
+    }
+
+    bool
+    isDebug() const
+    {
+        return _flags.isSet(DEBUG);
     }
 
     /**


### PR DESCRIPTION
The Request::DEBUG explicitly indicates that request is from debug model (GDB, etc). Which is useful to bypass access check and probe data in device model