### PR TITLE
cpu-o3: Delay misc reg dependent wake until commit

### DIFF
--- a/src/cpu/o3/commit.cc
+++ b/src/cpu/o3/commit.cc
@@ -1023,6 +1023,9 @@ Commit::commitInsts()
 
                 // Updates misc. registers.
                 head_inst->updateMiscRegs();
+                if (head_inst->numDestRegs(MiscRegClass)) {
+                    iewStage->wakeCommittedMiscRegDependents(head_inst);
+                }
 
                 // Check instruction execution if it successfully commits and
                 // is not carrying a fault.

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -578,6 +578,7 @@ void
 IEW::wakeCommittedMiscRegDependents(const DynInstPtr &inst)
 {
     int dependents = 0;
+    const bool update_producer = inst->lastWakeDependents == -1;
 
     DPRINTF(IEW,
             "Waking misc register dependents of committed instruction.\n");
@@ -599,7 +600,9 @@ IEW::wakeCommittedMiscRegDependents(const DynInstPtr &inst)
 
     if (dependents) {
         ThreadID tid = inst->threadNumber;
-        iewStats.producerInst[tid]++;
+        if (update_producer) {
+            iewStats.producerInst[tid]++;
+        }
         iewStats.consumerInst[tid] += dependents;
     }
 }

--- a/src/cpu/o3/iew.cc
+++ b/src/cpu/o3/iew.cc
@@ -575,6 +575,36 @@ IEW::wakeDependents(const DynInstPtr& inst)
 }
 
 void
+IEW::wakeCommittedMiscRegDependents(const DynInstPtr &inst)
+{
+    int dependents = 0;
+
+    DPRINTF(IEW,
+            "Waking misc register dependents of committed instruction.\n");
+
+    assert(!inst->isSquashed());
+
+    for (int i = 0; i < inst->numDestRegs(); i++) {
+        PhysRegIdPtr dest_reg = inst->renamedDestIdx(i);
+        if (!dest_reg->is(MiscRegClass)) {
+            continue;
+        }
+
+        dependents += instQueue.wakeDependents(dest_reg);
+
+        DPRINTF(IEW, "Setting committed misc register %i (%s)\n",
+                dest_reg->index(), dest_reg->className());
+        scoreboard->setReg(dest_reg);
+    }
+
+    if (dependents) {
+        ThreadID tid = inst->threadNumber;
+        iewStats.producerInst[tid]++;
+        iewStats.consumerInst[tid] += dependents;
+    }
+}
+
+void
 IEW::rescheduleMemInst(const DynInstPtr& inst)
 {
     instQueue.rescheduleMemInst(inst);
@@ -1422,20 +1452,27 @@ IEW::writebackInsts()
             int dependents = instQueue.wakeDependents(inst);
 
             for (int i = 0; i < inst->numDestRegs(); i++) {
+                PhysRegIdPtr dest_reg = inst->renamedDestIdx(i);
+                if (dest_reg->is(MiscRegClass)) {
+                    continue;
+                }
+
                 // Mark register as ready if not pinned
-                if (inst->renamedDestIdx(i)->
-                        getNumPinnedWritesToComplete() == 0) {
-                    DPRINTF(IEW,"Setting Destination Register %i (%s)\n",
-                            inst->renamedDestIdx(i)->index(),
-                            inst->renamedDestIdx(i)->className());
-                    scoreboard->setReg(inst->renamedDestIdx(i));
+                if (dest_reg->getNumPinnedWritesToComplete() == 0) {
+                    DPRINTF(IEW, "Setting Destination Register %i (%s)\n",
+                            dest_reg->index(), dest_reg->className());
+                    scoreboard->setReg(dest_reg);
                 }
             }
 
+            // Misc-register dependents are excluded here. They are woken and
+            // accounted for after the producer commits its misc-register
+            // updates.
             if (dependents) {
                 iewStats.producerInst[tid]++;
-                iewStats.consumerInst[tid]+= dependents;
+                iewStats.consumerInst[tid] += dependents;
             }
+
             iewStats.writebackCount[tid]++;
         }
     }

--- a/src/cpu/o3/iew.hh
+++ b/src/cpu/o3/iew.hh
@@ -172,6 +172,9 @@ class IEW
     /** Wakes all dependents of a completed instruction. */
     void wakeDependents(const DynInstPtr &inst);
 
