### PR TITLE
misc: Hide modulo-based interleaving constructor

### DIFF
--- a/src/base/addr_range.hh
+++ b/src/base/addr_range.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, 2017-2019, 2021 Arm Limited
+ * Copyright (c) 2012, 2014, 2017-2019, 2021, 2026 Arm Limited
  * Copyright (c) 2026 Google Inc.
  * All rights reserved
  *
@@ -194,21 +194,32 @@ class AddrRange
     }
 
     /**
-     * Create an address range with modulo-based interleaving.
+     * Create an address range with mask-based interleaving.
      *
-     * If the user provides a stripe count of 1, the address range is not
-     * interleaved.
-     * Using modulo instead of interleaving allows for non-power
-     * of 2 stripe counts.
+     * The direct constructor remains public for backwards compatibility, but
+     * new code should prefer this factory for clearer call sites.
      *
-     * @param start The start address of the range.
-     * @param end The end address of the range.
-     * @param stripes The number of stripes (channels).
-     * @param intlv_match The stripe index for this range.
-     * @param intlv_low_bit The bit position of the interleaving granularity
-     *                      (log2).
+     * @param start The start address of this range
+     * @param end The end address of this range (not included in the range)
+     * @param masks The input vector of masks
+     * @param intlv_match The matching value of the xor operations
      *
      * @ingroup api_addr_range
+     */
+    static AddrRange
+    withMaskInterleaving(Addr start, Addr end, const std::vector<Addr> &masks,
+                         uint8_t intlv_match)
+    {
+        return AddrRange(start, end, masks, intlv_match);
+    }
+
+  private:
+    /**
+     * The modulo-based interleaving constructor is private.
+     * An address range with modulo-based interleaving can only
+     * be constructed via the factory method below (withModuloInterleaving).
+     * This is done to improve readability and decrease chances of
+     * misconfiguring the interleaving policy.
      */
     AddrRange(Addr start, Addr end, uint32_t stripes, uint32_t intlv_match,
               uint32_t intlv_low_bit = 0)
@@ -233,6 +244,31 @@ class AddrRange
             _policy = std::make_shared<ModuloInterleavingPolicy>(
                 stripes, intlv_match, intlv_low_bit);
         }
+    }
+
+  public:
+    /**
+     * Create an address range with modulo-based interleaving.
+     *
+     * If the user provides a stripe count of 1, the address range is not
+     * interleaved.
+     * Using modulo instead of interleaving allows for non-power
+     * of 2 stripe counts.
+     *
+     * @param start The start address of the range.
+     * @param end The end address of the range.
+     * @param stripes The number of stripes (channels).
+     * @param intlv_match The stripe index for this range.
+     * @param intlv_low_bit The bit position of the interleaving granularity
+     *                      (log2).
+     *
+     * @ingroup api_addr_range
+     */
+    static AddrRange
+    withModuloInterleaving(Addr start, Addr end, uint32_t stripes,
+                           uint32_t intlv_match, uint32_t intlv_low_bit = 0)
+    {
+        return AddrRange(start, end, stripes, intlv_match, intlv_low_bit);
     }
 
     /**
@@ -303,20 +339,27 @@ class AddrRange
     }
 
     /**
-     * Create an address range with sparse sub-ranges and modulo interleaving.
+     * Create an address range with sparse sub-ranges and mask-based
+     * interleaving.
      *
-     * This constructor will create an interleaved address range in the same
-     * way as the modulo interleaving constructor, but with sparse sub-ranges.
-     * If the stripes are 1, the address range will be sparse only.
+     * The direct constructor remains public for backwards compatibility, but
+     * new code should prefer this factory for clearer call sites.
      *
      * @param ranges Vector of valid address chunks (start, end).
      *               Must be sorted and non-overlapping.
-     * @param stripes The number of stripes (channels).
-     * @param intlv_match The matching value of the modulo operation.
-     * @param intlv_low_bit The lowest bit to use for the modulo operation.
+     * @param masks The input vector of masks.
+     * @param intlv_match The matching value of the xor operations.
      *
      * @ingroup api_addr_range
      */
