### PR TITLE
util: Update matplotlib usage in dram_sweep_plot

### DIFF
--- a/util/plot_dram/dram_sweep_plot.py
+++ b/util/plot_dram/dram_sweep_plot.py
@@ -166,7 +166,7 @@ def main():
         exit(-1)
 
     fig = plt.figure()
-    ax = fig.gca(projection="3d")
+    ax = fig.add_subplot(projection="3d")
     X = np.arange(burst_size, max_size + 1, burst_size)
     Y = np.arange(1, banks + 1, 1)
     X, Y = np.meshgrid(X, Y)


### PR DESCRIPTION
The Figure.gca does not support a keyword argument anymore. Should be using add_subplot instead [1]

[1]: https://stackoverflow.com/questions/67095247/gca-and-latest-version-of-matplotlib

Change-Id: I81d3cc2752798ee23ccf6827052ffb86a552ad7b