### PR TITLE
misc: Add AI agent repository guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -5,28 +5,33 @@ changes reviewable and mechanical.
 
 ## CI Surfaces
 
-`ci-tests.yaml` is pull-request validation. `daily-tests.yaml`,
-`weekly-tests.yaml`, and `compiler-tests.yaml` are broader scheduled or manual
-coverage. Keep related changes aligned across workflows, Docker images, bake
-targets, and documentation.
+`ci-tests.yaml` runs for non-draft pull-request updates. `daily-tests.yaml`,
+`weekly-tests.yaml`, and `compiler-tests.yaml` expose `workflow_dispatch`; the
+hourly `scheduler.yaml` dispatches them on their daily or weekly cadence. Keep
+related changes aligned across workflows, Docker images, bake targets, and
+documentation.
 
-The `clang-format-check` job is advisory for merge validity: a failure does not
-need to block a valid merge, but the formatting error should still be relayed
-in the PR comment section whenever the check fails.
+The aggregate `ci-tests` job does not depend on `clang-format-check`, so the
+workflow dependency graph does not make formatting a prerequisite for that
+aggregate job. Branch-protection settings live on GitHub and can change; check
+them before claiming any individual job is required or advisory. Regardless, a
+formatting failure is evidence that should be reported to the contributor.
 
 ## Validation
 
-Run `git diff --check` for all workflow edits. Parse YAML before finishing, for
-example with Ruby or Python, and inspect the expanded matrix logic when a
-change affects TestLib suite selection.
+Run `git diff --check` for all workflow edits and validate syntax with
+`pre-commit run check-yaml --files <workflow-files>`. A YAML parser cannot
+validate GitHub expressions or job semantics, so also inspect `needs`, `if`,
+matrix expansion, permissions, and the exact shell commands changed.
 
 ## Failure Investigation
 
 Use the failing job log as evidence. Workflow-level failure status can hide the
-real failing matrix entry. For GPU jobs, confirm both `--host` and `--isa`
+real failing matrix entry. For GPU jobs, confirm the effective host and ISA
 selection; the container alone does not determine the selected gem5 build.
 
 Docker containers define the intended CI environment. When reproducing a
-failure, inspect the relevant workflow file and use the same image where
-practical, especially for Ubuntu all-dependency jobs and GPU SE-mode jobs using
+failure, inspect the relevant workflow revision and use the same image digest
+where available; a mutable `:latest` tag may no longer match an older run. This
+especially matters for Ubuntu all-dependency jobs and GPU SE-mode jobs using
 the `gcn-gpu` image.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,32 @@
