### PR TITLE
misc,util-m5,ext-testlib: add color to panics/warnings/infos

### DIFF
--- a/ext/systemc/SConscript
+++ b/ext/systemc/SConscript
@@ -57,7 +57,7 @@ with gem5_scons.Configure(systemc) as conf:
         systemc['QT_ARCH'] = 'iX86_64'
         arch = 'x86_64'
     else:
-        termcap = get_termcap(GetOption('use_colors'))
+        termcap = get_termcap(use_colors=GetOption('use_colors'))
         print(termcap.Yellow + termcap.Bold +
               "Warning: Unrecognized architecture for systemc." + termcap.Normal)
 

--- a/ext/testlib/terminal.py
+++ b/ext/testlib/terminal.py
@@ -107,7 +107,7 @@ def should_use_colors(out: TextIO):
     should_force = (
         "CLICOLOR_FORCE" in os.environ or "FORCE_COLOR" in os.environ
     )
-    istty = out.isatty() and os.environ["TERM"] not in [None, "dumb"]
+    istty = out.isatty() and os.getenv("TERM", default="dumb") != "dumb"
     return (not must_not_colour) and (should_force or istty)
 
 
@@ -117,10 +117,10 @@ else:
     tty_termcap = no_termcap
 
 
-def get_termcap(use_colors=None):
+def get_termcap(stream=sys.stdout, use_colors=None):
     if use_colors is None:
         # option unspecified; default behavior is to use colors iff isatty && NO_COLOR is not set
-        use_colors = should_use_colors(sys.stdout)
+        use_colors = should_use_colors(stream)
 
     if use_colors:
         return termcap

--- a/ext/testlib/terminal.py
+++ b/ext/testlib/terminal.py
@@ -27,9 +27,11 @@
 # Author: Steve Reinhardt
 
 import fcntl
+import os
 import struct
 import sys
 import termios
+from typing import TextIO
 
 # Intended usage example:
 #
@@ -99,18 +101,29 @@ class ColorStrings:
 termcap = ColorStrings(cap_string)
 no_termcap = ColorStrings(null_cap_string)
 
-if sys.stdout.isatty():
+
+def should_use_colors(out: TextIO):
+    must_not_colour = "NO_COLOR" in os.environ or "NOCOLOR" in os.environ
+    should_force = (
+        "CLICOLOR_FORCE" in os.environ or "FORCE_COLOR" in os.environ
+    )
+    istty = out.isatty() and os.environ["TERM"] not in [None, "dumb"]
+    return (not must_not_colour) and (should_force or istty)
+
+
+if should_use_colors(sys.stdout):
     tty_termcap = termcap
 else:
     tty_termcap = no_termcap
 
 
 def get_termcap(use_colors=None):
+    if use_colors is None:
+        # option unspecified; default behavior is to use colors iff isatty && NO_COLOR is not set
+        use_colors = should_use_colors(sys.stdout)
+
     if use_colors:
         return termcap
-    elif use_colors is None:
-        # option unspecified; default behavior is to use colors iff isatty
-        return tty_termcap
     else:
         return no_termcap
 

--- a/ext/testlib/terminal.py
+++ b/ext/testlib/terminal.py
@@ -103,12 +103,17 @@ no_termcap = ColorStrings(null_cap_string)
 
 
 def should_use_colors(out: TextIO):
-    must_not_colour = "NO_COLOR" in os.environ or "NOCOLOR" in os.environ
+    must_not_colour = (
+        os.getenv("NO_COLOR", default=os.getenv("NOCOLOR", default="")) != ""
+    )
     should_force = (
-        "CLICOLOR_FORCE" in os.environ or "FORCE_COLOR" in os.environ
+        os.getenv(
+            "CLICOLOR_FORCE", default=os.getenv("FORCE_COLOR", default="")
+        )
+        != ""
     )
     istty = out.isatty() and os.getenv("TERM", default="dumb") != "dumb"
-    return (not must_not_colour) and (should_force or istty)
+    return should_force or ((not must_not_colour) and istty)
 
 
 if should_use_colors(sys.stdout):

