### PR TITLE
arch-vega: Instructions related to 16-bit data types

### DIFF
--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -4551,8 +4551,7 @@ Decoder::decode_OP_SOP2__S_PACK_LL_B32_B16(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_SOP2__S_PACK_LH_B32_B16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_SOP2__S_PACK_LH_B32_B16(&iFmt->iFmt_SOP2);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -4545,8 +4545,7 @@ Decoder::decode_OP_SOP2__S_LSHL4_ADD_U32(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_SOP2__S_PACK_LL_B32_B16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_SOP2__S_PACK_LL_B32_B16(&iFmt->iFmt_SOP2);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -4557,8 +4557,7 @@ Decoder::decode_OP_SOP2__S_PACK_LH_B32_B16(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_SOP2__S_HH_B32_B16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_SOP2__S_PACK_HH_B32_B16(&iFmt->iFmt_SOP2);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -8719,8 +8719,7 @@ Decoder::decode_OP_FLAT__FLAT_STORE_BYTE(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_STORE_BYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_STORE_BYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
@@ -8762,43 +8761,37 @@ Decoder::decode_OP_FLAT__FLAT_STORE_DWORDX4(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_LOAD_UBYTE_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_UBYTE_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_LOAD_UBYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_LOAD_SBYTE_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SBYTE_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_LOAD_SBYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_LOAD_SHORT_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SHORT_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_FLAT__FLAT_LOAD_SHORT_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SHORT_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
@@ -9038,8 +9031,7 @@ Decoder::decode_OP_GLOBAL__GLOBAL_STORE_BYTE(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_STORE_BYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_STORE_BYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
@@ -9081,43 +9073,37 @@ Decoder::decode_OP_GLOBAL__GLOBAL_STORE_DWORDX4(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_UBYTE_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_UBYTE_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_UBYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SBYTE_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SBYTE_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SBYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SHORT_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SHORT_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_GLOBAL__GLOBAL_LOAD_SHORT_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SHORT_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
@@ -10440,8 +10426,7 @@ Decoder::decode_OP_SCRATCH__SCRATCH_STORE_BYTE(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_STORE_BYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_STORE_BYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
@@ -10483,43 +10468,37 @@ Decoder::decode_OP_SCRATCH__SCRATCH_STORE_DWORDX4(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_LOAD_UBYTE_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_UBYTE_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_LOAD_UBYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_LOAD_SBYTE_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SBYTE_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_LOAD_SBYTE_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_LOAD_SHORT_D16(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SHORT_D16(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *
 Decoder::decode_OP_SCRATCH__SCRATCH_LOAD_SHORT_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_FLAT__FLAT_LOAD_SHORT_D16_HI(&iFmt->iFmt_FLAT);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -8179,8 +8179,7 @@ Decoder::decode_OP_DS__DS_WRITE_B8_D16_HI(MachInst iFmt)
 GPUStaticInst *
 Decoder::decode_OP_DS__DS_WRITE_B16_D16_HI(MachInst iFmt)
 {
-    fatal("Trying to decode instruction without a class\n");
-    return nullptr;
+    return new Inst_DS__DS_WRITE_B16_D16_HI(&iFmt->iFmt_DS);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/insts/ds.cc
+++ b/src/arch/amdgpu/vega/insts/ds.cc
@@ -843,7 +843,7 @@ Inst_DS__DS_WRITE_B8_D16_HI::execute(GPUDynInstPtr gpuDynInst)
     gpuDynInst->latency.set(
         gpuDynInst->computeUnit()->cyclesToTicks(Cycles(24)));
     ConstVecOperandU32 addr(gpuDynInst, extData.ADDR);
-    ConstVecOperandU8 data(gpuDynInst, extData.DATA0);
+    ConstVecOperandU32 data(gpuDynInst, extData.DATA0);
 
     addr.read();
     data.read();
@@ -933,6 +933,67 @@ Inst_DS__DS_WRITE_B16::initiateAcc(GPUDynInstPtr gpuDynInst)
 
 void
 Inst_DS__DS_WRITE_B16::completeAcc(GPUDynInstPtr gpuDynInst)
+{} // completeAcc
+// --- Inst_DS__DS_WRITE_B16_D16_HI class methods ---
+
+Inst_DS__DS_WRITE_B16_D16_HI::Inst_DS__DS_WRITE_B16_D16_HI(InFmt_DS *iFmt)
+    : Inst_DS(iFmt, "ds_write_b16_d16_hi")
+{
+    setFlag(MemoryRef);
+    setFlag(Store);
+} // Inst_DS__DS_WRITE_B16_D16_HI
+
+Inst_DS__DS_WRITE_B16_D16_HI::~Inst_DS__DS_WRITE_B16_D16_HI()
+{} // ~Inst_DS__DS_WRITE_B16_D16_HI
+
+// --- description from .arch file ---
+// MEM[ADDR] = DATA[23:16].
+// Word write in to high word.
+void
+Inst_DS__DS_WRITE_B16_D16_HI::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decLGKMInstsIssued();
+        wf->untrackLGKMInst(gpuDynInst);
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(
+        gpuDynInst->computeUnit()->cyclesToTicks(Cycles(24)));
+    ConstVecOperandU32 addr(gpuDynInst, extData.ADDR);
+    ConstVecOperandU32 data(gpuDynInst, extData.DATA0);
+
+    addr.read();
+    data.read();
+
+    calcAddr(gpuDynInst, addr);
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            (reinterpret_cast<VecElemU16 *>(gpuDynInst->d_data))[lane] =
+                bits(data[lane], 31, 16);
+        }
+    }
+
+    gpuDynInst->computeUnit()->localMemoryPipe.issueRequest(gpuDynInst);
+} // execute
+
+void
+Inst_DS__DS_WRITE_B16_D16_HI::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    Addr offset0 = instData.OFFSET0;
+    Addr offset1 = instData.OFFSET1;
+    Addr offset = (offset1 << 8) | offset0;
+
+    initMemWrite<VecElemU16>(gpuDynInst, offset);
+} // initiateAcc
+
+void
+Inst_DS__DS_WRITE_B16_D16_HI::completeAcc(GPUDynInstPtr gpuDynInst)
 {} // completeAcc
 // --- Inst_DS__DS_ADD_RTN_U32 class methods ---
 

--- a/src/arch/amdgpu/vega/insts/flat.cc
+++ b/src/arch/amdgpu/vega/insts/flat.cc
@@ -93,7 +93,130 @@ Inst_FLAT__FLAT_LOAD_UBYTE::completeAcc(GPUDynInstPtr gpuDynInst)
     }
     vdst.write();
 } // execute
-// --- Inst_FLAT__FLAT_LOAD_SBYTE class methods ---
+// --- Inst_FLAT__FLAT_LOAD_UBYTE_D16 class methods ---
+
+Inst_FLAT__FLAT_LOAD_UBYTE_D16::Inst_FLAT__FLAT_LOAD_UBYTE_D16(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_load_ubyte_d16")
+{
+    setFlag(MemoryRef);
+    setFlag(Load);
+} // Inst_FLAT__FLAT_LOAD_UBYTE_D16
+
+Inst_FLAT__FLAT_LOAD_UBYTE_D16::~Inst_FLAT__FLAT_LOAD_UBYTE_D16()
+{} // ~Inst_FLAT__FLAT_LOAD_UBYTE_D16
+
+// VDATA[15 : 0].u16 = 16'U({ 8'0U, MEM[addr].u8 });
+// VDATA[31:16] is preserved.
+void
+Inst_FLAT__FLAT_LOAD_UBYTE_D16::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_LOAD_UBYTE_D16::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemRead<VecElemU8>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_LOAD_UBYTE_D16::completeAcc(GPUDynInstPtr gpuDynInst)
+{
+    VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+    // Read vdst to preserve bytes
+    vdst.read();
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            VecElemU16 tmp = (VecElemU16)((
+                reinterpret_cast<VecElemU8 *>(gpuDynInst->d_data))[lane]);
+            replaceBits(vdst[lane], 15, 0, tmp);
+        }
+    }
+    vdst.write();
+} // completeAcc
+// --- Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI class methods ---
+
+Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI::Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_load_ubyte_d16_hi")
+{
+    setFlag(MemoryRef);
+    setFlag(Load);
+} // Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI
+
+Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI::~Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI()
+{} // ~Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI
+
+// VDATA[31 : 16].u16 = 16'U({ 8'0U, MEM[addr].u8 });
+// VDATA[15:0] is preserved.
+void
+Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemRead<VecElemU8>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI::completeAcc(GPUDynInstPtr gpuDynInst)
+{
+    VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+    // Read vdst to preserve bytes
+    vdst.read();
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            VecElemU16 tmp = (VecElemU16)((
+                reinterpret_cast<VecElemU8 *>(gpuDynInst->d_data))[lane]);
+            replaceBits(vdst[lane], 31, 16, tmp);
+        }
+    }
+    vdst.write();
+} // completeAcc
 
 Inst_FLAT__FLAT_LOAD_SBYTE::Inst_FLAT__FLAT_LOAD_SBYTE(InFmt_FLAT *iFmt)
     : Inst_FLAT(iFmt, "flat_load_sbyte")
@@ -146,6 +269,130 @@ Inst_FLAT__FLAT_LOAD_SBYTE::completeAcc(GPUDynInstPtr gpuDynInst)
         if (gpuDynInst->exec_mask[lane]) {
             vdst[lane] = (VecElemI32)((
                 reinterpret_cast<VecElemI8 *>(gpuDynInst->d_data))[lane]);
+        }
+    }
+    vdst.write();
+} // execute
+// --- Inst_FLAT__FLAT_LOAD_SBYTE_D16 class methods ---
+
+Inst_FLAT__FLAT_LOAD_SBYTE_D16 ::Inst_FLAT__FLAT_LOAD_SBYTE_D16(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_load_sbyte_d16")
+{
+    setFlag(MemoryRef);
+    setFlag(Load);
+} // Inst_FLAT__FLAT_LOAD_SBYTE_D16
+
+Inst_FLAT__FLAT_LOAD_SBYTE_D16::~Inst_FLAT__FLAT_LOAD_SBYTE_D16()
+{} // ~Inst_FLAT__FLAT_LOAD_SBYTE_D16
+
+// VDATA[15 : 0].i16 = 16'I(signext(MEM[addr].i8));
+// VDATA[31:16] is preserved.
+void
+Inst_FLAT__FLAT_LOAD_SBYTE_D16::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_LOAD_SBYTE_D16::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemRead<VecElemI8>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_LOAD_SBYTE_D16::completeAcc(GPUDynInstPtr gpuDynInst)
+{
+    VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+    // Read vdst to preserve bytes
+    vdst.read();
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            VecElemI16 tmp = (VecElemI16)((
+                reinterpret_cast<VecElemI8 *>(gpuDynInst->d_data))[lane]);
+            replaceBits(vdst[lane], 15, 0, tmp);
+        }
+    }
+    vdst.write();
+} // execute
+// --- Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI class methods ---
+
+Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI ::Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_load_sbyte_d16_hi")
+{
+    setFlag(MemoryRef);
+    setFlag(Load);
+} // Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI
+
+Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI::~Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI()
+{} // ~Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI
+
+// VDATA[31 : 16].i16 = 16'I(signext(MEM[addr].i8));
+// VDATA[15:0] is preserved.
+void
+Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemRead<VecElemI8>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI::completeAcc(GPUDynInstPtr gpuDynInst)
+{
+    VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+    // Read vdst to preserve bytes
+    vdst.read();
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            VecElemI16 tmp = (VecElemI16)((
+                reinterpret_cast<VecElemI8 *>(gpuDynInst->d_data))[lane]);
+            replaceBits(vdst[lane], 31, 16, tmp);
         }
     }
     vdst.write();
