### PR TITLE
mem-ruby: Add DAT/RSP channel out stats to TlmGenerator

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -258,7 +258,19 @@ TlmGenerator::send(Transaction *transaction)
     auto tlm_data = TlmData(payload, &phase);
     outPort.send(tlm_data);
 
-    stats.reqOut++;
+    switch (phase.channel) {
+        case ARM::CHI::CHANNEL_REQ:
+            stats.reqOut++;
+            break;
+        case ARM::CHI::CHANNEL_DAT:
+            stats.datOut++;
+            break;
+        case ARM::CHI::CHANNEL_RSP:
+            stats.rspOut++;
+            break;
+        default:
+            break;
+    }
 }
 
 void
@@ -440,6 +452,10 @@ TlmGenerator::Stats::Stats(statistics::Group *_parent)
     : statistics::Group(_parent),
       ADD_STAT(reqOut, statistics::units::Count::get(),
                "Number of transactions sent in the REQ channel"),
+      ADD_STAT(rspOut, statistics::units::Count::get(),
+               "Number of transactions sent in the RSP channel"),
+      ADD_STAT(datOut, statistics::units::Count::get(),
+               "Number of transactions sent in the DAT channel"),
       ADD_STAT(retryAck, statistics::units::Count::get(),
                "Number of RetryAck received"),
       ADD_STAT(pcrdGrant, statistics::units::Count::get(),

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -422,6 +422,10 @@ class TlmGenerator : public ClockedObject
 
         /* Number of transactions sent in the REQ channel */
         statistics::Scalar reqOut;
+        /* Number of transactions sent in the RSP channel */
+        statistics::Scalar rspOut;
+        /* Number of transactions sent in the DAT channel */
+        statistics::Scalar datOut;
         /* Number of RetryAck received */
         statistics::Scalar retryAck;
         /* Number of PCrdGrant received */


### PR DESCRIPTION
With this patch we start recording non-REQ messages as well in the TlmGenerator. This actually fixes a bug in the initial implementation, which was wrongly assuming every outgaing transaction was in the REQ channel

Change-Id: I1cbca5df04be99455adbfc70592fd5b8469db4c1