### PR TITLE
mem-ruby: MessageBuffer observation and validation patches

### DIFF
--- a/configs/example/msgbuffer_test.py
+++ b/configs/example/msgbuffer_test.py
@@ -1,5 +1,3 @@
-# -*- mode:python -*-
-
 # Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
@@ -11,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2009 The Hewlett-Packard Development Company
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -38,25 +33,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+# import the m5 (gem5) library created when gem5 is built
+import m5
 
-if not env['CONF']['RUBY']:
-    Return()
+# import all of the SimObjects
+from m5.objects import *
 
-DebugFlag('TraceRoutesDebug')
+# create the system we are going to simulate
+root = Root(full_system=False)
 
-SimObject('BasicLink.py', sim_objects=[
-    'BasicLink', 'BasicExtLink', 'BasicIntLink'])
-SimObject('BasicRouter.py', sim_objects=['BasicRouter'])
-SimObject('MessageBuffer.py', sim_objects=['MessageBuffer'],
-        enums=['MessageRandomization'])
-SimObject('MessageBufferTest.py', sim_objects=['MessageBufferProducerTest',
-    'MessageBufferConsumerTest'])
-SimObject('Network.py', sim_objects=['RubyNetwork'])
+# Set the clock fequency of the system (and all of its children)
+root.clk_domain = SrcClockDomain()
+root.clk_domain.clock = "1GHz"
+root.clk_domain.voltage_domain = VoltageDomain()
 
-Source('BasicLink.cc')
-Source('BasicRouter.cc')
-Source('MessageBuffer.cc')
-Source('Network.cc')
-Source('RouteProfiler.cc')
-Source('Topology.cc')
+latency = 12
+channels = 3
+# buffer_size = channels * latency * 2
+buffer_size = channels * (latency + 1)
+# buffer_size = channels
+
+num_msgs = 100000
+
+root.buffer = MessageBuffer(buffer_size=buffer_size, max_dequeue_rate=channels)
+
+root.producer = MessageBufferProducerTest(
+    rate=channels, num_msgs=num_msgs, latency=latency, buffer=root.buffer
+)
+
+root.consumer = MessageBufferConsumerTest(
+    rate=channels, stall_prob=0.01, num_msgs=num_msgs, buffer=root.buffer
+)
+
+# instantiate all of the objects we've created above
+m5.instantiate()
+
+print("Beginning simulation!")
+exit_event = m5.simulate()
+print("Exiting @ tick %i because %s" % (m5.curTick(), exit_event.getCause()))

--- a/src/mem/ruby/network/MessageBuffer.cc
+++ b/src/mem/ruby/network/MessageBuffer.cc
@@ -104,6 +104,7 @@ MessageBuffer::MessageBuffer(const Params &p)
     m_stall_msg_map.clear();
     m_input_link_id = 0;
     m_vnet_id = 0;
+    m_int_link = nullptr;
 
     m_buf_msgs = 0;
     m_stall_time = 0;

