### PR TITLE
stats: add runtime lookup of single values from multi-value stats

### DIFF
--- a/src/sim/mathexpr.cc
+++ b/src/sim/mathexpr.cc
@@ -136,7 +136,7 @@ MathExpr::parse(std::string expr) {
                 !( (c >= 'a' && c <= 'z') ||
                    (c >= 'A' && c <= 'Z') ||
                    (c >= '0' && c <= '9') ||
-                   c == '$' || c == '\\' || c == '.' || c == '_');
+                   c == '$' || c == '\\' || c == '.' || c == '_' || c == ':');
 
         if (!contains_non_alpha) {
             Node * n = new Node();

--- a/src/sim/mathexpr.cc
+++ b/src/sim/mathexpr.cc
@@ -132,11 +132,11 @@ MathExpr::parse(std::string expr) {
     {
         bool contains_non_alpha = false;
         for (auto & c: expr)
-            contains_non_alpha = contains_non_alpha or
-                !( (c >= 'a' && c <= 'z') ||
-                   (c >= 'A' && c <= 'Z') ||
-                   (c >= '0' && c <= '9') ||
-                   c == '$' || c == '\\' || c == '.' || c == '_' || c == ':');
+            contains_non_alpha =
+                contains_non_alpha or
+                !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                  (c >= '0' && c <= '9') || c == '$' || c == '\\' ||
+                  c == '.' || c == '_' || c == ':');
 
         if (!contains_non_alpha) {
             Node * n = new Node();

--- a/src/sim/power/mathexpr_powermodel.cc
+++ b/src/sim/power/mathexpr_powermodel.cc
@@ -67,7 +67,7 @@ MathExprPowerModel::startup()
             // Strip ::subname before resolving
             std::string statName = var;
             auto sepPos = var.find("::");
-            if (sepPos != std::string::npos){
+            if (sepPos != std::string::npos) {
                 statName = var.substr(0, sepPos);
             }
 
@@ -107,7 +107,7 @@ MathExprPowerModel::getStatValue(const std::string &name) const
     auto sepPos = name.find("::");
     if (sepPos != std::string::npos) {
         statName = name.substr(0, sepPos);
-        subName  = name.substr(sepPos + 2);  // skip "::"
+        subName = name.substr(sepPos + 2); // skip "::"
     }
     const auto it = statsMap.find(statName);
     assert(it != statsMap.cend());
@@ -123,16 +123,16 @@ MathExprPowerModel::getStatValue(const std::string &name) const
             // multi-bucket stat like overallAccesses
             // for now return total, later add #subname support here
             const VResult &results = fi->result();
-            for (size_t i = 0; i < fi->subnames.size(); i++){
-                if (fi->subnames[i] == subName)return results[i];
-
+            for (size_t i = 0; i < fi->subnames.size(); i++) {
+                if (fi->subnames[i] == subName) {
+                    return results[i];
+                }
             }
             return fi->total();
         }
-    // single value stat like ipc, simSeconds
-    return fi->total();
+        // single value stat like ipc, simSeconds
+        return fi->total();
     }
-
 
     panic("Unknown stat type!\n");
 }

--- a/src/sim/power/mathexpr_powermodel.cc
+++ b/src/sim/power/mathexpr_powermodel.cc
@@ -64,11 +64,17 @@ MathExprPowerModel::startup()
             if (var == "temp" || var == "voltage" || var == "clock_period") {
                 continue;
             }
+            // Strip ::subname before resolving
+            std::string statName = var;
+            auto sepPos = var.find("::");
+            if (sepPos != std::string::npos){
+                statName = var.substr(0, sepPos);
+            }
 
-            auto *info = statistics::resolve(var);
+            auto *info = statistics::resolve(statName);
             fatal_if(!info, "Failed to evaluate %s in expression:\n%s\n",
                      var, expr.toStr());
-            statsMap[var] = info;
+            statsMap[statName] = info;
         }
     }
 }
@@ -96,7 +102,14 @@ MathExprPowerModel::getStatValue(const std::string &name) const
         return clocked_object->clockPeriod();
     }
 
-    const auto it = statsMap.find(name);
+    std::string statName = name;
+    std::string subName = "";
+    auto sepPos = name.find("::");
+    if (sepPos != std::string::npos) {
+        statName = name.substr(0, sepPos);
+        subName  = name.substr(sepPos + 2);  // skip "::"
+    }
+    const auto it = statsMap.find(statName);
     assert(it != statsMap.cend());
     const Info *info = it->second;
 
@@ -105,8 +118,21 @@ MathExprPowerModel::getStatValue(const std::string &name) const
     if (si)
         return si->value();
     auto fi = dynamic_cast<const FormulaInfo *>(info);
-    if (fi)
-        return fi->total();
+    if (fi) {
+        if (fi->subnames.size() >= 2 && !subName.empty()) {
+            // multi-bucket stat like overallAccesses
+            // for now return total, later add #subname support here
+            const VResult &results = fi->result();
+            for (size_t i = 0; i < fi->subnames.size(); i++){
+                if (fi->subnames[i] == subName)return results[i];
+               
+            }
+            return fi->total();
+        }
+    // single value stat like ipc, simSeconds
+    return fi->total();
+    }
+    
 
     panic("Unknown stat type!\n");
 }

--- a/src/sim/power/mathexpr_powermodel.cc
+++ b/src/sim/power/mathexpr_powermodel.cc
@@ -125,14 +125,14 @@ MathExprPowerModel::getStatValue(const std::string &name) const
             const VResult &results = fi->result();
             for (size_t i = 0; i < fi->subnames.size(); i++){
                 if (fi->subnames[i] == subName)return results[i];
-               
+
             }
             return fi->total();
         }
     // single value stat like ipc, simSeconds
     return fi->total();
     }
-    
+
 
     panic("Unknown stat type!\n");
 }


### PR DESCRIPTION
Add a way to read gem5 statistics by name while the simulation is running, for use in live power and thermal models that need stat values during the run rather than from the stats file at the end. Github Issue : #3235