### PR TITLE
base, sim: FairUncontendedMutex

### DIFF
--- a/src/base/uncontended_mutex.hh
+++ b/src/base/uncontended_mutex.hh
@@ -59,7 +59,9 @@ class UncontendedMutex
 
     bool
     testAndSet(int expected, int desired)
-    { return flag.compare_exchange_strong(expected, desired); }
+    {
+        return flag.compare_exchange_strong(expected, desired);
+    }
 
   public:
     UncontendedMutex() : flag(0) {}

--- a/src/base/uncontended_mutex.hh
+++ b/src/base/uncontended_mutex.hh
@@ -59,9 +59,7 @@ class UncontendedMutex
 
     bool
     testAndSet(int expected, int desired)
-    {
-        return flag.compare_exchange_strong(expected, desired);
-    }
+    { return flag.compare_exchange_strong(expected, desired); }
 
   public:
     UncontendedMutex() : flag(0) {}
@@ -85,8 +83,9 @@ class UncontendedMutex
              * such case, we shouldn't wait for the condition variable because
              * there is no the other thread to notify us.
              */
-            if (flag++ == 0)
+            if (flag++ == 0) {
                 break;
+            }
             cv.wait(ul);
         }
     }
@@ -97,8 +96,9 @@ class UncontendedMutex
         /* In case there are no other threads waiting, we will just clear the
          * flag and return.
          */
-        if (testAndSet(1, 0))
+        if (testAndSet(1, 0)) {
             return;
+        }
 
         /*
          * Otherwise, clear the flag and notify all the waiting threads. We
@@ -114,6 +114,57 @@ class UncontendedMutex
          * However, tests show that notify_one() is much slower than
          * notify_all() in this case. Here we choose to use notify_all().
          */
+        cv.notify_all();
+    }
+};
+
+/*
+ * A fair mutex that is fast in uncontended cases.
+ *
+ * `FairUncontendedMutex` is implemented with index based FIFO queue.
+ * When the queue size is 1, the fast path does not involve `std::mutex`.
+ * Otherwise, all the waiting threads check if it is at the front of the queue.
+ */
+class FairUncontendedMutex
+{
+  private:
+    std::atomic<unsigned int> head_id;
+    std::atomic<unsigned int> tail_id;
+
+    std::mutex m;
+    std::condition_variable cv;
+
+  public:
+    FairUncontendedMutex() : head_id(0), tail_id(0) {}
+
+    void
+    lock()
+    {
+        unsigned int slot_id = tail_id++;
+        if (slot_id == head_id) { // Only one in the queue.
+            return;
+        }
+        std::unique_lock<std::mutex> ul(m);
+        while (slot_id != head_id) {
+            cv.wait(ul);
+        }
+    }
+
+    void
+    unlock()
+    {
+        /*
+         * Pop the first element in the queue and notify all.
+         * The thread with lock_id == head_id wakes and obtains the lock.
+         * Must increase head_id before loading tail_id to avoid race
+         * conditions.
+         */
+        unsigned int new_head = ++head_id;
+        if (new_head == tail_id) { // Only one in the queue.
+            return;
+        }
+        // Make sure the waiting thread is asleep before `notify_all`.
+        std::lock_guard<std::mutex> g(m);
         cv.notify_all();
     }
 };

--- a/src/base/uncontended_mutex.test.cc
+++ b/src/base/uncontended_mutex.test.cc
@@ -26,7 +26,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -87,4 +86,75 @@ TEST(UncontendedMutex, HeavyContention)
         t.join();
     }
     EXPECT_EQ(data, num_of_iter * num_of_thread);
