### PR TITLE
misc: Implement CustomMesh based cache hierarchies in stdlib

### DIFF
--- a/configs/example/arm/noc_configs/mesh_2x4.py
+++ b/configs/example/arm/noc_configs/mesh_2x4.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2021, 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from gem5.components.cachehierarchies.chi.nodes.abstract_node import (
+    CHI_NodeType,
+    Node_Params,
+)
+from gem5.components.cachehierarchies.chi.private_l1_private_l2_shared_l3_mesh_cache_hierarchy import (
+    PrivateL1PrivateL2SharedL3MeshCacheHierarchy,
+)
+from gem5.components.cachehierarchies.ruby.topologies.custom_mesh import (
+    NoC_Params as CustomMeshNoC_Params,
+)
+
+# CustomMesh parameters for a 2x4 mesh. Routers will have the following layout:
+#
+# 0 --- 1 --- 2 --- 3
+# |     |     |     |
+# 4 --- 5 --- 6 --- 7
+NoC_Params = CustomMeshNoC_Params(num_rows=2, num_cols=4)
+
+
+# 4 RNFs with dedicated router for the RNF
+rnf_in_mesh = Node_Params(
+    node_type=CHI_NodeType.CHI_RNF,
+    router_list=[1, 2, 5, 6],
+    dedicated_router=True,
+)
+hnf_in_mesh = Node_Params(
+    node_type=CHI_NodeType.CHI_HNF, router_list=[1, 2, 5, 6]
+)
+mn_in_mesh = Node_Params(node_type=CHI_NodeType.CHI_MN, router_list=[4])
+snf_mainmem_in_mesh = Node_Params(
+    node_type=CHI_NodeType.CHI_SNF_MainMem, router_list=[0, 4]
+)
+snf_bootmem_in_mesh = Node_Params(
+    node_type=CHI_NodeType.CHI_SNF_BootMem, router_list=[3]
+)
+rni_dma_in_mesh = Node_Params(
+    node_type=CHI_NodeType.CHI_RNI_DMA, router_list=[7], num_nodes_per_router=2
+)
+rni_io_in_mesh = Node_Params(
+    node_type=CHI_NodeType.CHI_RNI_IO, router_list=[7]
+)
+
+
+class Example2x4Mesh(PrivateL1PrivateL2SharedL3MeshCacheHierarchy):
+    def __init__(self):
+        super().__init__(
+            l1d_size="32KiB",
+            l1d_assoc=4,
+            l1i_size="32KiB",
+            l1i_assoc=4,
+            l2_size="512KiB",
+            l2_assoc=8,
+            l3_size="16MiB",
+            l3_assoc=16,
+            noc_params=NoC_Params,
+        )
+
+    def add_default_nodes(self):
+        """
+        This adds all defined nodes to the mesh.
+        The fact that this method is not called by default
+        during __init__ is because we want to be able to
+        add_nodes manually in case some customization
+        is required in the client config
+        """
+        self.add_nodes(rnf_in_mesh)
+        self.add_nodes(hnf_in_mesh)
+        self.add_nodes(snf_mainmem_in_mesh)
+        self.add_nodes(snf_bootmem_in_mesh)
+        self.add_nodes(rni_dma_in_mesh)
+
+
+cache_hierarchy_type = Example2x4Mesh
+
+_NODE_PARAMS_BY_TYPE = {
+    rnf_in_mesh.node_type: rnf_in_mesh,
+    hnf_in_mesh.node_type: hnf_in_mesh,
+    mn_in_mesh.node_type: mn_in_mesh,
+    snf_mainmem_in_mesh.node_type: snf_mainmem_in_mesh,
+    snf_bootmem_in_mesh.node_type: snf_bootmem_in_mesh,
+    rni_dma_in_mesh.node_type: rni_dma_in_mesh,
+    rni_io_in_mesh.node_type: rni_io_in_mesh,
+}
+
+
+def get_node_params(node_type: CHI_NodeType) -> Node_Params:
+    if node_type not in _NODE_PARAMS_BY_TYPE:
+        raise ValueError(
+            f"No Node_Params configured for node type: {node_type}"
+        )
+    return _NODE_PARAMS_BY_TYPE[node_type]

--- a/configs/example/arm/ruby_fs_mesh.py
+++ b/configs/example/arm/ruby_fs_mesh.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2016-2017, 2020-2022, 2025-2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import sys
+from typing import List
+
+import m5
+from m5.objects import (
+    ArmFsLinux,
+    CowDiskImage,
+    MinorCPU,
+    NonCachingSimpleCPU,
+    PciVirtIO,
+    Root,
+    VExpress_GEM5_Foundation,
+    VirtIOBlock,
+)
+from m5.util import addToPath
+
+addToPath("../..")
+
+import devices
+from common import SysPaths
+from common.cores.arm import (
+    HPI,
+    O3_ARM_v7a,
+)
+
+from gem5.coherence_protocol import CoherenceProtocol
+from gem5.components.cachehierarchies.chi.nodes.abstract_node import (
+    CHI_NodeType,
+)
+from gem5.components.cachehierarchies.ruby.topologies.custom_mesh import (
+    load_topology_config,
+)
+from gem5.components.memory.dram_interfaces.ddr4 import DDR4_2400_16x4
+from gem5.components.memory.memory import ChanneledMemory
+from gem5.isas import ISA
+from gem5.utils.requires import requires
+
+default_kernel = "vmlinux.arm64"
+default_disk = "linaro-minimal-aarch64.img"
+default_root_device = "/dev/vda1"
+
+cpu_types = {
+    "noncaching": NonCachingSimpleCPU,
+    "minor": MinorCPU,
+    "hpi": HPI.HPI,
+    "o3": O3_ARM_v7a.O3_ARM_v7a_3,
+}
+
+
+def create_cow_image(name):
+    image = CowDiskImage()
+    image.child.image_file = SysPaths.disk(name)
+    return image
+
+
+class _LegacyCoreAdapter:
+    def __init__(self, cpu):
+        self._cpu = cpu
+
+    def requires_send_evicts(self) -> bool:
+        # Mirror stdlib ARM behavior.
+        return True
+
+    def connect_icache(self, port):
+        self._cpu.icache_port = port
+
+    def connect_dcache(self, port):
+        self._cpu.dcache_port = port
+
+    def connect_walker_ports(self, port1, port2):
+        self._cpu.mmu.connectWalkerPorts(port1, port2)
+
+    def connect_interrupt(self):
+        self._cpu.createInterruptController()
+
+
+class _LegacyProcessorAdapter:
+    def __init__(self, cpus: List):
+        self._cores = [_LegacyCoreAdapter(cpu) for cpu in cpus]
+
+    def get_cores(self):
+        return self._cores
+
+    def get_isa(self):
+        return ISA.ARM
+
+
+class _LegacyBoardAdapter:
+    def __init__(self, system, processor_adapter, memory):
+        self._system = system
+        self._system.memory = memory
+        self._processor = processor_adapter
+
+    def get_processor(self):
+        return self._processor
+
+    def get_mem_ranges(self):
+        return self._system.memory.get_uninterleaved_range() + [
+            self._system.realview.bootmem.range
+        ]
+
+    def get_mem_ports(self):
+        all_ports = [
+            (
+                self._system.realview.bootmem.range,
+                self._system.realview.bootmem.port,
+            ),
+        ] + self._system.memory.get_mem_ports()
+
+        return all_ports
+
+    def has_dma_ports(self):
+        return len(self._system._dma_ports) > 0
+
+    def get_dma_ports(self):
+        return self._system._dma_ports
+
+    def has_io_bus(self):
+        return True
+
+    def get_io_bus(self):
+        return self._system.iobus
+
+    def get_cache_line_size(self):
+        return self._system.cache_line_size
+
+    def get_clock_domain(self):
+        return self._system.clk_domain
+
+    def connect_system_port(self, port):
+        self._system.system_port = port
+
+
+def create(args):
+    requires(
+        isa_required=ISA.ARM,
+        coherence_protocol_required=CoherenceProtocol.CHI,
+    )
+
+    if args.script and not os.path.isfile(args.script):
+        print(f"Error: Bootscript {args.script} does not exist")
+        sys.exit(1)
+
+    cpu_class = cpu_types[args.cpu]
+    mem_mode = cpu_class.memory_mode()
+
+    system = devices.ArmRubySystem(
+        args.mem_size,
+        platform=VExpress_GEM5_Foundation(),
+        mem_mode=mem_mode,
+        workload=ArmFsLinux(object_file=SysPaths.binary(args.kernel)),
+        readfile=args.script,
+    )
+
+    system.cpu_cluster = [
+        devices.ArmCpuCluster(
+            system,
+            args.num_cpus,
+            args.cpu_freq,
+            "1.0V",
+            cpu_class,
+            None,
+            None,
+            None,
+        )
+    ]
+
+    topology_config = load_topology_config(args.topology_config)
+
+    # Import the cache hierarchy
+    cache_hierarchy = topology_config.cache_hierarchy_type
+    # Import the topology node parameters
+    get_node_params = topology_config.get_node_params
+    rnf_in_mesh = get_node_params(CHI_NodeType.CHI_RNF)
+    snf_mainmem_in_mesh = get_node_params(CHI_NodeType.CHI_SNF_MainMem)
+
+    if args.num_cpus != rnf_in_mesh.num_nodes():
+        raise ValueError(
+            f"--num-cpus ({args.num_cpus}) must match topology-config "
+            f"RNF node count ({rnf_in_mesh.num_nodes()})."
+        )
+
+    system.pci_devices = [
+        PciVirtIO(vio=VirtIOBlock(image=create_cow_image(args.disk_image)))
+    ]
+    for dev in system.pci_devices:
+        system.attach_pci(dev)
+
+    system.connect()
+
+    # Setup the system memory.
+    num_channels = snf_mainmem_in_mesh.num_nodes()
+    memory = ChanneledMemory(
+        dram_interface_class=DDR4_2400_16x4,
+        num_channels=num_channels,
+        interleaving_size=64,
+        size=args.mem_size,
+    )
+    if len(system.mem_ranges) != 1:
+        raise ValueError(
+            "This example requires a single contiguous system mem range."
+        )
+    memory.set_memory_range(system.mem_ranges)
+
+    cpus = [cpu for cl in system.cpu_cluster for cpu in cl.cpus]
+    proc_adapter = _LegacyProcessorAdapter(cpus)
+    board_adapter = _LegacyBoardAdapter(system, proc_adapter, memory)
+
+    system.mesh_cache = cache_hierarchy()
+    system.mesh_cache.add_default_nodes()
+    system.mesh_cache.incorporate_cache(board_adapter)
+
+    system.realview.setupBootLoader(system, SysPaths.binary)
+    system.workload.dtb_filename = os.path.join(
+        m5.options.outdir, "system.dtb"
+    )
+    system.generateDtb(system.workload.dtb_filename)
+    system.workload.command_line = " ".join(
+        [
+            "console=ttyAMA0",
+            "lpj=19988480",
+            "norandmaps",
+            f"root={args.root_device}",
+            "rw",
+            f"mem={args.mem_size}",
+        ]
+    )
+
+    return system
+
+
+def run():
+    event = m5.simulate()
+    print(event.getCause(), " @ ", m5.curTick())
+    sys.exit(event.getCode())
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", type=str, default=default_kernel)
+    parser.add_argument("--disk-image", type=str, default=default_disk)
+    parser.add_argument("--root-device", type=str, default=default_root_device)
+    parser.add_argument("--script", type=str, default="")
+    parser.add_argument(
+        "--cpu", choices=list(cpu_types.keys()), default="minor"
+    )
+    parser.add_argument("--cpu-freq", type=str, default="4GHz")
+    parser.add_argument("-n", "--num-cpus", type=int, default=4)
+    parser.add_argument("--mem-size", type=str, default="2GiB")
+    parser.add_argument(
+        "--topology-config",
+        type=str,
+        required=True,
+        help=(
+            "Path to a Python topology config module that defines "
+            "cache_hierarchy and get_node_params(node_type: CHI_NodeType) "
+            "-> Node_Params."
+        ),
+    )
+    args = parser.parse_args()
+
+    root = Root(full_system=True)
+    root.system = create(args)
+    m5.instantiate()
+    run()
+
+
+if __name__ == "__m5_main__":
+    main()