+    /** Wakes misc register dependents after their producer commits. */
+    void wakeCommittedMiscRegDependents(const DynInstPtr &inst);
+
     /** Tells memory dependence unit that a memory instruction needs to be
      * rescheduled. It will re-execute once replayMemInst() is called.
      */

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1209,8 +1209,6 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
         iqIOStats.intInstQueueWakeupAccesses++;
     }
 
-    completed_inst->lastWakeDependents = curTick();
-
     DPRINTF(IQ, "Waking dependents of completed instruction.\n");
 
     assert(!completed_inst->isSquashed());
@@ -1266,6 +1264,10 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
         }
 
         dependents += wakeDependents(dest_reg);
+    }
+
+    if (dependents) {
+        completed_inst->lastWakeDependents = curTick();
     }
 
     return dependents;

--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1151,10 +1151,55 @@ InstructionQueue::commit(const InstSeqNum &inst, ThreadID tid)
 }
 
 int
-InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
+InstructionQueue::wakeDependents(PhysRegIdPtr dest_reg)
 {
     int dependents = 0;
 
+    // Serializing fixed-mapping registers do not use the IQ dependency
+    // graph.
+    if (dest_reg->isAlwaysReady()) {
+        DPRINTF(IQ, "Reg %d [%s] is part of a fix mapping, skipping\n",
+                dest_reg->index(), dest_reg->className());
+        return dependents;
+    }
+
+    DPRINTF(IQ, "Waking any dependents on register %i (%s).\n",
+            dest_reg->index(), dest_reg->className());
+
+    // Go through the dependency chain, marking the registers as ready within
+    // the waiting instructions.
+    DynInstPtr dep_inst = dependGraph.pop(dest_reg->flatIndex());
+
+    while (dep_inst) {
+        DPRINTF(IQ, "Waking up a dependent instruction, [sn:%llu] PC %s.\n",
+                dep_inst->seqNum, dep_inst->pcState());
+
+        // Might want to give more information to the instruction so that it
+        // knows which of its source registers is ready. However that would
+        // mean that the dependency graph entries would need to hold the
+        // src_reg_idx.
+        dep_inst->markSrcRegReady();
+
+        addIfReady(dep_inst);
+
+        dep_inst = dependGraph.pop(dest_reg->flatIndex());
+
+        ++dependents;
+    }
+
+    // Reset the head node now that all of its dependents have been woken up.
+    assert(dependGraph.empty(dest_reg->flatIndex()));
+    dependGraph.clearInst(dest_reg->flatIndex());
+
+    // Mark the scoreboard as having that register ready.
+    regScoreboard[dest_reg->flatIndex()] = true;
+
+    return dependents;
+}
+
+int
+InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
+{
     // The instruction queue here takes care of both floating and int ops
     if (completed_inst->isFloating()) {
         iqIOStats.fpInstQueueWakeupAccesses++;
@@ -1178,7 +1223,7 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
         memDepUnit[tid].completeInst(completed_inst);
 
         DPRINTF(IQ, "Completing mem instruction PC: %s [sn:%llu]\n",
-            completed_inst->pcState(), completed_inst->seqNum);
+                completed_inst->pcState(), completed_inst->seqNum);
 
         completed_inst->clearInIQ();
         completed_inst->memOpDone(true);
@@ -1188,25 +1233,31 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
         memDepUnit[tid].completeInst(completed_inst);
     }
 
