### PR TITLE
base: Fix ldMin/ldMax not updated in handleLoadableSegment

### DIFF
--- a/src/base/loader/elf_object.cc
+++ b/src/base/loader/elf_object.cc
@@ -46,6 +46,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cassert>
 #include <string>
 
@@ -391,6 +392,9 @@ ElfObject::handleLoadableSegment(GElf_Phdr phdr, int seg_num)
         image.addSegment({ name + "(uninitialized)",
                            phdr.p_paddr + phdr.p_filesz, uninitialized });
     }
+
+    ldMin = std::min(ldMin, phdr.p_vaddr);
+    ldMax = std::max(ldMax, phdr.p_vaddr + phdr.p_memsz);
 
     const Addr file_start = phdr.p_offset;
     const Addr file_end = file_start + phdr.p_filesz;

--- a/src/base/loader/elf_object.hh
+++ b/src/base/loader/elf_object.hh
@@ -94,7 +94,7 @@ class ElfObject : public ObjectFile
     // The ldMin and ldMax fields are required to know how large of an
     // area is required to map the interpreter.
     Addr ldMin = MaxAddr;
-    Addr ldMax = MaxAddr;
+    Addr ldMax = 0;
 
     /// Helper functions for loadGlobalSymbols() and loadLocalSymbols().
     bool loadSomeSymbols(SymbolTable *symtab, int binding, Addr mask,
@@ -116,7 +116,14 @@ class ElfObject : public ObjectFile
 
     Addr bias() const override { return ldBias; }
     bool relocatable() const override { return relocate; }
-    Addr mapSize() const override { return ldMax - ldMin; }
+    Addr
+    mapSize() const override
+    {
+        // ldMin/ldMax stay at their sentinel values if no non-empty
+        // PT_LOAD segment was seen. Returning ldMax - ldMin in that case
+        // would underflow, so report an empty mapping instead.
+        return (ldMin <= ldMax) ? (ldMax - ldMin) : 0;
+    }
     void updateBias(Addr bias_addr) override;
 
     bool hasTLS() override { return sectionExists(".tbss"); }


### PR DESCRIPTION
## Summary

In SE mode, `ElfObject::handleLoadableSegment()` never updates `ldMin`
and `ldMax`, causing `mapSize()` to always return 0. As a result,
`Process::updateBias()` computes `interp_mapsize=0` and `mmap_end` is
never advanced to reserve space for the dynamic linker. This can cause
subsequent `mmap` allocations to overlap the interpreter's address region.

Fixes #3217

## Root Cause

The bug was introduced as a regression in `d856e5ce71` ("arch,base:
Restructure the object file loaders"), which extracted the PT_LOAD
loop body into `handleLoadableSegment()` but accidentally dropped the
two lines that tracked `ldMin`/`ldMax`.

Before the refactoring, the constructor explicitly set these:
```cpp
ldMin(std::numeric_limits<Addr>::max()),
ldMax(std::numeric_limits<Addr>::min())
...
ldMin = std::min(ldMin, phdr.p_vaddr);
ldMax = std::max(ldMax, phdr.p_vaddr + phdr.p_memsz);
```

## Changes

**`src/base/loader/elf_object.cc`** — add the missing two lines to
`handleLoadableSegment()`:
```cpp
ldMin = std::min(ldMin, phdr.p_vaddr);
ldMax = std::max(ldMax, phdr.p_vaddr + phdr.p_memsz);
```

**`src/base/loader/elf_object.hh`** — fix the initial value of `ldMax`:
```cpp
Addr ldMax = 0;  // was MaxAddr; should be 0 for correct max-tracking
```

## Test Plan

- [ ] SE mode: run a dynamically-linked binary and confirm `mmap_end`
      advances by the interpreter's actual size after `updateBias()`
- [ ] SE mode: confirm interpreter load address does not overlap with
      subsequent `mmap` allocations