+    static AddrRange
+    withMaskInterleaving(const std::vector<std::pair<Addr, Addr>> &ranges,
+                         const std::vector<Addr> &masks, uint8_t intlv_match)
+    {
+        return AddrRange(ranges, masks, intlv_match);
+    }
+
+  private:
     AddrRange(const std::vector<std::pair<Addr, Addr>> &ranges,
               uint32_t stripes, uint32_t intlv_match,
               uint32_t intlv_low_bit = 0)
@@ -343,6 +386,30 @@ class AddrRange
             _policy = std::make_shared<ModuloInterleavingPolicy>(
                 stripes, intlv_match, intlv_low_bit);
         }
+    }
+
+  public:
+    /**
+     * Create an address range with sparse sub-ranges and modulo interleaving.
+     *
+     * This function will create an interleaved address range in the same way
+     * as the modulo interleaving factory, but with sparse sub-ranges. If the
+     * stripes are 1, the address range will be sparse only.
+     *
+     * @param ranges Vector of valid address chunks (start, end).
+     *               Must be sorted and non-overlapping.
+     * @param stripes The number of stripes (channels).
+     * @param intlv_match The matching value of the modulo operation.
+     * @param intlv_low_bit The lowest bit to use for the modulo operation.
+     *
+     * @ingroup api_addr_range
+     */
+    static AddrRange
+    withModuloInterleaving(const std::vector<std::pair<Addr, Addr>> &ranges,
+                           uint32_t stripes, uint32_t intlv_match,
+                           uint32_t intlv_low_bit = 0)
+    {
+        return AddrRange(ranges, stripes, intlv_match, intlv_low_bit);
     }
 
     /**
@@ -513,14 +580,14 @@ class AddrRange
                 if (auto masked =
                         std::dynamic_pointer_cast<MaskedInterleavingPolicy>(
                             _policy)) {
-                    decomposed.emplace_back(chunk.first, chunk.second,
-                                            masked->getMasks(),
-                                            masked->getMatch());
+                    decomposed.push_back(withMaskInterleaving(
+                        chunk.first, chunk.second, masked->getMasks(),
+                        masked->getMatch()));
                 } else if (auto modulo = std::dynamic_pointer_cast<
                                ModuloInterleavingPolicy>(_policy)) {
-                    decomposed.emplace_back(
+                    decomposed.push_back(withModuloInterleaving(
                         chunk.first, chunk.second, modulo->getStripes(),
-                        modulo->getMatch(), modulo->getLowBit());
+                        modulo->getMatch(), modulo->getLowBit()));
                 } else {
                     panic("Unknown policy type in AddrRange::decompose");
                 }

--- a/src/base/addr_range.test.cc
+++ b/src/base/addr_range.test.cc
@@ -1611,9 +1611,9 @@ TEST(AddrRangeTest, ModuloSimple)
     // Stripe 0: 0, 3, 6...
     // Stripe 1: 1, 4, 7...
     // Stripe 2: 2, 5, 8...
-    AddrRange r0(0, 300, 3, 0);
-    AddrRange r1(0, 300, 3, 1);
-    AddrRange r2(0, 300, 3, 2);
+    AddrRange r0 = AddrRange::withModuloInterleaving(0, 300, 3, 0);
+    AddrRange r1 = AddrRange::withModuloInterleaving(0, 300, 3, 1);
+    AddrRange r2 = AddrRange::withModuloInterleaving(0, 300, 3, 2);
 
     EXPECT_TRUE(r0.contains(0));
     EXPECT_FALSE(r0.contains(1));
@@ -1644,7 +1644,7 @@ TEST(AddrRangeTest, ModuloSimple)
 TEST(AddrRangeTest, ModuloOffset)
 {
     // Range 0-300, 3 stripes, intlv_bit=0.
-    AddrRange r(0, 300, 3, 1); // matches 1, 4, 7...
+    AddrRange r = AddrRange::withModuloInterleaving(0, 300, 3, 1);
 
     // 1 is the 0th element in this range.
     EXPECT_EQ(0, r.getOffset(1));
@@ -1660,7 +1660,7 @@ TEST(AddrRangeTest, ModuloGranularity)
     // range 0-96.
     // stripe 0: 0-3, 8-11, 16-19...
     // stripe 1: 4-7, 12-15, 20-23...
-    AddrRange r(0, 96, 2, 1, 2);
+    AddrRange r = AddrRange::withModuloInterleaving(0, 96, 2, 1, 2);
 
     EXPECT_FALSE(r.contains(0)); // 0>>2 = 0. 0%2 = 0 != 1.
     EXPECT_FALSE(r.contains(3));
@@ -1781,10 +1781,8 @@ TEST(AddrRangeTest, ConstructorMergeTest)
     // r1: match 0. (0, 2, 4...)
     // r2: match 1. (1, 3, 5...)
     // Combined: 0-100 flat.
-    // Wait, Modulo constructor signature:
-    // AddrRange(start, end, stripes, intlvMatch, intlvLowBit)
-    AddrRange m1(0, 100, 2, 0, 0); // stripes=2, match=0, bit=0
-    AddrRange m2(0, 100, 2, 1, 0); // stripes=2, match=1, bit=0
+    AddrRange m1 = AddrRange::withModuloInterleaving(0, 100, 2, 0, 0);
+    AddrRange m2 = AddrRange::withModuloInterleaving(0, 100, 2, 1, 0);
     std::vector<AddrRange> ranges = {m1, m2};
     AddrRange merged(ranges);
     EXPECT_FALSE(merged.interleaved());
@@ -1807,7 +1805,7 @@ TEST(AddrRangeTest, ConstructorMergeTest)
 
     // 4. Incompatible policies (Modulo mismatch)
     // Different stripes
-    AddrRange m3(0, 99, 3, 0, 0); // 3 stripes
+    AddrRange m3 = AddrRange::withModuloInterleaving(0, 99, 3, 0, 0);
     std::vector<AddrRange> mismatch = {m1, m3};
     EXPECT_ANY_THROW({ AddrRange r(mismatch); });
 }
@@ -1821,7 +1819,7 @@ TEST(AddrRangeTest, NestedSparseTest)
     // Interleaving: 3 stripes, match 0.
     std::vector<std::pair<Addr, Addr>> chunks = {{0, 0x1002},
                                                  {0x2000, 0x3002}};
-    AddrRange r(chunks, 3, 0); // stripes=3, match=0
+    AddrRange r = AddrRange::withModuloInterleaving(chunks, 3, 0);
 
     // Check contains
     // System Interleaving:
@@ -1868,9 +1866,9 @@ TEST(AddrRangeTest, SparseMergeTest)
 
     // Create 2 ranges with Modulo(2) interleaving
     // range1: Match 0
-    AddrRange r1(chunks, 2, 0);
+    AddrRange r1 = AddrRange::withModuloInterleaving(chunks, 2, 0);
     // range2: Match 1
-    AddrRange r2(chunks, 2, 1);
+    AddrRange r2 = AddrRange::withModuloInterleaving(chunks, 2, 1);
 
     // Merge them
     AddrRange merged(std::vector<AddrRange>{r1, r2});

--- a/src/base/addr_range_map.test.cc
+++ b/src/base/addr_range_map.test.cc
@@ -174,8 +174,9 @@ TEST(AddrRangeMapTest, ModuloInterleavingTest)
 
     // Populate AddrRangeMap with 3-way modulo interleaved ranges
     for (uint32_t k = 0; k < stripes; k++) {
-        // AddrRange(start, end, stripes, match, intlv_bit)
-        r.insert(AddrRange(start, end, stripes, k, intlvBit), k);
+        r.insert(AddrRange::withModuloInterleaving(start, end, stripes, k,
+                                                   intlvBit),
+                 k);
     }
 
     // Verify mapping
@@ -211,9 +212,9 @@ TEST(AddrRangeMapTest, NestedSparse)
     AddrRangeMap<int> r;
 
     // Insert 0, 1, 2 matches
-    r.insert(AddrRange(chunks, 3, 0), 0);
-    r.insert(AddrRange(chunks, 3, 1), 1);
-    r.insert(AddrRange(chunks, 3, 2), 2);
+    r.insert(AddrRange::withModuloInterleaving(chunks, 3, 0), 0);
+    r.insert(AddrRange::withModuloInterleaving(chunks, 3, 1), 1);
+    r.insert(AddrRange::withModuloInterleaving(chunks, 3, 2), 2);
 
     // Verify mapping
     auto it = r.contains(0x0);

--- a/src/python/m5/params/param_types.py
+++ b/src/python/m5/params/param_types.py
@@ -645,7 +645,7 @@ class AddrRange(ParamValue):
         # Go from the Python class to the wrapped C++ class
         from _m5.range import AddrRange
 
-        return AddrRange(
+        return AddrRange.withMaskInterleaving(
             int(self.start), int(self.end), self.masks, int(self.intlvMatch)
         )
 
@@ -735,7 +735,7 @@ class ModuloAddrRange(AddrRange):
     def getValue(self):
         from _m5.range import AddrRange
 
-        return AddrRange(
+        return AddrRange.withModuloInterleaving(
             int(self.start),
             int(self.end),
             int(self.stripes),
@@ -784,7 +784,7 @@ class SparseModuloAddrRange(ModuloAddrRange):
         from _m5.range import AddrRange
 
         cxx_ranges = [r.getValue() for r in self.ranges]
-        return AddrRange(
+        return AddrRange.withModuloInterleaving(
             cxx_ranges,
             int(self.stripes),
             int(self.stripeMatch),
@@ -813,7 +813,9 @@ class SparseMaskedAddrRange(AddrRange):
         from _m5.range import AddrRange
 
         cxx_ranges = [r.getValue() for r in self.ranges]
-        return AddrRange(cxx_ranges, self.masks, int(self.intlvMatch))
+        return AddrRange.withMaskInterleaving(
+            cxx_ranges, self.masks, int(self.intlvMatch)
+        )
 
 
 # Boolean parameter type.  Python doesn't let you subclass bool, since

--- a/src/python/pybind11/core.cc
+++ b/src/python/pybind11/core.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, 2021, 2025 Arm Limited
+ * Copyright (c) 2017, 2019, 2021, 2025-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -154,6 +154,20 @@ init_range(py::module_ &m_native)
              ":param end: The end address of this range (not included)\n"
              ":param masks: The input vector of masks\n"
              ":param intlv_match: The matching value of the xor operations")
+        .def_static(
+            "withMaskInterleaving",
+            py::overload_cast<Addr, Addr, const std::vector<Addr> &, uint8_t>(
+                &AddrRange::withMaskInterleaving),
+            "Create an address range with masked interleaving.\n"
+            "\n"
+            "The address a is in the range if start <= a < end and "
+            "sel == intlv_match, where sel is determined by the XOR of "
+            "bits specified by the masks.\n"
+            "\n"
+            ":param start: The start address of this range\n"
+            ":param end: The end address of this range (not included)\n"
+            ":param masks: The input vector of masks\n"
+            ":param intlv_match: The matching value of the xor operations")
         .def(py::init<const std::vector<AddrRange> &>(),
              "Create an address range by merging a collection of interleaved "
              "ranges.\n"
@@ -170,18 +184,21 @@ init_range(py::module_ &m_native)
             ":param xor_high_bit: The MSB of the xor bit (disabled if 0)\n"
             ":param intlv_bits: The size, in bits, of the intlv and xor bits\n"
             ":param intlv_match: The matching value of the xor operations")
-        .def(py::init<Addr, Addr, uint32_t, uint32_t, uint32_t>(),
-             "Create an address range with modulo-based interleaving.\n"
-             "\n"
-             "Using modulo instead of interleaving allows for non-power "
-             "of 2 stripe counts.\n"
-             "\n"
-             ":param start: The start address of the range.\n"
-             ":param end: The end address of the range (not included).\n"
-             ":param stripes: The number of stripes (channels).\n"
-             ":param intlv_match: The stripe index for this range.\n"
-             ":param intlv_low_bit: The bit position of the interleaving "
-             "granularity (log2).")
+        .def_static(
+            "withModuloInterleaving",
+            py::overload_cast<Addr, Addr, uint32_t, uint32_t, uint32_t>(
+                &AddrRange::withModuloInterleaving),
+            "Create an address range with modulo-based interleaving.\n"
+            "\n"
+            "Using modulo instead of interleaving allows for non-power "
+            "of 2 stripe counts.\n"
+            "\n"
+            ":param start: The start address of the range.\n"
+            ":param end: The end address of the range (not included).\n"
+            ":param stripes: The number of stripes (channels).\n"
+            ":param intlv_match: The stripe index for this range.\n"
+            ":param intlv_low_bit: The bit position of the interleaving "
+            "granularity (log2).")
         .def(py::init([](const std::vector<AddrRange> &ranges,
                          const std::vector<Addr> &masks, uint8_t intlv_match) {
                  std::vector<std::pair<Addr, Addr>> chunks;
@@ -196,16 +213,34 @@ init_range(py::module_ &m_native)
              ":param ranges: List of valid address chunks (start, end).\n"
              ":param masks: The input vector of masks.\n"
              ":param intlv_match: The matching value of the xor operations.")
-        .def(
-            py::init([](const std::vector<AddrRange> &ranges, uint32_t stripes,
-                        uint32_t intlv_match, uint32_t intlv_low_bit) {
+        .def_static(
+            "withMaskInterleaving",
+            [](const std::vector<AddrRange> &ranges,
+               const std::vector<Addr> &masks, uint8_t intlv_match) {
                 std::vector<std::pair<Addr, Addr>> chunks;
                 for (const auto &r : ranges) {
                     chunks.emplace_back(r.start(), r.end());
                 }
-                return new AddrRange(chunks, stripes, intlv_match,
-                                     intlv_low_bit);
-            }),
+                return AddrRange::withMaskInterleaving(chunks, masks,
+                                                       intlv_match);
+            },
+            "Create an address range with sparse sub-ranges and masked "
+            "interleaving.\n"
+            "\n"
+            ":param ranges: List of valid address chunks (start, end).\n"
+            ":param masks: The input vector of masks.\n"
+            ":param intlv_match: The matching value of the xor operations.")
+        .def_static(
+            "withModuloInterleaving",
+            [](const std::vector<AddrRange> &ranges, uint32_t stripes,
+               uint32_t intlv_match, uint32_t intlv_low_bit) {
+                std::vector<std::pair<Addr, Addr>> chunks;
+                for (const auto &r : ranges) {
+                    chunks.emplace_back(r.start(), r.end());
+                }
+                return AddrRange::withModuloInterleaving(
+                    chunks, stripes, intlv_match, intlv_low_bit);
+            },
             "Create an address range with sparse sub-ranges and modulo "
             "interleaving.\n"
             "\n"


### PR DESCRIPTION
A recent PR added modulo-based interleaving for
the AddrRange class in gem5 [1]

With this patch we mark the modulo-based interleaving constructor as private.
An address range with modulo-based interleaving can only be constructed via a factory method:

auto addr_range = AddrRange::withModuloInterleaving(..)

This is done to improve readibility and decrease chances of misconfiguring the interleaving policy (for example if someone mistakenly uses masked interleaving in lieu of modulo-based) and also to improve readability, so that it is obvious what's the interleaving policy being used.

For symmetry we add a withMaskInterleaving method though we don't mark the matching constructor as privare since it would be a compatibility nightmare

[1]: https://github.com/gem5/gem5/pull/2861

Change-Id: Ia579c6f9ee97846e7d754d15635925eb938f949a