--- a/src/mem/ruby/network/MessageBuffer.hh
+++ b/src/mem/ruby/network/MessageBuffer.hh
@@ -71,6 +71,8 @@ namespace gem5
 namespace ruby
 {
 
+class BasicIntLink;
+
 class MessageBuffer : public SimObject
 {
   public:
@@ -204,6 +206,19 @@ class MessageBuffer : public SimObject
         return m_is_inport;
     }
 
+    BasicIntLink *
+    getIntLink()
+    {
+        return m_int_link;
+    }
+
+    void
+    setIntLink(BasicIntLink *int_link)
+    {
+        assert(m_int_link == nullptr);
+        m_int_link = int_link;
+    }
+
   private:
     void reanalyzeList(std::list<MsgPtr> &, Tick);
 
@@ -296,6 +311,8 @@ class MessageBuffer : public SimObject
 
     int m_input_link_id;
     int m_vnet_id;
+
+    BasicIntLink *m_int_link;
 
     // Count the # of times I didn't have N slots available
     statistics::Scalar m_not_avail_count;

--- a/src/mem/ruby/network/MessageBufferTest.hh
+++ b/src/mem/ruby/network/MessageBufferTest.hh
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_NETWORK_MESSAGEBUFFERTEST_HH__
+#define __MEM_RUBY_NETWORK_MESSAGEBUFFERTEST_HH__
+
+#include "base/random.hh"
+#include "mem/ruby/common/Consumer.hh"
+#include "mem/ruby/network/MessageBuffer.hh"
+#include "params/MessageBufferConsumerTest.hh"
+#include "params/MessageBufferProducerTest.hh"
+#include "sim/sim_exit.hh"
+#include "sim/stats.hh"
+
+namespace gem5
+{
+
+namespace ruby
+{
+
+class MessageBufferConsumerTest : public ClockedObject, Consumer
+{
+  public:
+    MessageBuffer *buffer;
+    int num_msgs;
+    const int max_msgs;
+    const int rate;
+    const float stall_prob;
+
+    typedef MessageBufferConsumerTestParams Params;
+    MessageBufferConsumerTest(const Params &p)
+        : ClockedObject(p),
+          Consumer(this),
+          buffer(p.buffer),
+          num_msgs(0),
+          max_msgs(p.num_msgs),
+          rate(p.rate),
+          stall_prob(p.stall_prob)
+    {
+        buffer->setConsumer(this);
+    }
+
+    statistics::Scalar msgsTotal;
+    statistics::Formula msgsPerCy;
+
+    void
+    regStats() override
+    {
+        ClockedObject::regStats();
+
+        msgsTotal.name(name() + ".msgsTotal").desc("Messages");
+        msgsPerCy.name(name() + ".msgsPerCy").desc("Messages per cycle");
+        msgsPerCy = msgsTotal / (simTicks / cyclesToTicks(Cycles(1)));
+    }
+
+    void
+    wakeup() override
+    {
+        static Random::RandomPtr rng(Random::genRandom());
+        if (rng->random<float>() >= stall_prob) {
+            for (int i = 0; (i < rate) && buffer->isReady(curTick()); ++i) {
+                buffer->dequeue(curTick(), true);
+                ++msgsTotal;
+                ++num_msgs;
+            }
+        }
+        if (buffer->isReady(curTick())) {
+            scheduleEvent(Cycles(1));
+        }
+        if (num_msgs >= max_msgs) {
+            exitSimLoop("max number of operations reached");
+        }
+    }
+
+    void
+    print(std::ostream &out) const override
+    {
+        out << name();
+    };
+};
+
+class MessageBufferProducerTest : public ClockedObject
+{
+  public:
+    MessageBuffer *buffer;
+    const int rate;
+    const int max_msgs;
+    const Cycles latency;
+    int num_msgs;
+    int pending_msgs;
+    EventFunctionWrapper prod_event;
+    EventFunctionWrapper enq_event;
+
+    typedef MessageBufferProducerTestParams Params;
+    MessageBufferProducerTest(const Params &p)
+        : ClockedObject(p),
+          buffer(p.buffer),
+          rate(p.rate),
+          max_msgs(p.num_msgs),
+          latency(p.latency),
+          num_msgs(0),
+          pending_msgs(0),
+          prod_event([this] { produce(); }, "Produce Event"),
+          enq_event([this] { enqueue(); }, "Enqueue Event")
+    {}
+
+    void
+    scheduleProduce()
+    {
+        assert(rate != 0);
+        if (rate > 0) {
+            schedule(&prod_event, clockEdge(Cycles(1)));
+        } else {
+            schedule(&prod_event, clockEdge(Cycles(rate * -1)));
+        }
+    }
+
+    void
+    scheduleEnqueue(Tick tick)
+    {
+        if (pending_msgs > 0) {
+            if (enq_event.scheduled()) {
+                reschedule(&enq_event, tick, true);
+            } else {
+                schedule(&enq_event, tick);
+            }
+        }
+    }
+
+    void
+    init() override
+    {
+        ClockedObject::init();
+        scheduleProduce();
+    }
+
+    statistics::Scalar msgsTotal;
+    statistics::Formula msgsPerCy;
+
+    void
+    regStats() override
+    {
+        ClockedObject::regStats();
+
+        msgsTotal.name(name() + ".msgsTotal").desc("Messages");
+        msgsPerCy.name(name() + ".msgsPerCy").desc("Messages per cycle");
+        msgsPerCy = msgsTotal / (simTicks / cyclesToTicks(Cycles(1)));
+    }
+
+    void
+    produce()
+    {
+        if (num_msgs >= max_msgs) {
+            return;
+        }
+        int prod_msgs = 0;
+        if (rate >= 1) {
+            prod_msgs += rate;
+        } else {
+            prod_msgs += 1;
+        }
+        prod_msgs = std::min(prod_msgs, max_msgs - num_msgs);
+        pending_msgs += prod_msgs;
+        num_msgs += prod_msgs;
+        scheduleEnqueue(curTick());
+        scheduleProduce();
+    }
+
+    struct DummyMessage : Message
+    {
+        DummyMessage(Tick curTick) : Message(curTick, 64, nullptr) {}
+        MsgPtr
+        clone() const override
+        {
+            return std::make_shared<DummyMessage>(getTime());
+        }
+        void print(std::ostream &out) const override {};
+    };
+
+    void
+    enqueue()
+    {
+        while (pending_msgs > 0) {
+            if (buffer->areNSlotsAvailable(1, curTick())) {
+                buffer->enqueue(std::make_shared<DummyMessage>(curTick()),
+                                curTick(), cyclesToTicks(latency), false,
+                                false);
+                ++msgsTotal;
+                --pending_msgs;
+            } else {
+                scheduleEnqueue(clockEdge(Cycles(1)));
+                break;
+            }
+        }
+    }
+};
+
+} // namespace ruby
+} // namespace gem5
+
+#endif //__MEM_RUBY_NETWORK_MESSAGEBUFFER_HH__

--- a/src/mem/ruby/network/MessageBufferTest.py
+++ b/src/mem/ruby/network/MessageBufferTest.py
@@ -1,5 +1,3 @@
-# -*- mode:python -*-
-
 # Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
@@ -11,9 +9,6 @@
 # terms below provided that you ensure that this notice is replicated
 # unmodified and in its entirety in all distributions of the software,
 # modified or unmodified, in source code or in binary form.
-#
-# Copyright (c) 2009 The Hewlett-Packard Development Company
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -38,25 +33,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from m5.objects.ClockedObject import ClockedObject
+from m5.params import *
+from m5.proxy import *
 
-if not env['CONF']['RUBY']:
-    Return()
 
-DebugFlag('TraceRoutesDebug')
+class MessageBufferProducerTest(ClockedObject):
+    type = "MessageBufferProducerTest"
+    cxx_class = "gem5::ruby::MessageBufferProducerTest"
+    cxx_header = "mem/ruby/network/MessageBufferTest.hh"
 
-SimObject('BasicLink.py', sim_objects=[
-    'BasicLink', 'BasicExtLink', 'BasicIntLink'])
-SimObject('BasicRouter.py', sim_objects=['BasicRouter'])
-SimObject('MessageBuffer.py', sim_objects=['MessageBuffer'],
-        enums=['MessageRandomization'])
-SimObject('MessageBufferTest.py', sim_objects=['MessageBufferProducerTest',
-    'MessageBufferConsumerTest'])
-SimObject('Network.py', sim_objects=['RubyNetwork'])
+    rate = Param.Int(
+        1,
+        "Number of messages to produce per cycle,"
+        "note negative values are taken as fractional e.g. -5"
+        "is 5 cycles per message",
+    )
 
-Source('BasicLink.cc')
-Source('BasicRouter.cc')
-Source('MessageBuffer.cc')
-Source('Network.cc')
-Source('RouteProfiler.cc')
-Source('Topology.cc')
+    num_msgs = Param.Int(1, "Total number of messages to produce")
+
+    latency = Param.Cycles(1, "Cycles until message is ready after production")
+
+    buffer = Param.MessageBuffer("")
+
+
+class MessageBufferConsumerTest(ClockedObject):
+    type = "MessageBufferConsumerTest"
+    cxx_class = "gem5::ruby::MessageBufferConsumerTest"
+    cxx_header = "mem/ruby/network/MessageBufferTest.hh"
+
+    rate = Param.Int(1, "Maximum number of messages consumable within a cycle")
+
+    num_msgs = Param.Int(1, "Total number of messages to consume")
+
+    stall_prob = Param.Float(
+        0, "Probability consumer cannot consume messages in a cycle"
+    )
+
+    buffer = Param.MessageBuffer("")

--- a/src/mem/ruby/network/RouteProfiler.cc
+++ b/src/mem/ruby/network/RouteProfiler.cc
@@ -69,8 +69,11 @@ RouteProfiler::profFrontEndRdy(Message *msg, BasicRouter *router,
     }
     if (entry.entries.empty() || (entry.entries.back().router != router)) {
         entry.entries.emplace_back(router, curTick());
-        DPRINTFS(TraceRoutesDebug, router, "Msg %#x entering router vnet=%d\n",
-                 msg, vnet);
+        DPRINTFS(TraceRoutesDebug, router,
+                 "Msg %#x entering router vnet=%d port=%s\n", msg, vnet,
+                 src_link->getIntLink() == nullptr
+                     ? ""
+                     : src_link->getIntLink()->params().dst_inport);
     }
     assert(entry.entries.back().router == router);
 }
