### PR TITLE
cpu: fix PCState leak in SimpleThread::clearArchRegs

### DIFF
--- a/src/cpu/simple_thread.hh
+++ b/src/cpu/simple_thread.hh
@@ -244,7 +244,7 @@ class SimpleThread : public ThreadState, public ThreadContext
     void
     clearArchRegs() override
     {
-        set(_pcState, isa->newPCState());
+        _pcState.reset(isa->newPCState());
         for (auto &rf: regFiles)
             rf.clear();
         isa->clear();


### PR DESCRIPTION
SimpleThread::clearArchRegs() reset the architectural PC state with set(_pcState, isa->newPCState()). The newPCState() call returns a newly allocated PCStateBase, but the PCState set() helper treats pointer arguments as borrowed source objects. For a unique_ptr destination it clones or updates the destination from the source; it does not adopt the raw pointer.

As a result, the temporary PCStateBase returned by newPCState() was leaked every time clearArchRegs() ran. This includes SimpleThread construction, which calls clearArchRegs() during initialization.

Adopt the new PC state directly with
_pcState.reset(isa->newPCState()). This preserves the intended reset behavior, avoids the extra clone, and makes ownership explicit.