### PR TITLE
mem-cache: Add profiling statistics to replacement policy

### DIFF
--- a/src/mem/cache/replacement_policies/SConscript
+++ b/src/mem/cache/replacement_policies/SConscript
@@ -46,13 +46,35 @@ Source('ship_rp.cc')
 Source('tree_plru_rp.cc')
 Source('weighted_lru_rp.cc')
 
+# The common replacement policy base class (replacement_policy::Base) now
+# gathers profiling statistics. Instantiating any policy therefore pulls in
+# the statistics implementation and its dependencies, none of which are part
+# of the 'gem5 simobject' tag. The unit tests below must link them explicitly,
+# and the 'socket_test' tag is reused to pull in the zlib (-lz) dependency
+# required by base/output.cc.
+stats_srcs = [
+    '../../../base/statistics.cc',
+    '../../../base/stats/info.cc',
+    '../../../base/stats/storage.cc',
+    '../../../base/time.cc',
+    '../../../base/hostinfo.cc',
+    '../../../base/output.cc',
+    '../../../sim/core.cc',
+    '../../../sim/root.cc',
+    '../../../sim/globals.cc',
+    '../../../sim/tags.cc',
+]
+stats_tags = [with_tag('gem5 simobject'), with_tag('socket_test')]
+
 GTest('replaceable_entry.test', 'replaceable_entry.test.cc')
+GTest('base_rp.test', 'lru_rp.cc', 'base_rp.test.cc', *stats_srcs,
+    *stats_tags)
 GTest('tree_plru_rp.test', 'tree_plru_rp.cc', 'tree_plru_rp.test.cc',
-    with_tag('gem5 simobject'))
-GTest('fifo_rp.test', 'fifo_rp.cc', 'fifo_rp.test.cc',
-    with_tag('gem5 simobject'))
-GTest('lfu_rp.test', 'lfu_rp.cc', 'lfu_rp.test.cc', with_tag('gem5 simobject'))
-GTest('lru_rp.test', 'lru_rp.cc', 'lru_rp.test.cc', with_tag('gem5 simobject'))
-GTest('mru_rp.test', 'mru_rp.cc', 'mru_rp.test.cc', with_tag('gem5 simobject'))
+    *stats_srcs, *stats_tags)
+GTest('fifo_rp.test', 'fifo_rp.cc', 'fifo_rp.test.cc', *stats_srcs,
+    *stats_tags)
+GTest('lfu_rp.test', 'lfu_rp.cc', 'lfu_rp.test.cc', *stats_srcs, *stats_tags)
+GTest('lru_rp.test', 'lru_rp.cc', 'lru_rp.test.cc', *stats_srcs, *stats_tags)
+GTest('mru_rp.test', 'mru_rp.cc', 'mru_rp.test.cc', *stats_srcs, *stats_tags)
 GTest('second_chance_rp.test', 'fifo_rp.cc', 'second_chance_rp.cc',
-    'second_chance_rp.test.cc', with_tag('gem5 simobject'))
+    'second_chance_rp.test.cc', *stats_srcs, *stats_tags)

--- a/src/mem/cache/replacement_policies/base.hh
+++ b/src/mem/cache/replacement_policies/base.hh
@@ -32,6 +32,7 @@
 #include <memory>
 
 #include "base/compiler.hh"
+#include "base/statistics.hh"
 #include "mem/cache/replacement_policies/replaceable_entry.hh"
 #include "mem/packet.hh"
 #include "params/BaseReplacementPolicy.hh"
