### PR TITLE
arch-riscv: refactor vector reduction instructions

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -893,11 +893,10 @@ VCpyVsMicroInst::generateDisassembly(Addr pc,
 
 VPinVdMicroInst::VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                                  uint32_t _numVdPins, uint32_t _elen,
-                                 uint32_t _vlen, bool _isSlideupVx,
-                                 bool _isReduction)
+                                 uint32_t _vlen, bool _isSlideupVx)
     : VectorArithMicroInst("vpinvd_v_micro", _machInst, SimdMiscOp, 0,
                            _microIdx, _elen, _vlen),
-      isSlideupVx(_isSlideupVx), isReduction(_isReduction)
+      isSlideupVx(_isSlideupVx)
 {
     setRegIdxArrays(
         reinterpret_cast<RegIdArrayPtr>(
@@ -940,7 +939,7 @@ VPinVdMicroInst::execute(ExecContext* xc, trace::InstRecord* traceData) const
     const uint32_t sewb = getSew(machInst.vtype8.vsew) >> 3;
     const uint32_t micro_vlmax = vtype_VLMAX(machInst.vtype8, vlen, true);
     const uint32_t micro_vl = std::min(vl - micro_vlmax*microIdx, micro_vlmax);
-    const uint32_t active_bytes = isReduction ? sewb:micro_vl*sewb;
+    const uint32_t active_bytes = micro_vl * sewb;
     const uint32_t total_bytes  = micro_vlmax*sewb;
 
     vreg_t& vd_container = *(vreg_t *)xc->getWritableRegOperand(this, 0);

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -811,12 +811,11 @@ class VPinVdMicroInst : public VectorArithMicroInst
         RegId srcRegIdxArr[3];
         RegId destRegIdxArr[1];
         const bool isSlideupVx;
-        const bool isReduction;
 
       public:
         VPinVdMicroInst(ExtMachInst _machInst, uint32_t _microIdx,
                         uint32_t _numVdPins, uint32_t _elen, uint32_t _vlen,
-                        bool _isSlideupVx = false, bool _isReduction = false);
+                        bool _isSlideupVx = false);
         Fault execute(ExecContext *, trace::InstRecord *) const override;
         std::string generateDisassembly(
                 Addr pc, const loader::SymbolTable *symtab) const override;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3862,14 +3862,14 @@ decode QUADRANT default Unknown::unknown() {
                         Vd_vi[i] = val >> sh;
                     }}, OPIVV, SimdShiftOp);
                 }