--- a/src/mem/ruby/protocol/chi/generic/CHIGeneric.py
+++ b/src/mem/ruby/protocol/chi/generic/CHIGeneric.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 ARM Limited
+# Copyright (c) 2023, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -54,3 +54,24 @@ class CHIGenericController(RubyController):
     snpIn = Param.MessageBuffer("")
     rspIn = Param.MessageBuffer("")
     datIn = Param.MessageBuffer("")
+
+    def connectQueues(self, network):
+        """Connect all of the queues for this controller.
+        This may be extended in subclasses.
+        """
+        self.reqOut = MessageBuffer()
+        self.rspOut = MessageBuffer()
+        self.snpOut = MessageBuffer()
+        self.datOut = MessageBuffer()
+        self.reqIn = MessageBuffer()
+        self.rspIn = MessageBuffer()
+        self.snpIn = MessageBuffer()
+        self.datIn = MessageBuffer()
+        self.reqOut.out_port = network.in_port
+        self.rspOut.out_port = network.in_port
+        self.snpOut.out_port = network.in_port
+        self.datOut.out_port = network.in_port
+        self.reqIn.in_port = network.out_port
+        self.rspIn.in_port = network.out_port
+        self.snpIn.in_port = network.out_port
+        self.datIn.in_port = network.out_port