@@ -50,12 +51,57 @@ namespace replacement_policy
 
 /**
  * A common base class of cache replacement policy objects.
+ *
+ * Concrete policies do not override the public interface directly. Instead,
+ * they implement the protected @c *Impl methods, while the public methods
+ * (invalidate, touch, reset and getVictim) are non-virtual wrappers provided
+ * by this base class. These wrappers gather profiling statistics common to
+ * every policy and then forward to the policy-specific implementation. This
+ * Non-Virtual Interface keeps statistics collection in a single place, so no
+ * policy can accidentally bypass it.
  */
 class Base : public SimObject
 {
+  protected:
+    /** Profiling information shared by all replacement policies. */
+    struct ReplacementStats : public statistics::Group
+    {
+        ReplacementStats(statistics::Group *parent)
+            : statistics::Group(parent),
+              ADD_STAT(victimizations, statistics::units::Count::get(),
+                       "Number of entries selected for eviction by getVictim"),
+              ADD_STAT(hits, statistics::units::Count::get(),
+                       "Number of accesses to entries already present"),
+              ADD_STAT(insertions, statistics::units::Count::get(),
+                       "Number of entries inserted/validated"),
+              ADD_STAT(invalidations, statistics::units::Count::get(),
+                       "Number of entries invalidated"),
+              ADD_STAT(
+                  avgHitsPerInsertion, statistics::units::Ratio::get(),
+                  "Average number of hits seen by an entry before replacement")
+        { avgHitsPerInsertion = hits / insertions; }
+
+        /** Number of entries selected for eviction by getVictim. */
+        statistics::Scalar victimizations;
+        /** Number of accesses to entries already present (cache hits). */
+        statistics::Scalar hits;
+        /** Number of entries inserted/validated. */
+        statistics::Scalar insertions;
+        /** Number of entries invalidated. */
+        statistics::Scalar invalidations;
+        /** Average number of hits seen by an entry before it is replaced. */
+        statistics::Formula avgHitsPerInsertion;
+    };
+
+    /**
+     * Profiling counters. Marked mutable because the const interface methods
+     * (e.g. touch and getVictim) must be able to update them.
+     */
+    mutable ReplacementStats stats;
+
   public:
     typedef BaseReplacementPolicyParams Params;
-    Base(const Params &p) : SimObject(p) {}
+    Base(const Params &p) : SimObject(p), stats(this) {}
     virtual ~Base() = default;
 
     /**
@@ -63,8 +109,12 @@ class Base : public SimObject
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    virtual void invalidate(const std::shared_ptr<ReplacementData>&
-        replacement_data) = 0;
+    void
+    invalidate(const std::shared_ptr<ReplacementData> &replacement_data)
+    {
+        stats.invalidations++;
+        invalidateImpl(replacement_data);
+    }
 
     /**
      * Update replacement data.
@@ -72,13 +122,19 @@ class Base : public SimObject
      * @param replacement_data Replacement data to be touched.
      * @param pkt Packet that generated this access.
      */
-    virtual void touch(const std::shared_ptr<ReplacementData>&
-        replacement_data, const PacketPtr pkt)
+    void
+    touch(const std::shared_ptr<ReplacementData> &replacement_data,
+          const PacketPtr pkt)
     {
-        touch(replacement_data);
+        stats.hits++;
+        touchImpl(replacement_data, pkt);
     }
-    virtual void touch(const std::shared_ptr<ReplacementData>&
-        replacement_data) const = 0;
+    void
+    touch(const std::shared_ptr<ReplacementData> &replacement_data) const
+    {
+        stats.hits++;
+        touchImpl(replacement_data);
+    }
 
     /**
      * Reset replacement data. Used when it's holder is inserted/validated.
@@ -86,13 +142,19 @@ class Base : public SimObject
      * @param replacement_data Replacement data to be reset.
      * @param pkt Packet that generated this access.
      */
-    virtual void reset(const std::shared_ptr<ReplacementData>&
-        replacement_data, const PacketPtr pkt)
+    void
+    reset(const std::shared_ptr<ReplacementData> &replacement_data,
+          const PacketPtr pkt)
     {
-        reset(replacement_data);
+        stats.insertions++;
+        resetImpl(replacement_data, pkt);
     }
-    virtual void reset(const std::shared_ptr<ReplacementData>&
-        replacement_data) const = 0;
+    void
+    reset(const std::shared_ptr<ReplacementData> &replacement_data) const
+    {
+        stats.insertions++;
+        resetImpl(replacement_data);
+    }
 
     /**
      * Find replacement victim among candidates.
@@ -100,8 +162,12 @@ class Base : public SimObject
      * @param candidates Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    virtual ReplaceableEntry* getVictim(
-                           const ReplacementCandidates& candidates) const = 0;
+    ReplaceableEntry *
+    getVictim(const ReplacementCandidates &candidates) const
+    {
+        stats.victimizations++;
+        return getVictimImpl(candidates);
+    }
 
     /**
      * Instantiate a replacement data entry.
@@ -109,6 +175,33 @@ class Base : public SimObject
      * @return A shared pointer to the new replacement data.
      */
     virtual std::shared_ptr<ReplacementData> instantiateEntry() = 0;
+
+  protected:
+    /**
+     * Policy-specific implementation of the public interface. See the
+     * corresponding public methods for the expected behavior.
+     * @{
+     */
+    virtual void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) = 0;
+
+    virtual void
+    touchImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+              const PacketPtr pkt)
+    { touchImpl(replacement_data); }
+    virtual void touchImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) const = 0;
+
+    virtual void
+    resetImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+              const PacketPtr pkt)
+    { resetImpl(replacement_data); }
+    virtual void resetImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) const = 0;
+
+    virtual ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const = 0;
+    /** @} */
 };
 
 } // namespace replacement_policy

