### PR TITLE
scons: No omit frame pointer

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -132,6 +132,8 @@ AddOption('--without-python', action='store_true',
           help='Build without Python configuration support')
 AddOption('--without-tcmalloc', action='store_true',
           help='Disable linking against tcmalloc')
+AddOption('--no-omit-frame-pointer', action='store_true',
+          help='No omit frame pointer')
 AddOption('--with-ubsan', action='store_true',
           help='Build with Undefined Behavior Sanitizer if available')
 AddOption('--with-asan', action='store_true',
@@ -779,6 +781,9 @@ for variant_path in variant_paths:
     else:
         gem5py_env = env.Clone()
         config_embedded_python(gem5py_env)
+
+    if GetOption('no_omit_frame_pointer'):
+        env.Append(CCFLAGS=['-fno-omit-frame-pointer'])
 
     # Add sanitizers flags
     sanitizers=[]


### PR DESCRIPTION
This option disables the optimization for frame pointers. This helps linux perf tool to reconstruct the stack for the flamegraph.