### PR TITLE
tests: add stats.txt parser utility

### DIFF
--- a/tests/pyunit/stats/fixtures/duplicate_stat.txt
+++ b/tests/pyunit/stats/fixtures/duplicate_stat.txt
@@ -1,0 +1,6 @@
+
+---------- Begin Simulation Statistics ----------
+simInsts 1
+simInsts 2
+
+---------- End Simulation Statistics   ----------

--- a/tests/pyunit/stats/fixtures/edge_values.txt
+++ b/tests/pyunit/stats/fixtures/edge_values.txt
@@ -2,6 +2,7 @@
 ---------- Begin Simulation Statistics ----------
 system.cpu.dcache.overallAccesses::cpu.data     42 # subname preserved
 system.cpu.branch-predictor.hits[0]              0 # zero value
+system.cpu.big_tick           18446744073709551615 # uint64 max preserved
 system.cpu.negative                             -7.5
 system.cpu.scientific                         1.25e+03 # scientific notation
 system.cpu.percentages                            4 25.00% 75.00% # pdf/cdf columns

--- a/tests/pyunit/stats/fixtures/edge_values.txt
+++ b/tests/pyunit/stats/fixtures/edge_values.txt
@@ -1,0 +1,12 @@
+
+---------- Begin Simulation Statistics ----------
+system.cpu.dcache.overallAccesses::cpu.data     42 # subname preserved
+system.cpu.branch-predictor.hits[0]              0 # zero value
+system.cpu.negative                             -7.5
+system.cpu.scientific                         1.25e+03 # scientific notation
+system.cpu.percentages                            4 25.00% 75.00% # pdf/cdf columns
+system.cpu.not_a_number                        nan
+system.cpu.infinity                            inf
+system.cpu.oneline_vector                       |           1 |           2 # ignored
+
+---------- End Simulation Statistics   ----------

--- a/tests/pyunit/stats/fixtures/empty_dump.txt
+++ b/tests/pyunit/stats/fixtures/empty_dump.txt
@@ -1,0 +1,4 @@
+
+---------- Begin Simulation Statistics ----------
+
+---------- End Simulation Statistics   ----------

--- a/tests/pyunit/stats/fixtures/malformed_line.txt
+++ b/tests/pyunit/stats/fixtures/malformed_line.txt
@@ -1,0 +1,5 @@
+
+---------- Begin Simulation Statistics ----------
+system.cpu.numCycles not_a_number # malformed
+
+---------- End Simulation Statistics   ----------

--- a/tests/pyunit/stats/fixtures/multiple_dumps.txt
+++ b/tests/pyunit/stats/fixtures/multiple_dumps.txt
@@ -1,0 +1,12 @@
+
+---------- Begin Simulation Statistics : before reset ----------
+simInsts                                      100
+simOps                                        200
+
+---------- End Simulation Statistics   ----------
+
+---------- Begin Simulation Statistics : after reset ----------
+simInsts                                        2
+simOps                                          4
+
+---------- End Simulation Statistics   ----------

--- a/tests/pyunit/stats/fixtures/no_dump.txt
+++ b/tests/pyunit/stats/fixtures/no_dump.txt
@@ -1,0 +1,3 @@
+# A file with comments and non-stats text outside dump delimiters.
+gem5 Simulator System.  https://www.gem5.org
+This text should be ignored by the parser.

--- a/tests/pyunit/stats/fixtures/single_dump.txt
+++ b/tests/pyunit/stats/fixtures/single_dump.txt
@@ -1,0 +1,7 @@
+
+---------- Begin Simulation Statistics ----------
+simSeconds                                  0.000001 # Number of seconds simulated
+simTicks                                      1000 # Number of ticks simulated
+system.cpu.numCycles                           500 # CPU cycles
+
+---------- End Simulation Statistics   ----------

--- a/tests/pyunit/stats/pyunit_stats_txt.py
+++ b/tests/pyunit/stats/pyunit_stats_txt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 The Regents of the University of California
+# Copyright (c) 2026 Sungkyunkwan University
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -55,8 +55,8 @@ class StatsTxtParserTestCase(unittest.TestCase):
             list(dumps[0].stats.keys()),
         )
         self.assertEqual(0.000001, dumps[0]["simSeconds"])
