### PR TITLE
scons: no error on 'nonportable-include-path'

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -678,6 +678,7 @@ for variant_path in variant_paths:
         env.Append(CCFLAGS=['-Werror',
                              '-Wno-error=deprecated-declarations',
                              '-Wno-error=deprecated',
+                             '-Wno-error=nonportable-include-path',
                             ])
     else:
         error('\n'.join((


### PR DESCRIPTION
This is a quick 'fix' to get the tests working until a better solution is developed.

Current PR under consideration: #3292 (This change should be reverted after this is merged, assuming it fixes warning).