### PR TITLE
mem: remove deprecated owner reference in ports

### DIFF
--- a/src/mem/port.cc
+++ b/src/mem/port.cc
@@ -118,26 +118,8 @@ DefaultResponsePort defaultResponsePort;
 
 } // anonymous namespace
 
-/**
- * Request port
- */
-[[deprecated]]
-RequestPort::RequestPort(const std::string& name,
-                         SimObject* _owner,
-                         PortID _id):
-    Port(name, _id), _responsePort(&defaultResponsePort), owner{*_owner}
-{
-}
-
-/*** FIXME:
- * The owner reference member is going through a deprecation path. In the
- * meantime, it must be initialized but no valid reference is available here.
- * Using 1 instead of nullptr prevents warning upon dereference. It should be
- * OK until definitive removal of owner.
- */
-RequestPort::RequestPort(const std::string& name, PortID _id) :
-    Port(name, _id), _responsePort(&defaultResponsePort),
-    owner{*reinterpret_cast<SimObject*>(1)}
+RequestPort::RequestPort(const std::string &name, PortID _id)
+    : Port(name, _id), _responsePort(&defaultResponsePort)
 {
 }
 
@@ -214,29 +196,10 @@ RequestPort::removeTrace(PacketPtr pkt) const
  * Response port
  */
 
-[[deprecated]]
-ResponsePort::ResponsePort(const std::string& name,
-                           SimObject* _owner,
-                           PortID _id):
-    Port(name, _id),
-    _requestPort(&defaultRequestPort),
-    defaultBackdoorWarned(false),
-    owner{*_owner}
-{
-}
-
-
-/*** FIXME:
- * The owner reference member is going through a deprecation path. In the
- * meantime, it must be initialized but no valid reference is available here.
- * Using 1 instead of nullptr prevents warning upon dereference. It should be
- * OK until definitive removal of owner.
- */
-ResponsePort::ResponsePort(const std::string& name, PortID id) :
-    Port(name, id),
-    _requestPort(&defaultRequestPort),
-    defaultBackdoorWarned(false),
-    owner{*reinterpret_cast<SimObject*>(1)}
+ResponsePort::ResponsePort(const std::string &name, PortID id)
+    : Port(name, id),
+      _requestPort(&defaultRequestPort),
+      defaultBackdoorWarned(false)
 {
 }
 

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -139,15 +139,7 @@ class RequestPort: public Port, public AtomicRequestProtocol,
   private:
     ResponsePort *_responsePort;
 
-  protected:
-    SimObject &owner;
-
   public:
-    [[deprecated("RequestPort ownership is deprecated. "
-                 "Owner should now be registered in derived classes.")]]
-    RequestPort(const std::string& name, SimObject* _owner,
-                PortID id=InvalidPortID);
-
     RequestPort(const std::string& name, PortID id=InvalidPortID);
 
     virtual ~RequestPort();
@@ -354,15 +346,7 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
 
     bool defaultBackdoorWarned;
 
-  protected:
-    SimObject& owner;
-
   public:
-    [[deprecated("ResponsePort ownership is deprecated. "
-                 "Owner should now be registered in derived classes.")]]
-    ResponsePort(const std::string& name, SimObject* _owner,
-                 PortID id=InvalidPortID);
-
     ResponsePort(const std::string& name, PortID id=InvalidPortID);
 
     virtual ~ResponsePort();


### PR DESCRIPTION
`reinterpret_cast<SimObject*>(1)` triggers UBSan alignment warning. Let's just remove this 3-year-deprecated member.