### PR TITLE
mem-cache: fix WriteClean snoop response in write buffer

### DIFF
--- a/src/mem/cache/cache.cc
+++ b/src/mem/cache/cache.cc
@@ -1333,8 +1333,12 @@ Cache::recvTimingSnoopReq(PacketPtr pkt)
         // this cache, so the behaviour is modelled after handleSnoop,
         // the difference being that instead of querying the block
         // state to determine if it is dirty and writable, we use the
-        // command and fields of the writeback packet
-        bool respond = wb_pkt->cmd == MemCmd::WritebackDirty &&
+        // command and fields of the writeback packet.
+        // Note: WriteClean packets also carry dirty data that must be
+        // supplied to snooping requests, otherwise the requestor will
+        // fetch stale data from memory below.
+        bool respond = (wb_pkt->cmd == MemCmd::WritebackDirty ||
+                        wb_pkt->cmd == MemCmd::WriteClean) &&
             pkt->needsResponse();
         bool have_writable = !wb_pkt->hasSharers();
         bool invalidate = pkt->isInvalidate();


### PR DESCRIPTION
When a snoop request (e.g., ReadExReq) hits a WriteClean packet in the write buffer, the cache should supply the dirty data carried by the WriteClean to the snooping requestor. Previously, only WritebackDirty packets in the write buffer would trigger a data response; WriteClean packets were silently skipped.

This caused a coherence violation in multi-core scenarios involving cache maintenance operations (e.g., RISC-V cbo.flush). The race condition occurs when:

1. Core A executes a store followed by cbo.flush
2. The cbo.flush generates a WriteClean (carrying the store data) that enters the L1 write buffer
3. Core B issues a ReadExReq for the same line, which snoops Core A L1 and hits the WriteClean in the write buffer
4. Because WriteClean was not handled, Core B receives no data and fetches stale data from lower memory
5. The stale data is later written back, overwriting the correct value

Fix by extending the respond condition to also match WriteClean packets, ensuring their dirty data is supplied to snooping requests.