### PR TITLE
arch-riscv: Add BF16 scalar and vector ISA support

### DIFF
--- a/src/arch/riscv/RiscvISA.py
+++ b/src/arch/riscv/RiscvISA.py
@@ -215,7 +215,7 @@ _EXTENSION_REGISTRY = {
     "Zcmt": {"implemented": True},
     "Zdinx": {"implemented": False},
     "Zfa": {"implemented": True},
-    "Zfbfmin": {"implemented": False},
+    "Zfbfmin": {"implemented": True},
     "Zfh": {"implemented": True},
     "Zfhmin": {"implemented": True},
     "Zfinx": {"implemented": False},
@@ -260,8 +260,8 @@ _EXTENSION_REGISTRY = {
     "Zve64d": {"implemented": True},
     "Zve64f": {"implemented": True},
     "Zve64x": {"implemented": True},
-    "Zvfbfmin": {"implemented": False},
-    "Zvfbfwma": {"implemented": False},
+    "Zvfbfmin": {"implemented": True},
+    "Zvfbfwma": {"implemented": True},
     "Zvfh": {"implemented": True},
     "Zvfhmin": {"implemented": True},
     "Zvkb": {"implemented": False},
@@ -537,6 +537,7 @@ class RiscvISA(BaseISA):
             # "Zcf",        # RV32-only and implied by C+F
             # "Zcmp",       # C+D implies Zcd which is used by default
             # "Zcmt",       # C+D implies Zcd which is used by default
+            "Zfbfmin",
             "Zfh",
             "Zknd",
             "Zkne",
@@ -544,6 +545,8 @@ class RiscvISA(BaseISA):
             "Zksed",
             "Zksh",
             "Zvbc",
+            "Zvfbfmin",
+            "Zvfbfwma",
             "Zvfh",
             # "Smrnmi",     # Not enabled by default, changes trapping behavior
         ],
@@ -603,7 +606,10 @@ class RiscvISA(BaseISA):
             extension.value if hasattr(extension, "value") else extension
             for extension in self.extra_extensions
         }
-        return mandatory, requested, mandatory | requested
+        effective = mandatory | requested
+        if "Zvfbfwma" in effective:
+            effective.update(("Zfbfmin", "Zvfbfmin"))
+        return mandatory, requested, effective
 
     def _is_supported(self, extension):
         if extension == "H" and self.privilege_mode_set.value != "MHSU":
@@ -617,6 +623,39 @@ class RiscvISA(BaseISA):
                 raise ValueError(
                     "Unknown standard RISC-V extension: %s" % extension
                 )
