### PR TITLE
scons: remove stale SLICC outputs

### DIFF
--- a/src/mem/ruby/protocol/SConscript
+++ b/src/mem/ruby/protocol/SConscript
@@ -81,6 +81,7 @@ def remove_stale_protocol_outputs(slicc):
         if os.path.dirname(filename) == slicc.protocol:
             expected.add(os.path.basename(filename))
 
+    expected.add(f"{slicc.protocol}ProtocolInfo.hh")
     for filename in os.listdir(protocol_dir_path):
         filepath = os.path.join(protocol_dir_path, filename)
         if not os.path.isfile(filepath):

--- a/src/mem/ruby/protocol/SConscript
+++ b/src/mem/ruby/protocol/SConscript
@@ -69,6 +69,43 @@ slicc_includes = ["mem/ruby/slicc_interface/RubySlicc_includes.hh"] + env[
 ]
 
 
+def remove_stale_protocol_outputs(slicc):
+    protocol_dir = output_dir.Dir(slicc.protocol)
+    protocol_dir_path = protocol_dir.abspath
+
+    if not os.path.isdir(protocol_dir_path):
+        return
+
+    expected = set()
+    for filename in slicc.files():
+        if os.path.dirname(filename) == slicc.protocol:
+            expected.add(os.path.basename(filename))
+
+    for filename in os.listdir(protocol_dir_path):
+        filepath = os.path.join(protocol_dir_path, filename)
+        if not os.path.isfile(filepath):
+            continue
+
+        if filename.endswith(".py.cc"):
+            continue
+
+        if (
+            filename.endswith((".cc", ".hh", ".py"))
+            and filename not in expected
+        ):
+            os.remove(filepath)
+
+            if filename.endswith(".cc"):
+                objpath = filepath[:-3] + ".o"
+                if os.path.exists(objpath):
+                    os.remove(objpath)
+            elif filename.endswith(".py"):
+                for suffix in (".cc", ".o", ".pyo"):
+                    sidecar = filepath + suffix
+                    if os.path.exists(sidecar):
+                        os.remove(sidecar)
+
+
 def slicc_emitter(target, source, env):
     files = set(target)
     for s in source:
@@ -115,6 +152,7 @@ def slicc_action(target, source, env):
             verbose=GetOption("verbose"),
         )
         slicc.process()
+        remove_stale_protocol_outputs(slicc)
         slicc.writeCodeFiles(output_dir.abspath, slicc_includes)
         if env["CONF"]["SLICC_HTML"]:
             slicc.writeHTMLFiles(html_dir.abspath)


### PR DESCRIPTION
## Summary

This removes stale protocol-specific SLICC generated outputs from the build
directory when the current SLICC output set no longer contains them.

Previously, if a `.sm` file was removed from a protocol after an incremental
build, generated files such as `CodexAddedSmType.cc`,
`CodexAddedSmType.hh`, and `CodexAddedSmType.o` could remain under
`build/<variant>/mem/ruby/protocol/<protocol>/`. The binary would no longer
reference the type once the protocol was regenerated, but the stale files were
still present in the build tree and could mask deleted generated code until a
clean build.

The cleanup runs in the SLICC action after parsing the current protocol and
before writing fresh outputs. It removes stale `.cc`, `.hh`, and `.py` files
from the protocol-specific output directory, plus local object/embedded
sidecars for those stale generated files.

## Validation

Built and tested with `build/ALL/gem5.opt`.

1. Started from `develop` and built `build/ALL/gem5.opt` successfully.
2. Added a temporary `src/mem/ruby/protocol/MESI_Two_Level-codex-added.sm`
   file defining `CodexAddedSmType` and included it from
   `MESI_Two_Level.slicc`.
3. Rebuilt `build/ALL/gem5.opt` and confirmed SLICC generated the new type,
   compiled `ALL/mem/ruby/protocol/MESI_Two_Level/CodexAddedSmType.cc -> .o`,
   and linked `gem5.opt`.
4. Confirmed the build directory contained:
   - `build/ALL/mem/ruby/protocol/MESI_Two_Level/CodexAddedSmType.cc`
   - `build/ALL/mem/ruby/protocol/MESI_Two_Level/CodexAddedSmType.hh`
   - `build/ALL/mem/ruby/protocol/MESI_Two_Level/CodexAddedSmType.o`
5. Removed the temporary include and deleted the temporary `.sm` file.
6. Rebuilt `build/ALL/gem5.opt` and confirmed the cleanup removed all
   `CodexAddedSmType*` files from
   `build/ALL/mem/ruby/protocol/MESI_Two_Level`.
7. Confirmed `CodexAddedSmType` / `CODEX_ADDED_SM_VALUE` no longer appeared
   in `build/ALL/mem/ruby/protocol/MESI_Two_Level/Types.hh` or
   `build/ALL/gem5.opt`.

I also ran follow-up no-source-change rebuilds. On this `develop`-based branch,
those still showed the existing generated-file churn unrelated to this cleanup,
but they did not rerun SLICC and did not recreate the deleted SLICC type.

Local warnings observed during builds were the existing host/toolchain warnings:
unsupported Clang 21, missing KVM headers/support, missing POSIX clocks, and
linker search-path warnings for local Homebrew/googletest paths.