--- a/src/mem/cache/replacement_policies/base_rp.test.cc
+++ b/src/mem/cache/replacement_policies/base_rp.test.cc
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2026 Hiruna Vishwamith
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Tests for the profiling statistics gathered by the common replacement
+ * policy interface (gem5::replacement_policy::Base). LRU is used as a
+ * concrete policy, as the counters live in the base class and are therefore
+ * shared by every policy.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "mem/cache/replacement_policies/lru_rp.hh"
+#include "params/LRURP.hh"
+#include "sim/cur_tick.hh"
+#include "sim/eventq.hh"
+
+using namespace gem5;
+
+namespace
+{
+
+// LRU calls curTick(), so a current event queue must exist for the policy to
+// be exercised. See the fixture below.
+EventQueue eventQueue("BaseRPStatsTest Event Queue");
+
+/**
+ * LRU subclass that exposes the base class' protected profiling counters so
+ * that the Non-Virtual Interface wrappers can be observed from the tests.
+ */
+class TestableLRU : public replacement_policy::LRU
+{
+  public:
+    using LRU::LRU;
+
+    double
+    victimizations() const
+    { return stats.victimizations.value(); }
+    double
+    hits() const
+    { return stats.hits.value(); }
+    double
+    insertions() const
+    { return stats.insertions.value(); }
+    double
+    invalidations() const
+    { return stats.invalidations.value(); }
+};
+
+std::shared_ptr<TestableLRU>
+makeReplacementPolicy()
+{
+    LRURPParams params;
+    params.eventq_index = 0;
+    return std::make_shared<TestableLRU>(params);
+}
+
+/// Fixture that makes an event queue current so the policy can call curTick().
+class BaseRPStatsTest : public ::testing::Test
+{
+  protected:
+    BaseRPStatsTest() { curEventQueue(&eventQueue); }
+};
+
+} // namespace
+
+/// A freshly built policy must not have recorded any activity.
+TEST_F(BaseRPStatsTest, CountersStartAtZero)
+{
+    const auto rp = makeReplacementPolicy();
+    EXPECT_EQ(rp->victimizations(), 0);
+    EXPECT_EQ(rp->hits(), 0);
+    EXPECT_EQ(rp->insertions(), 0);
+    EXPECT_EQ(rp->invalidations(), 0);
+}
+
+/// Each public interface call must increment exactly one counter, exactly
+/// once, regardless of the concrete policy.
+TEST_F(BaseRPStatsTest, CountersTrackInterfaceCalls)
+{
+    const auto rp = makeReplacementPolicy();
+    const auto data = rp->instantiateEntry();
+
+    rp->reset(data);
+    rp->reset(data);
+    rp->reset(data);
+    EXPECT_EQ(rp->insertions(), 3);
+
+    rp->touch(data);
+    rp->touch(data);
+    EXPECT_EQ(rp->hits(), 2);
+
+    rp->invalidate(data);
+    EXPECT_EQ(rp->invalidations(), 1);
+
+    // The other counters must be unaffected by unrelated operations.
+    EXPECT_EQ(rp->victimizations(), 0);
+}
+
+/// getVictim must bump the victimization counter once per call.
+TEST_F(BaseRPStatsTest, VictimizationsAreCounted)
+{
+    const auto rp = makeReplacementPolicy();
+
+    ReplaceableEntry entry;
+    entry.replacementData = rp->instantiateEntry();
+    ReplacementCandidates candidates;
+    candidates.push_back(&entry);
+
+    rp->getVictim(candidates);
+    rp->getVictim(candidates);
+    EXPECT_EQ(rp->victimizations(), 2);
+
+    // Selecting a victim is not an insertion, hit or invalidation.
+    EXPECT_EQ(rp->hits(), 0);
+    EXPECT_EQ(rp->insertions(), 0);
+    EXPECT_EQ(rp->invalidations(), 0);
+}

--- a/src/mem/cache/replacement_policies/bip_rp.cc
+++ b/src/mem/cache/replacement_policies/bip_rp.cc
@@ -45,7 +45,7 @@ BIP::BIP(const Params &p)
 }
 
 void
-BIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+BIP::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     std::shared_ptr<LRUReplData> casted_replacement_data =
         std::static_pointer_cast<LRUReplData>(replacement_data);

--- a/src/mem/cache/replacement_policies/bip_rp.hh
+++ b/src/mem/cache/replacement_policies/bip_rp.hh
@@ -76,8 +76,8 @@ class BIP : public LRU
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 };
 
 } // namespace replacement_policy

--- a/src/mem/cache/replacement_policies/brrip_rp.cc
+++ b/src/mem/cache/replacement_policies/brrip_rp.cc
@@ -48,7 +48,7 @@ BRRIP::BRRIP(const Params &p)
 }
 
 void
-BRRIP::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+BRRIP::invalidateImpl(const std::shared_ptr<ReplacementData> &replacement_data)
 {
     std::shared_ptr<BRRIPReplData> casted_replacement_data =
         std::static_pointer_cast<BRRIPReplData>(replacement_data);
@@ -58,7 +58,8 @@ BRRIP::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-BRRIP::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+BRRIP::touchImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     std::shared_ptr<BRRIPReplData> casted_replacement_data =
         std::static_pointer_cast<BRRIPReplData>(replacement_data);
@@ -74,7 +75,8 @@ BRRIP::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 void
-BRRIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+BRRIP::resetImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     std::shared_ptr<BRRIPReplData> casted_replacement_data =
         std::static_pointer_cast<BRRIPReplData>(replacement_data);
@@ -91,8 +93,8 @@ BRRIP::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
     casted_replacement_data->valid = true;
 }
 
-ReplaceableEntry*
-BRRIP::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+BRRIP::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/brrip_rp.hh
+++ b/src/mem/cache/replacement_policies/brrip_rp.hh
@@ -125,16 +125,16 @@ class BRRIP : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -142,8 +142,8 @@ class BRRIP : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using rrpv.
@@ -151,8 +151,8 @@ class BRRIP : public Base
      * @param cands Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/dueling_rp.cc
+++ b/src/mem/cache/replacement_policies/dueling_rp.cc
@@ -48,7 +48,8 @@ Dueling::Dueling(const Params &p)
 }
 
 void
-Dueling::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+Dueling::invalidateImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data)
 {
     std::shared_ptr<DuelerReplData> casted_replacement_data =
         std::static_pointer_cast<DuelerReplData>(replacement_data);
@@ -57,8 +58,8 @@ Dueling::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-Dueling::touch(const std::shared_ptr<ReplacementData>& replacement_data,
-    const PacketPtr pkt)
+Dueling::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                   const PacketPtr pkt)
 {
     std::shared_ptr<DuelerReplData> casted_replacement_data =
         std::static_pointer_cast<DuelerReplData>(replacement_data);
@@ -67,7 +68,8 @@ Dueling::touch(const std::shared_ptr<ReplacementData>& replacement_data,
 }
 
 void
-Dueling::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+Dueling::touchImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     std::shared_ptr<DuelerReplData> casted_replacement_data =
         std::static_pointer_cast<DuelerReplData>(replacement_data);
@@ -76,8 +78,8 @@ Dueling::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 void
-Dueling::reset(const std::shared_ptr<ReplacementData>& replacement_data,
-    const PacketPtr pkt)
+Dueling::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                   const PacketPtr pkt)
 {
     std::shared_ptr<DuelerReplData> casted_replacement_data =
         std::static_pointer_cast<DuelerReplData>(replacement_data);
@@ -92,7 +94,8 @@ Dueling::reset(const std::shared_ptr<ReplacementData>& replacement_data,
 }
 
 void
-Dueling::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+Dueling::resetImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     std::shared_ptr<DuelerReplData> casted_replacement_data =
         std::static_pointer_cast<DuelerReplData>(replacement_data);
@@ -106,8 +109,8 @@ Dueling::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
     duelingMonitor.sample(static_cast<Dueler*>(casted_replacement_data.get()));
 }
 
-ReplaceableEntry*
-Dueling::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+Dueling::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // This function assumes that all candidates are either part of the same
     // sampled set, or are not samples.

--- a/src/mem/cache/replacement_policies/dueling_rp.hh
+++ b/src/mem/cache/replacement_policies/dueling_rp.hh
@@ -97,18 +97,18 @@ class Dueling : public Base
     Dueling(const Params &p);
     ~Dueling() = default;
 
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data,
-        const PacketPtr pkt) override;
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data,
-        const PacketPtr pkt) override;
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                   const PacketPtr pkt) override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                   const PacketPtr pkt) override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
     std::shared_ptr<ReplacementData> instantiateEntry() override;
 };
 

