### PR TITLE
tests,misc: Update GitHub Action workflow deps to latest major version

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-24.04
         if: github.event.pull_request.draft == false
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - uses: actions/setup-python@v5
               with:
                   python-version: '3.10'
@@ -31,7 +31,7 @@ jobs:
         if: github.event.pull_request.draft == false
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0  # Need full history to get the merge base
 
@@ -85,7 +85,7 @@ jobs:
         needs: [pre-commit] # only runs if pre-commit passes.
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: CI Unittests (${{ matrix.type }})
               working-directory: ${{ github.workspace }}
               run: scons --no-compress-debug build/ALL/unittests.${{ matrix.type }} -j $(nproc)
@@ -99,7 +99,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         needs: [pre-commit]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Get directories for testlib-quick
               working-directory: ${{ github.workspace }}/tests
               id: dir-matrix
@@ -143,7 +143,7 @@ jobs:
         needs: [pre-commit]
         timeout-minutes: 90
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Clang Compilation
               working-directory: ${{ github.workspace }}
               run: scons build/ALL/gem5.fast -j $(nproc)
@@ -160,7 +160,7 @@ jobs:
 
         steps:
             - name: Checkout the gem5 repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Install the gem5 dependencies
               run: |
@@ -196,7 +196,7 @@ jobs:
             matrix:
                 build-target: ${{ fromJson(needs.testlib-quick-matrix.outputs.build-matrix) }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Cache build/ALL
               uses: actions/cache/restore@v4
@@ -244,7 +244,7 @@ jobs:
                 test-dir: ${{ fromJson(needs.testlib-quick-matrix.outputs.test-dirs-matrix) }}
         steps:
         # Checkout the repository then download the gem5.opt artifact.
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - uses: actions/download-artifact@v4
               name: Download gem5 artifacts
               with:
@@ -286,7 +286,7 @@ jobs:
         timeout-minutes: 180
         needs: [pre-commit, get-date]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             # Obtain the cache if available.
             - name: Cache build/VEGA_X86

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -224,7 +224,7 @@ jobs:
         # stripping the "build" directory. By adding the "anchor.txt" file, we
         # ensure the "build" directory is preserved.
             - run: echo "anchor" > anchor.txt
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               with:
                   name: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds-${{ steps.sanitize-build-target.outputs.sanitized-build-target }}
                   path: |
@@ -273,7 +273,7 @@ jobs:
         # Upload the tests/testing-results directory as an artifact.
             - name: Upload results
               if: success() || failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-quick-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
                       }}-status-${{ steps.run-tests.outcome }}-output
@@ -306,7 +306,7 @@ jobs:
             # Upload the tests/testing-results directory as an artifact.
             - name: Upload results
               if: success() || failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output
                   path: tests/testing-results

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -175,7 +175,7 @@ jobs:
 
 
             - name: Restore macOS build/ALL cache
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v6
               with:
                   path: build/ALL
                   key: macos-all-gem5-${{ matrix.type }}-${{ needs.get-date.outputs.date }}
@@ -199,7 +199,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Cache build/ALL
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v6
               if: ${{ endsWith(matrix.build-target, 'build/ALL/gem5.opt') }}
               with:
                   path: build/ALL
@@ -290,7 +290,7 @@ jobs:
 
             # Obtain the cache if available.
             - name: Cache build/VEGA_X86
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v6
               with:
                   path: build/VEGA_X86
                   key: testlib-build-vega-${{ needs.get-date.outputs.date }}

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -245,7 +245,7 @@ jobs:
         steps:
         # Checkout the repository then download the gem5.opt artifact.
             - uses: actions/checkout@v7
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               name: Download gem5 artifacts
               with:
                   pattern: ci-tests-${{ github.run_number }}-testlib-quick-all-gem5-builds*

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         if: github.event.pull_request.draft == false
         steps:
             - uses: actions/checkout@v7
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                   python-version: '3.10'
             - uses: pre-commit/action@v3.0.1
@@ -36,7 +36,7 @@ jobs:
                   fetch-depth: 0  # Need full history to get the merge base
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: '3.10'
 

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -20,7 +20,7 @@ jobs:
         timeout-minutes: 2880 # 48 hours
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.image }}
               run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/ALL/gem5${{ matrix.opts }} -j$(nproc)
               timeout-minutes: 600 # 10 hours
@@ -38,7 +38,7 @@ jobs:
         timeout-minutes: 2880 # 48 hours
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Compile build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} with ${{ matrix.image }}
               run: /usr/bin/env python3 /usr/bin/scons --ignore-style build/${{ matrix.gem5-compilation }}/gem5${{ matrix.opts }} -j$(nproc)
               timeout-minutes: 600 # 10 hours
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 2880 # 48 hours
         container: ghcr.io/gem5/${{ matrix.image }}:latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Compile build/ALL/gem5${{ matrix.opts }} with ${{ matrix.sanitizer }} in ${{ matrix.image }}
               # The address sanitizer is quite memory intensive; triggering OOM errors on smaller runners.
               # To mitigate this, we limit scons to a single thread (`-j1`)

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -49,7 +49,7 @@ jobs:
 
 
             - name: Cache macOS build/ALL
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: build/ALL
                   key: macos-all-gem5-${{ matrix.type }}-${{ needs.get-date.outputs.date }}