+
+        bf16_extensions = effective & {
+            "Zfbfmin",
+            "Zvfbfmin",
+            "Zvfbfwma",
+        }
+        if bf16_extensions and "F" not in effective:
+            extensions = ", ".join(_ordered_extension_names(bf16_extensions))
+            if len(bf16_extensions) == 1:
+                raise ValueError(
+                    "RISC-V extension %s requires the F extension" % extensions
+                )
+            raise ValueError(
+                "RISC-V extensions %s require the F extension" % extensions
+            )
+
+        vector_bf16_extensions = effective & {
+            "Zvfbfmin",
+            "Zvfbfwma",
+        }
+        if vector_bf16_extensions and not effective.intersection(
+            ("V", "Zve32f")
+        ):
+            extensions = ", ".join(
+                _ordered_extension_names(vector_bf16_extensions)
+            )
+            if len(vector_bf16_extensions) == 1:
+                raise ValueError(
+                    "RISC-V extension %s requires V or Zve32f" % extensions
+                )
+            raise ValueError(
+                "RISC-V extensions %s require V or Zve32f" % extensions
+            )
 
         unimplemented_extras = sorted(
             extension

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3102,6 +3102,14 @@ decode QUADRANT default Unknown::unknown() {
                         fd = freg(f16_to_f32(f16(freg(Fs1_bits))));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
+                    format FPROp {
+                        0x6: fcvt_s_bf16({{
+                            RM_REQUIRED;
+                            freg_t fd;
+                            fd = freg(bf16_to_f32(bf16(freg(Fs1_bits))));
+                            Fd_bits = fd.v;
+                        }}, FloatCvtOp);
+                    }
                     0x4: fround_s({{
                         RM_REQUIRED;
                         freg_t fd;
@@ -3158,6 +3166,14 @@ decode QUADRANT default Unknown::unknown() {
                         fd = freg(f64_to_f16(f64(freg(Fs1_bits))));
                         Fd_bits = fd.v;
                     }}, FloatCvtOp);
+                    format FPROp {
+                        0x8: fcvt_bf16_s({{
+                            RM_REQUIRED;
+                            freg_t fd;
+                            fd = freg(f32_to_bf16(f32(freg(Fs1_bits))));
+                            Fd_bits = fd.v;
+                        }}, FloatCvtOp);
+                    }
                     0x4: fround_h({{
                         RM_REQUIRED;
                         freg_t fd;
@@ -4100,6 +4116,11 @@ decode QUADRANT default Unknown::unknown() {
                                 ftype<et>(Vs2_vu[i + offset]));
                             Vd_vwu[i] = fd.v;
                         }}, OPFVV, SimdFloatCvtOp);
+                        0x0d: vfwcvtbf16_f_f_v({{
+                            auto fd = f_to_wf<et>(
+                                ftype<et>(Vs2_vu[i + offset]));
+                            Vd_vwu[i] = fd.v;
+                        }}, OPFVV, SimdFloatCvtOp);
                         0x0e: vfwcvt_rtz_xu_f_v({{
                             Vd_vwu[i] = f_to_wui<et>(
                                 ftype<et>(Vs2_vu[i + offset]),
@@ -4132,6 +4153,11 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPFVV, SimdFloatCvtOp);
                         0x14: vfncvt_f_f_w({{
                             auto fd = f_to_nf<et>(ftype<ewt>(Vs2_vwu[i]));
+                            Vd_vu[i + offset] = fd.v;
+                        }}, OPFVV, SimdFloatCvtOp);
+                        0x1d: vfncvtbf16_f_f_w({{
+                            auto fd = f_to_nf<et>(
+                                ftype<ewt>(Vs2_vwu[i]));
                             Vd_vu[i + offset] = fd.v;
                         }}, OPFVV, SimdFloatCvtOp);
                         0x15: vfncvt_rod_f_f_w({{
@@ -4303,6 +4329,13 @@ decode QUADRANT default Unknown::unknown() {
                             fwiden(ftype<et>(Vs1_vu[i + offset])));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVV, SimdFloatMultOp);
+                    0x3b: vfwmaccbf16_vv({{
+                        auto fd = fmadd<ewt>(
+                            fwiden(ftype<et>(Vs1_vu[i + offset])),
+                            fwiden(ftype<et>(Vs2_vu[i + offset])),
+                            ftype<ewt>(Vs3_vwu[i]));
+                        Vd_vwu[i] = fd.v;
+                    }}, OPFVV, SimdFloatMultAccOp);
                     0x3c: vfwmacc_vv({{
                         auto fd = fmadd<ewt>(
                             fwiden(ftype<et>(Vs1_vu[i + offset])),
@@ -5426,6 +5459,13 @@ decode QUADRANT default Unknown::unknown() {
                             fwiden(ftype_freg<et>(freg(Fs1_bits))));
                         Vd_vwu[i] = fd.v;
                     }}, OPFVF, SimdFloatMultOp);
+                    0x3b: vfwmaccbf16_vf({{
+                        auto fd = fmadd<ewt>(
+                            fwiden(ftype_freg<et>(freg(Fs1_bits))),
+                            fwiden(ftype<et>(Vs2_vu[i + offset])),
+                            ftype<ewt>(Vs3_vwu[i]));
+                        Vd_vwu[i] = fd.v;
+                    }}, OPFVF, SimdFloatMultAccOp);
                     0x3c: vfwmacc_vf({{
                         auto fd = fmadd<ewt>(
                             fwiden(ftype_freg<et>(freg(Fs1_bits))),

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -888,6 +888,9 @@ def format VectorFloatCvtFormat(code, category, *flags) {{
 
 def format VectorFloatWideningFormat(code, category, *flags) {{
     varith_macro_declare = declareVArithTemplate(Name, 'float', 16, 32)
+    if "bf16" in name:
+        varith_macro_declare = f"template class {Name}<bfloat16_t>;\n"
+
     iop = InstObjParams(
         name,
         Name,
@@ -952,8 +955,11 @@ def format VectorFloatWideningFormat(code, category, *flags) {{
 
     set_vlenb = setVlenb();
 
-    varith_micro_declare = declareVArithTemplate(
-        Name + "Micro", 'float', 16, 32)
+    if "bf16" in name:
+        varith_micro_declare = f"template class {Name}Micro<bfloat16_t>;\n"
+    else:
+        varith_micro_declare = declareVArithTemplate(
+            Name + "Micro", 'float', 16, 32)
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
         'VectorArithMicroInst',
@@ -973,11 +979,17 @@ def format VectorFloatWideningFormat(code, category, *flags) {{
         VectorIntWideningMicroConstructor.subst(microiop) + \
         VectorIntWideningMacroConstructor.subst(iop)
     exec_output = VectorFloatWideningMicroExecute.subst(microiop)
-    decode_block = VectorFloatWideningDecodeBlock.subst(iop)
+    if "bf16" in name:
+        decode_block = VectorBFloatWideningDecodeBlock.subst(iop)
+    else:
+        decode_block = VectorFloatWideningDecodeBlock.subst(iop)
 }};
 
 def format VectorFloatWideningCvtFormat(code, category, *flags) {{
     varith_macro_declare = declareVArithTemplate(Name, 'float', 8, 32)
+    if "bf16" in name:
+        varith_macro_declare = f"template class {Name}<bfloat16_t>;\n"
+
     iop = InstObjParams(
         name,
         Name,
@@ -1006,8 +1018,11 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
 
     set_vlenb = setVlenb();
 
-    varith_micro_declare = declareVArithTemplate(
-        Name + "Micro", 'float', 8, 32)
+    if "bf16" in name:
+        varith_micro_declare = f"template class {Name}Micro<bfloat16_t>;\n"
+    else:
+        varith_micro_declare = declareVArithTemplate(
+            Name + "Micro", 'float', 8, 32)
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
         'VectorArithMicroInst',
@@ -1027,11 +1042,19 @@ def format VectorFloatWideningCvtFormat(code, category, *flags) {{
         VectorIntWideningMicroConstructor.subst(microiop) + \
         VectorIntWideningMacroConstructor.subst(iop)
     exec_output = VectorFloatWideningMicroExecute.subst(microiop)
-    decode_block = VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
+    if "bf16" in name:
+        decode_block = \
+            VectorBFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
+    else:
+        decode_block = \
+            VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
 }};
 
 def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
     varith_macro_declare = declareVArithTemplate(Name, 'float', 8, 32)
+    if "bf16" in name:
+        varith_macro_declare = f"template class {Name}<bfloat16_t>;\n"
+
     iop = InstObjParams(
         name,
         Name,
@@ -1061,8 +1084,11 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
 
     set_vlenb = setVlenb();
 
-    varith_micro_declare = declareVArithTemplate(
-        Name + "Micro", 'float', 8, 32)
+    if "bf16" in name:
+        varith_micro_declare = f"template class {Name}Micro<bfloat16_t>;\n"
+    else:
+        varith_micro_declare = declareVArithTemplate(
+            Name + "Micro", 'float', 8, 32)
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
         'VectorArithMicroInst',
@@ -1081,7 +1107,12 @@ def format VectorFloatNarrowingCvtFormat(code, category, *flags) {{
         VectorIntNarrowingMicroConstructor.subst(microiop) + \
         VectorIntNarrowingMacroConstructor.subst(iop)
     exec_output = VectorFloatNarrowingMicroExecute.subst(microiop)
-    decode_block = VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
+    if "bf16" in name:
+        decode_block = \
+            VectorBFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
+    else:
+        decode_block = \
+            VectorFloatWideningAndNarrowingCvtDecodeBlock.subst(iop)
 }};
 
 def format VectorFloatMaskFormat(code, category, *flags) {{

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -862,6 +862,7 @@ Fault
     using ewt = typename double_width<et>::type;
     using vwu = decltype(ewt::v);
 
+
     if (vtype_vlmul(machInst.vtype8) == 3)
         return std::make_shared<IllegalInstFault>("LMUL=8 is illegal for widening inst", machInst);
 
@@ -904,6 +905,7 @@ Fault
     using vu [[maybe_unused]] = decltype(et::v);
     using ewt = typename double_width<et>::type;
     using vwu = decltype(ewt::v);
+
 
     bool set_dirty = true;
     bool check_vill = true;
@@ -949,6 +951,24 @@ switch(machInst.vtype8.vsew) {
 case 0b000: return new %(class_name)s<float8_t>(machInst, elen, vlen);
 case 0b001: return new %(class_name)s<float16_t>(machInst, elen, vlen);
 case 0b010: return new %(class_name)s<float32_t>(machInst, elen, vlen);
+default: GEM5_UNREACHABLE;
+}
+
+}};
+
+def template VectorBFloatWideningDecodeBlock {{
+
+switch(machInst.vtype8.vsew) {
+case 0b001: return new %(class_name)s<bfloat16_t>(machInst, elen, vlen);
+default: GEM5_UNREACHABLE;
+}
+
+}};
+
+def template VectorBFloatWideningAndNarrowingCvtDecodeBlock {{
+
+switch(machInst.vtype8.vsew) {
+case 0b001: return new %(class_name)s<bfloat16_t>(machInst, elen, vlen);
 default: GEM5_UNREACHABLE;
 }
 

--- a/src/arch/riscv/regs/float.hh
+++ b/src/arch/riscv/regs/float.hh
@@ -54,6 +54,7 @@
 #include <vector>
 
 #include "base/bitfield.hh"
+#include "base/logging.hh"
 #include "cpu/reg_class.hh"
 #include "debug/FloatRegs.hh"
 
@@ -93,23 +94,153 @@ unboxF32(uint64_t v)
 static constexpr uint64_t boxF16(uint16_t v) { return mask(63, 16) | v; }
 static constexpr uint64_t boxF32(uint32_t v) { return mask(63, 32) | v; }
 
+struct bfloat16_t
+{
+    uint16_t v;
+};
+
+static constexpr uint16_t defaultNaNBF16UI = 0x7fc0;
+
+static constexpr uint16_t
+unboxBF16(uint64_t v)
+{
+    // The upper 48 bits should all be ones.
+    if (bits(v, 63, 16) == mask(48)) {
+        return bits(v, 15, 0);
+    } else {
+        return defaultNaNBF16UI;
+    }
+}
+
+static constexpr uint64_t
+boxBF16(uint16_t v)
+{
+    return mask(63, 16) | v;
+}
+
 // Create fixed size floats from raw bytes or generic floating point values.
 static constexpr float16_t f16(uint16_t v) { return {v}; }
 static constexpr float32_t f32(uint32_t v) { return {v}; }
 static constexpr float64_t f64(uint64_t v) { return {v}; }
+static constexpr bfloat16_t
+bf16(uint16_t v)
+{
+    return {v};
+}
 static constexpr float16_t f16(freg_t r) { return {unboxF16(r.v)}; }
 static constexpr float32_t f32(freg_t r) { return {unboxF32(r.v)}; }
 static constexpr float64_t f64(freg_t r) { return r; }
+static constexpr bfloat16_t
+bf16(freg_t r)
+{
+    return {unboxBF16(r.v)};
+}
 
 // Create generic floating point values from fixed size floats.
 static constexpr freg_t freg(float16_t f) { return {boxF16(f.v)}; }
 static constexpr freg_t freg(float32_t f) { return {boxF32(f.v)}; }
 static constexpr freg_t freg(float64_t f) { return f; }
+static constexpr freg_t
+freg(bfloat16_t f)
+{
+    return {boxBF16(f.v)};
+}
 static constexpr freg_t freg(uint_fast64_t f) { return {f}; }
 
 #define F16_SIGN ((uint16_t)1 << 15)
+#define BF16_SIGN ((uint16_t)1 << 15)
 #define F32_SIGN ((uint32_t)1 << 31)
 #define F64_SIGN ((uint64_t)1 << 63)
+
+static inline bool
+isNaNBF16UI(uint16_t ui)
+{
+    return ((ui & 0x7f80) == 0x7f80) && (ui & 0x007f);
+}
+
+static inline bool
+isSigNaNBF16UI(uint16_t ui)
+{
+    return ((ui & 0x7fc0) == 0x7f80) && (ui & 0x003f);
+}
+
+static inline float32_t
+bf16_to_f32(bfloat16_t a)
+{
+    if (isNaNBF16UI(a.v)) {
+        if (isSigNaNBF16UI(a.v)) {
+            softfloat_exceptionFlags |= softfloat_flag_invalid;
+        }
+        return f32(defaultNaNF32UI);
+    }
+
+    return f32(static_cast<uint32_t>(a.v) << 16);
+}
+
+static inline bfloat16_t
+f32_to_bf16(float32_t a)
+{
+    const uint32_t ui = a.v;
+    const uint32_t exp = bits(ui, 30, 23);
+    const uint32_t frac = bits(ui, 22, 0);
+    const bool sign = bits(ui, 31);
+
+    if (exp == 0xff) {
+        if (frac != 0) {
+            if (softfloat_isSigNaNF32UI(ui)) {
+                softfloat_exceptionFlags |= softfloat_flag_invalid;
+            }
+            return bf16(defaultNaNBF16UI);
+        }
+        return bf16(bits(ui, 31, 16));
+    }
+
+    const uint32_t discarded = ui & 0xffff;
+    uint16_t result = bits(ui, 31, 16);
+    bool increment = false;
+
+    switch (softfloat_roundingMode) {
+        case softfloat_round_near_even:
+            increment =
+                discarded > 0x8000 || (discarded == 0x8000 && (result & 1));
+            break;
+        case softfloat_round_minMag:
+            increment = false;
+            break;
+        case softfloat_round_min:
+            increment = sign && discarded != 0;
+            break;
+        case softfloat_round_max:
+            increment = !sign && discarded != 0;
+            break;
+        case softfloat_round_near_maxMag:
+            increment = discarded >= 0x8000;
+            break;
+        default:
+            GEM5_UNREACHABLE;
+    }
+
+    if (discarded != 0) {
+        softfloat_exceptionFlags |= softfloat_flag_inexact;
+    }
+
+    if (increment) {
+        result++;
+    }
+
+    const bool overflow = exp != 0xff && bits(result, 14, 7) == 0xff;
+    if (overflow) {
+        softfloat_exceptionFlags |=
+            softfloat_flag_overflow | softfloat_flag_inexact;
+    }
+
+    const bool underflow = discarded != 0 && bits(result, 14, 7) == 0;
+    if (underflow) {
+        softfloat_exceptionFlags |= softfloat_flag_underflow;
+    }
+
+    return bf16(result);
+}
 
 namespace float_reg
 {

--- a/src/arch/riscv/utility.hh
+++ b/src/arch/riscv/utility.hh
@@ -76,6 +76,10 @@ template<> struct double_width<int32_t>     { using type = int64_t; };
 template<> struct double_width<int64_t>     { using type = __int128_t; };
 template<> struct double_width<float32_t>   { using type = float64_t;};
 template<> struct double_width<float16_t>   { using type = float32_t;};
+template <> struct double_width<bfloat16_t>
+{
+    using type = float32_t;
+};
 template<> struct double_width<float8_t>    { using type = float16_t;};
 
 template<typename Type> struct double_widthf;
@@ -326,12 +330,15 @@ elem_mask_vseg(const T* vs, const int elem, const int num_fields)
 template<typename FloatType, typename IntType = decltype(FloatType::v)> auto
 ftype(IntType a) -> FloatType
 {
-    if constexpr(std::is_same_v<uint32_t, IntType>)
+    if constexpr (std::is_same_v<bfloat16_t, FloatType>) {
+        return bf16(a);
+    } else if constexpr (std::is_same_v<uint32_t, IntType>) {
         return f32(a);
-    else if constexpr(std::is_same_v<uint64_t, IntType>)
+    } else if constexpr (std::is_same_v<uint64_t, IntType>) {
         return f64(a);
-    else if constexpr(std::is_same_v<uint16_t, IntType>)
+    } else if constexpr (std::is_same_v<uint16_t, IntType>) {
         return f16(a);
+    }
     GEM5_UNREACHABLE;
 }
 
@@ -340,12 +347,15 @@ ftype(IntType a) -> FloatType
 template<typename FloatType, typename IntType = decltype(FloatType::v)> auto
 ftype_freg(freg_t a) -> FloatType
 {
-    if constexpr(std::is_same_v<uint32_t, IntType>)
+    if constexpr (std::is_same_v<bfloat16_t, FloatType>) {
+        return bf16(a);
+    } else if constexpr (std::is_same_v<uint32_t, IntType>) {
         return f32(a);
-    else if constexpr(std::is_same_v<uint64_t, IntType>)
+    } else if constexpr (std::is_same_v<uint64_t, IntType>) {
         return f64(a);
-    else if constexpr(std::is_same_v<uint16_t, IntType>)
+    } else if constexpr (std::is_same_v<uint16_t, IntType>) {
         return f16(a);
+    }
     GEM5_UNREACHABLE;
 }
 
@@ -548,6 +558,9 @@ fwiden(FT a)
         return f32_to_f64(a);
     else if constexpr(std::is_same_v<float16_t, FT>)
         return f16_to_f32(a);
+    else if constexpr (std::is_same_v<bfloat16_t, FT>) {
+        return bf16_to_f32(a);
+    }
     GEM5_UNREACHABLE;
 }
 
@@ -725,6 +738,9 @@ f_to_wf(FloatType a)
         return f32_to_f64(a);
     else if constexpr(std::is_same_v<float16_t, FloatType>)
         return f16_to_f32(a);
+    else if constexpr (std::is_same_v<bfloat16_t, FloatType>) {
+        return bf16_to_f32(a);
+    }
     GEM5_UNREACHABLE;
 }
 
@@ -736,8 +752,13 @@ f_to_nf(FloatType a)
 {
     if constexpr(std::is_same_v<float64_t, FloatType>)
         return f64_to_f32(a);
-    else if constexpr(std::is_same_v<float32_t, FloatType>)
-        return f32_to_f16(a);
+    else if constexpr (std::is_same_v<float32_t, FloatType>) {
+        if constexpr (std::is_same_v<bfloat16_t, FloatNType>) {
+            return f32_to_bf16(a);
+        } else {
+            return f32_to_f16(a);
+        }
+    }
     GEM5_UNREACHABLE;
 }
 


### PR DESCRIPTION
Add RISC-V BF16 extension support for scalar conversion and vector BF16 operations. This wires BF16 extension enablement through the ISA params and decoder state, adds BF16 type/helper support, and implements decode/execution for the BF16 vector conversion and widening MAC instructions.

Implemented extension coverage:

- Zfbfmin scalar BF16 conversion support
- Zvfbfmin vector BF16 widening/narrowing conversions
- Zvfbfwma vector BF16 widening multiply-accumulate operations

