### PR TITLE
dev: Expose serial terminal listen address to Python

### DIFF
--- a/src/dev/serial/Terminal.py
+++ b/src/dev/serial/Terminal.py
@@ -39,7 +39,10 @@
 from m5.objects.Serial import SerialDevice
 from m5.params import *
 from m5.proxy import *
-from m5.SimObject import SimObject
+from m5.SimObject import (
+    SimObject,
+    cxxMethod,
+)
 
 
 class TerminalDump(ScopedEnum):
@@ -55,3 +58,16 @@ class Terminal(SerialDevice):
     outfile = Param.TerminalDump(
         "file", "Selects if and where the terminal is dumping its output"
     )
+
+    @cxxMethod
+    def getListenerOutput(self):
+        """
+        Returns the actual bound address of the listener as a string.
+        Returns an empty string if no listener is attached.
+        """
+        pass
+
+    @cxxMethod
+    def hasListener(self):
+        """Returns True if a listener is attached to this terminal."""
+        pass

--- a/src/dev/serial/terminal.cc
+++ b/src/dev/serial/terminal.cc
@@ -356,4 +356,16 @@ Terminal::writeData(uint8_t c)
 
 }
 
+std::string
+Terminal::getListenerOutput() const
+{
+    if (!listener) {
+        return "";
+    }
+
+    std::stringstream ss;
+    listener->output(ss);
+    return ss.str();
+}
+
 } // namespace gem5

--- a/src/dev/serial/terminal.hh
+++ b/src/dev/serial/terminal.hh
@@ -118,6 +118,27 @@ class Terminal : public SerialDevice
     ///////////////////////
     // Terminal Interface
 
+    /**
+     * @return true if there is a listener (socket or other endpoint)
+     * configured and listening for this terminal.
+     */
+    bool
+    hasListener() const
+    {
+        return (bool)listener;
+    }
+
+    /**
+     * Returns the actual bound address of the listener.
+     *
+     * This method provides a snapshot of the current listening endpoint
+     * (e.g., a TCP port number or a UNIX socket path). It does NOT
+     * consume or clear any buffered serial data.
+     *
+     * @return A string representation of the listening endpoint, or an
+     * empty string if no listener is attached or configured.
+     */
+    std::string getListenerOutput() const;
     void data();
 
     void read(uint8_t &c) { read(&c, 1); }


### PR DESCRIPTION
This patch adds a `getListenerOutput()` interface to the Terminal object to retrieve the actual bound address after potential runtime increments.

This allows external tools to accurately detect serial terminals regardless of TCP or UNIX socket usage.