--- a/src/mem/cache/replacement_policies/fifo_rp.cc
+++ b/src/mem/cache/replacement_policies/fifo_rp.cc
@@ -46,7 +46,7 @@ FIFO::FIFO(const Params &p)
 }
 
 void
-FIFO::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+FIFO::invalidateImpl(const std::shared_ptr<ReplacementData> &replacement_data)
 {
     assert(replacement_data);
 
@@ -57,7 +57,7 @@ FIFO::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-FIFO::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+FIFO::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     // A touch does not modify the insertion tick. We still check if the data
     // exists to standardize the API
@@ -65,7 +65,7 @@ FIFO::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 void
-FIFO::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+FIFO::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -74,8 +74,8 @@ FIFO::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
         replacement_data)->tickInserted = ++timeTicks;
 }
 
-ReplaceableEntry*
-FIFO::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+FIFO::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/fifo_rp.hh
+++ b/src/mem/cache/replacement_policies/fifo_rp.hh
@@ -79,8 +79,8 @@ class FIFO : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -88,8 +88,8 @@ class FIFO : public Base
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -97,8 +97,8 @@ class FIFO : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using insertion timestamps.
@@ -106,8 +106,8 @@ class FIFO : public Base
      * @param cands Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/lfu_rp.cc
+++ b/src/mem/cache/replacement_policies/lfu_rp.cc
@@ -45,7 +45,7 @@ LFU::LFU(const Params &p)
 }
 
 void
-LFU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+LFU::invalidateImpl(const std::shared_ptr<ReplacementData> &replacement_data)
 {
     assert(replacement_data);
 
@@ -54,7 +54,7 @@ LFU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-LFU::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+LFU::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -63,7 +63,7 @@ LFU::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 void
-LFU::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+LFU::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -71,8 +71,8 @@ LFU::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
     std::static_pointer_cast<LFUReplData>(replacement_data)->refCount = 1;
 }
 
-ReplaceableEntry*
-LFU::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+LFU::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/lfu_rp.hh
+++ b/src/mem/cache/replacement_policies/lfu_rp.hh
@@ -73,8 +73,8 @@ class LFU : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -82,8 +82,8 @@ class LFU : public Base
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -91,8 +91,8 @@ class LFU : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using reference frequency.
@@ -100,8 +100,8 @@ class LFU : public Base
      * @param cands Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/lru_rp.cc
+++ b/src/mem/cache/replacement_policies/lru_rp.cc
@@ -46,7 +46,7 @@ LRU::LRU(const Params &p)
 }
 
 void
-LRU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+LRU::invalidateImpl(const std::shared_ptr<ReplacementData> &replacement_data)
 {
     assert(replacement_data);
 
@@ -56,7 +56,7 @@ LRU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-LRU::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+LRU::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -66,7 +66,7 @@ LRU::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 void
-LRU::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+LRU::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -75,8 +75,8 @@ LRU::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
         replacement_data)->lastTouchTick = curTick();
 }
 
-ReplaceableEntry*
-LRU::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+LRU::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/lru_rp.hh
+++ b/src/mem/cache/replacement_policies/lru_rp.hh
@@ -71,8 +71,8 @@ class LRU : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -80,8 +80,8 @@ class LRU : public Base
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -89,8 +89,8 @@ class LRU : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using LRU timestamps.
@@ -98,8 +98,8 @@ class LRU : public Base
      * @param candidates Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/mru_rp.cc
+++ b/src/mem/cache/replacement_policies/mru_rp.cc
@@ -46,7 +46,7 @@ MRU::MRU(const Params &p)
 }
 
 void
-MRU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+MRU::invalidateImpl(const std::shared_ptr<ReplacementData> &replacement_data)
 {
     assert(replacement_data);
 
@@ -56,7 +56,7 @@ MRU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-MRU::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+MRU::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -66,7 +66,7 @@ MRU::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
 }
 
 void
-MRU::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+MRU::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     assert(replacement_data);
 
@@ -75,8 +75,8 @@ MRU::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
         replacement_data)->lastTouchTick = curTick();
 }
 
-ReplaceableEntry*
-MRU::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+MRU::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/mru_rp.hh
+++ b/src/mem/cache/replacement_policies/mru_rp.hh
@@ -73,8 +73,8 @@ class MRU : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -82,8 +82,8 @@ class MRU : public Base
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -91,8 +91,8 @@ class MRU : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using access timestamps.
@@ -100,8 +100,8 @@ class MRU : public Base
      * @param cands Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/random_rp.cc
