### PR TITLE
sim: fix false positive warning in sim/serialize.cc

### DIFF
--- a/src/sim/serialize.cc
+++ b/src/sim/serialize.cc
@@ -93,7 +93,10 @@ Serializable::generateCheckpointOut(const std::string &cpt_dir,
             fatal("couldn't mkdir %s\n", dir);
 
     std::string cpt_file = dir + CheckpointIn::baseFilename;
-    assert(!outstream.is_open());
+    if (outstream.is_open()) {
+        outstream.close();
+    }
+    outstream.clear();
     outstream.open(cpt_file);
     time_t t = time(NULL);
     if (!outstream)

--- a/src/sim/serialize.cc
+++ b/src/sim/serialize.cc
@@ -93,7 +93,8 @@ Serializable::generateCheckpointOut(const std::string &cpt_dir,
             fatal("couldn't mkdir %s\n", dir);
 
     std::string cpt_file = dir + CheckpointIn::baseFilename;
-    outstream = std::ofstream(cpt_file.c_str());
+    assert(!outstream.is_open());
+    outstream.open(cpt_file);
     time_t t = time(NULL);
     if (!outstream)
         fatal("Unable to open file %s for writing\n", cpt_file.c_str());


### PR DESCRIPTION

Change from constructing a new ostream object to just call the `open` method.
Fixes the warning when compiling `gem5.opt` with `--with-asan --with-ubsan`.

relevant error:
```
In file included from /usr/include/c++/14/bits/stl_pair.h:61,
                 from /usr/include/c++/14/bits/stl_algobase.h:64,
                 from /usr/include/c++/14/algorithm:60,
                 from src/sim/serialize.hh:48,
                 from src/sim/serialize.cc:43:
In function ‘constexpr std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = char]’,
    inlined from ‘void std::basic_ios<_CharT, _Traits>::swap(std::basic_ios<_CharT, _Traits>&) [with _CharT = char; _Traits = std::char_traits<char>]’ at /usr/include/c++/14/bits/basic_ios.h:504:11,
    inlined from ‘void std::basic_ostream<_CharT, _Traits>::swap(std::basic_ostream<_CharT, _Traits>&) [with _CharT = char; _Traits = std::char_traits<char>]’ at /usr/include/c++/14/ostream:466:25,
    inlined from ‘std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator=(std::basic_ostream<_CharT, _Traits>&&) [with _CharT = char; _Traits = std::char_traits<char>]’ at /usr/include/c++/14/ostream:460:6,
    inlined from ‘std::basic_ofstream<_CharT, _Traits>& std::basic_ofstream<_CharT, _Traits>::operator=(std::basic_ofstream<_CharT, _Traits>&&) [with _CharT = char; _Traits = std::char_traits<char>]’ at /usr/include/c++/14/fstream:923:27,
    inlined from ‘static void gem5::Serializable::generateCheckpointOut(const std::string&, std::ofstream&)’ at src/sim/serialize.cc:96:47:
/usr/include/c++/14/bits/move.h:235:11: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  235 |       __a = _GLIBCXX_MOVE(__b);
      |           ^
In file included from /usr/include/c++/14/istream:41,
                 from /usr/include/c++/14/fstream:40,
                 from src/sim/serialize.hh:50:
/usr/include/c++/14/ostream: In static member function ‘static void gem5::Serializable::generateCheckpointOut(const std::string&, std::ofstream&)’:
/usr/include/c++/14/ostream:66:11: note: at offset [224, 232] into destination object ‘std::basic_ostream<char>::_vptr.basic_ostream’ of size 8
   66 |     class basic_ostream : virtual public basic_ios<_CharT, _Traits>
      |           ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```