+}
+
+TEST(UncontendedMutex, SingleThread)
+{
+    int num_of_iter = 100000000;
+
+    UncontendedMutex m;
+    int data = 0;
+    for (int i = 0; i < num_of_iter; i++) {
+        std::lock_guard<UncontendedMutex> g(m);
+        ++data;
+    }
+    EXPECT_EQ(data, num_of_iter);
+}
+
+/*
+ * FairUncontendedMutex solves the barging issue.
+ * This test makes sure the lock is not occupied by a same thread continuously.
+ */
+TEST(FairUncontendedMutex, NoBarging)
+{
+    int num_of_iter = 1000;
+    int num_of_thread = 10;
+    std::vector<std::thread> threads;
+
+    int data = 0;
+    int last_served_id = -1;
+    int occupy_streaks = 0;
+    int max_occupy_streaks = 0;
+
+    FairUncontendedMutex m;
+    m.lock();
+    for (int t = 0; t < num_of_thread; ++t) {
+        threads.emplace_back([&, t]() {
+            for (int k = 0; k < num_of_iter; ++k) {
+                std::lock_guard<FairUncontendedMutex> g(m);
+
+                if (last_served_id == t) {
+                    ++occupy_streaks;
+                } else {
+                    last_served_id = t;
+                    occupy_streaks = 1;
+                }
+                max_occupy_streaks =
+                    std::max(max_occupy_streaks, occupy_streaks);
+
+                data++;
+            }
+        });
+    }
+    m.unlock(); // Start when all threads created.
+
+    for (auto &t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(data, num_of_iter * num_of_thread);
+    EXPECT_LE(max_occupy_streaks, num_of_iter / 10);
+}
+
+TEST(FairUncontendedMutex, SingleThread)
+{
+    int num_of_iter = 100000000;
+
+    FairUncontendedMutex m;
+    int data = 0;
+    for (int i = 0; i < num_of_iter; i++) {
+        std::lock_guard<FairUncontendedMutex> g(m);
+        ++data;
+    }
+    EXPECT_EQ(data, num_of_iter);
 }

--- a/src/base/uncontended_mutex.test.cc
+++ b/src/base/uncontended_mutex.test.cc
@@ -26,6 +26,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -38,7 +39,7 @@ TEST(UncontendedMutex, Lock)
     int data = 0;
     UncontendedMutex m;
 
-    std::thread t1([&] () {
+    std::thread t1([&]() {
         std::lock_guard<UncontendedMutex> g(m);
         // Simulate += operation with a racing change between read and write.
         int tmp = data;
@@ -46,13 +47,13 @@ TEST(UncontendedMutex, Lock)
         data = tmp + 1;
     });
 
-    std::thread t2([&] () {
+    std::thread t2([&]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         std::lock_guard<UncontendedMutex> g(m);
         data = data + 1;
     });
 
-    std::thread t3([&] () {
+    std::thread t3([&]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         std::lock_guard<UncontendedMutex> g(m);
         data = data + 1;
@@ -73,8 +74,8 @@ TEST(UncontendedMutex, HeavyContention)
     int data = 0;
     UncontendedMutex m;
 
-    for (int t = 0 ; t < num_of_thread; ++t) {
-        threads.emplace_back([&] () {
+    for (int t = 0; t < num_of_thread; ++t) {
+        threads.emplace_back([&]() {
             for (int k = 0; k < num_of_iter; ++k) {
                 std::lock_guard<UncontendedMutex> g(m);
                 data++;
@@ -82,7 +83,7 @@ TEST(UncontendedMutex, HeavyContention)
         });
     }
 
-    for (auto& t : threads) {
+    for (auto &t : threads) {
         t.join();
     }
     EXPECT_EQ(data, num_of_iter * num_of_thread);
@@ -103,47 +104,47 @@ TEST(UncontendedMutex, SingleThread)
 
 /*
  * FairUncontendedMutex solves the barging issue.
- * This test makes sure the lock is not occupied by a same thread continuously.
+ * This test makes sure the lock is distributed fair enough.
  */
 TEST(FairUncontendedMutex, NoBarging)
 {
-    int num_of_iter = 1000;
     int num_of_thread = 10;
+    int total_work = 10000;
+    int remaining_work = total_work;
+    std::vector<int> workload(num_of_thread);
     std::vector<std::thread> threads;
 
-    int data = 0;
-    int last_served_id = -1;
-    int occupy_streaks = 0;
-    int max_occupy_streaks = 0;
-
+    std::atomic<int> ready_threads = 0;
     FairUncontendedMutex m;
-    m.lock();
+
     for (int t = 0; t < num_of_thread; ++t) {
         threads.emplace_back([&, t]() {
-            for (int k = 0; k < num_of_iter; ++k) {
-                std::lock_guard<FairUncontendedMutex> g(m);
+            ++ready_threads;
+            while (ready_threads.load() < num_of_thread) {
+                std::this_thread::yield();
+            }
+            while (true) {
+                std::scoped_lock<FairUncontendedMutex> g(m);
 
-                if (last_served_id == t) {
-                    ++occupy_streaks;
-                } else {
-                    last_served_id = t;
-                    occupy_streaks = 1;
+                if (remaining_work <= 0) {
+                    break;
                 }
-                max_occupy_streaks =
-                    std::max(max_occupy_streaks, occupy_streaks);
-
-                data++;
+                --remaining_work;
+                ++workload[t];
             }
         });
     }
-    m.unlock(); // Start when all threads created.
 
     for (auto &t : threads) {
         t.join();
     }
 
-    EXPECT_EQ(data, num_of_iter * num_of_thread);
-    EXPECT_LE(max_occupy_streaks, num_of_iter / 10);
+    int minimum_workload = total_work / num_of_thread / 2;
+    EXPECT_EQ(remaining_work, 0);
+    for (int t = 0; t < num_of_thread; ++t) {
+        EXPECT_GT(workload[t], minimum_workload)
+            << "Thread " << t << " did not get enough workload.";
+    }
 }
 
 TEST(FairUncontendedMutex, SingleThread)

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -622,7 +622,7 @@ class EventQueue
     Tick _curTick;
 
     //! Mutex to protect async queue.
-    UncontendedMutex async_queue_mutex;
+    FairUncontendedMutex async_queue_mutex;
 
     //! List of events added by other threads to this event queue.
     std::list<Event*> async_queue;
@@ -647,7 +647,7 @@ class EventQueue
      * @see EventQueue::lock()
      * @see EventQueue::unlock()
      */
-    UncontendedMutex service_mutex;
+    FairUncontendedMutex service_mutex;
 
     //! Insert / remove event from the queue. Should only be called
     //! by thread operating this queue.


### PR DESCRIPTION
# **Objective**

gem5::FairUncontendedMutex is a fair mutex that is also fast for uncontended scenarios.

# **Background**

The upstream gem5 has a gem5::UncontendedMutex to replace std::mutex that optimizes the single thread case. The solution works perfectly for single thread cases. However, when two threads fight for the UncontendedMutex there is a starvation issue. It worked for 5 years. However, recently we observed a serious delay on intensive TunnelIp requests for both UFS and ISP. The goal of this mutex is to be fair while being fast for uncontended scenarios.

## **Barging Issue of gem5::UncontendedMutex**

The following is the implementation of gem5::UncontendedMutex:

```
void
lock()
{
    while (!testAndSet(0, 1)) {
        std::unique_lock<std::mutex> ul(m);
        if (flag++ == 0) {
            break;
        }
        cv.wait(ul);

    }
}

void
unlock()
{
    if (testAndSet(1, 0)) {
        return;
    }
    {
        std::lock_guard<std::mutex> g(m);
        flag = 0;
    }
    cv.notify_all();
}

```

When the lock owner releases the lock and notify\_all the chance is high that it locks it again before the waiting thread is awake. If that happens, the flag is 0 and it hits the fast path and sets it back to 1\. The one that was previously waiting for the lock then wakes and finds the flag is still 1 and gets back to sleep again. The lock holder then keeps looping on the fast path (lock and unlock) and never notify\_all anymore. The waiter gets very little chance to win the fight against the barging thread. After the tickless timer removes the redundant events, the gRPC gets abnormal delay waiting for the lock. Under the unittest, when 10 threads fight together for 1000 iterations, a thread can dominate the thread for all its 1000 iterations.

# **Design**

The gem5::FairUncontendedMutex has a FIFO queue to keep all the waiting threads fair. It uses head and tail ids to implement the index based queue to get better performance than std::queue.

We use unsigned int for the id so that if it reaches UINT\_MAX, it'll wrap around back to 0\. It works as long as there are less than 2^32 threads waiting for the lock.

## **Fast Path**

When a thread is the only one acquiring the lock, the queue size is 1 and it returns without acquiring the real std::mutex. When a thread unlocks without other threads waiting for it, the queue size is 1 and it returns without waking up other threads. Therefore, no system call is required on both fast paths.

## **Waiting**

When a thread locks while another thread is already holding the lock, it 

```
void
lock()
{
    unsigned int slot_id = tail_id++;
    // 1
    if (slot_id == head_id) { // Only one in the queue.
        // 2
        return;
    }
    std::unique_lock<std::mutex> ul(m);
    while (slot_id != head_id) {
        // 3
        cv.wait(ul);
    }
}

void
unlock()
{
    int current = ++head_id
    // 4
    if (tail_id == current) { // Only one in the queue.
        // 5
        return;
    }
    {
        std::lock_guard<std::mutex> g(m);
        cv.notify_all();
    }
}
```

# **Tests**

We use some tests to make sure gem5::FairUncontendedMutex meets our requirements.

1. SingleThread tests make sure gem5::FairUncontendedMutex has similar performance on single thread (most common case).  
2. NoBarging test makes sure gem5::FairUncontendedMutex doesn't serve the same thread continuously.

```
[==========] Running 5 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from UncontendedMutex
[ RUN      ] UncontendedMutex.Lock
[       OK ] UncontendedMutex.Lock (200 ms)
[ RUN      ] UncontendedMutex.HeavyContention
[       OK ] UncontendedMutex.HeavyContention (71 ms)
[ RUN      ] UncontendedMutex.SingleThread
[       OK ] UncontendedMutex.SingleThread (550 ms)
[----------] 3 tests from UncontendedMutex (823 ms total)

[----------] 2 tests from FairUncontendedMutex
[ RUN      ] FairUncontendedMutex.NoBarging
[       OK ] FairUncontendedMutex.NoBarging (316 ms)
[ RUN      ] FairUncontendedMutex.SingleThread
[       OK ] FairUncontendedMutex.SingleThread (497 ms)
[----------] 2 tests from FairUncontendedMutex (813 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 2 test suites ran. (1636 ms total)
[  PASSED  ] 5 tests

```
# **Potential Race Condition Discussion**

This section discusses the potential races. For the reviewer, please add a comment to this section if you suspect races in any place.

## **Lock Early Return (1)**

If the locking thread gets context switch at (1), there is no early return issue as only the true "first" locker will get lock\_id \== head\_id. (Due to the "atomic" constraints)

## **Lock Early Return (2)**

After checking lock\_id \== head\_id the condition may not hold if head\_id changes. If the lock is released, head\_id won't change because no one can unlock before locking. (Due to the usage of mutex). If the lock is acquired, the condition will never hold.

## **Unlock Early Return (4)**

If tail\_id is changed in (4), the tail\_id \== current becomes false even if nobody is waiting. This causes any extra std::mutex lock and notify. But it does not harm the correctness.

## **Unlock Early Return (5)**

If tail\_id is changed after the comparison tail\_id \== current, that means another thread lock after the only locker releases. That case, the holder could release the lock without notify\_all. Nobody is waiting for its notification (because the new locker should go the fast path).

## **Lost Wake-up (3)**

If notify\_all happens on (3), the notification may arrive before the threads wait. To avoid that, we acquire the lock before notify\_all to avoid lost wake-up problems.

# **Limitation and Alternative Design**

The current implementation enhances the fairness of the mutex. However, the throughput decreases because the context switch happens.

OTOH, the current implementation does not set up the std::memory\_order. The default std::memory\_order\_seq\_cst is the most expensive constraint. It is possible to optimize it with fine grain control of the memory order.