### PR TITLE
util: Fix m5ops build failure with SCons >= 4.6.0

### DIFF
--- a/util/m5/SConstruct
+++ b/util/m5/SConstruct
@@ -141,7 +141,6 @@ if not main['HAVE_LUA51']:
 
 conf.Finish()
 
-print('Checking for ext/googletest ...')
 main['HAVE_GTEST'] = googletest_dir.File('SConscript').exists()
 if not main['HAVE_GTEST']:
     print('googletest not found, not building unit tests.')

--- a/util/m5/SConstruct
+++ b/util/m5/SConstruct
@@ -141,6 +141,11 @@ if not main['HAVE_LUA51']:
 
 conf.Finish()
 
+print('Checking for ext/googletest ...')
+main['HAVE_GTEST'] = googletest_dir.File('SConscript').exists()
+if not main['HAVE_GTEST']:
+    print('googletest not found, not building unit tests.')
+
 # Put the sconsign file in the build dir so everything can be deleted at once.
 main.SConsignFile(os.path.join(abspath(build_dir), 'sconsign'))
 # Use soft links instead of hard links when setting up a build directory.
@@ -181,9 +186,11 @@ native = main.Clone()
 native_dir = build_dir.Dir('native')
 
 # Bring in the googletest sources.
-native.SConscript(googletest_dir.File('SConscript'),
-        variant_dir=native_dir.Dir('googletest'), exports={ 'env': native },
-                  duplicate=GetOption('duplicate_sources'))
+if native['HAVE_GTEST']:
+    native.SConscript(googletest_dir.File('SConscript'),
+            variant_dir=native_dir.Dir('googletest'),
+            exports={ 'env': native },
+            duplicate=GetOption('duplicate_sources'))
 
 native.SConscript(src_dir.File('SConscript.native'),
         variant_dir=native_dir, exports={ 'env': native },
@@ -271,9 +278,11 @@ for root, dirs, files in os.walk(abspath(src_dir)):
         # this abi.
         abi_dir = build_dir.Dir(env.subst('${ABI}'))
         # Bring in the googletest sources.
-        env.SConscript(googletest_dir.File('SConscript'),
-                variant_dir=abi_dir.Dir('googletest'),
-                exports='env', duplicate=GetOption('duplicate_sources'))
+        if env['HAVE_GTEST']:
+            env.SConscript(googletest_dir.File('SConscript'),
+                    variant_dir=abi_dir.Dir('googletest'),
+                    exports='env',
+                    duplicate=GetOption('duplicate_sources'))
         env.SConscript(src_dir.File('SConscript'),
                        variant_dir=abi_dir, exports='env',
                        duplicate=GetOption('duplicate_sources'))


### PR DESCRIPTION
SCons 4.6.0 changed the default for `must_exist` in SConscript() calls from False to True, completing a deprecation that started in 3.0. This causes the m5ops build to fail when the googletest submodule is not present.

This change explicitly checks for googletest and only adds it if the files are present