@@ -83,7 +83,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Cache build/ALL
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: build/ALL
                   key: testlib-build-all-${{ needs.get-date.outputs.date }}
@@ -156,7 +156,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
             - name: Restore build/ALL cache
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v6
               with:
                   path: build/ALL
                   key: testlib-build-all-${{ needs.get-date.outputs.date }}
@@ -195,7 +195,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
             - name: Cache build/VEGA_X86
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: build/VEGA_X86
                   key: testlib-build-vega-${{ needs.get-date.outputs.date }}

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -176,7 +176,7 @@ jobs:
 
             - name: Upload results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               env:
                   MY_STEP_VAR: ${{ steps.sanitize-test-dir.outputs.sanitized-test-dir }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
               with:
@@ -211,7 +211,7 @@ jobs:
 
             - name: Upload results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output
                   path: tests/testing-results

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -34,7 +34,7 @@ jobs:
 
         steps:
             - name: Checkout the gem5 repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Install the gem5 dependencies
               run: |
@@ -80,7 +80,7 @@ jobs:
         needs: get-date
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Cache build/ALL
               uses: actions/cache@v4
@@ -102,7 +102,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Run ALL/unittests.${{ matrix.type }} UnitTests
               run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
@@ -113,7 +113,7 @@ jobs:
         outputs:
             test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Get directories for testlib-long
               working-directory: ${{ github.workspace }}/tests
               id: dir-matrix
@@ -154,7 +154,7 @@ jobs:
                 test-type: ${{ fromJson(needs.get-testlib-long-dirs.outputs.test-dirs-matrix) }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Restore build/ALL cache
               uses: actions/cache/restore@v4
               with:
@@ -193,7 +193,7 @@ jobs:
             - get-date
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Cache build/VEGA_X86
               uses: actions/cache@v4
               with:
@@ -224,7 +224,7 @@ jobs:
         timeout-minutes: 180
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Build RISCV/libgem5_opt.so with SST
               run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style -j $(nproc)
             - name: Makefile ext/sst
@@ -245,7 +245,7 @@ jobs:
         timeout-minutes: 180
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Build ARM/gem5.opt
               run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources -j$(nproc)
             - name: disable systemc
@@ -265,7 +265,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         timeout-minutes: 360 # 6 hours
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
               run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.3.1 --depth 1 DRAMSys

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -39,7 +39,7 @@ jobs:
               uses: docker/setup-qemu-action@v4
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
@@ -79,7 +79,7 @@ jobs:
               uses: docker/setup-qemu-action@v4
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v7
 
             - name: List targets
               id: generate

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,7 +23,7 @@ jobs:
 
             - name: List targets
               id: generate
-              uses: docker/bake-action/subaction/list-targets@v4
+              uses: docker/bake-action/subaction/list-targets@v6
               with:
                   target: default
                   workdir: util/dockerfiles
@@ -49,7 +49,7 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and Push
-              uses: docker/bake-action@v6
+              uses: docker/bake-action@v7
               with:
                   source: '{{defaultContext}}:util/dockerfiles'
                   targets: base-images
@@ -89,7 +89,7 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and Push
-              uses: docker/bake-action@v6
+              uses: docker/bake-action@v7
               with:
                   source: '{{defaultContext}}:util/dockerfiles'
                   targets: ${{ matrix.target }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -42,7 +42,7 @@ jobs:
               uses: docker/setup-buildx-action@v4
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@v4
               with:
                   registry: ghcr.io
                   username: ${{ github.repository_owner }}
@@ -82,7 +82,7 @@ jobs:
               uses: docker/setup-buildx-action@v4
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@v4
               with:
                   registry: ghcr.io
                   username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, linux, x64]
         steps:
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@v4
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
@@ -76,7 +76,7 @@ jobs:
         steps:
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@v4
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -33,7 +33,7 @@ jobs:
             # and needs to be used inside a the same repository where the
             # workflows are defined.
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Record day and time
               id: timedate-recorder

--- a/.github/workflows/utils.yaml
+++ b/.github/workflows/utils.yaml
@@ -12,7 +12,7 @@ jobs:
     close-stale-issues:
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/stale@v8.0.0
+            - uses: actions/stale@v10
               with:
                   close-issue-message: This issue is being closed because it has been inactive waiting for response for 30 days. If this is still an issue,
                       please open a new issue and reference this one.

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -120,7 +120,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Cache build/ALL
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: build/ALL
                   key: testlib-build-all-${{ needs.get-date.outputs.date }}
@@ -167,7 +167,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Cache build/VEGA_X86
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: build/VEGA_X86
                   key: testlib-build-vega-${{ needs.get-date.outputs.date }}

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Run ALL/unittests.${{ matrix.type.build }} UnitTests
               run: scons build/ALL/unittests.${{ matrix.type.build }} --gcov -j $(nproc)
@@ -51,7 +51,7 @@ jobs:
             test-dirs-matrix-long: ${{ steps.dir-matrix.outputs.test-dirs-matrix-long }}
             test-dirs-matrix-very-long: ${{ steps.dir-matrix.outputs.test-dirs-matrix-very-long }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Get directories for testlib-${{ matrix.type }}
               working-directory: ${{ github.workspace }}/tests
               id: dir-matrix
@@ -117,7 +117,7 @@ jobs:
         timeout-minutes: 4320 # 3 days
         needs: [get-date, get-testlib-dirs, flatten-length-and-testdir-matrices]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Cache build/ALL
               uses: actions/cache@v4
@@ -164,7 +164,7 @@ jobs:
         needs: get-date
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Cache build/VEGA_X86
               uses: actions/cache@v4
@@ -206,7 +206,7 @@ jobs:
         timeout-minutes: 180
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Build RISCV/libgem5_opt.so with SST
               run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style --gcov -j $(nproc)
             - name: Makefile ext/sst
@@ -231,7 +231,7 @@ jobs:
         timeout-minutes: 180
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Build ARM/gem5.opt
               run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources --gcov -j$(nproc)
             - name: disable systemc
@@ -257,7 +257,7 @@ jobs:
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         timeout-minutes: 360 # 6 hours
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
               run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.3.1 --depth 1 DRAMSys

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -141,7 +141,7 @@ jobs:
 
             - name: Upload results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-${{ matrix.test-type.length }}-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
                       }}-status-${{ steps.run-tests.outcome }}-output
@@ -187,7 +187,7 @@ jobs:
 
             - name: Upload results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: weekly-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-length-${{
                       matrix.test-length }}-output

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -34,7 +34,7 @@ jobs:
               run: scons build/ALL/unittests.${{ matrix.type.build }} --gcov -j $(nproc)
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   flags: unittests-${{ matrix.type.build }},overall-unittests,overall-length-${{ matrix.type.length }}
@@ -148,7 +148,7 @@ jobs:
                   path: tests/testing-results
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   flags: overall-testdir-${{steps.sanitize-test-dir.outputs.sanitized-test-dir}},overall-length-${{matrix.test-type.length}},${{steps.sanitize-test-dir.outputs.sanitized-test-dir}}-${{matrix.test-type.length}}
@@ -194,7 +194,7 @@ jobs:
                   path: tests/testing-results
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   flags: overall-gpu-tests,overall-length-${{ matrix.test-length }},gpu-tests-${{ matrix.test-length }}
@@ -219,7 +219,7 @@ jobs:
               working-directory: ${{ github.workspace }}/ext/sst
               run: sst --add-lib-path=./ sst/example.py
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   flags: sst-test,overall-length-long
@@ -246,7 +246,7 @@ jobs:
             - name: Continue gem5 within SystemC test
               run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   flags: systemc-test,overall-length-long
@@ -274,7 +274,7 @@ jobs:
                   ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/dramsys-traffic.py
                   ./build/ALL/gem5.opt configs/example/dramsys.py
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   flags: dramsys-tests,overall-length-long


### PR DESCRIPTION
 Update the GitHub Actions workflow dependencies to their latest compatible major versions across `.github/
  workflows`.

  This keeps the workflow action stack current while preserving the existing workflow behavior and inputs.

  ## Key Changes

  - Updated core GitHub-maintained actions:
    - `actions/checkout` to `v7`
    - `actions/cache` and `actions/cache/restore` to `v6`
    - `actions/upload-artifact` to `v7`
    - `actions/download-artifact` to `v8`
    - `actions/setup-python` to `v6`
    - `actions/stale` to `v10`

  - Updated Docker workflow actions:
    - `docker/setup-qemu-action` to `v4`
    - `docker/setup-buildx-action` to `v4`
    - `docker/login-action` to `v4`
    - `docker/bake-action` to `v7` for the direct bake steps

  - Updated coverage upload action:
    - `codecov/codecov-action` to `v7`

  - Kept `docker/bake-action/subaction/list-targets` on the latest compatible `v6` ref.
    - `docker/bake-action@v7` removed the `subaction/list-targets` helper, so moving that specific use to `v7`
    is not a drop-in replacement and would require rewriting the matrix generation step.

  ## Compatibility Notes

  The updated actions were checked against upstream release notes. Existing workflow inputs such as `fetch-
  depth`, cache `path`/`key`/`restore-keys`, artifact `name`/`path`, Codecov `token`/`flags`, and Docker login
  inputs remain valid.

  Several updated actions now run on Node 24 and require Actions runner `2.327.1` or newer. GitHub-hosted
  runners satisfy this requirement; self-hosted runners used by the Docker and test workflows must be kept
  current.

  ## Validation

  - Parsed all workflow YAML files successfully.
  - Ran `git diff --check` across the new commits.