### PR TITLE
arch-arm: Decode invalid 64-bit SADDV as unknown

### DIFF
--- a/src/arch/arm/isa/insts/sve.isa
+++ b/src/arch/arm/isa/insts/sve.isa
@@ -103,8 +103,11 @@ output header {{
                 return new BaseS<int32_t, int64_t>(machInst, dest, op1, gp);
             }
           case 3:
-            assert(u);
-            return new BaseU<uint64_t, uint64_t>(machInst, dest, op1, gp);
+            if (u) {
+                return new BaseU<uint64_t, uint64_t>(machInst, dest, op1, gp);
+            } else {
+                return new Unknown64(machInst);
+            }
           default:
             return new Unknown64(machInst);
         }


### PR DESCRIPTION
The SVE integer add-reduction decoder uses u == 0 for SADDV and u == 1 for UADDV. UADDV defines a 64-bit element-size form, but SADDV only has the widening 8-, 16-, and 32-bit forms.

For size == 3 && u == 0, return Unknown64 instead of asserting. The valid size == 3 && u == 1 case still decodes to SveUaddv<uint64_t, uint64_t>.