### PR TITLE
configs: update CHI cross_links/custom_links

### DIFF
--- a/configs/ruby/CHI_config.py
+++ b/configs/ruby/CHI_config.py
@@ -112,8 +112,13 @@ class NoC_Params:
     router_buffer_size = 4
     cntrl_msg_size = 8
     data_width = 32
-    cross_links = []
-    cross_link_latency = 0
+    # Map of (src,dst) -> weight,latency (cycles)
+    # Customizes the weight and latency for the link between the routers src
+    # and dst.
+    # The custom latency applies in both directions unless both (src,dst) and
+    # (dst,src) are present.
+    # A new link is created if no src->dst link exists.
+    custom_links = {}
 
 
 class CHI_Node(SubSystem):

--- a/configs/topologies/CustomMesh.py
+++ b/configs/topologies/CustomMesh.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2022 ARM Limited
+# Copyright (c) 2021,2022,2026 ARM Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -54,113 +54,87 @@ class CustomMesh(SimpleTopology):
         self.nodes = controllers
 
     # --------------------------------------------------------------------------
-    # _makeMesh
+    # _makeXYMesh, _makeCustomMesh
     # --------------------------------------------------------------------------
 
-    def _makeMesh(
-        self,
-        IntLink,
-        link_latency,
-        num_rows,
-        num_columns,
-        cross_links,
-        cross_link_latency,
-    ):
+    def _connectRouters(self, latency, weight, src_node, dst_node, dst_port):
+        self._int_links.append(
+            self._IntLink(
+                link_id=self._link_count,
+                src_node=self._routers[src_node],
+                dst_node=self._routers[dst_node],
+                dst_inport=dst_port,
+                latency=latency,
+                weight=weight,
+            )
+        )
+        self._link_count += 1
+
+    def _connectXYRouters(self, weight, src_node, dst_node, dst_port):
+        latency = self._router_link_latency
+        if (src_node, dst_node) in self._custom_links:
+            custom_weight, latency = self._custom_links[(src_node, dst_node)]
+            if (custom_weight != None) and (custom_weight != weight):
+                fatal(
+                    "XY custom link weight (src=%d, dst=%d, weight=%d) "
+                    "must be either 'None' or same as XY weight (=%d)",
+                    src_node,
+                    dst_node,
+                    custom_weight,
+                    weight,
+                )
+            assert (src_node, dst_node) in self._custom_non_XY_links
+            del self._custom_non_XY_links[(src_node, dst_node)]
+        self._connectRouters(latency, weight, src_node, dst_node, dst_port)
+
+    def _makeXYMesh(self, num_rows, num_columns):
+
         # East->West, West->East, North->South, South->North
         # XY routing weights
         link_weights = [1, 1, 2, 2]
 
-        # East output to West input links
-        for row in range(num_rows):
-            for col in range(num_columns):
-                if col + 1 < num_columns:
-                    east_out = col + (row * num_columns)
-                    west_in = (col + 1) + (row * num_columns)
-                    llat = (
-                        cross_link_latency
-                        if (east_out, west_in) in cross_links
-                        else link_latency
-                    )
-                    self._int_links.append(
-                        IntLink(
-                            link_id=self._link_count,
-                            src_node=self._routers[east_out],
-                            dst_node=self._routers[west_in],
-                            dst_inport="West",
-                            latency=llat,
-                            weight=link_weights[0],
-                        )
-                    )
-                    self._link_count += 1
+        # Non-XY custom links will be created later
+        self._custom_non_XY_links = self._custom_links.copy()
 
+        # East output to West input links
         # West output to East input links
         for row in range(num_rows):
             for col in range(num_columns):
                 if col + 1 < num_columns:
-                    east_in = col + (row * num_columns)
-                    west_out = (col + 1) + (row * num_columns)
-                    llat = (
-                        cross_link_latency
-                        if (west_out, east_in) in cross_links
-                        else link_latency
-                    )
-                    self._int_links.append(
-                        IntLink(
-                            link_id=self._link_count,
-                            src_node=self._routers[west_out],
-                            dst_node=self._routers[east_in],
-                            dst_inport="East",
-                            latency=llat,
-                            weight=link_weights[1],
-                        )
-                    )
-                    self._link_count += 1
+                    east = col + (row * num_columns)
+                    west = (col + 1) + (row * num_columns)
+                    # East output to West input
+                    self._connectXYRouters(link_weights[0], east, west, "West")
+                    # West output to East input
+                    self._connectXYRouters(link_weights[1], west, east, "East")
 
         # North output to South input links
-        for col in range(num_columns):
-            for row in range(num_rows):
-                if row + 1 < num_rows:
-                    north_out = col + (row * num_columns)
-                    south_in = col + ((row + 1) * num_columns)
-                    llat = (
-                        cross_link_latency
-                        if (north_out, south_in) in cross_links
-                        else link_latency
-                    )
-                    self._int_links.append(
-                        IntLink(
-                            link_id=self._link_count,
-                            src_node=self._routers[north_out],
-                            dst_node=self._routers[south_in],
-                            dst_inport="South",
-                            latency=llat,
-                            weight=link_weights[2],
-                        )
-                    )
-                    self._link_count += 1
-
         # South output to North input links
         for col in range(num_columns):
             for row in range(num_rows):
                 if row + 1 < num_rows:
-                    north_in = col + (row * num_columns)
-                    south_out = col + ((row + 1) * num_columns)
-                    llat = (
-                        cross_link_latency
-                        if (south_out, north_in) in cross_links
-                        else link_latency
+                    north = col + (row * num_columns)
+                    south = col + ((row + 1) * num_columns)
+                    # North output to South input
+                    self._connectXYRouters(
+                        link_weights[2], north, south, "South"
                     )
-                    self._int_links.append(
-                        IntLink(
-                            link_id=self._link_count,
-                            src_node=self._routers[south_out],
-                            dst_node=self._routers[north_in],
-                            dst_inport="North",
-                            latency=llat,
-                            weight=link_weights[3],
-                        )
+                    # South output to North input
+                    self._connectXYRouters(
+                        link_weights[3], south, north, "North"
                     )
-                    self._link_count += 1
+
+    def _makeCustomMesh(self):
+        for src, dst in self._custom_non_XY_links:
+            weight, latency = self._custom_non_XY_links[(src, dst)]
+            if weight == None:
+                fatal(
+                    "Non XY custom link weight (src=%d, dst=%d) "
+                    "not specified",
+                    src,
+                    dst,
+                )
+            self._connectRouters(latency, weight, src, dst, None)
 
     # --------------------------------------------------------------------------
     # distributeNodes
@@ -278,6 +252,7 @@ class CustomMesh(SimpleTopology):
             print("WARNING: router/node link latencies not provided")
             self._router_link_latency = options.link_latency
             self._node_link_latency = options.link_latency
+        self._custom_links = options.custom_links
 
         # classify nodes into different types
         rnf_nodes = []
@@ -339,15 +314,17 @@ class CustomMesh(SimpleTopology):
         self._int_links = []
         self._ext_links = []
 
+        # Expands custom links
+        self._custom_links = {}
+        for k in options.custom_links:
+            weight, latency = options.custom_links[k]
+            self._custom_links[k] = weight, latency
+            if (k[1], k[0]) not in options.custom_links:
+                self._custom_links[(k[1], k[0])] = weight, latency
+
         # Create all the mesh internal links.
-        self._makeMesh(
-            IntLink,
-            self._router_link_latency,
-            num_rows,
-            num_cols,
-            options.cross_links,
-            options.cross_link_latency,
-        )
+        self._makeXYMesh(num_rows, num_cols)
+        self._makeCustomMesh()
 
         # Place CHI_RNF on the mesh
         self.distributeNodes(rnf_params, rnf_nodes)


### PR DESCRIPTION
We replace cross_links with custom_links allowing links with their own routing weight and latency to be defined.
custom_links can be defined between any two routers rather than just setting latency for existing links within the mesh.

Change-Id: I74a306086611150404c38f93b562fc55e633e14a
Reviewed-by: Giacomo Travaglini <giacomo.travaglini@arm.com>