### PR TITLE
base, dev: Replace libdnet with POSIX standard netinet header

### DIFF
--- a/src/base/inet.cc
+++ b/src/base/inet.cc
@@ -57,21 +57,51 @@ namespace gem5
 namespace networking
 {
 
+namespace
+{
+
+int
+ip_cksum_add(const void *buf, size_t len, int cksum)
+{
+    uint16_t *sp = (uint16_t *)buf;
+    int sn = len / 2;
+
+    while (sn--) {
+        cksum += *sp++;
+    }
+
+    if (len & 1) {
+        cksum += htons(*(uint8_t *)sp << 8);
+    }
+
+    return cksum;
+}
+
+uint16_t
+ip_cksum_carry(int cksum)
+{
+    while (cksum >> 16) {
+        cksum = (cksum & 0xffff) + (cksum >> 16);
+    }
+
+    return (~(uint16_t)cksum);
+}
+
+} // anonymous namespace
+
 EthAddr::EthAddr()
 {
-    std::memset(data, 0, ETH_ADDR_LEN);
+    std::memset(ether_addr_octet, 0, ETHER_ADDR_LEN);
 }
 
-EthAddr::EthAddr(const uint8_t ea[ETH_ADDR_LEN])
+EthAddr::EthAddr(const uint8_t ea[ETHER_ADDR_LEN])
 {
-    for (int i = 0; i < ETH_ADDR_LEN; ++i)
-        data[i] = ea[i];
+    std::memcpy(ether_addr_octet, ea, ETHER_ADDR_LEN);
 }
 
-EthAddr::EthAddr(const eth_addr &ea)
+EthAddr::EthAddr(const ether_addr &ea)
 {
-    for (int i = 0; i < ETH_ADDR_LEN; ++i)
-        data[i] = ea.data[i];
+    std::memcpy(ether_addr_octet, ea.ether_addr_octet, ETHER_ADDR_LEN);
 }
 
 EthAddr::EthAddr(const std::string &addr)
@@ -80,9 +110,9 @@ EthAddr::EthAddr(const std::string &addr)
 }
 
 const EthAddr &
-EthAddr::operator=(const eth_addr &ea)
+EthAddr::operator=(const ether_addr &ea)
 {
-    *data = *ea.data;
+    std::memcpy(ether_addr_octet, ea.ether_addr_octet, ETHER_ADDR_LEN);
     return *this;
 }
 
@@ -96,22 +126,22 @@ EthAddr::operator=(const std::string &addr)
 void
 EthAddr::parse(const std::string &addr)
 {
-    // the hack below is to make sure that ETH_ADDR_LEN is 6 otherwise
+    // the hack below is to make sure that ETHER_ADDR_LEN is 6 otherwise
     // the sscanf function won't work.
-    int bytes[ETH_ADDR_LEN == 6 ? ETH_ADDR_LEN : -1];
+    int bytes[ETHER_ADDR_LEN == 6 ? ETHER_ADDR_LEN : -1];
     if (sscanf(addr.c_str(), "%x:%x:%x:%x:%x:%x", &bytes[0], &bytes[1],
-               &bytes[2], &bytes[3], &bytes[4], &bytes[5]) != ETH_ADDR_LEN) {
-        std::memset(data, 0xff, ETH_ADDR_LEN);
+               &bytes[2], &bytes[3], &bytes[4], &bytes[5]) != ETHER_ADDR_LEN) {
+        std::memset(ether_addr_octet, 0xff, ETHER_ADDR_LEN);
         return;
     }
 
-    for (int i = 0; i < ETH_ADDR_LEN; ++i) {
+    for (int i = 0; i < ETHER_ADDR_LEN; ++i) {
         if (bytes[i] & ~0xff) {
-            std::memset(data, 0xff, ETH_ADDR_LEN);
+            std::memset(ether_addr_octet, 0xff, ETHER_ADDR_LEN);
             return;
         }
 
-        data[i] = bytes[i];
+        ether_addr_octet[i] = bytes[i];
     }
 }
 
@@ -126,7 +156,7 @@ EthAddr::string() const
 bool
 operator==(const EthAddr &left, const EthAddr &right)
 {
-    return !std::memcmp(left.bytes(), right.bytes(), ETH_ADDR_LEN);
+    return !std::memcmp(left.bytes(), right.bytes(), ETHER_ADDR_LEN);
 }
 
     std::ostream &
