### PR TITLE
dev: refactor PciUpstream to be a C++ interface

### DIFF
--- a/configs/common/FSConfig.py
+++ b/configs/common/FSConfig.py
@@ -499,7 +499,7 @@ def connectX86RubySystem(x86_sys):
 
     # add the PCI host bridge to the list of dma devices that later
     # need to attach to dma controllers
-    x86_sys._dma_ports = [x86_sys.pc.pci_host.up_request_port()]
+    x86_sys._dma_ports = [x86_sys.pc.pci_host.dma_port()]
     x86_sys.pc.attachIO(x86_sys.iobus, x86_sys._dma_ports)
 
 

--- a/configs/deprecated/example/riscv/fs_linux.py
+++ b/configs/deprecated/example/riscv/fs_linux.py
@@ -222,16 +222,8 @@ system.platform = HiFive()
 system.platform.rtc = RiscvRTC(frequency=Frequency("100MHz"))
 system.platform.clint.int_pin = system.platform.rtc.int_pin
 
-system.iobus.cpu_side_ports = system.platform.pci_host.up_request_port()
-system.iobus.mem_side_ports = system.platform.pci_host.up_response_port()
-
-system.platform.pci_bus.cpu_side_ports = (
-    system.platform.pci_host.down_request_port()
-)
-system.platform.pci_bus.default = system.platform.pci_host.down_response_port()
-system.platform.pci_bus.config_error_port = (
-    system.platform.pci_host.config_error.pio
-)
+system.platform.pci_host.internal_connect()
+system.platform.pci_host.connect_upper_bus(system.iobus, True)
 
 # VirtIOMMIO
 if args.disk_image:

--- a/configs/example/sst/riscv_fs.py
+++ b/configs/example/sst/riscv_fs.py
@@ -111,18 +111,8 @@ def createHiFivePlatform(system):
     system.bridge.cpu_side_port = system.membus.mem_side_ports
     system.bridge.ranges = system.platform._off_chip_ranges()
 
-    system.iobus.cpu_side_ports = system.platform.pci_host.up_request_port()
-    system.iobus.mem_side_ports = system.platform.pci_host.up_response_port()
-
-    system.platform.pci_bus.cpu_side_ports = (
-        system.platform.pci_host.down_request_port()
-    )
-    system.platform.pci_bus.default = (
-        system.platform.pci_host.down_response_port()
-    )
-    system.platform.pci_bus.config_error_port = (
-        system.platform.pci_host.config_error.pio
-    )
+    system.platform.pci_host.internal_connect()
+    system.platform.pci_host.connect_upper_bus(system.iobus, True)
 
     system.platform.setNumCores(1)
 

--- a/src/dev/arm/RealView.py
+++ b/src/dev/arm/RealView.py
@@ -75,7 +75,6 @@ from m5.objects.PciDevice import (
     PciLegacyIoBar,
 )
 from m5.objects.PciHost import *
-from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.PS2 import *
 from m5.objects.Scmi import *
@@ -869,11 +868,6 @@ class RealView(Platform):
             else:
                 dma_ports.append(device.dma)
 
-    def _attach_pci_device(self, device, upstream, bus):
-        device.pio = bus.mem_side_ports
-        device.dma = bus.cpu_side_ports
-        upstream.devices.append(device)
-
     def _attach_io(self, devices, *args, **kwargs):
         for d in devices:
             self._attach_device(d, *args, **kwargs)
@@ -1012,7 +1006,6 @@ class VExpress_EMM(RealView):
         conf_device_bits=16,
         pci_pio_base=0,
     )
-    pci_bus = PciBus()
 
     sys_counter = SystemCounter()
     generic_timer = GenericTimer(
@@ -1125,21 +1118,19 @@ class VExpress_EMM(RealView):
         )
 
     def attachPciDevice(self, device):
-        self._attach_pci_device(device, self.pci_host, self.pci_bus)
+        self.pci_host.connect_device(device)
 
     def _attach_pci(self, devices, bus, dma_ports=None):
-        self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
-        self.pci_bus.default = self.pci_host.down_response_port()
-        self.pci_bus.config_error_port = self.pci_host.config_error.pio
+        self.pci_host.internal_connect()
 
-        bus.mem_side_ports = self.pci_host.up_response_port()
         if dma_ports is None:
-            bus.cpu_side_ports = self.pci_host.up_request_port()
+            self.pci_host.connect_upper_bus(bus, True)
         else:
-            dma_ports.append(self.pci_host.up_request_port())
+            pci_dma = self.pci_host.connect_upper_bus(bus, False)
+            dma_ports.append(pci_dma)
 
         for d in devices:
-            self._attach_pci_device(d, self.pci_host, self.pci_bus)
+            self.pci_host.connect_device(d)
 
     def enableMSIX(self):
         self.gic = Gic400(
@@ -1469,7 +1460,6 @@ class VExpress_GEM5_Base(RealView):
         int_base=100,
         int_count=4,
     )
-    pci_bus = PciBus()
 
     energy_ctrl = EnergyCtrl(pio_addr=0x10000000)
 
@@ -1523,21 +1513,19 @@ class VExpress_GEM5_Base(RealView):
         self._num_pci_dev += 1
         device.pci_dev = self._num_pci_dev
         device.pci_func = 0
-        self._attach_pci_device(device, self.pci_host, self.pci_bus)
+        self.pci_host.connect_device(device)
 
     def _attach_pci(self, devices, bus, dma_ports=None):
-        self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
-        self.pci_bus.default = self.pci_host.down_response_port()
-        self.pci_bus.config_error_port = self.pci_host.config_error.pio
+        self.pci_host.internal_connect()
 
-        bus.mem_side_ports = self.pci_host.up_response_port()
         if dma_ports is None:
-            bus.cpu_side_ports = self.pci_host.up_request_port()
+            self.pci_host.connect_upper_bus(bus, True)
         else:
-            dma_ports.append(self.pci_host.up_request_port())
+            pci_dma = self.pci_host.connect_upper_bus(bus, False)
+            dma_ports.append(pci_dma)
 
         for d in devices:
