### PR TITLE
cpu/timebuf: replace raw memory management with std::deque - clean version

### DIFF
--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -45,8 +45,7 @@ class TimeBuffer
     unsigned size;
     int _id;
 
-    char *data;
-    std::vector<char *> index;
+    std::vector<T> data;
     unsigned base;
 
     void valid(int idx) const
@@ -138,33 +137,15 @@ class TimeBuffer
 
   public:
     TimeBuffer(int p, int f)
-        : past(p), future(f), size(past + future + 1),
-          data(new char[size * sizeof(T)]), index(size), base(0)
+        : past(p), future(f), size(past + future + 1), data(size), base(0)
     {
         static_assert(std::is_default_constructible_v<T>,
                       "T must be default constructible.");
         assert(past >= 0 && future >= 0);
-        char *ptr = data;
-        for (unsigned i = 0; i < size; i++) {
-            index[i] = ptr;
-            new (ptr) T();
-            ptr += sizeof(T);
-        }
-
         _id = -1;
     }
 
-    TimeBuffer()
-        : data(NULL)
-    {
-    }
-
-    ~TimeBuffer()
-    {
-        for (unsigned i = 0; i < size; ++i)
-            (reinterpret_cast<T *>(index[i]))->~T();
-        delete [] data;
-    }
+    TimeBuffer() : past(0), future(0), size(0), data(0), base(0) {}
 
     void id(int id)
     {
@@ -185,8 +166,7 @@ class TimeBuffer
         int ptr = base + future;
         if (ptr >= (int)size)
             ptr -= size;
-        (reinterpret_cast<T *>(index[ptr]))->~T();
-        new (index[ptr]) T();
+        data[ptr] = T{};
     }
 
   protected:
@@ -212,21 +192,21 @@ class TimeBuffer
     {
         int vector_index = calculateVectorIndex(idx);
 
-        return reinterpret_cast<T *>(index[vector_index]);
+        return &data[vector_index];
     }
 
     T &operator[](int idx)
     {
         int vector_index = calculateVectorIndex(idx);
 
-        return reinterpret_cast<T &>(*index[vector_index]);
+        return data[vector_index];
     }
 
     const T &operator[] (int idx) const
     {
         int vector_index = calculateVectorIndex(idx);
 
-        return reinterpret_cast<const T &>(*index[vector_index]);
+        return data[vector_index];
     }
 
     wire getWire(int idx)

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -30,7 +30,7 @@
 #define __BASE_TIMEBUF_HH__
 
 #include <cassert>
-#include <deque
+#include <deque>
 #include <type_traits>
 
 namespace gem5

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -145,7 +145,7 @@ class TimeBuffer
         _id = -1;
     }
 
-    TimeBuffer() : past(0), future(0), size(0), data(0), base(0) {}
+    TimeBuffer() : past(0), future(0), size(0), _id(-1), data(0), base(0) {}
 
     void id(int id)
     {

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -172,7 +172,7 @@ class TimeBuffer
     }
 
   protected:
-    // Calculate the index into this->index for element at position idx
+    // Calculate the index into this->data for element at position idx
     // relative to now
     inline int calculateVectorIndex(int idx) const
     {

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -30,8 +30,8 @@
 #define __BASE_TIMEBUF_HH__
 
 #include <cassert>
+#include <deque
 #include <type_traits>
-#include <vector>
 
 namespace gem5
 {
@@ -45,10 +45,11 @@ class TimeBuffer
     unsigned size;
     int _id;
 
-    std::vector<T> data;
+    std::deque<T> data;
     unsigned base;
 
-    void valid(int idx) const
+    void
+    valid(int idx) const
     {
         assert (idx >= -past && idx <= future);
     }
@@ -134,7 +135,6 @@ class TimeBuffer
         T *operator->() const { return buffer->access(index); }
     };
 
-
   public:
     TimeBuffer(int p, int f)
         : past(p), future(f), size(past + future + 1), data(size), base(0)
@@ -147,7 +147,8 @@ class TimeBuffer
 
     TimeBuffer() : past(0), future(0), size(0), _id(-1), data(0), base(0) {}
 
-    void id(int id)
+    void
+    id(int id)
     {
         _id = id;
     }
@@ -164,14 +165,15 @@ class TimeBuffer
             base = 0;
 
         int ptr = base + future;
-        if (ptr >= (int)size)
+        if (ptr >= (int)size) {
             ptr -= size;
+        }
         data[ptr] = T{};
     }
 
   protected:
-    //Calculate the index into this->index for element at position idx
-    //relative to now
+    // Calculate the index into this->index for element at position idx
+    // relative to now
     inline int calculateVectorIndex(int idx) const
     {
         //Need more complex math here to calculate index.
@@ -195,21 +197,24 @@ class TimeBuffer
         return &data[vector_index];
     }
 
-    T &operator[](int idx)
+    T &
+    operator[](int idx)
     {
         int vector_index = calculateVectorIndex(idx);
 
         return data[vector_index];
     }
 
-    const T &operator[] (int idx) const
+    const T &
+    operator[](int idx) const
     {
         int vector_index = calculateVectorIndex(idx);
 
         return data[vector_index];
     }
 
-    wire getWire(int idx)
+    wire
+    getWire(int idx)
     {
         valid(idx);
 

--- a/src/cpu/timebuf.hh
+++ b/src/cpu/timebuf.hh
@@ -31,6 +31,7 @@
 
 #include <cassert>
 #include <deque>
+#include <memory>
 #include <type_traits>
 
 namespace gem5


### PR DESCRIPTION
This PR is the cleaned up PR without the rebase errors in #3230 

Original comment from #3230 

`TimeBuffer<T>` managed storage via a raw `char*` buffer with manual placement-`new`, `memset`, and explicit destructor calls — a pattern with C++ object-lifetime UB (`memset` before placement-`new` is a dead store on memory where no object yet lives). Replace it with a `std::deque<T>`.

**Why `std::deque` and not `std::vector`:** `std::vector<bool>` is a packed-bit specialisation whose `operator[]` returns a proxy, not a `bool&`. `TimeBuffer<bool>` is used by `ActivityBuffer` in `cpu/activity.hh`, so `std::vector` would silently break that.

## Changes

- **Storage:** `char *data` + `std::vector<char*> index` → `std::deque<T> data`
- **Construction:** `data(size)` value-initialises all elements; no manual `new`/`memset` loop
- **Destruction:** explicit `~TimeBuffer()` with manual destructor calls and `delete[]` removed — `std::deque` owns element lifetimes
- **`advance()`:** `~T()` + `memset` + placement-`new` replaced with `data[ptr] = T{}`
- **`access()` / `operator[]`:** `reinterpret_cast` dropped; return direct references/pointers into the deque

**Before / after the advance slot-reset:**
```cpp
// Before — UB: object lifetime games
(reinterpret_cast<T *>(index[ptr]))->~T();
std::memset(index[ptr], 0, sizeof(T));   // dead store
new (index[ptr]) T;

// After
data[ptr] = T{};
```