--- a/ext/testlib/terminal.py
+++ b/ext/testlib/terminal.py
@@ -104,13 +104,12 @@ no_termcap = ColorStrings(null_cap_string)
 
 def should_use_colors(out: TextIO):
     must_not_colour = (
-        os.getenv("NO_COLOR", default=os.getenv("NOCOLOR", default="")) != ""
+        os.getenv("NO_COLOR", default="") != ""
+        or os.getenv("NOCOLOR", default="") != ""
     )
     should_force = (
-        os.getenv(
-            "CLICOLOR_FORCE", default=os.getenv("FORCE_COLOR", default="")
-        )
-        != ""
+        os.getenv("CLICOLOR_FORCE", default="") != ""
+        or os.getenv("FORCE_COLOR", default="") != ""
     )
     istty = out.isatty() and os.getenv("TERM", default="dumb") != "dumb"
     return should_force or ((not must_not_colour) and istty)

--- a/site_scons/gem5_scons/util.py
+++ b/site_scons/gem5_scons/util.py
@@ -53,7 +53,9 @@ def ignore_style():
 
 
 def get_termcap():
-    return m5.util.terminal.get_termcap(SCons.Script.GetOption("use_colors"))
+    return m5.util.terminal.get_termcap(
+        use_colors=SCons.Script.GetOption("use_colors")
+    )
 
 
 def readCommand(cmd, **kwargs):

--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -75,10 +75,13 @@ static bool
 shouldANSI()
 {
     bool mustNotColour =
-        getenv("NO_COLOR") != NULL || getenv("NOCOLOR") != NULL;
+        (getenv("NO_COLOR") != NULL && getenv("NO_COLOR")[0] != '\0') ||
+        (getenv("NOCOLOR") != NULL && getenv("NOCOLOR")[0] != '\0');
 
     bool shouldForce =
-        getenv("CLICOLOR_FORCE") != NULL || getenv("FORCE_COLOR") != NULL;
+        (getenv("CLICOLOR_FORCE") != NULL &&
+         getenv("CLICOLOR_FORCE")[0] != '\0') ||
+        (getenv("FORCE_COLOR") != NULL && getenv("FORCE_COLOR")[0] != '\0');
 
     char *term = getenv("TERM");
     bool isTerminal =

--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -40,7 +40,7 @@
 
 #include "base/logging.hh"
 
-#include <sstream>
+#include <unistd.h>
 
 #include "base/hostinfo.hh"
 
@@ -69,6 +69,18 @@ class FatalLogger : public ExitLogger
     void exit() override { ::exit(1); }
 };
 
+static bool
+shouldANSI()
+{
+    bool mustNotColour =
+        getenv("NO_COLOR") != NULL || getenv("NOCOLOR") != NULL;
+    bool shouldForce =
+        getenv("CLICOLOR_FORCE") != NULL || getenv("FORCE_COLOR") != NULL;
+    char *term = getenv("TERM");
+    bool isTerminal = isatty(2) && (term == NULL || strcmp(term, "dumb") != 0);
+    return !mustNotColour && (shouldForce || isTerminal);
+}
+
 } // anonymous namespace
 
 // We intentionally put all the loggers on the heap to prevent them from being
@@ -79,31 +91,41 @@ class FatalLogger : public ExitLogger
 
 Logger&
 Logger::getPanic() {
-    static ExitLogger* panic_logger = new ExitLogger("panic: ");
+    // bold red
+    auto prefix = shouldANSI() ? "\t\e[1;31mpanic\e[0m: " : "panic: ";
+    static ExitLogger *panic_logger = new ExitLogger(prefix);
     return *panic_logger;
 }
 
 Logger&
 Logger::getFatal() {
-    static FatalLogger* fatal_logger = new FatalLogger("fatal: ");
+    // bold red
+    auto prefix = shouldANSI() ? "\t\e[1;31mfatal\e[0m: " : "fatal: ";
+    static FatalLogger *fatal_logger = new FatalLogger(prefix);
     return *fatal_logger;
 }
 
 Logger&
 Logger::getWarn() {
-    static Logger* warn_logger = new Logger("warn: ");
+    // bold yellow
+    auto prefix = shouldANSI() ? "\t\e[1;33mwarn\e[0m: " : "warn: ";
+    static Logger *warn_logger = new Logger(prefix);
     return *warn_logger;
 }
 
 Logger&
 Logger::getInfo() {
-    static Logger* info_logger = new Logger("info: ");
+    // bold cyan
+    auto prefix = shouldANSI() ? "\t\e[1;36minfo\e[0m: " : "info: ";
+    static Logger *info_logger = new Logger(prefix);
     return *info_logger;
 }
 
 Logger&
 Logger::getHack() {
-    static Logger* hack_logger = new Logger("hack: ");
+    // yellow, non-bold
+    auto prefix = shouldANSI() ? "\t\e[33mhack\e[0m: " : "hack: ";
+    static Logger *hack_logger = new Logger(prefix);
     return *hack_logger;
 }
 