@@ -263,8 +293,8 @@ IpHdr::options(std::vector<const IpOpt *> &vec) const
 {
     vec.clear();
 
-    const uint8_t *data = bytes() + sizeof(struct ip_hdr);
-    int all = hlen() - sizeof(struct ip_hdr);
+    const uint8_t *data = bytes() + sizeof(struct ip);
+    int all = hlen() - sizeof(struct ip);
     while (all > 0) {
         const IpOpt *opt = (const IpOpt *)data;
         int len = opt->len();
@@ -285,9 +315,9 @@ namespace
 bool
 ip6Extension(uint8_t nxt)
 {
-    return nxt == IP_PROTO_HOPOPTS || nxt == IP_PROTO_ROUTING ||
-        nxt == IP_PROTO_FRAGMENT || nxt == IP_PROTO_AH ||
-        nxt == IP_PROTO_ESP || nxt == IP_PROTO_DSTOPTS;
+    return nxt == IPPROTO_HOPOPTS || nxt == IPPROTO_ROUTING ||
+           nxt == IPPROTO_FRAGMENT || nxt == IPPROTO_AH ||
+           nxt == IPPROTO_ESP || nxt == IPPROTO_DSTOPTS;
 }
 
 } // anonymous namespace
@@ -366,8 +396,8 @@ TcpHdr::options(std::vector<const TcpOpt *> &vec) const
 {
     vec.clear();
 
-    const uint8_t *data = bytes() + sizeof(struct tcp_hdr);
-    int all = off() - sizeof(struct tcp_hdr);
+    const uint8_t *data = bytes() + sizeof(struct tcphdr);
+    int all = off() - sizeof(struct tcphdr);
     while (all > 0) {
         const TcpOpt *opt = (const TcpOpt *)data;
         int len = opt->len();

--- a/src/base/inet.hh
+++ b/src/base/inet.hh
@@ -42,6 +42,15 @@
 #ifndef __BASE_INET_HH__
 #define __BASE_INET_HH__
 
+#include <arpa/inet.h>
+#include <netinet/if_ether.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/ip_icmp.h>
+#include <netinet/tcp.h>
+#include <netinet/udp.h>
+
 #include <iosfwd>
 #include <string>
 #include <utility>
@@ -50,20 +59,6 @@
 #include "base/compiler.hh"
 #include "base/types.hh"
 #include "dev/net/etherpkt.hh"
-#include "dnet/os.h"
-#include "dnet/eth.h"
-#include "dnet/ip.h"
-#include "dnet/ip6.h"
-#include "dnet/addr.h"
-#include "dnet/arp.h"
-#include "dnet/icmp.h"
-#include "dnet/tcp.h"
-#include "dnet/udp.h"
-#include "dnet/intf.h"
-#include "dnet/route.h"
-#include "dnet/fw.h"
-#include "dnet/blob.h"
-#include "dnet/rand.h"
 
 namespace gem5
 {
@@ -71,10 +66,98 @@ namespace gem5
 namespace networking
 {
 
+constexpr size_t IP6_HDR_LEN = 40;
+
+#define IPOPT_TYPEONLY(o) ((o) == IPOPT_EOL || (o) == IPOPT_NOP)
+#define TCPOPT_TYPEONLY(o) ((o) == TCPOPT_EOL || (o) == TCPOPT_NOP)
+
+/*
+ * Security option data - RFC 791, 3.1
+ */
+struct GEM5_PACKED ip_opt_data_sec
+{
+    uint16_t s;     /* security */
+    uint16_t c;     /* compartments */
+    uint16_t h;     /* handling restrictions */
+    uint8_t tcc[3]; /* transmission control code */
+};
+
+/*
+ * {Loose Source, Record, Strict Source} Route option data - RFC 791, 3.1
+ */
+struct GEM5_PACKED ip_opt_data_rr
+{
+    uint8_t ptr;        /* from start of option, >= 4 */
+    uint32_t iplist[0]; /* list of IP addresses */
+};
+
+/*
+ * Timestamp option data - RFC 791, 3.1
+ */
+struct GEM5_PACKED ip_opt_data_ts
+{
+    uint8_t ptr; /* from start of option, >= 5 */
+#if BYTE_ORDER == BIG_ENDIAN
+    uint8_t oflw : 4, /* number of IPs skipped */
+        flg : 4;      /* address[ / timestamp] flag */
+#elif BYTE_ORDER == LITTLE_ENDIAN
+    uint8_t flg : 4, oflw : 4;
+#endif
+    uint32_t ipts[0]; /* IP address [/ timestamp] pairs */
+};
+
+/*
+ * Traceroute option data - RFC 1393, 2.2
+ */
+struct GEM5_PACKED ip_opt_data_tr
+{
+    uint16_t id;     /* ID number */
+    uint16_t ohc;    /* outbound hop count */
+    uint16_t rhc;    /* return hop count */
+    uint32_t origip; /* originator IP address */
+};
+
+struct GEM5_PACKED ip_opt
+{
+    uint8_t opt_type;
+    uint8_t opt_len;
+    union ip_opt_data
+    {
+        ip_opt_data_sec sec;
+        ip_opt_data_rr rr;
+        ip_opt_data_ts ts;
+        uint16_t satid;
+        uint16_t mtu;
+        ip_opt_data_tr tr;
+        uint32_t addext[2];
+        uint16_t rtralt;
+        uint32_t sdb[9];
+        uint8_t data8[38];
+    } opt_data;
+};
+
+struct GEM5_PACKED tcp_opt
+{
+    uint8_t opt_type;
+    uint8_t opt_len;
+    union
+    {
+        uint16_t mss;
+        uint8_t wscale;
+        uint32_t sack[8];
+        uint32_t echo;
+        uint32_t timestamp[2];
+        uint32_t cc;
+        uint8_t cksum;
+        uint8_t md5[16];
+        uint8_t data8[40];
+    } opt_data;
+};
+
 /*
  * Ethernet Stuff
  */
-struct EthAddr : protected eth_addr
+struct EthAddr : protected ether_addr
 {
   protected:
     void parse(const std::string &addr);
@@ -85,39 +168,58 @@ struct EthAddr : protected eth_addr
      * @{
      */
     EthAddr();
-    EthAddr(const uint8_t ea[ETH_ADDR_LEN]);
-    EthAddr(const eth_addr &ea);
+    EthAddr(const uint8_t ea[ETHER_ADDR_LEN]);
+    EthAddr(const ether_addr &ea);
     EthAddr(const std::string &addr);
-    const EthAddr &operator=(const eth_addr &ea);
+    const EthAddr &operator=(const ether_addr &ea);
     const EthAddr &operator=(const std::string &addr);
     /** @} */ // end of api_inet
 
     /**
      * @ingroup api_inet
      */
-    int size() const { return sizeof(eth_addr); }
-
+    int
+    size() const
+    {
+        return sizeof(ether_addr);
+    }
 
     /**
      * @ingroup api_inet
      * @{
      */
-    const uint8_t *bytes() const { return &data[0]; }
-    uint8_t *bytes() { return &data[0]; }
+    const uint8_t *
+    bytes() const
+    {
+        return &ether_addr_octet[0];
+    }
+    uint8_t *
+    bytes()
+    {
+        return &ether_addr_octet[0];
+    }
     /** @} */ // end of api_inet
 
     /**
      * @ingroup api_inet
      * @{
      */
-    const uint8_t *addr() const { return &data[0]; }
-    bool unicast() const { return !(data[0] & 0x01); }
+    const uint8_t *
+    addr() const
+    {
+        return &ether_addr_octet[0];
+    }
+    bool
+    unicast() const
+    {
+        return !(ether_addr_octet[0] & 0x01);
+    }
     bool multicast() const { return !unicast() && !broadcast(); }
     bool broadcast() const
     {
         bool isBroadcast = true;
-        for (int i = 0; i < ETH_ADDR_LEN; ++i) {
-            isBroadcast = isBroadcast && data[i] == 0xff;
+        for (int i = 0; i < ETHER_ADDR_LEN; ++i) {
+            isBroadcast = isBroadcast && ether_addr_octet[i] == 0xff;
         }
 
         return isBroadcast;
@@ -135,12 +237,12 @@ struct EthAddr : protected eth_addr
     operator uint64_t() const
     {
         uint64_t reg = 0;
-        reg |= ((uint64_t)data[0]) << 40;
-        reg |= ((uint64_t)data[1]) << 32;
-        reg |= ((uint64_t)data[2]) << 24;
-        reg |= ((uint64_t)data[3]) << 16;
-        reg |= ((uint64_t)data[4]) << 8;
-        reg |= ((uint64_t)data[5]) << 0;
+        reg |= ((uint64_t)ether_addr_octet[0]) << 40;
+        reg |= ((uint64_t)ether_addr_octet[1]) << 32;
+        reg |= ((uint64_t)ether_addr_octet[2]) << 24;
+        reg |= ((uint64_t)ether_addr_octet[3]) << 16;
+        reg |= ((uint64_t)ether_addr_octet[4]) << 8;
+        reg |= ((uint64_t)ether_addr_octet[5]) << 0;
         return reg;
     }
 
@@ -154,15 +256,19 @@ std::ostream &operator<<(std::ostream &stream, const EthAddr &ea);
 bool operator==(const EthAddr &left, const EthAddr &right);
 /** @} */ // end of api_inet
 
-struct EthHdr : public eth_hdr
+struct EthHdr : public ether_header
 {
-    bool isVlan() const { return (ntohs(eth_type) == ETH_TYPE_8021Q); }
+    bool
+    isVlan() const
+    {
+        return (ntohs(ether_type) == ETHERTYPE_VLAN);
+    }
     uint16_t type() const {
         if (!isVlan())
-            return ntohs(eth_type);
+            return ntohs(ether_type);
         else
             // L3 type is now 16 bytes into the hdr with 802.1Q
-            // instead of 12.  dnet/eth.h only supports 802.1
+            // instead of 12.  802.1 is supported.
             return ntohs(*((uint16_t*)(((uint8_t *)this) + 16)));
     }
     uint16_t vlanId() const {
@@ -172,14 +278,22 @@ struct EthHdr : public eth_hdr
             return 0x0000;
     }
 
-    const EthAddr &src() const { return *(EthAddr *)&eth_src; }
-    const EthAddr &dst() const { return *(EthAddr *)&eth_dst; }
+    const EthAddr &
+    src() const
+    {
+        return *(EthAddr *)&ether_shost;
+    }
+    const EthAddr &
+    dst() const
+    {
+        return *(EthAddr *)&ether_dhost;
+    }
 
     int size() const {
         if (!isVlan())
-            return sizeof(eth_hdr);
+            return sizeof(ether_header);
         else
-            return (sizeof(eth_hdr)+4);
+            return (sizeof(ether_header) + 4);
     }
 
     const uint8_t *bytes() const { return (const uint8_t *)this; }
@@ -325,7 +439,7 @@ bool operator==(const IpWithPort &left, const IpWithPort &right);
 /** @} */ // end of api_inet
 
 struct IpOpt;
-struct IpHdr : public ip_hdr
+struct IpHdr : public ip
 {
     uint8_t  version() const { return ip_v; }
     uint8_t  hlen() const { return ip_hl * 4; }
@@ -337,8 +451,16 @@ struct IpHdr : public ip_hdr
     uint8_t  ttl() const { return ip_ttl; }
     uint8_t  proto() const { return ip_p; }
     uint16_t sum() const { return ip_sum; }
-    uint32_t src() const { return ntohl(ip_src); }
-    uint32_t dst() const { return ntohl(ip_dst); }
+    uint32_t
+    src() const
+    {
+        return ntohl(ip_src.s_addr);
+    }
+    uint32_t
+    dst() const
+    {
+        return ntohl(ip_dst.s_addr);
+    }
 
     void sum(uint16_t sum) { ip_sum = sum; }
     void id(uint16_t _id) { ip_id = htons(_id); }
@@ -368,8 +490,9 @@ class IpPtr
 
         if (ptr) {
             EthHdr *eth = (EthHdr *)ptr->data;
-            if (eth->type() == ETH_TYPE_IP)
+            if (eth->type() == ETHERTYPE_IP) {
                 p = ptr;
+            }
             if (eth->isVlan())
                 eth_hdr_vlan = true;
         }
@@ -386,8 +509,12 @@ class IpPtr
     IpPtr(const IpPtr &ptr) : p(ptr.p), eth_hdr_vlan(ptr.eth_hdr_vlan) { }
     /** @} */ // end of api_inet
 
-    IpHdr *get() { return (IpHdr *)(p->data + sizeof(eth_hdr) +
-                                   ((eth_hdr_vlan) ? 4 : 0)); }
+    IpHdr *
+    get()
+    {
+        return (IpHdr *)(p->data + sizeof(ether_header) +
+                         ((eth_hdr_vlan) ? 4 : 0));
+    }
     IpHdr *operator->() { return get(); }
     IpHdr &operator*() { return *get(); }
 
@@ -396,8 +523,10 @@ class IpPtr
      * @{
      */
     const IpHdr *get() const
-    { return (const IpHdr *)(p->data + sizeof(eth_hdr) +
-                            ((eth_hdr_vlan) ? 4 : 0)); }
+    {
+        return (const IpHdr *)(p->data + sizeof(ether_header) +
+                               ((eth_hdr_vlan) ? 4 : 0));
+    }
     const IpHdr *operator->() const { return get(); }
     const IpHdr &operator*() const { return *get(); }
     /** @} */ // end of api_inet
@@ -414,7 +543,11 @@ class IpPtr
     EthPacketPtr packet() { return p; }
     bool operator!() const { return !p; }
     operator bool() const { return (p != nullptr); }
-    int off() const { return (sizeof(eth_hdr) + ((eth_hdr_vlan) ? 4 : 0)); }
+    int
+    off() const
+    {
+        return (sizeof(ether_header) + ((eth_hdr_vlan) ? 4 : 0));
+    }
     int pstart() const { return (off() + get()->size()); }
     /** @} */ // end of api_inet
 };
@@ -427,14 +560,42 @@ uint16_t cksum(const IpPtr &ptr);
 struct IpOpt : public ip_opt
 {
     uint8_t type() const { return opt_type; }
-    uint8_t typeNumber() const { return IP_OPT_NUMBER(opt_type); }
-    uint8_t typeClass() const { return IP_OPT_CLASS(opt_type); }
-    uint8_t typeCopied() const { return IP_OPT_COPIED(opt_type); }
-    uint8_t len() const { return IP_OPT_TYPEONLY(type()) ? 1 : opt_len; }
+    uint8_t
+    typeNumber() const
+    {
+        return IPOPT_NUMBER(opt_type);
+    }
+    uint8_t
+    typeClass() const
+    {
+        return IPOPT_CLASS(opt_type);
+    }
+    uint8_t
+    typeCopied() const
+    {
+        return IPOPT_COPIED(opt_type);
+    }
+    uint8_t
+    len() const
+    {
+        return IPOPT_TYPEONLY(type()) ? 1 : opt_len;
+    }
 
-    bool isNumber(int num) const { return typeNumber() == IP_OPT_NUMBER(num); }
-    bool isClass(int cls) const { return typeClass() == IP_OPT_CLASS(cls); }
-    bool isCopied(int cpy) const { return typeCopied() == IP_OPT_COPIED(cpy); }
+    bool
+    isNumber(int num) const
+    {
+        return typeNumber() == IPOPT_NUMBER(num);
+    }
+    bool
+    isClass(int cls) const
+    {
+        return typeClass() == IPOPT_CLASS(cls);
+    }
+    bool
+    isCopied(int cpy) const
+    {
+        return typeCopied() == IPOPT_COPIED(cpy);
+    }
 
     const uint8_t *data() const { return opt_data.data8; }
     void sec(ip_opt_data_sec &sec) const;
@@ -462,14 +623,34 @@ struct Ip6Hdr : public ip6_hdr
     uint8_t nxt() const { return ip6_nxt; }
     uint8_t hlim() const { return ip6_hlim; }
 
-    const uint8_t* src() const { return ip6_src.data; }
-    const uint8_t* dst() const { return ip6_dst.data; }
+    const uint8_t *
+    src() const
+    {
+        return ip6_src.s6_addr;
+    }
+    const uint8_t *
+    dst() const
+    {
+        return ip6_dst.s6_addr;
+    }
 
     int extensionLength() const;
     const Ip6Opt* getExt(uint8_t ext) const;
-    const Ip6Opt* fragmentExt() const { return getExt(IP_PROTO_FRAGMENT); }
-    const Ip6Opt* rtTypeExt() const { return getExt(IP_PROTO_ROUTING); }
-    const Ip6Opt* dstOptExt() const { return getExt(IP_PROTO_DSTOPTS); }
+    const Ip6Opt *
+    fragmentExt() const
+    {
+        return getExt(IPPROTO_FRAGMENT);
+    }
+    const Ip6Opt *
+    rtTypeExt() const
+    {
+        return getExt(IPPROTO_ROUTING);
+    }
+    const Ip6Opt *
+    dstOptExt() const
+    {
+        return getExt(IPPROTO_DSTOPTS);
+    }
     uint8_t proto() const;
 
     void plen(uint16_t _plen) { ip6_plen = htons(_plen); }
@@ -498,8 +679,9 @@ class Ip6Ptr
 
         if (ptr) {
             EthHdr *eth = (EthHdr *)ptr->data;
-            if (eth->type() == ETH_TYPE_IPV6)
+            if (eth->type() == ETHERTYPE_IPV6) {
                 p = ptr;
+            }
             if (eth->isVlan())
                 eth_hdr_vlan = true;
         }
@@ -516,14 +698,20 @@ class Ip6Ptr
     Ip6Ptr(const Ip6Ptr &ptr) : p(ptr.p), eth_hdr_vlan(ptr.eth_hdr_vlan) { }
     /** @} */ // end of api_inet
 
-    Ip6Hdr *get() { return (Ip6Hdr *)(p->data + sizeof(eth_hdr)
-                                      + ((eth_hdr_vlan) ? 4 : 0)); }
+    Ip6Hdr *
+    get()
+    {
+        return (Ip6Hdr *)(p->data + sizeof(ether_header) +
+                          ((eth_hdr_vlan) ? 4 : 0));
+    }
     Ip6Hdr *operator->() { return get(); }
     Ip6Hdr &operator*() { return *get(); }
 
     const Ip6Hdr *get() const
-    { return (const Ip6Hdr *)(p->data + sizeof(eth_hdr)
-                              + ((eth_hdr_vlan) ? 4 : 0)); }
+    {
+        return (const Ip6Hdr *)(p->data + sizeof(ether_header) +
+                                ((eth_hdr_vlan) ? 4 : 0));
+    }
     const Ip6Hdr *operator->() const { return get(); }
     const Ip6Hdr &operator*() const { return *get(); }
 
@@ -547,12 +735,16 @@ class Ip6Ptr
     EthPacketPtr packet() { return p; }
     bool operator!() const { return !p; }
     operator bool() const { return (p != nullptr); }
-    int off() const { return sizeof(eth_hdr) + ((eth_hdr_vlan) ? 4 : 0); }
+    int
+    off() const
+    {
+        return sizeof(ether_header) + ((eth_hdr_vlan) ? 4 : 0);
+    }
     int pstart() const { return off() + get()->size(); }
     /** @} */ // end of api_inet
 };
 
-// Dnet supplied ipv6 opt header is incomplete and
+// The ipv6 opt header is incomplete and
 // newer NIC card filters expect a more robust
 // ipv6 header option declaration.
 struct ip6_opt_fragment
@@ -566,14 +758,14 @@ struct ip6_opt_routing_type2
     uint8_t type;
     uint8_t segleft;
     uint32_t reserved;
-    ip6_addr_t addr;
+    in6_addr addr;
 };
 
 struct GEM5_PACKED ip6_opt_dstopts
 {
     uint8_t type;
     uint8_t length;
-    ip6_addr_t addr;
+    in6_addr addr;
 };
 
 struct GEM5_PACKED ip6_opt_hdr
@@ -600,7 +792,11 @@ struct Ip6Opt : public ip6_opt_hdr
     // Routing type 2
     uint8_t  rtType2Type() const { return ext_data.rtType2.type; }
     uint8_t  rtType2SegLft() const { return ext_data.rtType2.segleft; }
-    const uint8_t* rtType2Addr() const { return ext_data.rtType2.addr.data; }
+    const uint8_t *
+    rtType2Addr() const
+    {
+        return ext_data.rtType2.addr.s6_addr;
+    }
 
     // Fragment
     uint16_t fragmentOfflg() const { return ntohs(ext_data.fragment.offlg); }
@@ -609,7 +805,11 @@ struct Ip6Opt : public ip6_opt_hdr
     // Dst Options/Home Address Option
     uint8_t dstOptType() const { return ext_data.dstOpts.type; }
     uint8_t dstOptLength() const { return ext_data.dstOpts.length; }
-    const uint8_t* dstOptAddr() const { return ext_data.dstOpts.addr.data; }
+    const uint8_t *
+    dstOptAddr() const
+    {
+        return ext_data.dstOpts.addr.s6_addr;
+    }
 };
 
 
@@ -617,7 +817,7 @@ struct Ip6Opt : public ip6_opt_hdr
  * TCP Stuff
  */
 struct TcpOpt;
-struct TcpHdr : public tcp_hdr
+struct TcpHdr : public tcphdr
 {
     uint16_t sport() const { return ntohs(th_sport); }
     uint16_t dport() const { return ntohs(th_dport); }
@@ -651,17 +851,19 @@ class TcpPtr
     void set(const EthPacketPtr &ptr, int offset) { p = ptr; _off = offset; }
     void set(const IpPtr &ptr)
     {
-        if (ptr && ptr->proto() == IP_PROTO_TCP)
+        if (ptr && ptr->proto() == IPPROTO_TCP) {
             set(ptr.p, ptr.pstart());
-        else
+        } else {
             set(0, 0);
+        }
     }
     void set(const Ip6Ptr &ptr)
     {
-        if (ptr && ptr->proto() == IP_PROTO_TCP)
+        if (ptr && ptr->proto() == IPPROTO_TCP) {
             set(ptr.p, ptr.pstart());
-        else
+        } else {
             set(0, 0);
+        }
     }
 
   public:
@@ -714,7 +916,11 @@ uint16_t cksum(const TcpPtr &ptr);
 struct TcpOpt : public tcp_opt
 {
     uint8_t type() const { return opt_type; }
-    uint8_t len() const { return TCP_OPT_TYPEONLY(type()) ? 1 : opt_len; }
+    uint8_t
+    len() const
+    {
+        return TCPOPT_TYPEONLY(type()) ? 1 : opt_len;
+    }
 
     bool isopt(int opt) const { return type() == opt; }
 
@@ -739,7 +945,7 @@ struct TcpOpt : public tcp_opt
 /*
  * UDP Stuff
  */
-struct UdpHdr : public udp_hdr
+struct UdpHdr : public udphdr
 {
     uint16_t sport() const { return ntohs(uh_sport); }
     uint16_t dport() const { return ntohs(uh_dport); }
@@ -749,7 +955,11 @@ struct UdpHdr : public udp_hdr
     void sum(uint16_t sum) { uh_sum = sum; }
     void len(uint16_t _len) { uh_ulen = htons(_len); }
 
-    int size() const { return sizeof(udp_hdr); }
+    int
+    size() const
+    {
+        return sizeof(udphdr);
+    }
     const uint8_t *bytes() const { return (const uint8_t *)this; }
     const uint8_t *payload() const { return bytes() + size(); }
     uint8_t *bytes() { return (uint8_t *)this; }
@@ -765,17 +975,19 @@ class UdpPtr
     void set(const EthPacketPtr &ptr, int offset) { p = ptr; _off = offset; }
     void set(const IpPtr &ptr)
     {
-        if (ptr && ptr->proto() == IP_PROTO_UDP)
+        if (ptr && ptr->proto() == IPPROTO_UDP) {
             set(ptr.p, ptr.pstart());
-        else
+        } else {
             set(0, 0);
+        }
     }
     void set(const Ip6Ptr &ptr)
     {
-        if (ptr && ptr->proto() == IP_PROTO_UDP)
+        if (ptr && ptr->proto() == IPPROTO_UDP) {
             set(ptr.p, ptr.pstart());
-        else
+        } else {
             set(0, 0);
+        }
     }
 
   public:

--- a/src/dev/net/i8254xGBe.cc
+++ b/src/dev/net/i8254xGBe.cc
@@ -109,9 +109,10 @@ IGbE::IGbE(const Params &p)
     memset(&flash, 0, EEPROM_SIZE * 2);
 
     // Set the MAC address
-    memcpy(flash, p.hardware_address.bytes(), ETH_ADDR_LEN);
-    for (int x = 0; x < ETH_ADDR_LEN / 2; x++)
+    memcpy(flash, p.hardware_address.bytes(), ETHER_ADDR_LEN);
+    for (int x = 0; x < ETHER_ADDR_LEN / 2; x++) {
         flash[x] = htobe(flash[x]);
+    }
 
     uint16_t csum = 0;
     for (int x = 0; x < EEPROM_SIZE; x++)

--- a/src/dev/net/ns_gige.cc
+++ b/src/dev/net/ns_gige.cc
@@ -131,7 +131,7 @@ NSGigE::NSGigE(const Params &p)
     interface = new NSGigEInt(name() + ".int0", this);
 
     regsReset();
-    memcpy(&rom.perfectMatch, p.hardware_address.bytes(), ETH_ADDR_LEN);
+    memcpy(&rom.perfectMatch, p.hardware_address.bytes(), ETHER_ADDR_LEN);
 
     memset(&rxDesc32, 0, sizeof(rxDesc32));
     memset(&txDesc32, 0, sizeof(txDesc32));
@@ -1922,8 +1922,9 @@ NSGigE::rxFilter(const EthPacketPtr &packet)
         if (acceptPerfect && dst == rom.perfectMatch)
             drop = false;
 
-        if (acceptArp && eth->type() == ETH_TYPE_ARP)
+        if (acceptArp && eth->type() == ETHERTYPE_ARP) {
             drop = false;
+        }
 
     } else if (dst.broadcast()) {
         // if we're accepting broadcasts
@@ -2063,7 +2064,7 @@ NSGigE::serialize(CheckpointOut &cp) const
     SERIALIZE_SCALAR(regs.taner);
     SERIALIZE_SCALAR(regs.tesr);
 
-    SERIALIZE_ARRAY(rom.perfectMatch, ETH_ADDR_LEN);
+    SERIALIZE_ARRAY(rom.perfectMatch, ETHER_ADDR_LEN);
     SERIALIZE_ARRAY(rom.filterHash, FHASH_SIZE);
 
     SERIALIZE_SCALAR(ioEnable);
@@ -2228,7 +2229,7 @@ NSGigE::unserialize(CheckpointIn &cp)
     UNSERIALIZE_SCALAR(regs.taner);
     UNSERIALIZE_SCALAR(regs.tesr);
 
-    UNSERIALIZE_ARRAY(rom.perfectMatch, ETH_ADDR_LEN);
+    UNSERIALIZE_ARRAY(rom.perfectMatch, ETHER_ADDR_LEN);
     UNSERIALIZE_ARRAY(rom.filterHash, FHASH_SIZE);
 
     UNSERIALIZE_SCALAR(ioEnable);

--- a/src/dev/net/ns_gige.hh
+++ b/src/dev/net/ns_gige.hh
@@ -105,7 +105,7 @@ struct dp_rom
      * for perfect match memory.
      * the linux driver doesn't use any other ROM
      */
-    uint8_t perfectMatch[ETH_ADDR_LEN];
+    uint8_t perfectMatch[ETHER_ADDR_LEN];
 
     /**
      * for hash table memory.


### PR DESCRIPTION
Replace libdnet with POSIX standard netinet header to avoid ODR violation

```
ext/dnet/ip6.h:36: warning: type ‘union <anon>’ violates the C++ One Definition Rule [-Wodr]
   36 |         union {
/usr/include/netinet/ip6.h:27: note: a different type is defined in another translation unit
   27 |       {
ext/dnet/ip6.h:42: note: the first difference of corresponding definitions is field ‘ip6_un1’
   42 |                 } ip6_un1;
/usr/include/netinet/ip6.h:35: note: a field of same name but different type is defined in another translation unit
   35 |           } ip6_un1;
ext/dnet/ip6.h:37: note: type name ‘ip6_hdr::{unnamed type#1}::ip6_hdr_ctl’ should match type name ‘ip6_hdr::{unnamed type#1}::ip6_hdrctl’
   37 |                 struct ip6_hdr_ctl {
/usr/include/netinet/ip6.h:28: note: the incompatible type is defined here
   28 |         struct ip6_hdrctl
```