+++ b/src/mem/cache/replacement_policies/random_rp.cc
@@ -45,7 +45,8 @@ Random::Random(const Params &p)
 }
 
 void
-Random::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+Random::invalidateImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data)
 {
     // Unprioritize replacement data victimization
     std::static_pointer_cast<RandomReplData>(
@@ -53,20 +54,22 @@ Random::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-Random::touch(const std::shared_ptr<ReplacementData>& replacement_data) const
+Random::touchImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
 }
 
 void
-Random::reset(const std::shared_ptr<ReplacementData>& replacement_data) const
+Random::resetImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     // Unprioritize replacement data victimization
     std::static_pointer_cast<RandomReplData>(
         replacement_data)->valid = true;
 }
 
-ReplaceableEntry*
-Random::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+Random::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/random_rp.hh
+++ b/src/mem/cache/replacement_policies/random_rp.hh
@@ -77,8 +77,8 @@ class Random : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -86,8 +86,8 @@ class Random : public Base
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -95,8 +95,8 @@ class Random : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim at random.
@@ -104,8 +104,8 @@ class Random : public Base
      * @param candidates Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/second_chance_rp.cc
+++ b/src/mem/cache/replacement_policies/second_chance_rp.cc
@@ -48,17 +48,17 @@ SecondChance::useSecondChance(
     const std::shared_ptr<SecondChanceReplData>& replacement_data) const
 {
     // Reset FIFO data
-    FIFO::reset(replacement_data);
+    FIFO::resetImpl(replacement_data);
 
     // Use second chance
     replacement_data->hasSecondChance = false;
 }
 
 void
-SecondChance::invalidate(
-    const std::shared_ptr<ReplacementData>& replacement_data)
+SecondChance::invalidateImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data)
 {
-    FIFO::invalidate(replacement_data);
+    FIFO::invalidateImpl(replacement_data);
 
     // Do not give a second chance to invalid entries
     std::static_pointer_cast<SecondChanceReplData>(
@@ -66,10 +66,10 @@ SecondChance::invalidate(
 }
 
 void
-SecondChance::touch(
-    const std::shared_ptr<ReplacementData>& replacement_data) const
+SecondChance::touchImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
-    FIFO::touch(replacement_data);
+    FIFO::touchImpl(replacement_data);
 
     // Whenever an entry is touched, it is given a second chance
     std::static_pointer_cast<SecondChanceReplData>(
@@ -77,18 +77,18 @@ SecondChance::touch(
 }
 
 void
-SecondChance::reset(
-    const std::shared_ptr<ReplacementData>& replacement_data) const
+SecondChance::resetImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
-    FIFO::reset(replacement_data);
+    FIFO::resetImpl(replacement_data);
 
     // Entries are inserted with a second chance
     std::static_pointer_cast<SecondChanceReplData>(
         replacement_data)->hasSecondChance = false;
 }
 
-ReplaceableEntry*
-SecondChance::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+SecondChance::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);
@@ -112,7 +112,7 @@ SecondChance::getVictim(const ReplacementCandidates& candidates) const
     bool search_victim = true;
     while (search_victim) {
         // Do a FIFO victim search
-        victim = FIFO::getVictim(candidates);
+        victim = FIFO::getVictimImpl(candidates);
 
         // Cast victim's replacement data for code readability
         std::shared_ptr<SecondChanceReplData> victim_replacement_data =

--- a/src/mem/cache/replacement_policies/second_chance_rp.hh
+++ b/src/mem/cache/replacement_policies/second_chance_rp.hh
@@ -88,16 +88,16 @@ class SecondChance : public FIFO
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its re-insertion tick and second chance bit.
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted or re-inserted
@@ -106,8 +106,8 @@ class SecondChance : public FIFO
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using insertion timestamps and second chance
@@ -116,8 +116,8 @@ class SecondChance : public FIFO
      * @param cands Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/ship_rp.cc
+++ b/src/mem/cache/replacement_policies/ship_rp.cc
@@ -76,7 +76,7 @@ SHiP::SHiP(const Params &p)
 }
 
 void
-SHiP::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+SHiP::invalidateImpl(const std::shared_ptr<ReplacementData> &replacement_data)
 {
     std::shared_ptr<SHiPReplData> casted_replacement_data =
         std::static_pointer_cast<SHiPReplData>(replacement_data);
@@ -87,12 +87,12 @@ SHiP::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
         SHCT[casted_replacement_data->getSignature()]--;
     }
 
-    BRRIP::invalidate(replacement_data);
+    BRRIP::invalidateImpl(replacement_data);
 }
 
 void