@@ -207,7 +454,130 @@ Inst_FLAT__FLAT_LOAD_USHORT::completeAcc(GPUDynInstPtr gpuDynInst)
     }
     vdst.write();
 } // execute
+// --- Inst_FLAT__FLAT_LOAD_SHORT_D16 class methods ---
 
+Inst_FLAT__FLAT_LOAD_SHORT_D16::Inst_FLAT__FLAT_LOAD_SHORT_D16(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_load_short_d16")
+{
+    setFlag(MemoryRef);
+    setFlag(Load);
+} // Inst_FLAT__FLAT_LOAD_SHORT_D16
+
+Inst_FLAT__FLAT_LOAD_SHORT_D16::~Inst_FLAT__FLAT_LOAD_SHORT_D16()
+{} // ~Inst_FLAT__FLAT_LOAD_SHORT_D16
+
+// VDATA[15 : 0].b16 = MEM[addr].b16;
+// VDATA[31:16] is preserved.
+void
+Inst_FLAT__FLAT_LOAD_SHORT_D16::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_LOAD_SHORT_D16::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemRead<VecElemU16>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_LOAD_SHORT_D16::completeAcc(GPUDynInstPtr gpuDynInst)
+{
+    VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+    // Read vdst to preserve bytes
+    vdst.read();
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            VecElemU16 tmp = (VecElemU16)((
+                reinterpret_cast<VecElemU16 *>(gpuDynInst->d_data))[lane]);
+            replaceBits(vdst[lane], 15, 0, tmp);
+        }
+    }
+    vdst.write();
+} // completeAcc
+// --- Inst_FLAT__FLAT_LOAD_SHORT_D16_HI class methods ---
+
+Inst_FLAT__FLAT_LOAD_SHORT_D16_HI::Inst_FLAT__FLAT_LOAD_SHORT_D16_HI(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_load_short_d16_hi")
+{
+    setFlag(MemoryRef);
+    setFlag(Load);
+} // Inst_FLAT__FLAT_LOAD_SHORT_D16_HI
+
+Inst_FLAT__FLAT_LOAD_SHORT_D16_HI::~Inst_FLAT__FLAT_LOAD_SHORT_D16_HI()
+{} // ~Inst_FLAT__FLAT_LOAD_SHORT_D16_HI
+
+// VDATA[31 : 16].b16 = MEM[addr].b16;
+// VDATA[15:0] is preserved.
+void
+Inst_FLAT__FLAT_LOAD_SHORT_D16_HI::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_LOAD_SHORT_D16_HI::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemRead<VecElemU16>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_LOAD_SHORT_D16_HI::completeAcc(GPUDynInstPtr gpuDynInst)
+{
+    VecOperandU32 vdst(gpuDynInst, extData.VDST);
+
+    // Read vdst to preserve bytes
+    vdst.read();
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            VecElemU16 tmp = (VecElemU16)((
+                reinterpret_cast<VecElemU16 *>(gpuDynInst->d_data))[lane]);
+            replaceBits(vdst[lane], 31, 16, tmp);
+        }
+    }
+    vdst.write();
+} // completeAcc
 // --- Inst_FLAT__FLAT_LOAD_SSHORT class methods ---
 
 Inst_FLAT__FLAT_LOAD_SSHORT::Inst_FLAT__FLAT_LOAD_SSHORT(InFmt_FLAT *iFmt)
