### PR TITLE
stdlib: fix Addr comparison by casting to int

### DIFF
--- a/src/python/gem5/components/memory/memory.py
+++ b/src/python/gem5/components/memory/memory.py
@@ -227,9 +227,8 @@ class ChanneledMemory(AbstractMemorySystem):
 
         sorted_ranges = sorted(ranges, key=lambda r: r.start)
         for i in range(len(sorted_ranges) - 1):
-            if (
-                sorted_ranges[i].start + sorted_ranges[i].size()
-                >= sorted_ranges[i + 1].start
+            if sorted_ranges[i].start + sorted_ranges[i].size() >= int(
+                sorted_ranges[i + 1].start
             ):
                 raise ValueError(
                     "Memory ranges must be non-overlapping and non-contiguous."


### PR DESCRIPTION
Previously, this comparison was failing because it was comparing an Addr and an int. This commit casts the Addr to an int to fix the comparison, and fix the test failures in the Daily `readfile_tests/x86` and `example_configs/x86` tests.