### PR TITLE
mem-ruby: Fix MII→I assert when local directory entry still exists

### DIFF
--- a/src/mem/ruby/protocol/MOESI_CMP_directory-L2cache.sm
+++ b/src/mem/ruby/protocol/MOESI_CMP_directory-L2cache.sm
@@ -1586,6 +1586,13 @@ machine(MachineType:L2Cache, "Token protocol")
     localDirectory.deallocate(address);
   }
 
+  action(removeFromDirIfExists, "/rmdir1", desc="Remove dir state if exists") {
+    if(isDirTagPresent(address)){
+      assert(isDirEntryClean(getDirEntry(address)));
+      localDirectory.deallocate(address);
+    }
+  }
+
   action(zz_recycleGlobalRequestQueue, "\zglb", desc="Send the head of the mandatory queue to the back of the queue.") {
     peek(requestNetwork_in, RequestMsg) {
       APPEND_TRANSITION_COMMENT(in_msg.Requestor);
@@ -2907,6 +2914,7 @@ machine(MachineType:L2Cache, "Token protocol")
 
   transition(MII, Writeback_Nack, I) {
     s_deallocateTBE;
+    removeFromDirIfExists;
     n_popResponseQueue;
     wa_wakeUpDependents;
   }
@@ -2925,6 +2933,7 @@ machine(MachineType:L2Cache, "Token protocol")
 
   transition(MII, Writeback_Ack, I) {
     f_sendUnblock;
+    removeFromDirIfExists;
     s_deallocateTBE;
     n_popResponseQueue;
     wa_wakeUpDependents;


### PR DESCRIPTION
As noted in the prior issue, state MII previously incorrectly invoked removeFromDir when no local directory entry was present (https://github.com/gem5/gem5/pull/1944).

However, the existence of the directory entry for MII is non-deterministic, as this state can be reached via different paths:
Directory entry exists: OLSX → OLSI → ILSI → MII
Directory entry does not exist: M → MI → MII
Previously removing removeFromDir may cause _setState(I)_ asserts when MII goes back to I from the first path.

Splitting the MII state might be a better fix, which aligns with SLICC conventions.