@@ -143,7 +146,8 @@ RouteProfiler::profBackEndRdy(Message *msg, BasicRouter *router, int vnet)
 }
 
 void
-RouteProfiler::profBackEndFwd(Message *msg, BasicRouter *router, int vnet)
+RouteProfiler::profBackEndFwd(Message *msg, BasicRouter *router,
+                              MessageBuffer *dest_link, int vnet)
 {
     if (!m_enabled) {
         return;
@@ -157,10 +161,15 @@ RouteProfiler::profBackEndFwd(Message *msg, BasicRouter *router, int vnet)
     OutstandingRouteEntry &entry = iter->second.entries.back();
     assert(entry.router == router);
     entry.backend_fwd = curTick();
-    DPRINTFS(TraceRoutesDebug, router,
-             "Msg %#x leaving router vnet=%d delay=%d delay_total=%d\n", msg,
-             vnet, entry.backend_fwd - entry.frontend_rdy,
-             entry.backend_fwd - iter->second.entries.front().frontend_rdy);
+    DPRINTFS(
+        TraceRoutesDebug, router,
+        "Msg %#x leaving router vnet=%d port=%s delay=%d delay_total=%d\n",
+        msg, vnet,
+        dest_link->getIntLink() == nullptr
+            ? ""
+            : dest_link->getIntLink()->params().src_outport,
+        entry.backend_fwd - entry.frontend_rdy,
+        entry.backend_fwd - iter->second.entries.front().frontend_rdy);
 }
 
 void
@@ -171,7 +180,7 @@ RouteProfiler::profBackEndFwdExt(Message *msg, BasicRouter *router,
         return;
     }
 
-    profBackEndFwd(msg, router, vnet);
+    profBackEndFwd(msg, router, dest_link, vnet);
     auto iter = outstanding_routes.find(msg);
     OutstandingRoute &entry = iter->second;
 

--- a/src/mem/ruby/network/RouteProfiler.hh
+++ b/src/mem/ruby/network/RouteProfiler.hh
@@ -74,7 +74,8 @@ class RouteProfiler
     void profBackEndRdy(Message *msg, BasicRouter *router, int vnet);
 
     // Notifies a ready message was sent through the output link
-    void profBackEndFwd(Message *msg, BasicRouter *router, int vnet);
+    void profBackEndFwd(Message *msg, BasicRouter *router,
+                        MessageBuffer *dest_link, int vnet);
 
     // Notifies a ready message was sent through the output link to
     // its final destination

--- a/src/mem/ruby/network/simple/SimpleNetwork.cc
+++ b/src/mem/ruby/network/simple/SimpleNetwork.cc
@@ -162,6 +162,11 @@ SimpleNetwork::makeInternalLink(SwitchID src, SwitchID dest, BasicLink* link,
                                 simple_link->m_bw_multiplier,
                                 false,
                                 dst_inport);
+
+    for (auto buffer : simple_link->m_buffers) {
+        buffer->setIntLink(simple_link);
+    }
+
     // Maitain a global list of buffers (used for functional accesses only)
     m_int_link_buffers.insert(m_int_link_buffers.end(),
             simple_link->m_buffers.begin(), simple_link->m_buffers.end());

--- a/src/mem/ruby/network/simple/Switch.cc
+++ b/src/mem/ruby/network/simple/Switch.cc
@@ -249,9 +249,9 @@ Switch::profBackEndRdy(Message *msg, int vnet)
 }
 
 void
