### PR TITLE
arch-riscv: Add AT_BASE to the SE-mode auxiliary vector

### DIFF
--- a/src/arch/riscv/process.cc
+++ b/src/arch/riscv/process.cc
@@ -156,6 +156,7 @@ RiscvProcess::argsInit(int pageSize)
         auxv.emplace_back(gem5::auxv::Phnum, elfObject->programHeaderCount());
         auxv.emplace_back(gem5::auxv::Phent, elfObject->programHeaderSize());
         auxv.emplace_back(gem5::auxv::Phdr, elfObject->programHeaderTable());
+        auxv.emplace_back(gem5::auxv::Base, getBias());
         auxv.emplace_back(gem5::auxv::Pagesz, PageBytes);
         auxv.emplace_back(gem5::auxv::Secure, 0);
         auxv.emplace_back(gem5::auxv::Random, stack_top);
@@ -242,6 +243,7 @@ RiscvProcess::argsInit(int pageSize)
         {gem5::auxv::Phnum, "gem5::auxv::Phnum"},
         {gem5::auxv::Phent, "gem5::auxv::Phent"},
         {gem5::auxv::Phdr, "gem5::auxv::Phdr"},
+        {gem5::auxv::Base, "gem5::auxv::Base"},
         {gem5::auxv::Pagesz, "gem5::auxv::Pagesz"},
         {gem5::auxv::Secure, "gem5::auxv::Secure"},
         {gem5::auxv::Random, "gem5::auxv::Random"},


### PR DESCRIPTION
### Summary
In RISC-V SE mode, the auxiliary vector built by `RiscvProcess::argsInit`
(`src/arch/riscv/process.cc`) omitted `AT_BASE`. Without it the dynamic linker
(`ld.so`) cannot determine its own load bias and performs relative/self
relocations against a base of `0`, so relocated pointers end up holding raw
link-time offsets instead of `base + addend`. Dereferencing such a pointer
(e.g. data reached via a `dlsym`'d symbol in a shared object) faults.

### Why
RISC-V was the only ISA missing this entry — `x86`, `arm`, `sparc`, `power`
and `mips` all emit `auxv::Base` with `getBias()` right after `Phdr`:

```
$ grep -L auxv::Base src/arch/*/process.cc
src/arch/riscv/process.cc      # the only one
```

### Change
Add `auxv.emplace_back(gem5::auxv::Base, getBias());` after the `Phdr` entry,
mirroring the other ISAs, and register `Base` in the `Stack` debug name map.

### Notes
gem5 generally recommends `-static` for SE mode, so dynamic linking may still
hit further gaps afterwards (e.g. unimplemented syscalls). This patch only
fixes the isolated, clear inconsistency vs. the other ISAs.

Closes #3239
