### PR TITLE
mem-cache: prevent FDP address wraparound hang

### DIFF
--- a/src/mem/cache/prefetch/fdp.cc
+++ b/src/mem/cache/prefetch/fdp.cc
@@ -80,8 +80,8 @@ FetchDirectedPrefetcher::notifyFTQInsert(const o3::FetchTargetPtr &ft)
 
     // Advancing an Addr past the final block near MaxAddr wraps it to zero.
     // Bound iteration by a non-address counter so the loop still terminates.
-    const Addr num_blocks = (end_blk_addr - start_blk_addr) / blkSize + 1;
-    for (Addr block = 0; block < num_blocks; ++block) {
+    const uint64_t num_blocks = (end_blk_addr - start_blk_addr) / blkSize + 1;
+    for (uint64_t block = 0; block < num_blocks; ++block) {
         const Addr blk_addr = start_blk_addr + block * blkSize;
 
         // Check if the address is already in the prefetch queue

--- a/src/mem/cache/prefetch/fdp.cc
+++ b/src/mem/cache/prefetch/fdp.cc
@@ -70,8 +70,19 @@ FetchDirectedPrefetcher::notifyFTQInsert(const o3::FetchTargetPtr &ft)
     const Addr start_blk_addr = blockAddress(ft->startAddress());
     const Addr end_blk_addr = blockAddress(ft->endAddress());
 
-    for (Addr blk_addr = start_blk_addr; blk_addr <= end_blk_addr;
-         blk_addr += blkSize) {
+    if (end_blk_addr < start_blk_addr) {
+        DPRINTF(HWPrefetch,
+                "Ignoring invalid FetchTarget range: "
+                "%#x -> %#x\n",
+                start_blk_addr, end_blk_addr);
+        return;
+    }
+
+    // Advancing an Addr past the final block near MaxAddr wraps it to zero.
+    // Bound iteration by a non-address counter so the loop still terminates.
+    const Addr num_blocks = (end_blk_addr - start_blk_addr) / blkSize + 1;
+    for (Addr block = 0; block < num_blocks; ++block) {
+        const Addr blk_addr = start_blk_addr + block * blkSize;
 
         // Check if the address is already in the prefetch queue
         auto it = std::find(pfq.begin(), pfq.end(), blk_addr);


### PR DESCRIPTION
This bug occurs when the decoupled frontend and the Fetch Directed Prefetcher (FDP) are enabled.

The BAC creates a Fetch Target from the speculative next PC. When that Fetch Target is inserted into the FTQ, the following call chain invokes the FDP:

```cpp
FTQ::insert()
  -> FetchDirectedPrefetcher::notifyFTQInsert()
```

The FDP then iterates over every cache block covered by the Fetch Target and creates prefetch requests for those blocks.

Normally, a Fetch Target lies within an ordinary address range, so the loop performs only a small number of iterations. The bug is triggered when speculative control flow produces a target PC near the top of the 64-bit address space. For example, the observed Fetch Target was:

```cpp
Fetch Target start = 0xffffffffffffff88
Fetch Target end   = 0xffffffffffffffc8
```

With a 64-byte cache block size, these addresses are aligned to:

```cpp
start_blk_addr = 0xffffffffffffff80
end_blk_addr   = 0xffffffffffffffc0
```

The Fetch Target therefore covers the last two cache blocks near the top of the address space.


`0xffffffffffffff88` is the 64-bit two’s-complement representation of `-0x78`:

```text
-0x78 -> 0xffffffffffffff88
```

The decoupled frontend operates on speculative control flow. A mispredicted return, indirect branch, or another frontend redirect can temporarily provide a stale or otherwise invalid target address. If such a target is a small negative value represented as an unsigned `Addr`, it appears as an address close to `MaxAddr`.

This address is therefore not generated by the FDP itself. The FDP receives it as the start address of a speculative Fetch Target. The BAC then searches a bounded instruction window starting at that PC, which can produce a Fetch Target such as:

```text
0xffffffffffffff88 -> 0xffffffffffffffc8
```

An incorrect speculative target should not by itself terminate or hang the simulation. The target may later fail address translation or be corrected by a squash. The FDP must therefore handle arbitrary speculative addresses safely instead of assuming that every Fetch Target belongs to valid, committed control flow.

The directly observed state was a Fetch Target beginning at `0xffffffffffffff88`. Its value is consistent with a stale or incorrect return or indirect-branch target, but the FDP fix does not depend on which particular prediction mechanism produced it.

The original implementation used the cache-block address as both the loop variable and the termination condition:

```cpp
for (Addr blk_addr = start_blk_addr; blk_addr <= end_blk_addr;
     blk_addr += blkSize) {
    ...
}
```

`Addr` is an unsigned 64-bit integer. For the range above, the loop processes:

```text
0xffffffffffffff80
0xffffffffffffffc0
```

After processing the final block, the update expression still executes:

```cpp
blk_addr += 64;
```

Because the address is already at the top of the address space, this unsigned addition wraps around:

```text
0xffffffffffffffc0 + 0x40
    = 0x0000000000000000
```

The loop condition then becomes:

```cpp
0x0 <= 0xffffffffffffffc0
```

This remains true, so the loop continues enumerating cache blocks from address zero. After eventually reaching the top of the address space again, it wraps to zero again. The loop therefore never terminates.

The fix calculates the finite number of cache blocks before entering the loop and then uses a non-address counter as the loop-control variable:

```cpp
if (end_blk_addr < start_blk_addr) {
    DPRINTF(HWPrefetch, "Ignoring invalid FetchTarget range: "
            "%#x -> %#x\n", start_blk_addr, end_blk_addr);
    return;
}

// Advancing an Addr past the final block near MaxAddr wraps it to zero.
// Bound iteration by a non-address counter so the loop still terminates.
const uint64_t num_blocks =
    (end_blk_addr - start_blk_addr) / blkSize + 1;

for (uint64_t block = 0; block < num_blocks; ++block) {
    const Addr blk_addr = start_blk_addr + block * blkSize;
    ...
}
```

For the observed range:

```cpp
num_blocks = 2
```

The loop constructs only:

```text
block 0 -> 0xffffffffffffff80
block 1 -> 0xffffffffffffffc0
```

After the second block, the counter becomes 2 and the loop terminates. The implementation never attempts to calculate `end_blk_addr + blkSize`, so no address wraparound occurs.

The preceding range check ensures that:

```cpp
end_blk_addr - start_blk_addr
```

cannot undergo unsigned underflow. It also preserves the original loop’s behavior of performing no iterations for a reversed address range.