-                format VectorReduceIntWideningFormat {
+                format VectorReduceFormat {
                     0x30: vwredsumu_vs({{
                         Vd_vwu[0] = reduce_loop(std::plus<vwu>(),
-                            Vs1_vwu, Vs2_vu);
+                            Vs1_vwu[0]);
                     }}, OPIVV, SimdReduceAddOp);
                     0x31: vwredsum_vs({{
-                        Vd_vwu[0] = reduce_loop(std::plus<vwi>(),
-                            Vs1_vwi, Vs2_vi);
+                        Vd_vwi[0] = reduce_loop(std::plus<vwi>(),
+                            Vs1_vwi[0]);
                     }}, OPIVV, SimdReduceAddOp);
                 }
                 format VectorIntMaskFormat {
@@ -3988,40 +3988,40 @@ decode QUADRANT default Unknown::unknown() {
                                        ftype<et>(Vs1_vu[i]));
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, SimdFloatAddOp);
-                0x01: VectorReduceFloatFormat::vfredusum_vs({{
+                0x01: VectorReduceFormat::vfredusum_vs({{
                     Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fadd<et>(ftype<et>(src1), ftype<et>(src2));
-                    }, Vs1_vu, Vs2_vu);
+                    }, Vs1_vu[0]);
                 }}, OPFVV, SimdFloatReduceAddOp);
                 0x02: VectorFloatFormat::vfsub_vv({{
                     auto fd = fsub<et>(ftype<et>(Vs2_vu[i]),
                                        ftype<et>(Vs1_vu[i]));
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, SimdFloatAddOp);
-                0x03: VectorReduceFloatFormat::vfredosum_vs({{
+                0x03: VectorReduceFormat::vfredosum_vs({{
                     Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fadd<et>(ftype<et>(src1), ftype<et>(src2));
-                    }, Vs1_vu, Vs2_vu);
-                }}, OPFVV, SimdFloatReduceAddOp, IsSerializeAfter);
+                    }, Vs1_vu[0]);
+                }}, OPFVV, SimdFloatReduceAddOp);
                 0x04: VectorFloatFormat::vfmin_vv({{
                     auto fd = fmin<et>(ftype<et>(Vs2_vu[i]),
                                        ftype<et>(Vs1_vu[i]));
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, SimdFloatCmpOp);
-                0x05: VectorReduceFloatFormat::vfredmin_vs({{
+                0x05: VectorReduceFormat::vfredmin_vs({{
                     Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fmin<et>(ftype<et>(src1), ftype<et>(src2));
-                    }, Vs1_vu, Vs2_vu);
+                    }, Vs1_vu[0]);
                 }}, OPFVV, SimdFloatReduceCmpOp);
                 0x06: VectorFloatFormat::vfmax_vv({{
                     auto fd = fmax<et>(ftype<et>(Vs2_vu[i]),
                                        ftype<et>(Vs1_vu[i]));
                     Vd_vu[i] = fd.v;
                 }}, OPFVV, SimdFloatCmpOp);
-                0x07: VectorReduceFloatFormat::vfredmax_vs({{
+                0x07: VectorReduceFormat::vfredmax_vs({{
                     Vd_vu[0] = reduce_loop([](const vu& src1, const vu& src2) {
                         return fmax<et>(ftype<et>(src1), ftype<et>(src2));
-                    }, Vs1_vu, Vs2_vu);
+                    }, Vs1_vu[0]);
                 }}, OPFVV, SimdFloatReduceCmpOp);
                 0x08: VectorFloatFormat::vfsgnj_vv({{
                     Vd_vu[i] = fsgnj<et>(ftype<et>(Vs2_vu[i]),
@@ -4253,24 +4253,24 @@ decode QUADRANT default Unknown::unknown() {
                                             ftype<et>(Vs3_vu[i]));
                         Vd_vu[i] = fd.v;
                     }}, OPFVV, SimdFloatMultAccOp);
-                    0x31: VectorReduceFloatWideningFormat::vfwredusum_vs({{
+                    0x31: VectorReduceFormat::vfwredusum_vs({{
                         Vd_vwu[0] = reduce_loop(
                             [](const vwu& src1, const vu& src2) {
                                 return fadd<ewt>(
                                     ftype<ewt>(src1),
                                     f_to_wf<et>(ftype<et>(src2))
                                 );
-                            }, Vs1_vwu, Vs2_vu);
+                            }, Vs1_vwu[0]);
                     }}, OPFVV, SimdFloatReduceAddOp);
-                    0x33: VectorReduceFloatWideningFormat::vfwredosum_vs({{
+                    0x33: VectorReduceFormat::vfwredosum_vs({{
                         Vd_vwu[0] = reduce_loop(
                             [](const vwu& src1, const vu& src2) {
                                 return fadd<ewt>(
                                     ftype<ewt>(src1),
                                     f_to_wf<et>(ftype<et>(src2))
                                 );
-                            }, Vs1_vwu, Vs2_vu);
-                    }}, OPFVV, SimdFloatReduceAddOp, IsSerializeAfter);
+                            }, Vs1_vwu[0]);
+                    }}, OPFVV, SimdFloatReduceAddOp);
                 }
                 format VectorFloatWideningFormat {
                     0x30: vfwadd_vv({{
@@ -4335,46 +4335,46 @@ decode QUADRANT default Unknown::unknown() {
             }
             // OPMVV
             0x2: decode VFUNCT6 {
-                format VectorReduceIntFormat {
+                format VectorReduceFormat {
                     0x0: vredsum_vs({{
                         Vd_vi[0] =
-                            reduce_loop(std::plus<vi>(), Vs1_vi, Vs2_vi);
+                            reduce_loop(std::plus<vi>(), Vs1_vi[0]);
                     }}, OPMVV, SimdReduceAddOp);
                     0x1: vredand_vs({{
                         Vd_vi[0] =
-                            reduce_loop(std::bit_and<vi>(), Vs1_vi, Vs2_vi);
+                            reduce_loop(std::bit_and<vi>(), Vs1_vi[0]);
                     }}, OPMVV, SimdReduceAluOp);
                     0x2: vredor_vs({{
                         Vd_vi[0] =
-                            reduce_loop(std::bit_or<vi>(), Vs1_vi, Vs2_vi);
+                            reduce_loop(std::bit_or<vi>(), Vs1_vi[0]);
                     }}, OPMVV, SimdReduceAluOp);
                     0x3: vredxor_vs({{
                         Vd_vi[0] =
-                            reduce_loop(std::bit_xor<vi>(), Vs1_vi, Vs2_vi);
+                            reduce_loop(std::bit_xor<vi>(), Vs1_vi[0]);
                     }}, OPMVV, SimdReduceAluOp);
                     0x4: vredminu_vs({{
                         Vd_vu[0] =
                             reduce_loop([](const vu& src1, const vu& src2) {
                                 return std::min<vu>(src1, src2);
-                            }, Vs1_vu, Vs2_vu);
+                            }, Vs1_vu[0]);
                     }}, OPMVV, SimdReduceCmpOp);
                     0x5: vredmin_vs({{
                         Vd_vi[0] =
                             reduce_loop([](const vi& src1, const vi& src2) {
                                 return std::min<vi>(src1, src2);
-                            }, Vs1_vi, Vs2_vi);
+                            }, Vs1_vi[0]);
                     }}, OPMVV, SimdReduceCmpOp);
                     0x6: vredmaxu_vs({{
                         Vd_vu[0] =
                             reduce_loop([](const vu& src1, const vu& src2) {
                                 return std::max<vu>(src1, src2);
-                            }, Vs1_vu, Vs2_vu);
+                            }, Vs1_vu[0]);
                     }}, OPMVV, SimdReduceCmpOp);
                     0x7: vredmax_vs({{
                         Vd_vi[0] =
                             reduce_loop([](const vi& src1, const vi& src2) {
                                 return std::max<vi>(src1, src2);
-                            }, Vs1_vi, Vs2_vi);
+                            }, Vs1_vi[0]);
                     }}, OPMVV, SimdReduceCmpOp);
                 }
                 format VectorIntFormat {

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -35,6 +35,43 @@ let {{
                "_numTypedDestRegs[VecRegClass]++;\n"
     def setSrcWrapper(srcRegId):
         return "setSrcRegIdx(_numSrcRegs++, " + srcRegId + ");\n"
+    def setVecRegGroupSrcWrapper(num_regs_expr, reg_base_expr):
+        return '''
+            for (unsigned i=0; i < %s; i++) {
+                setSrcRegIdx(_numSrcRegs++, vecRegClass[%s + i]);
+            }
+        ''' % (num_regs_expr, reg_base_expr)
+    def generateReduceLoop(is_float=False):
+        dot_v = ".v" if is_float else ""
+        vs2_type = "vu" if is_float else \
+            "std::conditional_t<std::is_signed_v<acc_t>, vi, vu>"
+        return '''
+            auto reduce_loop =
+                [&, this](const auto& f, const auto& vs1_val) {
+                    using acc_t = std::decay_t<decltype(vs1_val)>;
+                    acc_t result = vs1_val;
+                    uint32_t num_elems = this->microVl;
+                    uint32_t elems_per_reg = vtype_VLMAX(vtype, vlen, true);
+                    uint32_t num_regs = (num_elems+elems_per_reg-1)
+                                        / elems_per_reg;
+                    for (uint32_t r=0; r < num_regs; r++) {
+                        RiscvISA::vreg_t vs2_reg;
+                        xc->getRegOperand(this, 1+r, &vs2_reg);
+                        auto vs2 = vs2_reg.as<%s>();
+                        uint32_t elems_so_far = r*elems_per_reg;
+                        uint32_t num_reg_elems =
+                            (elems_so_far+elems_per_reg > num_elems)
+                            ? num_elems-elems_so_far : elems_per_reg;
+
+                        for (uint32_t i=0; i < num_reg_elems; i++) {
+                            if (this->vm || elem_mask(v0, elems_so_far+i)) {
+                                result = f(result, vs2[i])%s;
+                            }
+                        }
+                    }
+                    return result;
+                };
+        ''' % (vs2_type, dot_v)
     def tailMaskCondSetSrcWrapper(setSrcRegCode):
         return "if (!_machInst.vtype8.vta || (!_machInst.vm " \
             + "&& !_machInst.vtype8.vma)) {\n" \
@@ -44,12 +81,6 @@ let {{
     def setSrcVm():
         return "if (!this->vm)\n" + \
                "    setSrcRegIdx(_numSrcRegs++, vecRegClass[0]);"
-    def setSrcVmOrTmp0():
-        return "if (!this->vm){\n" + \
-               "(_machInst.vd == 0) ? " + \
-               "setSrcRegIdx(_numSrcRegs++,vecRegClass[VecMemInternalReg0]):"+\
-               "setSrcRegIdx(_numSrcRegs++,vecRegClass[0]);\n" + \
-               "}\n"
     def vmDeclAndReadData():
         return '''
             [[maybe_unused]] RiscvISA::vreg_t tmp_v0;
@@ -60,7 +91,7 @@ let {{
             }
         '''
     def copyOldVd(vd_idx):
-        return 'COPY_OLD_VD(%d);' % vd_idx
+        return f"COPY_OLD_VD({vd_idx});"
     def copyOldVdIfVL(vd_idx):
         return 'COPY_OLD_VD_IF_VL(%d);' % vd_idx
     def loopWrapper(code, micro_inst = True):
@@ -1292,86 +1323,73 @@ def format VectorMaskFormat(code, category, *flags) {{
     decode_block = VectorMaskDecodeBlock.subst(iop)
 }};
 
-def format VectorReduceIntFormat(code, category, *flags) {{
+def format VectorReduceFormat(code, category, *flags) {{
+    is_float = name.startswith("vf");
+    is_widening = name.startswith("vw") or name.startswith("vfw")
+
+    varith_template_iop = declareVArithTemplate(
+        Name,
+        type_name = "float" if is_float else "uint",
+        min_size = 16 if is_float else 8,
+        max_size = 32 if is_widening else 64
+    )
+
     iop = InstObjParams(
         name,
         Name,
         'VectorArithMacroInst',
         {'code': code,
-         'declare_varith_template': declareVArithTemplate(Name)},
+         'declare_varith_template': varith_template_iop},
         flags
     )
     inst_name, inst_suffix = name.split("_", maxsplit=1)
     dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs1]"
-    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs2)\
-                               + _microIdx]"
+    src1_reg_id = "vecRegClass[_machInst.vs1]"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
     set_src_reg_idx = setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVmOrTmp0()
+
+    set_src_reg_idx += '''
+        uint32_t num_elems = this->microVl;
+        uint32_t elems_per_reg = vtype_VLMAX(vtype, vlen, true);
+        uint32_t num_vs2_regs = (num_elems+elems_per_reg-1) / elems_per_reg;
+    '''
+    set_src_reg_idx += setVecRegGroupSrcWrapper("num_vs2_regs",
+                                                "_machInst.vs2")
+
+    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
+    set_src_reg_idx += setSrcVm()
     vm_decl_rd = vmDeclAndReadData()
     set_vlenb = setVlenb()
 
-    type_def = '''
-        using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
-        using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
-    '''
-    microiop = InstObjParams(name + "_micro",
+    if is_float:
+        code = fflags_wrapper(code)
+        type_def = '''
+            using et = ElemType;
+            using vu = decltype(et::v);
+        '''
+        if is_widening:
+            type_def += '''
+                using ewt = typename double_width<et>::type;
+                using vwu [[maybe_unused]] = decltype(ewt::v);
+            '''
+    else:
+        type_def = '''
+            using vu = std::make_unsigned_t<ElemType>;
+            using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
+        '''
+        if is_widening:
+            type_def += '''
+                using vwu [[maybe_unused]] = typename double_width<vu>::type;
+                using vwi [[maybe_unused]] = typename double_width<vi>::type;
+            '''
+
+    varith_template_microiop = declareVArithTemplate(
         Name + "Micro",
-        'VectorArithMicroInst',
-        {'code': code,
-         'set_dest_reg_idx': set_dest_reg_idx,
-         'set_src_reg_idx': set_src_reg_idx,
-         'set_vlenb' : set_vlenb,
-         'vm_decl_rd': vm_decl_rd,
-         'type_def': type_def,
-         'declare_varith_template': declareVArithTemplate(Name + "Micro")},
-        flags)
-
-    header_output = \
-        VectorReduceMicroDeclare.subst(microiop) + \
-        VectorReduceMacroDeclare.subst(iop)
-    decoder_output = \
-        VectorReduceMicroConstructor.subst(microiop) + \
-        VectorReduceMacroConstructor.subst(iop)
-    exec_output = VectorReduceIntMicroExecute.subst(microiop)
-    decode_block = VectorIntDecodeBlock.subst(iop)
-}};
-
-def format VectorReduceFloatFormat(code, category, *flags) {{
-    iop = InstObjParams(
-        name,
-        Name,
-        'VectorArithMacroInst',
-        {'code': code,
-         'declare_varith_template': declareVArithTemplate(Name, 'float', 16)},
-        flags
+        type_name = "float" if is_float else "uint",
+        min_size = 16 if is_float else 8,
+        max_size = 32 if is_widening else 64
     )
-    inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs1]"
-    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs2)\
-                               + _microIdx]"
-    set_dest_reg_idx = setDestWrapper(dest_reg_id)
-    set_src_reg_idx = setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVmOrTmp0()
-    vm_decl_rd = vmDeclAndReadData()
-    set_vlenb = setVlenb()
 
-    type_def = '''
-        using et = ElemType;
-        using vu = decltype(et::v);
-    '''
-
-    code = fflags_wrapper(code)
-
-    varith_micro_declare = declareVArithTemplate(Name + "Micro", 'float', 16)
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
         'VectorArithMicroInst',
@@ -1381,7 +1399,9 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
          'type_def': type_def,
-         'declare_varith_template': varith_micro_declare},
+         'copy_old_vd': copyOldVd('oldDstIdx'),
+         'reduce_loop': generateReduceLoop(is_float=is_float),
+         'declare_varith_template': varith_template_microiop},
         flags)
 
     header_output = \
