### PR TITLE
cpu: Fix BPU overriding at squash

### DIFF
--- a/src/cpu/o3/bac.cc
+++ b/src/cpu/o3/bac.cc
@@ -522,6 +522,10 @@ BAC::squash(const PCStateBase &new_pc, ThreadID tid)
 
     // Then squash all fetch targets
     ftq->squash(tid);
+
+    // Also clear BPU stall cycles
+    branchPredictRemaining[tid] = Cycles(0);
+    stalls[tid].bpu = false;
 }
 
 void
@@ -780,6 +784,10 @@ BAC::generateFetchTargets(ThreadID tid, bool &status_change)
             DPRINTF(BAC, "FTQ full\n");
             bacStatus[tid] = FTQFull;
             status_change = true;
+            break;
+        }
+
+        if (branchPredictRemaining[tid] != 0) {
             break;
         }
     }


### PR DESCRIPTION
In case the BAC stage was blocked due to override
it also did so in case of a squash.
Furthermore, the generation of fetch targets should be stopped once the latency is greater than zero.