-    for (int dest_reg_idx = 0;
-         dest_reg_idx < completed_inst->numDestRegs();
-         dest_reg_idx++)
-    {
+    int dependents = 0;
+    for (int dest_reg_idx = 0; dest_reg_idx < completed_inst->numDestRegs();
+         ++dest_reg_idx) {
         PhysRegIdPtr dest_reg =
             completed_inst->renamedDestIdx(dest_reg_idx);
 
-        // Special case of uniq or control registers.  They are not
-        // handled by the IQ and thus have no dependency graph entry.
+        // Misc register writes become visible at commit, so their dependents
+        // are woken by the commit-time path.
+        if (dest_reg->is(MiscRegClass)) {
+            continue;
+        }
+
+        // Serializing fixed-mapping registers do not use the IQ dependency
+        // graph or pinned-write accounting.
         if (dest_reg->isAlwaysReady()) {
             DPRINTF(IQ, "Reg %d [%s] is part of a fix mapping, skipping\n",
                     dest_reg->index(), dest_reg->className());
             continue;
         }
 
-        // Avoid waking up dependents if the register is pinned
+        // Avoid waking up dependents if the register is pinned.
         dest_reg->decrNumPinnedWritesToComplete();
-        if (dest_reg->isPinned())
+        if (dest_reg->isPinned()) {
             completed_inst->setPinnedRegsWritten();
+        }
 
         if (dest_reg->getNumPinnedWritesToComplete() != 0) {
             DPRINTF(IQ, "Reg %d [%s] is pinned, skipping\n",
@@ -1214,39 +1265,9 @@ InstructionQueue::wakeDependents(const DynInstPtr &completed_inst)
             continue;
         }
 
-        DPRINTF(IQ, "Waking any dependents on register %i (%s).\n",
-                dest_reg->index(),
-                dest_reg->className());
-
-        //Go through the dependency chain, marking the registers as
-        //ready within the waiting instructions.
-        DynInstPtr dep_inst = dependGraph.pop(dest_reg->flatIndex());
-
-        while (dep_inst) {
-            DPRINTF(IQ, "Waking up a dependent instruction, [sn:%llu] "
-                    "PC %s.\n", dep_inst->seqNum, dep_inst->pcState());
-
-            // Might want to give more information to the instruction
-            // so that it knows which of its source registers is
-            // ready.  However that would mean that the dependency
-            // graph entries would need to hold the src_reg_idx.
-            dep_inst->markSrcRegReady();
-
-            addIfReady(dep_inst);
-
-            dep_inst = dependGraph.pop(dest_reg->flatIndex());
-
-            ++dependents;
-        }
-
-        // Reset the head node now that all of its dependents have
-        // been woken up.
-        assert(dependGraph.empty(dest_reg->flatIndex()));
-        dependGraph.clearInst(dest_reg->flatIndex());
-
-        // Mark the scoreboard as having that register ready.
-        regScoreboard[dest_reg->flatIndex()] = true;
+        dependents += wakeDependents(dest_reg);
     }
+
     return dependents;
 }
 

--- a/src/cpu/o3/inst_queue.hh
+++ b/src/cpu/o3/inst_queue.hh
@@ -57,6 +57,7 @@
 #include "cpu/o3/mem_dep_unit.hh"
 #include "cpu/o3/store_set.hh"
 #include "cpu/op_class.hh"
+#include "cpu/reg_class.hh"
 #include "cpu/timebuf.hh"
 #include "enums/IQInsertionPolicy.hh"
 #include "enums/SMTQueuePolicy.hh"
@@ -333,6 +334,9 @@ class InstructionQueue
 
     /** Wakes all dependents of a completed instruction. */
     int wakeDependents(const DynInstPtr &completed_inst);
+
+    /** Wakes all dependents waiting on a destination register. */
+    int wakeDependents(PhysRegIdPtr dest_reg);
 
     /** Adds a ready memory instruction to the ready list. */
     void addReadyMemInst(const DynInstPtr &ready_inst);


### PR DESCRIPTION
O3 already models non-serializing misc registers with fixed PhysRegIds so
that same-register readers can wait on older writers in the IQ dependency
graph. However, the old wakeup point was still too early for misc
registers.

A misc register write does not update the architectural misc register file
when the instruction executes. DynInst::setMiscReg() records the write in
the dynamic instruction, and commit later makes the value visible through
updateMiscRegs(). If IEW writeback wakes dependents for that misc
destination, a younger same-register read can issue after the writer
executed but before the writer committed. The read then goes through
readMiscRegOperand(), which reads the still-stale architectural misc
register file.

This allowed sequences such as msr tpidr_el0 followed by mrs tpidr_el0 to
observe the old thread-pointer value under O3. The instructions still
retired in program order, but the younger read had already captured the
stale value and dependent TLS address calculations could fault before
retirement repaired architectural state.

Keep normal destination wakeups at IEW writeback, but skip misc-register
destinations there. After commit applies updateMiscRegs(), wake the IQ
dependents for committed misc-register destinations and update the rename
scoreboard. This preserves per-misc-register RAW ordering without making
every system register globally serializing.