### PR TITLE
mem: Fix latency calculation in SerialLink

### DIFF
--- a/src/mem/serial_link.cc
+++ b/src/mem/serial_link.cc
@@ -147,8 +147,9 @@ SerialLink::SerialLinkRequestPort::recvTimingResp(PacketPtr pkt)
     // deserialization latency.
     Cycles cycles = delay;
     cycles += serial_link.ticksToCycles(
-        divCeil(sim_clock::as_int::s * pkt->getSize() * 8,
-                serial_link.num_lanes * serial_link.link_speed * 1000000000));
+        sim_clock::as_int::ns *
+        divCeil(pkt->getSize() * 8,
+                serial_link.num_lanes * serial_link.link_speed));
     Tick t = serial_link.clockEdge(cycles);
 
     //@todo: If the processor sends two uncached requests towards HMC and the
@@ -208,9 +209,10 @@ SerialLink::SerialLinkResponsePort::recvTimingReq(PacketPtr pkt)
             // serial link, we should account for its deserialization latency
             // only.
             Cycles cycles = delay;
-            cycles += serial_link.ticksToCycles(divCeil(
-                sim_clock::as_int::s * pkt->getSize() * 8,
-                serial_link.num_lanes * serial_link.link_speed * 1000000000));
+            cycles += serial_link.ticksToCycles(
+                sim_clock::as_int::ns *
+                divCeil(pkt->getSize() * 8,
+                        serial_link.num_lanes * serial_link.link_speed));
             Tick t = serial_link.clockEdge(cycles);
 
             //@todo: If the processor sends two uncached requests towards HMC
@@ -296,9 +298,10 @@ SerialLink::SerialLinkRequestPort::trySendTiming()
             DPRINTF(SerialLink, "Scheduling next send\n");
 
             // Make sure bandwidth limitation is met
-            Cycles cycles = serial_link.ticksToCycles(divCeil(
-                sim_clock::as_int::s * pkt->getSize() * 8,
-                serial_link.num_lanes * serial_link.link_speed * 1000000000));
+            Cycles cycles = serial_link.ticksToCycles(
+                sim_clock::as_int::ns *
+                divCeil(pkt->getSize() * 8,
+                        serial_link.num_lanes * serial_link.link_speed));
             Tick t = serial_link.clockEdge(cycles);
             serial_link.schedule(sendEvent, std::max(next_req.tick, t));
         }
@@ -342,9 +345,10 @@ SerialLink::SerialLinkResponsePort::trySendTiming()
             DPRINTF(SerialLink, "Scheduling next send\n");
 
             // Make sure bandwidth limitation is met
-            Cycles cycles = serial_link.ticksToCycles(divCeil(
-                sim_clock::as_int::s * pkt->getSize() * 8,
-                serial_link.num_lanes * serial_link.link_speed * 1000000000));
+            Cycles cycles = serial_link.ticksToCycles(
+                sim_clock::as_int::ns *
+                divCeil(pkt->getSize() * 8,
+                        serial_link.num_lanes * serial_link.link_speed));
             Tick t = serial_link.clockEdge(cycles);
             serial_link.schedule(sendEvent, std::max(next_resp.tick, t));
         }

--- a/src/mem/serial_link.cc
+++ b/src/mem/serial_link.cc
@@ -147,8 +147,9 @@ SerialLink::SerialLinkRequestPort::recvTimingResp(PacketPtr pkt)
     // deserialization latency.
     Cycles cycles = delay;
     cycles += serial_link.ticksToCycles(
-        1000 * divCeil(pkt->getSize() * 8,
-                       serial_link.num_lanes * serial_link.link_speed));
+        sim_clock::as_int::s *
+        divCeil(pkt->getSize() * 8,
+                serial_link.num_lanes * serial_link.link_speed * 1000000000));
     Tick t = serial_link.clockEdge(cycles);
 
     //@todo: If the processor sends two uncached requests towards HMC and the
@@ -209,9 +210,10 @@ SerialLink::SerialLinkResponsePort::recvTimingReq(PacketPtr pkt)
             // only.
             Cycles cycles = delay;
             cycles += serial_link.ticksToCycles(
-                1000 *
-                divCeil(pkt->getSize() * 8,
-                        serial_link.num_lanes * serial_link.link_speed));
+                sim_clock::as_int::s *
+                divCeil(pkt->getSize() * 8, serial_link.num_lanes *
+                                                serial_link.link_speed *
+                                                1000000000));
             Tick t = serial_link.clockEdge(cycles);
 
             //@todo: If the processor sends two uncached requests towards HMC
@@ -297,8 +299,11 @@ SerialLink::SerialLinkRequestPort::trySendTiming()
             DPRINTF(SerialLink, "Scheduling next send\n");
 
             // Make sure bandwidth limitation is met
-            Cycles cycles = Cycles(divCeil(pkt->getSize() * 8,
-                serial_link.num_lanes * serial_link.link_speed));
+            Cycles cycles = serial_link.ticksToCycles(
+                sim_clock::as_int::s *
+                divCeil(pkt->getSize() * 8, serial_link.num_lanes *
+                                                serial_link.link_speed *
+                                                1000000000));
             Tick t = serial_link.clockEdge(cycles);
             serial_link.schedule(sendEvent, std::max(next_req.tick, t));
         }
@@ -342,8 +347,11 @@ SerialLink::SerialLinkResponsePort::trySendTiming()
             DPRINTF(SerialLink, "Scheduling next send\n");
 
             // Make sure bandwidth limitation is met