@@ -577,6 +947,64 @@ Inst_FLAT__FLAT_STORE_BYTE::initiateAcc(GPUDynInstPtr gpuDynInst)
 void
 Inst_FLAT__FLAT_STORE_BYTE::completeAcc(GPUDynInstPtr gpuDynInst)
 {} // execute
+// --- Inst_FLAT__FLAT_STORE_BYTE_D16_HI class methods ---
+
+Inst_FLAT__FLAT_STORE_BYTE_D16_HI::Inst_FLAT__FLAT_STORE_BYTE_D16_HI(
+    InFmt_FLAT *iFmt)
+    : Inst_FLAT(iFmt, "flat_store_byte_d16_hi")
+{
+    setFlag(MemoryRef);
+    setFlag(Store);
+} // Inst_FLAT__FLAT_STORE_BYTE_D16_HI
+
+Inst_FLAT__FLAT_STORE_BYTE_D16_HI::~Inst_FLAT__FLAT_STORE_BYTE_D16_HI()
+{} // ~Inst_FLAT__FLAT_STORE_BYTE_D16_HI
+
+// MEM[addr].b8 = VDATA[23 : 16]
+void
+Inst_FLAT__FLAT_STORE_BYTE_D16_HI::execute(GPUDynInstPtr gpuDynInst)
+{
+    Wavefront *wf = gpuDynInst->wavefront();
+
+    if (gpuDynInst->exec_mask.none()) {
+        wf->decVMemInstsIssued();
+        wf->untrackVMemInst(gpuDynInst);
+        if (isFlat()) {
+            wf->decLGKMInstsIssued();
+            wf->untrackLGKMInst(gpuDynInst);
+        }
+        return;
+    }
+
+    gpuDynInst->execUnitId = wf->execUnitId;
+    gpuDynInst->latency.init(gpuDynInst->computeUnit());
+    gpuDynInst->latency.set(gpuDynInst->computeUnit()->clockPeriod());
+
+    ConstVecOperandU32 data(gpuDynInst, extData.DATA);
+
+    data.read();
+
+    calcAddr(gpuDynInst, extData.ADDR, extData.SADDR, instData.OFFSET);
+
+    for (int lane = 0; lane < NumVecElemPerVecReg; ++lane) {
+        if (gpuDynInst->exec_mask[lane]) {
+            (reinterpret_cast<VecElemU8 *>(gpuDynInst->d_data))[lane] =
+                (bits(data[lane], 23, 16));
+        }
+    }
+
+    issueRequestHelper(gpuDynInst);
+} // execute
+
+void
+Inst_FLAT__FLAT_STORE_BYTE_D16_HI::initiateAcc(GPUDynInstPtr gpuDynInst)
+{
+    initMemWrite<VecElemU8>(gpuDynInst);
+} // initiateAcc
+
+void
+Inst_FLAT__FLAT_STORE_BYTE_D16_HI::completeAcc(GPUDynInstPtr gpuDynInst)
+{} // completeAcc
 // --- Inst_FLAT__FLAT_STORE_SHORT class methods ---
 
 Inst_FLAT__FLAT_STORE_SHORT::Inst_FLAT__FLAT_STORE_SHORT(InFmt_FLAT *iFmt)

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -2021,6 +2021,48 @@ class Inst_SOP2__S_PACK_LL_B32_B16 : public Inst_SOP2
     void execute(GPUDynInstPtr) override;
 }; // Inst_SOP2__S_PACK_LL_B32_B16
 
