### PR TITLE
cpu-o3: Add RISC-V E-Trace (Efficient Trace) encoder

### DIFF
--- a/configs/example/gem5_library/riscv-etrace-se.py
+++ b/configs/example/gem5_library/riscv-etrace-se.py
@@ -90,5 +90,7 @@ board.set_se_binary_workload(
 simulator = Simulator(board=board)
 simulator.run()
 
-print(f"Simulation done. Exit cause: '{simulator.get_last_exit_event_cause()}'")
+print(
+    f"Simulation done. Exit cause: '{simulator.get_last_exit_event_cause()}'"
+)
 print("E-Trace output written to m5out/ directory")

--- a/configs/example/gem5_library/riscv-etrace-se.py
+++ b/configs/example/gem5_library/riscv-etrace-se.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 Rajesh Gangam
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Run a RISC-V SE binary on an O3 CPU with E-Trace enabled.  Produces a
+protobuf trace file that can be decoded with util/decode_etrace.py.
+
+Usage
+-----
+
+```
+scons build/RISCV/gem5.opt
+./build/RISCV/gem5.opt configs/example/gem5_library/riscv-etrace-se.py
+```
+
+After the simulation completes, decode the trace:
+
+```
+cd util && python3 decode_etrace.py ../m5out/system.processor.cores0\
+.core.etrace.etrace.pb.gz
+```
+"""
+
+from m5.objects import ETrace
+
+from gem5.components.boards.simple_board import SimpleBoard
+from gem5.components.cachehierarchies.classic.private_l1_cache_hierarchy import (
+    PrivateL1CacheHierarchy,
+)
+from gem5.components.memory.single_channel import SingleChannelDDR3_1600
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.simulator import Simulator
+
+cache_hierarchy = PrivateL1CacheHierarchy(
+    l1d_size="32kB",
+    l1i_size="32kB",
+)
+
+memory = SingleChannelDDR3_1600("512MiB")
+
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.O3,
+    isa=ISA.RISCV,
+    num_cores=1,
+)
+
+for core in processor.get_cores():
+    core.core.probeListener = ETrace(
+        traceFile="etrace.pb.gz",
+        resyncPeriod=10000,
+    )
+
+board = SimpleBoard(
+    clk_freq="1GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+)
+
+board.set_se_binary_workload(
+    obtain_resource("riscv-hello", resource_version="1.0.0")
+)
+
+simulator = Simulator(board=board)
+simulator.run()
+
+print(f"Simulation done. Exit cause: '{simulator.get_last_exit_event_cause()}'")
+print("E-Trace output written to m5out/ directory")

--- a/src/cpu/o3/probe/ETrace.py
+++ b/src/cpu/o3/probe/ETrace.py
@@ -1,16 +1,5 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2013 ARM Limited
+# Copyright (c) 2026 Rajesh Gangam
 # All rights reserved.
-#
-# The license below extends only to copyright in the software and shall
-# not be construed as granting a license to any other intellectual
-# property including but not limited to intellectual property relating
-# to a hardware implementation of the functionality of the software
-# licensed hereunder.  You may use the software subject to the license
-# terms below provided that you ensure that this notice is replicated
-# unmodified and in its entirety in all distributions of the software,
-# modified or unmodified, in source code or in binary form.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -35,26 +24,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from m5.objects.Probe import *
+from m5.params import *
 
-if env['CONF']['BUILD_ISA']:
-    SimObject('SimpleTrace.py', sim_objects=['SimpleTrace'])
-    Source('simple_trace.cc')
-    DebugFlag('SimpleTrace')
 
-    if env['CONF']['HAVE_PROTOBUF']:
-        SimObject(
-            'ElasticTrace.py',
-            sim_objects=['ElasticTrace'],
-            tags=['protobuf']
-        )
-        Source('elastic_trace.cc', tags=['protobuf'])
-        DebugFlag('ElasticTrace', tags=['protobuf'])
+class ETrace(ProbeListenerObject):
+    type = "ETrace"
+    cxx_class = "gem5::o3::ETrace"
+    cxx_header = "cpu/o3/probe/etrace.hh"
 
-        SimObject(
-            'ETrace.py',
-            sim_objects=['ETrace'],
-            tags=['protobuf']
-        )
-        Source('etrace.cc', tags=['protobuf'])
-        DebugFlag('ETrace', tags=['protobuf'])
+    traceFile = Param.String(
+        "etrace.pb.gz",
+        "Output file for E-Trace packets (protobuf)")
+    startTraceInst = Param.UInt64(0,
+        "Instruction count after which to start tracing")
+    resyncPeriod = Param.UInt64(10000,
+        "Instructions between periodic resync packets")

--- a/src/cpu/o3/probe/ETrace.py
+++ b/src/cpu/o3/probe/ETrace.py
@@ -34,9 +34,11 @@ class ETrace(ProbeListenerObject):
     cxx_header = "cpu/o3/probe/etrace.hh"
 
     traceFile = Param.String(
-        "etrace.pb.gz",
-        "Output file for E-Trace packets (protobuf)")
-    startTraceInst = Param.UInt64(0,
-        "Instruction count after which to start tracing")
-    resyncPeriod = Param.UInt64(10000,
-        "Instructions between periodic resync packets")
+        "etrace.pb.gz", "Output file for E-Trace packets (protobuf)"
+    )
+    startTraceInst = Param.UInt64(
+        0, "Instruction count after which to start tracing"
+    )
+    resyncPeriod = Param.UInt64(
+        10000, "Instructions between periodic resync packets"
+    )

--- a/src/cpu/o3/probe/etrace.cc
+++ b/src/cpu/o3/probe/etrace.cc
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2026 Rajesh Gangam
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cpu/o3/probe/etrace.hh"
+
+#include "arch/riscv/isa.hh"
+#include "arch/riscv/regs/misc.hh"
+#include "base/callback.hh"
+#include "base/output.hh"
+#include "base/trace.hh"
+#include "cpu/o3/cpu.hh"
+#include "cpu/o3/dyn_inst.hh"
+#include "cpu/thread_context.hh"
+#include "debug/ETrace.hh"
+
+namespace gem5
+{
+
+namespace o3
+{
+
+ETrace::ETrace(const ETraceParams &params)
+    : ProbeListenerObject(params),
+      cpu(nullptr),
+      traceStream(nullptr),
+      branchMap(0),
+      branchCount(0),
+      lastReportedAddr(0),
+      expectedNextPC(0),
+      haveExpectedPC(false),
+      lastCommittedAddr(0),
+      lastPriv(0),
+      instsSinceSync(0),
+      resyncPeriod(params.resyncPeriod),
+      startTraceInst(params.startTraceInst),
+      totalInstsCommitted(0),
+      tracingActive(params.startTraceInst == 0),
+      needsInitialSync(true),
+      stats(this)
+{
+    cpu = dynamic_cast<CPU *>(params.manager);
+    fatal_if(!cpu, "Manager of %s is not of type O3CPU.\n", name());
+    fatal_if(cpu->numThreads > 1, "%s supports single-threaded "
+             "workloads only.\n", name());
+
+    std::string filename = simout.resolve(name() + "." + params.traceFile);
+    traceStream = new ProtoOutputStream(filename);
+
+    ProtoMessage::ETraceHeader header;
+    header.set_obj_id(name());
+    header.set_tick_freq(sim_clock::Frequency);
+    header.set_arch_width(64);
+    traceStream->write(header);
+
+    registerExitCallback([this]() { flushTrace(); });
+}
+
+ETrace::~ETrace()
+{
+    delete traceStream;
+}
+
+void
+ETrace::regProbeListeners()
+{
+    typedef ProbeListenerArg<ETrace, DynInstConstPtr> DynInstListener;
+    connectListener<DynInstListener>(this, "Commit", &ETrace::traceCommit);
+}
+
+ETrace::IType
+ETrace::classifyInstruction(const DynInstConstPtr &dynInst)
+{
+    // Exception return: sret/mret are NonSpeculative returns in RISC-V
+    if (dynInst->isNonSpeculative() && dynInst->isReturn()) {
+        return ITYPE_EXCEPT_RET;
+    }
+
+    if (dynInst->isCondCtrl()) {
+        Addr pc = dynInst->pcState().instAddr();
+        Addr npc = dynInst->pcState().as<RiscvISA::PCState>().npc();
+        unsigned instSize =
+            dynInst->pcState().as<RiscvISA::PCState>().compressed() ? 2 : 4;
+        bool taken = (npc != pc + instSize);
+        return taken ? ITYPE_TAKEN_BRANCH : ITYPE_NTAKEN_BRANCH;
+    }
+
+    if (dynInst->isCall() && dynInst->isReturn()) {
+        // Co-routine swap: both call and return (e.g. jalr x1, x5)
+        return ITYPE_COROUTINE;
+    }
+
+    if (dynInst->isCall()) {
+        return dynInst->isDirectCtrl() ? ITYPE_INF_CALL : ITYPE_UNINF_CALL;
+    }
+
+    if (dynInst->isReturn()) {
+        return ITYPE_RETURN;
+    }
+
+    if (dynInst->isControl()) {
+        if (dynInst->isDirectCtrl()) {
+            return ITYPE_INF_JUMP2;
+        }
+        return ITYPE_UNINF_JUMP;
+    }
+
+    return ITYPE_NONE;
+}
+
+void
+ETrace::traceCommit(const DynInstConstPtr &dynInst)
+{
+    totalInstsCommitted++;
+
+    if (!tracingActive) {
+        if (totalInstsCommitted >= startTraceInst) {
+            tracingActive = true;
+            needsInitialSync = true;
+        } else {
+            return;
+        }
+    }
+
+    Addr pc = dynInst->pcState().instAddr();
+    gem5::ThreadContext *tc = cpu->getContext(0);
+    uint8_t curPriv = tc->readMiscRegNoEffect(RiscvISA::MISCREG_PRV);
+
+    // Detect exception/interrupt via PC discontinuity
+    if (haveExpectedPC && pc != expectedNextPC) {
+        uint64_t cause = 0;
+        uint64_t tval = 0;
+        bool isInterrupt = false;
+
+        if (curPriv == RiscvISA::PRV_M) {
+            cause = tc->readMiscRegNoEffect(RiscvISA::MISCREG_MCAUSE);
+            tval = tc->readMiscRegNoEffect(RiscvISA::MISCREG_MTVAL);
+        } else {
+            cause = tc->readMiscRegNoEffect(RiscvISA::MISCREG_SCAUSE);
+            tval = tc->readMiscRegNoEffect(RiscvISA::MISCREG_STVAL);
+        }
+
+        // MSB of cause indicates interrupt vs exception
+        isInterrupt = (cause >> 63) & 1;
+        uint64_t causeCode = cause & ((1ULL << 63) - 1);
+
+        // Emit any pending branch map before the trap packet
+        if (branchCount > 0) {
+            emitBranchMapPacket(true, lastCommittedAddr);
+        }
+
+        emitTrapPacket(pc, causeCode, tval, isInterrupt, curPriv);
+        needsInitialSync = false;
+        instsSinceSync = 0;
+    }
+
+    // Emit initial sync packet on first traced instruction
+    if (needsInitialSync) {
+        IType itype = classifyInstruction(dynInst);
+        bool isBranch = (itype == ITYPE_TAKEN_BRANCH ||
+                         itype == ITYPE_NTAKEN_BRANCH);
+        bool taken = (itype == ITYPE_TAKEN_BRANCH);
+        emitSyncPacket(pc, curPriv, isBranch, taken);
+        needsInitialSync = false;
+        instsSinceSync = 0;
+    }
+
+    // Detect privilege change
+    if (curPriv != lastPriv && !needsInitialSync) {
+        if (branchCount > 0) {
+            emitBranchMapPacket(true, pc);
+        }
+        IType itype = classifyInstruction(dynInst);
+        bool isBranch = (itype == ITYPE_TAKEN_BRANCH ||
+                         itype == ITYPE_NTAKEN_BRANCH);
+        bool taken = (itype == ITYPE_TAKEN_BRANCH);
+        emitSyncPacket(pc, curPriv, isBranch, taken);
+        instsSinceSync = 0;
+    }
+
+    lastPriv = curPriv;
+    instsSinceSync++;
+    stats.totalInstsTraced++;
+
+    IType itype = classifyInstruction(dynInst);
+
+    DPRINTF(ETrace, "Commit 0x%08x itype=%d %s\n",
+            pc, itype,
+            dynInst->staticInst->disassemble(pc));
+
+    switch (itype) {
+      case ITYPE_NONE:
+        break;
+
+      case ITYPE_NTAKEN_BRANCH:
+        branchMap |= (1U << branchCount);
+        branchCount++;
+        stats.numBranches++;
+        if (branchCount >= maxBranchMapBits) {
+            emitBranchMapPacket(false, 0);
+        }
+        break;
+
+      case ITYPE_TAKEN_BRANCH:
+        // taken = 0 bit (already zero in branchMap)
+        branchCount++;
+        stats.numBranches++;
+        if (branchCount >= maxBranchMapBits) {
+            emitBranchMapPacket(false, 0);
+        }
+        break;
+
+      case ITYPE_INF_CALL:
+      case ITYPE_INF_JUMP2:
+      case ITYPE_OTHER_INF:
+        emitBranchMapPacket(false, 0);
+        break;
+
+      case ITYPE_UNINF_JUMP:
+      case ITYPE_UNINF_CALL:
+      case ITYPE_UNINF_JUMP2:
+      case ITYPE_OTHER_UNINF:
+      case ITYPE_RETURN:
+      case ITYPE_COROUTINE:
+      case ITYPE_EXCEPT_RET: {
+        Addr npc = dynInst->pcState().as<RiscvISA::PCState>().npc();
+        emitBranchMapPacket(true, npc);
+        break;
+      }
+
+      case ITYPE_EXCEPTION:
+      case ITYPE_INTERRUPT:
+        // Handled above via PC discontinuity detection
+        break;
+    }
+
+    // Update expected next PC for discontinuity detection
+    expectedNextPC = dynInst->pcState().as<RiscvISA::PCState>().npc();
+    haveExpectedPC = true;
+    lastCommittedAddr = pc;
+
+    // Periodic resync
+    if (instsSinceSync >= resyncPeriod) {
+        if (branchCount > 0) {
+            emitBranchMapPacket(true, pc);
+        }
+        IType curIType = classifyInstruction(dynInst);
+        bool isBranch = (curIType == ITYPE_TAKEN_BRANCH ||
+                         curIType == ITYPE_NTAKEN_BRANCH);
+        bool taken = (curIType == ITYPE_TAKEN_BRANCH);
+        emitSyncPacket(pc, curPriv, isBranch, taken);
+        instsSinceSync = 0;
+    }
+}
+
+void
+ETrace::emitSyncPacket(Addr addr, uint8_t priv,
+                        bool isBranch, bool taken)
+{
+    ProtoMessage::ETracePacket pkt;
+    pkt.set_tick(curTick());
+    pkt.set_format(ProtoMessage::ETracePacket::SYNC);
+    pkt.set_subformat(ProtoMessage::ETracePacket::START);
+    pkt.set_address(addr);
+    pkt.set_priv(priv);
+    // Per spec: branch field is 0 if address is a taken branch, 1 otherwise
+    pkt.set_branch_map(isBranch && taken ? 0 : 1);
+    pkt.set_branch_count(1);
+    traceStream->write(pkt);
+
+    lastReportedAddr = addr;
+    resetBranchMap();
+    stats.numSyncPackets++;
+    stats.numPackets++;
+
+    DPRINTF(ETrace, "Sync packet: addr=0x%08x priv=%d\n", addr, priv);
+}
+
+void
+ETrace::emitTrapPacket(Addr addr, uint64_t cause, uint64_t tval,
+                        bool isInterrupt, uint8_t priv)
+{
+    ProtoMessage::ETracePacket pkt;
+    pkt.set_tick(curTick());
+    pkt.set_format(ProtoMessage::ETracePacket::SYNC);
+    pkt.set_subformat(ProtoMessage::ETracePacket::TRAP);
+    pkt.set_address(addr);
+    pkt.set_priv(priv);
+    pkt.set_cause(cause);
+    pkt.set_tval(tval);
+    pkt.set_interrupt(isInterrupt);
+    traceStream->write(pkt);
+
+    lastReportedAddr = addr;
+    resetBranchMap();
+    stats.numTrapPackets++;
+    stats.numPackets++;
+
+    DPRINTF(ETrace, "Trap packet: addr=0x%08x cause=%llu int=%d priv=%d\n",
+            addr, cause, isInterrupt, priv);
+}
+
+void
+ETrace::emitBranchMapPacket(bool withAddress, Addr addr)
+{
+    ProtoMessage::ETracePacket pkt;
+    pkt.set_tick(curTick());
+
+    if (withAddress) {
+        pkt.set_format(ProtoMessage::ETracePacket::BRANCH_MAP_ADDR);
+        // Delta address encoding
+        pkt.set_address(addr - lastReportedAddr);
+        lastReportedAddr = addr;
+    } else {
+        pkt.set_format(ProtoMessage::ETracePacket::BRANCH_MAP);
+    }
+
+    pkt.set_branch_map(branchMap);
+    pkt.set_branch_count(branchCount);
+    traceStream->write(pkt);
+
+    resetBranchMap();
+    stats.numBranchMapPackets++;
+    stats.numPackets++;
+
+    DPRINTF(ETrace, "BranchMap packet: withAddr=%d addr=0x%08x "
+            "map=0x%x count=%d\n",
+            withAddress, addr, branchMap, branchCount);
+}
+
+void
+ETrace::resetBranchMap()
+{
+    branchMap = 0;
+    branchCount = 0;
+}
+
+void
+ETrace::flushTrace()
+{
+    // Emit any remaining branch map
+    if (branchCount > 0) {
+        emitBranchMapPacket(true, lastCommittedAddr);
+    }
+
+    DPRINTF(ETrace, "Flushing trace: %llu packets, %llu instructions\n",
+            stats.numPackets.value(), stats.totalInstsTraced.value());
+
+    delete traceStream;
+    traceStream = nullptr;
+}
+
+ETrace::ETraceStats::ETraceStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(numPackets, statistics::units::Count::get(),
+               "Total E-Trace packets emitted"),
+      ADD_STAT(numSyncPackets, statistics::units::Count::get(),
+               "Sync packets emitted"),
+      ADD_STAT(numTrapPackets, statistics::units::Count::get(),
+               "Trap packets emitted"),
+      ADD_STAT(numBranchMapPackets, statistics::units::Count::get(),
+               "Branch map packets emitted"),
+      ADD_STAT(numBranches, statistics::units::Count::get(),
+               "Branches traced"),
+      ADD_STAT(totalInstsTraced, statistics::units::Count::get(),
+               "Total instructions traced")
+{
+}
+
+} // namespace o3
+} // namespace gem5

--- a/src/cpu/o3/probe/etrace.hh
+++ b/src/cpu/o3/probe/etrace.hh
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Rajesh Gangam
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CPU_O3_PROBE_ETRACE_HH__
+#define __CPU_O3_PROBE_ETRACE_HH__
+
+#include "base/statistics.hh"
+#include "cpu/o3/dyn_inst_ptr.hh"
+#include "params/ETrace.hh"
+#include "proto/etrace.pb.h"
+#include "proto/protoio.hh"
+#include "sim/probe/probe_listener_object.hh"
+
+namespace gem5
+{
+
+namespace o3
+{
+
+class CPU;
+
+class ETrace : public ProbeListenerObject
+{
+
+  public:
+    ETrace(const ETraceParams &params);
+    ~ETrace();
+
+    void regProbeListeners() override;
+
+    std::string
+    name() const override
+    {
+        return ProbeListenerObject::name() + ".etrace";
+    }
+
+  private:
+    // E-Trace itype encoding per RISC-V Efficient Trace spec v2.0
+    enum IType : uint8_t
+    {
+        ITYPE_NONE          = 0,
+        ITYPE_EXCEPTION     = 1,
+        ITYPE_INTERRUPT     = 2,
+        ITYPE_EXCEPT_RET    = 3,
+        ITYPE_NTAKEN_BRANCH = 4,
+        ITYPE_TAKEN_BRANCH  = 5,
+        ITYPE_UNINF_JUMP    = 6,
+        ITYPE_UNINF_CALL    = 8,
+        ITYPE_INF_CALL      = 9,
+        ITYPE_UNINF_JUMP2   = 10,
+        ITYPE_INF_JUMP2     = 11,
+        ITYPE_COROUTINE     = 12,
+        ITYPE_RETURN        = 13,
+        ITYPE_OTHER_UNINF   = 14,
+        ITYPE_OTHER_INF     = 15,
+    };
+
+    void traceCommit(const DynInstConstPtr &dynInst);
+    IType classifyInstruction(const DynInstConstPtr &dynInst);
+
+    void emitSyncPacket(Addr addr, uint8_t priv, bool isBranch, bool taken);
+    void emitTrapPacket(Addr addr, uint64_t cause, uint64_t tval,
+                        bool isInterrupt, uint8_t priv);
+    void emitBranchMapPacket(bool withAddress, Addr addr);
+    void resetBranchMap();
+    void flushTrace();
+
+    CPU *cpu;
+    ProtoOutputStream *traceStream;
+
+    static constexpr uint32_t maxBranchMapBits = 31;
+
+    // Branch map state
+    uint32_t branchMap;
+    uint32_t branchCount;
+
+    // Address tracking for delta encoding
+    Addr lastReportedAddr;
+
+    // Expected next PC for exception detection
+    Addr expectedNextPC;
+    bool haveExpectedPC;
+    Addr lastCommittedAddr;
+
+    // Privilege tracking
+    uint8_t lastPriv;
+
+    // Resync tracking
+    uint64_t instsSinceSync;
+    uint64_t resyncPeriod;
+
+    // Start tracing control
+    uint64_t startTraceInst;
+    uint64_t totalInstsCommitted;
+    bool tracingActive;
+
+    // Whether initial sync has been sent
+    bool needsInitialSync;
+
+    struct ETraceStats : public statistics::Group
+    {
+        ETraceStats(statistics::Group *parent);
+        statistics::Scalar numPackets;
+        statistics::Scalar numSyncPackets;
+        statistics::Scalar numTrapPackets;
+        statistics::Scalar numBranchMapPackets;
+        statistics::Scalar numBranches;
+        statistics::Scalar totalInstsTraced;
+    } stats;
+};
+
+} // namespace o3
+} // namespace gem5
+
+#endif // __CPU_O3_PROBE_ETRACE_HH__

--- a/src/proto/SConscript
+++ b/src/proto/SConscript
@@ -42,5 +42,6 @@ if env['CONF']['HAVE_PROTOBUF']:
     ProtoBuf('inst_dep_record.proto', tags=['protobuf'])
     ProtoBuf('packet.proto', tags=['protobuf'])
     ProtoBuf('inst.proto', tags=['protobuf'])
+    ProtoBuf('etrace.proto', tags=['protobuf'])
     Source('protobuf.cc', tags=['protobuf'])
     Source('protoio.cc', tags=['protobuf'])

--- a/src/proto/etrace.proto
+++ b/src/proto/etrace.proto
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Rajesh Gangam
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met: redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer;
+// redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution;
+// neither the name of the copyright holders nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto2";
+
+package ProtoMessage;
+
+// Header for an E-Trace stream, written once at the start.
+message ETraceHeader {
+  optional string obj_id = 1;
+  optional uint32 ver = 2 [default = 1];
+  optional uint64 tick_freq = 3;
+  optional uint32 arch_width = 4;
+}
+
+// A single E-Trace packet following the RISC-V Efficient Trace spec v2.0.
+// Packet formats:
+//   0 - branch map only (no address, target is inferable)
+//   1 - branch map with address (uninferable discontinuity)
+//   2 - address only (no branch map)
+//   3 - sync/trap/context/support (subformat selects which)
+message ETracePacket {
+  enum Format {
+    BRANCH_MAP = 0;
+    BRANCH_MAP_ADDR = 1;
+    ADDR_ONLY = 2;
+    SYNC = 3;
+  }
+  enum SubFormat {
+    START = 0;
+    TRAP = 1;
+    CONTEXT = 2;
+    SUPPORT = 3;
+  }
+  optional uint64 tick = 1;
+  optional Format format = 2;
+  optional SubFormat subformat = 3;
+  optional uint64 address = 4;
+  optional uint32 branch_map = 5;
+  optional uint32 branch_count = 6;
+  optional uint32 priv = 7;
+  optional uint64 cause = 8;
+  optional uint64 tval = 9;
+  optional bool interrupt = 10;
+  optional uint32 itype = 11;
+}

--- a/util/decode_etrace.py
+++ b/util/decode_etrace.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Rajesh Gangam
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Decode a gem5 E-Trace protobuf file and print packets in human-readable
+# format.  Follows the same pattern as util/decode_inst_dep_trace.py.
+
+import sys
+
+import protolib
+
+try:
+    import etrace_pb2
+except ImportError:
+    print("Did not find proto definition, attempting to generate")
+    from subprocess import call
+
+    error = call(
+        [
+            "protoc",
+            "--python_out=util",
+            "--proto_path=src/proto",
+            "src/proto/etrace.proto",
+        ]
+    )
+    if not error:
+        import etrace_pb2
+
+        print("Generated proto definitions for E-Trace")
+    else:
+        print("Failed to import proto definitions")
+        exit(-1)
+
+FORMAT_NAMES = {
+    etrace_pb2.ETracePacket.BRANCH_MAP: "BRANCH_MAP",
+    etrace_pb2.ETracePacket.BRANCH_MAP_ADDR: "BRANCH_MAP_ADDR",
+    etrace_pb2.ETracePacket.ADDR_ONLY: "ADDR_ONLY",
+    etrace_pb2.ETracePacket.SYNC: "SYNC",
+}
+
+SUBFORMAT_NAMES = {
+    etrace_pb2.ETracePacket.START: "START",
+    etrace_pb2.ETracePacket.TRAP: "TRAP",
+    etrace_pb2.ETracePacket.CONTEXT: "CONTEXT",
+    etrace_pb2.ETracePacket.SUPPORT: "SUPPORT",
+}
+
+PRIV_NAMES = {0: "U", 1: "S", 3: "M"}
+
+
+def format_branch_map(bmap, count):
+    bits = []
+    for i in range(count):
+        bits.append("N" if (bmap >> i) & 1 else "T")
+    return "".join(bits)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage:", sys.argv[0], "<protobuf input> [--stats]")
+        exit(-1)
+
+    show_stats = "--stats" in sys.argv
+
+    proto_in = protolib.openFileRd(sys.argv[1])
+
+    magic_number = proto_in.read(4).decode()
+    if magic_number != "gem5":
+        print("Unrecognized file")
+        exit(-1)
+
+    header = etrace_pb2.ETraceHeader()
+    protolib.decodeMessage(proto_in, header)
+
+    print(f"Object: {header.obj_id}")
+    print(f"Tick freq: {header.tick_freq}")
+    print(f"Arch width: {header.arch_width}")
+    print()
+
+    num_packets = 0
+    num_sync = 0
+    num_trap = 0
+    num_branch_map = 0
+    total_branches = 0
+    reconstructed_addr = 0
+
+    packet = etrace_pb2.ETracePacket()
+    while protolib.decodeMessage(proto_in, packet):
+        num_packets += 1
+        fmt = FORMAT_NAMES.get(packet.format, str(packet.format))
+
+        if not show_stats:
+            line = f"[{num_packets:6d}] tick={packet.tick:12d} fmt={fmt:<16s}"
+
+            if packet.format == etrace_pb2.ETracePacket.SYNC:
+                subfmt = SUBFORMAT_NAMES.get(
+                    packet.subformat, str(packet.subformat)
+                )
+                priv = PRIV_NAMES.get(packet.priv, str(packet.priv))
+                reconstructed_addr = packet.address
+                line += f" sub={subfmt:<8s} addr=0x{packet.address:016x}"
+                line += f" priv={priv}"
+                if packet.subformat == etrace_pb2.ETracePacket.TRAP:
+                    num_trap += 1
+                    line += f" cause={packet.cause}"
+                    line += f" tval=0x{packet.tval:x}"
+                    line += f" int={packet.interrupt}"
+                else:
+                    num_sync += 1
+                    if packet.branch_count > 0:
+                        bm = format_branch_map(
+                            packet.branch_map, packet.branch_count
+                        )
+                        line += f" branch={bm}"
+
+            elif packet.format == etrace_pb2.ETracePacket.BRANCH_MAP_ADDR:
+                num_branch_map += 1
+                reconstructed_addr += packet.address
+                bm = format_branch_map(packet.branch_map, packet.branch_count)
+                total_branches += packet.branch_count
+                line += (
+                    f" addr=0x{reconstructed_addr:016x}"
+                    f" (delta={packet.address:+d})"
+                    f" branches={bm}"
+                )
+
+            elif packet.format == etrace_pb2.ETracePacket.BRANCH_MAP:
+                num_branch_map += 1
+                bm = format_branch_map(packet.branch_map, packet.branch_count)
+                total_branches += packet.branch_count
+                line += f" branches={bm}"
+
+            elif packet.format == etrace_pb2.ETracePacket.ADDR_ONLY:
+                reconstructed_addr += packet.address
+                line += f" addr=0x{reconstructed_addr:016x}"
+
+            print(line)
+        else:
+            if packet.format == etrace_pb2.ETracePacket.SYNC:
+                if packet.subformat == etrace_pb2.ETracePacket.TRAP:
+                    num_trap += 1
+                else:
+                    num_sync += 1
+            else:
+                num_branch_map += 1
+                total_branches += packet.branch_count
+
+    print()
+    print("--- Statistics ---")
+    print(f"Total packets:      {num_packets}")
+    print(f"Sync packets:       {num_sync}")
+    print(f"Trap packets:       {num_trap}")
+    print(f"Branch map packets: {num_branch_map}")
+    print(f"Total branches:     {total_branches}")
+
+    proto_in.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the RISC-V Efficient Trace (E-Trace) v2.0 ratified specification as an O3 CPU probe listener. The encoder captures program execution by recording only branch outcomes, uninferable jump targets, exceptions, and privilege changes — producing a compact protobuf trace file suitable for post-silicon debug, performance analysis, and trace-driven simulation.

**Key features:**
- Instruction classification per E-Trace itype encoding (all 16 types from spec Table 4.4)
- Branch map accumulation (31-bit, taken=0 / not-taken=1 encoding per spec)
- Delta address encoding for uninferable discontinuities (Format 1 packets)
- Exception/interrupt detection via PC discontinuity with CSR readback (mcause/scause, mtval/stval)
- Privilege level tracking with sync packets on privilege changes
- Periodic resynchronization for decoder recovery
- Configurable trace start point and resync period

**Architecture:** Follows the same ProbeListenerObject pattern as ElasticTrace — listens to the O3 CPU "Commit" probe point and uses protobuf for trace output.

**New files:**
- `src/cpu/o3/probe/etrace.hh/.cc` — ETrace probe listener implementation
- `src/cpu/o3/probe/ETrace.py` — SimObject configuration (params: traceFile, startTraceInst, resyncPeriod)
- `src/proto/etrace.proto` — Protobuf message definitions (ETraceHeader, ETracePacket)

**Modified files:**
- `src/cpu/o3/probe/SConscript` — Build rules for ETrace
- `src/proto/SConscript` — Protobuf compilation for etrace.proto

**Spec reference:** [RISC-V Efficient Trace v2.0](https://github.com/riscv-non-isa/riscv-trace-spec)

## Test plan

- [x] Compiles successfully with `scons build/RISCV/gem5.opt`
- [ ] Run SE mode with simple RISC-V branch/call/return program, verify packet classifications
- [ ] Run FS mode with Linux boot, verify trap and privilege change packets
- [ ] Decode protobuf output and cross-check against SimpleTrace for same workload
- [ ] Verify statistics counters (branch count, packet count, sync count)

## Usage example

```python
from m5.objects import ETrace

system.cpu.probeListener = ETrace()
system.cpu.probeListener.traceFile = "etrace.pb.gz"
system.cpu.probeListener.startTraceInst = 0
system.cpu.probeListener.resyncPeriod = 10000
```