### PR TITLE
arch-riscv: Fix Zvbc decoding for non-64-bit SEW

### DIFF
--- a/src/arch/riscv/isa/bitfields.isa
+++ b/src/arch/riscv/isa/bitfields.isa
@@ -142,6 +142,7 @@ def bitfield KFUNCT5    <29:25>;
 def bitfield BS         <31:30>;
 
 // Vector instructions
+def bitfield VSEW       vtype8.vsew;
 def bitfield VFUNCT6    vfunct6;
 def bitfield VFUNCT5    vfunct5;
 def bitfield VFUNCT3    vfunct3;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -4417,28 +4417,34 @@ decode QUADRANT default Unknown::unknown() {
                         );
                         Vd_vi[i] = res >> 1;
                     }}, OPMVV, SimdAddOp);
-                    0x0c: vclmul_vv({{
-                        uint64_t result = 0;
-                        uint64_t src1 = Vs1_vu[i];
-                        uint64_t src2 = Vs2_vu[i];
-                        for (int j = 0; j < 64; j++) {
-                            if ((src2 >> j) & 1) {
-                                result ^= src1 << j;
+                    0x0c: decode VSEW {
+                        0x3: vclmul_vv({{
+                            uint64_t result = 0;
+                            uint64_t src1 = Vs1_vu[i];
+                            uint64_t src2 = Vs2_vu[i];
+                            for (int j = 0; j < 64; j++) {
+                                if ((src2 >> j) & 1) {
+                                    result ^= src1 << j;
+                                }
                             }
-                        }
-                        Vd_vu[i] = result;
-                    }}, OPMVV, SimdMultOp);
-                    0x0d: vclmulh_vv({{
-                        uint64_t result = 0;
-                        uint64_t src1 = Vs1_vu[i];
-                        uint64_t src2 = Vs2_vu[i];
-                        for (int j = 1; j < 64; j++) {
-                            if ((src2 >> j) & 1) {
-                                result ^= src1 >> (64-j);
+                            Vd_vu[i] = result;
+                        }}, OPMVV, SimdMultOp);
+                        default: Unknown::unknown();
+                    }
+                    0x0d: decode VSEW {
+                        0x3: vclmulh_vv({{
+                            uint64_t result = 0;
+                            uint64_t src1 = Vs1_vu[i];
+                            uint64_t src2 = Vs2_vu[i];
+                            for (int j = 1; j < 64; j++) {
+                                if ((src2 >> j) & 1) {
+                                    result ^= src1 >> (64-j);
+                                }
                             }
-                        }
-                        Vd_vu[i] = result;
-                    }}, OPMVV, SimdMultOp);
+                            Vd_vu[i] = result;
+                        }}, OPMVV, SimdMultOp);
+                        default: Unknown::unknown();
+                    }
                 }
                 // VWXUNARY0
                 0x10: decode VS1 {
@@ -5780,28 +5786,34 @@ decode QUADRANT default Unknown::unknown() {
                         );
                         Vd_vi[i] = res >> 1;
                     }}, OPMVX, SimdAddOp);
-                   0x0c: vclmul_vx({{
-                        uint64_t result = 0;
-                        uint64_t src1 = Rs1_vu;
-                        uint64_t src2 = Vs2_vu[i];
-                        for (int j = 0; j < 64; j++) {
-                            if ((src2 >> j) & 1) {
-                                result ^= src1 << j;
+                    0x0c: decode VSEW {
+                        0x3: vclmul_vx({{
+                            uint64_t result = 0;
+                            uint64_t src1 = Rs1_vu;
+                            uint64_t src2 = Vs2_vu[i];
+                            for (int j = 0; j < 64; j++) {
+                                if ((src2 >> j) & 1) {
+                                    result ^= src1 << j;
+                                }
                             }
-                        }
-                        Vd_vu[i] = result;
-                    }}, OPMVX, SimdMultOp);
-                    0x0d: vclmulh_vx({{
-                        uint64_t result = 0;
-                        uint64_t src1 = Rs1_vu;
-                        uint64_t src2 = Vs2_vu[i];
-                        for (int j = 1; j < 64; j++) {
-                            if ((src2 >> j) & 1) {
-                                result ^= src1 >> (64-j);
+                            Vd_vu[i] = result;
+                        }}, OPMVX, SimdMultOp);
+                        default: Unknown::unknown();
+                    }
+                    0x0d: decode VSEW {
+                        0x3: vclmulh_vx({{
+                            uint64_t result = 0;
+                            uint64_t src1 = Rs1_vu;
+                            uint64_t src2 = Vs2_vu[i];
+                            for (int j = 1; j < 64; j++) {
+                                if ((src2 >> j) & 1) {
+                                    result ^= src1 >> (64-j);
+                                }
                             }
-                        }
-                        Vd_vu[i] = result;
-                    }}, OPMVX, SimdMultOp);
+                            Vd_vu[i] = result;
+                        }}, OPMVX, SimdMultOp);
+                        default: Unknown::unknown();
+                    }
                 }
                 0x0e: VectorSlide1UpFormat::vslide1up_vx({{
                     int offset = 1;


### PR DESCRIPTION
## Problem

The RISC-V `Zvbc` vector carryless-multiplication extension defines the
`vclmul` and `vclmulh` instructions only for an element width of 64
bits.

gem5 previously decoded the following instructions independently of the
current `vtype.vsew` value:

- `vclmul.vv`
- `vclmul.vx`
- `vclmulh.vv`
- `vclmulh.vx`

Their implementations operate on `uint64_t` values and perform a
fixed-width 64-bit carryless multiplication. Consequently, executing
one of these instructions with SEW set to 8, 16, or 32 could reach the
64-bit implementation instead of raising an illegal-instruction
exception.

This does not match the architectural definition of `Zvbc`, where
encodings using an unsupported SEW are reserved. It could also allow
software to observe or rely on behavior that is not defined by the
extension.

## Fix

Expose the `vsew` field from `vtype` as the `VSEW` decoder bitfield and
use it directly when decoding the four `Zvbc` instruction forms.