-            self._attach_pci_device(d, self.pci_host, self.pci_bus)
+            self.pci_host.connect_device(d)
 
     def attachSmmu(self, devices, bus):
         """

--- a/src/dev/arm/RealView.py
+++ b/src/dev/arm/RealView.py
@@ -872,7 +872,7 @@ class RealView(Platform):
     def _attach_pci_device(self, device, upstream, bus):
         device.pio = bus.mem_side_ports
         device.dma = bus.cpu_side_ports
-        device.upstream = upstream
+        upstream.devices.append(device)
 
     def _attach_io(self, devices, *args, **kwargs):
         for d in devices:

--- a/src/dev/arm/pci_host.cc
+++ b/src/dev/arm/pci_host.cc
@@ -37,6 +37,7 @@
 
 #include "dev/arm/pci_host.hh"
 
+#include "dev/pci/device.hh"
 #include "params/GenericArmPciHost.hh"
 
 namespace gem5
@@ -50,24 +51,27 @@ GenericArmPciHost::GenericArmPciHost(const GenericArmPciHostParams &p)
 }
 
 uint32_t
-GenericArmPciHost::mapPciInterrupt(const PciDevAddr &addr, PciIntPin pin) const
+GenericArmPciHost::mapPciInterrupt(const PciDevice &device) const
 {
+    PciIntPin pin = device.interruptPin();
+    PciDevAddr addr = device.devAddr();
+
     fatal_if(pin == PciIntPin::NO_INT,
              "%02x:%02x.%i: Interrupt from a device without interrupts\n",
              getBusNum(), addr.dev, addr.func);
 
     switch (intPolicy) {
       case enums::ARM_PCI_INT_STATIC:
-        return GenericPciHost::mapPciInterrupt(addr, pin);
+          return GenericPciHost::mapPciInterrupt(device);
 
       case enums::ARM_PCI_INT_DEV:
-        return intBase + (addr.dev % intCount);
+          return intBase + (addr.dev % intCount);
 
       case enums::ARM_PCI_INT_PIN:
-        return intBase + ((static_cast<uint8_t>(pin) - 1) % intCount);
+          return intBase + ((static_cast<uint8_t>(pin) - 1) % intCount);
 
       default:
-        fatal("Unsupported PCI interrupt routing policy.");
+          fatal("Unsupported PCI interrupt routing policy.");
     }
 }
 

--- a/src/dev/arm/pci_host.hh
+++ b/src/dev/arm/pci_host.hh
@@ -55,8 +55,7 @@ class GenericArmPciHost
     virtual ~GenericArmPciHost() {}
 
   protected:
-    uint32_t mapPciInterrupt(const PciDevAddr &addr,
-                             PciIntPin pin) const override;
+    uint32_t mapPciInterrupt(const PciDevice &device) const override;
 
   protected:
     const enums::ArmPciIntRouting intPolicy;

--- a/src/dev/pci/PciDevice.py
+++ b/src/dev/pci/PciDevice.py
@@ -37,7 +37,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from m5.objects.Device import DmaDevice
-from m5.objects.PciUpstream import PciUpstream
 from m5.params import *
 from m5.proxy import *
 from m5.SimObject import SimObject
@@ -96,7 +95,6 @@ class PciDevice(DmaDevice):
     cxx_header = "dev/pci/device.hh"
     abstract = True
 
-    upstream = Param.PciUpstream(Parent.any, "PCI upstream")
     pci_dev = Param.Int("PCI device number")
     pci_func = Param.Int("PCI function code")
 

--- a/src/dev/pci/PciHost.py
+++ b/src/dev/pci/PciHost.py
@@ -40,6 +40,7 @@ from m5.objects.Bridge import (
 from m5.objects.ClockedObject import ClockedObject
 from m5.objects.PciDevice import PciDevice
 from m5.objects.PciUpstream import (
+    PciBus,
     PciConfigError,
     PciUpDownBridge,
 )
@@ -59,6 +60,11 @@ class PciHost(ClockedObject):
     )
     down_to_up = Param.BridgeBase(Bridge(), "Bridge downstream -> upstream")
 
+    internal_bus = Param.PciBus(
+        PciBus(),
+        "Internal PCI bus XBar used to transmit packets between devices",
+    )
+
     config_error = Param.PciConfigError(
         PciConfigError(), "Device to handle config errors"
     )
@@ -67,17 +73,50 @@ class PciHost(ClockedObject):
         [], "List of all PCI device connected to this upstream"
     )
 
-    def down_response_port(self):
-        return self.down_to_up.cpu_side_port
+    def internal_connect(self):
+        """Helper function to connect the host bridge internal ports"""
+        self.up_to_down.mem_side_port = self.internal_bus.cpu_side_ports
+        self.down_to_up.cpu_side_port = self.internal_bus.default
+        self.config_error.pio = self.internal_bus.config_error_port
 
-    def down_request_port(self):
-        return self.up_to_down.mem_side_port
+    def connect_upper_bus(self, bus, connect_dma):
+        """
+        Connect the host bridge to given bus. If connect_dma is set to False,
+        the DMA port will not be connected to the bus and it will be returned,
+        allowing it to be connected on a ruby hierarchy. Otherwise, the port
+        is connected to the bus and None is returned.
+        """
+        self.up_to_down.cpu_side_port = bus.mem_side_ports
 
-    def up_response_port(self):
-        return self.up_to_down.cpu_side_port
+        if not connect_dma:
+            return self.down_to_up.mem_side_port
 
-    def up_request_port(self):
+        self.down_to_up.mem_side_port = bus.cpu_side_ports
+        return None
+
+    def dma_port(self):
         return self.down_to_up.mem_side_port
+
+    def connect_device(self, device: PciDevice):
+        """Connect given PCI device to the host bridge"""
+        if device in self.devices:
+            raise ValueError(
+                f"Device {device} is already connected to this PCI host"
+            )
+        for existing in self.devices:
+            if (
+                existing.pci_dev == device.pci_dev
+                and existing.pci_func == device.pci_func
+            ):
+                raise ValueError(
+                    f"PCI slot (dev={existing.pci_dev}, func={existing.pci_func}) is already "
+                    f"occupied by {existing}"
+                )
+
+        self.devices.append(device)
+
+        device.pio = self.internal_bus.mem_side_ports
+        device.dma = self.internal_bus.cpu_side_ports
 
 
 class GenericPciHost(PciHost):

--- a/src/dev/pci/PciHost.py
+++ b/src/dev/pci/PciHost.py
@@ -33,17 +33,51 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects.PciUpstream import PciUpstream
+from m5.objects.Bridge import (
+    Bridge,
+    BridgeBase,
+)
+from m5.objects.ClockedObject import ClockedObject
+from m5.objects.PciDevice import PciDevice
+from m5.objects.PciUpstream import (
+    PciConfigError,
+    PciUpDownBridge,
+)
 from m5.objects.Platform import Platform
 from m5.params import *
 from m5.proxy import *
 
 
-class PciHost(PciUpstream):
+class PciHost(ClockedObject):
     type = "PciHost"
     cxx_class = "gem5::PciHost"
     cxx_header = "dev/pci/host.hh"
     abstract = True
+
+    up_to_down = Param.PciUpDownBridge(
+        PciUpDownBridge(), "Bridge upstream -> downstream"
+    )
+    down_to_up = Param.BridgeBase(Bridge(), "Bridge downstream -> upstream")
+
+    config_error = Param.PciConfigError(
+        PciConfigError(), "Device to handle config errors"
+    )
+
+    devices = VectorParam.PciDevice(
+        [], "List of all PCI device connected to this upstream"
+    )
+
+    def down_response_port(self):
+        return self.down_to_up.cpu_side_port
+
+    def down_request_port(self):
+        return self.up_to_down.mem_side_port
+
+    def up_response_port(self):
+        return self.up_to_down.cpu_side_port
+
+    def up_request_port(self):
+        return self.down_to_up.mem_side_port
 
 
 class GenericPciHost(PciHost):

--- a/src/dev/pci/PciUpstream.py
+++ b/src/dev/pci/PciUpstream.py
@@ -37,7 +37,6 @@ from m5.objects.Bridge import (
     Bridge,
     BridgeBase,
 )
-from m5.objects.ClockedObject import ClockedObject
 from m5.objects.Device import IsaFake
 from m5.objects.XBar import NoncoherentXBar
 from m5.params import *
@@ -72,31 +71,3 @@ class PciUpDownBridge(BridgeBase):
     type = "PciUpDownBridge"
     cxx_class = "gem5::PciUpDownBridge"
     cxx_header = "dev/pci/up_down_bridge.hh"
-
-
-class PciUpstream(ClockedObject):
-    type = "PciUpstream"
-    cxx_class = "gem5::PciUpstream"
-    cxx_header = "dev/pci/upstream.hh"
-    abstract = True
-
-    up_to_down = Param.PciUpDownBridge(
-        PciUpDownBridge(), "Bridge upstream -> downstream"
-    )
-    down_to_up = Param.BridgeBase(Bridge(), "Bridge downstream -> upstream")
-
-    config_error = Param.PciConfigError(
-        PciConfigError(), "Device to handle config errors"
-    )
-
-    def down_response_port(self):
-        return self.down_to_up.cpu_side_port
-
-    def down_request_port(self):
-        return self.up_to_down.mem_side_port
-
-    def up_response_port(self):
-        return self.up_to_down.cpu_side_port
-
-    def up_request_port(self):
-        return self.down_to_up.mem_side_port

--- a/src/dev/pci/SConscript
+++ b/src/dev/pci/SConscript
@@ -47,7 +47,7 @@ Source('device.cc')
 DebugFlag('PciDevice')
 
 SimObject('PciUpstream.py', sim_objects=[
-    'PciUpstream', 'PciUpDownBridge', 'PciBus', 'PciConfigError'
+    'PciUpDownBridge', 'PciBus', 'PciConfigError'
 ])
 Source('upstream.cc')
 Source('up_down_bridge.cc')

--- a/src/dev/pci/device.cc
+++ b/src/dev/pci/device.cc
@@ -78,8 +78,7 @@ PciDevice::PciDevice(const PciDeviceParams &p,
       MSIXCAP_MPBA_OFFSET(p.MSIXCAPBaseOffset + MSIXCAP_MPBA),
       PXCAP_BASE(p.PXCAPBaseOffset),
       BARs(BARs_init),
-      upstreamInterface(p.upstream->registerDevice(this, _devAddr,
-                                                   (PciIntPin)p.InterruptPin)),
+      upstreamInterface(nullptr),
       pioDelay(p.pio_latency),
       configDelay(p.config_latency)
 {
@@ -203,6 +202,26 @@ PciDevice::PciDevice(const PciDeviceParams &p,
     pxcap.pxss2 = p.PXCAPSlotStatus2;
 }
 
+void
+PciDevice::init()
+{
+    DmaDevice::init();
+
+    fatal_if(upstreamInterface == nullptr,
+             "%s: Missing upstream interface, ensure this device is connected "
+             "to a PCI upstream (host bridge or PCI to PCI bridge).",
+             name());
+}
+
+void
+PciDevice::setUpstreamInterface(
+    std::unique_ptr<PciUpstream::DeviceInterface> &&interface)
+{
+    fatal_if(upstreamInterface,
+             "%s: PCI device already has an upstream interface.", name());
+    upstreamInterface = std::move(interface);
+}
+
 Tick
 PciDevice::readConfig(PacketPtr pkt)
 {
@@ -263,7 +282,7 @@ PciDevice::readConfig(PacketPtr pkt)
 Tick
 PciDevice::read(PacketPtr pkt)
 {
-    if (upstreamInterface.configRange().contains(pkt->getAddr())) {
+    if (upstreamInterface->configRange().contains(pkt->getAddr())) {
         return readConfig(pkt);
     }
 
@@ -282,7 +301,7 @@ PciDevice::getAddrRanges() const
             ranges.push_back(bar->range());
     }
 
-    ranges.push_back(upstreamInterface.configRange());
+    ranges.push_back(upstreamInterface->configRange());
 
     return ranges;
 }
@@ -395,17 +414,11 @@ PciDevice::writeConfig(PacketPtr pkt)
 Tick
 PciDevice::write(PacketPtr pkt)
 {
-    if (upstreamInterface.configRange().contains(pkt->getAddr())) {
+    if (upstreamInterface->configRange().contains(pkt->getAddr())) {
         return writeConfig(pkt);
     }
 
     return writeDevice(pkt);
-}
-
-void
-PciDevice::recvBusChange()
-{
-    pioPort.sendRangeChange();
 }
 
 void
@@ -490,6 +503,9 @@ PciDevice::unserialize(CheckpointIn &cp)
 {
     UNSERIALIZE_ARRAY(_config.data,
                       sizeof(_config.data) / sizeof(_config.data[0]));
+
+    // Update all BAR address ranges
+    recvBusChange();
 
     // unserialize the capability list registers
     uint16_t tmp16;
@@ -605,10 +621,6 @@ PciEndpoint::PciEndpoint(const PciEndpointParams &p)
 {
     fatal_if((_config.common.headerType & 0x7F) != 0, "HeaderType is invalid");
 
-    int idx = 0;
-    for (auto *bar : BARs)
-        _config.type0.baseAddr[idx++] = bar->write(upstreamInterface, 0);
-
     _config.type0.cardbusCIS = htole(p.CardbusCIS);
     _config.type0.subsystemVendorID = htole(p.SubsystemVendorID);
     _config.type0.subsystemID = htole(p.SubsystemID);
@@ -619,6 +631,19 @@ PciEndpoint::PciEndpoint(const PciEndpointParams &p)
 
     _config.type0.minimumGrant = htole(p.MinimumGrant);
     _config.type0.maximumLatency = htole(p.MaximumLatency);
+}
+
+void
+PciEndpoint::init()
+{
+    PciDevice::init();
+
+    int idx = 0;
+    for (auto *bar : BARs) {
+        _config.type0.baseAddr[idx++] = bar->write(*upstreamInterface, 0);
+    }
+
+    pioPort.sendRangeChange();
 }
 
 Tick
@@ -672,7 +697,7 @@ PciEndpoint::writeConfig(PacketPtr pkt)
                 int num = PCI0_BAR_NUMBER(offset);
                 auto *bar = BARs[num];
                 _config.type0.baseAddr[num] = htole(
-                    bar->write(upstreamInterface, pkt->getLE<uint32_t>()));
+                    bar->write(*upstreamInterface, pkt->getLE<uint32_t>()));
                 pioPort.sendRangeChange();
             }
             break;
@@ -700,12 +725,11 @@ PciEndpoint::writeConfig(PacketPtr pkt)
 }
 
 void
-PciEndpoint::unserialize(CheckpointIn &cp)
+PciEndpoint::recvBusChange()
 {
-    PciDevice::unserialize(cp);
-
-    for (int idx = 0; idx < BARs.size(); idx++)
-        BARs[idx]->write(upstreamInterface, _config.type0.baseAddr[idx]);
+    for (int idx = 0; idx < BARs.size(); idx++) {
+        BARs[idx]->write(*upstreamInterface, _config.type0.baseAddr[idx]);
+    }
 
     pioPort.sendRangeChange();
 }
@@ -714,10 +738,6 @@ PciType1Device::PciType1Device(const PciType1DeviceParams &p)
     : PciDevice(p, {p.BAR0, p.BAR1})
 {
     fatal_if((_config.common.headerType & 0x7F) != 1, "HeaderType is invalid");
-
-    int idx = 0;
-    for (auto *bar : BARs)
-        _config.type1.baseAddr[idx++] = bar->write(upstreamInterface, 0);
 
     _config.type1.primaryBusNum = htole(p.PrimaryBusNumber);
     _config.type1.secondaryBusNum = htole(p.SecondaryBusNumber);
@@ -736,6 +756,19 @@ PciType1Device::PciType1Device(const PciType1DeviceParams &p)
     _config.type1.ioLimitUpper = htole(p.IOLimitUpper);
     _config.type1.expansionROM = htole(p.ExpansionROM);
     _config.type1.bridgeControl = htole(p.BridgeControl);
+}
+
+void
+PciType1Device::init()
+{
+    PciDevice::init();
+
+    int idx = 0;
+    for (auto *bar : BARs) {
+        _config.type1.baseAddr[idx++] = bar->write(*upstreamInterface, 0);
+    }
+
+    pioPort.sendRangeChange();
 }
 
 Tick
@@ -830,8 +863,8 @@ PciType1Device::writeConfig(PacketPtr pkt)
             {
               int num = PCI1_BAR_NUMBER(offset);
               auto *bar = BARs[num];
-              _config.type1.baseAddr[num] =
-                  htole(bar->write(upstreamInterface, pkt->getLE<uint32_t>()));
+              _config.type1.baseAddr[num] = htole(
+                  bar->write(*upstreamInterface, pkt->getLE<uint32_t>()));
               pioPort.sendRangeChange();
             }
             break;
@@ -863,12 +896,11 @@ PciType1Device::writeConfig(PacketPtr pkt)
 }
 
 void
-PciType1Device::unserialize(CheckpointIn &cp)
+PciType1Device::recvBusChange()
 {
-    PciDevice::unserialize(cp);
-
-    for (int idx = 0; idx < BARs.size(); idx++)
-        BARs[idx]->write(upstreamInterface, _config.type1.baseAddr[idx]);
+    for (int idx = 0; idx < BARs.size(); idx++) {
+        BARs[idx]->write(*upstreamInterface, _config.type1.baseAddr[idx]);
+    }
 
     pioPort.sendRangeChange();
 }

--- a/src/dev/pci/device.hh
+++ b/src/dev/pci/device.hh
@@ -419,34 +419,55 @@ class PciDevice : public DmaDevice
     virtual Tick readDevice(PacketPtr pkt) = 0;
 
   protected:
-    PciUpstream::DeviceInterface upstreamInterface;
+    std::unique_ptr<PciUpstream::DeviceInterface> upstreamInterface;
 
     Tick pioDelay;
     Tick configDelay;
 
   public:
+    /**
+     * Bind the PCI upstream interface for this device.
+     *
+     * Ownership is transferred from the caller: the argument must be passed as
+     * an rvalue `std::unique_ptr`, and this device becomes the sole owner.
+     *
+     * Expected usage: call exactly once during system construction (before
+     * `init()` and before any config/PIO/DMA transactions). Rebinding after
+     * the device is active is not supported.
+     *
+     * @param interface Rvalue `std::unique_ptr` to the upstream interface.
+     */
+    void setUpstreamInterface(
+        std::unique_ptr<PciUpstream::DeviceInterface> &&interface);
+
     Addr
     pciToDma(Addr pci_addr) const
     {
-        return upstreamInterface.dmaAddr(pci_addr);
+        return upstreamInterface->dmaAddr(pci_addr);
     }
 
     void
     intrPost()
     {
-        upstreamInterface.postInt();
+        upstreamInterface->postInt();
     }
 
     void
     intrClear()
     {
-        upstreamInterface.clearInt();
+        upstreamInterface->clearInt();
     }
 
     uint8_t
     interruptLine() const
     {
         return letoh(_config.common.interruptLine);
+    }
+
+    PciIntPin
+    interruptPin() const
+    {
+        return (PciIntPin)letoh(_config.common.interruptPin);
     }
 
     /**
@@ -463,6 +484,8 @@ class PciDevice : public DmaDevice
      */
     PciDevice(const PciDeviceParams &params,
               std::initializer_list<PciBar *> BARs_init);
+
+    void init() override;
 
     /**
      * Serialize this object to the given output stream.
@@ -489,7 +512,7 @@ class PciDevice : public DmaDevice
      * (configuration, ...) can be changed, so this will send a range
      * change to the peer request port.
      */
-    void recvBusChange();
+    virtual void recvBusChange() = 0;
 };
 
 /**
@@ -523,12 +546,8 @@ class PciEndpoint : public PciDevice
      */
     PciEndpoint(const PciEndpointParams &params);
 
-    /**
-     * Reconstruct the state of this object from a checkpoint.
-     * @param cp The checkpoint use.
-     * @param section The section name of this object
-     */
-    void unserialize(CheckpointIn &cp) override;
+    void init() override;
+    void recvBusChange() override;
 };
 
 /**
@@ -563,12 +582,8 @@ class PciType1Device : public PciDevice
      */
     PciType1Device(const PciType1DeviceParams &params);
 
-    /**
-     * Reconstruct the state of this object from a checkpoint.
-     * @param cp The checkpoint use.
-     * @param section The section name of this object
-     */
-    void unserialize(CheckpointIn &cp) override;
+    void init() override;
+    void recvBusChange() override;
 };
 
 } // namespace gem5

--- a/src/dev/pci/host.cc
+++ b/src/dev/pci/host.cc
@@ -49,11 +49,20 @@
 namespace gem5
 {
 
-PciHost::PciHost(const PciHostParams &p) : PciUpstream(p)
+PciHost::PciHost(const PciHostParams &p)
+    : ClockedObject(p),
+      PciUpstream(p.up_to_down, p.config_error, p.devices, p.name)
 {}
 
 PciHost::~PciHost()
 {
+}
+
+void
+PciHost::init()
+{
+    ClockedObject::init();
+    PciUpstream::init();
 }
 
 GenericPciHost::GenericPciHost(const GenericPciHostParams &p)
@@ -77,8 +86,9 @@ GenericPciHost::getConfigAddrRange() const
 }
 
 AddrRange
-GenericPciHost::interfaceConfigRange(const PciDevAddr &dev_addr) const
+GenericPciHost::interfaceConfigRange(const PciDevice &device) const
 {
+    PciDevAddr dev_addr = device.devAddr();
     Addr bus_addr = (getBusNum() << 8) + (dev_addr.dev << 3) + dev_addr.func;
 
     Addr start = confBase + (bus_addr << confDeviceBits);
@@ -87,24 +97,21 @@ GenericPciHost::interfaceConfigRange(const PciDevAddr &dev_addr) const
 }
 
 void
-GenericPciHost::interfacePostInt(const PciDevAddr &addr, PciIntPin pin)
+GenericPciHost::interfacePostInt(const PciDevice &device)
 {
-    platform.postPciInt(mapPciInterrupt(addr, pin));
+    platform.postPciInt(mapPciInterrupt(device));
 }
 
 void
-GenericPciHost::interfaceClearInt(const PciDevAddr &addr, PciIntPin pin)
+GenericPciHost::interfaceClearInt(const PciDevice &device)
 {
-    platform.clearPciInt(mapPciInterrupt(addr, pin));
+    platform.clearPciInt(mapPciInterrupt(device));
 }
 
 uint32_t
-GenericPciHost::mapPciInterrupt(const PciDevAddr &addr, PciIntPin pin) const
+GenericPciHost::mapPciInterrupt(const PciDevice &device) const
 {
-    const PciDevice *dev(getDevice(addr));
-    assert(dev);
-
-    return dev->interruptLine();
+    return device.interruptLine();
 }
 
 } // namespace gem5

--- a/src/dev/pci/host.hh
+++ b/src/dev/pci/host.hh
@@ -70,11 +70,16 @@ class Platform;
  * PciHost functionality is implemented by the GenericPciHost class. The actual
  * bridge is implemented by PciHostBridge which is a member of this class.
  */
-class PciHost : public PciUpstream
+class PciHost : public ClockedObject, public PciUpstream
 {
   public:
+    /* Remove name() ambiguity. */
+    using ClockedObject::name;
+
     PciHost(const PciHostParams &p);
     virtual ~PciHost();
+
+    void init() override;
 };
 
 /**
@@ -114,22 +119,22 @@ class GenericPciHost : public PciHost
     AddrRange getConfigAddrRange() const override;
 
   protected: // PciUpstream
-    AddrRange interfaceConfigRange(const PciDevAddr &dev_addr) const override;
+    AddrRange interfaceConfigRange(const PciDevice &device) const override;
 
     Addr
-    interfacePioAddr(const PciDevAddr &dev_addr, Addr pci_addr) const override
+    interfacePioAddr(const PciDevice &device, Addr pci_addr) const override
     {
         return pciPioBase + pci_addr;
     }
 
     Addr
-    interfaceMemAddr(const PciDevAddr &dev_addr, Addr pci_addr) const override
+    interfaceMemAddr(const PciDevice &device, Addr pci_addr) const override
     {
         return pciMemBase + pci_addr;
     }
 
     Addr
-    interfaceDmaAddr(const PciDevAddr &dev_addr, Addr pci_addr) const override
+    interfaceDmaAddr(const PciDevice &device, Addr pci_addr) const override
     {
         return pciDmaBase + pci_addr;
     }
@@ -141,11 +146,10 @@ class GenericPciHost : public PciHost
     }
 
   protected: // Interrupt handling
-    void interfacePostInt(const PciDevAddr &addr, PciIntPin pin) override;
-    void interfaceClearInt(const PciDevAddr &addr, PciIntPin pin) override;
+    void interfacePostInt(const PciDevice &device) override;
+    void interfaceClearInt(const PciDevice &device) override;
 
-    virtual uint32_t mapPciInterrupt(const PciDevAddr &dev_addr,
-                                     PciIntPin pin) const;
+    virtual uint32_t mapPciInterrupt(const PciDevice &device) const;
 
   protected:
     Platform &platform;

--- a/src/dev/pci/upstream.cc
+++ b/src/dev/pci/upstream.cc
@@ -44,7 +44,6 @@
 #include "dev/pci/device.hh"
 #include "dev/pci/types.hh"
 #include "params/PciConfigError.hh"
-#include "params/PciUpstream.hh"
 
 namespace gem5
 {
@@ -66,11 +65,29 @@ PciConfigError::setAddrRange(AddrRange range)
     pioPort.sendRangeChange();
 }
 
-PciUpstream::PciUpstream(const Params &p)
-    : ClockedObject(p),
-      upToDown(p.up_to_down),
-      configErrorDevice(p.config_error)
-{}
+PciUpstream::PciUpstream(PciUpDownBridge *up_to_down,
+                         PciConfigError *config_error_dev,
+                         const std::vector<PciDevice *> &pci_devices,
+                         std::string upstream_name)
+    : upToDown(up_to_down),
+      configErrorDevice(config_error_dev),
+      upstreamName(upstream_name)
+{
+    for (PciDevice *device : pci_devices) {
+        PciDevAddr dev_addr = device->devAddr();
+        DPRINTF(PciUpstream, "%02x.%i: Registering device\n", dev_addr.dev,
+                dev_addr.func);
+
+        auto map_entry = devices.emplace(dev_addr, device);
+        fatal_if(!map_entry.second, "%s - %02x.%i: PCI bus ID collision\n",
+                 upstreamName, dev_addr.dev, dev_addr.func);
+
+        // Manually allocate instead of using make_unique due to
+        // DeviceInterface constructor being protected.
+        device->setUpstreamInterface(std::unique_ptr<DeviceInterface>(
+            new DeviceInterface(*this, *device)));
+    }
+}
 
 void
 PciUpstream::init()
@@ -80,19 +97,10 @@ PciUpstream::init()
     sendBusChange();
 }
 
-PciUpstream::DeviceInterface
-PciUpstream::registerDevice(PciDevice *device, PciDevAddr dev_addr,
-                            PciIntPin pin)
+std::string
+PciUpstream::name() const
 {
-    auto map_entry = devices.emplace(dev_addr, device);
-
-    DPRINTF(PciUpstream, "%02x:%02x.%i: Registering device\n", getBusNum(),
-            dev_addr.dev, dev_addr.func);
-
-    fatal_if(!map_entry.second, "%02x:%02x.%i: PCI bus ID collision\n",
-             getBusNum(), dev_addr.dev, dev_addr.func);
-
-    return DeviceInterface(*this, dev_addr, pin);
+    return upstreamName;
 }
 
 PciDevice *
@@ -110,16 +118,16 @@ PciUpstream::getDevice(const PciDevAddr &addr) const
 }
 
 PciUpstream::DeviceInterface::DeviceInterface(PciUpstream &upstream,
-                                              const PciDevAddr &dev_addr,
-                                              PciIntPin pin)
-    : upstream(upstream), devAddr(dev_addr), interruptPin(pin)
+                                              PciDevice &device)
+    : upstream(upstream), device(device)
 {}
 
 const std::string
 PciUpstream::DeviceInterface::name() const
 {
+    PciDevAddr dev_addr = device.devAddr();
     return csprintf("%s.interface[%02x:%02x.%i]", upstream.name(),
-                    upstream.getBusNum(), devAddr.dev, devAddr.func);
+                    upstream.getBusNum(), dev_addr.dev, dev_addr.func);
 }
 
 void
@@ -127,7 +135,7 @@ PciUpstream::DeviceInterface::postInt()
 {
     DPRINTF(PciUpstream, "postInt\n");
 
-    upstream.interfacePostInt(devAddr, interruptPin);
+    upstream.interfacePostInt(device);
 }
 
 void
@@ -135,7 +143,31 @@ PciUpstream::DeviceInterface::clearInt()
 {
     DPRINTF(PciUpstream, "clearInt\n");
 
-    upstream.interfaceClearInt(devAddr, interruptPin);
+    upstream.interfaceClearInt(device);
+}
+
+AddrRange
+PciUpstream::DeviceInterface::configRange() const
+{
+    return upstream.interfaceConfigRange(device);
+}
+
+Addr
+PciUpstream::DeviceInterface::pioAddr(Addr addr) const
+{
+    return upstream.interfacePioAddr(device, addr);
+}
+
+Addr
+PciUpstream::DeviceInterface::memAddr(Addr addr) const
+{
+    return upstream.interfaceMemAddr(device, addr);
+}
+
+Addr
+PciUpstream::DeviceInterface::dmaAddr(Addr addr) const
+{
+    return upstream.interfaceDmaAddr(device, addr);
 }
 
 void

--- a/src/dev/pci/upstream.hh
+++ b/src/dev/pci/upstream.hh
@@ -48,8 +48,6 @@
 #include "dev/pci/types.hh"
 #include "dev/pci/up_down_bridge.hh"
 #include "params/PciConfigError.hh"
-#include "params/PciUpstream.hh"
-#include "sim/clocked_object.hh"
 
 namespace gem5
 {
@@ -79,23 +77,40 @@ class PciConfigError : public IsaFake
  *         prefetchable memory) to physical memory.
  * </ol>
  *
- * PCI devices need to register themselves with a PCI upstream using the
- * PciUpstream::registerDevice() call. This call returns a
- * PciUpstream::DeviceInterface that provides for common functionality
- * such as interrupt delivery and memory mapping.
+ * PCI devices directly downstream will receive a PciUpstream::DeviceInterface
+ * that provides for common functionality such as interrupt delivery and memory
+ * mapping.
  *
  * The PciUpstream is an abstract class that provides the device registering
  * part and should be inherited by the actual upstream classes, which must
  * provides implementation for the interrupts and memory mapping.
+ *
+ * It can be double inherited with a SimObject to implement an actual objects.
+ * In that case, like shown in the following example, the declaration "using
+ * SimObject::name;" must be added in the derived class to avoid any ambiguity
+ * of name(). (SimObject must be replaced by the actual class name of the
+ * simulation object)
+ *
+ *   class Example : public SimObject, public PciUpstream
+ *   {
+ *     public:
+ *       using SimObject::name;
+ *   };
  */
-class PciUpstream : public ClockedObject
+class PciUpstream
 {
   public:
-    PARAMS(PciUpstream);
+    PciUpstream(PciUpDownBridge *up_to_down, PciConfigError *config_error_dev,
+                const std::vector<PciDevice *> &pci_devices,
+                std::string upstream_name);
 
-    PciUpstream(const Params &p);
+    void init();
 
-    void init() override;
+    /**
+     * Get name of the upstream. Used to print correct object name with
+     * DPRINTF.
+     */
+    std::string name() const;
 
     /**
      * @{
@@ -105,8 +120,8 @@ class PciUpstream : public ClockedObject
     /**
      * Callback interface from PCI devices to the upstream.
      *
-     * Devices get an instance of this object by calling
-     * PciUpstream::registerDevice() on their direct upstream.
+     * Devices get an instance of this object during PciUpstream
+     * initialization.
      */
     class DeviceInterface
     {
@@ -117,11 +132,9 @@ class PciUpstream : public ClockedObject
          * Instantiate a device interface
          *
          * @param upstream PCI upstream that this device belongs to.
-         * @param dev_addr The device's position on the PCI bus
-         * @param pin Interrupt pin
+         * @param device The device associated with the interface
          */
-        DeviceInterface(PciUpstream &upstream, const PciDevAddr &dev_addr,
-                        PciIntPin pin);
+        DeviceInterface(PciUpstream &upstream, PciDevice &device);
 
       public:
         DeviceInterface() = delete;
@@ -145,11 +158,7 @@ class PciUpstream : public ClockedObject
          *
          * @return Address range in the system's physical address space.
          */
-        AddrRange
-        configRange() const
-        {
-            return upstream.interfaceConfigRange(devAddr);
-        }
+        AddrRange configRange() const;
 
         /**
          * Calculate the physical address of an IO location on the PCI
@@ -158,11 +167,7 @@ class PciUpstream : public ClockedObject
          * @param addr Address in the PCI IO address space
          * @return Address in the system's physical address space.
          */
-        Addr
-        pioAddr(Addr addr) const
-        {
-            return upstream.interfacePioAddr(devAddr, addr);
-        }
+        Addr pioAddr(Addr addr) const;
 
         /**
          * Calculate the physical address of a non-prefetchable memory
@@ -171,11 +176,7 @@ class PciUpstream : public ClockedObject
          * @param addr Address in the PCI memory address space
          * @return Address in the system's physical address space.
          */
-        Addr
-        memAddr(Addr addr) const
-        {
-            return upstream.interfaceMemAddr(devAddr, addr);
-        }
+        Addr memAddr(Addr addr) const;
 
         /**
          * Calculate the physical address of a prefetchable memory
@@ -184,29 +185,12 @@ class PciUpstream : public ClockedObject
          * @param addr Address in the PCI DMA memory address space
          * @return Address in the system's physical address space.
          */
-        Addr
-        dmaAddr(Addr addr) const
-        {
-            return upstream.interfaceDmaAddr(devAddr, addr);
-        }
+        Addr dmaAddr(Addr addr) const;
 
       protected:
         PciUpstream &upstream;
-
-        const PciDevAddr devAddr;
-        const PciIntPin interruptPin;
+        PciDevice &device;
     };
-
-    /**
-     * Register a PCI device with the host.
-     *
-     * @param device Device to register
-     * @param dev_addr The device's position on the PCI bus
-     * @param pin Interrupt pin
-     * @return A device-specific DeviceInterface instance.
-     */
-    virtual DeviceInterface registerDevice(PciDevice *device,
-                                           PciDevAddr dev_addr, PciIntPin pin);
 
     /** @} */
 
@@ -232,63 +216,58 @@ class PciUpstream : public ClockedObject
     /**
      * Post an interrupt to the CPU.
      *
-     * @param dev_addr The device's position on the PCI bus
-     * @param pin PCI interrupt pin
+     * @param device The requesting PCI device
      */
-    virtual void interfacePostInt(const PciDevAddr &dev_addr,
-                                  PciIntPin pin) = 0;
+    virtual void interfacePostInt(const PciDevice &device) = 0;
 
     /**
-     * Post an interrupt to the CPU.
+     * Clear an interrupt to the CPU.
      *
-     * @param dev_addr The device's position on the PCI bus
-     * @param pin PCI interrupt pin
+     * @param device The requesting PCI device
      */
-    virtual void interfaceClearInt(const PciDevAddr &dev_addr,
-                                   PciIntPin pin) = 0;
+    virtual void interfaceClearInt(const PciDevice &device) = 0;
 
     /**
      * Calculate the physical address range of the PCI device
      * configuration space.
      *
-     * @param dev_addr The device's position on the PCI bus
+     * @param device The requesting PCI device
      * @return Configuration address range in the system's physical address
      *         space.
      */
-    virtual AddrRange
-    interfaceConfigRange(const PciDevAddr &dev_addr) const = 0;
+    virtual AddrRange interfaceConfigRange(const PciDevice &device) const = 0;
 
     /**
      * Calculate the physical address of an IO location on the PCI
      * bus.
      *
-     * @param dev_addr The device's position on the PCI bus
+     * @param device The requesting PCI device
      * @param pci_addr Address in the PCI IO address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfacePioAddr(const PciDevAddr &dev_addr,
+    virtual Addr interfacePioAddr(const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**
      * Calculate the physical address of a non-prefetchable memory
      * location in the PCI address space.
      *
-     * @param dev_addr The device's position on the PCI bus
+     * @param device The requesting PCI device
      * @param pci_addr Address in the PCI memory address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfaceMemAddr(const PciDevAddr &dev_addr,
+    virtual Addr interfaceMemAddr(const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /**
      * Calculate the physical address of a prefetchable memory
      * location in the PCI address space.
      *
-     * @param dev_addr The device's position on the PCI bus
+     * @param device The requesting PCI device
      * @param pci_addr Address in the PCI DMA memory address space
      * @return Address in the system's physical address space.
      */
-    virtual Addr interfaceDmaAddr(const PciDevAddr &dev_addr,
+    virtual Addr interfaceDmaAddr(const PciDevice &device,
                                   Addr pci_addr) const = 0;
 
     /** @} */
@@ -323,6 +302,8 @@ class PciUpstream : public ClockedObject
     PciUpDownBridge *upToDown;
 
     PciConfigError *configErrorDevice;
+
+    std::string upstreamName;
 };
 
 } // namespace gem5

--- a/src/dev/riscv/HiFive.py
+++ b/src/dev/riscv/HiFive.py
@@ -37,7 +37,6 @@
 
 from m5.objects.Clint import Clint
 from m5.objects.PciHost import GenericPciHost
-from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.Plic import Plic
 from m5.objects.PMAChecker import PMAChecker
@@ -189,7 +188,6 @@ class HiFive(HiFiveBase):
         pci_pio_base=0x2F000000,
         pci_mem_base=0x40000000,
     )
-    pci_bus = PciBus()
 
     # Uart
     uart = RiscvUart8250(pio_addr=0x10000000)

--- a/src/dev/riscv/pci_host.cc
+++ b/src/dev/riscv/pci_host.cc
@@ -36,6 +36,8 @@
  */
 
 #include "dev/riscv/pci_host.hh"
+
+#include "dev/pci/device.hh"
 #include "params/GenericRiscvPciHost.hh"
 
 namespace gem5
@@ -47,9 +49,11 @@ GenericRiscvPciHost::GenericRiscvPciHost(const GenericRiscvPciHostParams &p)
 }
 
 uint32_t
-GenericRiscvPciHost::mapPciInterrupt(const PciDevAddr &addr,
-                                     PciIntPin pin) const
+GenericRiscvPciHost::mapPciInterrupt(const PciDevice &device) const
 {
+    PciIntPin pin = device.interruptPin();
+    PciDevAddr addr = device.devAddr();
+
     fatal_if(pin == PciIntPin::NO_INT,
              "%02x:%02x.%i: Interrupt from a device without interrupts\n",
              getBusNum(), addr.dev, addr.func);

--- a/src/dev/riscv/pci_host.hh
+++ b/src/dev/riscv/pci_host.hh
@@ -56,8 +56,7 @@ class GenericRiscvPciHost : public GenericPciHost
     GenericRiscvPciHost(const GenericRiscvPciHostParams &p);
 
   protected:
-    uint32_t mapPciInterrupt(const PciDevAddr &addr,
-                             PciIntPin pin) const override;
+    uint32_t mapPciInterrupt(const PciDevice &device) const override;
 };
 
 }

--- a/src/dev/x86/Pc.py
+++ b/src/dev/x86/Pc.py
@@ -92,7 +92,7 @@ class Pc(Platform):
     bad_addr = BadAddr(pio=default_bus.default)
 
     def attachIO(self, bus, dma_ports=[]):
-        self.south_bridge.attachIO(bus, self.pci_bus, dma_ports)
+        self.south_bridge.attachIO(bus, self.pci_bus, self.pci_host, dma_ports)
         self.com_1.pio = bus.mem_side_ports
         self.fake_com_2.pio = bus.mem_side_ports
         self.fake_com_3.pio = bus.mem_side_ports
@@ -113,3 +113,4 @@ class Pc(Platform):
     def attachPciDevice(self, device):
         self.pci_bus.cpu_side_ports = device.dma
         self.pci_bus.mem_side_ports = device.pio
+        self.pci_host.devices.append(device)

--- a/src/dev/x86/Pc.py
+++ b/src/dev/x86/Pc.py
@@ -29,7 +29,6 @@ from m5.objects.Device import (
     IsaFake,
 )
 from m5.objects.PciHost import GenericPciHost
-from m5.objects.PciUpstream import PciBus
 from m5.objects.Platform import Platform
 from m5.objects.SouthBridge import SouthBridge
 from m5.objects.Terminal import Terminal
@@ -59,7 +58,6 @@ class Pc(Platform):
 
     south_bridge = Param.SouthBridge(SouthBridge(), "Southbridge")
     pci_host = PcPciHost()
-    pci_bus = PciBus()
 
     # Serial port and terminal
     com_1 = Uart8250()
@@ -92,25 +90,19 @@ class Pc(Platform):
     bad_addr = BadAddr(pio=default_bus.default)
 
     def attachIO(self, bus, dma_ports=[]):
-        self.south_bridge.attachIO(bus, self.pci_bus, self.pci_host, dma_ports)
+        self.south_bridge.attachIO(bus, self.pci_host, dma_ports)
         self.com_1.pio = bus.mem_side_ports
         self.fake_com_2.pio = bus.mem_side_ports
         self.fake_com_3.pio = bus.mem_side_ports
         self.fake_com_4.pio = bus.mem_side_ports
         self.fake_floppy.pio = bus.mem_side_ports
 
-        self.pci_bus.default = self.pci_host.down_response_port()
-        self.pci_bus.cpu_side_ports = self.pci_host.down_request_port()
-        self.pci_bus.config_error_port = self.pci_host.config_error.pio
-
-        bus.mem_side_ports = self.pci_host.up_response_port()
-
-        if dma_ports.count(self.pci_host.up_request_port()) == 0:
-            bus.cpu_side_ports = self.pci_host.up_request_port()
+        self.pci_host.internal_connect()
+        pci_dma = self.pci_host.connect_upper_bus(bus, False)
+        if dma_ports.count(pci_dma) == 0:
+            bus.cpu_side_ports = pci_dma
 
         self.default_bus.cpu_side_ports = bus.default
 
     def attachPciDevice(self, device):
-        self.pci_bus.cpu_side_ports = device.dma
-        self.pci_bus.mem_side_ports = device.pio
-        self.pci_host.devices.append(device)
+        self.pci_host.connect_device(device)

--- a/src/dev/x86/SouthBridge.py
+++ b/src/dev/x86/SouthBridge.py
@@ -79,7 +79,7 @@ class SouthBridge(SimObject):
     # IDE controller
     ide = X86IdeController(disks=[], pci_func=0, pci_dev=4)
 
-    def attachIO(self, bus, pci_bus, pci_host, dma_ports):
+    def attachIO(self, bus, pci_host, dma_ports):
         # Route interrupt signals
         self.pic1.output = self.io_apic.inputs[0]
         self.pic2.output = self.pic1.inputs[2]
@@ -106,6 +106,4 @@ class SouthBridge(SimObject):
         self.io_apic.pio = bus.mem_side_ports
         self.io_apic.int_requestor = bus.cpu_side_ports
         # Connect PCI devices
-        self.ide.pio = pci_bus.mem_side_ports
-        self.ide.dma = pci_bus.cpu_side_ports
-        pci_host.devices.append(self.ide)
+        pci_host.connect_device(self.ide)

--- a/src/dev/x86/SouthBridge.py
+++ b/src/dev/x86/SouthBridge.py
@@ -79,7 +79,7 @@ class SouthBridge(SimObject):
     # IDE controller
     ide = X86IdeController(disks=[], pci_func=0, pci_dev=4)
 
-    def attachIO(self, bus, pci_bus, dma_ports):
+    def attachIO(self, bus, pci_bus, pci_host, dma_ports):
         # Route interrupt signals
         self.pic1.output = self.io_apic.inputs[0]
         self.pic2.output = self.pic1.inputs[2]
@@ -108,3 +108,4 @@ class SouthBridge(SimObject):
         # Connect PCI devices
         self.ide.pio = pci_bus.mem_side_ports
         self.ide.dma = pci_bus.cpu_side_ports
+        pci_host.devices.append(self.ide)

--- a/src/python/gem5/components/boards/abstract_board.py
+++ b/src/python/gem5/components/boards/abstract_board.py
@@ -52,7 +52,7 @@ from typing import (
 from m5.objects import (
     ClockDomain,
     IOXBar,
-    PciBus,
+    PciHost,
     Root,
     SrcClockDomain,
     System,
@@ -350,24 +350,23 @@ class AbstractBoard:
         raise NotImplementedError
 
     @abstractmethod
-    def has_pci_bus(self) -> bool:
-        """Determine whether the board has an PCI bus or not.
+    def has_pci_host(self) -> bool:
+        """Determine whether the board has a PCI host or not.
 
-        :returns: ``True`` if the board has an PCI bus, otherwise ``False``.
+        :returns: ``True`` if the board has a PCI host, otherwise ``False``.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def get_pci_bus(self) -> PciBus:
-        """Get the board's main PCI Bus.
+    def get_pci_host(self) -> PciHost:
+        """Get the board's main PCI host.
 
         This abstract method must be implemented within the subclasses if they
         support PCI and/or full system simulation.
 
-        The PCI bus is a non-coherent bus (in the classic caches). This bus is
-        connected to the PCI host bridge and to each PCI devices of the system.
+        The PCI host is the main PCI host bridge connecting the system bus to the PCI buses.
 
-        :returns: The PCI Bus.
+        :returns: The PCI host.
         """
         raise NotImplementedError
 