-SHiP::touch(const std::shared_ptr<ReplacementData>& replacement_data,
-    const PacketPtr pkt)
+SHiP::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                const PacketPtr pkt)
 {
     std::shared_ptr<SHiPReplData> casted_replacement_data =
         std::static_pointer_cast<SHiPReplData>(replacement_data);
@@ -103,12 +103,11 @@ SHiP::touch(const std::shared_ptr<ReplacementData>& replacement_data,
     casted_replacement_data->setReReferenced();
 
     // This was a hit; update replacement data accordingly
-    BRRIP::touch(replacement_data);
+    BRRIP::touchImpl(replacement_data);
 }
 
 void
-SHiP::touch(const std::shared_ptr<ReplacementData>& replacement_data)
-    const
+SHiP::touchImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     panic("SHiP replacement policy requires packet access information "
           "to train its predictor, but was called without it. "
@@ -120,8 +119,8 @@ SHiP::touch(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-SHiP::reset(const std::shared_ptr<ReplacementData>& replacement_data,
-    const PacketPtr pkt)
+SHiP::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                const PacketPtr pkt)
 {
     std::shared_ptr<SHiPReplData> casted_replacement_data =
         std::static_pointer_cast<SHiPReplData>(replacement_data);
@@ -134,15 +133,14 @@ SHiP::reset(const std::shared_ptr<ReplacementData>& replacement_data,
 
     // If SHCT for signature is set, predict intermediate re-reference.
     // Predict distant re-reference otherwise
-    BRRIP::reset(replacement_data);
+    BRRIP::resetImpl(replacement_data);
     if (SHCT[signature].calcSaturation() >= insertionThreshold) {
         casted_replacement_data->rrpv--;
     }
 }
 
 void
-SHiP::reset(const std::shared_ptr<ReplacementData>& replacement_data)
-    const
+SHiP::resetImpl(const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     panic("SHiP replacement policy requires packet access information "
           "to train its predictor, but was called without it. "

--- a/src/mem/cache/replacement_policies/ship_rp.hh
+++ b/src/mem/cache/replacement_policies/ship_rp.hh
@@ -125,8 +125,8 @@ class SHiP : public BRRIP
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -135,10 +135,10 @@ class SHiP : public BRRIP
      * @param replacement_data Replacement data to be touched.
      * @param pkt Packet that generated this hit.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data,
-        const PacketPtr pkt) override;
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-        override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                   const PacketPtr pkt) override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted.
@@ -147,10 +147,10 @@ class SHiP : public BRRIP
      * @param replacement_data Replacement data to be reset.
      * @param pkt Packet that generated this miss.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data,
-        const PacketPtr pkt) override;
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-        override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data,
+                   const PacketPtr pkt) override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Instantiate a replacement data entry.

--- a/src/mem/cache/replacement_policies/tree_plru_rp.cc
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.cc
@@ -109,7 +109,8 @@ TreePLRU::TreePLRU(const Params &p)
 }
 
 void
-TreePLRU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
+TreePLRU::invalidateImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data)
 {
     // Cast replacement data
     std::shared_ptr<TreePLRUReplData> treePLRU_replacement_data =
@@ -134,8 +135,8 @@ TreePLRU::invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
 }
 
 void
-TreePLRU::touch(const std::shared_ptr<ReplacementData>& replacement_data)
-const
+TreePLRU::touchImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     // Cast replacement data
     std::shared_ptr<TreePLRUReplData> treePLRU_replacement_data =
@@ -160,15 +161,15 @@ const
 }
 
 void
-TreePLRU::reset(const std::shared_ptr<ReplacementData>& replacement_data)
-const
+TreePLRU::resetImpl(
+    const std::shared_ptr<ReplacementData> &replacement_data) const
 {
     // A reset has the same functionality of a touch
     touch(replacement_data);
 }
 
-ReplaceableEntry*
-TreePLRU::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+TreePLRU::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     // There must be at least one replacement candidate
     assert(candidates.size() > 0);

--- a/src/mem/cache/replacement_policies/tree_plru_rp.hh
+++ b/src/mem/cache/replacement_policies/tree_plru_rp.hh
@@ -165,8 +165,8 @@ class TreePLRU : public Base
      *
      * @param replacement_data Replacement data to be invalidated.
      */