--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -83,6 +83,11 @@ PySource('gem5.components.cachehierarchies.chi',
 PySource('gem5.components.cachehierarchies.chi',
     'gem5/components/cachehierarchies/chi/'
     'private_l1_private_l2_cache_hierarchy.py')
+PySource('gem5.components.cachehierarchies.chi',
+    'gem5/components/cachehierarchies/chi/'
+    'private_l1_private_l2_mesh_cache_hierarchy.py')
+PySource('gem5.components.cachehierarchies.chi',
+    'gem5/components/cachehierarchies/chi/noc.py')
 PySource('gem5.components.cachehierarchies.chi.nodes',
     'gem5/components/cachehierarchies/chi/nodes/__init__.py')
 PySource('gem5.components.cachehierarchies.chi.nodes',
@@ -97,6 +102,12 @@ PySource('gem5.components.cachehierarchies.chi.nodes',
     'gem5/components/cachehierarchies/chi/nodes/l2_cache.py')
 PySource('gem5.components.cachehierarchies.chi.nodes',
     'gem5/components/cachehierarchies/chi/nodes/memory_controller.py')
+PySource('gem5.components.cachehierarchies.chi.nodes',
+    'gem5/components/cachehierarchies/chi/nodes/rnf.py')
+PySource('gem5.components.cachehierarchies.chi.nodes',
+    'gem5/components/cachehierarchies/chi/nodes/hnf.py')
+PySource('gem5.components.cachehierarchies.chi.nodes',
+    'gem5/components/cachehierarchies/chi/nodes/snf.py')
 PySource('gem5.components.cachehierarchies.classic',
     'gem5/components/cachehierarchies/classic/__init__.py')
 PySource('gem5.components.cachehierarchies.classic',
@@ -220,6 +231,8 @@ PySource('gem5.components.cachehierarchies.ruby.topologies',
     'gem5/components/cachehierarchies/ruby/topologies/__init__.py')
 PySource('gem5.components.cachehierarchies.ruby.topologies',
     'gem5/components/cachehierarchies/ruby/topologies/simple_pt2pt.py')
+PySource('gem5.components.cachehierarchies.ruby.topologies',
+    'gem5/components/cachehierarchies/ruby/topologies/custom_mesh.py')
 
 PySource('gem5.components.devices',
     'gem5/components/devices/__init__.py')

--- a/src/python/SConscript
+++ b/src/python/SConscript
@@ -87,6 +87,9 @@ PySource('gem5.components.cachehierarchies.chi',
     'gem5/components/cachehierarchies/chi/'
     'private_l1_private_l2_mesh_cache_hierarchy.py')
 PySource('gem5.components.cachehierarchies.chi',
+    'gem5/components/cachehierarchies/chi/'
+    'private_l1_private_l2_shared_l3_mesh_cache_hierarchy.py')
+PySource('gem5.components.cachehierarchies.chi',
     'gem5/components/cachehierarchies/chi/noc.py')
 PySource('gem5.components.cachehierarchies.chi.nodes',
     'gem5/components/cachehierarchies/chi/nodes/__init__.py')

--- a/src/python/gem5/components/cachehierarchies/chi/noc.py
+++ b/src/python/gem5/components/cachehierarchies/chi/noc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Arm Limited
+# Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -9,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2021 The Regents of the University of California
-# All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -36,66 +33,30 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects import (
-    CBusyTracker,
-    ClockDomain,
-    RubyCache,
-    RubyNetwork,
+
+from dataclasses import (
+    dataclass,
+    field,
 )
-from m5.params import (
-    NULL,
+from typing import (
+    List,
+    Tuple,
 )
 
-from .....isas import ISA
-from .abstract_node import CacheController
 
+@dataclass
+class NoC_Params:
+    """
+    Default parameters for the interconnect. The value of data_width is
+    also used to set the data_channel_size for all CHI controllers.
+    (see configs/ruby/CHI.py)
+    """
 
-class L1CacheController(CacheController):
-    def __init__(
-        self,
-        size: str,
-        assoc: int,
-        network: RubyNetwork,
-        requires_send_evicts: bool,
-        cache_line_size,
-        target_isa: ISA,
-        clk_domain: ClockDomain,
-    ):
-        super().__init__(network, cache_line_size)
-
-        self.cache = RubyCache(
-            size=size, assoc=assoc, start_index_bit=self.getBlockSizeBits()
-        )
-
-        self.clk_domain = clk_domain
-        self.send_evictions = requires_send_evicts
-        self.use_prefetcher = False
-        self.prefetcher = NULL
-        self.cbusy_generator = NULL
-        self.cbusy_tracker = CBusyTracker()
-
-        # Only applies to home nodes
-        self.is_HN = False
-        self.enable_DMT = False
-        self.enable_DCT = False
-
-        # MOESI states for a 1 level cache
-        self.allow_SD = True
-        self.alloc_on_seq_acc = True
-        self.alloc_on_seq_line_write = False
-        self.alloc_on_readshared = True
-        self.alloc_on_readunique = True
-        self.alloc_on_readonce = True
-        self.alloc_on_writeback = False  # Should never happen in an L1
-        self.alloc_on_atomic = False
-        self.dealloc_on_unique = False
-        self.dealloc_on_shared = False
-        self.dealloc_backinv_unique = True
-        self.dealloc_backinv_shared = True
-        # Some reasonable default TBE params
-        self.number_of_TBEs = 16
-        self.number_of_repl_TBEs = 16
-        self.number_of_snoop_TBEs = 4
-        self.number_of_DVM_TBEs = 16
-        self.number_of_DVM_snoop_TBEs = 4
-        self.unify_repl_TBEs = False
+    router_link_latency: int = 1
+    node_link_latency: int = 1
+    router_latency: int = 1
+    router_buffer_size: int = 4
+    cntrl_msg_size: int = 8
+    data_width: int = 32
+    cross_links: List[Tuple[int, int]] = field(default_factory=list)
+    cross_link_latency: int = 0

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/abstract_node.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/abstract_node.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2021-2024,2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2021 The Regents of the University of California
 # All Rights Reserved.
 #
@@ -26,11 +38,18 @@
 
 import math
 from abc import abstractmethod
+from dataclasses import (
+    dataclass,
+    field,
+)
+from enum import Enum
+from typing import List
 
 from m5.objects import (
     CHI_Cache_Controller,
     MessageBuffer,
     RubyNetwork,
+    SubSystem,
 )
 
 from .....isas import ISA
@@ -53,10 +72,10 @@ class OrderedTriggerMessageBuffer(TriggerMessageBuffer):
     ordered = True
 
 
-class AbstractNode(CHI_Cache_Controller):
+class CacheController(CHI_Cache_Controller):
     """A node is the abstract unit for caches in the CHI protocol.
 
-    You can extend the AbstractNode to create caches (private or shared) and
+    You can extend the CacheController to create caches (private or shared) and
     directories with or without data caches.
     """
 
@@ -74,7 +93,7 @@ class AbstractNode(CHI_Cache_Controller):
 
         # Note: Need to call versionCount method on *this* class, not the
         # potentially derived class
-        self.version = AbstractNode.versionCount()
+        self.version = CacheController.versionCount()
         self._cache_line_size = cache_line_size
 
         # Set somewhat large number since we really a lot on internal
@@ -129,3 +148,83 @@ class AbstractNode(CHI_Cache_Controller):
         self.rspIn.in_port = network.out_port
         self.snpIn.in_port = network.out_port
         self.datIn.in_port = network.out_port
+
+
+class CHI_NodeType(Enum):
+    CHI_RNF = 1
+    CHI_HNF = 2
+    CHI_MN = 3
+    CHI_SNF_MainMem = 4
+    CHI_SNF_BootMem = 5
+    CHI_RNI_DMA = 6
+    CHI_RNI_IO = 7
+
+
+@dataclass(kw_only=True)
+class Node_Params:
+    """
+    NoC config. parameters and bindings required for CustomMesh topology.
+
+    Maps 'num_nodes_per_router' CHI nodes to each router provided in
+    'router_list'. This assumes len(router_list)*num_nodes_per_router
+    equals the number of nodes
+    If 'num_nodes_per_router' is left undefined, we circulate around
+    'router_list' until all nodes are mapped.
+    See 'distributeNodes' in configs/topologies/CustomMesh.py
+    """
+
+    node_type: CHI_NodeType
+    num_nodes_per_router: int = 1
+    router_list: List[int] = field(default_factory=list)
+    dedicated_router: bool = False
+
+    def num_nodes(self) -> int:
+        """Derive node count from Node_Params placement metadata."""
+
+        if self.num_nodes_per_router < 0:
+            raise ValueError("num_nodes_per_router must be >= 0.")
+        return len(self.router_list) * self.num_nodes_per_router
+
+
+class CHI_Node(SubSystem):
+    """
+    Base class with common functions for setting up Cache or Memory
+    controllers that are part of a CHI RNF, RNFI, HNF, or SNF nodes.
+    Notice getNetworkSideControllers and getAllControllers must be implemented
+    in the derived classes.
+    """
+
+    def __init__(self, ruby_system, node_type):
+        super().__init__()
+        self._ruby_system = ruby_system
+        self._network = ruby_system.network
+        self._node_type = node_type
+
+    def getNetworkSideControllers(self):
+        """
+        Returns all ruby controllers that need to be connected to the
+        network
+        """
+        raise NotImplementedError()
+
+    def getAllControllers(self):
+        """
+        Returns all ruby controllers associated with this node
+        """
+        raise NotImplementedError()
+
+    def setDownstream(self, cntrls):
+        """
+        Sets cntrls as the downstream list of all controllers in this node
+        """
+        for c in self.getNetworkSideControllers():
+            c.downstream_destinations = cntrls
+
+    def setDownstreamNodes(self, nodes):
+        """
+        Sets cntrls as the downstream list of all controllers in this node
+        """
+        cntrls = [
+            cntrl for node in nodes for cntrl in node.getAllControllers()
+        ]
+        self.setDownstream(cntrls)

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
@@ -154,3 +154,54 @@ class SimpleDirectory(BaseDirectory):
 
         self.cbusy_generator = CBusy()
         self.cbusy_tracker = CBusyTracker()
+
+
+class CachedDirectory(BaseDirectory):
+    """A directory/home node (HNF) with an attached cache."""
+
+    def __init__(
+        self,
+        network: RubyNetwork,
+        cache_line_size: int,
+        clk_domain: ClockDomain,
+        cache: RubyCache,
+        prefetcher,
+        addr_ranges: List[AddrRange],
+    ):
+        super().__init__(network, cache_line_size)
+
+        self.sequencer = NULL
+        self.cache = cache
+        self.prefetcher = prefetcher
+        self.use_prefetcher = prefetcher != NULL
+        self.addr_ranges = addr_ranges
+        self.clk_domain = clk_domain
+        self.allow_SD = True
+        self.is_HN = True
+        self.enable_DMT = True
+        self.enable_DCT = True
+        self.send_evictions = False
+
+        # Match CHI_config.py HN defaults.
+        self.alloc_on_seq_acc = False
+        self.alloc_on_seq_line_write = False
+        self.alloc_on_readshared = True
+        self.alloc_on_readunique = False
+        self.alloc_on_readonce = True
+        self.alloc_on_writeback = True
+        self.alloc_on_atomic = True
+        self.dealloc_on_unique = True
+        self.dealloc_on_shared = False
+        self.dealloc_backinv_unique = False
+        self.dealloc_backinv_shared = False
+
+        # Match CHI_config.py HN defaults for TBEs.
+        self.number_of_TBEs = 32
+        self.number_of_repl_TBEs = 32
+        self.number_of_snoop_TBEs = 1  # should not receive any snoop
+        self.number_of_DVM_TBEs = 1  # should not receive any dvm
+        self.number_of_DVM_snoop_TBEs = 1  # should not receive any dvm
+        self.unify_repl_TBEs = False
+
+        self.cbusy_generator = CBusy()
+        self.cbusy_tracker = CBusyTracker()

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/directory.py
@@ -51,10 +51,10 @@ from m5.params import (
     AddrRange,
 )
 
-from .abstract_node import AbstractNode
+from .abstract_node import CacheController
 
 
-class BaseDirectory(AbstractNode):
+class BaseDirectory(CacheController):
     """
     BaseDirectory. Mainly providing address range generation
     capabilities (see create_addr_ranges method)

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/dma_requestor.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/dma_requestor.py
@@ -35,10 +35,10 @@ from m5.params import (
 
 from .....isas import ISA
 from ....processors.abstract_core import AbstractCore
-from .abstract_node import AbstractNode
+from .abstract_node import CacheController
 
 
-class DMARequestor(AbstractNode):
+class DMARequestor(CacheController):
     def __init__(self, network, cache_line_size, clk_domain: ClockDomain):
         super().__init__(network, cache_line_size)
 

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/hnf.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/hnf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Arm Limited
+# Copyright (c) 2021-2024, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -9,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2021 The Regents of the University of California
-# All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -36,66 +33,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects import (
-    CBusyTracker,
-    ClockDomain,
-    RubyCache,
-    RubyNetwork,
+
+import m5
+from m5.objects import *
+
+from gem5.components.cachehierarchies.chi.nodes.abstract_node import (
+    CHI_Node,
+    CHI_NodeType,
 )
-from m5.params import (
-    NULL,
-)
-
-from .....isas import ISA
-from .abstract_node import CacheController
 
 
-class L1CacheController(CacheController):
+class CHI_HNF(CHI_Node):
+    """
+    Encapsulates an HNF cache/directory controller.
+    Before the first controller is created, the class method
+    CHI_HNF.createAddrRanges must be called before creating any CHI_HNF object
+    to set-up the interleaved address ranges used by the HNFs
+    """
+
     def __init__(
         self,
-        size: str,
-        assoc: int,
-        network: RubyNetwork,
-        requires_send_evicts: bool,
-        cache_line_size,
-        target_isa: ISA,
-        clk_domain: ClockDomain,
+        ruby_system,
+        cntrl,
     ):
-        super().__init__(network, cache_line_size)
+        super().__init__(ruby_system, CHI_NodeType.CHI_HNF)
+        self.cntrl = cntrl
 
-        self.cache = RubyCache(
-            size=size, assoc=assoc, start_index_bit=self.getBlockSizeBits()
-        )
+    def getNetworkSideControllers(self):
+        """
+        Returns all ruby controllers that need to be connected to the
+        network
+        """
+        return [self.cntrl]
 
-        self.clk_domain = clk_domain
-        self.send_evictions = requires_send_evicts
-        self.use_prefetcher = False
-        self.prefetcher = NULL
-        self.cbusy_generator = NULL
-        self.cbusy_tracker = CBusyTracker()
-
-        # Only applies to home nodes
-        self.is_HN = False
-        self.enable_DMT = False
-        self.enable_DCT = False
-
-        # MOESI states for a 1 level cache
-        self.allow_SD = True
-        self.alloc_on_seq_acc = True
-        self.alloc_on_seq_line_write = False
-        self.alloc_on_readshared = True
-        self.alloc_on_readunique = True
-        self.alloc_on_readonce = True
-        self.alloc_on_writeback = False  # Should never happen in an L1
-        self.alloc_on_atomic = False
-        self.dealloc_on_unique = False
-        self.dealloc_on_shared = False
-        self.dealloc_backinv_unique = True
-        self.dealloc_backinv_shared = True
-        # Some reasonable default TBE params
-        self.number_of_TBEs = 16
-        self.number_of_repl_TBEs = 16
-        self.number_of_snoop_TBEs = 4
-        self.number_of_DVM_TBEs = 16
-        self.number_of_DVM_snoop_TBEs = 4
-        self.unify_repl_TBEs = False
+    def getAllControllers(self):
+        """
+        Returns all ruby controllers associated with this node
+        """
+        return [self.cntrl]

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/l2_cache.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/l2_cache.py
@@ -49,7 +49,7 @@ from m5.params import (
 
 from .....isas import ISA
 from ....processors.abstract_core import AbstractCore
-from .abstract_node import AbstractNode
+from .abstract_node import CacheController
 
 
 class L2Cache(RubyCache):
@@ -58,7 +58,7 @@ class L2Cache(RubyCache):
     tagAccessLatency = 2
 
 
-class L2CacheController(AbstractNode):
+class L2CacheController(CacheController):
     """
     Strictly inclusive MOESI L2 controller.
     Strictly inclusive:

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/rnf.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/rnf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Arm Limited
+# Copyright (c) 2021-2024, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -9,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2021 The Regents of the University of California
-# All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -36,66 +33,82 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects import (
-    CBusyTracker,
-    ClockDomain,
-    RubyCache,
-    RubyNetwork,
+
+import m5
+from m5.objects import *
+
+from gem5.components.cachehierarchies.chi.nodes.abstract_node import (
+    CHI_Node,
+    CHI_NodeType,
 )
-from m5.params import (
-    NULL,
-)
-
-from .....isas import ISA
-from .abstract_node import CacheController
 
 
-class L1CacheController(CacheController):
+class CHI_RNF(CHI_Node):
+    """
+    Defines a CHI request node.
+    Notice all contollers and sequencers are set as children of the cpus, so
+    this object acts more like a proxy for seting things up and has no topology
+    significance unless the cpus are set as its children at the top level
+    """
+
     def __init__(
         self,
-        size: str,
-        assoc: int,
-        network: RubyNetwork,
-        requires_send_evicts: bool,
-        cache_line_size,
-        target_isa: ISA,
-        clk_domain: ClockDomain,
+        ruby_system,
+        cntrls,
     ):
-        super().__init__(network, cache_line_size)
+        super().__init__(ruby_system, CHI_NodeType.CHI_RNF)
+        self.cntrls = cntrls
+        # last level controler is the last one on the list
+        self._ll_cntrls = [cntrls[-1]]
 
-        self.cache = RubyCache(
-            size=size, assoc=assoc, start_index_bit=self.getBlockSizeBits()
-        )
+    def getNetworkSideControllers(self):
+        """
+        Returns all ruby controllers that need to be connected to the
+        network
+        """
+        return self.cntrls
 
-        self.clk_domain = clk_domain
-        self.send_evictions = requires_send_evicts
-        self.use_prefetcher = False
-        self.prefetcher = NULL
-        self.cbusy_generator = NULL
-        self.cbusy_tracker = CBusyTracker()
+    def setDownstream(self, cntrls):
+        """
+        Sets cntrls as the downstream list of all *last level* controllers
+        of this node
+        """
+        for c in self._ll_cntrls:
+            c.downstream_destinations = cntrls
 
-        # Only applies to home nodes
-        self.is_HN = False
-        self.enable_DMT = False
-        self.enable_DCT = False
 
-        # MOESI states for a 1 level cache
-        self.allow_SD = True
-        self.alloc_on_seq_acc = True
-        self.alloc_on_seq_line_write = False
-        self.alloc_on_readshared = True
-        self.alloc_on_readunique = True
-        self.alloc_on_readonce = True
-        self.alloc_on_writeback = False  # Should never happen in an L1
-        self.alloc_on_atomic = False
-        self.dealloc_on_unique = False
-        self.dealloc_on_shared = False
-        self.dealloc_backinv_unique = True
-        self.dealloc_backinv_shared = True
-        # Some reasonable default TBE params
-        self.number_of_TBEs = 16
-        self.number_of_repl_TBEs = 16
-        self.number_of_snoop_TBEs = 4
-        self.number_of_DVM_TBEs = 16
-        self.number_of_DVM_snoop_TBEs = 4
-        self.unify_repl_TBEs = False
+class CHI_RNI_Base(CHI_Node):
+    def __init__(self, ruby_system, node_type, cntrl):
+        super().__init__(ruby_system, node_type)
+        self.cntrl = cntrl
+
+    def getNetworkSideControllers(self):
+        """
+        Returns all ruby controllers that need to be connected to the
+        network
+        """
+        return [self.cntrl]
+
+    def getAllControllers(self):
+        """
+        Returns all ruby controllers associated with this node
+        """
+        return [self.cntrl]
+
+
+class CHI_RNI_DMA(CHI_RNI_Base):
+    """
+    DMA controller wiredup to a given dma port
+    """
+
+    def __init__(self, ruby_system, cntrl):
+        super().__init__(ruby_system, CHI_NodeType.CHI_RNI_DMA, cntrl)
+
+
+class CHI_RNI_IO(CHI_RNI_Base):
+    """
+    DMA controller wiredup to ruby_system IO port
+    """
+
+    def __init__(self, ruby_system, cntrl):
+        super().__init__(ruby_system, CHI_NodeType.CHI_RNI_IO, cntrl)

--- a/src/python/gem5/components/cachehierarchies/chi/nodes/snf.py
+++ b/src/python/gem5/components/cachehierarchies/chi/nodes/snf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Arm Limited
+# Copyright (c) 2021-2024, 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -9,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2021 The Regents of the University of California
-# All Rights Reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -36,66 +33,57 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from m5.objects import (
-    CBusyTracker,
-    ClockDomain,
-    RubyCache,
-    RubyNetwork,
+
+import m5
+from m5.objects import *
+
+from gem5.components.cachehierarchies.chi.nodes.abstract_node import (
+    CHI_Node,
+    CHI_NodeType,
 )
-from m5.params import (
-    NULL,
-)
-
-from .....isas import ISA
-from .abstract_node import CacheController
 
 
-class L1CacheController(CacheController):
+class CHI_SNF_Base(CHI_Node):
+    """
+    Creates CHI node controllers for the memory controllers
+    """
+
     def __init__(
         self,
-        size: str,
-        assoc: int,
-        network: RubyNetwork,
-        requires_send_evicts: bool,
-        cache_line_size,
-        target_isa: ISA,
-        clk_domain: ClockDomain,
+        ruby_system,
+        node_type,
+        cntrl,
     ):
-        super().__init__(network, cache_line_size)
+        super().__init__(ruby_system, node_type)
+        self.cntrl = cntrl
 
-        self.cache = RubyCache(
-            size=size, assoc=assoc, start_index_bit=self.getBlockSizeBits()
-        )
+    def getNetworkSideControllers(self):
+        """
+        Returns all ruby controllers that need to be connected to the
+        network
+        """
+        return [self.cntrl]
 
-        self.clk_domain = clk_domain
-        self.send_evictions = requires_send_evicts
-        self.use_prefetcher = False
-        self.prefetcher = NULL
-        self.cbusy_generator = NULL
-        self.cbusy_tracker = CBusyTracker()
+    def getAllControllers(self):
+        """
+        Returns all ruby controllers associated with this node
+        """
+        return [self.cntrl]
 
-        # Only applies to home nodes
-        self.is_HN = False
-        self.enable_DMT = False
-        self.enable_DCT = False
 
-        # MOESI states for a 1 level cache
-        self.allow_SD = True
-        self.alloc_on_seq_acc = True
-        self.alloc_on_seq_line_write = False
-        self.alloc_on_readshared = True
-        self.alloc_on_readunique = True
-        self.alloc_on_readonce = True
-        self.alloc_on_writeback = False  # Should never happen in an L1
-        self.alloc_on_atomic = False
-        self.dealloc_on_unique = False
-        self.dealloc_on_shared = False
-        self.dealloc_backinv_unique = True
-        self.dealloc_backinv_shared = True
-        # Some reasonable default TBE params
-        self.number_of_TBEs = 16
-        self.number_of_repl_TBEs = 16
-        self.number_of_snoop_TBEs = 4
-        self.number_of_DVM_TBEs = 16
-        self.number_of_DVM_snoop_TBEs = 4
-        self.unify_repl_TBEs = False
+class CHI_SNF_BootMem(CHI_SNF_Base):
+    """
+    Create the SNF for the boot memory
+    """
+
+    def __init__(self, ruby_system, cntrl):
+        super().__init__(ruby_system, CHI_NodeType.CHI_SNF_BootMem, cntrl)
+
+
+class CHI_SNF_MainMem(CHI_SNF_Base):
+    """
+    Create the SNF for a list main memory controllers
+    """
+
+    def __init__(self, ruby_system, cntrl):
+        super().__init__(ruby_system, CHI_NodeType.CHI_SNF_MainMem, cntrl)

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
@@ -255,7 +255,7 @@ class PrivateL1CacheHierarchy(AbstractRubyCacheHierarchy):
 
     @overrides(AbstractRubyCacheHierarchy)
     def _reset_version_numbers(self):
-        from .nodes.abstract_node import AbstractNode
+        from .nodes.abstract_node import CacheController
 
-        AbstractNode._version = 0
+        CacheController._version = 0
         MemoryController._version = 0

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_cache_hierarchy.py
@@ -301,7 +301,7 @@ class PrivateL1PrivateL2CacheHierarchy(
 
     @overrides(AbstractRubyCacheHierarchy)
     def _reset_version_numbers(self):
-        from .nodes.abstract_node import AbstractNode
+        from .nodes.abstract_node import CacheController
 
-        AbstractNode._version = 0
+        CacheController._version = 0
         MemoryController._version = 0

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
@@ -1,0 +1,446 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from itertools import chain
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from m5.objects import (
+    NULL,
+    RubyPortProxy,
+    RubySequencer,
+    RubySystem,
+)
+from m5.objects.SubSystem import SubSystem
+
+from gem5.coherence_protocol import CoherenceProtocol
+from gem5.utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.CHI)
+
+from gem5.components.boards.abstract_board import AbstractBoard
+from gem5.components.cachehierarchies.abstract_cache_hierarchy import (
+    AbstractCacheHierarchy,
+)
+from gem5.components.cachehierarchies.abstract_two_level_cache_hierarchy import (
+    AbstractTwoLevelCacheHierarchy,
+)
+from gem5.components.cachehierarchies.ruby.abstract_ruby_cache_hierarchy import (
+    AbstractRubyCacheHierarchy,
+)
+from gem5.components.cachehierarchies.ruby.topologies.custom_mesh import (
+    CustomMesh,
+)
+from gem5.components.cachehierarchies.ruby.topologies.custom_mesh import (
+    NoC_Params as CustomMeshNoC_Params,
+)
+from gem5.components.processors.abstract_core import AbstractCore
+from gem5.isas import ISA
+from gem5.utils.override import overrides
+
+from .nodes.abstract_node import (
+    CHI_NodeType,
+    Node_Params,
+)
+from .nodes.directory import (
+    BaseDirectory,
+    SimpleDirectory,
+)
+from .nodes.dma_requestor import DMARequestor
+from .nodes.hnf import (
+    CHI_HNF,
+)
+from .nodes.l1_cache import L1CacheController
+from .nodes.l2_cache import L2CacheController
+from .nodes.memory_controller import MemoryController
+from .nodes.rnf import (
+    CHI_RNF,
+    CHI_RNI_DMA,
+)
+from .nodes.snf import (
+    CHI_SNF_BootMem,
+    CHI_SNF_MainMem,
+)
+
+
+class PrivateL1PrivateL2MeshCacheHierarchy(
+    AbstractRubyCacheHierarchy, AbstractTwoLevelCacheHierarchy
+):
+    """A CHI private L1/private L2 hierarchy wired with a configurable mesh."""
+
+    def __init__(
+        self,
+        l1i_size: str,
+        l1i_assoc: int,
+        l1d_size: str,
+        l1d_assoc: int,
+        l2_size: str,
+        l2_assoc: int,
+        noc_params: CustomMeshNoC_Params,
+    ):
+        AbstractRubyCacheHierarchy.__init__(self=self)
+        AbstractTwoLevelCacheHierarchy.__init__(
+            self,
+            l1i_size=l1i_size,
+            l1i_assoc=l1i_assoc,
+            l1d_size=l1d_size,
+            l1d_assoc=l1d_assoc,
+            l2_size=l2_size,
+            l2_assoc=l2_assoc,
+        )
+
+        self._noc_params = noc_params
+        self._node_params: Dict[CHI_NodeType, Node_Params] = {}
+
+    def add_nodes(self, node_params: Node_Params):
+        self._node_params[node_params.node_type] = node_params
+
+    def _get_node_params(
+        self, node_type: CHI_NodeType
+    ) -> Optional[Node_Params]:
+        mandatory_node_types = (
+            CHI_NodeType.CHI_RNF,
+            CHI_NodeType.CHI_HNF,
+            CHI_NodeType.CHI_SNF_MainMem,
+        )
+
+        node_params = self._node_params.get(node_type)
+        if node_params is None and node_type in mandatory_node_types:
+            raise ValueError(
+                f"Node parameters for {node_type.name} must be provided via add_nodes()."
+            )
+        return node_params
+
+    @overrides(AbstractCacheHierarchy)
+    def get_coherence_protocol(self):
+        return CoherenceProtocol.CHI
+
+    @overrides(AbstractCacheHierarchy)
+    def incorporate_cache(self, board: AbstractBoard) -> None:
+        super().incorporate_cache(board)
+        self.ruby_system = RubySystem()
+
+        # Ruby's global network.
+        self.ruby_system.network = CustomMesh(
+            ruby_system=self.ruby_system,
+            noc_params=self._noc_params,
+        )
+
+        self.ruby_system.network.physical_vnets_bandwidth = [
+            self._noc_params.cntrl_msg_size,
+            self._noc_params.cntrl_msg_size,
+            self._noc_params.cntrl_msg_size,
+            self._noc_params.cntrl_msg_size + self._noc_params.data_width,
+        ]
+        self.ruby_system.network.physical_vnets_channels = [1] * 4
+
+        # Network configurations
+        # virtual networks: 0=request, 1=snoop, 2=response, 3=data
+        self.ruby_system.number_of_virtual_networks = 4
+        self.ruby_system.network.number_of_virtual_networks = 4
+
+        rnf_params = self._get_node_params(CHI_NodeType.CHI_RNF)
+        hnf_params = self._get_node_params(CHI_NodeType.CHI_HNF)
+        snf_params = self._get_node_params(CHI_NodeType.CHI_SNF_MainMem)
+        snf_boot_params = self._get_node_params(CHI_NodeType.CHI_SNF_BootMem)
+        rni_params = self._get_node_params(CHI_NodeType.CHI_RNI_DMA)
+
+        num_hnfs = hnf_params.num_nodes()
+        num_rnfs = rnf_params.num_nodes()
+        num_snfs = snf_params.num_nodes()
+        num_boot_snfs = (
+            snf_boot_params.num_nodes() if snf_boot_params is not None else 0
+        )
+        num_rnis = rni_params.num_nodes() if rni_params is not None else 0
+
+        if num_hnfs < 1:
+            raise ValueError("Number of HNFs must be at least 1.")
+        if num_hnfs & (num_hnfs - 1):
+            raise ValueError("Number of HNFs must be a power of 2.")
+
+        cores = list(board.get_processor().get_cores())
+
+        # This is where we start instantiating CHI nodes
+        # The logic might appear weird, because of how
+        # we first generate a list and then we assign
+        # it to a member variable immediately after.
+        # This is because we need to allow for the following
+        # gem5 constraints
+        #
+        # 1) A SimObject cannot have empty list as a child
+        # (unless it is a Param), therefore we cannot do
+        # direct assignment for optional nodes like for example
+        # self.rni_nodes = self._create_dma_controllers(..)
+        #
+        # 2) If we do the member assignment at the end, all
+        # CHI nodes names will be wrong. This is because
+        # the first assignment specifies the name. However
+        # as we are creating and connecting nodes at the same
+        # time, doing something like
+        #
+        # rnf.setDownstreamNodes(self._hnf_nodes)
+        #
+        # will name all hnf nodes as rnf.upstream_destination
+        # Therefore by immediately doing self.hnf_nodes = hnf_nodes
+        # We make sure they are properly named as "hnf_nodes"
+
+        # Create the coherent side of the memory controllers
+        snf_nodes, snf_boot_nodes = self._create_snfs(
+            board, num_snfs, num_boot_snfs
+        )
+        self.snf_nodes = snf_nodes
+        if num_boot_snfs > 0:
+            self.snf_boot_nodes = snf_boot_nodes
+
+        hnf_nodes = self._create_hnfs(board, num_hnfs)
+        self.hnf_nodes = hnf_nodes
+
+        # Create one core cluster with a split I/D cache for each core
+        rnf_nodes = self._create_rnfs(board, cores, num_rnfs)
+        self.rnf_nodes = rnf_nodes
+
+        # Create the DMA Controllers, if required.
+        rni_nodes = self._create_dma_controllers(board, num_rnis)
+        if num_rnis > 0:
+            self.rni_nodes = rni_nodes
+
+        self.ruby_system.num_of_sequencers = len(self.rnf_nodes) * 2 + len(
+            rni_nodes
+        )
+
+        self.ruby_system.network.connectControllers(
+            rnf=(rnf_nodes, rnf_params),
+            hnf=(hnf_nodes, hnf_params),
+            snf=(snf_nodes, snf_params),
+            snf_boot=(snf_boot_nodes, snf_boot_params),
+            rni=(rni_nodes, rni_params),
+        )
+
+        self.ruby_system.network.setup_buffers()
+
+        # Set up a proxy port for the system_port. Used for load binaries and
+        # other functional-only things.
+        self.ruby_system.sys_port_proxy = RubyPortProxy(
+            ruby_system=self.ruby_system
+        )
+        board.connect_system_port(self.ruby_system.sys_port_proxy.in_ports)
+
+    def _create_hnfs(
+        self, board: AbstractBoard, num_hnfs: int
+    ) -> List[CHI_HNF]:
+        hnfs = []
+        mem_ranges = list(board.get_mem_ranges())
+        for idx in range(num_hnfs):
+            ranges = BaseDirectory.create_addr_ranges(
+                num_directories=num_hnfs,
+                dir_idx=idx,
+                mem_ranges=mem_ranges,
+                cache_line_size=board.get_cache_line_size(),
+            )
+            directory = SimpleDirectory(
+                self.ruby_system.network,
+                cache_line_size=board.get_cache_line_size(),
+                clk_domain=board.get_clock_domain(),
+                addr_ranges=ranges,
+            )
+            directory.ruby_system = self.ruby_system
+
+            hnf = CHI_HNF(self.ruby_system, directory)
+            downstream_nodes = self.snf_nodes + getattr(
+                self, "snf_boot_nodes", []
+            )
+            hnf.setDownstreamNodes(downstream_nodes)
+
+            hnfs.append(hnf)
+
+        return hnfs
+
+    def _create_rnfs(
+        self,
+        board: AbstractBoard,
+        cores: List[AbstractCore],
+        num_rnfs: int,
+    ) -> List[CHI_RNF]:
+        """Given the core and core number, create a split I/D + private L2."""
+        rnfs = []
+        for core_num, core in enumerate(cores):
+            dcache = L1CacheController(
+                size=self._l1d_size,
+                assoc=self._l1d_assoc,
+                network=self.ruby_system.network,
+                requires_send_evicts=core.requires_send_evicts(),
+                cache_line_size=board.get_cache_line_size(),
+                target_isa=board.get_processor().get_isa(),
+                clk_domain=board.get_clock_domain(),
+            )
+            dcache.sc_lock_enabled = True
+            icache = L1CacheController(
+                size=self._l1i_size,
+                assoc=self._l1i_assoc,
+                network=self.ruby_system.network,
+                requires_send_evicts=core.requires_send_evicts(),
+                cache_line_size=board.get_cache_line_size(),
+                target_isa=board.get_processor().get_isa(),
+                clk_domain=board.get_clock_domain(),
+            )
+
+            icache.sequencer = RubySequencer(
+                version=core_num,
+                dcache=NULL,
+                clk_domain=icache.clk_domain,
+                ruby_system=self.ruby_system,
+            )
+            dcache.sequencer = RubySequencer(
+                version=core_num,
+                dcache=dcache.cache,
+                clk_domain=dcache.clk_domain,
+                ruby_system=self.ruby_system,
+            )
+
+            l2 = L2CacheController(
+                size=self._l2_size,
+                assoc=self._l2_assoc,
+                network=self.ruby_system.network,
+                cache_line_size=board.get_cache_line_size(),
+                clk_domain=board.get_clock_domain(),
+            )
+
+            rnf = CHI_RNF(self.ruby_system, [dcache, icache, l2])
+
+            if board.has_io_bus():
+                dcache.sequencer.connectIOPorts(board.get_io_bus())
+
+            dcache.ruby_system = self.ruby_system
+            icache.ruby_system = self.ruby_system
+            l2.ruby_system = self.ruby_system
+
+            core.connect_icache(icache.sequencer.in_ports)
+            core.connect_dcache(dcache.sequencer.in_ports)
+
+            core.connect_walker_ports(
+                dcache.sequencer.in_ports,
+                icache.sequencer.in_ports,
+            )
+
+            # Connect the interrupt ports
+            core.connect_interrupt()
+
+            dcache.downstream_destinations = [l2]
+            icache.downstream_destinations = [l2]
+
+            rnf.setDownstreamNodes(self.hnf_nodes)
+
+            rnfs.append(rnf)
+
+        return rnfs
+
+    def _create_snfs(
+        self,
+        board: AbstractBoard,
+        num_snfs: int,
+        num_boot_snfs: int,
+    ) -> Tuple[List[CHI_SNF_MainMem], List[CHI_SNF_BootMem]]:
+
+        mem_ports = board.get_mem_ports()
+
+        if num_snfs + num_boot_snfs != len(mem_ports):
+            raise ValueError(
+                f"Defining {num_snfs + num_boot_snfs} CHI_SNF nodes with "
+                f"{len(mem_ports)} memory ports."
+            )
+
+        snfs_main = []
+        snfs_boots = []
+        for idx, (rng, port) in enumerate(mem_ports):
+            mc = MemoryController(self.ruby_system.network, [rng], port)
+            mc.ruby_system = self.ruby_system
+            # Clear hack, assuming bootmem ranges are appended at the end
+            # of normal memory ranges
+            if idx < num_snfs:
+                snf = CHI_SNF_MainMem(self.ruby_system, mc)
+                snfs_main.append(snf)
+            else:
+                snf = CHI_SNF_BootMem(self.ruby_system, mc)
+                snfs_boots.append(snf)
+
+        return snfs_main, snfs_boots
+
+    def _create_dma_controllers(
+        self,
+        board: AbstractBoard,
+        num_rnis: int,
+    ) -> List[CHI_RNI_DMA]:
+        rnis = []
+
+        dma_ports = board.get_dma_ports()
+        if num_rnis != len(dma_ports):
+            raise ValueError(
+                f"Defining {num_rnis} CHI_RNI nodes with "
+                f"{len(dma_ports)} dma ports."
+            )
+
+        for i, port in enumerate(dma_ports):
+            ctrl = DMARequestor(
+                self.ruby_system.network,
+                board.get_cache_line_size(),
+                board.get_clock_domain(),
+            )
+            ctrl.ruby_system = self.ruby_system
+
+            version = len(board.get_processor().get_cores()) + i
+            ctrl.sequencer = RubySequencer(
+                version=version,
+                dcache=NULL,
+                in_ports=port,
+                ruby_system=self.ruby_system,
+            )
+
+            rni = CHI_RNI_DMA(self.ruby_system, ctrl)
+            rni.setDownstreamNodes(self.hnf_nodes)
+
+            rnis.append(rni)
+
+        return rnis
+
+    @overrides(AbstractRubyCacheHierarchy)
+    def _reset_version_numbers(self):
+        from .nodes.abstract_node import CacheController
+
+        CacheController._version = 0
+        MemoryController._version = 0

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_shared_l3_mesh_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_shared_l3_mesh_cache_hierarchy.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import math
+from typing import List
+
+from m5.objects import RubyCache
+from m5.params import NULL
+
+from gem5.components.boards.abstract_board import AbstractBoard
+
+from .nodes.directory import (
+    BaseDirectory,
+    CachedDirectory,
+)
+from .nodes.hnf import CHI_HNF
+from .private_l1_private_l2_mesh_cache_hierarchy import (
+    CustomMeshNoC_Params,
+    PrivateL1PrivateL2MeshCacheHierarchy,
+)
+
+
+class PrivateL1PrivateL2SharedL3MeshCacheHierarchy(
+    PrivateL1PrivateL2MeshCacheHierarchy
+):
+    """Mesh CHI hierarchy identical to PrivateL1PrivateL2Mesh with shared L3 HNF cache slices."""
+
+    def __init__(
+        self,
+        l1i_size: str,
+        l1i_assoc: int,
+        l1d_size: str,
+        l1d_assoc: int,
+        l2_size: str,
+        l2_assoc: int,
+        l3_size: str,
+        l3_assoc: int,
+        noc_params: CustomMeshNoC_Params,
+    ):
+        super().__init__(
+            l1i_size=l1i_size,
+            l1i_assoc=l1i_assoc,
+            l1d_size=l1d_size,
+            l1d_assoc=l1d_assoc,
+            l2_size=l2_size,
+            l2_assoc=l2_assoc,
+            noc_params=noc_params,
+        )
+        self._l3_size = l3_size
+        self._l3_assoc = l3_assoc
+
+    def _create_hnfs(
+        self, board: AbstractBoard, num_hnfs: int
+    ) -> List[CHI_HNF]:
+        hnfs = []
+        mem_ranges = list(board.get_mem_ranges())
+        for idx in range(num_hnfs):
+            # Apply AddrRange interleaving for each HNF/L3 slice.
+            ranges = BaseDirectory.create_addr_ranges(
+                num_directories=num_hnfs,
+                dir_idx=idx,
+                mem_ranges=mem_ranges,
+                cache_line_size=board.get_cache_line_size(),
+            )
+            block_size_bits = int(math.log(board.get_cache_line_size(), 2))
+            llc_bits = int(math.log(num_hnfs, 2))
+            intlv_high_bit = block_size_bits + llc_bits - 1
+
+            ll_cache = RubyCache(
+                size=self._l3_size,
+                assoc=self._l3_assoc,
+                dataAccessLatency=10,
+                tagAccessLatency=2,
+                start_index_bit=intlv_high_bit + 1,
+            )
+
+            directory = CachedDirectory(
+                network=self.ruby_system.network,
+                cache_line_size=board.get_cache_line_size(),
+                clk_domain=board.get_clock_domain(),
+                cache=ll_cache,
+                prefetcher=NULL,
+                addr_ranges=ranges,
+            )
+            directory.ruby_system = self.ruby_system
+
+            hnf = CHI_HNF(self.ruby_system, directory)
+            downstream_nodes = self.snf_nodes + getattr(
+                self, "snf_boot_nodes", []
+            )
+            hnf.setDownstreamNodes(downstream_nodes)
+            hnfs.append(hnf)
+
+        return hnfs

--- a/src/python/gem5/components/cachehierarchies/ruby/topologies/custom_mesh.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/topologies/custom_mesh.py
@@ -1,0 +1,505 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import importlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Any,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from m5.objects import (
+    SimpleExtLink,
+    SimpleIntLink,
+    SimpleNetwork,
+    Switch,
+)
+from m5.util import (
+    fatal,
+    warn,
+)
+
+from ...chi.noc import NoC_Params as CHI_NoC_Params
+from ...chi.nodes.abstract_node import (
+    CHI_NodeType,
+    Node_Params,
+)
+
+
+@dataclass(kw_only=True)
+class NoC_Params(CHI_NoC_Params):
+    """NoC defaults specialized for the stdlib CustomMesh topology."""
+
+    num_rows: int = 0
+    num_cols: int = 0
+    pairing: Optional[Sequence[Any]] = None
+
+
+class CustomMesh(SimpleNetwork):
+    """Custom mesh topology for CHI stdlib cache hierarchies."""
+
+    def __init__(self, ruby_system, noc_params: NoC_Params):
+        super().__init__()
+        self.netifs = []
+
+        # TODO: These should be in a base class.
+        # https://gem5.atlassian.net/browse/GEM5-1039
+        self.ruby_system = ruby_system
+
+        self._num_rows = noc_params.num_rows
+        self._num_cols = noc_params.num_cols
+        if self._num_rows is None or self._num_cols is None:
+            raise ValueError("noc_params must define num_rows and num_cols.")
+        if self._num_rows <= 0 or self._num_cols <= 0:
+            raise ValueError("num_rows and num_cols must both be > 0.")
+
+        self._num_mesh_routers = self._num_rows * self._num_cols
+        self._router_latency = noc_params.router_latency
+        self._router_link_latency = noc_params.router_link_latency
+        self._node_link_latency = noc_params.node_link_latency
+        self._cross_link_latency = noc_params.cross_link_latency
+        self._cross_links = {
+            (int(src), int(dst)) for src, dst in noc_params.cross_links
+        }
+        self._pairing = noc_params.pairing
+
+        # Keep aligned with CustomMesh in configs/topologies for non-garnet use.
+        self._node_router_latency = 0
+
+        self._link_count = 0
+        self._int_links = []
+        self._ext_links = []
+
+    def _check_router_id(self, router_id: int, node_type: CHI_NodeType):
+        if router_id < 0 or router_id >= self._num_mesh_routers:
+            raise ValueError(
+                f"Invalid router index {router_id} for {node_type.name}. "
+                f"Valid range is [0, {self._num_mesh_routers - 1}]."
+            )
+
+    def _make_mesh(self):
+        # East->West, West->East, North->South, South->North
+        # XY routing weights
+        link_weights = [1, 1, 2, 2]
+
+        # East output to West input links
+        for row in range(self._num_rows):
+            for col in range(self._num_cols):
+                if col + 1 < self._num_cols:
+                    east_out = col + (row * self._num_cols)
+                    west_in = (col + 1) + (row * self._num_cols)
+                    latency = (
+                        self._cross_link_latency
+                        if (east_out, west_in) in self._cross_links
+                        else self._router_link_latency
+                    )
+                    self._int_links.append(
+                        SimpleIntLink(
+                            link_id=self._link_count,
+                            src_node=self._routers[east_out],
+                            dst_node=self._routers[west_in],
+                            dst_inport="West",
+                            latency=latency,
+                            weight=link_weights[0],
+                        )
+                    )
+                    self._link_count += 1
+
+        # West output to East input links
+        for row in range(self._num_rows):
+            for col in range(self._num_cols):
+                if col + 1 < self._num_cols:
+                    east_in = col + (row * self._num_cols)
+                    west_out = (col + 1) + (row * self._num_cols)
+                    latency = (
+                        self._cross_link_latency
+                        if (west_out, east_in) in self._cross_links
+                        else self._router_link_latency
+                    )
+                    self._int_links.append(
+                        SimpleIntLink(
+                            link_id=self._link_count,
+                            src_node=self._routers[west_out],
+                            dst_node=self._routers[east_in],
+                            dst_inport="East",
+                            latency=latency,
+                            weight=link_weights[1],
+                        )
+                    )
+                    self._link_count += 1
+
+        # North output to South input links
+        for col in range(self._num_cols):
+            for row in range(self._num_rows):
+                if row + 1 < self._num_rows:
+                    north_out = col + (row * self._num_cols)
+                    south_in = col + ((row + 1) * self._num_cols)
+                    latency = (
+                        self._cross_link_latency
+                        if (north_out, south_in) in self._cross_links
+                        else self._router_link_latency
+                    )
+                    self._int_links.append(
+                        SimpleIntLink(
+                            link_id=self._link_count,
+                            src_node=self._routers[north_out],
+                            dst_node=self._routers[south_in],
+                            dst_inport="South",
+                            latency=latency,
+                            weight=link_weights[2],
+                        )
+                    )
+                    self._link_count += 1
+
+        # South output to North input links
+        for col in range(self._num_cols):
+            for row in range(self._num_rows):
+                if row + 1 < self._num_rows:
+                    north_in = col + (row * self._num_cols)
+                    south_out = col + ((row + 1) * self._num_cols)
+                    latency = (
+                        self._cross_link_latency
+                        if (south_out, north_in) in self._cross_links
+                        else self._router_link_latency
+                    )
+                    self._int_links.append(
+                        SimpleIntLink(
+                            link_id=self._link_count,
+                            src_node=self._routers[south_out],
+                            dst_node=self._routers[north_in],
+                            dst_inport="North",
+                            latency=latency,
+                            weight=link_weights[3],
+                        )
+                    )
+                    self._link_count += 1
+
+    def _create_rnf_router(self, mesh_router):
+        # Create a zero-latency router bridging RNF controllers and mesh router.
+        node_router = Switch(
+            router_id=len(self._routers), latency=self._node_router_latency
+        )
+        self._routers.append(node_router)
+
+        self._int_links.append(
+            SimpleIntLink(
+                link_id=self._link_count,
+                src_node=node_router,
+                dst_node=mesh_router,
+                latency=self._router_link_latency,
+            )
+        )
+        self._link_count += 1
+
+        self._int_links.append(
+            SimpleIntLink(
+                link_id=self._link_count,
+                src_node=mesh_router,
+                dst_node=node_router,
+                latency=self._router_link_latency,
+            )
+        )
+        self._link_count += 1
+
+        return node_router
+
+    def _iter_node_controllers(self, node):
+        ctrls = node.getNetworkSideControllers()
+        return ctrls if isinstance(ctrls, (list, tuple)) else [ctrls]
+
+    def distribute_nodes(
+        self, node_params: Node_Params, node_list: Sequence[Any]
+    ):
+        if len(node_list) == 0:
+            return
+        if node_params is None:
+            raise ValueError(
+                "Node_Params must be provided for non-empty nodes."
+            )
+        if len(node_params.router_list) == 0:
+            raise ValueError(
+                f"router_list must not be empty for {node_params.node_type.name}."
+            )
+
+        num_nodes_per_router = node_params.num_nodes_per_router
+        router_idx_list = node_params.router_list
+
+        for router_id in router_idx_list:
+            self._check_router_id(int(router_id), node_params.node_type)
+
+        if num_nodes_per_router < 0:
+            raise ValueError("num_nodes_per_router must be >= 0.")
+
+        if num_nodes_per_router:
+            # Evenly distribute nodes to all listed routers.
+            expected_nodes = len(router_idx_list) * num_nodes_per_router
+
+            if expected_nodes < len(node_list):
+                fatal(
+                    f"{node_params.node_type.name}: Too many nodes for mesh. Expected "
+                    f"{expected_nodes}, got {len(node_list)}"
+                )
+            elif expected_nodes > len(node_list):
+                warn(
+                    f"{node_params.node_type.name}: Too few nodes for mesh. Expected "
+                    f"{expected_nodes}, got {len(node_list)}"
+                )
+
+            for idx, node in enumerate(node_list):
+                mesh_router_idx = router_idx_list[idx // num_nodes_per_router]
+                router = self._routers[mesh_router_idx]
+
+                if node_params.dedicated_router:
+                    if node_params.node_type != CHI_NodeType.CHI_RNF:
+                        raise ValueError(
+                            "Node_Params.dedicated_router is only valid for RNFs."
+                        )
+                    router = self._create_rnf_router(router)
+
+                for controller in self._iter_node_controllers(node):
+                    self._ext_links.append(
+                        SimpleExtLink(
+                            link_id=self._link_count,
+                            ext_node=controller,
+                            int_node=router,
+                            latency=self._node_link_latency,
+                        )
+                    )
+                    self._link_count += 1
+        else:
+            # Circulate nodes across router_list when num_nodes_per_router == 0.
+            idx = 0
+            for node in node_list:
+                mesh_router_idx = router_idx_list[idx]
+                router = self._routers[mesh_router_idx]
+
+                if node_params.dedicated_router:
+                    if node_params.node_type != CHI_NodeType.CHI_RNF:
+                        raise ValueError(
+                            "Node_Params.dedicated_router is only valid for RNFs."
+                        )
+                    router = self._create_rnf_router(router)
+
+                for controller in self._iter_node_controllers(node):
+                    self._ext_links.append(
+                        SimpleExtLink(
+                            link_id=self._link_count,
+                            ext_node=controller,
+                            int_node=router,
+                            latency=self._node_link_latency,
+                        )
+                    )
+                    self._link_count += 1
+
+                idx = (idx + 1) % len(router_idx_list)
+
+    def _auto_pair_hnf_and_snf(self, cache_nodes, mem_nodes, pairing):
+        # Use the pairing defined by the configuration to reassign
+        # memory ranges.
+        pair_debug = False
+
+        print("Pairing HNFs to SNFs")
+        print(pairing)
+
+        all_cache = []
+        for cache_node in cache_nodes:
+            all_cache.extend(cache_node.getNetworkSideControllers())
+        all_mem = []
+        for mem_node in mem_nodes:
+            all_mem.extend(mem_node.getNetworkSideControllers())
+
+        # checks and maps index from pairing map to component
+        assert len(pairing) == len(all_cache)
+
+        def _to_list(val):
+            return val if isinstance(val, list) else [val]
+
+        for mem in all_mem:
+            mem._pairing = []
+
+        pairing_check = max(1, len(all_mem) / len(all_cache))
+        for cache_idx, cache in enumerate(all_cache):
+            cache._pairing = []
+            for mem_idx in _to_list(pairing[cache_idx]):
+                cache._pairing.append(all_mem[mem_idx])
+                if cache not in all_mem[mem_idx]._pairing:
+                    all_mem[mem_idx]._pairing.append(cache)
+            assert len(cache._pairing) == pairing_check
+            if pair_debug:
+                print(cache.path())
+                for addr_range in cache.addr_ranges:
+                    print(f"{addr_range}")
+                for paired in cache._pairing:
+                    print("\t" + paired.path())
+                    for addr_range in paired.addr_ranges:
+                        print(f"\t{addr_range}")
+
+        # all must be paired
+        for cache in all_cache:
+            assert len(cache._pairing) > 0
+        for mem in all_mem:
+            assert len(mem._pairing) > 0
+
+        # only support a single range for the main memory controllers
+        tgt_range_start = all_mem[0].addr_ranges[0].start.value
+        for mem in all_mem:
+            for addr_range in mem.addr_ranges:
+                if addr_range.start.value != tgt_range_start:
+                    fatal(
+                        "topologies.CustomMesh: not supporting pairing of "
+                        "main memory with multiple ranges"
+                    )
+
+        # reassign ranges for a 1 -> N pairing
+        def _rerange(src_cntrls, tgt_cntrls, fix_tgt_peer):
+            assert len(tgt_cntrls) >= len(src_cntrls)
+
+            def _range_to_bit(addr_ranges):
+                bit = None
+                for addr_range in addr_ranges:
+                    if bit is None:
+                        bit = addr_range.intlvMatch
+                    else:
+                        assert bit == addr_range.intlvMatch
+                return bit
+
+            def _get_peer(cntrl):
+                return cntrl.memory_out_port.peer.simobj
+
+            sorted_src = list(src_cntrls)
+            sorted_src.sort(key=lambda x: _range_to_bit(x.addr_ranges))
+
+            # Paired controllers need sequential interleaving match values.
+            intlv_match = 0
+            for src in sorted_src:
+                for tgt in src._pairing:
+                    for addr_range in tgt.addr_ranges:
+                        addr_range.intlvMatch = intlv_match
+                    if fix_tgt_peer:
+                        _get_peer(tgt).range.intlvMatch = intlv_match
+                    intlv_match = intlv_match + 1
+
+            # Recreate masks.
+            for src in sorted_src:
+                for src_range in src.addr_ranges:
+                    if src_range.start.value != tgt_range_start:
+                        continue
+                    new_src_mask = []
+                    for mask in src_range.masks:
+                        # TODO should mask all the way to the max range size
+                        new_src_mask.append(
+                            mask
+                            | (mask * 2)
+                            | (mask * 4)
+                            | (mask * 8)
+                            | (mask * 16)
+                        )
+                    for tgt in src._pairing:
+                        paired = False
+                        for tgt_range in tgt.addr_ranges:
+                            if tgt_range.start.value == src_range.start.value:
+                                src_range.masks = new_src_mask
+                                new_tgt_mask = []
+                                lsbs = len(tgt_range.masks) - len(new_src_mask)
+                                for idx in range(lsbs):
+                                    new_tgt_mask.append(tgt_range.masks[idx])
+                                for mask in new_src_mask:
+                                    new_tgt_mask.append(mask)
+                                tgt_range.masks = new_tgt_mask
+                                if fix_tgt_peer:
+                                    _get_peer(tgt).range.masks = new_tgt_mask
+                                paired = True
+                        if not paired:
+                            fatal(
+                                "topologies.CustomMesh: could not reassign "
+                                f"ranges {src.path()} {tgt.path()}"
+                            )
+
+        if len(all_mem) >= len(all_cache):
+            _rerange(all_cache, all_mem, True)
+        else:
+            _rerange(all_mem, all_cache, False)
+
+        if pair_debug:
+            print("")
+            for cache in all_cache:
+                assert len(cache._pairing) == pairing_check
+                print(cache.path())
+                for addr_range in cache.addr_ranges:
+                    print(f"{addr_range}")
+                for paired in cache._pairing:
+                    print("\t" + paired.path())
+                    for addr_range in paired.addr_ranges:
+                        print(f"\t{addr_range}")
+
+    def connectControllers(
+        self,
+        rnf: Optional[Tuple[Sequence[Any], Node_Params]] = None,
+        hnf: Optional[Tuple[Sequence[Any], Node_Params]] = None,
+        snf: Optional[Tuple[Sequence[Any], Node_Params]] = None,
+        snf_boot: Optional[Tuple[Sequence[Any], Node_Params]] = None,
+        rni: Optional[Tuple[Sequence[Any], Node_Params]] = None,
+    ):
+        # Create all mesh routers.
+        self._routers = [
+            Switch(router_id=i, latency=self._router_latency)
+            for i in range(self._num_mesh_routers)
+        ]
+
+        self._link_count = 0
+        self._int_links = []
+        self._ext_links = []
+
+        # Create all mesh internal links.
+        self._make_mesh()
+
+        # Place nodes using only provided (nodes, node_params) tuples.
+        for node_group in (rnf, hnf, snf, snf_boot, rni):
+            if node_group is None:
+                continue
+            nodes, nodes_params = node_group
+            self.distribute_nodes(nodes_params, nodes)
+
+        if self._pairing is not None:
+            hnf_nodes = [] if hnf is None else hnf[0]
+            snf_nodes = [] if snf is None else snf[0]
+            self._auto_pair_hnf_and_snf(hnf_nodes, snf_nodes, self._pairing)
+
+        self.routers = self._routers
+        self.int_links = self._int_links
+        self.ext_links = self._ext_links

--- a/src/python/gem5/components/cachehierarchies/ruby/topologies/custom_mesh.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/topologies/custom_mesh.py
@@ -34,6 +34,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import importlib
+import importlib.machinery
+import importlib.util
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -59,6 +61,24 @@ from ...chi.nodes.abstract_node import (
     CHI_NodeType,
     Node_Params,
 )
+
+
+def load_topology_config(topology_path: str):
+    """Load a topology config Python file as a module."""
+
+    path = Path(topology_path).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Topology config does not exist: {topology_path}"
+        )
+
+    module_name = f"topology_config_{path.stem}"
+    loader = importlib.machinery.SourceFileLoader(module_name, str(path))
+    module = importlib.util.module_from_spec(
+        importlib.util.spec_from_loader(module_name, loader)
+    )
+    loader.exec_module(module)
+    return module
 
 
 @dataclass(kw_only=True)

--- a/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run_mesh.py
+++ b/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run_mesh.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2025 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2022 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This example runs a simple linux boot on the ArmBoard.
+
+Characteristics
+---------------
+
+* Runs exclusively on the ARM ISA with the custom mesh
+"""
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+from m5.objects import (
+    ArmDefaultRelease,
+    VExpress_GEM5_Foundation,
+)
+
+from gem5.coherence_protocol import CoherenceProtocol
+from gem5.components.boards.arm_board import ArmBoard
+from gem5.components.memory.dram_interfaces.ddr4 import DDR4_2400_16x4
+from gem5.components.memory.memory import ChanneledMemory
+from gem5.components.processors.cpu_types import (
+    CPUTypes,
+    get_cpu_type_from_str,
+    get_cpu_types_str_set,
+)
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.CHI)
+from gem5.components.cachehierarchies.chi.nodes.abstract_node import (
+    CHI_NodeType,
+)
+from gem5.components.cachehierarchies.ruby.topologies.custom_mesh import (
+    load_topology_config,
+)
+
+parser = argparse.ArgumentParser(
+    description="A script to run the ARM boot exit tests."
+)
+
+parser.add_argument(
+    "-n",
+    "--num-cpus",
+    type=int,
+    required=True,
+    help="The number of CPUs.",
+)
+
+parser.add_argument(
+    "-c",
+    "--cpu",
+    type=str,
+    choices=get_cpu_types_str_set(),
+    required=True,
+    help="The CPU type.",
+)
+
+systemd_group = parser.add_mutually_exclusive_group(required=True)
+systemd_group.add_argument(
+    "--systemd",
+    action="store_true",
+    help="Enable systemd on boot.",
+)
+systemd_group.add_argument(
+    "--no-systemd",
+    action="store_true",
+    help="Disable systemd on boot.",
+)
+
+parser.add_argument(
+    "-t",
+    "--tick-exit",
+    type=int,
+    required=False,
+    help="The tick to exit the simulation.",
+)
+
+parser.add_argument(
+    "-r",
+    "--resource-directory",
+    type=str,
+    required=False,
+    help="The directory in which resources will be downloaded or exist.",
+)
+parser.add_argument(
+    "--topology-config",
+    type=str,
+    required=True,
+    help=(
+        "Path to a Python topology config module that defines NoC_Params and "
+        "get_node_params(node_type: CHI_NodeType) -> Node_Params."
+    ),
+)
+
+args = parser.parse_args()
+
+
+# Run a check to ensure the right version of gem5 is being used.
+requires(isa_required=ISA.ARM)
+
+topology_config = load_topology_config(args.topology_config)
+get_node_params = topology_config.get_node_params
+rnf_in_mesh = get_node_params(CHI_NodeType.CHI_RNF)
+snf_mainmem_in_mesh = get_node_params(CHI_NodeType.CHI_SNF_MainMem)
+
+if args.num_cpus != rnf_in_mesh.num_nodes():
+    raise ValueError(
+        f"--num-cpus ({args.num_cpus}) must match "
+        f"topology-config RNF node count ({rnf_in_mesh.num_nodes()})."
+    )
+
+noc_params = topology_config.NoC_Params
+cache_hierarchy = topology_config.cache_hierarchy_type()
+cache_hierarchy.add_default_nodes()
+
+# Setup the system memory.
+num_channels = snf_mainmem_in_mesh.num_nodes()
+
+memory = ChanneledMemory(
+    dram_interface_class=DDR4_2400_16x4,
+    num_channels=num_channels,
+    interleaving_size=64,
+    size="4GiB",
+)
+
+# Setup a processor.
+
+cpu_type = get_cpu_type_from_str(args.cpu)
+
+processor = SimpleProcessor(
+    cpu_type=cpu_type, num_cores=args.num_cpus, isa=ISA.ARM
+)
+
+
+# The ArmBoard requires a `release` to be specified.
+
+release = ArmDefaultRelease()
+
+# The platform sets up the memory ranges of all the on-chip and off-chip
+# devices present on the ARM system.
+
+platform = VExpress_GEM5_Foundation()
+
+# Setup the board.
+board = ArmBoard(
+    clk_freq="1GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+    release=release,
+    platform=platform,
+)
+
+# Set the Full System workload.
+board.set_workload(
+    obtain_resource(
+        (
+            "arm-ubuntu-24.04-boot-with-systemd"
+            if args.systemd
+            else "arm-ubuntu-24.04-boot-no-systemd"
+        ),
+        resource_directory=args.resource_directory,
+        resource_version=("3.0.0" if args.systemd else "2.0.0"),
+    ),
+)
+
+simulator = Simulator(board=board)
+
+if args.tick_exit:
+    simulator.set_max_ticks(args.tick_exit)
+
+simulator.run()
+
+print(
+    "Exiting @ tick {} because {}.".format(
+        simulator.get_current_tick(),
+        simulator.get_last_exit_event_cause(),
+    )
+)

--- a/tests/gem5/arm_boot_tests/test_linux_boot_mesh.py
+++ b/tests/gem5/arm_boot_tests/test_linux_boot_mesh.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+
+from testlib import *
+
+if config.bin_path:
+    resource_path = config.bin_path
+else:
+    resource_path = joinpath(absdirpath(__file__), "..", "resources")
+
+
+def test_boot_mesh(
+    cpu: str,
+    num_cpus: int,
+    length: str,
+    systemd: bool,
+    to_tick: int,
+):
+    name = f"{cpu}-cpu_{num_cpus}-cores_{mem_system}_" "arm_boot_test_mesh_2x4"
+
+    config_args = [
+        "--cpu",
+        cpu,
+        "--num-cpus",
+        str(num_cpus),
+        "--resource-directory",
+        resource_path,
+        "--topology-config",
+        joinpath(
+            config.base_dir,
+            "configs",
+            "example",
+            "arm",
+            "noc_configs",
+            "mesh_2x4.py",
+        ),
+        "--systemd" if systemd else "--no-systemd",
+        "--tick-exit",
+        str(to_tick),
+    ]
+
+    verifiers = [
+        verifier.MatchRegex(
+            re.compile(
+                f"Exiting @ tick {str(to_tick)} because simulate\\(\\) limit reached"
+            )
+        )
+    ]
+
+    gem5_verify_config(
+        name=name,
+        verifiers=verifiers,
+        fixtures=(),
+        config=joinpath(
+            config.base_dir,
+            "tests",
+            "gem5",
+            "arm_boot_tests",
+            "configs",
+            "arm_boot_exit_run_mesh.py",
+        ),
+        config_args=config_args,
+        valid_isas=(constants.all_compiled_tag,),
+        valid_hosts=constants.supported_hosts,
+        length=length,
+    )
+
+
+test_boot_mesh(
+    cpu="timing",
+    num_cpus=4,
+    length=constants.quick_tag,
+    to_tick=10000000000,
+    systemd=False,
+)


### PR DESCRIPTION
This PR adds the following CustomMesh based cache hierarchies in stdlib:

- PrivateL1PrivateL2MeshCacheHierarchy
- PrivateL1PrivateL2SharedL3MeshCacheHIerarchy

To do so the CustomMesh model in configs/topologies/CustomMesh has been ported
to the stdlib environment.
The philosophy behind these new hierarchies is the same behind the original
CustomMesh topology in configs/ruby: the user will provide a topology file
which details the placement and configuration of relevant CHI nodes in the
mesh. See for example the old 2x4.py chi-config file:

https://github.com/gem5/gem5/blob/stable/configs/example/noc_config/2x4.py

With the PR we provide the porting of the same example into the new stdlib format:

https://github.com/gem5/gem5/compare/develop...giactra:gem5:stdlib-mesh?expand=1#diff-ee2a51d9c1acecb76233b7fcfeb05dcf6a9a9adc20ceef288cde72e33a9d48af

The structure is more or less similar with the following distinctions:

1) Distinct Node_Params (CHI node specific) and NoC_Params (MESH specific) as
opposed to global NoC_Params and Node::NoC_Params
2) configuration is not based on subclassing anymore and Node_Params are
objects which get initialized with different values
3) The example file has to respect a particular interface which is
assumed by consumer scripts; the following symbols have to be defined/exposed:
**get_node_params** (to retrieve node parameters) and **cache_hierarchy_type**
(to instantiate the cache hierarchy)

The PR also contains a testlib config to be added to our CI, and a hybrid configs/example/arm
script (ruby_fs_mesh.py) which uses the new cache hierarchy (without using the ArmBoard)