### PR TITLE
mem-ruby: Enable P-credit mgmt in TlmGenerator with multi-HN

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -172,7 +172,7 @@ TlmGenerator::TlmGenerator(const Params &p)
       transPerCycle(p.tran_per_cycle),
       maxPendingTrans(
           p.max_pending_tran.value_or(std::numeric_limits<uint16_t>::max())),
-      pCredit(0),
+      pCredit(),
       tickEvent([this] { tick(); }, "TlmGenerator tick", false,
                 Event::CPU_Tick_Pri),
       outPort(name() + ".out_port", 0, this),
@@ -294,24 +294,47 @@ TlmGenerator::terminate(Transaction *transaction)
 }
 
 TlmGenerator::Transaction *
-TlmGenerator::getPCrdWaiting()
+TlmGenerator::PCrdWaitingQueues::get(uint16_t tgt_id)
 {
-    if (waitingForPCrd.empty()) {
+    if (auto it = waitingForPCrd.find(tgt_id); it == waitingForPCrd.end()) {
+
         return nullptr;
     } else {
-        auto waiting = waitingForPCrd.front();
-        waitingForPCrd.pop_front();
-        return waiting;
+        if (auto &queue = it->second; queue.empty()) {
+            return nullptr;
+        } else {
+            auto waiting = queue.front();
+            queue.pop_front();
+            return waiting;
+        }
     }
 }
 
-bool
-TlmGenerator::getPCrd()
+void
+TlmGenerator::PCrdWaitingQueues::insert(uint16_t tgt_id, Transaction *tran)
 {
-    if (pCredit > 0) {
-        return pCredit--;
+    waitingForPCrd[tgt_id].push_back(tran);
+}
+
+bool
+TlmGenerator::PCrdWaitingQueues::empty() const
+{
+    for (auto it : waitingForPCrd) {
+        if (!it.second.empty()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
+TlmGenerator::getPCrd(uint16_t tgt_id)
+{
+    auto &p_credit = pCredit[tgt_id];
+    if (p_credit > 0) {
+        return p_credit--;
     } else {
-        return pCredit;
+        return p_credit;
     }
 }
 
@@ -385,12 +408,12 @@ bool
 TlmGenerator::handlePCredit(ARM::CHI::Phase *phase)
 {
     if (isPCrdGrant(phase)) {
-        if (auto tran = getPCrdWaiting(); tran) {
+        if (auto tran = pCreditQueues.get(phase->src_id); tran) {
             // There is a waiting transaction, pass it the credit
             tran->phase().allow_retry = false;
             enqueueFront(tran);
         } else {
-            pCredit++;
+            pCredit[phase->src_id]++;
         }
 
         stats.pcrdGrant++;
@@ -404,11 +427,12 @@ TlmGenerator::handlePCredit(ARM::CHI::Phase *phase)
 
         pendingTransactions.erase(it);
 
-        if (getPCrd()) {
+        auto completer_id = phase->src_id;
+        if (getPCrd(completer_id)) {
             tran->phase().allow_retry = false;
             enqueueFront(tran);
         } else {
-            waitingForPCrd.push_back(tran);
+            pCreditQueues.insert(completer_id, tran);
         }
 
         stats.retryAck++;

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -303,7 +303,7 @@ class TlmGenerator : public ClockedObject
     isActive() const
     {
         return !pendingTransactions.empty() ||
-               !unscheduledTransactions.empty() || !waitingForPCrd.empty();
+               !unscheduledTransactions.empty() || !pCreditQueues.empty();
     }
 
     Port &getPort(const std::string &if_name, PortID idx) override;
@@ -359,9 +359,10 @@ class TlmGenerator : public ClockedObject
 
     /**
      * Require a P-credit from the generator
-     * Returns true if a p-credit is available
+     * Returns true if a p-credit is available for
+     * a particular target node
      */
-    bool getPCrd();
+    bool getPCrd(uint16_t tgt_id);
 
     /**
      * Return a list of transactions waiting for
@@ -390,7 +391,7 @@ class TlmGenerator : public ClockedObject
     const uint16_t maxPendingTrans;
 
     /** Numbers of p-credit available to the generator */
-    unsigned pCredit;
+    std::unordered_map<uint16_t, unsigned> pCredit;
 
     /** tick event used to schedule unscheduled transactions */
     EventFunctionWrapper tickEvent;
@@ -398,8 +399,42 @@ class TlmGenerator : public ClockedObject
     /** List of transactions whose injection needs to be scheduled */
     std::list<Transaction *> unscheduledTransactions;
 
-    /** List of processes waiting for a P-credit grant */
-    std::list<Transaction *> waitingForPCrd;
+    /** P-credit waiting queues:
+     * Shelves transactions waiting for a P-credit on apposite
+     * queues. There is a queue per completer, so that whenever
+     * such completers sends a credit to the generator, we
+     * are able to forward it to the right queue/transaction.
+     */
+    struct PCrdWaitingQueues
+    {
+      public:
+        PCrdWaitingQueues() = default;
+        PCrdWaitingQueues(const PCrdWaitingQueues &rhs) = delete;
+
+        /**
+         * Return/Extract a transaction waiting for
+         * a credit from the tgt_id completer passes
+         * as a parameter
+         */
+        Transaction *get(uint16_t tgt_id);
+
+        /**
+         * The passed transaction is going to wait for
+         * a P-credit from tgt_id
+         */
+        void insert(uint16_t tgt_id, Transaction *tran);
+
+        /**
+         * The passed transaction is going to wait for
+         * a P-credit from tgt_id
+         */
+        bool empty() const;
+
+      protected:
+        /** Map of transactions waiting for a P-credit grant indexed by the
+         * tgt_id */
+        std::unordered_map<uint16_t, std::list<Transaction *>> waitingForPCrd;
+    } pCreditQueues;
 
     /** Map of pending (injected) transactions indexed by the txn_id */
     std::unordered_map<uint16_t, Transaction*> pendingTransactions;


### PR DESCRIPTION
Current P-credit handling in the TlmGenerator assumes and supports a single completer only (HN).

There is only one queue where all transactions are shelved irrespective to the completer. Similarly
credits are encoded in a single variable.

To support multi completers we need to extend current logic. The TlmGenerator would need to be aware of which completer is sending the credit to make sure that
it forwards only transactions targeting the
available completer.

We implement this by defining a PCrdQueues data structure, which essentially keeps separate lists per completer, which is extracted from the src_id field in RetryAck and PCrdGrant messages

Change-Id: I70e15e4930ffa61d5043adfdf30798de31c1859f