### PR TITLE
scons: Run large Python generators in subprocesses

### DIFF
--- a/build_tools/run_isa_parser.py
+++ b/build_tools/run_isa_parser.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 The Regents of The University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir")
+    parser.add_argument("isa_desc")
+    parser.add_argument("--src-root", required=True)
+    args = parser.parse_args()
+
+    sys.path.insert(0, os.path.join(args.src_root, "ext", "ply"))
+    sys.path.insert(0, os.path.join(args.src_root, "build_tools"))
+    sys.path.insert(0, os.path.join(args.src_root, "src", "arch"))
+
+    import isa_parser
+
+    parser = isa_parser.ISAParser(args.output_dir)
+    parser.parse_isa_desc(args.isa_desc)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/run_slicc.py
+++ b/build_tools/run_slicc.py
@@ -77,9 +77,8 @@ def main():
     parser.add_argument("slicc_files", nargs="+")
     args = parser.parse_args()
 
-    sys.path.append(os.path.join(args.src_root, "src", "mem"))
-    sys.path.append(os.path.join(args.src_root, "ext", "ply"))
-
+    sys.path.insert(0, os.path.join(args.src_root, "ext", "ply"))
+    sys.path.insert(0, os.path.join(args.src_root, "src", "mem"))
     from slicc.parser import SLICC
 
     for slicc_file in args.slicc_files:

--- a/build_tools/run_slicc.py
+++ b/build_tools/run_slicc.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 The Regents of The University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import sys
+
+
+def remove_stale_protocol_outputs(slicc, output_dir):
+    protocol_dir_path = os.path.join(output_dir, slicc.protocol)
+
+    if not os.path.isdir(protocol_dir_path):
+        return
+
+    expected = set()
+    for filename in slicc.files():
+        if os.path.dirname(filename) == slicc.protocol:
+            expected.add(os.path.basename(filename))
+
+    expected.add(f"{slicc.protocol}ProtocolInfo.hh")
+    for filename in os.listdir(protocol_dir_path):
+        filepath = os.path.join(protocol_dir_path, filename)
+        if not os.path.isfile(filepath):
+            continue
+
+        if filename.endswith(".py.cc"):
+            continue
+
+        if (
+            filename.endswith((".cc", ".hh", ".py"))
+            and filename not in expected
+        ):
+            os.remove(filepath)
+
+            if filename.endswith(".cc"):
+                objpath = filepath[:-3] + ".o"
+                if os.path.exists(objpath):
+                    os.remove(objpath)
+            elif filename.endswith(".py"):
+                for suffix in (".cc", ".o", ".pyo"):
+                    sidecar = filepath + suffix
+                    if os.path.exists(sidecar):
+                        os.remove(sidecar)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--src-root", required=True)
+    parser.add_argument("--code-path", required=True)
+    parser.add_argument("--protocol-base", required=True)
+    parser.add_argument("--html-path")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--include", action="append", default=[])
+    parser.add_argument("slicc_files", nargs="+")
+    args = parser.parse_args()
+
+    sys.path.append(os.path.join(args.src_root, "src", "mem"))
+    sys.path.append(os.path.join(args.src_root, "ext", "ply"))
+
+    from slicc.parser import SLICC
+
+    for slicc_file in args.slicc_files:
+        slicc = SLICC(
+            slicc_file,
+            [os.path.join(args.protocol_base, "RubySlicc_interfaces.slicc")],
+            args.protocol_base,
+            verbose=args.verbose,
+        )
+        slicc.process()
+        remove_stale_protocol_outputs(slicc, args.code_path)
+        slicc.writeCodeFiles(args.code_path, args.include)
+        if args.html_path:
+            slicc.writeHTMLFiles(args.html_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/arch/SConscript
+++ b/src/arch/SConscript
@@ -42,6 +42,7 @@ import sys
 import os
 import os.path
 import re
+import subprocess
 
 from gem5_scons import Transform
 
@@ -122,12 +123,14 @@ import ply
 arch_dir = Dir('.')
 
 def run_parser(target, source, env):
-    # Add the current directory to the system path so we can import files.
-    sys.path[0:0] = [ arch_dir.srcnode().abspath ]
-    import isa_parser
-
-    parser = isa_parser.ISAParser(target[0].dir.abspath)
-    parser.parse_isa_desc(source[0].abspath)
+    subprocess.check_call([
+        sys.executable,
+        File('#build_tools/run_isa_parser.py').abspath,
+        target[0].dir.abspath,
+        source[0].abspath,
+        '--src-root',
+        Dir('#').abspath,
+    ])
 
 desc_action = MakeAction(run_parser, Transform("ISA DESC", 1))
 

--- a/src/mem/ruby/protocol/SConscript
+++ b/src/mem/ruby/protocol/SConscript
@@ -28,6 +28,7 @@
 
 import os.path
 import re
+import subprocess
 import sys
 
 from SCons.Scanner import Classic
@@ -137,23 +138,30 @@ def slicc_emitter(target, source, env):
 
 
 def slicc_action(target, source, env):
+    cmd = [
+        sys.executable,
+        Dir("#").File("build_tools/run_slicc.py").abspath,
+        "--src-root",
+        Dir("#").abspath,
+        "--code-path",
+        output_dir.abspath,
+        "--protocol-base",
+        protocol_base.abspath,
+    ]
+
+    if GetOption("verbose"):
+        cmd.append("--verbose")
+
+    if env["CONF"]["SLICC_HTML"]:
+        cmd.extend(["--html-path", html_dir.abspath])
+
+    for include in slicc_includes:
+        cmd.extend(["--include", include])
+
     for s in source:
-        filepath = s.srcnode().abspath
-        slicc = SLICC(
-            filepath,
-            [
-                os.path.join(
-                    protocol_base.abspath, "RubySlicc_interfaces.slicc"
-                )
-            ],
-            protocol_base.abspath,
-            verbose=GetOption("verbose"),
-        )
-        slicc.process()
-        remove_stale_protocol_outputs(slicc)
-        slicc.writeCodeFiles(output_dir.abspath, slicc_includes)
-        if env["CONF"]["SLICC_HTML"]:
-            slicc.writeHTMLFiles(html_dir.abspath)
+        cmd.append(s.srcnode().abspath)
+
+    subprocess.run(cmd, check=True)
 
 
 slicc_builder = Builder(


### PR DESCRIPTION
 The gpu-tests job, in both CI and daily testing, has been failing in the
  `gcn-gpu` image with SCons dying from `SIGSEGV: 11`.

  The first visible failure occurred while creating the `GPU_VIPER`
  protocol. Investigation showed standalone `GPU_VIPER` SLICC generation
  in the same container succeeds and uses little memory, so this is not an
  out-of-memory failure in the generated protocol itself. The failure comes
  from running large Python generation steps inside SCons worker threads.

  This PR moves the SLICC write action into a small Python helper launched
  as a subprocess. SCons still uses the existing emitter to enumerate the
  generated files and preserve dependency tracking, but protocol
  translation and stale-output cleanup now run outside the SCons worker
  process.

  After that change, PR CI exposed the same class of failure in the X86 ISA
  parser. With `PYTHONFAULTHANDLER=1`, the crash reproduced in the
  `gcn-gpu` container while the ISA parser imported ISA description modules
  from a SCons worker thread. This PR therefore also runs the ISA parser
  body in a subprocess.

  This is safe for other compilations because SCons still owns the same
  targets, sources, dependencies, and output paths. The generated file sets
  and build ordering are unchanged; only the process boundary around the
  Python generators changes. If either generator now fails, SCons reports a
  normal subprocess failure instead of crashing with `SIGSEGV`.