--- a/src/python/gem5/components/boards/arm_board.py
+++ b/src/python/gem5/components/boards/arm_board.py
@@ -56,7 +56,7 @@ from m5.objects import (
     CowDiskImage,
     GenericTimer,
     IOXBar,
-    PciBus,
+    PciHost,
     PciVirtIO,
     RawDiskImage,
     Root,
@@ -314,12 +314,12 @@ class ArmBoard(ArmSystem, AbstractBoard, KernelDiskWorkload):
         return self.iobus
 
     @overrides(AbstractBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return True
 
     @overrides(AbstractBoard)
-    def get_pci_bus(self) -> PciBus:
-        return self.realview.pci_bus
+    def get_pci_host(self) -> PciHost:
+        return self.realview.pci_host
 
     @overrides(AbstractBoard)
     def has_coherent_io(self) -> bool:

--- a/src/python/gem5/components/boards/experimental/lupv_board.py
+++ b/src/python/gem5/components/boards/experimental/lupv_board.py
@@ -43,7 +43,7 @@ from m5.objects import (
     LupioTMR,
     LupioTTY,
     LupV,
-    PciBus,
+    PciHost,
     Plic,
     PMAChecker,
     RawDiskImage,
@@ -275,14 +275,14 @@ class LupvBoard(RiscvSystem, AbstractBoard, KernelDiskWorkload):
         return self.iobus
 
     @overrides(AbstractBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return False
 
     @overrides(AbstractBoard)
-    def get_pci_bus(self) -> PciBus:
+    def get_pci_host(self) -> PciHost:
         raise NotImplementedError(
-            "The LupvBoard does not have PCI bus. "
-            "Use `has_pci_bus()` to check this."
+            "The LupvBoard does not have PCI host. "
+            "Use `has_pci_host()` to check this."
         )
 
     def has_coherent_io(self) -> bool:

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -181,7 +181,7 @@ class RiscvBoard(
             pci_dev=0, pci_func=0, InterruptLine=1, InterruptPin=1
         )
 
-        self.ethernet.upstream = self.platform.pci_host
+        self.platform.pci_host.devices.append(self.ethernet)
         self.ethernet.pio = self.platform.pci_bus.mem_side_ports
         self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
 

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -41,7 +41,7 @@ from m5.objects import (
     HiFive,
     IGbE_e1000,
     IOXBar,
-    PciBus,
+    PciHost,
     PMAChecker,
     RawDiskImage,
     RiscvBootloaderKernelWorkload,
@@ -164,26 +164,15 @@ class RiscvBoard(
     def _setup_io_devices(self) -> None:
         """Connect the I/O devices to the I/O bus."""
         # Add PCI
-        self.iobus.mem_side_ports = self.platform.pci_host.up_response_port()
-        self.iobus.cpu_side_ports = self.platform.pci_host.up_request_port()
-        self.platform.pci_bus.default = (
-            self.platform.pci_host.down_response_port()
-        )
-        self.platform.pci_bus.cpu_side_ports = (
-            self.platform.pci_host.down_request_port()
-        )
-        self.platform.pci_bus.config_error_port = (
-            self.platform.pci_host.config_error.pio
-        )
+        self.platform.pci_host.internal_connect()
+        self.platform.pci_host.connect_upper_bus(self.iobus, True)
 
         # Add Ethernet card
         self.ethernet = IGbE_e1000(
             pci_dev=0, pci_func=0, InterruptLine=1, InterruptPin=1
         )
 
-        self.platform.pci_host.devices.append(self.ethernet)
-        self.ethernet.pio = self.platform.pci_bus.mem_side_ports
-        self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
+        self.platform.pci_host.connect_device(self.ethernet)
 
         if self.get_cache_hierarchy().is_ruby():
             for device in self._off_chip_devices + self._on_chip_devices:
@@ -255,17 +244,17 @@ class RiscvBoard(
             )
 
     @overrides(AbstractBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return self.is_fullsystem()
 
     @overrides(AbstractBoard)
-    def get_pci_bus(self) -> PciBus:
-        if self.has_pci_bus():
-            return self.platform.pci_bus
+    def get_pci_host(self) -> PciHost:
+        if self.has_pci_host():
+            return self.platform.pci_host
         else:
             raise Exception(
-                "Cannot execute `get_pci_bus()`: Board does not have an PCI "
-                "bus to return. Use `has_pci_bus()` to check this."
+                "Cannot execute `get_pci_host()`: Board does not have a PCI "
+                "host to return. Use `has_pci_host()` to check this."
             )
 
     @overrides(AbstractBoard)

--- a/src/python/gem5/components/boards/simple_board.py
+++ b/src/python/gem5/components/boards/simple_board.py
@@ -28,7 +28,7 @@ from typing import List
 
 from m5.objects import (
     IOXBar,
-    PciBus,
+    PciHost,
 )
 from m5.params import (
     AddrRange,
@@ -84,14 +84,14 @@ class SimpleBoard(AbstractSystemBoard, SEBinaryWorkload):
         )
 
     @overrides(AbstractSystemBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return False
 
     @overrides(AbstractSystemBoard)
-    def get_pci_bus(self) -> PciBus:
+    def get_pci_host(self) -> PciHost:
         raise NotImplementedError(
-            "SimpleBoard does not have an PCI Bus. "
-            "Use `has_pci_bus()` to check this."
+            "SimpleBoard does not have a PCI host. "
+            "Use `has_pci_host()` to check this."
         )
 
     @overrides(AbstractSystemBoard)

--- a/src/python/gem5/components/boards/test_board.py
+++ b/src/python/gem5/components/boards/test_board.py
@@ -31,7 +31,7 @@ from typing import (
 
 from m5.objects import (
     IOXBar,
-    PciBus,
+    PciHost,
 )
 from m5.params import (
     AddrRange,
@@ -89,14 +89,14 @@ class TestBoard(AbstractSystemBoard):
         )
 
     @overrides(AbstractSystemBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return False
 
     @overrides(AbstractSystemBoard)
-    def get_pci_bus(self) -> PciBus:
+    def get_pci_host(self) -> PciHost:
         raise NotImplementedError(
-            "The TestBoard does not have an PCI Bus. "
-            "Use `has_pci_bus()` to check this."
+            "The TestBoard does not have a PCI host. "
+            "Use `has_pci_host()` to check this."
         )
 
     @overrides(AbstractSystemBoard)

--- a/src/python/gem5/components/boards/x86_board.py
+++ b/src/python/gem5/components/boards/x86_board.py
@@ -37,7 +37,7 @@ from m5.objects import (
     IdeDisk,
     IOXBar,
     Pc,
-    PciBus,
+    PciHost,
     RawDiskImage,
     X86ACPIMadt,
     X86ACPIMadtIntSourceOverride,
@@ -109,9 +109,9 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
             # which will hang forever. The hanging can be reproduced b
             # removing the following three lines then running gem5 with the
             # "configs/example/gem5_library/x86-ubuntu-run.py" script.
-            self.pc.pci_bus.frontend_latency = 0
-            self.pc.pci_bus.forward_latency = 0
-            self.pc.pci_bus.response_latency = 0
+            self.pc.pci_host.internal_bus.frontend_latency = 0
+            self.pc.pci_host.internal_bus.forward_latency = 0
+            self.pc.pci_host.internal_bus.response_latency = 0
 
             self.workload = X86FsLinux()
 
@@ -140,9 +140,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
 
         # Setup memory system specific settings.
         if self.get_cache_hierarchy().is_ruby():
-            self.pc.attachIO(
-                self.get_io_bus(), [self.pc.pci_host.up_request_port()]
-            )
+            self.pc.attachIO(self.get_io_bus(), [self.pc.pci_host.dma_port()])
         else:
             self.bridge = Bridge(delay="50ns")
             self.bridge.mem_side_port = self.get_io_bus().cpu_side_ports
@@ -321,17 +319,17 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
             )
 
     @overrides(AbstractSystemBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return self.is_fullsystem()
 
     @overrides(AbstractSystemBoard)
-    def get_pci_bus(self) -> PciBus:
-        if self.has_pci_bus():
-            return self.pc.pci_bus
+    def get_pci_host(self) -> PciHost:
+        if self.has_pci_host():
+            return self.pc.pci_host
         else:
             raise Exception(
-                "Cannot execute `get_pci_bus()`: Board does not have a PCI "
-                "bus to return. Use `has_pci_bus()` to check this."
+                "Cannot execute `get_pci_host()`: Board does not have a PCI "
+                "host to return. Use `has_pci_host()` to check this."
             )
 
     @overrides(AbstractSystemBoard)
@@ -342,7 +340,7 @@ class X86Board(AbstractSystemBoard, KernelDiskWorkload, SEBinaryWorkload):
     def get_dma_ports(self) -> Sequence[Port]:
         if self.has_dma_ports():
             return [
-                self.pc.pci_host.up_request_port(),
+                self.pc.pci_host.dma_port(),
                 self.iobus.mem_side_ports,
             ]
         else:

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -109,7 +109,7 @@ class BaseViperGPU(SubSystem):
         # pointer required by the AbstractMemory class is set by AMDGPUDevice.
         self.device.memories = self.memory.get_mem_interfaces()
 
-        self.device.upstream = board.get_pci_host()
+        board.get_pci_host().devices.append(self.device)
 
 
 # A scaled down MI210-like device. Defaults to ~1/4th of an MI210.

--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -101,7 +101,7 @@ class BaseViperGPU(SubSystem):
         self.shader.set_cpu_pointer(cpus.cores[0].core)
 
         # Connect all PIO buses
-        self.shader.connect_iobus(board.get_io_bus(), board.get_pci_bus())
+        self.shader.connect_iobus(board.get_io_bus(), board.get_pci_host())
 
         # Collect GPU memory controllers created in the GPU cache hierarchy.
         # First assign them as a child to the device so the SimObject unproxy.

--- a/src/python/gem5/components/devices/gpus/viper_shader.py
+++ b/src/python/gem5/components/devices/gpus/viper_shader.py
@@ -42,6 +42,7 @@ from m5.objects import (
     GPUDispatcher,
     HSAPacketProcessor,
     LdsState,
+    PciHost,
     PciLegacyIoBar,
     PciMemBar,
     PM4PacketProcessor,
@@ -369,12 +370,12 @@ class ViperShader(Shader):
 
         self._gpu_dma_ports.append(self.l3_tlb.walker.port)
 
-    def connect_iobus(self, iobus: BaseXBar, pci_bus: BaseXBar):
+    def connect_iobus(self, iobus: BaseXBar, pci_host: PciHost):
         """Connect the GPU objects to the IO bus."""
         self.gpu_cmd_proc.pio = iobus.mem_side_ports
         self.gpu_cmd_proc.hsapp.pio = iobus.mem_side_ports
         self.system_hub.pio = iobus.mem_side_ports
-        self._device.pio = pci_bus.mem_side_ports
+        self._device.pio = pci_host.internal_bus.mem_side_ports
         self._device.device_ih.pio = iobus.mem_side_ports
         for sdma in self._device.sdmas:
             sdma.pio = iobus.mem_side_ports

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -42,7 +42,7 @@ from m5.objects import (
     HiFive,
     IGbE_e1000,
     IOXBar,
-    PciBus,
+    PciHost,
     PMAChecker,
     Port,
     RawDiskImage,
@@ -200,21 +200,8 @@ class RISCVMatchedBoard(
         """Connect the I/O devices to the I/O bus in FS mode."""
         if self._fs:
             # Add PCI
-            self.iobus.mem_side_ports = (
-                self.platform.pci_host.up_response_port()
-            )
-            self.iobus.cpu_side_ports = (
-                self.platform.pci_host.up_request_port()
-            )
-            self.platform.pci_bus.default = (
-                self.platform.pci_host.down_response_port()
-            )
-            self.platform.pci_bus.cpu_side_ports = (
-                self.platform.pci_host.down_request_port()
-            )
-            self.platform.pci_bus.config_error_port = (
-                self.platform.pci_host.config_error.pio
-            )
+            self.platform.pci_host.internal_connect()
+            self.platform.pci_host.connect_upper_bus(self.iobus, True)
 
             # Add Ethernet card
             self.ethernet = IGbE_e1000(
@@ -224,9 +211,7 @@ class RISCVMatchedBoard(
                 InterruptPin=1,
             )
 
-            self.platform.pci_host.devices.append(self.ethernet)
-            self.ethernet.pio = self.platform.pci_bus.mem_side_ports
-            self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
+            self.platform.pci_host.connect_device(self.ethernet)
 
             if self.get_cache_hierarchy().is_ruby():
                 for device in self._off_chip_devices + self._on_chip_devices:
@@ -298,17 +283,17 @@ class RISCVMatchedBoard(
             )
 
     @overrides(AbstractBoard)
-    def has_pci_bus(self) -> bool:
+    def has_pci_host(self) -> bool:
         return self.is_fullsystem()
 
     @overrides(AbstractBoard)
-    def get_pci_bus(self) -> PciBus:
-        if self.has_pci_bus():
-            return self.platform.pci_bus
+    def get_pci_host(self) -> PciHost:
+        if self.has_pci_host():
+            return self.platform.pci_host
         else:
             raise Exception(
-                "Cannot execute `get_pci_bus()`: Board does not have a PCI "
-                "bus to return. Use `has_pci_bus()` to check this."
+                "Cannot execute `get_pci_host()`: Board does not have a PCI "
+                "host to return. Use `has_pci_host()` to check this."
             )
 
     @overrides(AbstractBoard)

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -224,7 +224,7 @@ class RISCVMatchedBoard(
                 InterruptPin=1,
             )
 
-            self.ethernet.upstream = self.platform.pci_host
+            self.platform.pci_host.devices.append(self.ethernet)
             self.ethernet.pio = self.platform.pci_bus.mem_side_ports
             self.ethernet.dma = self.platform.pci_bus.cpu_side_ports
 


### PR DESCRIPTION
This PR refactor PciUpstream to be a C++ interface instead of a full SimObject. As discussed in #2561, this allows to keep common code between PCI host bridge and (futur) PCI to PCI bridges, without having distinct SimObject for the PCI to PCI bridge.

Also, this move PciBus (the XBar to which are connected PciDevice) to be a child of PciHost, as it will always be needed and adds some helper functions to connect ports related to PciHost, PciBus and device, reducing possible point of mistake. This represent most of the Python changes and may be put in another PR if required.

Made in collaboration with @marinazapater