### PR TITLE
cpu: fix memory leak in SimpleIndirectPredictor

### DIFF
--- a/src/cpu/pred/simple_indirect.cc
+++ b/src/cpu/pred/simple_indirect.cc
@@ -132,15 +132,15 @@ SimpleIndirectPredictor::lookup(ThreadID tid, InstSeqNum sn,
     history->was_indirect = true;
 
     /** Do the prediction for indirect branches (no returns) */
-    PCStateBase* target = nullptr;
+    const PCStateBase *target = nullptr;
     history->hit = lookup(tid, pc, target, history);
     return target;
 }
 
 bool
 SimpleIndirectPredictor::lookup(ThreadID tid, Addr br_addr,
-                                PCStateBase * &target,
-                                IndirectHistory * &history)
+                                const PCStateBase *&target,
+                                IndirectHistory *&history)
 {
 
     history->set_index = getSetIndex(br_addr, tid);
@@ -159,7 +159,7 @@ SimpleIndirectPredictor::lookup(ThreadID tid, Addr br_addr,
         // check that way->target has been initialized.
         if (way->tag == history->tag && way->target) {
             DPRINTF(Indirect, "Hit %x (target:%s)\n", br_addr, *way->target);
-            set(target, *way->target);
+            target = way->target.get();
             history->hit = true;
             stats.hits++;
             return history->hit;

--- a/src/cpu/pred/simple_indirect.hh
+++ b/src/cpu/pred/simple_indirect.hh
@@ -144,8 +144,8 @@ class SimpleIndirectPredictor : public IndirectPredictor
 
 
     // ---- Internal functions ----- //
-    bool lookup(ThreadID tid, Addr br_addr,
-                PCStateBase * &target, IndirectHistory * &history);
+    bool lookup(ThreadID tid, Addr br_addr, const PCStateBase *&target,
+                IndirectHistory *&history);
     void recordTarget(ThreadID tid, InstSeqNum sn,
                       const PCStateBase& target, IndirectHistory * &history);
 


### PR DESCRIPTION
This commit fixes a memory leak in SimpleIndirectPredictor. The leak occurs with the following gem5 simulation, which is the first 10 billion ticks of the currently failing very-long x86 boot test:

```bash
build/ALL/gem5.opt tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py \
--cpu=o3 --num-cpus=8 --mem-system=classic \
--dram-class=DualChannelDDR4_2400 --boot-type=init \
--tick-exit 10000000000
```

When running Valgrind with the following options, it reports that 511kB of memory is lost. After applying this fix, this loss record no longer appears.

```bash
valgrind --leak-check=full \
--show-leak-kinds=all \
--track-origins=yes \
--suppressions=util/valgrind-suppressions \
--error-limit=no \
--log-file=valgrind-out.txt
```

```txt
==896839== 511,000 bytes in 12,775 blocks are definitely lost in loss record 11,544 of 11,597
...

==896839==    by 0x42DF586: gem5::X86ISA::PCState::clone() const (pcstate.hh:58)
==896839==    by 0x5A19603: set (pcstate.hh:233)
==896839==    by 0x5A19603: set (pcstate.hh:226)
==896839==    by 0x5A19603: gem5::branch_prediction::SimpleIndirectPredictor::lookup(
short, unsigned long, gem5::PCStateBase*&,
gem5::branch_prediction::SimpleIndirectPredictor::IndirectHistory*&) (simple_indirect.cc:162)
==896839==    by 0x5A1978A: gem5::branch_prediction::SimpleIndirectPredictor::lookup(
short, unsigned long, unsigned long, void*&) (simple_indirect.cc:136)
==896839==    by 0x5A0E7B3: gem5::branch_prediction::BPredUnit::predict(
gem5::RefCountingPtr<gem5::StaticInst> const&, unsigned long const&,
gem5::PCStateBase&, short, gem5::branch_prediction::BPredUnit::PredictorHistory*&)
(bpred_unit.cc:288)
==896839==    by 0x5A0F355: gem5::branch_prediction::BPredUnit::predict(
gem5::RefCountingPtr<gem5::StaticInst> const&, unsigned long const&,
gem5::PCStateBase&, short) (bpred_unit.cc:106)
```

NOTE: This fix was generated by Copilot; please review carefully.