-Switch::profBackEndFwd(Message *msg, int vnet)
+Switch::profBackEndFwd(Message *msg, MessageBuffer *dest_link, int vnet)
 {
-    m_network_ptr->routeProfiler.profBackEndFwd(msg, this, vnet);
+    m_network_ptr->routeProfiler.profBackEndFwd(msg, this, dest_link, vnet);
 }
 
 void

--- a/src/mem/ruby/network/simple/Switch.hh
+++ b/src/mem/ruby/network/simple/Switch.hh
@@ -150,7 +150,7 @@ class Switch : public BasicRouter
                               Message *clone_from_msg);
     void profFrontEndFwd(Message *msg, int vnet);
     void profBackEndRdy(Message *msg, int vnet);
-    void profBackEndFwd(Message *msg, int vnet);
+    void profBackEndFwd(Message *msg, MessageBuffer *dest_link, int vnet);
     void profBackEndFwdExt(Message *msg, MessageBuffer *dest_link, int vnet);
 };
 

--- a/src/mem/ruby/network/simple/Throttle.cc
+++ b/src/mem/ruby/network/simple/Throttle.cc
@@ -212,7 +212,7 @@ Throttle::operateVnet(int vnet, int channel, int &total_bw_remaining,
             if (out->isInport()) {
                 m_switch->profBackEndFwdExt(net_msg_ptr, out, vnet);
             } else {
-                m_switch->profBackEndFwd(net_msg_ptr, vnet);
+                m_switch->profBackEndFwd(net_msg_ptr, out, vnet);
             }
 
             // Could still have more ready but won't execute because no more


### PR DESCRIPTION
These commits both help to simplify and test behavior in the Ruby network. The first patch adds a small example test for MessageBuffer which contains dummy producers and consumers to create and dequeue messages at configurable rates.
Patch two extends TraceRoutesDebug to simplify tracking routes around a SimpleNetwork building on #3134
