### PR TITLE
mem-ruby: Add Cbusy handling logic to the TlmGenerator

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -35,6 +35,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from m5.objects.CBusy import CBusyTracker
 from m5.objects.ClockedObject import ClockedObject
 from m5.objects.TlmController import TlmController
 from m5.params import *
@@ -90,5 +91,9 @@ class TlmGenerator(ClockedObject):
     max_pending_tran = OptionalParam.Unsigned(
         "Max number of pending transactions issued via the inject API"
     )
+    cbusy_tracker = Param.BackpressureTracker(
+        CBusyTracker(), "Tracks observed incoming CBusy levels"
+    )
+
     in_port = TlmSinkPort("CHI TLM input/response port")
     out_port = TlmSourcePort("CHI TLM output/request port")

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -64,6 +64,19 @@ CacheController::CacheController(const Params &p)
     };
 }
 
+void
+CacheController::init()
+{
+    uint64_t max_nodes_system = std::max(
+        {m_ruby_system->MachineType_base_count(ruby::MachineType_Cache),
+         m_ruby_system->MachineType_base_count(ruby::MachineType_Memory),
+         m_ruby_system->MachineType_base_count(ruby::MachineType_MiscNode)});
+    panic_if(max_nodes_system > MAX_NODES,
+             "Increse number of supported MAX_NODES\n");
+
+    CHIGenericController::init();
+}
+
 Port &
 CacheController::getPort(const std::string &if_name, PortID idx)
 {
@@ -188,6 +201,7 @@ CacheController::Transaction::handle(const CHIResponseMsg *msg)
     phase.resp = ruby_to_tlm::rspResp(msg->m_type);
     phase.txn_id = msg->m_txnId;
     phase.c_busy = msg->m_cbusy;
+    phase.src_id = ruby_to_tlm::srcId(msg->m_responder);
 
     controller->bw(payload, &phase);
     return opcode != ARM::CHI::RSP_OPCODE_RETRY_ACK;
@@ -210,6 +224,7 @@ CacheController::ReadTransaction::handle(const CHIDataMsg *msg)
     phase.txn_id = msg->m_txnId;
     phase.data_id = dataId(msg->m_addr + msg->m_bitMask.firstBitSet(true));
     phase.c_busy = msg->m_cbusy;
+    phase.src_id = ruby_to_tlm::srcId(msg->m_responder);
 
     // This is a hack, we should fix it on the ruby side
     if (forward(msg)) {

--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -92,6 +92,9 @@ namespace tlm::chi {
 class CacheController : public ruby::CHIGenericController
 {
   public:
+    /** We mainly use this when we flatten MachineID into src_id/tgt_id */
+    static constexpr uint64_t MAX_NODES = 1024;
+
     PARAMS(TlmController);
     CacheController(const Params &p);
 
@@ -105,6 +108,8 @@ class CacheController : public ruby::CHIGenericController
     std::function<void(ARM::CHI::Payload* payload, ARM::CHI::Phase* phase)> bw;
 
     Port &getPort(const std::string &if_name, PortID idx) override;
+
+    void init() override;
 
     bool recvRequestMsg(const CHIRequestMsg *msg) override;
     bool recvSnoopMsg(const CHIRequestMsg *msg) override;

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -178,6 +178,7 @@ TlmGenerator::TlmGenerator(const Params &p)
       outPort(name() + ".out_port", 0, this),
       inPort(name() + ".in_port", 0, this),
       suiteFailure(false),
+      cbusyTracker(p.cbusy_tracker),
       stats(this)
 {
     inPort.onChange([this](const TlmData &data) {
@@ -307,6 +308,8 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
 {
     DPRINTF(TLM, "[c%d] rcvd %s\n", cpuId, transactionToString(*payload, *phase));
 
+    handleCBusy(phase);
+
     if (handlePCredit(phase)) {
         return;
     } else if (auto it = pendingTransactions.find(phase->txn_id);
@@ -328,6 +331,28 @@ TlmGenerator::scheduleEvaluation(unsigned cycles, Transaction *transaction)
     auto &event = transaction->runCallbacksEvent;
     panic_if(event.scheduled(), "Already scheduled\n");
     schedule(event, clockEdge(Cycles(cycles)));
+}
+
+void
+TlmGenerator::handleCBusy(ARM::CHI::Phase *phase)
+{
+    if (phase->channel != ARM::CHI::CHANNEL_RSP &&
+        phase->channel != ARM::CHI::CHANNEL_DAT) {
+        return;
+    }
+
+    uint8_t cbusy10 = bits(phase->c_busy, 1, 0);
+    bool cbusy2 = bits(phase->c_busy, 2);
+
+    if (cbusy2) {
+        stats.cbusy2++;
+    }
+    stats.cbusy10[cbusy10]++;
+
+    if (cbusyTracker) {
+        const ruby::MachineID responder(tlm_to_ruby::srcId(phase->src_id));
+        cbusyTracker->update(responder, phase->c_busy);
+    }
 }
 
 bool
@@ -418,8 +443,14 @@ TlmGenerator::Stats::Stats(statistics::Group *_parent)
       ADD_STAT(retryAck, statistics::units::Count::get(),
                "Number of RetryAck received"),
       ADD_STAT(pcrdGrant, statistics::units::Count::get(),
-               "Number of PCrdGrant received")
-{}
+               "Number of PCrdGrant received"),
+      ADD_STAT(cbusy2, statistics::units::Count::get(),
+               "CBusy signals revceived"),
+      ADD_STAT(cbusy10, statistics::units::Count::get(),
+               "CBusy signals revceived")
+{
+    cbusy10.init(4);
+}
 
 } // namespace tlm::chi
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -45,6 +45,7 @@
 
 #include "mem/ruby/protocol/chi/tlm/port.hh"
 #include "mem/ruby/protocol/chi/tlm/utils.hh"
+#include "mem/ruby/structures/BackpressureTracker.hh"
 #include "params/TlmGenerator.hh"
 #include "sim/clocked_object.hh"
 #include "sim/eventq.hh"
@@ -375,6 +376,9 @@ class TlmGenerator : public ClockedObject
      */
     bool handlePCredit(ARM::CHI::Phase *phase);
 
+    /** Handle a C-busy message */
+    void handleCBusy(ARM::CHI::Phase *phase);
+
   protected:
     /** cpuId to mimic the behaviour of a CPU */
     uint8_t cpuId;
@@ -409,6 +413,9 @@ class TlmGenerator : public ClockedObject
     /** Has any transaction of the suite failed? */
     bool suiteFailure;
 
+    /** Tracks responder-reported CBusy values observed by the generator */
+    ruby::BackpressureTracker *cbusyTracker;
+
     struct Stats : public statistics::Group
     {
         Stats(statistics::Group *parent);
@@ -419,6 +426,10 @@ class TlmGenerator : public ClockedObject
         statistics::Scalar retryAck;
         /* Number of PCrdGrant received */
         statistics::Scalar pcrdGrant;
+
+        /* CBusy signals revceived */
+        statistics::Scalar cbusy2;
+        statistics::Vector cbusy10;
     } stats;
 };
 

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -38,7 +38,9 @@
 #include "mem/ruby/protocol/chi/tlm/utils.hh"
 
 #include "base/bitfield.hh"
+#include "base/intmath.hh"
 #include "base/logging.hh"
+#include "mem/ruby/protocol/chi/tlm/controller.hh"
 
 namespace gem5 {
 
@@ -328,6 +330,23 @@ rspOpcode(RspOpcode opc, Resp resp)
     };
 }
 
+ruby::MachineID
+srcId(uint16_t src_id)
+{
+    constexpr auto node_bits = log2i(CacheController::MAX_NODES);
+    uint16_t node_opcode = bits(src_id, 16, node_bits);
+    uint16_t node_id = bits(src_id, node_bits - 1, 0);
+    switch (node_opcode) {
+        case 0:
+            return {ruby::MachineType_Cache, node_id};
+        case 1:
+            return {ruby::MachineType_Memory, node_id};
+        case 2:
+            return {ruby::MachineType_MiscNode, node_id};
+        default:
+            panic("Invalid src_id\n");
+    }
+}
 }
 
 namespace ruby_to_tlm {
@@ -483,6 +502,26 @@ rspResp(CHIResponseType rsp)
     }
 }
 
+uint16_t
+srcId(ruby::MachineID src_id)
+{
+    uint16_t type_identifier;
+    switch (src_id.type) {
+        case ruby::MachineType_Cache:
+            type_identifier = 0;
+            break;
+        case ruby::MachineType_Memory:
+            type_identifier = 1;
+            break;
+        case ruby::MachineType_MiscNode:
+            type_identifier = 2;
+            break;
+        default:
+            panic("Invalid src_id\n");
+    }
+
+    return (type_identifier << log2i(CacheController::MAX_NODES)) | src_id.num;
+}
 }
 
 ::gem5::ArmISA::mpam::MpamBundle

--- a/src/mem/ruby/protocol/chi/tlm/utils.hh
+++ b/src/mem/ruby/protocol/chi/tlm/utils.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 ARM Limited
+ * Copyright (c) 2023, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -42,6 +42,7 @@
 
 #include "arch/arm/mpam.hh"
 #include "base/types.hh"
+#include "mem/ruby/common/MachineID.hh"
 #include "mem/ruby/protocol/CHI/CHIDataType.hh"
 #include "mem/ruby/protocol/CHI/CHIRequestType.hh"
 #include "mem/ruby/protocol/CHI/CHIResponseType.hh"
@@ -58,7 +59,7 @@ namespace tlm_to_ruby {
 ruby::CHI::CHIRequestType reqOpcode(ARM::CHI::ReqOpcode req);
 ruby::CHI::CHIDataType datOpcode(ARM::CHI::DatOpcode dat, ARM::CHI::Resp resp);
 ruby::CHI::CHIResponseType rspOpcode(ARM::CHI::RspOpcode res, ARM::CHI::Resp resp);
-
+ruby::MachineID srcId(uint16_t src_id);
 }
 
 namespace ruby_to_tlm {
@@ -69,7 +70,7 @@ uint8_t snpOpcode(ruby::CHI::CHIRequestType snp);
 
 ARM::CHI::Resp datResp(ruby::CHI::CHIDataType dat);
 ARM::CHI::Resp rspResp(ruby::CHI::CHIResponseType rsp);
-
+uint16_t srcId(ruby::MachineID src_id);
 }
 
 ::gem5::ArmISA::mpam::MpamBundle getMpam(const ARM::CHI::Payload &payload);


### PR DESCRIPTION
This PR adds CBusy handling logic to the TLMGenerator

1) Incoming values are recorded in the cbusy tracker child
2) Incoming values are recorded as cbusy10 and cbusy2 stats

The PR also adds a CHI-TLM <-> ruby srcId converstion logic