+# GitHub Workflow Agent Notes
+
+This directory controls GitHub metadata and Actions workflows. Keep workflow
+changes reviewable and mechanical.
+
+## CI Surfaces
+
+`ci-tests.yaml` is pull-request validation. `daily-tests.yaml`,
+`weekly-tests.yaml`, and `compiler-tests.yaml` are broader scheduled or manual
+coverage. Keep related changes aligned across workflows, Docker images, bake
+targets, and documentation.
+
+The `clang-format-check` job is advisory for merge validity: a failure does not
+need to block a valid merge, but the formatting error should still be relayed
+in the PR comment section whenever the check fails.
+
+## Validation
+
+Run `git diff --check` for all workflow edits. Parse YAML before finishing, for
+example with Ruby or Python, and inspect the expanded matrix logic when a
+change affects TestLib suite selection.
+
+## Failure Investigation
+
+Use the failing job log as evidence. Workflow-level failure status can hide the
+real failing matrix entry. For GPU jobs, confirm both `--host` and `--isa`
+selection; the container alone does not determine the selected gem5 build.
+
+Docker containers define the intended CI environment. When reproducing a
+failure, inspect the relevant workflow file and use the same image where
+practical, especially for Ubuntu all-dependency jobs and GPU SE-mode jobs using
+the `gcn-gpu` image.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Copilot Instructions
+
+Use the repository guidance in `../AGENTS.md` as the source of truth. Important
+defaults for generated changes:
+
+- Target contributor work at `develop`; `stable` is release-only except for
+  maintainer-directed hotfixes.
+- Use GitHub issues or GitHub Discussions where issue context is needed.
+- Keep gem5 commit subjects tagged with `MAINTAINERS.yaml` components and wrap
+  body text to 72 columns.
+- Do not edit generated files under `build/`.
+- Avoid changing `gem5/ext/` for dependency or policy work unless explicitly
+  directed.
+- For tests, distinguish C++ GTests, Python PyUnit tests, and TestLib
+  quick/long/very-long suites.
+- For CI/debugging, inspect concrete job logs and SCons config logs before
+  assigning root cause.
+- `clang-format-check` does not need to pass for a valid merge, but if it fails
+  the error should be relayed to the PR comment section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,186 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+gem5 is a simulator repository with mixed C++, Python, SCons, and test assets.
+Core simulator code lives in `src/`; public headers are in `include/`.
+Configuration scripts and examples are in `configs/`. Build-system support is
+split between `SConstruct`, `site_scons/`, `build_tools/`, and `build_opts/`.
+Tests and regressions live under `tests/`, with unit, PyUnit, and TestLib
+harnesses. Utility scripts are in `util/`, optional external packages are under
+`ext/`.
+
+## Dependency Policy
+
+gem5 dependency support is driven by current Ubuntu LTS releases. The oldest
+supported Ubuntu LTS sets ordinary dependency minimums, while the newest
+supported Ubuntu LTS must continue to work. Non-compiler dependency floors
+should normally be written as `major.minor+`; compiler support is tracked by
+major GCC/Clang version.
+
+## Build, Test, and Development Commands
+
+- `scons build/ALL/gem5.opt -j <jobs>`: build the optimized gem5 binary with
+  all ISA targets.
+- `scons build/X86/gem5.opt`: build a single-ISA binary; replace `X86` with an
+  entry from `build_opts/`.
+- `scons build/ALL/unittests.opt`: build and run C++ GoogleTest unit tests.
+- `cd tests && ./main.py run -j <jobs>`: run the default quick TestLib tests.
+- `./build/ALL/gem5.opt tests/run_pyunit.py`: run Python unit tests after
+  building `build/ALL/gem5.opt`.
+- `cd tests && ./main.py run --length=long`: run longer TestLib suites; use
+  `--length=very-long` only for broad validation.
+
+## Coding Style & Naming Conventions
+
+Use 4 spaces, no tabs, no trailing whitespace, and a 79-column line limit.
+C++ style is enforced by `.clang-format` and gem5 hooks; use upper camel case
+for classes, lower camel case for functions and members, snake case for local
+variables and parameters, and all-caps macros. Python is formatted with Black
+and imports are managed by isort using the settings in `pyproject.toml`.
+Install hooks with:
+
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+Keep the hooks installed and active so commit-time errors can be fixed locally
+before pushing PR updates to GitHub.
+
+## Testing Guidelines
+
+gem5 has three major local test layers. C++ GTests are usually `*.test.cc`
+files under `src/` and are built and run through SCons targets such as
+`build/ALL/unittests.opt` or matching `*.test.opt` binaries. Python PyUnit
+tests live under `tests/gem5/pyunit` and run through `tests/run_pyunit.py`.
+Broader regression coverage uses TestLib, whose framework is in `ext/testlib`
+and whose tests are mostly under `tests/gem5`.
+
+TestLib suites are tagged by duration. `quick` is the default and is expected
+for most pull requests. `long` covers heavier daily-style validation and runs
+as part of the `daily-tests.yaml` workflow.
+`very-long` is for tests that may take days and should be reserved for
+release-level or high-risk changes. Use `./main.py list -q --suites` to find
+suites and `./main.py run --uid <SuiteUID> --skip-build` for focused reruns.
+
+## CI Workflows
+
+GitHub Actions live in `.github/workflows`. `ci-tests.yaml` runs pull request
+checks, including pre-commit, clang-format, unit tests, builds, and quick
+TestLib execution. `daily-tests.yaml` runs long TestLib coverage, extra daily
+tests, unittests, and cache-warming builds. `weekly-tests.yaml` runs quick,
+long, and very-long TestLib suites plus coverage upload. `compiler-tests.yaml`
+validates supported GCC/Clang and dependency-image build configurations.
+
+## Validation Tiers
+
+Match validation to the edit. For docs-only changes, run `git diff --check`.
+For Python or SCons edits, add `py_compile` on touched files and
+`scons -Q --help` when build configuration may be affected. For C++ edits,
+prefer targeted object or unit-test builds before broad binaries. For TestLib
+changes, start with `./main.py list ... -q` to confirm suite selection, then
+run the narrowest relevant `./main.py run --uid <SuiteUID> --skip-build`.
+
+## Commit & Pull Request Guidelines
+
+Develop changes on branches based on `develop`, not `stable`. Commit subjects
+use gem5 component tags from `MAINTAINERS.yaml`, for example
+`tests,base: Add coverage for bit helpers`; keep the subject under 65
+characters and body lines under 72 characters. Preserve blank lines between
+body paragraphs and backtick literal code identifiers, commands, and paths.
+Prefer small, focused commits and include relevant GitHub issue links. Pull
+requests target
+`gem5/gem5:develop`, should explain the change and validation performed, and
+must pass CI and review before merge.
+
+Before broad or cross-subsystem edits, inspect `MAINTAINERS.yaml` for component
+tags, maintainers, experts, and orphaned status. Use those tags in commit
+subjects and use the ownership information to frame PRs and likely reviewers.
+Follow the user's preference for local commits and pushing; never rewrite
+shared history or disrupt another contributor's work unless explicitly
+directed.
+
+Every source code file must include a copyright notice and license text. Use
+the 3-Clause BSD license text from `LICENSE` for new files unless there is a
+specific legal or institutional reason to do otherwise. Some existing files,
+especially ARM-authored code, use a slightly modified BSD-3-Clause-style
+header; do not copy that non-standard variant into new files unless it is
+required.
+
+## Release Process
+
+Regular gem5 releases typically occur two times per year. Maintainers announce
+the release window, create `release-staging-{VERSION}` from `develop`, run the
+full test suite, then merge the staging branch to `stable` when ready. The
+stable branch is tagged as `v{YY}.{MAJOR}.{MINOR}.{HOTFIX}`. During staging,
+target normal work at `develop`; submit to staging only for release-critical
+fixes. Hotfixes branch from `stable`, require normal review, merge back to both
+`stable` and `develop`, and receive an incremented hotfix tag.
+
+# Code Review Guidance
+
+When reviewing pull requests:
+
+- Prioritize correctness over style.
+- Treat changes that could alter simulator behaviour as high priority.
+- Look for API compatibility issues.
+- Look for missing regression tests.
+- Verify documentation remains correct.
+- Consider host-side performance implications.
+- Ignore cosmetic formatting unless it harms readability.
+- Prefer existing gem5 idioms over generic C++ best practices.
+- When reporting a bug, explain the failure scenario.
+- Suggest a concrete fix where practical.
+
+## Agent-Specific Notes
+
+Preserve user constraints. If asked not to compile or run simulations, stay
+with source, logs, artifacts, and metadata. For CI failures, inspect the actual
+failing job logs before assigning cause; SCons configure failures often require
+reading `build/ALL/gem5.build/scons_config.log`, not just the headline error.
+
+Every new source file should use the copyright holder required by the
+contributor's institution or other obligation. Avoid editing `gem5/ext/` for
+policy or dependency updates; prefer build logic, Dockerfiles, workflows, and
+documentation.
+
+For dependency or compiler-support maintenance, keep `SConstruct`,
+`.github/workflows`, `util/dockerfiles`, and docs aligned with the Ubuntu LTS
+policy above.
+
+Docker images are central to gem5 testing because they provide stable,
+reproducible environments. The Ubuntu all-dependency images are the baseline
+for many CI jobs. To reproduce a CI failure, inspect the relevant workflow file
+and run the same container locally when practical. GPU SE-mode testing
+currently requires the `gcn-gpu` image.
+
+For TestLib GPU work, both `--host` and `--isa` matter. A GPU container alone
+does not constrain selected suites; use dry runs such as
+`cd tests && ./main.py list --host gcn_gpu --isa=VEGA_X86 -q` to confirm the
+selected build target before running expensive tests.
+
+Do not edit generated build outputs under `build/`. When generated files look
+wrong, change the source generator, SCons rule, SLICC input, or SimObject
+definition that produces them.
+
+Common investigation paths: for SCons configure failures, read
+`build/ALL/gem5.build/scons_config.log`; for GitHub Actions, inspect the
+specific failing job rather than only the workflow conclusion; for long test
+failures, use harness metadata such as `results.xml` before estimating rerun
+cost from suite wall time.
+
+Useful research sources, in rough order, are the current codebase and commit
+history; GitHub PRs, issues, and Discussions; public archives for
+`gem5-dev@gem5.org` and `gem5-users@gem5.org`; the gem5 website and its linked
+resources; and comments or documentation embedded near the relevant source
+code.
+
+Concrete sources:
+`https://github.com/gem5/gem5`,
+`https://github.com/gem5/gem5/pulls`,
+`https://github.com/gem5/gem5/issues`,
+`https://github.com/orgs/gem5/discussions`,
+`https://www.mail-archive.com/gem5-dev%40gem5.org/`,
+`https://www.mail-archive.com/gem5-users%40gem5.org/`, and
+`https://www.gem5.org/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,28 +6,32 @@ gem5 is a simulator repository with mixed C++, Python, SCons, and test assets.
 Core simulator code lives in `src/`; public headers are in `include/`.
 Configuration scripts and examples are in `configs/`. Build-system support is
 split between `SConstruct`, `site_scons/`, `build_tools/`, and `build_opts/`.
-Tests and regressions live under `tests/`, with unit, PyUnit, and TestLib
-harnesses. Utility scripts are in `util/`, optional external packages are under
-`ext/`.
+System-level, PyUnit, and TestLib assets live under `tests/`; C++ unit tests
+are usually colocated with their source under `src/`. Utility scripts are in
+`util/`, and vendored third-party or integration code is under `ext/`.
 
 ## Dependency Policy
 
-gem5 dependency support is driven by current Ubuntu LTS releases. The oldest
-supported Ubuntu LTS sets ordinary dependency minimums, while the newest
-supported Ubuntu LTS must continue to work. Non-compiler dependency floors
-should normally be written as `major.minor+`; compiler support is tracked by
-major GCC/Clang version.
+The project policy for dependency-support updates is to cover Ubuntu LTS
+releases still in standard support. The oldest supported LTS sets ordinary
+dependency minimums, while dependencies from the newest LTS must also work.
+Non-compiler floors should normally be written as `major.minor+`; compiler
+policy uses GCC and Clang major-version ranges.
+
+Policy intent is not proof of current coverage. Before claiming a release,
+compiler, or dependency is supported, verify the checks in `SConstruct`, the
+workflow matrices, Docker images and bake targets, and user documentation.
 
 ## Build, Test, and Development Commands
 
 - `scons build/ALL/gem5.opt -j <jobs>`: build the optimized gem5 binary with
   all ISA targets.
-- `scons build/X86/gem5.opt`: build a single-ISA binary; replace `X86` with an
-  entry from `build_opts/`.
+- `scons build/X86/gem5.opt`: build with the `build_opts/X86` configuration;
+  replace `X86` with another configuration name from `build_opts/`.
 - `scons build/ALL/unittests.opt`: build and run C++ GoogleTest unit tests.
 - `cd tests && ./main.py run -j <jobs>`: run the default quick TestLib tests.
-- `./build/ALL/gem5.opt tests/run_pyunit.py`: run Python unit tests after
-  building `build/ALL/gem5.opt`.
+- `cd tests && ../build/ALL/gem5.opt run_pyunit.py`: run Python unit tests
+  after building `build/ALL/gem5.opt`.
 - `cd tests && ./main.py run --length=long`: run longer TestLib suites; use
   `--length=very-long` only for broad validation.
 
@@ -52,10 +56,11 @@ before pushing PR updates to GitHub.
 
 gem5 has three major local test layers. C++ GTests are usually `*.test.cc`
 files under `src/` and are built and run through SCons targets such as
-`build/ALL/unittests.opt` or matching `*.test.opt` binaries. Python PyUnit
-tests live under `tests/gem5/pyunit` and run through `tests/run_pyunit.py`.
-Broader regression coverage uses TestLib, whose framework is in `ext/testlib`
-and whose tests are mostly under `tests/gem5`.
+`build/ALL/unittests.opt` or matching `*.test.opt` binaries. Python unittest
+files live under `tests/pyunit` and run through `tests/run_pyunit.py` from the
+`tests` directory. `tests/gem5/pyunit/test_run.py` registers them as a quick
+TestLib suite. Broader regression coverage uses TestLib, whose framework is in
+`ext/testlib` and whose suites are mostly under `tests/gem5`.
 
 TestLib suites are tagged by duration. `quick` is the default and is expected
 for most pull requests. `long` covers heavier daily-style validation and runs
@@ -63,6 +68,7 @@ as part of the `daily-tests.yaml` workflow.
 `very-long` is for tests that may take days and should be reserved for
 release-level or high-risk changes. Use `./main.py list -q --suites` to find
 suites and `./main.py run --uid <SuiteUID> --skip-build` for focused reruns.
+Only use `--skip-build` when the required binaries already exist.
 
 ## CI Workflows
 
@@ -76,11 +82,15 @@ validates supported GCC/Clang and dependency-image build configurations.
 ## Validation Tiers
 
 Match validation to the edit. For docs-only changes, run `git diff --check`.
-For Python or SCons edits, add `py_compile` on touched files and
-`scons -Q --help` when build configuration may be affected. For C++ edits,
-prefer targeted object or unit-test builds before broad binaries. For TestLib
-changes, start with `./main.py list ... -q` to confirm suite selection, then
-run the narrowest relevant `./main.py run --uid <SuiteUID> --skip-build`.
+For Python or SCons files, `python3 -m py_compile <files>` checks syntax only.
+`scons -Q --help` evaluates the top-level `SConstruct` and imported site setup,
+but without a target it does not read build-specific `SConsopts` or
+`SConscript` files, run configure probes, or validate source registration.
+Use a narrow explicit SCons target when those behaviors may be affected. For
+C++ edits, prefer targeted object or unit-test builds before broad binaries.
+For TestLib changes, start with `./main.py list ... -q` to confirm selection,
+then run the narrowest relevant suite; use `--skip-build` only when all
+required binaries already exist.
 
 ## Commit & Pull Request Guidelines
 
@@ -90,29 +100,27 @@ use gem5 component tags from `MAINTAINERS.yaml`, for example
 characters and body lines under 72 characters. Preserve blank lines between
 body paragraphs and backtick literal code identifiers, commands, and paths.
 Prefer small, focused commits and include relevant GitHub issue links. Pull
-requests target
-`gem5/gem5:develop`, should explain the change and validation performed, and
-must pass CI and review before merge.
+requests target `gem5/gem5:develop`, should explain the change and validation
+performed, and must pass CI and review before merge.
 
 Before broad or cross-subsystem edits, inspect `MAINTAINERS.yaml` for component
 tags, maintainers, experts, and orphaned status. Use those tags in commit
 subjects and use the ownership information to frame PRs and likely reviewers.
-Follow the user's preference for local commits and pushing; never rewrite
-shared history or disrupt another contributor's work unless explicitly
+Follow the user's explicit instructions about committing and pushing; never
+rewrite shared history or disrupt another contributor's work unless explicitly
 directed.
 
-Every source code file must include a copyright notice and license text. Use
-the 3-Clause BSD license text from `LICENSE` for new files unless there is a
-specific legal or institutional reason to do otherwise. Some existing files,
-especially ARM-authored code, use a slightly modified BSD-3-Clause-style
-header; do not copy that non-standard variant into new files unless it is
-required.
+New source files should carry an appropriate copyright notice and license
+header. Follow the 3-Clause BSD license in `LICENSE` unless the contributor's
+copyright holder or institutional requirements call for another repository-
+accepted header; do not infer a copyright holder from nearby files.
 
 ## Release Process
 
-Regular gem5 releases typically occur two times per year. Maintainers announce
-the release window, create `release-staging-{VERSION}` from `develop`, run the
-full test suite, then merge the staging branch to `stable` when ready. The
+The documented gem5 release process targets three releases per year.
+Maintainers announce the release window, create `release-staging-{VERSION}`
+from `develop`, run the full test suite, then merge the staging branch to
+`stable` when ready. The
 stable branch is tagged as `v{YY}.{MAJOR}.{MINOR}.{HOTFIX}`. During staging,
 target normal work at `develop`; submit to staging only for release-critical
 fixes. Hotfixes branch from `stable`, require normal review, merge back to both
@@ -134,16 +142,18 @@ For dependency or compiler-support maintenance, keep `SConstruct`,
 `.github/workflows`, `util/dockerfiles`, and docs aligned with the Ubuntu LTS
 policy above.
 
-Docker images are central to gem5 testing because they provide stable,
-reproducible environments. The Ubuntu all-dependency images are the baseline
-for many CI jobs. To reproduce a CI failure, inspect the relevant workflow file
-and run the same container locally when practical. GPU SE-mode testing
-currently requires the `gcn-gpu` image.
+Docker images provide standardized environments for many gem5 tests. Exact
+historical reproduction also requires the workflow revision and the image
+digest used by the failing job because a `:latest` tag can change. Ubuntu
+all-dependency images are the baseline for many CI jobs. To reproduce a
+failure, inspect the relevant workflow and use its image where practical. GPU
+SE-mode CI uses the `gcn-gpu` image.
 
-For TestLib GPU work, both `--host` and `--isa` matter. A GPU container alone
-does not constrain selected suites; use dry runs such as
-`cd tests && ./main.py list --host gcn_gpu --isa=VEGA_X86 -q` to confirm the
-selected build target before running expensive tests.
+A GPU container alone does not select GPU TestLib suites; use `--host gcn_gpu`.
+Current GPU suites also declare `VEGA_X86`, so the host-only selector resolves
+to that build today. Add `--isa=VEGA_X86` when the task must explicitly lock
+the target, and always confirm selection with `./main.py list ... -q` before
+an expensive run.
 
 Do not edit generated build outputs under `build/`. When generated files look
 wrong, change the source generator, SCons rule, SLICC input, or SimObject

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,21 +118,6 @@ target normal work at `develop`; submit to staging only for release-critical
 fixes. Hotfixes branch from `stable`, require normal review, merge back to both
 `stable` and `develop`, and receive an incremented hotfix tag.
 
-# Code Review Guidance
-
-When reviewing pull requests:
-
-- Prioritize correctness over style.
-- Treat changes that could alter simulator behaviour as high priority.
-- Look for API compatibility issues.
-- Look for missing regression tests.
-- Verify documentation remains correct.
-- Consider host-side performance implications.
-- Ignore cosmetic formatting unless it harms readability.
-- Prefer existing gem5 idioms over generic C++ best practices.
-- When reporting a bug, explain the failure scenario.
-- Suggest a concrete fix where practical.
-
 ## Agent-Specific Notes
 
 Preserve user constraints. If asked not to compile or run simulations, stay

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@ This document serves as a guide to contributing to gem5.
 The following subsections outline, in order, the steps involved in contributing
 to the gem5 project.
 
+Contributors using coding agents should also consult [AGENTS.md](AGENTS.md).
+More specific `AGENTS.md` files under the repository provide additional
+guidance for changes in their directory trees.
+
 ## Determining what you can contribute
 
 The easiest way to see how you can contribute to gem5 is to check our Jira

--- a/build_tools/AGENTS.md
+++ b/build_tools/AGENTS.md
@@ -25,6 +25,8 @@ output is wrong, fix the relevant source declaration or generator rather than
 
 ## Validation
 
-Run `python3 -m py_compile` on touched generator files. Prefer a targeted SCons
-build of the generated target or a dry run with `--debug=explain` before
-running broad builds.
+Run `python3 -m py_compile` on touched generator files as a syntax check. A dry
+run can inspect command and dependency selection, but it does not execute the
+generator and may fail when configure outputs need updating. Build the
+narrowest target that actually regenerates and compiles the affected output;
+compare generated files when output text or ordering changes.

--- a/build_tools/AGENTS.md
+++ b/build_tools/AGENTS.md
@@ -1,0 +1,30 @@
+# Build Tools Agent Notes
+
+This directory contains helper generators used by SCons to produce C++, Python,
+headers, enums, debug flags, config data, and embedded blobs. Outputs usually
+land under `build/` and should not be edited directly.
+
+## Generator Changes
+
+Treat generator output as a public build contract. Small formatting or ordering
+changes can force broad rebuilds, perturb generated diffs, or break downstream
+includes. Keep output deterministic by sorting unordered inputs and avoiding
+host-specific paths, timestamps, or dictionary iteration where order matters.
+
+When changing a generator, identify every SCons rule that calls it and the
+generated files it owns. Update the source definition, SCons rule, and
+generator together when their contracts change.
+
+## Common Generated Surfaces
+
+SimObject params and pybind glue are generated from Python SimObject
+declarations. Enums, debug flags, Kconfig data, C++ config support, and
+embedded Python blobs each have dedicated generator scripts here. If generated
+output is wrong, fix the relevant source declaration or generator rather than
+`build/` artifacts.
+
+## Validation
+
+Run `python3 -m py_compile` on touched generator files. Prefer a targeted SCons
+build of the generated target or a dry run with `--debug=explain` before
+running broad builds.

--- a/configs/AGENTS.md
+++ b/configs/AGENTS.md
@@ -1,0 +1,26 @@
+# Config Agent Notes
+
+This directory contains simulation configuration scripts and examples. These
+files are not the primary public interface to gem5. Do not treat
+`configs/example` as canonical APIs or copy its patterns blindly into new work.
+
+## Creating Simulations
+
+When a task requires a new simulation configuration, prefer creating a focused
+config file for that task and use the gem5 standard library in
+`src/python/gem5` where practical. The stdlib provides higher-level boards,
+processors, memory systems, cache hierarchies, resources, and simulator helpers
+intended for user configuration scripts.
+
+The stdlib is occasionally limited. It is acceptable to use lower-level
+SimObject wiring when the experiment requires bare-bones control, unsupported
+hardware composition, or behavior the stdlib cannot express. In that case,
+keep the config narrow, document the reason for bypassing stdlib helpers, and
+avoid turning examples into reusable interfaces.
+
+## Legacy And Deprecated Configs
+
+`configs/deprecated` contains old scripts retained for reference or migration.
+Avoid extending deprecated scripts unless the task explicitly asks for legacy
+support. If changing `configs/common` or `configs/ruby`, check existing users
+and TestLib coverage because these helpers can affect many legacy examples.

--- a/configs/AGENTS.md
+++ b/configs/AGENTS.md
@@ -1,8 +1,10 @@
 # Config Agent Notes
 
-This directory contains simulation configuration scripts and examples. These
-files are not the primary public interface to gem5. Do not treat
-`configs/example` as canonical APIs or copy its patterns blindly into new work.
+This directory contains simulation configuration scripts and examples. Many
+are examples, compatibility helpers, or scripts for a specific test or study;
+their presence does not make every helper a stable public API. Treat
+`configs/example` as runnable examples, not as a single canonical interface to
+copy blindly.
 
 ## Creating Simulations
 
@@ -24,3 +26,10 @@ avoid turning examples into reusable interfaces.
 Avoid extending deprecated scripts unless the task explicitly asks for legacy
 support. If changing `configs/common` or `configs/ruby`, check existing users
 and TestLib coverage because these helpers can affect many legacy examples.
+
+## Validation
+
+Run `python3 -m py_compile` for syntax-only checks where imports permit it.
+Then run the narrowest configuration or TestLib suite that instantiates the
+changed path; compilation alone does not prove that SimObject wiring, resource
+requirements, or exit-event handling is correct.

--- a/site_scons/AGENTS.md
+++ b/site_scons/AGENTS.md
@@ -28,6 +28,14 @@ Keep dependency and compiler support policy aligned with `SConstruct`,
 ## Validation
 
 For SCons edits, run `python3 -m py_compile` on touched Python files and
-`scons -Q --help` when option parsing, registration, or configure behavior may
-be affected. For dependency-edge or generator changes, use targeted
-`scons -n ... --debug=explain` and `sconsign` checks before broad rebuilds.
+treat it as a syntax check only. `scons -Q --help` evaluates the top-level
+`SConstruct` and imported site initialization, so it is useful for that narrow
+startup and top-level option-registration path. With no build target it does
+not read build-specific `SConsopts` or `SConscript` files, run configure
+probes, or validate source and generator registration.
+
+Use the narrowest explicit build target that reaches the changed logic when
+registration or configure behavior matters. A dry run with
+`scons -n <target> --debug=explain` can help inspect dependency decisions after
+configure state is current, but it does not execute actions and can fail if a
+configure test needs to update its output.

--- a/site_scons/AGENTS.md
+++ b/site_scons/AGENTS.md
@@ -1,0 +1,33 @@
+# SCons Agent Notes
+
+This directory contains gem5's SCons extensions, source registration helpers,
+configure probes, Kconfig integration, Python path setup, and git-hook support.
+Small changes here can affect every build variant.
+
+## Build Logic
+
+Keep emitters and actions separated: emitters should discover targets and
+dependencies, while actions should write files. Avoid unstable generated
+output, implicit environment mutation, or dependency edges that change between
+builds.
+
+For configure checks, inspect the generated `scons_config.log` in the relevant
+build directory before assigning cause. Headline failures can hide compiler
+flag, include path, linker, Python, or pkg-config details.
+
+## Registration And Generated Files
+
+SCons registration controls C++ sources, Python sources, SimObjects, enums,
+debug flags, Kconfig files, and generated build products. If output under
+`build/` is wrong, change the registration rule, generator, or source input
+rather than generated files.
+
+Keep dependency and compiler support policy aligned with `SConstruct`,
+`.github/workflows`, `util/dockerfiles`, and docs.
+
+## Validation
+
+For SCons edits, run `python3 -m py_compile` on touched Python files and
+`scons -Q --help` when option parsing, registration, or configure behavior may
+be affected. For dependency-edge or generator changes, use targeted
+`scons -n ... --debug=explain` and `sconsign` checks before broad rebuilds.

--- a/src/arch/AGENTS.md
+++ b/src/arch/AGENTS.md
@@ -6,11 +6,13 @@ Most ISAs combine hand-written C++/Python with generated C++ from `.isa` files.
 
 ## Generated ISA Code
 
-The ISA parser in `src/arch/isa_parser` reads each ISA's `isa/main.isa` and the
-files it includes, such as `decoder.isa`, `operands.isa`, `bitfields.isa`, and
-`includes.isa`. The generated code creates decoder tables and `StaticInst`
-classes used by CPU models. Do not edit generated files under `build/`; change
-the `.isa` input, parser support code, or hand-written ISA files instead.
+For ISAs registered with `ISADesc`, the parser in `src/arch/isa_parser` reads
+the architecture's `isa/main.isa` and its includes. Common inputs include
+decoder fragments, `operands.isa`, `bitfields.isa`, and `includes.isa`; exact
+file organization differs by ISA. Generated decoder and instruction classes
+are used through `StaticInst`. Do not edit generated files under `build/`;
+change the `.isa` input, parser support code, or hand-written ISA files
+instead.
 
 `decoder.isa` describes instruction decode patterns and semantic code.
 `operands.isa` maps ISA operands onto gem5 register classes and memory
@@ -31,3 +33,10 @@ When adding or changing instructions, check decode, execution, disassembly,
 register operands, memory flags, faults, and PC advancement. For macroop or
 microop ISAs such as x86, preserve the macro/micro instruction contract and
 micro-PC behavior.
+
+## Validation
+
+Build a target containing the affected ISA so the parser executes and the
+generated C++ compiles. Add or run focused execution and disassembly coverage
+for the changed encoding; a successful parser run alone does not validate
+instruction semantics across CPU models.

--- a/src/arch/AGENTS.md
+++ b/src/arch/AGENTS.md
@@ -1,0 +1,33 @@
+# ISA Agent Notes
+
+The architecture directories define ISA-specific state, decoding, execution
+semantics, disassembly, faults, MMUs, TLBs, interrupts, and workload support.
+Most ISAs combine hand-written C++/Python with generated C++ from `.isa` files.
+
+## Generated ISA Code
+
+The ISA parser in `src/arch/isa_parser` reads each ISA's `isa/main.isa` and the
+files it includes, such as `decoder.isa`, `operands.isa`, `bitfields.isa`, and
+`includes.isa`. The generated code creates decoder tables and `StaticInst`
+classes used by CPU models. Do not edit generated files under `build/`; change
+the `.isa` input, parser support code, or hand-written ISA files instead.
+
+`decoder.isa` describes instruction decode patterns and semantic code.
+`operands.isa` maps ISA operands onto gem5 register classes and memory
+operands. `bitfields.isa` names encoding fields. `includes.isa` injects C++
+used by generated instruction classes. Keep decode predicates, operand
+definitions, and disassembly in sync when adding an instruction.
+
+## ISA Contracts
+
+Generated instructions execute through the ISA-neutral `StaticInst` interface
+in `src/cpu/static_inst.hh`. Instruction semantic code normally accesses CPU
+state through `ExecContext`, advances an ISA-specific `PCState`, and returns a
+`Fault`. The same decoded instruction may be consumed by AtomicSimpleCPU,
+TimingSimpleCPU, MinorCPU, O3CPU, or checker/trace code, so avoid assumptions
+about one CPU pipeline unless the ISA code explicitly requires it.
+
+When adding or changing instructions, check decode, execution, disassembly,
+register operands, memory flags, faults, and PC advancement. For macroop or
+microop ISAs such as x86, preserve the macro/micro instruction contract and
+micro-PC behavior.

--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -1,0 +1,34 @@
+# CPU Model Agent Notes
+
+CPU models in this directory are mostly ISA-agnostic. They fetch bytes through
+ISA-specific decoders, receive `StaticInst` objects, and execute those
+instructions through model-specific pipeline, dependency, and memory-access
+machinery.
+
+## Instruction Interface
+
+ISA code defines decoding and instruction semantics; CPU models define timing,
+ordering, speculation, commit, and memory interaction. The shared contract is
+centered on `StaticInst`, `ExecContext`, `ThreadContext`, `PCStateBase`, and
+the architectural register abstractions. Be careful when changing these
+interfaces: updates may affect every ISA and multiple CPU models.
+
+`StaticInst` records instruction properties, operands, op class, branch
+targets, microop state, and execution hooks. CPU models should use these
+properties rather than open-coding ISA-specific behavior. Instruction execution
+uses an `ExecContext` implementation supplied by the CPU model, so operand
+indexing and misc-register access must follow the instruction's operand tables.
+
+## Model Differences
+
+AtomicSimpleCPU and TimingSimpleCPU execute instructions in simple in-order
+loops with different memory timing behavior. MinorCPU models an in-order
+pipeline with explicit stage timing. O3CPU wraps decoded `StaticInst`s in
+dynamic instructions, renames registers, schedules dependencies, speculates,
+and commits in order. A fix that is correct for one model may need separate
+checks for the others.
+
+When changing instruction flow, memory requests, faults, branches, or
+squashing, trace the path through fetch/decode/execute/commit for the relevant
+CPU model. For O3, distinguish `StaticInst` architectural semantics from
+`DynInst` lifetime, request ownership, and squash/commit behavior.

--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -32,3 +32,11 @@ When changing instruction flow, memory requests, faults, branches, or
 squashing, trace the path through fetch/decode/execute/commit for the relevant
 CPU model. For O3, distinguish `StaticInst` architectural semantics from
 `DynInst` lifetime, request ownership, and squash/commit behavior.
+
+## Validation
+
+Build the narrowest target containing the changed model and run a focused test
+with that model. Do not generalize a pass from AtomicSimpleCPU or
+TimingSimpleCPU to MinorCPU or O3CPU: their timing, ownership, squash, and
+drain paths differ. For a cross-model interface change, exercise each affected
+model explicitly.

--- a/src/mem/AGENTS.md
+++ b/src/mem/AGENTS.md
@@ -1,0 +1,37 @@
+# Memory System Agent Notes
+
+This directory contains gem5's memory-system infrastructure: ports, packets,
+requests, crossbars, bridges, classic caches, memory controllers, protocol
+interfaces, external memory wrappers, probes, and Ruby.
+
+## Request Paths
+
+Start memory investigations by identifying the mode and path: atomic, timing,
+functional, or snoop; Classic or Ruby; CPU-side, memory-side, DMA, or external
+port. `Request` carries architectural request metadata, `Packet` carries a
+specific memory transaction, and ports define how SimObjects exchange packets.
+
+Do not assume timing-mode behavior applies to atomic or functional access.
+Functional accesses are for inspecting or updating simulated state, atomic
+accesses model instantaneous service with latency accounting, and timing
+accesses model queued/asynchronous packet flow.
+
+## Classic, Ruby, And Controllers
+
+Classic caches and interconnects are mostly hand-written C++ SimObjects under
+`src/mem/cache` and related files. Ruby coherence protocols live under
+`src/mem/ruby` and are generated from SLICC inputs. A change to packet fields,
+request flags, port semantics, or memory-controller behavior can affect both
+Classic and Ruby even when the immediate bug appears in only one hierarchy.
+
+For memory-controller work, check the relevant Python SimObject declaration,
+C++ interface, QoS behavior, external wrapper, and config/test coverage. Keep
+DRAM interface changes aligned with existing controllers and third-party
+wrapper expectations.
+
+## Validation
+
+Prefer focused builds or unit tests for touched components before broad
+simulator builds. When reproducing memory-system bugs, preserve the exact CPU
+model, memory mode, cache hierarchy, coherence protocol, and workload because
+small config differences can route requests through different code paths.

--- a/src/mem/AGENTS.md
+++ b/src/mem/AGENTS.md
@@ -6,15 +6,20 @@ interfaces, external memory wrappers, probes, and Ruby.
 
 ## Request Paths
 
-Start memory investigations by identifying the mode and path: atomic, timing,
-functional, or snoop; Classic or Ruby; CPU-side, memory-side, DMA, or external
-port. `Request` carries architectural request metadata, `Packet` carries a
+Start memory investigations by identifying the configured `System.mem_mode`
+(`atomic`, `timing`, or `atomic_noncaching`), the cache hierarchy (Classic or
+Ruby), and the request origin and path (CPU-side, memory-side, DMA, or external
+port). `Request` carries architectural request metadata, `Packet` carries a
 specific memory transaction, and ports define how SimObjects exchange packets.
 
 Do not assume timing-mode behavior applies to atomic or functional access.
-Functional accesses are for inspecting or updating simulated state, atomic
-accesses model instantaneous service with latency accounting, and timing
-accesses model queued/asynchronous packet flow.
+Functional accesses are zero-time debug operations for inspecting or updating
+simulated state and are not a `System.mem_mode`. Atomic accesses flow through
+the configured memory system without event-driven timing, while
+`atomic_noncaching` is used for paths that bypass caches, including KVM and
+Ruby atomic accesses. Timing accesses model queued, asynchronous packet flow.
+Snoops are cache-coherence traffic within these access mechanisms, not a
+separate memory mode.
 
 ## Classic, Ruby, And Controllers
 

--- a/src/mem/AGENTS.md
+++ b/src/mem/AGENTS.md
@@ -36,7 +36,9 @@ wrapper expectations.
 
 ## Validation
 
-Prefer focused builds or unit tests for touched components before broad
-simulator builds. When reproducing memory-system bugs, preserve the exact CPU
-model, memory mode, cache hierarchy, coherence protocol, and workload because
-small config differences can route requests through different code paths.
+Prefer focused builds and the narrowest unit test or simulation that exercises
+the touched path before broad validation. Compilation alone does not validate
+packet ordering or coherence behavior. When reproducing a memory-system bug,
+preserve the exact CPU model, memory mode, cache hierarchy, coherence protocol,
+and workload because small configuration differences can route requests
+through different code paths.

--- a/src/mem/ruby/AGENTS.md
+++ b/src/mem/ruby/AGENTS.md
@@ -1,7 +1,9 @@
 # Ruby Agent Notes
 
-Ruby combines hand-written C++/Python, SCons glue, and SLICC protocol inputs.
-Generated protocol output belongs under `build/`; do not edit it directly.
+Ruby combines hand-written C++/Python, SCons glue, and protocol inputs written
+in SLICC, a domain-specific language for describing cache-coherence state
+machines. Generated protocol output belongs under `build/`; do not edit it
+directly.
 
 ## SLICC And Generated Files
 

--- a/src/mem/ruby/AGENTS.md
+++ b/src/mem/ruby/AGENTS.md
@@ -1,0 +1,34 @@
+# Ruby Agent Notes
+
+Ruby combines hand-written C++/Python, SCons glue, and SLICC protocol inputs.
+Generated protocol output belongs under `build/`; do not edit it directly.
+
+## SLICC And Generated Files
+
+Protocol source files live under `src/mem/ruby/protocol`. If generated C++ or
+HTML looks wrong, change the SLICC input or generator path, then rebuild. Keep
+SCons emitters side-effect free: emitters should discover targets, while
+actions should write generated files.
+
+## Ruby And Classic
+
+gem5 has two main cache-hierarchy families. Classic caches model a relatively
+direct cache/memory object graph in C++ and are usually configured by composing
+cache, bus, and memory objects. Ruby models cache-coherence protocols as
+message-passing controller state machines connected through Ruby networks.
+
+Ruby protocols are written in SLICC under `src/mem/ruby/protocol`; SLICC
+generates controller C++ code, protocol message types, and HTML protocol
+documentation under `build/`. Protocol behavior should be changed in the SLICC
+state machines or the Ruby support code they call, not in generated files.
+
+When working on coherence behavior, identify whether the bug belongs to the
+Ruby protocol, the generated controller, the network, the Sequencer, or the
+memory-system interface. For Classic behavior, start with the concrete cache or
+interconnect object instead. Do not assume a Classic fix applies to Ruby or
+that a Ruby protocol fix applies to every protocol.
+
+## Review Notes
+
+For protocol path or case changes, verify generated paths and source directory
+case exactly.

--- a/src/mem/ruby/AGENTS.md
+++ b/src/mem/ruby/AGENTS.md
@@ -7,10 +7,11 @@ directly.
 
 ## SLICC And Generated Files
 
-Protocol source files live under `src/mem/ruby/protocol`. If generated C++ or
-HTML looks wrong, change the SLICC input or generator path, then rebuild. Keep
-SCons emitters side-effect free: emitters should discover targets, while
-actions should write generated files.
+Built-in protocol source files live under `src/mem/ruby/protocol`; build logic
+can add other protocol directories. If generated C++ or HTML looks wrong,
+change the SLICC input or generator path, then rebuild. Keep SCons emitters
+side-effect free: emitters should discover targets, while actions should write
+generated files.
 
 ## Ruby And Classic
 
@@ -19,10 +20,12 @@ direct cache/memory object graph in C++ and are usually configured by composing
 cache, bus, and memory objects. Ruby models cache-coherence protocols as
 message-passing controller state machines connected through Ruby networks.
 
-Ruby protocols are written in SLICC under `src/mem/ruby/protocol`; SLICC
-generates controller C++ code, protocol message types, and HTML protocol
-documentation under `build/`. Protocol behavior should be changed in the SLICC
-state machines or the Ruby support code they call, not in generated files.
+Built-in Ruby protocols are written in SLICC under `src/mem/ruby/protocol`;
+additional protocol directories can be supplied by the build. SLICC generates
+controller C++ code and protocol types under the selected build directory. It
+generates HTML there only when the `SLICC_HTML` Kconfig option is enabled.
+Protocol behavior should be changed in the SLICC state machines or the Ruby
+support code they call, not in generated files.
 
 When working on coherence behavior, identify whether the bug belongs to the
 Ruby protocol, the generated controller, the network, the Sequencer, or the
@@ -34,3 +37,10 @@ that a Ruby protocol fix applies to every protocol.
 
 For protocol path or case changes, verify generated paths and source directory
 case exactly.
+
+## Validation
+
+Build a configuration that enables the affected Ruby protocol so SLICC runs
+and its generated C++ compiles. Then run a focused Ruby test for the changed
+state-machine path; successful generation alone does not validate coherence
+transitions or message ordering.

--- a/src/python/AGENTS.md
+++ b/src/python/AGENTS.md
@@ -36,9 +36,24 @@ systems, and cache hierarchies should expose clear constructor parameters and
 avoid hidden global state. Prefer adding small extension points over special
 cases in a prebuilt board unless the behavior is truly board-specific.
 
+## Pybind11 Bindings
+
+gem5 uses pybind11 to expose C++ simulator APIs to its embedded Python
+interpreter. Core hand-written bindings live under `src/python/pybind11` and
+are registered in `src/python/SConscript`. Subsystem-specific bindings may live
+beside their C++ implementation and use `EmbeddedPyBind` to add `_m5`
+submodules.
+
+Bindings for SimObject params, enums, and `cxx_exports` are generated from
+Python declarations by scripts under `build_tools`; update those declarations
+or generators rather than generated files under `build/`. Keep Python-facing
+names, C++ signatures, ownership and return-value policies, SCons registration,
+and tests synchronized when changing a binding.
+
 ## Validation
 
 For Python-only edits, run `python3 -m py_compile` on touched files when
-practical. For SimObject, param, enum, or pybind-facing edits, also use a
-targeted SCons build or `scons -Q --help` when build registration may be
-affected.
+practical. For SimObject, param, enum, or pybind-facing edits, build the
+affected gem5 target so the generated bindings are compiled. `scons -Q --help`
+only validates top-level configuration and is not a substitute for a binding
+build.

--- a/src/python/AGENTS.md
+++ b/src/python/AGENTS.md
@@ -1,0 +1,44 @@
+# Python And Stdlib Agent Notes
+
+This tree contains Python infrastructure for gem5. The `m5` package provides
+core simulator configuration machinery, SimObject support, params, proxies,
+events, ticks, and embedded-Python integration. The `gem5` package contains
+the gem5 standard library, including components, boards, processors, memory
+systems, cache hierarchies, resources, and simulator helpers.
+
+## Standard Library Stability
+
+`src/python/gem5` is user-facing stdlib code and has a higher API-stability bar
+than much of the rest of gem5. Users should generally be able to run older
+configuration files on newer gem5 releases without surprising breakage.
+
+Do not remove or rename stdlib APIs without a deprecation path. Provide at
+least one release with a user-visible warning before removal, and keep
+deprecations longer when migration risk is high. Existing examples include
+warnings in `gem5/simulate/simulator.py`, `gem5/resources/resource.py`,
+`gem5/resources/workload.py`, and `gem5/utils/simpoint.py`.
+
+Use `m5.util.warn` for runtime deprecation warnings and keep replacement
+guidance concrete. For renamed SimObject params, use `DeprecatedParam` from
+`m5.params.deprecated_params` so old config files continue to map to the new
+parameter name with a warning.
+
+## SimObjects And Components
+
+Python SimObject declarations are part of the C++/Python binding contract.
+Changes to params, enums, ports, or class names may require updates to C++,
+SCons registration, generated params, pybind output, tests, and documentation.
+Do not edit generated params or bindings under `build/`; change the SimObject
+definition or generator instead.
+
+For stdlib components, preserve composability. Boards, processors, memory
+systems, and cache hierarchies should expose clear constructor parameters and
+avoid hidden global state. Prefer adding small extension points over special
+cases in a prebuilt board unless the behavior is truly board-specific.
+
+## Validation
+
+For Python-only edits, run `python3 -m py_compile` on touched files when
+practical. For SimObject, param, enum, or pybind-facing edits, also use a
+targeted SCons build or `scons -Q --help` when build registration may be
+affected.

--- a/src/python/AGENTS.md
+++ b/src/python/AGENTS.md
@@ -8,14 +8,12 @@ systems, cache hierarchies, resources, and simulator helpers.
 
 ## Standard Library Stability
 
-`src/python/gem5` is user-facing stdlib code and has a higher API-stability bar
-than much of the rest of gem5. Users should generally be able to run older
-configuration files on newer gem5 releases without surprising breakage.
-
-Do not remove or rename stdlib APIs without a deprecation path. Provide at
-least one release with a user-visible warning before removal, and keep
-deprecations longer when migration risk is high. Existing examples include
-warnings in `gem5/simulate/simulator.py`, `gem5/resources/resource.py`,
+`src/python/gem5` is the user-facing standard library, so compatibility is an
+explicit review concern. The repository contains deprecation mechanisms, but
+does not define one universal deprecation period for every stdlib API. Follow
+the policy established by the affected subsystem and its maintainers; do not
+invent a fixed release count. Existing deprecation examples include warnings
+in `gem5/simulate/simulator.py`, `gem5/resources/resource.py`,
 `gem5/resources/workload.py`, and `gem5/utils/simpoint.py`.
 
 Use `m5.util.warn` for runtime deprecation warnings and keep replacement
@@ -53,7 +51,8 @@ and tests synchronized when changing a binding.
 ## Validation
 
 For Python-only edits, run `python3 -m py_compile` on touched files when
-practical. For SimObject, param, enum, or pybind-facing edits, build the
+practical, but remember that it checks syntax rather than imports or runtime
+behavior. For SimObject, param, enum, or pybind-facing edits, build the
 affected gem5 target so the generated bindings are compiled. `scons -Q --help`
-only validates top-level configuration and is not a substitute for a binding
-build.
+only evaluates the top-level SConstruct and site initialization; it does not
+process the build-specific SConscripts or generate and compile bindings.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,33 @@
+# Test Agent Notes
+
+This directory contains gem5 test entry points, TestLib suites, PyUnit tests,
+fixtures, and test resources.
+
+## Test Families
+
+C++ GTests are generally declared near the C++ code under `src/` and built with
+SCons as `*.test.opt` binaries. Python PyUnit tests live under `tests/pyunit`
+and `tests/gem5/pyunit` and are run with `tests/run_pyunit.py`. Broader
+regression tests use TestLib through `tests/main.py`.
+
+## TestLib Selection
+
+TestLib suites are tagged as `quick`, `long`, or `very-long`. The default
+`./main.py run` selects quick tests. Use `./main.py list -q --suites` before
+running expensive tests, and prefer focused `--uid <SuiteUID> --skip-build`
+runs when validating a specific suite.
+
+Host and ISA filters are part of suite selection. For GPU tests, `--host
+gcn_gpu` is not enough by itself; include `--isa=VEGA_X86` when that is the
+intended build target.
+
+## Validation Examples
+
+```sh
+./main.py list --length=long -q --suites
+./main.py list --host gcn_gpu --isa=VEGA_X86 -q
+./main.py run --uid <SuiteUID> --skip-build
+```
+
+When estimating rerun cost from artifacts, prefer per-test metadata in
+`results.xml` over total suite wall time.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -3,26 +3,38 @@
 This directory contains gem5 test entry points, TestLib suites, PyUnit tests,
 fixtures, and test resources.
 
-See [`../TESTING.md`](../TESTING.md) for the repository's testing overview and
-instructions for running each test family.
+See [`../TESTING.md`](../TESTING.md) for broader background on the repository's
+test infrastructure. Use the commands below for the test layout in this
+checkout.
 
 ## Test Families
 
 C++ GTests are generally declared near the C++ code under `src/` and built with
-SCons as `*.test.opt` binaries. Python PyUnit tests live under `tests/pyunit`
-and `tests/gem5/pyunit` and are run with `tests/run_pyunit.py`. Broader
-regression tests use TestLib through `tests/main.py`.
+SCons as `*.test.opt` binaries. Python PyUnit tests live under `tests/pyunit`.
+Run them from the `tests` directory so `run_pyunit.py` finds its default
+`pyunit` directory:
+
+```sh
+cd tests
+../build/ALL/gem5.opt run_pyunit.py
+```
+
+`tests/gem5/pyunit/test_run.py` is a quick TestLib suite which invokes that
+runner; it is not a second PyUnit test directory. Broader regression tests use
+TestLib through `tests/main.py`.
 
 ## TestLib Selection
 
 TestLib suites are tagged as `quick`, `long`, or `very-long`. The default
 `./main.py run` selects quick tests. Use `./main.py list -q --suites` before
-running expensive tests, and prefer focused `--uid <SuiteUID> --skip-build`
-runs when validating a specific suite.
+running expensive tests, and prefer focused `--uid <SuiteUID>` runs when
+validating a specific suite. Add `--skip-build` only when all required gem5 and
+unit-test binaries already exist.
 
-Host and ISA filters are part of suite selection. For GPU tests, `--host
-gcn_gpu` is not enough by itself; include `--isa=VEGA_X86` when that is the
-intended build target.
+Host and ISA filters are part of suite selection. In the current suite set,
+`--host gcn_gpu` selects GPU suites whose declared ISA is `VEGA_X86`, so an
+explicit `--isa=VEGA_X86` is optional. Supplying both can make the intended
+intersection explicit, but the container image alone does not select tests.
 
 ## Validation Examples
 
@@ -33,4 +45,5 @@ intended build target.
 ```
 
 When estimating rerun cost from artifacts, prefer per-test metadata in
