### PR TITLE
build: Add LoongArch host build support

### DIFF
--- a/ext/libelf/elfdefinitions.h
+++ b/ext/libelf/elfdefinitions.h
@@ -558,265 +558,227 @@ enum {
 /*
  * ELF Machine types: (EM_*).
  */
-#define	_ELF_DEFINE_ELF_MACHINES()					\
-_ELF_DEFINE_EM(EM_NONE,             0, "No machine")			\
-_ELF_DEFINE_EM(EM_M32,              1, "AT&T WE 32100")			\
-_ELF_DEFINE_EM(EM_SPARC,            2, "SPARC")				\
-_ELF_DEFINE_EM(EM_386,              3, "Intel 80386")			\
-_ELF_DEFINE_EM(EM_68K,              4, "Motorola 68000")		\
-_ELF_DEFINE_EM(EM_88K,              5, "Motorola 88000")		\
-_ELF_DEFINE_EM(EM_IAMCU,            6, "Intel MCU")			\
-_ELF_DEFINE_EM(EM_860,              7, "Intel 80860")			\
-_ELF_DEFINE_EM(EM_MIPS,             8, "MIPS I Architecture")		\
-_ELF_DEFINE_EM(EM_S370,             9, "IBM System/370 Processor")	\
-_ELF_DEFINE_EM(EM_MIPS_RS3_LE,      10, "MIPS RS3000 Little-endian")	\
-_ELF_DEFINE_EM(EM_SPARC64,          11, "SPARC64")				\
-_ELF_DEFINE_EM(EM_PARISC,           15, "Hewlett-Packard PA-RISC")	\
-_ELF_DEFINE_EM(EM_VPP500,           17, "Fujitsu VPP500")		\
-_ELF_DEFINE_EM(EM_SPARC32PLUS,      18,					\
-	"Enhanced instruction set SPARC")				\
-_ELF_DEFINE_EM(EM_960,              19, "Intel 80960")			\
-_ELF_DEFINE_EM(EM_PPC,              20, "PowerPC")			\
-_ELF_DEFINE_EM(EM_PPC64,            21, "64-bit PowerPC")		\
-_ELF_DEFINE_EM(EM_S390,             22, "IBM System/390 Processor")	\
-_ELF_DEFINE_EM(EM_SPU,              23, "IBM SPU/SPC")			\
-_ELF_DEFINE_EM(EM_V800,             36, "NEC V800")			\
-_ELF_DEFINE_EM(EM_FR20,             37, "Fujitsu FR20")			\
-_ELF_DEFINE_EM(EM_RH32,             38, "TRW RH-32")			\
-_ELF_DEFINE_EM(EM_RCE,              39, "Motorola RCE")			\
-_ELF_DEFINE_EM(EM_ARM,              40, "Advanced RISC Machines ARM")	\
-_ELF_DEFINE_EM(EM_ALPHA,            41, "Digital Alpha")		\
-_ELF_DEFINE_EM(EM_SH,               42, "Hitachi SH")			\
-_ELF_DEFINE_EM(EM_SPARCV9,          43, "SPARC Version 9")		\
-_ELF_DEFINE_EM(EM_TRICORE,          44,					\
-	"Siemens TriCore embedded processor")				\
-_ELF_DEFINE_EM(EM_ARC,              45,					\
-	"Argonaut RISC Core, Argonaut Technologies Inc.")		\
-_ELF_DEFINE_EM(EM_H8_300,           46, "Hitachi H8/300")		\
-_ELF_DEFINE_EM(EM_H8_300H,          47, "Hitachi H8/300H")		\
-_ELF_DEFINE_EM(EM_H8S,              48, "Hitachi H8S")			\
-_ELF_DEFINE_EM(EM_H8_500,           49, "Hitachi H8/500")		\
-_ELF_DEFINE_EM(EM_IA_64,            50,					\
-	"Intel IA-64 processor architecture")				\
-_ELF_DEFINE_EM(EM_MIPS_X,           51, "Stanford MIPS-X")		\
-_ELF_DEFINE_EM(EM_COLDFIRE,         52, "Motorola ColdFire")		\
-_ELF_DEFINE_EM(EM_68HC12,           53, "Motorola M68HC12")		\
-_ELF_DEFINE_EM(EM_MMA,              54,					\
-	"Fujitsu MMA Multimedia Accelerator")				\
-_ELF_DEFINE_EM(EM_PCP,              55, "Siemens PCP")			\
-_ELF_DEFINE_EM(EM_NCPU,             56,					\
-	"Sony nCPU embedded RISC processor")				\
-_ELF_DEFINE_EM(EM_NDR1,             57, "Denso NDR1 microprocessor")	\
-_ELF_DEFINE_EM(EM_STARCORE,         58, "Motorola Star*Core processor")	\
-_ELF_DEFINE_EM(EM_ME16,             59, "Toyota ME16 processor")	\
-_ELF_DEFINE_EM(EM_ST100,            60,					\
-	"STMicroelectronics ST100 processor")				\
-_ELF_DEFINE_EM(EM_TINYJ,            61,					\
-	"Advanced Logic Corp. TinyJ embedded processor family")		\
-_ELF_DEFINE_EM(EM_X86_64,           62, "AMD x86-64 architecture")	\
-_ELF_DEFINE_EM(EM_PDSP,             63, "Sony DSP Processor")		\
-_ELF_DEFINE_EM(EM_PDP10,            64,					\
-	"Digital Equipment Corp. PDP-10")				\
-_ELF_DEFINE_EM(EM_PDP11,            65,					\
-	"Digital Equipment Corp. PDP-11")				\
-_ELF_DEFINE_EM(EM_FX66,             66, "Siemens FX66 microcontroller")	\
-_ELF_DEFINE_EM(EM_ST9PLUS,          67,					\
-	"STMicroelectronics ST9+ 8/16 bit microcontroller")		\
-_ELF_DEFINE_EM(EM_ST7,              68,					\
-	"STMicroelectronics ST7 8-bit microcontroller")			\
-_ELF_DEFINE_EM(EM_68HC16,           69,					\
-	"Motorola MC68HC16 Microcontroller")				\
-_ELF_DEFINE_EM(EM_68HC11,           70,					\
-	"Motorola MC68HC11 Microcontroller")				\
-_ELF_DEFINE_EM(EM_68HC08,           71,					\
-	"Motorola MC68HC08 Microcontroller")				\
-_ELF_DEFINE_EM(EM_68HC05,           72,					\
-	"Motorola MC68HC05 Microcontroller")				\
-_ELF_DEFINE_EM(EM_SVX,              73, "Silicon Graphics SVx")		\
-_ELF_DEFINE_EM(EM_ST19,             74,					\
-	"STMicroelectronics ST19 8-bit microcontroller")		\
-_ELF_DEFINE_EM(EM_VAX,              75, "Digital VAX")			\
-_ELF_DEFINE_EM(EM_CRIS,             76,					\
-	"Axis Communications 32-bit embedded processor")		\
-_ELF_DEFINE_EM(EM_JAVELIN,          77,					\
-	"Infineon Technologies 32-bit embedded processor")		\
-_ELF_DEFINE_EM(EM_FIREPATH,         78,					\
-	"Element 14 64-bit DSP Processor")				\
-_ELF_DEFINE_EM(EM_ZSP,              79,					\
-	"LSI Logic 16-bit DSP Processor")				\
-_ELF_DEFINE_EM(EM_MMIX,             80,					\
-	"Donald Knuth's educational 64-bit processor")			\
-_ELF_DEFINE_EM(EM_HUANY,            81,					\
-	"Harvard University machine-independent object files")		\
-_ELF_DEFINE_EM(EM_PRISM,            82, "SiTera Prism")			\
-_ELF_DEFINE_EM(EM_AVR,              83,					\
-	"Atmel AVR 8-bit microcontroller")				\
-_ELF_DEFINE_EM(EM_FR30,             84, "Fujitsu FR30")			\
-_ELF_DEFINE_EM(EM_D10V,             85, "Mitsubishi D10V")		\
-_ELF_DEFINE_EM(EM_D30V,             86, "Mitsubishi D30V")		\
-_ELF_DEFINE_EM(EM_V850,             87, "NEC v850")			\
-_ELF_DEFINE_EM(EM_M32R,             88, "Mitsubishi M32R")		\
-_ELF_DEFINE_EM(EM_MN10300,          89, "Matsushita MN10300")		\
-_ELF_DEFINE_EM(EM_MN10200,          90, "Matsushita MN10200")		\
-_ELF_DEFINE_EM(EM_PJ,               91, "picoJava")			\
-_ELF_DEFINE_EM(EM_OPENRISC,         92,					\
-	"OpenRISC 32-bit embedded processor")				\
-_ELF_DEFINE_EM(EM_ARC_COMPACT,      93,					\
-	"ARC International ARCompact processor")			\
-_ELF_DEFINE_EM(EM_XTENSA,           94,					\
-	"Tensilica Xtensa Architecture")				\
-_ELF_DEFINE_EM(EM_VIDEOCORE,        95,					\
-	"Alphamosaic VideoCore processor")				\
-_ELF_DEFINE_EM(EM_TMM_GPP,          96,					\
-	"Thompson Multimedia General Purpose Processor")		\
-_ELF_DEFINE_EM(EM_NS32K,            97,					\
-	"National Semiconductor 32000 series")				\
-_ELF_DEFINE_EM(EM_TPC,              98, "Tenor Network TPC processor")	\
-_ELF_DEFINE_EM(EM_SNP1K,            99, "Trebia SNP 1000 processor")	\
-_ELF_DEFINE_EM(EM_ST200,            100,				\
-	"STMicroelectronics (www.st.com) ST200 microcontroller")	\
-_ELF_DEFINE_EM(EM_IP2K,             101,				\
-	"Ubicom IP2xxx microcontroller family")				\
-_ELF_DEFINE_EM(EM_MAX,              102, "MAX Processor")		\
-_ELF_DEFINE_EM(EM_CR,               103,				\
-	"National Semiconductor CompactRISC microprocessor")		\
-_ELF_DEFINE_EM(EM_F2MC16,           104, "Fujitsu F2MC16")		\
-_ELF_DEFINE_EM(EM_MSP430,           105,				\
-	"Texas Instruments embedded microcontroller msp430")		\
-_ELF_DEFINE_EM(EM_BLACKFIN,         106,				\
-	"Analog Devices Blackfin (DSP) processor")			\
-_ELF_DEFINE_EM(EM_SE_C33,           107,				\
-	"S1C33 Family of Seiko Epson processors")			\
-_ELF_DEFINE_EM(EM_SEP,              108,				\
-	"Sharp embedded microprocessor")				\
-_ELF_DEFINE_EM(EM_ARCA,             109, "Arca RISC Microprocessor")	\
-_ELF_DEFINE_EM(EM_UNICORE,          110,				\
-	"Microprocessor series from PKU-Unity Ltd. and MPRC of Peking University") \
-_ELF_DEFINE_EM(EM_EXCESS,           111,				\
-	"eXcess: 16/32/64-bit configurable embedded CPU")		\
-_ELF_DEFINE_EM(EM_DXP,              112,				\
-	"Icera Semiconductor Inc. Deep Execution Processor")		\
-_ELF_DEFINE_EM(EM_ALTERA_NIOS2,     113,				\
-	"Altera Nios II soft-core processor")				\
-_ELF_DEFINE_EM(EM_CRX,              114,				\
-	"National Semiconductor CompactRISC CRX microprocessor")	\
-_ELF_DEFINE_EM(EM_XGATE,            115,				\
-	"Motorola XGATE embedded processor")				\
-_ELF_DEFINE_EM(EM_C166,             116,				\
-	"Infineon C16x/XC16x processor")				\
-_ELF_DEFINE_EM(EM_M16C,             117,				\
-	"Renesas M16C series microprocessors")				\
-_ELF_DEFINE_EM(EM_DSPIC30F,         118,				\
-	"Microchip Technology dsPIC30F Digital Signal Controller")	\
-_ELF_DEFINE_EM(EM_CE,               119,				\
-	"Freescale Communication Engine RISC core")			\
-_ELF_DEFINE_EM(EM_M32C,             120,				\
-	"Renesas M32C series microprocessors")				\
-_ELF_DEFINE_EM(EM_TSK3000,          131, "Altium TSK3000 core")		\
-_ELF_DEFINE_EM(EM_RS08,             132,				\
-	"Freescale RS08 embedded processor")				\
-_ELF_DEFINE_EM(EM_SHARC,            133,				\
-	"Analog Devices SHARC family of 32-bit DSP processors")		\
-_ELF_DEFINE_EM(EM_ECOG2,            134,				\
-	"Cyan Technology eCOG2 microprocessor")				\
-_ELF_DEFINE_EM(EM_SCORE7,           135,				\
-	"Sunplus S+core7 RISC processor")				\
-_ELF_DEFINE_EM(EM_DSP24,            136,				\
-	"New Japan Radio (NJR) 24-bit DSP Processor")			\
-_ELF_DEFINE_EM(EM_VIDEOCORE3,       137,				\
-	"Broadcom VideoCore III processor")				\
-_ELF_DEFINE_EM(EM_LATTICEMICO32,    138,				\
-	"RISC processor for Lattice FPGA architecture")			\
-_ELF_DEFINE_EM(EM_SE_C17,           139, "Seiko Epson C17 family")	\
-_ELF_DEFINE_EM(EM_TI_C6000,         140,				\
-	"The Texas Instruments TMS320C6000 DSP family")			\
-_ELF_DEFINE_EM(EM_TI_C2000,         141,				\
-	"The Texas Instruments TMS320C2000 DSP family")			\
-_ELF_DEFINE_EM(EM_TI_C5500,         142,				\
-	"The Texas Instruments TMS320C55x DSP family")			\
-_ELF_DEFINE_EM(EM_MMDSP_PLUS,       160,				\
-	"STMicroelectronics 64bit VLIW Data Signal Processor")		\
-_ELF_DEFINE_EM(EM_CYPRESS_M8C,      161, "Cypress M8C microprocessor")	\
-_ELF_DEFINE_EM(EM_R32C,             162,				\
-	"Renesas R32C series microprocessors")				\
-_ELF_DEFINE_EM(EM_TRIMEDIA,         163,				\
-	"NXP Semiconductors TriMedia architecture family")		\
-_ELF_DEFINE_EM(EM_QDSP6,            164, "QUALCOMM DSP6 Processor")	\
-_ELF_DEFINE_EM(EM_8051,             165, "Intel 8051 and variants")	\
-_ELF_DEFINE_EM(EM_STXP7X,           166,				\
-	"STMicroelectronics STxP7x family of configurable and extensible RISC processors") \
-_ELF_DEFINE_EM(EM_NDS32,            167,				\
-	"Andes Technology compact code size embedded RISC processor family") \
-_ELF_DEFINE_EM(EM_ECOG1,            168,				\
-	"Cyan Technology eCOG1X family")				\
-_ELF_DEFINE_EM(EM_ECOG1X,           168,				\
-	"Cyan Technology eCOG1X family")				\
-_ELF_DEFINE_EM(EM_MAXQ30,           169,				\
-	"Dallas Semiconductor MAXQ30 Core Micro-controllers")		\
-_ELF_DEFINE_EM(EM_XIMO16,           170,				\
-	"New Japan Radio (NJR) 16-bit DSP Processor")			\
-_ELF_DEFINE_EM(EM_MANIK,            171,				\
-	"M2000 Reconfigurable RISC Microprocessor")			\
-_ELF_DEFINE_EM(EM_CRAYNV2,          172,				\
-	"Cray Inc. NV2 vector architecture")				\
-_ELF_DEFINE_EM(EM_RX,               173, "Renesas RX family")		\
-_ELF_DEFINE_EM(EM_METAG,            174,				\
-	"Imagination Technologies META processor architecture")		\
-_ELF_DEFINE_EM(EM_MCST_ELBRUS,      175,				\
-	"MCST Elbrus general purpose hardware architecture")		\
-_ELF_DEFINE_EM(EM_ECOG16,           176,				\
-	"Cyan Technology eCOG16 family")				\
-_ELF_DEFINE_EM(EM_CR16,             177,				\
-	"National Semiconductor CompactRISC CR16 16-bit microprocessor") \
-_ELF_DEFINE_EM(EM_ETPU,             178,				\
-	"Freescale Extended Time Processing Unit")			\
-_ELF_DEFINE_EM(EM_SLE9X,            179,				\
-	"Infineon Technologies SLE9X core")				\
-_ELF_DEFINE_EM(EM_AARCH64,          183,				\
-	"AArch64 (64-bit ARM)")						\
-_ELF_DEFINE_EM(EM_AVR32,            185,				\
-	"Atmel Corporation 32-bit microprocessor family")		\
-_ELF_DEFINE_EM(EM_STM8,             186,				\
-	"STMicroeletronics STM8 8-bit microcontroller")			\
-_ELF_DEFINE_EM(EM_TILE64,           187,				\
-	"Tilera TILE64 multicore architecture family")			\
-_ELF_DEFINE_EM(EM_TILEPRO,          188,				\
-	"Tilera TILEPro multicore architecture family")			\
-_ELF_DEFINE_EM(EM_MICROBLAZE,       189,				\
-	"Xilinx MicroBlaze 32-bit RISC soft processor core")		\
-_ELF_DEFINE_EM(EM_CUDA,             190, "NVIDIA CUDA architecture")	\
-_ELF_DEFINE_EM(EM_TILEGX,           191,				\
-	"Tilera TILE-Gx multicore architecture family")			\
-_ELF_DEFINE_EM(EM_CLOUDSHIELD,      192,				\
-	"CloudShield architecture family")				\
-_ELF_DEFINE_EM(EM_COREA_1ST,        193,				\
-	"KIPO-KAIST Core-A 1st generation processor family")		\
-_ELF_DEFINE_EM(EM_COREA_2ND,        194,				\
-	"KIPO-KAIST Core-A 2nd generation processor family")		\
-_ELF_DEFINE_EM(EM_ARC_COMPACT2,     195, "Synopsys ARCompact V2")	\
-_ELF_DEFINE_EM(EM_OPEN8,            196,				\
-	"Open8 8-bit RISC soft processor core")				\
-_ELF_DEFINE_EM(EM_RL78,             197, "Renesas RL78 family")		\
-_ELF_DEFINE_EM(EM_VIDEOCORE5,       198, "Broadcom VideoCore V processor") \
-_ELF_DEFINE_EM(EM_78KOR,            199, "Renesas 78KOR family")	\
-_ELF_DEFINE_EM(EM_56800EX,          200,				\
-	"Freescale 56800EX Digital Signal Controller")			\
-_ELF_DEFINE_EM(EM_BA1,              201, "Beyond BA1 CPU architecture")	\
-_ELF_DEFINE_EM(EM_BA2,              202, "Beyond BA2 CPU architecture")	\
-_ELF_DEFINE_EM(EM_XCORE,            203, "XMOS xCORE processor family") \
-_ELF_DEFINE_EM(EM_MCHP_PIC,         204, "Microchip 8-bit PIC(r) family") \
-_ELF_DEFINE_EM(EM_INTEL205,         205, "Reserved by Intel")           \
-_ELF_DEFINE_EM(EM_INTEL206,         206, "Reserved by Intel")           \
-_ELF_DEFINE_EM(EM_INTEL207,         207, "Reserved by Intel")           \
-_ELF_DEFINE_EM(EM_INTEL208,         208, "Reserved by Intel")           \
-_ELF_DEFINE_EM(EM_INTEL209,         209, "Reserved by Intel")           \
-_ELF_DEFINE_EM(EM_KM32,             210, "KM211 KM32 32-bit processor") \
-_ELF_DEFINE_EM(EM_KMX32,            211, "KM211 KMX32 32-bit processor") \
-_ELF_DEFINE_EM(EM_KMX16,            212, "KM211 KMX16 16-bit processor") \
-_ELF_DEFINE_EM(EM_KMX8,             213, "KM211 KMX8 8-bit processor")  \
-_ELF_DEFINE_EM(EM_KVARC,            214, "KM211 KMX32 KVARC processor") \
-_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V") \
-_ELF_DEFINE_EM(EM_LOONGARCH,        258, "LoongArch")
+#define _ELF_DEFINE_ELF_MACHINES()                                            \
+    _ELF_DEFINE_EM(EM_NONE, 0, "No machine")                                  \
+    _ELF_DEFINE_EM(EM_M32, 1, "AT&T WE 32100")                                \
+    _ELF_DEFINE_EM(EM_SPARC, 2, "SPARC")                                      \
+    _ELF_DEFINE_EM(EM_386, 3, "Intel 80386")                                  \
+    _ELF_DEFINE_EM(EM_68K, 4, "Motorola 68000")                               \
+    _ELF_DEFINE_EM(EM_88K, 5, "Motorola 88000")                               \
+    _ELF_DEFINE_EM(EM_IAMCU, 6, "Intel MCU")                                  \
+    _ELF_DEFINE_EM(EM_860, 7, "Intel 80860")                                  \
+    _ELF_DEFINE_EM(EM_MIPS, 8, "MIPS I Architecture")                         \
+    _ELF_DEFINE_EM(EM_S370, 9, "IBM System/370 Processor")                    \
+    _ELF_DEFINE_EM(EM_MIPS_RS3_LE, 10, "MIPS RS3000 Little-endian")           \
+    _ELF_DEFINE_EM(EM_SPARC64, 11, "SPARC64")                                 \
+    _ELF_DEFINE_EM(EM_PARISC, 15, "Hewlett-Packard PA-RISC")                  \
+    _ELF_DEFINE_EM(EM_VPP500, 17, "Fujitsu VPP500")                           \
+    _ELF_DEFINE_EM(EM_SPARC32PLUS, 18, "Enhanced instruction set SPARC")      \
+    _ELF_DEFINE_EM(EM_960, 19, "Intel 80960")                                 \
+    _ELF_DEFINE_EM(EM_PPC, 20, "PowerPC")                                     \
+    _ELF_DEFINE_EM(EM_PPC64, 21, "64-bit PowerPC")                            \
+    _ELF_DEFINE_EM(EM_S390, 22, "IBM System/390 Processor")                   \
+    _ELF_DEFINE_EM(EM_SPU, 23, "IBM SPU/SPC")                                 \
+    _ELF_DEFINE_EM(EM_V800, 36, "NEC V800")                                   \
+    _ELF_DEFINE_EM(EM_FR20, 37, "Fujitsu FR20")                               \
+    _ELF_DEFINE_EM(EM_RH32, 38, "TRW RH-32")                                  \
+    _ELF_DEFINE_EM(EM_RCE, 39, "Motorola RCE")                                \
+    _ELF_DEFINE_EM(EM_ARM, 40, "Advanced RISC Machines ARM")                  \
+    _ELF_DEFINE_EM(EM_ALPHA, 41, "Digital Alpha")                             \
+    _ELF_DEFINE_EM(EM_SH, 42, "Hitachi SH")                                   \
+    _ELF_DEFINE_EM(EM_SPARCV9, 43, "SPARC Version 9")                         \
+    _ELF_DEFINE_EM(EM_TRICORE, 44, "Siemens TriCore embedded processor")      \
+    _ELF_DEFINE_EM(EM_ARC, 45,                                                \
+                   "Argonaut RISC Core, Argonaut Technologies Inc.")          \
+    _ELF_DEFINE_EM(EM_H8_300, 46, "Hitachi H8/300")                           \
+    _ELF_DEFINE_EM(EM_H8_300H, 47, "Hitachi H8/300H")                         \
+    _ELF_DEFINE_EM(EM_H8S, 48, "Hitachi H8S")                                 \
+    _ELF_DEFINE_EM(EM_H8_500, 49, "Hitachi H8/500")                           \
+    _ELF_DEFINE_EM(EM_IA_64, 50, "Intel IA-64 processor architecture")        \
+    _ELF_DEFINE_EM(EM_MIPS_X, 51, "Stanford MIPS-X")                          \
+    _ELF_DEFINE_EM(EM_COLDFIRE, 52, "Motorola ColdFire")                      \
+    _ELF_DEFINE_EM(EM_68HC12, 53, "Motorola M68HC12")                         \
+    _ELF_DEFINE_EM(EM_MMA, 54, "Fujitsu MMA Multimedia Accelerator")          \
+    _ELF_DEFINE_EM(EM_PCP, 55, "Siemens PCP")                                 \
+    _ELF_DEFINE_EM(EM_NCPU, 56, "Sony nCPU embedded RISC processor")          \
+    _ELF_DEFINE_EM(EM_NDR1, 57, "Denso NDR1 microprocessor")                  \
+    _ELF_DEFINE_EM(EM_STARCORE, 58, "Motorola Star*Core processor")           \
+    _ELF_DEFINE_EM(EM_ME16, 59, "Toyota ME16 processor")                      \
+    _ELF_DEFINE_EM(EM_ST100, 60, "STMicroelectronics ST100 processor")        \
+    _ELF_DEFINE_EM(EM_TINYJ, 61,                                              \
+                   "Advanced Logic Corp. TinyJ embedded processor family")    \
+    _ELF_DEFINE_EM(EM_X86_64, 62, "AMD x86-64 architecture")                  \
+    _ELF_DEFINE_EM(EM_PDSP, 63, "Sony DSP Processor")                         \
+    _ELF_DEFINE_EM(EM_PDP10, 64, "Digital Equipment Corp. PDP-10")            \
+    _ELF_DEFINE_EM(EM_PDP11, 65, "Digital Equipment Corp. PDP-11")            \
+    _ELF_DEFINE_EM(EM_FX66, 66, "Siemens FX66 microcontroller")               \
+    _ELF_DEFINE_EM(EM_ST9PLUS, 67,                                            \
+                   "STMicroelectronics ST9+ 8/16 bit microcontroller")        \
+    _ELF_DEFINE_EM(EM_ST7, 68,                                                \
+                   "STMicroelectronics ST7 8-bit microcontroller")            \
+    _ELF_DEFINE_EM(EM_68HC16, 69, "Motorola MC68HC16 Microcontroller")        \
+    _ELF_DEFINE_EM(EM_68HC11, 70, "Motorola MC68HC11 Microcontroller")        \
+    _ELF_DEFINE_EM(EM_68HC08, 71, "Motorola MC68HC08 Microcontroller")        \
+    _ELF_DEFINE_EM(EM_68HC05, 72, "Motorola MC68HC05 Microcontroller")        \
+    _ELF_DEFINE_EM(EM_SVX, 73, "Silicon Graphics SVx")                        \
+    _ELF_DEFINE_EM(EM_ST19, 74,                                               \
+                   "STMicroelectronics ST19 8-bit microcontroller")           \
+    _ELF_DEFINE_EM(EM_VAX, 75, "Digital VAX")                                 \
+    _ELF_DEFINE_EM(EM_CRIS, 76,                                               \
+                   "Axis Communications 32-bit embedded processor")           \
+    _ELF_DEFINE_EM(EM_JAVELIN, 77,                                            \
+                   "Infineon Technologies 32-bit embedded processor")         \
+    _ELF_DEFINE_EM(EM_FIREPATH, 78, "Element 14 64-bit DSP Processor")        \
+    _ELF_DEFINE_EM(EM_ZSP, 79, "LSI Logic 16-bit DSP Processor")              \
+    _ELF_DEFINE_EM(EM_MMIX, 80,                                               \
+                   "Donald Knuth's educational 64-bit processor")             \
+    _ELF_DEFINE_EM(EM_HUANY, 81,                                              \
+                   "Harvard University machine-independent object files")     \
+    _ELF_DEFINE_EM(EM_PRISM, 82, "SiTera Prism")                              \
+    _ELF_DEFINE_EM(EM_AVR, 83, "Atmel AVR 8-bit microcontroller")             \
+    _ELF_DEFINE_EM(EM_FR30, 84, "Fujitsu FR30")                               \
+    _ELF_DEFINE_EM(EM_D10V, 85, "Mitsubishi D10V")                            \
+    _ELF_DEFINE_EM(EM_D30V, 86, "Mitsubishi D30V")                            \
+    _ELF_DEFINE_EM(EM_V850, 87, "NEC v850")                                   \
+    _ELF_DEFINE_EM(EM_M32R, 88, "Mitsubishi M32R")                            \
+    _ELF_DEFINE_EM(EM_MN10300, 89, "Matsushita MN10300")                      \
+    _ELF_DEFINE_EM(EM_MN10200, 90, "Matsushita MN10200")                      \
+    _ELF_DEFINE_EM(EM_PJ, 91, "picoJava")                                     \
+    _ELF_DEFINE_EM(EM_OPENRISC, 92, "OpenRISC 32-bit embedded processor")     \
+    _ELF_DEFINE_EM(EM_ARC_COMPACT, 93,                                        \
+                   "ARC International ARCompact processor")                   \
+    _ELF_DEFINE_EM(EM_XTENSA, 94, "Tensilica Xtensa Architecture")            \
+    _ELF_DEFINE_EM(EM_VIDEOCORE, 95, "Alphamosaic VideoCore processor")       \
+    _ELF_DEFINE_EM(EM_TMM_GPP, 96,                                            \
+                   "Thompson Multimedia General Purpose Processor")           \
+    _ELF_DEFINE_EM(EM_NS32K, 97, "National Semiconductor 32000 series")       \
+    _ELF_DEFINE_EM(EM_TPC, 98, "Tenor Network TPC processor")                 \
+    _ELF_DEFINE_EM(EM_SNP1K, 99, "Trebia SNP 1000 processor")                 \
+    _ELF_DEFINE_EM(EM_ST200, 100,                                             \
+                   "STMicroelectronics (www.st.com) ST200 microcontroller")   \
+    _ELF_DEFINE_EM(EM_IP2K, 101, "Ubicom IP2xxx microcontroller family")      \
+    _ELF_DEFINE_EM(EM_MAX, 102, "MAX Processor")                              \
+    _ELF_DEFINE_EM(EM_CR, 103,                                                \
+                   "National Semiconductor CompactRISC microprocessor")       \
+    _ELF_DEFINE_EM(EM_F2MC16, 104, "Fujitsu F2MC16")                          \
+    _ELF_DEFINE_EM(EM_MSP430, 105,                                            \
+                   "Texas Instruments embedded microcontroller msp430")       \
+    _ELF_DEFINE_EM(EM_BLACKFIN, 106,                                          \
+                   "Analog Devices Blackfin (DSP) processor")                 \
+    _ELF_DEFINE_EM(EM_SE_C33, 107, "S1C33 Family of Seiko Epson processors")  \
+    _ELF_DEFINE_EM(EM_SEP, 108, "Sharp embedded microprocessor")              \
+    _ELF_DEFINE_EM(EM_ARCA, 109, "Arca RISC Microprocessor")                  \
+    _ELF_DEFINE_EM(EM_UNICORE, 110,                                           \
+                   "Microprocessor series from PKU-Unity Ltd. and MPRC of "   \
+                   "Peking University")                                       \
+    _ELF_DEFINE_EM(EM_EXCESS, 111,                                            \
+                   "eXcess: 16/32/64-bit configurable embedded CPU")          \
+    _ELF_DEFINE_EM(EM_DXP, 112,                                               \
+                   "Icera Semiconductor Inc. Deep Execution Processor")       \
+    _ELF_DEFINE_EM(EM_ALTERA_NIOS2, 113,                                      \
+                   "Altera Nios II soft-core processor")                      \
+    _ELF_DEFINE_EM(EM_CRX, 114,                                               \
+                   "National Semiconductor CompactRISC CRX microprocessor")   \
+    _ELF_DEFINE_EM(EM_XGATE, 115, "Motorola XGATE embedded processor")        \
+    _ELF_DEFINE_EM(EM_C166, 116, "Infineon C16x/XC16x processor")             \
+    _ELF_DEFINE_EM(EM_M16C, 117, "Renesas M16C series microprocessors")       \
+    _ELF_DEFINE_EM(EM_DSPIC30F, 118,                                          \
+                   "Microchip Technology dsPIC30F Digital Signal Controller") \
+    _ELF_DEFINE_EM(EM_CE, 119, "Freescale Communication Engine RISC core")    \
+    _ELF_DEFINE_EM(EM_M32C, 120, "Renesas M32C series microprocessors")       \
+    _ELF_DEFINE_EM(EM_TSK3000, 131, "Altium TSK3000 core")                    \
+    _ELF_DEFINE_EM(EM_RS08, 132, "Freescale RS08 embedded processor")         \
+    _ELF_DEFINE_EM(EM_SHARC, 133,                                             \
+                   "Analog Devices SHARC family of 32-bit DSP processors")    \
+    _ELF_DEFINE_EM(EM_ECOG2, 134, "Cyan Technology eCOG2 microprocessor")     \
+    _ELF_DEFINE_EM(EM_SCORE7, 135, "Sunplus S+core7 RISC processor")          \
+    _ELF_DEFINE_EM(EM_DSP24, 136,                                             \
+                   "New Japan Radio (NJR) 24-bit DSP Processor")              \
+    _ELF_DEFINE_EM(EM_VIDEOCORE3, 137, "Broadcom VideoCore III processor")    \
+    _ELF_DEFINE_EM(EM_LATTICEMICO32, 138,                                     \
+                   "RISC processor for Lattice FPGA architecture")            \
+    _ELF_DEFINE_EM(EM_SE_C17, 139, "Seiko Epson C17 family")                  \
+    _ELF_DEFINE_EM(EM_TI_C6000, 140,                                          \
+                   "The Texas Instruments TMS320C6000 DSP family")            \
+    _ELF_DEFINE_EM(EM_TI_C2000, 141,                                          \
+                   "The Texas Instruments TMS320C2000 DSP family")            \
+    _ELF_DEFINE_EM(EM_TI_C5500, 142,                                          \
+                   "The Texas Instruments TMS320C55x DSP family")             \
+    _ELF_DEFINE_EM(EM_MMDSP_PLUS, 160,                                        \
+                   "STMicroelectronics 64bit VLIW Data Signal Processor")     \
+    _ELF_DEFINE_EM(EM_CYPRESS_M8C, 161, "Cypress M8C microprocessor")         \
+    _ELF_DEFINE_EM(EM_R32C, 162, "Renesas R32C series microprocessors")       \
+    _ELF_DEFINE_EM(EM_TRIMEDIA, 163,                                          \
+                   "NXP Semiconductors TriMedia architecture family")         \
+    _ELF_DEFINE_EM(EM_QDSP6, 164, "QUALCOMM DSP6 Processor")                  \
+    _ELF_DEFINE_EM(EM_8051, 165, "Intel 8051 and variants")                   \
+    _ELF_DEFINE_EM(EM_STXP7X, 166,                                            \
+                   "STMicroelectronics STxP7x family of configurable and "    \
+                   "extensible RISC processors")                              \
+    _ELF_DEFINE_EM(                                                           \
+        EM_NDS32, 167,                                                        \
+        "Andes Technology compact code size embedded RISC processor family")  \
+    _ELF_DEFINE_EM(EM_ECOG1, 168, "Cyan Technology eCOG1X family")            \
+    _ELF_DEFINE_EM(EM_ECOG1X, 168, "Cyan Technology eCOG1X family")           \
+    _ELF_DEFINE_EM(EM_MAXQ30, 169,                                            \
+                   "Dallas Semiconductor MAXQ30 Core Micro-controllers")      \
+    _ELF_DEFINE_EM(EM_XIMO16, 170,                                            \
+                   "New Japan Radio (NJR) 16-bit DSP Processor")              \
+    _ELF_DEFINE_EM(EM_MANIK, 171, "M2000 Reconfigurable RISC Microprocessor") \
+    _ELF_DEFINE_EM(EM_CRAYNV2, 172, "Cray Inc. NV2 vector architecture")      \
+    _ELF_DEFINE_EM(EM_RX, 173, "Renesas RX family")                           \
+    _ELF_DEFINE_EM(EM_METAG, 174,                                             \
+                   "Imagination Technologies META processor architecture")    \
+    _ELF_DEFINE_EM(EM_MCST_ELBRUS, 175,                                       \
+                   "MCST Elbrus general purpose hardware architecture")       \
+    _ELF_DEFINE_EM(EM_ECOG16, 176, "Cyan Technology eCOG16 family")           \
+    _ELF_DEFINE_EM(                                                           \
+        EM_CR16, 177,                                                         \
+        "National Semiconductor CompactRISC CR16 16-bit microprocessor")      \
+    _ELF_DEFINE_EM(EM_ETPU, 178, "Freescale Extended Time Processing Unit")   \
+    _ELF_DEFINE_EM(EM_SLE9X, 179, "Infineon Technologies SLE9X core")         \
+    _ELF_DEFINE_EM(EM_AARCH64, 183, "AArch64 (64-bit ARM)")                   \
+    _ELF_DEFINE_EM(EM_AVR32, 185,                                             \
+                   "Atmel Corporation 32-bit microprocessor family")          \
+    _ELF_DEFINE_EM(EM_STM8, 186,                                              \
+                   "STMicroeletronics STM8 8-bit microcontroller")            \
+    _ELF_DEFINE_EM(EM_TILE64, 187,                                            \
+                   "Tilera TILE64 multicore architecture family")             \
+    _ELF_DEFINE_EM(EM_TILEPRO, 188,                                           \
+                   "Tilera TILEPro multicore architecture family")            \
+    _ELF_DEFINE_EM(EM_MICROBLAZE, 189,                                        \
+                   "Xilinx MicroBlaze 32-bit RISC soft processor core")       \
+    _ELF_DEFINE_EM(EM_CUDA, 190, "NVIDIA CUDA architecture")                  \
+    _ELF_DEFINE_EM(EM_TILEGX, 191,                                            \
+                   "Tilera TILE-Gx multicore architecture family")            \
+    _ELF_DEFINE_EM(EM_CLOUDSHIELD, 192, "CloudShield architecture family")    \
+    _ELF_DEFINE_EM(EM_COREA_1ST, 193,                                         \
+                   "KIPO-KAIST Core-A 1st generation processor family")       \
+    _ELF_DEFINE_EM(EM_COREA_2ND, 194,                                         \
+                   "KIPO-KAIST Core-A 2nd generation processor family")       \
+    _ELF_DEFINE_EM(EM_ARC_COMPACT2, 195, "Synopsys ARCompact V2")             \
+    _ELF_DEFINE_EM(EM_OPEN8, 196, "Open8 8-bit RISC soft processor core")     \
+    _ELF_DEFINE_EM(EM_RL78, 197, "Renesas RL78 family")                       \
+    _ELF_DEFINE_EM(EM_VIDEOCORE5, 198, "Broadcom VideoCore V processor")      \
+    _ELF_DEFINE_EM(EM_78KOR, 199, "Renesas 78KOR family")                     \
+    _ELF_DEFINE_EM(EM_56800EX, 200,                                           \
+                   "Freescale 56800EX Digital Signal Controller")             \
+    _ELF_DEFINE_EM(EM_BA1, 201, "Beyond BA1 CPU architecture")                \
+    _ELF_DEFINE_EM(EM_BA2, 202, "Beyond BA2 CPU architecture")                \
+    _ELF_DEFINE_EM(EM_XCORE, 203, "XMOS xCORE processor family")              \
+    _ELF_DEFINE_EM(EM_MCHP_PIC, 204, "Microchip 8-bit PIC(r) family")         \
+    _ELF_DEFINE_EM(EM_INTEL205, 205, "Reserved by Intel")                     \
+    _ELF_DEFINE_EM(EM_INTEL206, 206, "Reserved by Intel")                     \
+    _ELF_DEFINE_EM(EM_INTEL207, 207, "Reserved by Intel")                     \
+    _ELF_DEFINE_EM(EM_INTEL208, 208, "Reserved by Intel")                     \
+    _ELF_DEFINE_EM(EM_INTEL209, 209, "Reserved by Intel")                     \
+    _ELF_DEFINE_EM(EM_KM32, 210, "KM211 KM32 32-bit processor")               \
+    _ELF_DEFINE_EM(EM_KMX32, 211, "KM211 KMX32 32-bit processor")             \
+    _ELF_DEFINE_EM(EM_KMX16, 212, "KM211 KMX16 16-bit processor")             \
+    _ELF_DEFINE_EM(EM_KMX8, 213, "KM211 KMX8 8-bit processor")                \
+    _ELF_DEFINE_EM(EM_KVARC, 214, "KM211 KMX32 KVARC processor")              \
+    _ELF_DEFINE_EM(EM_RISCV, 243, "RISC-V")                                   \
+    _ELF_DEFINE_EM(EM_LOONGARCH, 258, "LoongArch")
 
 #undef	_ELF_DEFINE_EM
 #define	_ELF_DEFINE_EM(N, V, DESCR)	N = V ,

--- a/ext/libelf/elfdefinitions.h
+++ b/ext/libelf/elfdefinitions.h
@@ -815,7 +815,8 @@ _ELF_DEFINE_EM(EM_KMX32,            211, "KM211 KMX32 32-bit processor") \
 _ELF_DEFINE_EM(EM_KMX16,            212, "KM211 KMX16 16-bit processor") \
 _ELF_DEFINE_EM(EM_KMX8,             213, "KM211 KMX8 8-bit processor")  \
 _ELF_DEFINE_EM(EM_KVARC,            214, "KM211 KMX32 KVARC processor") \
-_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V")
+_ELF_DEFINE_EM(EM_RISCV,            243, "RISC-V") \
+_ELF_DEFINE_EM(EM_LOONGARCH,        258, "LoongArch")
 
 #undef	_ELF_DEFINE_EM
 #define	_ELF_DEFINE_EM(N, V, DESCR)	N = V ,

--- a/ext/libelf/native-elf-format
+++ b/ext/libelf/native-elf-format
@@ -41,6 +41,8 @@ $1 ~ "Machine:" {
             elfarch = "EM_RISCV";
         } else if (match($0, "AArch64")) {
             elfarch = "EM_AARCH64";
+        } else if (match($0, "LoongArch")) {
+            elfarch = "EM_LOONGARCH";
         } else if (match($0, "ARM")) {
             elfarch = "EM_ARM";
         } else {

--- a/ext/libelf/native-elf-format
+++ b/ext/libelf/native-elf-format
@@ -54,4 +54,3 @@ END {
     printf("#define	ELFTC_ARCH	%s\n", elfarch);
     printf("#define	ELFTC_BYTEORDER	ELFDATA2%s\n", elfdata);
 }'
-

--- a/src/dev/hsa/hsa.h
+++ b/src/dev/hsa/hsa.h
@@ -79,7 +79,7 @@
 
 // Try to detect CPU endianness
 #if !defined(LITTLEENDIAN_CPU) && !defined(BIGENDIAN_CPU)
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || \
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) ||           \
     defined(_M_X64) || defined(__aarch64__) || defined(__loongarch__)
 #define LITTLEENDIAN_CPU
 #endif

--- a/src/dev/hsa/hsa.h
+++ b/src/dev/hsa/hsa.h
@@ -80,7 +80,7 @@
 // Try to detect CPU endianness
 #if !defined(LITTLEENDIAN_CPU) && !defined(BIGENDIAN_CPU)
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || \
-    defined(_M_X64) || defined(__aarch64__)
+    defined(_M_X64) || defined(__aarch64__) || defined(__loongarch__)
 #define LITTLEENDIAN_CPU
 #endif
 #endif

--- a/src/systemc/core/SConscript
+++ b/src/systemc/core/SConscript
@@ -74,6 +74,11 @@ if env['CONF']['USE_SYSTEMC']:
         Source('sc_time_python.cc', append=append)
 
     # Disable the false positive warning for the event members of the scheduler.
-    with gem5_scons.Configure(env) as conf:
-        flag = '-Wno-free-nonheap-object'
-        conf.CheckLinkFlag(flag)
+    flag = '-Wno-free-nonheap-object'
+    # Check whether the linker accepts the flag in an isolated environment so
+    # SCons does not build unrelated library targets during configuration.
+    flag_env = env.Clone()
+    flag_env.Replace(LIBS=[], LIBPATH=[])
+    with gem5_scons.Configure(flag_env) as conf:
+        if conf.CheckLinkFlag(flag, autoadd=False, set_for_shared=False):
+            env.Append(LINKFLAGS=[flag], SHLINKFLAGS=[flag])

--- a/src/systemc/ext/dt/int/sc_nbdefs.hh
+++ b/src/systemc/ext/dt/int/sc_nbdefs.hh
@@ -164,7 +164,7 @@ typedef unsigned int sc_digit; // 32-bit unsigned integer
 
 // Support for the long long type. This type is not in the standard
 // but is usually supported by compilers.
-#if defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__) || \
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__) ||  \
     defined(__loongarch64)
 typedef long long int64;
 typedef unsigned long long uint64;