-        self.assertEqual(1000.0, dumps[0]["simTicks"])
-        self.assertEqual(500.0, dumps[0]["system.cpu.numCycles"])
+        self.assertEqual(1000, dumps[0]["simTicks"])
+        self.assertEqual(500, dumps[0]["system.cpu.numCycles"])
 
     def test_multiple_dumps_preserve_order_and_messages(self):
         dumps = parse_stats_file(_FIXTURES / "multiple_dumps.txt")
@@ -64,8 +64,8 @@ class StatsTxtParserTestCase(unittest.TestCase):
         self.assertEqual(2, len(dumps))
         self.assertEqual("before reset", dumps[0].message)
         self.assertEqual("after reset", dumps[1].message)
-        self.assertEqual(100.0, dumps[0]["simInsts"])
-        self.assertEqual(2.0, dumps[1]["simInsts"])
+        self.assertEqual(100, dumps[0]["simInsts"])
+        self.assertEqual(2, dumps[1]["simInsts"])
 
     def test_subnames_and_numeric_edge_values(self):
         dumps = parse_stats_file(_FIXTURES / "edge_values.txt")
@@ -73,16 +73,18 @@ class StatsTxtParserTestCase(unittest.TestCase):
 
         self.assertIn("system.cpu.dcache.overallAccesses::cpu.data", stats)
         self.assertEqual(
-            42.0,
+            42,
             stats["system.cpu.dcache.overallAccesses::cpu.data"],
         )
         self.assertEqual(
-            0.0,
+            0,
             stats["system.cpu.branch-predictor.hits[0]"],
         )
+        self.assertEqual(18446744073709551615, stats["system.cpu.big_tick"])
+        self.assertIsInstance(stats["system.cpu.big_tick"], int)
         self.assertEqual(-7.5, stats["system.cpu.negative"])
         self.assertEqual(1250.0, stats["system.cpu.scientific"])
-        self.assertEqual(4.0, stats["system.cpu.percentages"])
+        self.assertEqual(4, stats["system.cpu.percentages"])
         self.assertTrue(math.isnan(stats["system.cpu.not_a_number"]))
         self.assertTrue(math.isinf(stats["system.cpu.infinity"]))
         self.assertNotIn("system.cpu.oneline_vector", stats)
