### PR TITLE
base: fix compile error when compiling unit tests in GCC 15

### DIFF
--- a/src/base/stl_helpers/hash_helpers.test.cc
+++ b/src/base/stl_helpers/hash_helpers.test.cc
@@ -52,7 +52,7 @@ TEST(HashHelpers, isHashEnabled)
     EXPECT_TRUE(stl_helpers::is_hash_enabled<tuple_t>);
     EXPECT_TRUE((stl_helpers::is_hash_enabled<std::pair<vector_t, tuple_t>>));
     EXPECT_TRUE((stl_helpers::is_hash_enabled<
-        std::unordered_map<tuple_t, vector_t>>));
+                 stl_helpers::unordered_map<tuple_t, vector_t>>));
 }
 
 // The following tests do not test the hash value as it is considered an


### PR DESCRIPTION
I tried to build the unit tests using GCC 15.2 and got related errors:

```bash
$ scons build/ALL/unittests.opt/base/stl_helpers -j32
...
/usr/include/c++/15/bits/hashtable.h: In instantiation of ‘class std::_Hashtable<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::pair<const std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> >, std::allocator<std::pair<const std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> > >, std::__detail::_Select1st, std::equal_to<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)> >, std::hash<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >’:
/usr/include/c++/15/bits/unordered_map.h:115:18:   required from ‘class std::unordered_map<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> >’
  115 |       _Hashtable _M_h;
      |                  ^~~~
src/base/type_traits.hh:102:31:   required by substitution of ‘template<class T> struct gem5::is_iterable<T, std::void_t<decltype (begin(declval<T>())), decltype (end(declval<T>()))> > [with T = std::unordered_map<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> >]’
  102 |     std::void_t<decltype(begin(std::declval<T>())),
      |                          ~~~~~^~~~~~~~~~~~~~~~~~~
src/base/type_traits.hh:106:48:   required from ‘constexpr const bool gem5::is_iterable_v<std::unordered_map<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> > >’
  106 | constexpr bool is_iterable_v = is_iterable<T>::value;
      |                                                ^~~~~
src/base/stl_helpers/hash_helpers.hh:142:34:   required by substitution of ‘template<class T> struct gem5::stl_helpers::hash_impl::hash<T, typename std::enable_if<((! is_std_hash_enabled_v<T>) && is_iterable_v<T>), void>::type> [with T = std::unordered_map<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> >]’
  142 |     !is_std_hash_enabled_v<T> && is_iterable_v<T>>>
      |                                  ^~~~~~~~~~~~~~~
src/base/stl_helpers/hash_helpers.hh:163:26:   required by substitution of ‘template<class T> constexpr const bool gem5::stl_helpers::hash_impl::is_hash_enabled<T, std::void_t<decltype (gem5::stl_helpers::hash_impl::hash<T, void>()(declval<T>()))> > [with T = std::unordered_map<std::tuple<int, bool, int**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(float)>, std::vector<int> >]’
  163 |     std::void_t<decltype(hash<T>()(std::declval<T>()))>> = true;
      |                          ^~~~~~~~~
src/base/stl_helpers/hash_helpers.test.cc:54:5:   required from here
   54 |     EXPECT_TRUE((stl_helpers::is_hash_enabled<
      |                               ^~~~~~~~~~~~~~~~
   55 |         std::unordered_map<tuple_t, vector_t>>));
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15/bits/hashtable.h:210:51: error: static assertion failed: hash function must be copy constructible
  210 |       static_assert(is_copy_constructible<_Hash>::value,
      |                                                   ^~~~~
/usr/include/c++/15/bits/hashtable.h:210:51: note: ‘std::integral_constant<bool, false>::value’ evaluates to false
scons: *** [build/ALL/base/stl_helpers/hash_helpers.test.to] Error 1
```
We should keep the change to `src/base/stl_helpers/hash_helpers.test.cc` in https://github.com/gem5/gem5/pull/3125.

I'd also like to know if there are any CI jobs ensuring that we can compile using the GCC version claimed in SConstruct.