--- a/src/systemc/ext/dt/int/sc_nbdefs.hh
+++ b/src/systemc/ext/dt/int/sc_nbdefs.hh
@@ -164,7 +164,8 @@ typedef unsigned int sc_digit; // 32-bit unsigned integer
 
 // Support for the long long type. This type is not in the standard
 // but is usually supported by compilers.
-#if defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__) || \
+    defined(__loongarch64)
 typedef long long int64;
 typedef unsigned long long uint64;
 #else

--- a/src/systemc/ext/utils/endian.hh
+++ b/src/systemc/ext/utils/endian.hh
@@ -68,7 +68,7 @@
    || defined(__amd64__) || defined(_M_AMD64) \
    || defined(__x86_64) || defined(__x86_64__) \
    || defined(_M_X64) || defined(__bfin__) \
-   || defined(__arm__) || defined(__aarch64__)
+   || defined(__arm__) || defined(__aarch64__) || defined(__loongarch__)
 
 # define SC_BOOST_LITTLE_ENDIAN
 # define SC_BOOST_BYTE_ORDER 1234

--- a/src/systemc/ext/utils/endian.hh
+++ b/src/systemc/ext/utils/endian.hh
@@ -61,14 +61,12 @@
    || defined(__s390__)
 # define SC_BOOST_BIG_ENDIAN
 # define SC_BOOST_BYTE_ORDER 4321