@@ -1390,62 +1410,18 @@ def format VectorReduceFloatFormat(code, category, *flags) {{
     decoder_output = \
         VectorReduceMicroConstructor.subst(microiop) + \
         VectorReduceMacroConstructor.subst(iop)
-    exec_output = VectorReduceFloatMicroExecute.subst(microiop)
-    decode_block = VectorFloatDecodeBlock.subst(iop)
-}};
+    exec_output = VectorReduceMicroExecute.subst(microiop)
 
-def format VectorReduceFloatWideningFormat(code, category, *flags) {{
-    varith_macro_declare = declareVArithTemplate(Name, 'float', 16, 32)
-    iop = InstObjParams(
-        name,
-        Name,
-        'VectorArithMacroInst',
-        {'code': code,
-         'declare_varith_template': varith_macro_declare},
-        flags
-    )
-    inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs1]"
-    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs2)\
-                               + _microIdx]"
-    set_dest_reg_idx = setDestWrapper(dest_reg_id)
-    set_src_reg_idx = setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVmOrTmp0()
-    vm_decl_rd = vmDeclAndReadData()
-    set_vlenb = setVlenb()
-    type_def = '''
-        using et = ElemType;
-        using vu [[maybe_unused]] = decltype(et::v);
-        using ewt = typename double_width<et>::type;
-        using vwu = decltype(ewt::v);
-    '''
-
-    varith_micro_declare = declareVArithTemplate(
-        Name + "Micro", 'float', 16, 32)
-    microiop = InstObjParams(name + "_micro",
-        Name + "Micro",
-        'VectorArithMicroInst',
-        {'code': code,
-         'set_dest_reg_idx': set_dest_reg_idx,
-         'set_src_reg_idx': set_src_reg_idx,
-         'set_vlenb': set_vlenb,
-         'vm_decl_rd': vm_decl_rd,
-         'type_def': type_def,
-         'declare_varith_template': varith_micro_declare},
-        flags)
-
-    header_output = \
-        VectorReduceMicroDeclare.subst(microiop) + \
-        VectorReduceMacroDeclare.subst(iop)
-    decoder_output = \
-        VectorReduceMicroConstructor.subst(microiop) + \
-        VectorReduceMacroConstructor.subst(iop)
-    exec_output = VectorReduceFloatWideningMicroExecute.subst(microiop)
-    decode_block = VectorFloatWideningDecodeBlock.subst(iop)
+    if is_float:
+        if is_widening:
+            decode_block = VectorFloatWideningDecodeBlock.subst(iop)
+        else:
+            decode_block = VectorFloatDecodeBlock.subst(iop)
+    else:
+        if is_widening:
+            decode_block = VectorIntWideningDecodeBlock.subst(iop)
+        else:
+            decode_block = VectorIntDecodeBlock.subst(iop)
 }};
 
 def format VectorIntVxsatFormat(code, category, *flags) {{
@@ -1506,51 +1482,6 @@ def format VectorIntVxsatFormat(code, category, *flags) {{
         VectorIntVxsatMacroConstructor.subst(iop)
     exec_output = VectorIntMicroExecute.subst(microiop)
     decode_block = VectorIntDecodeBlock.subst(iop)
-}};
-
-def format VectorReduceIntWideningFormat(code, category, *flags) {{
-    iop = InstObjParams(
-        name,
-        Name,
-        'VectorArithMacroInst',
-        {'code': code,
-         'declare_varith_template': declareVArithTemplate(Name, max_size=32)},
-        flags
-    )
-    inst_name, inst_suffix = name.split("_", maxsplit=1)
-    dest_reg_id = "vecRegClass[_machInst.vd]"
-    src1_reg_id = "vecRegClass[_machInst.vs1 == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs1]"
-    src2_reg_id = "vecRegClass[(_machInst.vs2 + _microIdx == _machInst.vd\
-                               ? VecMemInternalReg0 : _machInst.vs2)\
-                               + _microIdx]"
-    set_dest_reg_idx = setDestWrapper(dest_reg_id)
-    set_src_reg_idx = setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcVmOrTmp0()
-    vm_decl_rd = vmDeclAndReadData()
-    set_vlenb = setVlenb()
-
-    varith_micro_declare = declareVArithTemplate(Name + "Micro", max_size=32)
-    microiop = InstObjParams(name + "_micro",
-        Name + "Micro",
-        'VectorArithMicroInst',
-        {'code': code,
-         'set_dest_reg_idx': set_dest_reg_idx,
-         'set_src_reg_idx': set_src_reg_idx,
-         'set_vlenb': set_vlenb,
-         'vm_decl_rd': vm_decl_rd,
-         'declare_varith_template': varith_micro_declare},
-        flags)
-
-    header_output = \
-        VectorReduceMicroDeclare.subst(microiop) + \
-        VectorReduceMacroDeclare.subst(iop)
-    decoder_output = \
-        VectorReduceMicroConstructor.subst(microiop) + \
-        VectorReduceMacroConstructor.subst(iop)
-    exec_output = VectorReduceIntWideningMicroExecute.subst(microiop)
-    decode_block = VectorIntWideningDecodeBlock.subst(iop)
 }};
 
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1754,68 +1754,17 @@ template<typename ElemType>
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
-    const uint32_t num_microops = vtype_regs_per_group(vtype);
-    int32_t tmp_vl = this->vl;
-    const int32_t micro_vlmax = vtype_VLMAX(_machInst.vtype8, vlen, true);
-    int32_t micro_vl = std::min(tmp_vl, micro_vlmax);
     StaticInstPtr microop;
 
-    if (micro_vl == 0) {
+    if (this->vl == 0) {
         microop = new VectorNopMicroInst(_machInst);
-        this->microops.push_back(microop);
-    }
-
-    if (machInst.vd == machInst.vs1) {
-        microop = new VCpyVsMicroInst(machInst, 0, machInst.vs1, elen, vlen);
-        microop->setFlag(IsDelayedCommit);
-        this->microops.push_back(microop);
-    }
-
-    if (machInst.vd != machInst.vs1 && (machInst.vd == 0 && !machInst.vm)) {
-        microop = new VCpyVsMicroInst(machInst, 0, 0, elen, vlen);
-        microop->setFlag(IsDelayedCommit);
-        this->microops.push_back(microop);
-    }
-
-    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        if (machInst.vd == (machInst.vs2 + i) && machInst.vd != machInst.vs1 &&
-            !(machInst.vd == 0 && !machInst.vm)) {
-            microop = new VCpyVsMicroInst(machInst, i, machInst.vs2, elen,
-                                          vlen);
-            microop->setFlag(IsDelayedCommit);
-            this->microops.push_back(microop);
-        }
-        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
-    }
-
-    int k;
-    tmp_vl = this->vl;
-    micro_vl = std::min(tmp_vl, micro_vlmax);
-    for (k = 0; k < num_microops && micro_vl > 0; ++k) {
-        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
-    }
-
-    microop = new VPinVdMicroInst(machInst, 0, k, elen, vlen,
-                                  /*isSlideUpVx=*/false, /*isReduction=*/true);
-    microop->setFlag(IsDelayedCommit);
-    this->microops.push_back(microop);
-
-    tmp_vl = this->vl;
-    micro_vl = std::min(tmp_vl, micro_vlmax);
-    for (int i = 0; i < num_microops && micro_vl > 0; ++i) {
-        microop = new %(class_name)sMicro<ElemType>(_machInst, micro_vl, i,
+    } else {
+        microop = new %(class_name)sMicro<ElemType>(_machInst, this->vl, 0,
                                                     _elen, _vlen);
-        // serialize all ordered and initial unordered µop(s) (unless last) to
-        // guarantee architectural correcness with OoO execution
-        if ((flags[IsSerializeAfter] && i < num_microops-1)
-                || (i == 0 && num_microops > 1)) {
-            microop->setFlag(StaticInst::IsSerializeAfter);
-        }
         microop->setDelayedCommit();
-        this->microops.push_back(microop);
-        micro_vl = std::min(tmp_vl -= micro_vlmax, micro_vlmax);
     }
 
+    this->microops.push_back(microop);
     this->microops.front()->setFirstMicroop();
     this->microops.back()->setLastMicroop();
 }
@@ -1830,8 +1779,8 @@ template<typename ElemType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    // vs2, vs1, vm
-    RegId srcRegIdxArr[3];
+    // vs1, vs2 group (up to 8 regs), old vd (optional), vm (optional)
+    RegId srcRegIdxArr[11];
     RegId destRegIdxArr[1];
     bool vm;
 public:
@@ -1865,7 +1814,7 @@ template<typename ElemType>
 
 }};
 
