### PR TITLE
arch-riscv: fix vlseg/vsseg reg-group check for fractional LMUL

### DIFF
--- a/src/arch/riscv/isa/templates/vector_mem.isa
+++ b/src/arch/riscv/isa/templates/vector_mem.isa
@@ -1527,9 +1527,9 @@ Fault
     if (update_fault != NoFault) { return update_fault; }
 
 
-    const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-    if (((1 << vlmul) * this->numFields) > 8)
-        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vlseg inst", machInst);
+    if (vtype_regs_per_group(machInst.vtype8) * this->numFields > 8)
+        return std::make_shared<IllegalInstFault>(
+            "LMUL value is illegal for vlseg inst", machInst);
 
 
     if(!machInst.vm) {
@@ -1581,9 +1581,9 @@ Fault
     Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
     if (update_fault != NoFault) { return update_fault; }
 
-    const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-    if (((1 << vlmul) * this->numFields) > 8)
-        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vlseg inst", machInst);
+    if (vtype_regs_per_group(machInst.vtype8) * this->numFields > 8)
+        return std::make_shared<IllegalInstFault>(
+            "LMUL value is illegal for vlseg inst", machInst);
 
     const std::vector<bool> byte_enable(mem_size, true);
     Fault fault = initiateMemRead(xc, EA, mem_size, memAccessFlags,
@@ -1799,9 +1799,9 @@ Fault
     %(op_rd)s;
     %(ea_code)s;
 
-    const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-    if (((1 << vlmul) * this->numFields) > 8)
-        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vsseg inst", machInst);
+    if (vtype_regs_per_group(machInst.vtype8) * this->numFields > 8)
+        return std::make_shared<IllegalInstFault>(
+            "LMUL value is illegal for vsseg inst", machInst);
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
 
@@ -1854,9 +1854,9 @@ Fault
     %(op_rd)s;
     %(ea_code)s;
 
-    const int64_t vlmul = vtype_vlmul(machInst.vtype8);
-    if (((1 << vlmul) * this->numFields) > 8)
-        return std::make_shared<IllegalInstFault>("LMUL value is illegal for vsseg inst", machInst);
+    if (vtype_regs_per_group(machInst.vtype8) * this->numFields > 8)
+        return std::make_shared<IllegalInstFault>(
+            "LMUL value is illegal for vsseg inst", machInst);
 
     const size_t micro_vlmax = vlen / width_EEW(machInst.width);
 


### PR DESCRIPTION
The unit-stride segment load/store templates checked the number of vector registers occupied by the instruction with
`(1 << vlmul) * numFields`, where `vlmul` is the sign-extended vtype LMUL field returned by `vtype_vlmul()`.

For fractional LMUL settings (LMUL = 1/2, 1/4, 1/8) `vtype_vlmul()` returns a negative value (-1, -2, -3). Using it as a left-shift amount in `1 << vlmul` is undefined behaviour and in practice produces a huge value, so the `> 8` guard wrongly rejects perfectly legal segment accesses as illegal instructions.

Use the existing `vtype_regs_per_group()` helper instead, which clamps the effective register multiplier to a minimum of 1 for fractional LMUL, matching the RVV specification requirement that a segment instruction occupies at most 8 vector registers. This fixes spurious IllegalInstFault (previously panic) on code compiled with -march=rv64gcv, e.g. the RVV kernels emitted by llama.cpp/ggml.