### PR TITLE
base: Fix compilation after libdnet changes

### DIFF
--- a/src/base/inet.hh
+++ b/src/base/inet.hh
@@ -48,6 +48,12 @@
 #include <netinet/ip.h>
 #include <netinet/ip6.h>
 #include <netinet/ip_icmp.h>
+// We define __FAVOR_BSD to use the old BSD style names for parts of
+// network data packets, instead of the newer standard (POSIX) names
+// This is because some distribution will have a libdnet library
+// using new names for tcphdr class (source instead of th_sport
+// as an example)
+#define __FAVOR_BSD 1
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 


### PR DESCRIPTION
After a recent PR [1] it was not possible to compile gem5 in hosts machine with some particular versions of
libdnet.

This is because some tcphdr member variables
are named differently and the TcpHdr class
definition fails

struct TcpHdr : public tcphdr
{
    uint16_t sport() const { return ntohs(th_sport); }
    uint16_t dport() const { return ntohs(th_dport); }
[...]

In this example th_sport and th_dport are renamed to source and dest.
It is possible to force libdnet to use original names with the __FAVOR_BSD
flag. This *could* also be a requirement for macOS though this has not
been verified

[1]: https://github.com/gem5/gem5/pull/3256

Change-Id: If3e3ebed922eb34c770749a91c94caba33d7f874