-    void invalidate(const std::shared_ptr<ReplacementData>& replacement_data)
-                                                                    override;
+    void invalidateImpl(
+        const std::shared_ptr<ReplacementData> &replacement_data) override;
 
     /**
      * Touch an entry to update its replacement data.
@@ -174,8 +174,8 @@ class TreePLRU : public Base
      *
      * @param replacement_data Replacement data to be touched.
      */
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void touchImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Reset replacement data. Used when an entry is inserted. Provides the
@@ -183,8 +183,8 @@ class TreePLRU : public Base
      *
      * @param replacement_data Replacement data to be reset.
      */
-    void reset(const std::shared_ptr<ReplacementData>& replacement_data) const
-                                                                     override;
+    void resetImpl(const std::shared_ptr<ReplacementData> &replacement_data)
+        const override;
 
     /**
      * Find replacement victim using TreePLRU bits. It is assumed that all
@@ -193,8 +193,8 @@ class TreePLRU : public Base
      * @param candidates Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates& candidates) const
-                                                                     override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 
     /**
      * Instantiate a replacement data entry. Consecutive calls to this

--- a/src/mem/cache/replacement_policies/weighted_lru_rp.cc
+++ b/src/mem/cache/replacement_policies/weighted_lru_rp.cc
@@ -48,16 +48,18 @@ WeightedLRU::WeightedLRU(const Params &p)
 }
 
 void
-WeightedLRU::touch(const std::shared_ptr<ReplacementData>& replacement_data,
-    int occupancy) const
+WeightedLRU::touch(const std::shared_ptr<ReplacementData> &replacement_data,
+                   int occupancy) const
 {
-    LRU::touch(replacement_data);
+    // Go through the common interface so the access is counted as a hit, just
+    // like the non-occupancy touch() path.
+    Base::touch(replacement_data);
     std::static_pointer_cast<WeightedLRUReplData>(replacement_data)->
                                                   last_occ_ptr = occupancy;
 }
 
-ReplaceableEntry*
-WeightedLRU::getVictim(const ReplacementCandidates& candidates) const
+ReplaceableEntry *
+WeightedLRU::getVictimImpl(const ReplacementCandidates &candidates) const
 {
     assert(candidates.size() > 0);
 

--- a/src/mem/cache/replacement_policies/weighted_lru_rp.hh
+++ b/src/mem/cache/replacement_policies/weighted_lru_rp.hh
@@ -65,8 +65,17 @@ class WeightedLRU : public LRU
     ~WeightedLRU() = default;
 
     using Base::touch;
-    void touch(const std::shared_ptr<ReplacementData>& replacement_data,
-                                        int occupancy) const;
+    /**
+     * WeightedLRU-specific touch that records a block's occupancy. This is not
+     * part of the common replacement policy interface; it is called directly
+     * (with the policy's concrete type) by users that track occupancy, such as
+     * Ruby's CacheMemory.
+     *
+     * @param replacement_data Replacement data to be touched.
+     * @param occupancy Occupancy to associate with the entry.
+     */
+    void touch(const std::shared_ptr<ReplacementData> &replacement_data,
+               int occupancy) const;
 
     /**
      * Instantiate a replacement data entry.
@@ -81,8 +90,8 @@ class WeightedLRU : public LRU
      * @param candidates Replacement candidates, selected by indexing policy.
      * @return Replacement entry to be replaced.
      */
-    ReplaceableEntry* getVictim(const ReplacementCandidates&
-                                              candidates) const override;
+    ReplaceableEntry *
+    getVictimImpl(const ReplacementCandidates &candidates) const override;
 };
 
 } // namespace replacement_policy


### PR DESCRIPTION

The cache replacement policies did not expose any statistics, so their behavior could not be profiled. This change adds profiling counters that are shared by every replacement policy.

The public interface (invalidate, touch, reset and getVictim) is turned into a Non-Virtual Interface: the public methods are now small wrappers in replacement_policy::Base that gather statistics and then forward to protected *Impl methods implemented by each policy. Keeping the counters in one place means no policy can accidentally bypass them, and the callers in the cache tags are left unchanged.

The new statistics record the number of victimizations, hits, insertions and invalidations, plus a formula for the average number of hits an entry receives before being replaced. WeightedLRU keeps its occupancy-aware touch() overload, which is now routed through the common interface so the access is also counted.

All policies are updated to implement the *Impl methods. A unit test for the new counters is added. The existing replacement policy unit tests are updated to link the statistics implementation, which is now required to instantiate any policy.