### PR TITLE
scons: Fix compiler detection when CXX is clang++

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -461,7 +461,8 @@ main['TCMALLOC_CCFLAGS'] = []
 
 CXX_version = readCommand([main['CXX'], '--version'], exception=False)
 
-main['GCC'] = CXX_version and CXX_version.find('g++') >= 0
+main['GCC'] = CXX_version and CXX_version.find('g++') >= 0 and \
+              CXX_version.find('clang') < 0
 main['CLANG'] = CXX_version and CXX_version.find('clang') >= 0
 if main['GCC'] + main['CLANG'] > 1:
     error('Two compilers enabled at once?')


### PR DESCRIPTION
The GCC detection logic checked if '--version' output contained the substring 'g++'. When the C++ compiler is clang++, some distributions include a configuration file path such as
'/etc/clang19/x86_64-redhat-linux-gnu-clang++.cfg' in the version output. This caused both GCC and Clang to be detected simultaneously, triggering the 'Two compilers enabled at once?' error.

Ensure GCC is only detected when the version output contains 'g++' but does not contain 'clang', so clang++ is recognized correctly as Clang.

Reproduced with `CXX=clang++-19 scons build/RISCV/gem5.opt` on Fedora 44 with clang19.