### PR TITLE
mem-cache: Fix cache block movement logic

### DIFF
--- a/src/mem/cache/cache_blk.hh
+++ b/src/mem/cache/cache_blk.hh
@@ -168,6 +168,15 @@ class CacheBlk : public TaggedEntry
      * will become invalid, and the invalid, valid. All location related
      * variables will remain the same, that is, an entry cannot move its
      * data, just its metadata contents.
+     *
+     * This implementation has to be virtual, because move assignments are
+     * generally performed on the CacheBlk object. If the CacheBlk is backed
+     * by an inheriting class like CompressionBlk, we need the inheritor to
+     * handle the move operation, even if it's called on a CacheBlk type.
+     *
+     * @param other A valid CacheBlk whose metadata should be moved into the
+     *              current entry
+     * @return *this
      */
     virtual CacheBlk&
     operator=(CacheBlk&& other)
@@ -177,10 +186,10 @@ class CacheBlk : public TaggedEntry
         assert(!isValid());
         assert(other.isValid());
 
-        insert({other.getTag(), other.isSecure()});
-
         if (other.wasPrefetched()) {
             setPrefetched();
+        } else {
+            clearPrefetched();
         }
         setCoherenceBits(other.coherence);
         setTaskId(other.getTaskId());
@@ -190,7 +199,13 @@ class CacheBlk : public TaggedEntry
         setSrcRequestorId(other.getSrcRequestorId());
         std::swap(lockList, other.lockList);
 
-        other.invalidate();
+        /*
+         * We assume that the TaggedEntry move assignment operator invalidates
+         * the source block. We cannot call invalidate again, as this would
+         * cause side effects on some CacheBlk implementations.
+         */
+        TaggedEntry::operator=(std::move(other));
+        assert(!other.isValid());
 
         return *this;
     }
@@ -532,8 +547,55 @@ class TempCacheBlk final : public CacheBlk
         registerTagExtractor(ext);
     }
     TempCacheBlk(const TempCacheBlk&) = delete;
-    using CacheBlk::operator=;
+    TempCacheBlk(TempCacheBlk &&) = delete;
     TempCacheBlk& operator=(const TempCacheBlk&) = delete;
+    /**
+     * Move assignment operator.
+     * This should only be used to move an existing valid entry into an
+     * invalid one, not to create a new entry. In the end the valid entry
+     * will become invalid, and the invalid, valid. All location related
+     * variables will remain the same, that is, an entry cannot move its
+     * data, just its metadata contents. Because of this, we do not interact
+     * with any stored ReplaceableEntry data.
+     *
+     * This operator must only be used with other instances of TempCacheBlk. A
+     * similar operation cannot be done using any other CacheBlk instance,
+     * because the tempBlock's address needs to be stored.
+     *
+     * @param other A valid TempCacheBlk whose metadata should be moved into
+     *              the current entry
+     * @return *this
+     */
+    TempCacheBlk &
+    operator=(TempCacheBlk &&other)
+    {
+        // Copying an entry into a valid one would imply in skipping all
+        // replacement steps, so it cannot be allowed
+        assert(!isValid());
+        assert(other.isValid());
+
+        _addr = other._addr;
+
+        CacheBlk::operator=(std::move(other));
+        assert(!other.isValid());
+
+        return *this;
+    }
+
+    CacheBlk &
+    operator=(CacheBlk &&other) override
+    {
+        auto *temp_other = dynamic_cast<TempCacheBlk *>(&other);
+
+        if (!temp_other) {
+            panic("A CacheBlk instance must not be moved into a TempCacheBlk, "
+                  "because we cannot restore the address.");
+        }
+
+        TempCacheBlk::operator=(std::move(*temp_other));
+        return *this;
+    }
+
     ~TempCacheBlk() { delete [] data; };
 
     /**

--- a/src/mem/cache/tags/sector_blk.cc
+++ b/src/mem/cache/tags/sector_blk.cc
@@ -41,6 +41,13 @@
 namespace gem5
 {
 
+SectorSubBlk &
+SectorSubBlk::operator=(SectorSubBlk &&other)
+{
+    CacheBlk::operator=(std::move(other));
+    return *this;
+}
+
 void
 SectorSubBlk::setSectorBlock(SectorBlk* sector_blk)
 {

--- a/src/mem/cache/tags/sector_blk.hh
+++ b/src/mem/cache/tags/sector_blk.hh
@@ -63,8 +63,7 @@ class SectorSubBlk : public CacheBlk
 
   public:
     SectorSubBlk() : CacheBlk(), _sectorBlk(nullptr), _sectorOffset(0) {}
-    SectorSubBlk(const SectorSubBlk&) = delete;
-    using CacheBlk::operator=;
+    SectorSubBlk(const SectorSubBlk &) = delete;
     SectorSubBlk& operator=(const SectorSubBlk&) = delete;
     SectorSubBlk(SectorSubBlk&&) = delete;
     /**
@@ -72,10 +71,13 @@ class SectorSubBlk : public CacheBlk
      * This should only be used to move an existing valid entry into an
      * invalid one, not to create a new entry. In the end the valid entry
      * will become invalid, and the invalid, valid. All location related
-     * variables will remain the same, that is, an entry cannot change
-     * its sector block nor its offset.
+     * variables will remain the same, that is, an entry cannot move its
+     * data, just its metadata contents. As SectorSubBlk only holds additional
+     * location data, we can use the unmodified CacheBlk move assignment
+     * operator.
      */