-def template VectorReduceIntMicroExecute {{
+def template VectorReduceMicroExecute {{
 
 template <typename ElemType>
 Fault
@@ -1884,103 +1833,9 @@ Fault
     %(set_vlenb)s;
     %(vm_decl_rd)s;
 
-    auto reduce_loop =
-        [&, this](const auto& f, const auto* _, const auto* vs2) {
-            ElemType microop_result = (microIdx == 0) ? Vs1[0]:Vd[0];
-            for (uint32_t i = 0; i < this->microVl; i++) {
-                uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
-                    this->microIdx;
-                if (this->vm || elem_mask(v0, ei)) {
-                    microop_result = f(microop_result, Vs2[i]);
-                }
-            }
-            return microop_result;
-        };
+    %(copy_old_vd)s;
 
-    %(code)s;
-    %(op_wb)s;
-    return NoFault;
-}
-
-%(declare_varith_template)s;
-
-}};
-
-def template VectorReduceFloatMicroExecute {{
-
-template <typename ElemType>
-Fault
-%(class_name)s<ElemType>::execute(ExecContext* xc,
-                                  trace::InstRecord* traceData) const
-{
-    %(type_def)s;
-
-    bool set_dirty = true;
-    bool check_vill = true;
-    Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (update_fault != NoFault) { return update_fault; }
-
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    %(vm_decl_rd)s;
-
-    auto reduce_loop =
-        [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vu tmp_val = (microIdx == 0) ? Vs1[0]:Vd[0];
-            for (uint32_t i = 0; i < this->microVl; i++) {
-                uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
-                    this->microIdx;
-                if (this->vm || elem_mask(v0, ei)) {
-                    tmp_val = f(tmp_val, Vs2[i]).v;
-                }
-            }
-            return tmp_val;
-        };
-
-    %(code)s;
-    %(op_wb)s;
-    return NoFault;
-}
-
-%(declare_varith_template)s;
-
-}};
-
-def template VectorReduceFloatWideningMicroExecute {{
-
-template <typename ElemType>
-Fault
-%(class_name)s<ElemType>::execute(ExecContext* xc,
-                                  trace::InstRecord* traceData) const
-{
-    %(type_def)s;
-
-    if (vtype_vlmul(machInst.vtype8) == 3)
-        return std::make_shared<IllegalInstFault>("LMUL=8 is illegal for widening inst", machInst);
-
-    bool set_dirty = true;
-    bool check_vill = true;
-    Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (update_fault != NoFault) { return update_fault; }
-
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    %(vm_decl_rd)s;
-
-    auto reduce_loop =
-        [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vwu tmp_val = (microIdx == 0) ? Vs1[0] : Vd[0];
-            for (uint32_t i = 0; i < this->microVl; i++) {
-                uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
-                    this->microIdx;
-                if (this->vm || elem_mask(v0, ei)) {
-                    tmp_val = f(tmp_val, Vs2[i]).v;
-                }
-            }
-            return tmp_val;
-        };
+    %(reduce_loop)s;
 
     %(code)s;
     %(op_wb)s;
@@ -2290,51 +2145,6 @@ template<typename ElemType>
 %(declare_varith_template)s;
 
 }};
-
-def template VectorReduceIntWideningMicroExecute {{
-
-template <typename ElemType>
-Fault
-%(class_name)s<ElemType>::execute(ExecContext* xc,
-                                  trace::InstRecord* traceData) const
-{
-    using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
-    using vi [[maybe_unused]] = std::make_signed_t<ElemType>;
-    using vwu [[maybe_unused]] = typename double_width<vu>::type;
-    using vwi [[maybe_unused]] = typename double_width<vi>::type;
-
-    bool set_dirty = true;
-    bool check_vill = true;
-    Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
-    if (update_fault != NoFault) { return update_fault; }
-
-    %(op_decl)s;
-    %(op_rd)s;
-    %(set_vlenb)s;
-    %(vm_decl_rd)s;
-
-    auto reduce_loop =
-        [&, this](const auto& f, const auto* _, const auto* vs2) {
-            vwu tmp_val = (microIdx == 0) ? Vs1[0]:Vd[0];
-            for (uint32_t i = 0; i < this->microVl; i++) {
-                uint32_t ei = i + vtype_VLMAX(vtype, vlen, true) *
-                    this->microIdx;
-                if (this->vm || elem_mask(v0, ei)) {
-                    tmp_val = f(tmp_val, Vs2[i]);
-                }
-            }
-            return tmp_val;
-        };
-
-    %(code)s;
-    %(op_wb)s;
-    return NoFault;
-}
-
-%(declare_varith_template)s;
-
-}};
-
 
 def template VectorCompressMacroConstructor {{
 


### PR DESCRIPTION
The current implementation of vector reductions for RISC-V use one µop per vs2, leading to the use of register pinning and consequently the use of pipeline level serialization for correctness (both ordered and unordered versions #2920) .

This PR refactors vector reductions to use one µop (since reductions always write to one destination) which sources the whole vs2 group. With this approach we do not need register pinning nor serialization.

Related issue #2953.