--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -42,6 +42,8 @@
 
 #include <unistd.h>
 
+#include <cstdlib>
+
 #include "base/hostinfo.hh"
 
 namespace gem5
@@ -74,11 +76,15 @@ shouldANSI()
 {
     bool mustNotColour =
         getenv("NO_COLOR") != NULL || getenv("NOCOLOR") != NULL;
+
     bool shouldForce =
         getenv("CLICOLOR_FORCE") != NULL || getenv("FORCE_COLOR") != NULL;
+
     char *term = getenv("TERM");
-    bool isTerminal = isatty(2) && (term == NULL || strcmp(term, "dumb") != 0);
-    return !mustNotColour && (shouldForce || isTerminal);
+    bool isTerminal =
+        isatty(STDERR_FILENO) && (term == NULL || strcmp(term, "dumb") != 0);
+
+    return shouldForce || (!mustNotColour && isTerminal);
 }
 
 } // anonymous namespace
@@ -92,7 +98,7 @@ shouldANSI()
 Logger&
 Logger::getPanic() {
     // bold red
-    auto prefix = shouldANSI() ? "\t\e[1;31mpanic\e[0m: " : "panic: ";
+    auto prefix = shouldANSI() ? "\x1b[1;31mpanic\e[0m: " : "panic: ";
     static ExitLogger *panic_logger = new ExitLogger(prefix);
     return *panic_logger;
 }