-    SectorSubBlk& operator=(SectorSubBlk&& other) = default;
+    using CacheBlk::operator=;
+    SectorSubBlk &operator=(SectorSubBlk &&other);
     ~SectorSubBlk() = default;
 
     /**
@@ -144,6 +146,8 @@ class SectorBlk : public TaggedEntry
   public:
     SectorBlk();
     SectorBlk(const SectorBlk&) = delete;
+    SectorBlk(SectorBlk &&) = delete;
+    SectorBlk &operator=(SectorBlk &&) = delete;
     SectorBlk& operator=(const SectorBlk&) = delete;
     ~SectorBlk() {};
 

--- a/src/mem/cache/tags/super_blk.cc
+++ b/src/mem/cache/tags/super_blk.cc
@@ -50,13 +50,24 @@ CompressionBlk::CompressionBlk()
 CacheBlk&
 CompressionBlk::operator=(CacheBlk&& other)
 {
-    operator=(std::move(static_cast<CompressionBlk&&>(other)));
+    auto *comp_other = dynamic_cast<CompressionBlk *>(&other);
+
+    if (!comp_other) {
+        panic("CompressionBlk mixed with other CacheBlk types. Cannot move!");
+    }
+
+    operator=(std::move(*comp_other));
     return *this;
 }
 
 CompressionBlk&
 CompressionBlk::operator=(CompressionBlk&& other)
 {
+    // Copying an entry into a valid one would imply in skipping all
+    // replacement steps, so it cannot be allowed
+    assert(!isValid());
+    assert(other.isValid());
+
     // Copy internal variables; if moving, that means we had an expansion or
     // contraction, and therefore the size is no longer valid, so it is not
     // moved
@@ -67,7 +78,12 @@ CompressionBlk::operator=(CompressionBlk&& other)
         setUncompressed();
     }
 
+    // We assume that the TaggedEntry move assignment operator (called by
+    // the CacheBlk move assignment operator) invalidates the source block.
+    // We cannot call invalidate again, as this would cause side effects on
+    // some CacheBlk implementations.
     CacheBlk::operator=(std::move(other));
+    assert(!other.isValid());
     return *this;
 }
 

--- a/src/mem/cache/tags/super_blk.hh
+++ b/src/mem/cache/tags/super_blk.hh
@@ -183,7 +183,9 @@ class SuperBlk : public SectorBlk
   public:
     SuperBlk();
     SuperBlk(const SuperBlk&) = delete;
+    SuperBlk(SuperBlk &&) = delete;
     SuperBlk& operator=(const SuperBlk&) = delete;
+    SuperBlk &operator=(SuperBlk &&) = delete;
     ~SuperBlk() {};
 
     /**

--- a/src/mem/cache/tags/tagged_entry.hh
+++ b/src/mem/cache/tags/tagged_entry.hh
@@ -119,6 +119,46 @@ class TaggedEntry : public ReplaceableEntry
     {}
     ~TaggedEntry() = default;
 
+    TaggedEntry(const TaggedEntry &other) = default;
+    TaggedEntry(TaggedEntry &&other) = delete;
+
+    TaggedEntry &operator=(const TaggedEntry &other) = delete;
+
+    /**
+     * Move assignment operator.
+     * This should only be used to move an existing valid entry into an
+     * invalid one, not to create a new entry. In the end the valid entry
+     * will become invalid, and the invalid, valid. All location related
+     * variables will remain the same, that is, an entry cannot move its
+     * data, just its metadata contents. Because of this, we do not interact
+     * with any stored ReplaceableEntry data.
+     *
+     * @param other A valid TaggedEntry whose metadata should be moved into the
+     *              current entry
+     * @return *this
+     */
+    TaggedEntry &
+    operator=(TaggedEntry &&other)
+    {
+        // Copying an entry into a valid one would imply in skipping all
+        // replacement steps, so it cannot be allowed
+        assert(!isValid());
+        assert(other.isValid());
+
+        setValid();
+        setTag(other.getTag());
+
+        if (other.isSecure()) {
+            setSecure();
+        } else {
+            clearSecure();
+        }
+
+        other.invalidate();
+
+        return *this;
+    }
+
     void
     registerTagExtractor(TagExtractor ext)
     {


### PR DESCRIPTION
Moving metadata between classic cache blocks currently leads to inconsistent tags and coherency issues (gem5/gem5#2955).

To fix that, a dedicated move assignment operator is added to the `TaggedEntry` class so that `insert` is no longer needed for move operations. Subclass move operations are updated to reflect this change and its side-effects.

Fixes gem5/gem5#2955.