### PR TITLE
arch-riscv: refactor vector register gather instructions

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -216,6 +216,47 @@ std::string VectorSlideMacroInst::generateDisassembly(Addr pc,
     return ss.str();
 }
 
+std::string
+VectorGatherMacroInst::generateDisassembly(
+    Addr pc, const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    ss << mnemonic << ' ' << registerName(vecRegClass[machInst.vd]) << ", "
+       << registerName(vecRegClass[machInst.vs2]) << ", ";
+    if (machInst.funct3 == 0x3) {
+        ss << machInst.vecimm;
+    } else if (machInst.funct3 == 0x1) {
+        ss << registerName(intRegClass[machInst.rs1]);
+    } else {
+        ss << registerName(vecRegClass[machInst.vs1]);
+    }
+    if (machInst.vm == 0) {
+        ss << ", v0.t";
+    }
+    return ss.str();
+}
+
+std::string
+VectorGatherMicroInst::generateDisassembly(
+    Addr pc, const loader::SymbolTable *symtab) const
+{
+    std::stringstream ss;
+    ss << mnemonic << ' ' << registerName(destRegIdx(0)) << ", ";
+    ss << registerName(srcRegIdx(0));
+    if (numVs2Regs > 1) {
+        ss << "-" << registerName(srcRegIdx(numVs2Regs - 1));
+    }
+    ss << ", " << registerName(srcRegIdx(numVs2Regs));
+    if (numVs1Regs > 1) {
+        ss << "-" << registerName(srcRegIdx(numVs2Regs + numVs1Regs - 1));
+    }
+
+    if (machInst.vm == 0) {
+        ss << ", v0.t";
+    }
+    return ss.str();
+}
+
 std::string VleMicroInst::generateDisassembly(Addr pc,
         const loader::SymbolTable *symtab) const
 {

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -305,6 +305,38 @@ class VectorSlideMicroInst : public VectorMicroInst
             Addr pc, const loader::SymbolTable *symtab) const override;
 };
 