-`results.xml` over total suite wall time.
+`results.xml` (including each JUnit testcase's `time` attribute) over total
+suite wall time.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -3,6 +3,9 @@
 This directory contains gem5 test entry points, TestLib suites, PyUnit tests,
 fixtures, and test resources.
 
+See [`../TESTING.md`](../TESTING.md) for the repository's testing overview and
+instructions for running each test family.
+
 ## Test Families
 
 C++ GTests are generally declared near the C++ code under `src/` and built with

--- a/util/dockerfiles/AGENTS.md
+++ b/util/dockerfiles/AGENTS.md
@@ -1,0 +1,46 @@
+# Dockerfile Agent Notes
+
+This directory defines gem5 CI and development images. Changes here often need
+matching updates in `.github/workflows`, `util/dockerfiles/docker-bake.hcl`,
+and documentation.
+
+## Dependency Policy
+
+gem5 supports current Ubuntu LTS releases. General dependency minimums should
+track the oldest supported Ubuntu LTS defaults, while the newest supported LTS
+must continue to work. Prefer distro packages when they satisfy policy.
+
+For non-compiler dependencies, document floors as `major.minor+` where
+practical, not full distro patch strings. Compiler support is tracked by GCC
+and Clang major version.
+
+## Compiler Images
+
+When adding or raising supported GCC/Clang versions, keep compiler Dockerfiles,
+`docker-bake.hcl`, `.github/workflows/compiler-tests.yaml`, CI container
+references, and build documentation aligned. If a compiler package requires a
+newer Ubuntu base, add the image and bake target as part of the same change.
+
+## CI Reproduction
+
+Docker images are central to gem5 testing because they provide stable,
+reproducible environments. The Ubuntu all-dependency images are the common
+baseline for CI dependency coverage. When a CI job fails, inspect the relevant
+`.github/workflows` file and reproduce with the same container image where
+practical.
+
+GPU SE-mode tests currently require the `gcn-gpu` image. A GPU-capable
+container does not by itself select GPU tests; TestLib still needs matching
+`--host` and `--isa` filters.
+
+## Validation
+
+Use targeted checks before expensive builds:
+
+```sh
+docker buildx build --check -f util/dockerfiles/clang-compiler/Dockerfile .
+docker buildx build --check -f util/dockerfiles/gcc-compiler/Dockerfile .
+git diff --check
+```
+
+Avoid changing `gem5/ext/` to enforce dependency policy.

--- a/util/dockerfiles/AGENTS.md
+++ b/util/dockerfiles/AGENTS.md
@@ -6,9 +6,13 @@ and documentation.
 
 ## Dependency Policy
 
-gem5 supports current Ubuntu LTS releases. General dependency minimums should
-track the oldest supported Ubuntu LTS defaults, while the newest supported LTS
-must continue to work. Prefer distro packages when they satisfy policy.
+gem5's documented policy is to support current Ubuntu LTS releases. General
+dependency minimums should track the oldest supported Ubuntu LTS defaults,
+while the newest supported LTS should continue to work. This policy is not
+proof that every current LTS already has an image or CI job in this checkout;
+verify `docker-bake.hcl`, workflows, Dockerfiles, and build documentation
+before describing actual coverage. Prefer distro packages when they satisfy
+policy.
 
 For non-compiler dependencies, document floors as `major.minor+` where
 practical, not full distro patch strings. Compiler support is tracked by GCC
@@ -23,24 +27,36 @@ newer Ubuntu base, add the image and bake target as part of the same change.
 
 ## CI Reproduction
 
-Docker images are central to gem5 testing because they provide stable,
-reproducible environments. The Ubuntu all-dependency images are the common
-baseline for CI dependency coverage. When a CI job fails, inspect the relevant
-`.github/workflows` file and reproduce with the same container image where
-practical.
+Docker images are central to gem5 testing because they standardize the build
+environment. The Ubuntu all-dependency images are the common baseline for CI
+dependency coverage. Mutable tags such as `latest` do not identify an exactly
+reproducible environment; use the workflow revision and image digest when an
+exact reproduction matters. When a CI job fails, inspect the relevant
+`.github/workflows` file and reproduce with the same image where practical.
 
-GPU SE-mode tests currently require the `gcn-gpu` image. A GPU-capable
-container does not by itself select GPU tests; TestLib still needs matching
-`--host` and `--isa` filters.
+GPU SE-mode tests currently use the `gcn-gpu` image. A GPU-capable container
+does not by itself select GPU tests; TestLib still needs the `gcn_gpu` host
+filter. The current GPU suites declare `VEGA_X86`, so an ISA filter is optional
+unless a narrower host-and-ISA intersection is desired.
 
 ## Validation
 
-Use targeted checks before expensive builds:
+From `util/dockerfiles`, first inspect the resolved bake target and then lint a
+specific Dockerfile with the arguments that target supplies:
 
 ```sh
-docker buildx build --check -f util/dockerfiles/clang-compiler/Dockerfile .
-docker buildx build --check -f util/dockerfiles/gcc-compiler/Dockerfile .
+docker buildx bake --print clang-version-19
+docker buildx build --check --build-arg version=19 \
+    -f clang-compiler/Dockerfile clang-compiler
+docker buildx bake --print gcc-version-14
+docker buildx build --check --build-arg version=14 \
+    -f gcc-compiler/Dockerfile gcc-compiler
 git diff --check
 ```
+
+Replace the example versions with the targets being changed. `--check` parses
+and lints the Dockerfile; it does not prove that packages install or that gem5
+builds in the image. Build the affected target and run a focused gem5 build
+when those behaviors are in scope.
 
 Avoid changing `gem5/ext/` to enforce dependency policy.


### PR DESCRIPTION
Add and refine AGENTS.md guidance for AI-assisted gem5 development.

The new guidance documents repository-wide expectations for dependency policy, testing, CI reproduction, licensing, commit/PR conventions, and research sources. It also adds scoped notes for configs, stdlib Python, memory-system work, ISA generation, CPU models, SCons, build tools, Dockerfiles, tests, GitHub workflows, and Ruby coherence protocols.

These notes are intended to help agents choose the right source files, avoid generated build outputs, preserve stdlib compatibility, reproduce CI failures in the correct Docker environments, and route changes through the appropriate gem5 subsystem conventions.