+class Inst_SOP2__S_PACK_LH_B32_B16 : public Inst_SOP2
+{
+  public:
+    Inst_SOP2__S_PACK_LH_B32_B16(InFmt_SOP2 *);
+    ~Inst_SOP2__S_PACK_LH_B32_B16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // ssrc_0
+                return 4;
+            case 1: // ssrc_1
+                return 4;
+            case 2: // sdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_SOP2__S_PACK_LH_B32_B16
+
 class Inst_SOPK__S_MOVK_I32 : public Inst_SOPK
 {
   public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -41051,6 +41051,48 @@ class Inst_DS__DS_WRITE_B16 : public Inst_DS
     void completeAcc(GPUDynInstPtr) override;
 }; // Inst_DS__DS_WRITE_B16
 
+class Inst_DS__DS_WRITE_B16_D16_HI : public Inst_DS
+{
+  public:
+    Inst_DS__DS_WRITE_B16_D16_HI(InFmt_DS *);
+    ~Inst_DS__DS_WRITE_B16_D16_HI();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 0;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_a
+                return 4;
+            case 1: // vgpr_d0
+                return 2;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_DS__DS_WRITE_B16_D16_HI
+
 class Inst_DS__DS_ADD_RTN_U32 : public Inst_DS
 {
   public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -2063,6 +2063,48 @@ class Inst_SOP2__S_PACK_LH_B32_B16 : public Inst_SOP2
     void execute(GPUDynInstPtr) override;
 }; // Inst_SOP2__S_PACK_LH_B32_B16
 
+class Inst_SOP2__S_PACK_HH_B32_B16 : public Inst_SOP2
+{
+  public:
+    Inst_SOP2__S_PACK_HH_B32_B16(InFmt_SOP2 *);
+    ~Inst_SOP2__S_PACK_HH_B32_B16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // ssrc_0
+                return 4;
+            case 1: // ssrc_1
+                return 4;
+            case 2: // sdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_SOP2__S_PACK_HH_B32_B16
+
 class Inst_SOPK__S_MOVK_I32 : public Inst_SOPK
 {
   public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -1979,6 +1979,48 @@ class Inst_SOP2__S_MUL_HI_I32 : public Inst_SOP2
     void execute(GPUDynInstPtr) override;
 }; // Inst_SOP2__S_MUL_HI_I32
 
+class Inst_SOP2__S_PACK_LL_B32_B16 : public Inst_SOP2
+{
+  public:
+    Inst_SOP2__S_PACK_LL_B32_B16(InFmt_SOP2 *);
+    ~Inst_SOP2__S_PACK_LL_B32_B16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // ssrc_0
+                return 4;
+            case 1: // ssrc_1
+                return 4;
+            case 2: // sdst
+                return 4;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+}; // Inst_SOP2__S_PACK_LL_B32_B16
+
 class Inst_SOPK__S_MOVK_I32 : public Inst_SOPK
 {
   public:

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -53680,6 +53680,96 @@ class Inst_FLAT__FLAT_LOAD_UBYTE : public Inst_FLAT
     void completeAcc(GPUDynInstPtr) override;
 }; // Inst_FLAT__FLAT_LOAD_UBYTE
 
+class Inst_FLAT__FLAT_LOAD_UBYTE_D16 : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_LOAD_UBYTE_D16(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_LOAD_UBYTE_D16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 1 : 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_dst or saddr
+                return isFlat() ? 1 : 8;
+            case 2: // vgpr_dst
+                assert(!isFlat());
+                return 1;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_LOAD_UBYTE_D16
+
+class Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 1 : 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_dst or saddr
+                return isFlat() ? 1 : 8;
+            case 2: // vgpr_dst
+                assert(!isFlat());
+                return 1;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_LOAD_UBYTE_D16_HI
+
 class Inst_FLAT__FLAT_LOAD_SBYTE : public Inst_FLAT
 {
   public:
@@ -53724,6 +53814,186 @@ class Inst_FLAT__FLAT_LOAD_SBYTE : public Inst_FLAT
     void initiateAcc(GPUDynInstPtr) override;
     void completeAcc(GPUDynInstPtr) override;
 }; // Inst_FLAT__FLAT_LOAD_SBYTE
+
+class Inst_FLAT__FLAT_LOAD_SBYTE_D16 : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_LOAD_SBYTE_D16(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_LOAD_SBYTE_D16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 1 : 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_dst or saddr
+                return isFlat() ? 1 : 8;
+            case 2: // vgpr_dst
+                assert(!isFlat());
+                return 1;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_LOAD_SBYTE_D16
+
+class Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 1 : 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_dst or saddr
+                return isFlat() ? 1 : 8;
+            case 2: // vgpr_dst
+                assert(!isFlat());
+                return 1;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_LOAD_SBYTE_D16_HI
+
+class Inst_FLAT__FLAT_LOAD_SHORT_D16 : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_LOAD_SHORT_D16(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_LOAD_SHORT_D16();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 1 : 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_dst or saddr
+                return isFlat() ? 2 : 8;
+            case 2: // vgpr_dst
+                assert(!isFlat());
+                return 2;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_LOAD_SHORT_D16
+
+class Inst_FLAT__FLAT_LOAD_SHORT_D16_HI : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_LOAD_SHORT_D16_HI(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_LOAD_SHORT_D16_HI();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 1;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 1 : 2;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_dst or saddr
+                return isFlat() ? 2 : 8;
+            case 2: // vgpr_dst
+                assert(!isFlat());
+                return 2;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_LOAD_SHORT_D16_HI
 
 class Inst_FLAT__FLAT_LOAD_USHORT : public Inst_FLAT
 {
@@ -54039,6 +54309,51 @@ class Inst_FLAT__FLAT_STORE_BYTE : public Inst_FLAT
     void initiateAcc(GPUDynInstPtr) override;
     void completeAcc(GPUDynInstPtr) override;
 }; // Inst_FLAT__FLAT_STORE_BYTE
+
+class Inst_FLAT__FLAT_STORE_BYTE_D16_HI : public Inst_FLAT
+{
+  public:
+    Inst_FLAT__FLAT_STORE_BYTE_D16_HI(InFmt_FLAT *);
+    ~Inst_FLAT__FLAT_STORE_BYTE_D16_HI();
+
+    int
+    getNumOperands() override
+    {
+        return numDstRegOperands() + numSrcRegOperands();
+    } // getNumOperands
+
+    int
+    numDstRegOperands() override
+    {
+        return 0;
+    }
+    int
+    numSrcRegOperands() override
+    {
+        return isFlat() ? 2 : 3;
+    }
+
+    int
+    getOperandSize(int opIdx) override
+    {
+        switch (opIdx) {
+            case 0: // vgpr_addr
+                return vgprIsOffset() ? 4 : 8;
+            case 1: // vgpr_src
+                return 1;
+            case 2: // saddr
+                assert(!isFlat());
+                return 8;
+            default:
+                fatal("op idx %i out of bounds\n", opIdx);
+                return -1;
+        }
+    } // getOperandSize
+
+    void execute(GPUDynInstPtr) override;
+    void initiateAcc(GPUDynInstPtr) override;
+    void completeAcc(GPUDynInstPtr) override;
+}; // Inst_FLAT__FLAT_STORE_BYTE_D16_HI
 
 class Inst_FLAT__FLAT_STORE_SHORT : public Inst_FLAT
 {

--- a/src/arch/amdgpu/vega/insts/sop2.cc
+++ b/src/arch/amdgpu/vega/insts/sop2.cc
@@ -1569,5 +1569,32 @@ Inst_SOP2__S_PACK_LH_B32_B16::execute(GPUDynInstPtr gpuDynInst)
 
     sdst.write();
 } // execute
+
+// --- Inst_SOP2__S_PACK_HH_B32_B16 class methods ---
+
+Inst_SOP2__S_PACK_HH_B32_B16::Inst_SOP2__S_PACK_HH_B32_B16(InFmt_SOP2 *iFmt)
+    : Inst_SOP2(iFmt, "s_pack_hh_b32_b16")
+{} // Inst_SOP2__S_PACK_HH_B32_B16
+
+Inst_SOP2__S_PACK_HH_B32_B16::~Inst_SOP2__S_PACK_HH_B32_B16()
+{} // ~Inst_SOP2__S_PACK_HH_B32_B16
+
+// D.u[15:0]  = S0.u[31:16]  (HIGH half of S0 → low  half of SDST)
+// D.u[31:16] = S1.u[31:16]  (HIGH half of S1 → high half of SDST)
+void
+Inst_SOP2__S_PACK_HH_B32_B16::execute(GPUDynInstPtr gpuDynInst)
+{
+    ConstScalarOperandU32 src0(gpuDynInst, instData.SSRC0);
+    ConstScalarOperandU32 src1(gpuDynInst, instData.SSRC1);
+    ScalarOperandU32 sdst(gpuDynInst, instData.SDST);
+
+    src0.read();
+    src1.read();
+
+    sdst = ((src0.rawData() >> 16) & 0x0000FFFFU) |
+           (src1.rawData() & 0xFFFF0000U);
+
+    sdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/sop2.cc
+++ b/src/arch/amdgpu/vega/insts/sop2.cc
@@ -1510,5 +1510,35 @@ Inst_SOP2__S_MUL_HI_I32::execute(GPUDynInstPtr gpuDynInst)
 
     sdst.write();
 } // execute
+
+// --- Inst_SOP2__S_PACK_LL_B32_B16 class methods ---
+
+Inst_SOP2__S_PACK_LL_B32_B16::Inst_SOP2__S_PACK_LL_B32_B16(InFmt_SOP2 *iFmt)
+    : Inst_SOP2(iFmt, "s_pack_ll_b32_b16")
+{
+    setFlag(ALU);
+} // Inst_SOP2__S_PACK_LL_B32_B16
+
+Inst_SOP2__S_PACK_LL_B32_B16::~Inst_SOP2__S_PACK_LL_B32_B16()
+{} // ~Inst_SOP2__S_PACK_LL_B32_B16
+
+// --- description from .arch file ---
+// D.u[15:0]  = S0.u[15:0]   (low 16 bits of S0 → low  half of SDST)
+// D.u[31:16] = S1.u[15:0]   (low 16 bits of S1 → high half of SDST)
+void
+Inst_SOP2__S_PACK_LL_B32_B16::execute(GPUDynInstPtr gpuDynInst)
+{
+    ConstScalarOperandU32 src0(gpuDynInst, instData.SSRC0);
+    ConstScalarOperandU32 src1(gpuDynInst, instData.SSRC1);
+    ScalarOperandU32 sdst(gpuDynInst, instData.SDST);
+
+    src0.read();
+    src1.read();
+
+    sdst = (src0.rawData() & 0x0000FFFFU) |
+           ((src1.rawData() & 0x0000FFFFU) << 16);
+
+    sdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5

--- a/src/arch/amdgpu/vega/insts/sop2.cc
+++ b/src/arch/amdgpu/vega/insts/sop2.cc
@@ -1540,5 +1540,34 @@ Inst_SOP2__S_PACK_LL_B32_B16::execute(GPUDynInstPtr gpuDynInst)
 
     sdst.write();
 } // execute
+
+// --- Inst_SOP2__S_PACK_LH_B32_B16 class methods ---
+
+Inst_SOP2__S_PACK_LH_B32_B16::Inst_SOP2__S_PACK_LH_B32_B16(InFmt_SOP2 *iFmt)
+    : Inst_SOP2(iFmt, "s_pack_lh_b32_b16")
+{
+    setFlag(ALU);
+} // Inst_SOP2__S_PACK_LH_B32_B16
+
+Inst_SOP2__S_PACK_LH_B32_B16::~Inst_SOP2__S_PACK_LH_B32_B16()
+{} // ~Inst_SOP2__S_PACK_LH_B32_B16
+
+// --- description from .arch file ---
+// D.u[15:0]  = S0.u[15:0]   (low  half of S0 → low  half of SDST)
+// D.u[31:16] = S1.u[31:16]  (HIGH half of S1 → high half of SDST)
+void
+Inst_SOP2__S_PACK_LH_B32_B16::execute(GPUDynInstPtr gpuDynInst)
+{
+    ConstScalarOperandU32 src0(gpuDynInst, instData.SSRC0);
+    ConstScalarOperandU32 src1(gpuDynInst, instData.SSRC1);
+    ScalarOperandU32 sdst(gpuDynInst, instData.SDST);
+
+    src0.read();
+    src1.read();
+
+    sdst = (src0.rawData() & 0x0000FFFFU) | (src1.rawData() & 0xFFFF0000U);
+
+    sdst.write();
+} // execute
 } // namespace VegaISA
 } // namespace gem5


### PR DESCRIPTION
Adds several instructions related to 16-bit data types (bf16, fp16):
- Scalar packing instructions
- Flat and derivative segment D16 loads/stores
- LDS D16 reads/writes