-            Cycles cycles = Cycles(divCeil(pkt->getSize() * 8,
-                serial_link.num_lanes * serial_link.link_speed));
+            Cycles cycles = serial_link.ticksToCycles(
+                sim_clock::as_int::s *
+                divCeil(pkt->getSize() * 8, serial_link.num_lanes *
+                                                serial_link.link_speed *
+                                                1000000000));
             Tick t = serial_link.clockEdge(cycles);
             serial_link.schedule(sendEvent, std::max(next_resp.tick, t));
         }

--- a/src/mem/serial_link.cc
+++ b/src/mem/serial_link.cc
@@ -146,9 +146,10 @@ SerialLink::SerialLinkRequestPort::recvTimingResp(PacketPtr pkt)
     // have to wait to receive the whole packet. So we only account for the
     // deserialization latency.
     Cycles cycles = delay;
-    cycles += Cycles(divCeil(pkt->getSize() * 8, serial_link.num_lanes
-                * serial_link.link_speed));
-     Tick t = serial_link.clockEdge(cycles);
+    cycles += serial_link.ticksToCycles(
+        1000 * divCeil(pkt->getSize() * 8,
+                       serial_link.num_lanes * serial_link.link_speed));
+    Tick t = serial_link.clockEdge(cycles);
 
     //@todo: If the processor sends two uncached requests towards HMC and the
     // second one is smaller than the first one. It may happen that the second
@@ -207,8 +208,10 @@ SerialLink::SerialLinkResponsePort::recvTimingReq(PacketPtr pkt)
             // serial link, we should account for its deserialization latency
             // only.
             Cycles cycles = delay;
-            cycles += Cycles(divCeil(pkt->getSize() * 8,
-                    serial_link.num_lanes * serial_link.link_speed));
+            cycles += serial_link.ticksToCycles(
+                1000 *
+                divCeil(pkt->getSize() * 8,
+                        serial_link.num_lanes * serial_link.link_speed));
             Tick t = serial_link.clockEdge(cycles);
 
             //@todo: If the processor sends two uncached requests towards HMC

--- a/src/mem/serial_link.cc
+++ b/src/mem/serial_link.cc
@@ -147,8 +147,7 @@ SerialLink::SerialLinkRequestPort::recvTimingResp(PacketPtr pkt)
     // deserialization latency.
     Cycles cycles = delay;
     cycles += serial_link.ticksToCycles(
-        sim_clock::as_int::s *
-        divCeil(pkt->getSize() * 8,
+        divCeil(sim_clock::as_int::s * pkt->getSize() * 8,
                 serial_link.num_lanes * serial_link.link_speed * 1000000000));
     Tick t = serial_link.clockEdge(cycles);
 
@@ -209,11 +208,9 @@ SerialLink::SerialLinkResponsePort::recvTimingReq(PacketPtr pkt)
             // serial link, we should account for its deserialization latency
             // only.
             Cycles cycles = delay;
-            cycles += serial_link.ticksToCycles(
-                sim_clock::as_int::s *
-                divCeil(pkt->getSize() * 8, serial_link.num_lanes *
-                                                serial_link.link_speed *
-                                                1000000000));
+            cycles += serial_link.ticksToCycles(divCeil(
+                sim_clock::as_int::s * pkt->getSize() * 8,
+                serial_link.num_lanes * serial_link.link_speed * 1000000000));
             Tick t = serial_link.clockEdge(cycles);
 
             //@todo: If the processor sends two uncached requests towards HMC
@@ -299,11 +296,9 @@ SerialLink::SerialLinkRequestPort::trySendTiming()
             DPRINTF(SerialLink, "Scheduling next send\n");
 
             // Make sure bandwidth limitation is met
-            Cycles cycles = serial_link.ticksToCycles(
-                sim_clock::as_int::s *
-                divCeil(pkt->getSize() * 8, serial_link.num_lanes *
-                                                serial_link.link_speed *
-                                                1000000000));
+            Cycles cycles = serial_link.ticksToCycles(divCeil(
+                sim_clock::as_int::s * pkt->getSize() * 8,
+                serial_link.num_lanes * serial_link.link_speed * 1000000000));
             Tick t = serial_link.clockEdge(cycles);
             serial_link.schedule(sendEvent, std::max(next_req.tick, t));
         }
@@ -347,11 +342,9 @@ SerialLink::SerialLinkResponsePort::trySendTiming()
             DPRINTF(SerialLink, "Scheduling next send\n");
 
             // Make sure bandwidth limitation is met
-            Cycles cycles = serial_link.ticksToCycles(
-                sim_clock::as_int::s *
-                divCeil(pkt->getSize() * 8, serial_link.num_lanes *
-                                                serial_link.link_speed *
-                                                1000000000));
+            Cycles cycles = serial_link.ticksToCycles(divCeil(
+                sim_clock::as_int::s * pkt->getSize() * 8,
+                serial_link.num_lanes * serial_link.link_speed * 1000000000));
             Tick t = serial_link.clockEdge(cycles);
             serial_link.schedule(sendEvent, std::max(next_resp.tick, t));
         }


### PR DESCRIPTION
Fixes this issue: https://github.com/gem5/gem5/issues/3092.

Previously, the value returned by divCeil (in nanoseconds) was used. However, a value in cycles was expected. This commit modifies the conversion so the units are correct.