### PR TITLE
mem-ruby: Translate cbusy value for P-credit message

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -124,6 +124,8 @@ CacheController::pCreditGrant(const CHIResponseMsg *msg)
     phase.channel = ARM::CHI::CHANNEL_RSP;
     phase.rsp_opcode = ARM::CHI::RSP_OPCODE_PCRD_GRANT;
     phase.pcrd_type = 0; // TODO: set this one depending on allow retry
+    phase.c_busy = msg->m_cbusy;
+    phase.src_id = ruby_to_tlm::srcId(msg->m_responder);
 
     bw(payload, &phase);
 


### PR DESCRIPTION
While we were translating CBusy values for incoming responses, we forgot to do the same for the special protocol credit message

Change-Id: I0f70bdeafe237fbb6cc9cae3f8ae866419cfa38f