### PR TITLE
mem: allow physical memory without local address ranges

### DIFF
--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -208,17 +208,16 @@ PhysicalMemory::PhysicalMemory(const std::string &_name,
                            f->isKvmMap());
     }
 
-    if (validAddrMap.empty()) {
-        warn("No valid address ranges found in physical memory\n");
-    } else {
-        // Clean up the valid address map
-        // 1. Sort: Pairs are compared by 'first', then 'second'
-        std::sort(validAddrMap.begin(), validAddrMap.end());
-        // 2. Unique: Move consecutive identical duplicates to the end
-        auto last = std::unique(validAddrMap.begin(), validAddrMap.end());
-        // 3. Erase: Shrink the vector to remove the "garbage" at the end
-        validAddrMap.erase(last, validAddrMap.end());
-    }
+    warn_if(validAddrMap.empty(),
+            "No valid address ranges found in physical memory\n");
+
+    // Clean up the valid address map
+    // 1. Sort: Pairs are compared by 'first', then 'second'
+    std::sort(validAddrMap.begin(), validAddrMap.end());
+    // 2. Unique: Move consecutive identical duplicates to the end
+    auto last = std::unique(validAddrMap.begin(), validAddrMap.end());
+    // 3. Erase: Shrink the vector to remove the "garbage" at the end
+    validAddrMap.erase(last, validAddrMap.end());
 
     if (debug::AddrRanges) {
         for (const auto &r : validAddrMap) {

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -208,14 +208,17 @@ PhysicalMemory::PhysicalMemory(const std::string &_name,
                            f->isKvmMap());
     }
 
-    panic_if(validAddrMap.empty(), "No valid address ranges found\n");
-    // Clean up the valid address map
-    // 1. Sort: Pairs are compared by 'first', then 'second'
-    std::sort(validAddrMap.begin(), validAddrMap.end());
-    // 2. Unique: Move consecutive identical duplicates to the end
-    auto last = std::unique(validAddrMap.begin(), validAddrMap.end());
-    // 3. Erase: Shrink the vector to remove the "garbage" at the end
-    validAddrMap.erase(last, validAddrMap.end());
+    if (validAddrMap.empty()) {
+        warn("No valid address ranges found in physical memory\n");
+    } else {
+        // Clean up the valid address map
+        // 1. Sort: Pairs are compared by 'first', then 'second'
+        std::sort(validAddrMap.begin(), validAddrMap.end());
+        // 2. Unique: Move consecutive identical duplicates to the end
+        auto last = std::unique(validAddrMap.begin(), validAddrMap.end());
+        // 3. Erase: Shrink the vector to remove the "garbage" at the end
+        validAddrMap.erase(last, validAddrMap.end());
+    }
 
     if (debug::AddrRanges) {
         for (const auto &r : validAddrMap) {


### PR DESCRIPTION
Use `warn` instead of `panic_if` when `validAddrMap` is empty.
The physical memory object can still be valid for integrations such
as SST, where backing storage is needed even though gem5 does not own
any local address ranges.

This will fix the failing Daily SST Tests which is failing due to this `panic_if` (introduced in PR #2861).