-#elif defined(__i386__) || defined(__alpha__) \
-   || defined(__ia64) || defined(__ia64__) \
-   || defined(_M_IX86) || defined(_M_IA64) \
-   || defined(_M_ALPHA) || defined(__amd64) \
-   || defined(__amd64__) || defined(_M_AMD64) \
-   || defined(__x86_64) || defined(__x86_64__) \
-   || defined(_M_X64) || defined(__bfin__) \
-   || defined(__arm__) || defined(__aarch64__) || defined(__loongarch__)
+#elif defined(__i386__) || defined(__alpha__) || defined(__ia64) ||           \
+    defined(__ia64__) || defined(_M_IX86) || defined(_M_IA64) ||              \
+    defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) ||            \
+    defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) ||          \
+    defined(_M_X64) || defined(__bfin__) || defined(__arm__) ||               \
+    defined(__aarch64__) || defined(__loongarch__)
 
 # define SC_BOOST_LITTLE_ENDIAN
 # define SC_BOOST_BYTE_ORDER 1234


### PR DESCRIPTION
## Overview

  Enable gem5 to build and run natively on LoongArch64 hosts.

  This change only adds LoongArch host support. It does not add LoongArch as a simulated target ISA.

  ## Changes

  - Add `EM_LOONGARCH` to the bundled libelf definitions.
  - Detect LoongArch when generating the native libelf format header.
  - Ensure the generated native format header tracks the source-tree detection script when duplicate sources are
  disabled.
  - Recognize LoongArch as little endian in SystemC and HSA.
  - Use the appropriate SystemC 64-bit aliases on LoongArch64 to avoid LP64 overload conflicts.
  - Isolate the SystemC linker flag check from external libraries, avoiding SCons 4.3 failures caused by reused
  library build state.

  ## Testing

  Tested on:

  - Loongnix Server 23.2
  - LoongArch64
  - GCC/G++ 12.3.0
  - Python 3.11.6
  - SCons 4.3.0

  Built successfully with:

  ```bash
  scons --ignore-style --config=force build/ALL/gem5.opt -j32
 ```
 
 Verified that build/ALL/gem5.opt is a native LoongArch64 ELF executable.

  Ran the RISC-V SE hello-world workload:

```
  build/ALL/gem5.opt \
    --outdir=/tmp/gem5-loongarch-smoke \
    configs/deprecated/example/se.py \
    --cpu-type=RiscvAtomicSimpleCPU \
    --cmd=tests/test-progs/hello/bin/riscv/linux/hello
```

  Result:

```
  Hello world!
  Exiting @ tick 3306500 because exiting with last active thread context
```
  The simulator exited successfully with status 0 .