### PR TITLE
util: add experimental stats name canonicalizer

### DIFF
--- a/tests/pyunit/util/pyunit_stats_canonicalizer.py
+++ b/tests/pyunit/util/pyunit_stats_canonicalizer.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CANONICALIZER_PATH = _REPO_ROOT / "util" / "stats_canonicalizer.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "stats_canonicalizer",
+    _CANONICALIZER_PATH,
+)
+stats_canonicalizer = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(stats_canonicalizer)
+
+
+class StatsCanonicalizerTestCase(unittest.TestCase):
+    def _config(self):
+        return {
+            "type": "Root",
+            "name": None,
+            "path": "root",
+            "system": {
+                "type": "System",
+                "name": "system",
+                "path": "system",
+                "cpu": [
+                    {
+                        "type": "TimingSimpleCPU",
+                        "name": "cpu0",
+                        "path": "system.cpu0",
+                        "dcache": {
+                            "type": "Cache",
+                            "name": "dcache",
+                            "path": "system.cpu0.dcache",
+                        },
+                    },
+                    {
+                        "type": "TimingSimpleCPU",
+                        "name": "cpu1",
+                        "path": "system.cpu1",
+                    },
+                ],
+                "single": [
+                    {
+                        "type": "Cache",
+                        "name": "single",
+                        "path": "system.single",
+                    }
+                ],
+            },
+        }
+
+    def _canonicalize(self, text, config=None, allow_collisions=False):
+        path_map = {}
+        if config is not None:
+            path_map = stats_canonicalizer.build_path_map(config)
+        output, mapping = stats_canonicalizer.canonicalize_lines(
+            text.splitlines(keepends=True),
+            path_map=path_map,
+            allow_collisions=allow_collisions,
+        )
+        return "".join(output), mapping
+
+    def test_multi_element_vector_paths(self):
+        output, mapping = self._canonicalize(
+            "system.cpu0.numCycles 10 # comment\n"
+            "system.cpu1.numCycles 20\n",
+            config=self._config(),
+        )
+
+        self.assertEqual(
+            output,
+            "system.cpu[0].numCycles 10 # comment\n"
+            "system.cpu[1].numCycles 20\n",
+        )
+        self.assertEqual(
+            mapping["system.cpu0.numCycles"],
+            "system.cpu[0].numCycles",
+        )
+
+    def test_length_one_vector_path(self):
+        output, mapping = self._canonicalize(
+            "system.single.hits 7\n",
+            config=self._config(),
+        )
+
+        self.assertEqual(output, "system.single[0].hits 7\n")
+        self.assertEqual(
+            mapping["system.single.hits"],
+            "system.single[0].hits",
+        )
+
+    def test_substat_suffix_is_preserved(self):
+        output, _ = self._canonicalize(
+            "system.cpu0.dcache.overallMisses::total 3\n",
+            config=self._config(),
+        )
+
+        self.assertEqual(
+            output,
+            "system.cpu[0].dcache.overallMisses::total 3\n",
+        )
+
+    def test_distribution_columns_are_preserved(self):
+        output, _ = self._canonicalize(
+            "system.cpu0.issuedInstType_0::IntAlu"
+            " 7437 77.92% 77.92% # Number of insts issued\n",
+            config=self._config(),
+        )
+
+        self.assertEqual(
+            output,
+            "system.cpu[0].issuedInstType_0::IntAlu"
+            " 7437 77.92% 77.92% # Number of insts issued\n",
+        )
+
+    def test_unmapped_names_and_headers_are_preserved(self):
+        text = (
+            "---------- Begin Simulation Statistics ----------\n"
+            "system.cpu0x.numCycles 11\n"
+            "simTicks 100\n"
+            "---------- End Simulation Statistics   ----------\n"
+        )
+
+        output, mapping = self._canonicalize(text, config=self._config())
+
+        self.assertEqual(output, text)
+        self.assertEqual(
+            mapping["system.cpu0x.numCycles"], "system.cpu0x.numCycles"
+        )
+        self.assertEqual(mapping["simTicks"], "simTicks")
+
+    def test_idempotent_for_already_canonical_names(self):
+        text = "system.cpu[0].numCycles 10\n"
+
+        once, _ = self._canonicalize(text, config=self._config())
+        twice, _ = self._canonicalize(once, config=self._config())
+
+        self.assertEqual(once, text)
+        self.assertEqual(twice, text)
+
+    def test_collision_detection(self):
+        text = "system.cpu0.numCycles 10\n" "system.cpu[0].numCycles 20\n"
+
+        with self.assertRaises(stats_canonicalizer.CanonicalizationError):
+            self._canonicalize(text, config=self._config())
+
+        output, _ = self._canonicalize(
+            text,
+            config=self._config(),
+            allow_collisions=True,
+        )
+        self.assertEqual(
+            output,
+            "system.cpu[0].numCycles 10\n" "system.cpu[0].numCycles 20\n",
+        )
+
+    def test_without_config_does_not_guess_digit_suffixes(self):
+        text = "system.cpu0.numCycles 10\n"
+
+        output, mapping = self._canonicalize(text)
+
+        self.assertEqual(output, text)
+        self.assertEqual(
+            mapping["system.cpu0.numCycles"],
+            "system.cpu0.numCycles",
+        )
+
+    def test_value_tokens_require_a_boundary(self):
+        text = "system.cpu0.units nanosecond\n" "system.cpu0.note infinity\n"
+
+        output, mapping = self._canonicalize(text, config=self._config())
+
+        self.assertEqual(output, text)
+        self.assertEqual(mapping, {})
+
+    def test_cli_writes_output_and_mapping(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            tempdir = Path(tempdir)
+            input_path = tempdir / "stats.txt"
+            output_path = tempdir / "canonical-stats.txt"
+            config_path = tempdir / "config.json"
+            mapping_path = tempdir / "mapping.json"
+
+            input_path.write_text("system.cpu0.numCycles 10\n")
+            config_path.write_text(json.dumps(self._config()))
+
+            stats_canonicalizer.canonicalize_file(
+                input_path,
+                output_path,
+                config_json_path=config_path,
+                mapping_output_path=mapping_path,
+            )
+
+            self.assertEqual(
+                output_path.read_text(),
+                "system.cpu[0].numCycles 10\n",
+            )
+            self.assertEqual(
+                json.loads(mapping_path.read_text()),
+                {
+                    "system.cpu0.numCycles": "system.cpu[0].numCycles",
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/util/stats_canonicalizer.py
+++ b/util/stats_canonicalizer.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Experimental helper for canonicalizing gem5 text stat names.
+
+This tool does not infer SimObjectVector paths from stats.txt alone. When a
+config.json is supplied, it uses the explicit SimObject paths in that file to
+map vector elements such as ``system.cpu0`` to ``system.cpu[0]``.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_STAT_LINE_RE = re.compile(
+    r"^(?P<indent>\s*)"
+    r"(?P<name>\S+)"
+    r"(?P<sep>\s+)"
+    r"(?P<value>[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?|"
+    r"nan|inf))"
+    r"(?P<trailing>(?:\s.*)?)$",
+    re.IGNORECASE,
+)
+
+
+class CanonicalizationError(Exception):
+    """Raised when names cannot be safely canonicalized."""
+
+
+def build_path_map(config):
+    """Return actual SimObject paths mapped to canonical paths.
+
+    The mapping is conservative: vector indexes are added only when config.json
+    exposes a list of child SimObjects. All other child paths retain their
+    existing component names.
+    """
+
+    path_map = {}
+
+    def child_path(parent_path, child_name):
+        if parent_path == "root":
+            return child_name
+        return f"{parent_path}.{child_name}"
+
+    def walk(node, canonical_path=None):
+        if not isinstance(node, dict):
+            return
+
+        actual_path = node.get("path")
+        if canonical_path is None:
+            canonical_path = actual_path
+
+        if actual_path and canonical_path:
+            path_map[actual_path] = canonical_path
+
+        if canonical_path is None:
+            return
+
+        for name, value in node.items():
+            if isinstance(value, list):
+                for index, child in enumerate(value):
+                    if isinstance(child, dict) and "path" in child:
+                        walk(
+                            child,
+                            child_path(
+                                canonical_path,
+                                "{}[{}]".format(
+                                    name,
+                                    index,
+                                ),
+                            ),
+                        )
+            elif isinstance(value, dict) and "path" in value:
+                walk(value, child_path(canonical_path, name))
+
+    walk(config)
+    return path_map
+
+
+def canonicalize_name(name, path_map):
+    """Canonicalize one stat name using a config-derived path map."""
+
+    base_name, separator, subname = name.partition("::")
+
+    for actual_path, canonical_path in sorted(
+        path_map.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
+        if base_name == actual_path:
+            canonical = canonical_path
+            break
+        if base_name.startswith(actual_path + "."):
+            canonical = canonical_path + base_name[len(actual_path) :]
+            break
+    else:
+        canonical = base_name
+
+    if separator:
+        return canonical + separator + subname
+    return canonical
+
+
+def canonicalize_lines(lines, path_map=None, allow_collisions=False):
+    """Return canonicalized lines and an old-name to canonical-name mapping."""
+
+    if path_map is None:
+        path_map = {}
+
+    output = []
+    mapping = {}
+    canonical_to_old = {}
+
+    for line in lines:
+        content = line.rstrip("\r\n")
+        line_ending = line[len(content) :]
+        match = _STAT_LINE_RE.match(content)
+        if not match:
+            output.append(line)
+            continue
+
+        name = match.group("name")
+        canonical = canonicalize_name(name, path_map)
+        mapping[name] = canonical
+        canonical_to_old.setdefault(canonical, set()).add(name)
+        output.append(
+            "{indent}{name}{sep}{value}{trailing}".format(
+                indent=match.group("indent"),
+                name=canonical,
+                sep=match.group("sep"),
+                value=match.group("value"),
+                trailing=match.group("trailing"),
+            )
+            + line_ending
+        )
+
+    collisions = {
+        canonical: sorted(old_names)
+        for canonical, old_names in canonical_to_old.items()
+        if len(old_names) > 1
+    }
+    if collisions and not allow_collisions:
+        details = ", ".join(
+            "{} <- {}".format(
+                canonical,
+                ", ".join(old_names),
+            )
+            for canonical, old_names in sorted(collisions.items())
+        )
+        raise CanonicalizationError("canonical name collision: " + details)
+
+    return output, mapping
+
+
+def canonicalize_file(
+    input_path,
+    output_path,
+    config_json_path=None,
+    mapping_output_path=None,
+    allow_collisions=False,
+):
+    """Canonicalize a stats.txt file."""
+
+    path_map = {}
+    if config_json_path is not None:
+        with open(config_json_path, encoding="utf-8") as config_file:
+            path_map = build_path_map(json.load(config_file))
+
+    with open(input_path, encoding="utf-8") as input_file:
+        output, mapping = canonicalize_lines(
+            input_file,
+            path_map=path_map,
+            allow_collisions=allow_collisions,
+        )
+
+    with open(output_path, "w", encoding="utf-8") as output_file:
+        output_file.writelines(output)
+
+    if mapping_output_path is not None:
+        with open(mapping_output_path, "w", encoding="utf-8") as mapping_file:
+            json.dump(mapping, mapping_file, indent=2, sort_keys=True)
+            mapping_file.write("\n")
+
+
+def _get_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Experimentally canonicalize gem5 stats.txt names using "
+            "SimObjectVector paths from config.json."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Input stats.txt path.")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output stats.txt path for canonicalized names.",
+    )
+    parser.add_argument(
+        "--config-json",
+        help="Optional gem5 config.json used to identify SimObjectVectors.",
+    )
+    parser.add_argument(
+        "--mapping-output",
+        help="Optional JSON output path for old-name to canonical-name mapping.",
+    )
+    parser.add_argument(
+        "--allow-collisions",
+        action="store_true",
+        help=(
+            "Allow multiple old names to map to the same canonical name. "
+            "By default this is an error."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _get_args()
+    try:
+        canonicalize_file(
+            Path(args.input),
+            Path(args.output),
+            config_json_path=(
+                Path(args.config_json) if args.config_json else None
+            ),
+            mapping_output_path=(
+                Path(args.mapping_output) if args.mapping_output else None
+            ),
+            allow_collisions=args.allow_collisions,
+        )
+    except CanonicalizationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Summary:
- Add an optional sidecar utility for canonicalizing names in existing
  `stats.txt` files.
- Use `config.json` SimObjectVector metadata to map legacy paths such as
  `system.cpu0` to canonical paths such as `system.cpu[0]`.
- Emit an optional old-name to canonical-name mapping JSON.
- Add pyunit coverage for vector paths, length-one vectors, `::` substats,
  distribution-style trailing columns, unchanged names, idempotency, and
  collision handling.

Motivation:
- Issue #2744 describes how vector-stat naming special cases make machine
  parsing difficult.
- Changing default text stats output would be a broad user-facing compatibility
  change, so this starts with an optional utility instead.
- This PR is intentionally draft while maintainers decide whether this
  sidecar-tool direction is useful.

Implementation:
- `util/stats_canonicalizer.py` reads an input `stats.txt` and writes a
  canonicalized output file.
- Without `config.json`, the utility preserves names and does not guess from
  digit suffixes.
- With `config.json`, it walks explicit SimObjectVector lists and maps concrete
  paths to bracketed canonical paths.
- `::` substat suffixes are preserved.
- Comments, headers, footers, and non-stat lines are preserved.
- Multiple old names mapping to one canonical name fail by default unless
  `--allow-collisions` is passed.

Testing:
- [x] `git diff --check origin/develop...HEAD` passed.
- [x] `pre-commit run --files $(git diff --name-only origin/develop...HEAD)`
      passed.
- [x] `python3 -m unittest discover -s tests/pyunit/util -p 'pyunit_stats_canonicalizer.py' -v`
      passed, 10 tests.
- [x] `./build/ALL/gem5.opt tests/run_pyunit.py --directory tests/pyunit/util`
      passed, 28 tests.
- [x] CLI smoke test verified output generation, mapping JSON, idempotency, and
      collision failure behavior.
- [x] Real-output smoke test with `configs/learning_gem5/part1/simple.py`
      verified `stats.txt`/`config.json` canonicalization and idempotency.
      The latest run produced 609 mapping entries and changed two names:
      `system.cpu.interrupts.clk_domain.clock` and
      `system.cpu.workload.numSyscalls`.

Compatibility:
- Default gem5 stats output is unchanged.
- Simulator behavior is unchanged.
- SimObject naming is unchanged.
- Ambiguous digit-suffix names are not guessed from `stats.txt` alone.

Follow-up:
- If this direction is accepted, a later PR can discuss whether an opt-in stats
  visitor mode should emit canonical names directly.
