### PR TITLE
cpu-o3: Clear request state after no-access release

### DIFF
--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -370,7 +370,7 @@ class DynInst : public ExecContext, public RefCounted
      * Saved memory request (needed when the DTB address translation is
      * delayed due to a hw page table walk).
      */
-    LSQRequest *savedRequest;
+    LSQRequest *savedRequest = nullptr;
 
     /////////////////////// Checker //////////////////////
     // Need a copy of main request pointer to verify on writes.
@@ -954,6 +954,15 @@ class DynInst : public ExecContext, public RefCounted
     bool hasRequest() const { return instFlags[ReqMade]; }
     /** Assert this instruction has generated a memory request. */
     void setRequest() { instFlags[ReqMade] = true; }
+    /** Clear request and translation bookkeeping after request release. */
+    void
+    clearRequest()
+    {
+        instFlags.reset(ReqMade);
+        translationStarted(false);
+        translationCompleted(false);
+        savedRequest = nullptr;
+    }
 
     /** Returns iterator to this instruction in the list of all insts. */
     ListIt &getInstListIt() { return instListIt; }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -844,6 +844,7 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
                     thread[tid]->storeQueue[inst->sqIdx].setRequest(nullptr);
                 }
                 request->discard();
+                inst->clearRequest();
             }
         }
     }

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -648,6 +648,7 @@ LSQUnit::executeLoad(const DynInstPtr &inst)
                 // so the request no longer keeps the DynInst alive.
                 loadQueue[inst->lqIdx].setRequest(nullptr);
                 request->discard();
+                inst->clearRequest();
             }
         }
         return NoFault;


### PR DESCRIPTION
The weekly O3 x86 boot test can intermittently segfault in x86 decode after a no-access LSQ request is discarded. The crash is not locally reproducible, but the failing path can leave a `DynInst` with `translationStarted()` still set after its `LSQRequest` has been released and `savedRequest` has been cleared. A later replay or revisit can then treat the stale translation state as a live request and reuse a null or dangling `savedRequest`.

Initialize `savedRequest` to `nullptr` and add `DynInst::clearRequest()` to reset `ReqMade`, `translationStarted()`, `translationCompleted()`, and `savedRequest` together. Use it when the load and store no-access paths detach and discard their `LSQRequest` without any later packet or translation response to clean up that state.

This may help fix the weekly test-suite failure by keeping the short-circuited LSQ path from leaving stale request bookkeeping on an instruction that no longer owns an `LSQRequest`.