@@ -100,7 +106,7 @@ Logger::getPanic() {
 Logger&
 Logger::getFatal() {
     // bold red
-    auto prefix = shouldANSI() ? "\t\e[1;31mfatal\e[0m: " : "fatal: ";
+    auto prefix = shouldANSI() ? "\x1b[1;31mfatal\e[0m: " : "fatal: ";
     static FatalLogger *fatal_logger = new FatalLogger(prefix);
     return *fatal_logger;
 }
@@ -108,7 +114,7 @@ Logger::getFatal() {
 Logger&
 Logger::getWarn() {
     // bold yellow
-    auto prefix = shouldANSI() ? "\t\e[1;33mwarn\e[0m: " : "warn: ";
+    auto prefix = shouldANSI() ? "\x1b[1;33mwarn\e[0m: " : "warn: ";
     static Logger *warn_logger = new Logger(prefix);
     return *warn_logger;
 }
@@ -116,7 +122,7 @@ Logger::getWarn() {
 Logger&
 Logger::getInfo() {
     // bold cyan
-    auto prefix = shouldANSI() ? "\t\e[1;36minfo\e[0m: " : "info: ";
+    auto prefix = shouldANSI() ? "\x1b[1;36minfo\e[0m: " : "info: ";
     static Logger *info_logger = new Logger(prefix);
     return *info_logger;
 }
@@ -124,7 +130,7 @@ Logger::getInfo() {
 Logger&
 Logger::getHack() {
     // yellow, non-bold
-    auto prefix = shouldANSI() ? "\t\e[33mhack\e[0m: " : "hack: ";
+    auto prefix = shouldANSI() ? "\x1b[33mhack\e[0m: " : "hack: ";
     static Logger *hack_logger = new Logger(prefix);
     return *hack_logger;
 }

--- a/src/base/logging.test.cc
+++ b/src/base/logging.test.cc
@@ -29,6 +29,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+
 #include "base/gtest/logging.hh"
 #include "base/logging.hh"
 
@@ -38,12 +40,28 @@ using namespace gem5;
 class LoggingFixture : public ::testing::Test
 {
   public:
-    void SetUp() override { old = std::cerr.rdbuf(gtestLogOutput.rdbuf()); }
-    void TearDown() override { std::cerr.rdbuf(old); }
+    void
+    SetUp() override
+    {
+        old = std::cerr.rdbuf(gtestLogOutput.rdbuf());
+        oldTerm = getenv("TERM");
+        setenv("TERM", "dummy", /* overwrite */ true);
+    }
+    void
+    TearDown() override
+    {
+        std::cerr.rdbuf(old);
+        if (oldTerm == nullptr) {
+            unsetenv("TERM");
+        } else {
+            setenv("TERM", oldTerm, true);
+        }
+    }
 
   private:
     /** Used to restore cerr's streambuf. */
     std::streambuf *old;
+    const char *oldTerm;
 };
 
 /** Test the most basic print. */

--- a/src/base/logging.test.cc
+++ b/src/base/logging.test.cc
@@ -45,7 +45,7 @@ class LoggingFixture : public ::testing::Test
     {
         old = std::cerr.rdbuf(gtestLogOutput.rdbuf());
         oldTerm = getenv("TERM");
-        setenv("TERM", "dummy", /* overwrite */ true);
+        setenv("TERM", "dumb", /* overwrite */ true);
     }
     void
     TearDown() override

--- a/src/base/socket.cc
+++ b/src/base/socket.cc
@@ -246,8 +246,7 @@ ListenSocketInet::listen()
         _port++;
         fatal_if(_port > 65536, "%s: cannot find an available port.", name());
     }
-    ccprintf(std::cerr, "%s: Listening for connections on %s\n",
-            name(), *this);
+    inform("%s: Listening for connections on %s\n", name(), *this);
 }
 
 void
@@ -295,8 +294,7 @@ ListenSocketUnix::listen()
     fatal_if(::listen(fd, 1) == -1, "%s: Failed to listen on %s: %s\n",
             name(), *this, strerror(errno));
 
-    ccprintf(std::cerr, "%s: Listening for connections on %s\n",
-            name(), *this);
+    inform("%s: Listening for connections on %s\n", name(), *this);
 
     setListening();
 }

--- a/src/python/m5/util/__init__.py
+++ b/src/python/m5/util/__init__.py
@@ -49,13 +49,15 @@ from .attrdict import (
     optiondict,
 )
 from .multidict import multidict
+from .terminal import get_termcap
 
 
 # panic() should be called when something happens that should never
 # ever happen regardless of what the user does (i.e., an acutal m5
 # bug).
 def panic(fmt, *args):
-    print("panic:", fmt % args, file=sys.stderr)
+    tc = get_termcap(sys.stderr)
+    print(f"{tc.Bold}{tc.Red}panic{tc.Normal}:", fmt % args, file=sys.stderr)
     sys.exit(1)
 
 
@@ -63,7 +65,8 @@ def panic(fmt, *args):
 # some condition that is the user's fault (bad configuration, invalid
 # arguments, etc.) and not a simulator bug.
 def fatal(fmt, *args):
-    print("fatal:", fmt % args, file=sys.stderr)
+    tc = get_termcap(sys.stderr)
+    print(f"{tc.Bold}{tc.Red}fatal{tc.Normal}:", fmt % args, file=sys.stderr)
     sys.exit(1)
 
 
@@ -71,13 +74,15 @@ def fatal(fmt, *args):
 # that may or may not be the user's fault, but that they should be made aware
 # of as it may affect the simulation or results.
 def warn(fmt, *args):
-    print("warn:", fmt % args, file=sys.stderr)
+    tc = get_termcap(sys.stderr)
+    print(f"{tc.Bold}{tc.Yellow}warn{tc.Normal}:", fmt % args, file=sys.stderr)
 
 
 # inform() should be called when the user should be informed about some
 # condition that they may be interested in.
 def inform(fmt, *args):
-    print("info:", fmt % args, file=sys.stdout)
+    tc = get_termcap(sys.stdout)
+    print(f"{tc.Bold}{tc.Cyan}info{tc.Normal}:", fmt % args, file=sys.stdout)
 
 
 def callOnce(func):

--- a/src/python/m5/util/terminal.py
+++ b/src/python/m5/util/terminal.py
@@ -101,14 +101,13 @@ no_termcap = ColorStrings(null_cap_string)
 def should_use_colors(out: TextIO):
     # is there a *non-empty* variable named NO_COLOR/NOCOLOR in the env?
     must_not_colour = (
-        os.getenv("NO_COLOR", default=os.getenv("NOCOLOR", default="")) != ""
+        os.getenv("NO_COLOR", default="") != ""
+        or os.getenv("NOCOLOR", default="") != ""
     )
     # is there a *non-empty* variable named CLICOLOR_FORCE/FORCE_COLOR in the env?
     should_force = (
-        os.getenv(
-            "CLICOLOR_FORCE", default=os.getenv("FORCE_COLOR", default="")
-        )
-        != ""
+        os.getenv("CLICOLOR_FORCE", default="") != ""
+        or os.getenv("FORCE_COLOR", default="") != ""
     )
     istty = out.isatty() and os.getenv("TERM", default="dumb") != "dumb"
     return should_force or ((not must_not_colour) and istty)

--- a/src/python/m5/util/terminal.py
+++ b/src/python/m5/util/terminal.py
@@ -26,7 +26,9 @@
 #
 # Author: Steve Reinhardt
 
+import os
 import sys
+from typing import TextIO
 
 # Intended usage example:
 #
@@ -95,18 +97,29 @@ class ColorStrings:
 termcap = ColorStrings(cap_string)
 no_termcap = ColorStrings(null_cap_string)
 
-if sys.stdout.isatty():
+
+def should_use_colors(out: TextIO):
+    must_not_colour = "NO_COLOR" in os.environ or "NOCOLOR" in os.environ
+    should_force = (
+        "CLICOLOR_FORCE" in os.environ or "FORCE_COLOR" in os.environ
+    )
+    istty = out.isatty() and os.environ["TERM"] not in [None, "dumb"]
+    return (not must_not_colour) and (should_force or istty)
+
+
+if should_use_colors(sys.stdout):
     tty_termcap = termcap
 else:
     tty_termcap = no_termcap
 
 
 def get_termcap(use_colors=None):
+    if use_colors is None:
+        # option unspecified; default behavior is to use colors iff isatty && NO_COLOR is not set
+        use_colors = should_use_colors(sys.stdout)
+
     if use_colors:
         return termcap
-    elif use_colors is None:
-        # option unspecified; default behavior is to use colors iff isatty
-        return tty_termcap
     else:
         return no_termcap
 

--- a/src/python/m5/util/terminal.py
+++ b/src/python/m5/util/terminal.py
@@ -99,9 +99,16 @@ no_termcap = ColorStrings(null_cap_string)
 
 
 def should_use_colors(out: TextIO):
-    must_not_colour = "NO_COLOR" in os.environ or "NOCOLOR" in os.environ
+    # is there a *non-empty* variable named NO_COLOR/NOCOLOR in the env?
+    must_not_colour = (
+        os.getenv("NO_COLOR", default=os.getenv("NOCOLOR", default="")) != ""
+    )
+    # is there a *non-empty* variable named CLICOLOR_FORCE/FORCE_COLOR in the env?
     should_force = (
-        "CLICOLOR_FORCE" in os.environ or "FORCE_COLOR" in os.environ
+        os.getenv(
+            "CLICOLOR_FORCE", default=os.getenv("FORCE_COLOR", default="")
+        )
+        != ""
     )
     istty = out.isatty() and os.getenv("TERM", default="dumb") != "dumb"
     return should_force or ((not must_not_colour) and istty)

--- a/src/python/m5/util/terminal.py
+++ b/src/python/m5/util/terminal.py
@@ -103,8 +103,8 @@ def should_use_colors(out: TextIO):
     should_force = (
         "CLICOLOR_FORCE" in os.environ or "FORCE_COLOR" in os.environ
     )
-    istty = out.isatty() and os.environ["TERM"] not in [None, "dumb"]
-    return (not must_not_colour) and (should_force or istty)
+    istty = out.isatty() and os.getenv("TERM", default="dumb") != "dumb"
+    return should_force or ((not must_not_colour) and istty)
 
 
 if should_use_colors(sys.stdout):
@@ -113,10 +113,10 @@ else:
     tty_termcap = no_termcap
 
 
-def get_termcap(use_colors=None):
+def get_termcap(stream=sys.stdout, use_colors=None):
     if use_colors is None:
         # option unspecified; default behavior is to use colors iff isatty && NO_COLOR is not set
-        use_colors = should_use_colors(sys.stdout)
+        use_colors = should_use_colors(stream)
 
     if use_colors:
         return termcap


### PR DESCRIPTION
This PR colors the `panic`/`fatal`/`warn`/`info`/`hack` log prefixes with some color to make them easier to spot:
    - bold red for `panic` & `fatal`
    - bold yellow for `warn`
    - bold cyan for `info`
    - non-bold yellow for `hack`

This is also implemented for the equivalent python functions in src/python/m5/utils and ext/testlib.
    
It only uses those colors when stderr is a tty and [`NO_COLOR`](https://no-color.org) is not set, or when [`FORCE_COLOR`](https://force-color.org) is set. (In other words, it will only activate when the output is a terminal (thus avoiding weird sequences in log files), and it's possible to turn it off by setting `NO_COLOR=true`, and possible to forcing when piping input by setting `FORCE_COLOR=true`.) This logic has also been integrated into the `m5.util.terminal` module, so that it better respects those environment variables.