+class VectorGatherMacroInst : public VectorMacroInst
+{
+  protected:
+    VectorGatherMacroInst(const char *mnem, ExtMachInst _machInst,
+                          OpClass __opClass, uint32_t _elen, uint32_t _vlen)
+        : VectorMacroInst(mnem, _machInst, __opClass, _elen, _vlen)
+    {
+        this->flags[IsVector] = true;
+    }
+
+    std::string
+    generateDisassembly(Addr pc,
+                        const loader::SymbolTable *symtab) const override;
+};
+
+class VectorGatherMicroInst : public VectorMicroInst
+{
+  protected:
+    uint8_t numVs1Regs = 0;
+    uint8_t numVs2Regs = 0;
+    VectorGatherMicroInst(const char *mnem, ExtMachInst _machInst,
+                          OpClass __opClass, uint32_t _microVl,
+                          uint32_t _microIdx, uint32_t _elen, uint32_t _vlen)
+        : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
+                          _elen, _vlen)
+    {}
+
+    std::string
+    generateDisassembly(Addr pc,
+                        const loader::SymbolTable *symtab) const override;
+};
+
 class VectorMemMicroInst : public VectorMicroInst
 {
   protected:

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3734,30 +3734,12 @@ decode QUADRANT default Unknown::unknown() {
                     }}, OPIVV, SimdAluOp);
                 }
                 0x0c: VectorGatherFormat::vrgather_vv({{
-                    for (uint32_t i = 0; i < microVl; i++) {
-                        uint32_t ei = i + vs1_idx * vs1_elems + vs1_bias;
-                        if (this->vm || elem_mask(v0, ei)) {
-                            const uint64_t idx = Vs1_vu[i]
-                                - vs2_elems * vs2_idx;
-                            if (Vs1_vu[i] >= vlmax)
-                                Vd_vu[i] = 0;
-                            else if (idx < vs2_elems)
-                                Vd_vu[i] = Vs2_vu[idx];
-                        }
-                    }
+                    IndexType idx = vs1_regs[i/vs1_elems].as<IndexType>()[i];
                 }}, OPIVV, SimdMiscOp);
                 0x0e: VectorGatherFormat::vrgatherei16_vv({{
-                    for (uint32_t i = 0; i < microVl; i++) {
-                        uint32_t ei = i + vs1_idx * vs1_elems + vs1_bias;
-                        if (this->vm || elem_mask(v0, ei)) {
-                            const uint32_t idx = Vs1_uh[i + vs1_bias]
-                                - vs2_elems * vs2_idx;
-                            if (Vs1_uh[i + vs1_bias] >= vlmax)
-                                Vd_vu[i + vd_bias] = 0;
-                            else if (idx < vs2_elems)
-                                Vd_vu[i + vd_bias] = Vs2_vu[idx];
-                        }
-                    }
+                    uint32_t offset = microIdx*vd_elems % vs1_elems;
+                    IndexType idx = vs1_regs[(i+offset)/vs1_elems]
+                                    .as<IndexType>()[i+offset];
                 }}, OPIVV, SimdMiscOp);
                 format VectorIntFormat {
                     0x10: decode VM {
@@ -4745,17 +4727,7 @@ decode QUADRANT default Unknown::unknown() {
                     }}, OPIVI, SimdAluOp);
                 }
                 0x0c: VectorGatherFormat::vrgather_vi({{
-                    for (uint32_t i = 0; i < microVl; i++) {
-                        uint32_t ei = i + vs1_idx * vs1_elems + vs1_bias;
-                        uint64_t zextImm = rvZext(SIMM5);
-                        if (this->vm || elem_mask(v0, ei)) {
-                            const uint64_t idx = zextImm - vs2_elems * vs2_idx;
-                            if (zextImm >= vlmax)
-                                Vd_vu[i] = 0;
-                            else if (idx < vs2_elems)
-                                Vd_vu[i] = Vs2_vu[idx];
-                        }
-                    }
+                    IndexType idx = rvZext(SIMM5);
                 }}, OPIVI, SimdMiscOp);
                 0x0e: VectorSlideUpVIFormat::vslideup_vi({{
                     int offset = (int)(uint64_t)(SIMM5);
@@ -5183,17 +5155,7 @@ decode QUADRANT default Unknown::unknown() {
                     }
                 }}, OPIVX, SimdMiscOp);
                 0x0c: VectorGatherFormat::vrgather_vx({{
-                    for (uint32_t i = 0; i < microVl; i++) {
-                        uint32_t ei = i + vs1_idx * vs1_elems + vs1_bias;
-                        uint64_t zextRs1 = rvZext(Rs1);
-                        if (this->vm || elem_mask(v0, ei)) {
-                            const uint64_t idx = zextRs1 - vs2_elems * vs2_idx;
-                            if (zextRs1 >= vlmax)
-                                Vd_vu[i] = 0;
-                            else if (idx < vs2_elems)
-                                Vd_vu[i] = Vs2_vu[idx];
-                        }
-                    }
+                    IndexType idx = rvZext(rs1);
                 }}, OPIVX, SimdMiscOp);
                 format VectorIntFormat {
                     0x10: decode VM {

--- a/src/arch/riscv/isa/formats/vector_arith.isa
+++ b/src/arch/riscv/isa/formats/vector_arith.isa
@@ -220,6 +220,14 @@ let {{
             code += ('template class'
                      f' {class_name}<uint{size}_t, {idx_type}>;\n')
         return code
+
+    def getRegOperandGroup(name, num, offset="0"):
+        return ('''
+            std::vector<RiscvISA::vreg_t> %s(%s);
+            for (unsigned i=0; i < %s; i++) {
+                xc->getRegOperand(this, i + %s, &%s[i]);
+            }
+        ''' % (name, num, num, offset, name))
 }};
 
 
@@ -676,51 +684,83 @@ def format VectorGatherFormat(code, category, *flags) {{
         idx_type = "uint16_t"
     else:
         idx_type = "elem_type"
-    iop = InstObjParams(name, Name, 'VectorArithMacroInst',
+
+    iop = InstObjParams(name, Name, 'VectorGatherMacroInst',
         {'idx_type': idx_type,
          'code': code,
          'declare_varith_template': declareGatherTemplate(Name, idx_type)},
         flags)
-    dest_reg_id = "vecRegClass[_machInst.vd + vd_idx]"
-    src1_reg_id = ""
-    if category in ["OPIVV"]:
-        src1_reg_id = "vecRegClass[_machInst.vs1 + vs1_idx]"
-    elif category in ["OPIVX"]:
-        src1_reg_id = "intRegClass[_machInst.rs1]"
-    elif category == "OPIVI":
-        old_vd_idx = 1
-    else:
-        error("not supported category for VectorIntFormat: %s" % category)
-    src2_reg_id = "vecRegClass[_machInst.vs2 + vs2_idx]"
 
-    # vtmp0 as dummy src reg to create dependency with pin vd micro
-    src3_reg_id = "vecRegClass[VecMemInternalReg0 + vd_idx]"
-
+    dest_reg_id = "vecRegClass[_machInst.vd + _microIdx]"
     set_dest_reg_idx = setDestWrapper(dest_reg_id)
 
     set_src_reg_idx = ""
-    if category != "OPIVI":
-        set_src_reg_idx += setSrcWrapper(src1_reg_id)
-    set_src_reg_idx += setSrcWrapper(src2_reg_id)
-    set_src_reg_idx += setSrcWrapper(src3_reg_id)
+    get_vs_regs = ""
+
+    if category == "OPIVI":
+        set_src_reg_idx += '''
+            if (rvZext(SIMM5) < vtype_VLMAX(vtype, vlen, false)) {
+                uint8_t vs2_reg = rvZext(SIMM5)
+                                  / vtype_VLMAX(vtype, vlen, true);
+                %s
+                numVs2Regs = 1;
+            }
+        ''' % (setSrcWrapper("vecRegClass[_machInst.vs2 + vs2_reg]"))
+    else:
+        set_src_reg_idx += "numVs2Regs = vtype_regs_per_group(vtype);"
+        set_src_reg_idx += setVecRegGroupSrcWrapper(
+                "numVs2Regs", "_machInst.vs2")
+
+    get_vs_regs += getRegOperandGroup("vs2_regs", "numVs2Regs");
+
+    if category == "OPIVV":
+        set_src_reg_idx += """
+            constexpr uint32_t vd_eewb = sizeof(ElemType);
+            constexpr uint32_t vs1_eewb = sizeof(IndexType);
+            const uint32_t vs1_elems = vlenb / vs1_eewb;
+            numVs1Regs = (microVl+vs1_elems-1) / vs1_elems;
+        """
+        set_src_reg_idx += setVecRegGroupSrcWrapper(
+            "numVs1Regs",
+            "_machInst.vs1 + _microIdx*vs1_eewb/vd_eewb"
+        )
+
+        get_vs_regs += """
+            constexpr uint32_t vs1_eewb = sizeof(IndexType);
+            const uint32_t vs1_elems = vlenb / vs1_eewb;
+        """
+        get_vs_regs += getRegOperandGroup("vs1_regs", "numVs1Regs",
+                                          offset="numVs2Regs");
+    elif category == "OPIVX":
+        set_src_reg_idx += setSrcWrapper("intRegClass[_machInst.rs1]")
+        get_vs_regs += """
+            const uint64_t rs1 = xc->getRegOperand(this, numVs2Regs);
+        """
+    elif category == "OPIVI":
+        pass
+    else:
+        error("not supported category for VectorGatherFormat: %s" % category)
+
+    set_src_reg_idx += tailMaskCondSetSrcWrapper(setSrcWrapper(dest_reg_id))
     set_src_reg_idx += setSrcVm()
 
-    # code
-
     vm_decl_rd = vmDeclAndReadData()
-
     set_vlenb = setVlenb();
+    copy_old_vd = copyOldVd("oldDstIdx")
 
     varith_micro_declare = declareGatherTemplate(Name + "Micro", idx_type)
+
     microiop = InstObjParams(name + "_micro",
         Name + "Micro",
-        'VectorArithMicroInst',
+        'VectorGatherMicroInst',
         {'code': code,
          'set_dest_reg_idx': set_dest_reg_idx,
          'set_src_reg_idx': set_src_reg_idx,
          'set_vlenb': set_vlenb,
          'vm_decl_rd': vm_decl_rd,
          'idx_type': idx_type,
+         'copy_old_vd': copy_old_vd,
+         'get_vs_regs': get_vs_regs,
          'declare_varith_template': varith_micro_declare},
         flags)
 

--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1868,17 +1868,8 @@ template<typename ElemType, typename IndexType>
 {
     %(set_reg_idx_arr)s;
     %(constructor)s;
-    constexpr uint32_t vd_eewb = sizeof(ElemType);
-    constexpr uint32_t vs2_eewb = sizeof(ElemType);
-    constexpr uint32_t vs1_eewb = sizeof(IndexType);
-    const int8_t lmul = vtype_vlmul(vtype);
-    const int8_t vs1_emul = lmul + __builtin_ctz(vs1_eewb)
-                                 - __builtin_ctz(vs2_eewb);
-    const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    const uint8_t vs1_vregs = vs1_emul < 0 ? 1 : 1 << vs1_emul;
-    const uint8_t vd_vregs = vs2_vregs;
-    uint32_t vlenb = vlen >> 3;
-    const int32_t micro_vlmax = vlenb / std::max(vd_eewb, vs1_eewb);
+    const int32_t micro_vlmax = vtype_VLMAX(vtype, vlen, true);
+    const uint32_t num_microops = vtype_regs_per_group(vtype);
     int32_t remaining_vl = this->vl;
     int32_t micro_vl = std::min(remaining_vl, micro_vlmax);
     StaticInstPtr microop;
@@ -1888,28 +1879,11 @@ template<typename ElemType, typename IndexType>
         this->microops.push_back(microop);
     }
 
-    uint32_t vd_vlmax = vlenb / vd_eewb;
-    uint32_t vs1_vlmax = vlenb / vs1_eewb;
-    for (uint32_t i = 0; i < ceil((float) this->vl / vd_vlmax); i++) {
-        uint32_t pinvd_micro_vl = (vd_vlmax <= remaining_vl)
-                                  ? vd_vlmax : remaining_vl;
-        uint8_t num_vd_pins = ceil((float) pinvd_micro_vl/vs1_vlmax)*vs2_vregs;
-        microop = new VPinVdMicroInst(machInst, i, num_vd_pins, elen, vlen);
-        microop->setFlag(IsDelayedCommit);
+    for (uint32_t i = 0; i < num_microops && micro_vl > 0; i++) {
+        microop = new %(class_name)sMicro<ElemType, IndexType>(
+            _machInst, micro_vl, i, _elen, _vlen);
+        microop->setDelayedCommit();
         this->microops.push_back(microop);
-
-        remaining_vl -= pinvd_micro_vl;
-    }
-
-    remaining_vl = this->vl;
-    for (uint32_t i = 0; i < std::max(vs1_vregs, vd_vregs) && micro_vl > 0;
-            i++) {
-        for (uint8_t j = 0; j < vs2_vregs; j++) {
-            microop = new %(class_name)sMicro<ElemType, IndexType>(
-                _machInst, micro_vl, i * vs2_vregs + j, _elen, _vlen);
-            microop->setDelayedCommit();
-            this->microops.push_back(microop);
-        }
         micro_vl = std::min(remaining_vl -= micro_vlmax, micro_vlmax);
     }
 
@@ -1927,14 +1901,13 @@ template<typename ElemType, typename IndexType>
 class %(class_name)s : public %(base_class)s
 {
 private:
-    // vs2, vs1, vtmp0, vm
-    RegId srcRegIdxArr[4];
+    // vs2 (up to 8), rs1/vs1 (up to 2), old_vd (optional), vm (optional)
+    RegId srcRegIdxArr[12];
     RegId destRegIdxArr[1];
     bool vm;
 public:
-    %(class_name)s(ExtMachInst _machInst,
-                   uint32_t _microVl, uint32_t _microIdx, uint32_t _elen,
-                   uint32_t _vlen);
+    %(class_name)s(ExtMachInst _machInst, uint32_t _microVl,
+                   uint32_t _microIdx, uint32_t _elen, uint32_t _vlen);
     Fault execute(ExecContext* xc, trace::InstRecord* traceData)const override;
     using %(base_class)s::generateDisassembly;
 };
@@ -1953,18 +1926,9 @@ template<typename ElemType, typename IndexType>
     %(set_reg_idx_arr)s;
     _numSrcRegs = 0;
     _numDestRegs = 0;
-    [[maybe_unused]] constexpr uint32_t vd_eewb = sizeof(ElemType);
-    [[maybe_unused]] constexpr uint32_t vs2_eewb = sizeof(ElemType);
-    [[maybe_unused]] constexpr uint32_t vs1_eewb = sizeof(IndexType);
-    constexpr uint32_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
-    constexpr uint32_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
-    const int8_t lmul = vtype_vlmul(vtype);
-    const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    [[maybe_unused]] const uint32_t vs2_idx = _microIdx % vs2_vregs;
-    [[maybe_unused]] const uint32_t vs1_idx =
-        _microIdx / vs2_vregs / vs1_split_num;
-    [[maybe_unused]] const uint32_t vd_idx =
-        _microIdx / vs2_vregs / vd_split_num;
+
+    %(set_vlenb)s;
+
     %(set_dest_reg_idx)s;
     %(set_src_reg_idx)s;
 }
@@ -1980,9 +1944,6 @@ Fault
 %(class_name)s<ElemType, IndexType>::execute(ExecContext* xc,
                                   trace::InstRecord* traceData) const
 {
-    using vu [[maybe_unused]] = std::make_unsigned_t<ElemType>;
-    [[maybe_unused]] constexpr size_t sew = sizeof(vu) * 8;
-
     bool set_dirty = true;
     bool check_vill = true;
     Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
@@ -1992,30 +1953,43 @@ Fault
     %(op_rd)s;
     %(set_vlenb)s;
     %(vm_decl_rd)s;
-    const uint32_t vlmax = vtype_VLMAX(vtype,vlen);
+
     constexpr uint32_t vd_eewb = sizeof(ElemType);
-    constexpr uint32_t vs1_eewb = sizeof(IndexType);
     constexpr uint32_t vs2_eewb = sizeof(ElemType);
-    constexpr uint32_t vs1_split_num = (vd_eewb + vs1_eewb - 1) / vs1_eewb;
-    constexpr uint32_t vd_split_num = (vs1_eewb + vd_eewb - 1) / vd_eewb;
-    [[maybe_unused]] const uint32_t vd_elems = vlenb / vd_eewb;
-    [[maybe_unused]] const uint32_t vs1_elems = vlenb / vs1_eewb;
-    [[maybe_unused]] const uint32_t vs2_elems = vlenb / vs2_eewb;
-    [[maybe_unused]] const int8_t lmul = vtype_vlmul(vtype);
-    [[maybe_unused]] const uint8_t vs2_vregs = lmul < 0 ? 1 : 1 << lmul;
-    [[maybe_unused]] const uint32_t vs2_idx = microIdx % vs2_vregs;
-    [[maybe_unused]] const uint32_t vs1_idx =
-        microIdx / vs2_vregs / vs1_split_num;
-    [[maybe_unused]] const uint32_t vd_idx =
-        microIdx / vs2_vregs / vd_split_num;
-    [[maybe_unused]] const uint32_t vs1_bias =
-        vs1_elems * (vd_idx % vs1_split_num) / vs1_split_num;
-    [[maybe_unused]] const uint32_t vd_bias =
-        vd_elems * (vs1_idx % vd_split_num) / vd_split_num;
 
+    const uint32_t vlmax = vtype_VLMAX(vtype, vlen);
+    const uint32_t vd_elems = vlenb / vd_eewb;
+    const uint32_t vs2_elems = vlenb / vs2_eewb;
 
-    %(code)s;
-    %(op_wb)s;
+    RiscvISA::vreg_t& tmp_d0 = *(RiscvISAInst::VecRegContainer*)
+                               xc->getWritableRegOperand(this, 0);
+    ElemType* vd = tmp_d0.as<ElemType>();
+
+    %(copy_old_vd)s;
+    %(get_vs_regs)s
+
+    for (uint32_t i=0; i < microVl; i++) {
+        if (!this->vm && !elem_mask(v0, i + microIdx*vd_elems)) {
+            continue;
+        }
+
+        %(code)s
+
+        const IndexType vs2_reg_idx = idx / vs2_elems;
+        const IndexType elem_offset = idx - vs2_reg_idx*vs2_elems;
+
+        ElemType elem = 0;
+        if (idx < vlmax) {
+            const RiscvISA::vreg_t& vs2 = vs2_regs[vs2_reg_idx % numVs2Regs];
+            elem = vs2.as<ElemType>()[elem_offset];
+        }
+
+        vd[i] = elem;
+    }
+
+    if (traceData) {
+        traceData->setData(vecRegClass, &tmp_d0);
+    }
 
     return NoFault;
 }


### PR DESCRIPTION
This patch refactors RISC-V's vector register gather instructions to produce 1 µop per vd instead of LMUL (or 2*LMUL in the worst case with `vrgatherei16.vv` and SEW=8). With this change there's also no need for destination register pinning, further reducing the µop count. 

In other words, total µop count is now O(LMUL) instead of O(LMUL^2) assuming vl = vlmax.