@@ -94,7 +96,7 @@ class StatsTxtParserTestCase(unittest.TestCase):
             ---------- End Simulation Statistics   ----------
             """)
 
-        self.assertEqual(12.0, dumps[0]["system.cpu.numCycles"])
+        self.assertEqual(12, dumps[0]["system.cpu.numCycles"])
 
     def test_empty_dump_is_returned(self):
         dumps = parse_stats_file(_FIXTURES / "empty_dump.txt")

--- a/tests/pyunit/stats/pyunit_stats_txt.py
+++ b/tests/pyunit/stats/pyunit_stats_txt.py
@@ -88,13 +88,11 @@ class StatsTxtParserTestCase(unittest.TestCase):
         self.assertNotIn("system.cpu.oneline_vector", stats)
 
     def test_comments_after_values_are_ignored(self):
-        dumps = parse_stats_text(
-            """
+        dumps = parse_stats_text("""
             ---------- Begin Simulation Statistics ----------
             system.cpu.numCycles 12 # description with words and 99
             ---------- End Simulation Statistics   ----------
-            """
-        )
+            """)
 
         self.assertEqual(12.0, dumps[0]["system.cpu.numCycles"])
 
@@ -126,16 +124,16 @@ class StatsTxtParserTestCase(unittest.TestCase):
             StatsParseError,
             "stats dump was not terminated",
         ):
-            parse_stats_text(
-                """
+            parse_stats_text("""
                 ---------- Begin Simulation Statistics ----------
                 simInsts 1
-                """
-            )
+                """)
 
     def test_end_before_begin_raises_clear_error(self):
         with self.assertRaisesRegex(
             StatsParseError,
             "found stats dump end before begin",
         ):
-            parse_stats_text("---------- End Simulation Statistics   ----------")
+            parse_stats_text(
+                "---------- End Simulation Statistics   ----------"
+            )

--- a/tests/pyunit/stats/pyunit_stats_txt.py
+++ b/tests/pyunit/stats/pyunit_stats_txt.py
@@ -56,6 +56,7 @@ class StatsTxtParserTestCase(unittest.TestCase):
         )
         self.assertEqual(0.000001, dumps[0]["simSeconds"])
         self.assertEqual(1000, dumps[0]["simTicks"])
+        self.assertIsInstance(dumps[0]["simTicks"], int)
         self.assertEqual(500, dumps[0]["system.cpu.numCycles"])
 
     def test_multiple_dumps_preserve_order_and_messages(self):
@@ -121,6 +122,14 @@ class StatsTxtParserTestCase(unittest.TestCase):
         ):
             parse_stats_file(_FIXTURES / "duplicate_stat.txt")
 
+    def test_missing_value_raises_clear_error(self):
+        with self.assertRaisesRegex(StatsParseError, "missing stat value"):
+            parse_stats_text("""
+                ---------- Begin Simulation Statistics ----------
+                simInsts
+                ---------- End Simulation Statistics   ----------
+                """)
+
     def test_unterminated_dump_raises_clear_error(self):
         with self.assertRaisesRegex(
             StatsParseError,
@@ -139,3 +148,16 @@ class StatsTxtParserTestCase(unittest.TestCase):
             parse_stats_text(
                 "---------- End Simulation Statistics   ----------"
             )
+
+    def test_begin_before_previous_end_raises_clear_error(self):
+        with self.assertRaisesRegex(
+            StatsParseError,
+            "found a new stats dump before the previous dump ended",
+        ):
+            parse_stats_text("""
+                ---------- Begin Simulation Statistics ----------
+                simInsts 1
+                ---------- Begin Simulation Statistics ----------
+                simInsts 2
+                ---------- End Simulation Statistics   ----------
+                """)

--- a/tests/pyunit/stats/pyunit_stats_txt.py
+++ b/tests/pyunit/stats/pyunit_stats_txt.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import math
+import unittest
+from pathlib import Path
+
+if __package__:
+    from .stats_txt import (
+        StatsParseError,
+        parse_stats_file,
+        parse_stats_text,
+    )
+else:
+    from stats_txt import (
+        StatsParseError,
+        parse_stats_file,
+        parse_stats_text,
+    )
+
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class StatsTxtParserTestCase(unittest.TestCase):
+    def test_single_dump_with_scalar_stats(self):
+        dumps = parse_stats_file(_FIXTURES / "single_dump.txt")
+
+        self.assertEqual(1, len(dumps))
+        self.assertEqual(
+            ["simSeconds", "simTicks", "system.cpu.numCycles"],
+            list(dumps[0].stats.keys()),
+        )
+        self.assertEqual(0.000001, dumps[0]["simSeconds"])
+        self.assertEqual(1000.0, dumps[0]["simTicks"])
+        self.assertEqual(500.0, dumps[0]["system.cpu.numCycles"])
+
+    def test_multiple_dumps_preserve_order_and_messages(self):
+        dumps = parse_stats_file(_FIXTURES / "multiple_dumps.txt")
+
+        self.assertEqual(2, len(dumps))
+        self.assertEqual("before reset", dumps[0].message)
+        self.assertEqual("after reset", dumps[1].message)
+        self.assertEqual(100.0, dumps[0]["simInsts"])
+        self.assertEqual(2.0, dumps[1]["simInsts"])
+
+    def test_subnames_and_numeric_edge_values(self):
+        dumps = parse_stats_file(_FIXTURES / "edge_values.txt")
+        stats = dumps[0].stats
+
+        self.assertIn("system.cpu.dcache.overallAccesses::cpu.data", stats)
+        self.assertEqual(
+            42.0,
+            stats["system.cpu.dcache.overallAccesses::cpu.data"],
+        )
+        self.assertEqual(
+            0.0,
+            stats["system.cpu.branch-predictor.hits[0]"],
+        )
+        self.assertEqual(-7.5, stats["system.cpu.negative"])
+        self.assertEqual(1250.0, stats["system.cpu.scientific"])
+        self.assertEqual(4.0, stats["system.cpu.percentages"])
+        self.assertTrue(math.isnan(stats["system.cpu.not_a_number"]))
+        self.assertTrue(math.isinf(stats["system.cpu.infinity"]))
+        self.assertNotIn("system.cpu.oneline_vector", stats)
+
+    def test_comments_after_values_are_ignored(self):
+        dumps = parse_stats_text(
+            """
+            ---------- Begin Simulation Statistics ----------
+            system.cpu.numCycles 12 # description with words and 99
+            ---------- End Simulation Statistics   ----------
+            """
+        )
+
+        self.assertEqual(12.0, dumps[0]["system.cpu.numCycles"])
+
+    def test_empty_dump_is_returned(self):
+        dumps = parse_stats_file(_FIXTURES / "empty_dump.txt")
+
+        self.assertEqual(1, len(dumps))
+        self.assertEqual([], list(dumps[0].stats.items()))
+
+    def test_file_without_dump_sections_returns_no_dumps(self):
+        self.assertEqual([], parse_stats_file(_FIXTURES / "no_dump.txt"))
+
+    def test_malformed_value_raises_clear_error(self):
+        with self.assertRaisesRegex(
+            StatsParseError,
+            "invalid stat value 'not_a_number' for 'system.cpu.numCycles'",
+        ):
+            parse_stats_file(_FIXTURES / "malformed_line.txt")
+
+    def test_duplicate_stat_name_raises_clear_error(self):
+        with self.assertRaisesRegex(
+            StatsParseError,
+            "duplicate stat name 'simInsts'",
+        ):
+            parse_stats_file(_FIXTURES / "duplicate_stat.txt")
+
+    def test_unterminated_dump_raises_clear_error(self):
+        with self.assertRaisesRegex(
+            StatsParseError,
+            "stats dump was not terminated",
+        ):
+            parse_stats_text(
+                """
+                ---------- Begin Simulation Statistics ----------
+                simInsts 1
+                """
+            )
+
+    def test_end_before_begin_raises_clear_error(self):
+        with self.assertRaisesRegex(
+            StatsParseError,
+            "found stats dump end before begin",
+        ):
+            parse_stats_text("---------- End Simulation Statistics   ----------")

--- a/tests/pyunit/stats/stats_txt.py
+++ b/tests/pyunit/stats/stats_txt.py
@@ -32,7 +32,9 @@ from typing import (
     Iterable,
     List,
     Optional,
-    OrderedDict as OrderedDictType,
+)
+from typing import OrderedDict as OrderedDictType
+from typing import (
     Tuple,
     Union,
 )

--- a/tests/pyunit/stats/stats_txt.py
+++ b/tests/pyunit/stats/stats_txt.py
@@ -24,13 +24,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import annotations
-
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import (
+    Iterable,
+    List,
+    Optional,
+    OrderedDict as OrderedDictType,
+    Tuple,
+    Union,
+)
 
 _BEGIN_RE = re.compile(
     r"^---------- Begin Simulation Statistics(?: : (?P<message>.*))? ----------$"
@@ -44,7 +49,7 @@ class StatsParseError(ValueError):
 
 @dataclass
 class StatsDump:
-    stats: OrderedDict[str, float]
+    stats: OrderedDictType[str, float]
     line_number: int
     message: str = ""
 
@@ -52,17 +57,17 @@ class StatsDump:
         return self.stats[stat_name]
 
 
-def parse_stats_file(path: Path | str) -> list[StatsDump]:
+def parse_stats_file(path: Union[Path, str]) -> List[StatsDump]:
     with open(path, encoding="utf-8") as stats_file:
         return parse_stats_text(stats_file)
 
 
-def parse_stats_text(lines: Iterable[str] | str) -> list[StatsDump]:
+def parse_stats_text(lines: Union[Iterable[str], str]) -> List[StatsDump]:
     if isinstance(lines, str):
         lines = lines.splitlines()
 
-    dumps: list[StatsDump] = []
-    current: StatsDump | None = None
+    dumps: List[StatsDump] = []
+    current: Optional[StatsDump] = None
 
     for line_number, line in enumerate(lines, start=1):
         stripped = line.strip()
@@ -125,7 +130,9 @@ def _parse_message(line: str) -> str:
     return match.group("message") or ""
 
 
-def _parse_stat_line(line: str, line_number: int) -> tuple[str, float] | None:
+def _parse_stat_line(
+    line: str, line_number: int
+) -> Optional[Tuple[str, float]]:
     parts = line.split(maxsplit=2)
     if len(parts) < 2:
         raise StatsParseError(f"line {line_number}: missing stat value")

--- a/tests/pyunit/stats/stats_txt.py
+++ b/tests/pyunit/stats/stats_txt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 The Regents of the University of California
+# Copyright (c) 2026 Sungkyunkwan University
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,9 @@ _BEGIN_RE = re.compile(
     r"^---------- Begin Simulation Statistics(?: : (?P<message>.*))? ----------$"
 )
 _END_LINE = "---------- End Simulation Statistics   ----------"
+_INTEGER_RE = re.compile(r"^[+-]?\d+$")
+
+StatsValue = Union[int, float]
 
 
 class StatsParseError(ValueError):
@@ -51,11 +54,11 @@ class StatsParseError(ValueError):
 
 @dataclass
 class StatsDump:
-    stats: OrderedDictType[str, float]
+    stats: OrderedDictType[str, StatsValue]
     line_number: int
     message: str = ""
 
-    def __getitem__(self, stat_name: str) -> float:
+    def __getitem__(self, stat_name: str) -> StatsValue:
         return self.stats[stat_name]
 
 
@@ -134,7 +137,7 @@ def _parse_message(line: str) -> str:
 
 def _parse_stat_line(
     line: str, line_number: int
-) -> Optional[Tuple[str, float]]:
+) -> Optional[Tuple[str, StatsValue]]:
     parts = line.split(maxsplit=2)
     if len(parts) < 2:
         raise StatsParseError(f"line {line_number}: missing stat value")
@@ -145,12 +148,19 @@ def _parse_stat_line(
         # encode a single stat-name/value pair. Do not synthesize names here.
         return None
 
+    return name, _parse_value(value_text, line_number, name)
+
+
+def _parse_value(
+    value_text: str, line_number: int, stat_name: str
+) -> StatsValue:
+    if _INTEGER_RE.match(value_text):
+        return int(value_text)
+
     try:
-        value = float(value_text)
+        return float(value_text)
     except ValueError as error:
         raise StatsParseError(
             f"line {line_number}: invalid stat value '{value_text}' "
-            f"for '{name}'"
+            f"for '{stat_name}'"
         ) from error
-
-    return name, value

--- a/tests/pyunit/stats/stats_txt.py
+++ b/tests/pyunit/stats/stats_txt.py
@@ -26,12 +26,11 @@
 
 from __future__ import annotations
 
+import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-import re
 from typing import Iterable
-
 
 _BEGIN_RE = re.compile(
     r"^---------- Begin Simulation Statistics(?: : (?P<message>.*))? ----------$"
@@ -126,9 +125,7 @@ def _parse_message(line: str) -> str:
     return match.group("message") or ""
 
 
-def _parse_stat_line(
-    line: str, line_number: int
-) -> tuple[str, float] | None:
+def _parse_stat_line(line: str, line_number: int) -> tuple[str, float] | None:
     parts = line.split(maxsplit=2)
     if len(parts) < 2:
         raise StatsParseError(f"line {line_number}: missing stat value")

--- a/tests/pyunit/stats/stats_txt.py
+++ b/tests/pyunit/stats/stats_txt.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Iterable
+
+
+_BEGIN_RE = re.compile(
+    r"^---------- Begin Simulation Statistics(?: : (?P<message>.*))? ----------$"
+)
+_END_LINE = "---------- End Simulation Statistics   ----------"
+
+
+class StatsParseError(ValueError):
+    pass
+
+
+@dataclass
+class StatsDump:
+    stats: OrderedDict[str, float]
+    line_number: int
+    message: str = ""
+
+    def __getitem__(self, stat_name: str) -> float:
+        return self.stats[stat_name]
+
+
+def parse_stats_file(path: Path | str) -> list[StatsDump]:
+    with open(path, encoding="utf-8") as stats_file:
+        return parse_stats_text(stats_file)
+
+
+def parse_stats_text(lines: Iterable[str] | str) -> list[StatsDump]:
+    if isinstance(lines, str):
+        lines = lines.splitlines()
+
+    dumps: list[StatsDump] = []
+    current: StatsDump | None = None
+
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if _is_begin_line(stripped):
+            if current is not None:
+                raise StatsParseError(
+                    f"line {line_number}: found a new stats dump before "
+                    "the previous dump ended"
+                )
+            current = StatsDump(
+                stats=OrderedDict(),
+                line_number=line_number,
+                message=_parse_message(stripped),
+            )
+            continue
+
+        if stripped == _END_LINE:
+            if current is None:
+                raise StatsParseError(
+                    f"line {line_number}: found stats dump end before begin"
+                )
+            dumps.append(current)
+            current = None
+            continue
+
+        if current is None:
+            continue
+
+        parsed = _parse_stat_line(stripped, line_number)
+        if parsed is None:
+            continue
+
+        name, value = parsed
+        if name in current.stats:
+            raise StatsParseError(
+                f"line {line_number}: duplicate stat name '{name}'"
+            )
+        current.stats[name] = value
+
+    if current is not None:
+        raise StatsParseError(
+            f"line {current.line_number}: stats dump was not terminated"
+        )
+
+    return dumps
+
+
+def _is_begin_line(line: str) -> bool:
+    return _BEGIN_RE.match(line) is not None
+
+
+def _parse_message(line: str) -> str:
+    match = _BEGIN_RE.match(line)
+    if match is None:
+        return ""
+    return match.group("message") or ""
+
+
+def _parse_stat_line(
+    line: str, line_number: int
+) -> tuple[str, float] | None:
+    parts = line.split(maxsplit=2)
+    if len(parts) < 2:
+        raise StatsParseError(f"line {line_number}: missing stat value")
+
+    name, value_text = parts[0], parts[1]
+    if value_text == "|":
+        # Oneline vector/dist stats are valid text output, but they do not
+        # encode a single stat-name/value pair. Do not synthesize names here.
+        return None
+
+    try:
+        value = float(value_text)
+    except ValueError as error:
+        raise StatsParseError(
+            f"line {line_number}: invalid stat value '{value_text}' "
+            f"for '{name}'"
+        ) from error
+
+    return name, value


### PR DESCRIPTION
Summary:
- Add a small Python parser for text `stats.txt` files with one or more stats dumps.
- Preserve stat names as emitted, including names with `::`, brackets, hyphens, dots, and digits.
- Add fixture-based pyunit coverage for scalar stats, multi-dump files, edge numeric values, malformed input, duplicate names, and empty/no-dump files.

Motivation:
- This is a non-invasive first step toward #1644.
- A follow-up reset validation test can generate before/reset/after dumps in one invocation and compare selected resettable stats without relying on fixed reference stats files.

Implementation:
- Adds `tests/pyunit/stats/stats_txt.py`.
- Represents each dump as a `StatsDump` with ordered stat values and optional dump message text.
- Parses integer, float, scientific notation, `nan`, and `inf` values using Python `float`.
- Ignores text outside dump delimiters and skips valid `statistics::oneline` rows instead of synthesizing stat names.
- Raises `StatsParseError` for malformed stat values, duplicate stat names within one dump, unterminated dumps, and end-before-begin delimiters.

Testing:
- [x] `python3 -m unittest discover -s tests/pyunit/stats -p 'pyunit*.py' -v` passed, 10 tests.
- [x] `python3 -m unittest discover -s tests/pyunit -p 'pyunit_stats_txt.py' -v` passed, 10 tests.
- [x] Python 3.8 grammar check with `ast.parse(..., feature_version=(3, 8))` passed for the new parser/test files.
- [x] `git diff --check origin/develop...HEAD` passed.
- [x] `pre-commit.ci` passed on the PR after applying its automatic isort/black fix commit.
- [x] `pre-commit run --files $(git diff --name-only origin/develop...HEAD)` passed.
- [x] `scons build/ALL/gem5.opt -j4` passed.
- [x] `./build/ALL/gem5.opt tests/run_pyunit.py --directory tests/pyunit/stats` passed, 10 tests.
- [x] Real-output smoke with `configs/learning_gem5/part1/simple.py` parsed
      one generated `stats.txt` dump with 609 stats, including `simTicks`,
      `simInsts`, and `system.cpu.numCycles`.

Compatibility:
- Does not change simulator behavior or text stats output.
- Does not add external dependencies.
- Keeps parser behavior test-local for now.

Follow-up:
- Add a `m5.stats.reset()` validation test that generates before/after dumps in the same gem5 invocation and uses this parser to compare a narrow set of resettable stats.
