### PR TITLE
util-m5: Prevent duplication of quotes in `dot_writer.py`

### DIFF
--- a/src/python/m5/util/dot_writer.py
+++ b/src/python/m5/util/dot_writer.py
@@ -168,7 +168,7 @@ def dot_create_cluster(simNode, full_path, label):
     # Account for the quotes added later around the tooltip string
     tooltip = "&#10;\\".join(ini_strings)
     # Remove existing quotes from the tooltip string.
-    tooltip = tooltip.replace('"', '')
+    tooltip = tooltip.replace('"', "")
     max_tooltip_length = 16384 - 2
     if len(tooltip) > max_tooltip_length:
         truncated = "... (truncated)"

--- a/src/python/m5/util/dot_writer.py
+++ b/src/python/m5/util/dot_writer.py
@@ -167,6 +167,8 @@ def dot_create_cluster(simNode, full_path, label):
     # Pydot limit line length to 16384.
     # Account for the quotes added later around the tooltip string
     tooltip = "&#10;\\".join(ini_strings)
+    # Remove existing quotes from the tooltip string.
+    tooltip = tooltip.replace('"', '')
     max_tooltip_length = 16384 - 2
     if len(tooltip) > max_tooltip_length:
         truncated = "... (truncated)"


### PR DESCRIPTION
Removes existing quotes in tooltips for elements in `dot_writer.py` to prevent bug caused by tooltip text that contain quotes (e.g. "hello") resulting in two empty strings as quotes are inserted to all tooltip text (e.g. ""hello"").