### PR TITLE
arch-riscv: Add profile-based extension reporting

### DIFF
--- a/configs/deprecated/example/riscv/fs_linux.py
+++ b/configs/deprecated/example/riscv/fs_linux.py
@@ -285,7 +285,16 @@ system.cpu = [
 
 if args.riscv_32bits:
     for core in system.cpu:
-        core.ArchISA.riscv_type = "RV32"
+        core.ArchISA.riscv_profile = "RVI20U32"
+        core.ArchISA.extra_extensions = [
+            "M",
+            "A",
+            "F",
+            "D",
+            "C",
+            "Zicsr",
+            "Zifencei",
+        ]
 
 if args.caches or args.l2cache:
     # By default the IOCache runs at the system clock

--- a/src/arch/riscv/RiscvISA.py
+++ b/src/arch/riscv/RiscvISA.py
@@ -44,8 +44,11 @@ from m5.objects.BaseISA import BaseISA
 from m5.params import (
     Enum,
     Param,
+    String,
     UInt32,
+    VectorParam,
 )
+from m5.util import warn
 
 
 class RiscvVectorLength(UInt32):
@@ -74,6 +77,10 @@ class RiscvVectorElementLength(UInt32):
             raise TypeError("ELEN is not a power of 2: %d" % self.value)
 
 
+class RiscvInternalString(String):
+    cmd_line_settable = False
+
+
 class RiscvType(Enum):
     vals = ["RV32", "RV64"]
 
@@ -87,14 +94,467 @@ class PrivilegeModeSet(Enum):
     ]
 
 
+class RiscvProfile(Enum):
+    vals = [
+        "RVI20U32",
+        "RVI20U64",
+        "RVA20U64",
+        "RVA20S64",
+        "RVA22U64",
+        "RVA22S64",
+        "RVA23U64",
+        "RVA23S64",
+        "RVB23U64",
+        "RVB23S64",
+    ]
+
+
+# Ratified standard extensions from RISC-V Unified DB
+# spec/std/isa/ext. This registry is a recognition catalog plus gem5
+# support metadata; implemented=True is the support/reporting claim.
+_EXTENSION_REGISTRY = {
+    "A": {"implemented": True},
+    "B": {"implemented": True},
+    "C": {"implemented": True},
+    "D": {"implemented": True},
+    "F": {"implemented": True},
+    "H": {"implemented": True},
+    "I": {
+        "implemented": True,
+        "notes": "Base integer ISA is emitted from the selected profile.",
+    },
+    "M": {"implemented": True},
+    "Q": {"implemented": False},
+    "S": {"implemented": False},
+    "Sdext": {"implemented": False},
+    "Sdtrig": {"implemented": False},
+    "Sha": {"implemented": False},
+    "Shcounterenw": {"implemented": True},
+    "Shgatpa": {"implemented": False},
+    "Shtvala": {"implemented": False},
+    "Shvsatpa": {"implemented": False},
+    "Shvstvala": {"implemented": False},
+    "Shvstvecd": {"implemented": True},
+    "Sm": {"implemented": False},
+    "Smaia": {"implemented": False},
+    "Smcdeleg": {"implemented": False},
+    "Smcntrpmf": {"implemented": False},
+    "Smcsrind": {"implemented": False},
+    "Smctr": {"implemented": False},
+    "Smdbltrp": {"implemented": False},
+    "Smepmp": {"implemented": False},
+    "Smmpm": {"implemented": False},
+    "Smnpm": {"implemented": False},
+    "Smrnmi": {"implemented": True},
+    "Smstateen": {"implemented": False},
+    "Ssaia": {"implemented": False},
+    "Ss1p11": {"implemented": False},
+    "Ss1p12": {"implemented": False},
+    "Ss1p13": {"implemented": False},
+    "Ssccfg": {"implemented": False},
+    "Ssccptr": {"implemented": False},
+    "Sscofpmf": {"implemented": False},
+    "Sscounterenw": {"implemented": True},
+    "Sscsrind": {"implemented": False},
+    "Ssctr": {"implemented": False},
+    "Ssdbltrp": {"implemented": False},
+    "Ssnpm": {"implemented": False},
+    "Sspm": {"implemented": False},
+    "Ssqosid": {"implemented": False},
+    "Ssstateen": {"implemented": False},
+    "Ssstrict": {"implemented": False},
+    "Sstc": {"implemented": False},
+    "Sstvala": {"implemented": True},
+    "Sstvecd": {"implemented": True},
+    "Sstvecv": {"implemented": False},
+    "Ssu32xl": {"implemented": False},
+    "Ssu64xl": {"implemented": True},
+    "Ssube": {"implemented": False},
+    "Supm": {"implemented": False},
+    "Sv32": {"implemented": False},
+    "Sv39": {"implemented": True},
+    "Sv48": {"implemented": False},
+    "Sv57": {"implemented": False},
+    "Svade": {"implemented": False},
+    "Svadu": {"implemented": False},
+    "Svbare": {"implemented": True},
+    "Svinval": {"implemented": False},
+    "Svnapot": {
+        "implemented": True,
+        "isa": "svnapot",
+    },
+    "Svpbmt": {"implemented": False},
+    "Svrsw60t59b": {"implemented": False},
+    "Svvptc": {"implemented": False},
+    "U": {"implemented": False},
+    "V": {"implemented": True},
+    "Za128rs": {"implemented": False},
+    "Za64rs": {"implemented": False},
+    "Zaamo": {"implemented": False},
+    "Zabha": {"implemented": False},
+    "Zacas": {"implemented": False},
+    "Zalasr": {"implemented": False},
+    "Zalrsc": {"implemented": False},
+    "Zama16b": {"implemented": False},
+    "Zawrs": {"implemented": False},
+    "Zba": {"implemented": True},
+    "Zbb": {"implemented": True},
+    "Zbc": {"implemented": True},
+    "Zbkb": {"implemented": True},
+    "Zbkc": {"implemented": True},
+    "Zbkx": {"implemented": True},
+    "Zbs": {"implemented": True},
+    "Zca": {"implemented": True},
+    "Zcb": {"implemented": True},
+    "Zcd": {"implemented": True},
+    "Zce": {"implemented": False},
+    "Zcf": {"implemented": True},
+    "Zclsd": {"implemented": False},
+    "Zcmop": {"implemented": False},
+    "Zcmp": {"implemented": True},
+    "Zcmt": {"implemented": True},
+    "Zdinx": {"implemented": False},
+    "Zfa": {"implemented": True},
+    "Zfbfmin": {"implemented": False},
+    "Zfh": {"implemented": True},
+    "Zfhmin": {"implemented": True},
+    "Zfinx": {"implemented": False},
+    "Zhinx": {"implemented": False},
+    "Zhinxmin": {"implemented": False},
+    "Zic64b": {"implemented": True},
+    "Zicbom": {"implemented": True},
+    "Zicbop": {"implemented": True},
+    "Zicboz": {"implemented": True},
+    "Ziccamoa": {"implemented": False},
+    "Ziccamoc": {"implemented": False},
+    "Ziccif": {"implemented": False},
+    "Zicclsm": {"implemented": False},
+    "Ziccrse": {"implemented": False},
+    "Zicfilp": {"implemented": False},
+    "Zicfiss": {"implemented": False},
+    "Zicntr": {"implemented": True},
+    "Zicond": {"implemented": True},
+    "Zicsr": {"implemented": True},
+    "Zifencei": {"implemented": True},
+    "Zihintntl": {"implemented": False},
+    "Zihintpause": {"implemented": True},
+    "Zihpm": {"implemented": True},
+    "Zilsd": {"implemented": False},
+    "Zimop": {"implemented": False},
+    "Zk": {"implemented": False},
+    "Zkn": {"implemented": False},
+    "Zknd": {"implemented": True},
+    "Zkne": {"implemented": True},
+    "Zknh": {"implemented": True},
+    "Zkr": {"implemented": False},
+    "Zks": {"implemented": False},
+    "Zksed": {"implemented": True},
+    "Zksh": {"implemented": True},
+    "Zkt": {"implemented": False},
+    "Zmmul": {"implemented": False},
+    "Ztso": {"implemented": False},
+    "Zvbb": {"implemented": False},
+    "Zvbc": {"implemented": True},
+    "Zve32f": {"implemented": True},
+    "Zve32x": {"implemented": True},
+    "Zve64d": {"implemented": True},
+    "Zve64f": {"implemented": True},
+    "Zve64x": {"implemented": True},
+    "Zvfbfmin": {"implemented": False},
+    "Zvfbfwma": {"implemented": False},
+    "Zvfh": {"implemented": True},
+    "Zvfhmin": {"implemented": True},
+    "Zvkb": {"implemented": False},
+    "Zvkg": {"implemented": False},
+    "Zvkn": {"implemented": False},
+    "Zvknc": {"implemented": False},
+    "Zvkned": {"implemented": False},
+    "Zvkng": {"implemented": False},
+    "Zvknha": {"implemented": False},
+    "Zvknhb": {"implemented": False},
+    "Zvks": {"implemented": False},
+    "Zvksc": {"implemented": False},
+    "Zvksed": {"implemented": False},
+    "Zvksg": {"implemented": False},
+    "Zvksh": {"implemented": False},
+    "Zvkt": {"implemented": False},
+    "Zvl1024b": {"implemented": False},
+    "Zvl128b": {"implemented": False},
+    "Zvl256b": {"implemented": False},
+    "Zvl32b": {"implemented": False},
+    "Zvl512b": {"implemented": False},
+    "Zvl64b": {"implemented": False},
+}
+
+_SINGLE_LETTER_EXTENSION_ORDER = "MAFDQLCBKJTPVH"
+_MULTI_LETTER_EXTENSION_PREFIX_ORDER = {
+    "Z": 0,
+    "S": 1,
+    "H": 2,
+    "X": 3,
+}
+
+
+def _ordered_extension_names(extensions):
+    def sort_key(extension):
+        if len(extension) == 1:
+            order = _SINGLE_LETTER_EXTENSION_ORDER.find(extension)
+            if order != -1:
+                return (0, order, extension)
+            return (0, len(_SINGLE_LETTER_EXTENSION_ORDER), extension)
+
+        return (
+            1,
+            _MULTI_LETTER_EXTENSION_PREFIX_ORDER.get(extension[0], 4),
+            extension.lower(),
+        )
+
+    return tuple(sorted(extensions, key=sort_key))
+
+
+def _profile(parent=(), add=(), remove=()):
+    extensions = list(parent)
+    for extension in remove:
+        if extension in extensions:
+            extensions.remove(extension)
+    for extension in add:
+        if extension not in extensions:
+            extensions.append(extension)
+    return tuple(extensions)
+
+
+_RVI20 = ()
+_RVA20U64 = _profile(
+    _RVI20,
+    (
+        "M",
+        "A",
+        "F",
+        "D",
+        "C",
+        "Zicsr",
+        "Zicntr",
+        "Ziccif",
+        "Ziccrse",
+        "Ziccamoa",
+        "Za128rs",
+        "Zicclsm",
+    ),
+)
+_RVA20S64 = _profile(
+    _RVA20U64,
+    (
+        "Zifencei",
+        "Ss1p11",
+        "Svbare",
+        "Sv39",
+        "Svade",
+        "Ssccptr",
+        "Sstvecd",
+        "Sstvala",
+    ),
+)
+_RVA22U64 = _profile(
+    _RVA20U64,
+    (
+        "Zihpm",
+        "Za64rs",
+        "Zihintpause",
+        "Zba",
+        "Zbb",
+        "Zbs",
+        "Zic64b",
+        "Zicbom",
+        "Zicbop",
+        "Zicboz",
+        "Zfhmin",
+        "Zkt",
+    ),
+    remove=("Za128rs",),
+)
+_RVA22S64 = _profile(
+    _RVA22U64,
+    (
+        "Zifencei",
+        "Ss1p12",
+        "Svbare",
+        "Sv39",
+        "Svade",
+        "Ssccptr",
+        "Sstvecd",
+        "Sstvala",
+        "Sscounterenw",
+        "Svpbmt",
+        "Svinval",
+    ),
+)
+_RVA23U64 = _profile(
+    _RVA22U64,
+    (
+        "V",
+        "Zvfhmin",
+        "Zvbb",
+        "Zvkt",
+        "Zihintntl",
+        "Zicond",
+        "Zimop",
+        "Zcmop",
+        "Zcb",
+        "Zfa",
+        "Zawrs",
+        "Supm",
+    ),
+)
+_RVA23S64 = _profile(
+    _RVA23U64,
+    (
+        "Zifencei",
+        "Ss1p13",
+        "Svbare",
+        "Sv39",
+        "Svade",
+        "Ssccptr",
+        "Sstvecd",
+        "Sstvala",
+        "Sscounterenw",
+        "Svpbmt",
+        "Svinval",
+        "Svnapot",
+        "Sstc",
+        "Sscofpmf",
+        "Ssnpm",
+        "Ssu64xl",
+        "Sha",
+        "H",
+        "Ssstateen",
+        "Shcounterenw",
+        "Shvstvala",
+        "Shtvala",
+        "Shvstvecd",
+        "Shvsatpa",
+        "Shgatpa",
+    ),
+)
+_RVB23U64 = _profile(
+    _RVA22U64,
+    (
+        "Zihintntl",
+        "Zicond",
+        "Zimop",
+        "Zcmop",
+        "Zcb",
+        "Zfa",
+        "Zawrs",
+    ),
+    remove=("Zfhmin",),
+)
+_RVB23S64 = _profile(
+    _RVB23U64,
+    (
+        "Zifencei",
+        "Ss1p13",
+        "Svnapot",
+        "Svbare",
+        "Sv39",
+        "Svade",
+        "Ssccptr",
+        "Sstvecd",
+        "Sstvala",
+        "Sscounterenw",
+        "Svpbmt",
+        "Svinval",
+        "Sstc",
+        "Sscofpmf",
+        "Ssu64xl",
+    ),
+)
+
+_PROFILE_EXTENSIONS = {
+    "RVI20U32": _RVI20,
+    "RVI20U64": _RVI20,
+    "RVA20U64": _RVA20U64,
+    "RVA20S64": _RVA20S64,
+    "RVA22U64": _RVA22U64,
+    "RVA22S64": _RVA22S64,
+    "RVA23U64": _RVA23U64,
+    "RVA23S64": _RVA23S64,
+    "RVB23U64": _RVB23U64,
+    "RVB23S64": _RVB23S64,
+}
+
+
+def _validate_extension_tables():
+    known_extensions = set(_EXTENSION_REGISTRY)
+    invalid_entries = sorted(
+        extension
+        for extension, attributes in _EXTENSION_REGISTRY.items()
+        if not isinstance(attributes.get("implemented"), bool)
+    )
+    if invalid_entries:
+        raise ValueError(
+            "RISC-V extension registry entries missing implemented "
+            "metadata: %s" % ", ".join(invalid_entries)
+        )
+
+    profile_extensions = {
+        extension
+        for extensions in _PROFILE_EXTENSIONS.values()
+        for extension in extensions
+    }
+    unknown_profile_extensions = sorted(profile_extensions - known_extensions)
+    if unknown_profile_extensions:
+        raise ValueError(
+            "Profile RISC-V extensions missing from registry: %s"
+            % ", ".join(unknown_profile_extensions)
+        )
+
+
+_validate_extension_tables()
+
+
+_WARNED_PROFILE_CONFIGS = set()
+_WARNED_UNIMPLEMENTED_EXTRAS = set()
+
+
 class RiscvISA(BaseISA):
     type = "RiscvISA"
     cxx_class = "gem5::RiscvISA::ISA"
     cxx_header = "arch/riscv/isa.hh"
 
-    riscv_type = Param.RiscvType("RV64", "RV32 or RV64")
+    riscv_profile = Param.RiscvProfile(
+        "RVA23S64",
+        "RISC-V application profile used for extension reporting. Profile "
+        "selection does not gate instruction decoding or execution; it only "
+        "selects which supported mandatory profile extensions gem5 reports "
+        "to software.",
+    )
+    extra_extensions = VectorParam.String(
+        [
+            "Zbc",
+            "Zbkb",
+            "Zbkc",
+            "Zbkx",
+            # "Zcf",        # RV32-only and implied by C+F
+            # "Zcmp",       # C+D implies Zcd which is used by default
+            # "Zcmt",       # C+D implies Zcd which is used by default
+            "Zfh",
+            "Zknd",
+            "Zkne",
+            "Zknh",
+            "Zksed",
+            "Zksh",
+            "Zvbc",
+            "Zvfh",
+            # "Smrnmi",     # Not enabled by default, changes trapping behavior
+        ],
+        "Implemented extensions to expose in addition to the selected "
+        "profile.",
+    )
+    reported_extensions = VectorParam.RiscvInternalString(
+        [],
+        "Python-computed extension list passed to C++ for reporting.",
+    )
 
-    enable_rvv = Param.Bool(True, "Enable vector extension")
     vlen = Param.RiscvVectorLength(
         256,
         "Length of each vector register in bits. \
@@ -116,19 +576,6 @@ class RiscvISA(BaseISA):
         in Privilege Levels section of RISC-V privileged spec",
     )
 
-    enable_Zicbom_fs = Param.Bool(True, "Enable Zicbom extension in FS mode")
-    enable_Zicboz_fs = Param.Bool(True, "Enable Zicboz extension in FS mode")
-    enable_Zcd = Param.Bool(
-        True,
-        "Enable Zcd extensions. "
-        "Set the option to false implies the Zcmp and Zcmt is enable as "
-        "c.fsdsp is overlap with them."
-        "Refs: https://github.com/riscv/riscv-isa-manual/blob/main/src/zc.adoc",
-    )
-    enable_Smrnmi = Param.Bool(
-        False, "Resumable non-maskable interrupt in FS mode"
-    )
-
     wfi_resume_on_pending = Param.Bool(
         False,
         "If wfi_resume_on_pending is set to True, the hart will resume "
@@ -139,37 +586,147 @@ class RiscvISA(BaseISA):
         "pending.",
     )
 
+    def _effective_riscv_type(self):
+        profile = self.riscv_profile.value
+        if profile.endswith("U32"):
+            return "RV32"
+        if profile.endswith("U64") or profile.endswith("S64"):
+            return "RV64"
+        raise ValueError(
+            "Cannot determine XLEN from RISC-V profile: %s" % profile
+        )
+
+    def _configured_extensions(self):
+        profile = self.riscv_profile.value
+        mandatory = set(_PROFILE_EXTENSIONS[profile])
+        requested = {
+            extension.value if hasattr(extension, "value") else extension
+            for extension in self.extra_extensions
+        }
+        return mandatory, requested, mandatory | requested
+
+    def _is_supported(self, extension):
+        if extension == "H" and self.privilege_mode_set.value != "MHSU":
+            return False
+        return _EXTENSION_REGISTRY[extension]["implemented"]
+
+    def _validate_extensions(self):
+        mandatory, requested, effective = self._configured_extensions()
+        for extension in mandatory | requested:
+            if extension not in _EXTENSION_REGISTRY:
+                raise ValueError(
+                    "Unknown standard RISC-V extension: %s" % extension
+                )
+
+        unimplemented_extras = sorted(
+            extension
+            for extension in requested - mandatory
+            if not _EXTENSION_REGISTRY[extension]["implemented"]
+        )
+        if unimplemented_extras:
+            key = tuple(unimplemented_extras)
+            if key not in _WARNED_UNIMPLEMENTED_EXTRAS:
+                _WARNED_UNIMPLEMENTED_EXTRAS.add(key)
+                warn(
+                    "Ignoring RISC-V extensions that are recognized but not "
+                    "implemented/reportable: %s",
+                    ", ".join(unimplemented_extras),
+                )
+
+        missing = [
+            extension
+            for extension in mandatory
+            if not self._is_supported(extension)
+        ]
+        if missing:
+            key = (
+                self.riscv_profile.value,
+                tuple(_ordered_extension_names(missing)),
+            )
+            if key not in _WARNED_PROFILE_CONFIGS:
+                _WARNED_PROFILE_CONFIGS.add(key)
+                warn(
+                    "RISC-V profile %s has mandatory extensions not "
+                    "implemented/reportable by this gem5 configuration: %s",
+                    self.riscv_profile.value,
+                    ", ".join(_ordered_extension_names(missing)),
+                )
+        return mandatory, requested, effective
+
+    def _reported_extension_set(self, effective):
+        reportable = {
+            extension
+            for extension in effective
+            if self._is_supported(extension)
+        }
+
+        if {"Zba", "Zbb", "Zbs"}.issubset(reportable):
+            reportable.add("B")
+        if "C" in reportable:
+            reportable.add("Zca")
+        if {"C", "D"}.issubset(reportable):
+            reportable.add("Zcd")
+        if self._effective_riscv_type() == "RV32" and {"C", "F"}.issubset(
+            reportable
+        ):
+            reportable.add("Zcf")
+
+        return reportable
+
+    def reports_extension(self, extension):
+        _, _, effective = self._validate_extensions()
+        if extension not in _EXTENSION_REGISTRY:
+            return False
+        return extension in self._reported_extension_set(effective)
+
+    def get_reported_extensions(self):
+        _, _, effective = self._validate_extensions()
+        return list(
+            _ordered_extension_names(self._reported_extension_set(effective))
+        )
+
+    def get_missing_profile_extensions(self):
+        mandatory, _, _ = self._validate_extensions()
+        return [
+            extension
+            for extension in mandatory
+            if not self._is_supported(extension)
+        ]
+
     def get_isa_string(self):
-        isa_extensions = []
+        base_extensions = []
         # check for the base ISA type
-        if self.riscv_type.value == "RV32":
-            isa_extensions.append("rv32")
-        elif self.riscv_type.value == "RV64":
-            isa_extensions.append("rv64")
-        # use imafdc by default
-        isa_extensions.extend(["i", "m", "a", "f", "d", "c"])
-        # check for the vector extension
-        if self.enable_rvv.value == True:
-            isa_extensions.append("v")
+        if self._effective_riscv_type() == "RV32":
+            base_extensions.append("rv32")
+        elif self._effective_riscv_type() == "RV64":
+            base_extensions.append("rv64")
 
-        # H-extension is enabled whenever we choose
-        # MHSU privilege mode set
-        if self.privilege_mode_set.value == "MHSU":
-            isa_extensions.append("h")
+        reported_extensions = self.get_reported_extensions()
+        suppressed_extensions = set()
+        if "B" in reported_extensions:
+            suppressed_extensions.update(("Zba", "Zbb", "Zbs"))
+        if "C" in reported_extensions:
+            suppressed_extensions.update(("Zca", "Zcd", "Zcf"))
 
-        isa_string = "".join(isa_extensions)
+        single_letter = []
+        multi_letter = []
+        for extension in reported_extensions:
+            if extension == "I" or extension in suppressed_extensions:
+                continue
+            if len(extension) == 1:
+                single_letter.append(extension.lower())
+            else:
+                multi_letter.append(extension)
 
-        if self.enable_Zicbom_fs.value:
-            isa_string += "_Zicbom"  # Cache-block Management Instructions
-        if self.enable_Zicboz_fs.value:
-            isa_string += "_Zicboz"  # Cache-block Zero Instruction
-        isa_string += "_Zicntr"  # Performance Couter Spec
-        isa_string += "_Zicsr"  # RMW CSR Instructions (Privileged Spec)
-        isa_string += "_Zifencei"  # FENCE.I Instruction (Unprivileged Spec)
-        isa_string += "_Zihpm"  # Performance Couter Spec
-        isa_string += "_Zba"  # Address Generation
-        isa_string += "_Zbb"  # Basic Bit Manipulation
-        isa_string += "_Zbs"  # Single-bit Instructions
-        isa_string += "_svnapot"
+        isa_string = "".join(base_extensions + ["i"] + single_letter)
+
+        for extension in multi_letter:
+            isa_string += "_" + _EXTENSION_REGISTRY[extension].get(
+                "isa", extension
+            )
 
         return isa_string
+
+    def getCCParams(self):
+        self.reported_extensions = self.get_reported_extensions()
+        return super().getCCParams()

--- a/src/arch/riscv/SConscript
+++ b/src/arch/riscv/SConscript
@@ -96,7 +96,7 @@ SimObject(
 SimObject(
     'RiscvISA.py',
     sim_objects=['RiscvISA'],
-    enums=['RiscvType', 'PrivilegeModeSet'],
+    enums=['RiscvType', 'PrivilegeModeSet', 'RiscvProfile'],
     tags=['riscv isa']
 )
 SimObject(

--- a/src/arch/riscv/decoder.cc
+++ b/src/arch/riscv/decoder.cc
@@ -45,7 +45,7 @@ Decoder::Decoder(const RiscvDecoderParams &p) : InstDecoder(p, &machInst)
     ISA *isa = dynamic_cast<ISA*>(p.isa);
     vlen = isa->getVecLenInBits();
     elen = isa->getVecElemLenInBits();
-    _enableZcd = isa->enableZcd();
+    _hasZcd = isa->reportsExtension("Zcd");
     reset();
 }
 
@@ -167,7 +167,7 @@ Decoder::decode(PCStateBase &_next_pc)
     emi.vtype8  = vtype & 0xff;
     emi.vill    = vtype.vill;
     emi.rv_type = static_cast<int>(next_pc.rvType());
-    emi.enable_zcd = _enableZcd;
+    emi.has_zcd = _hasZcd;
 
     return decode(emi, next_pc.instAddr());
 }

--- a/src/arch/riscv/decoder.hh
+++ b/src/arch/riscv/decoder.hh
@@ -62,7 +62,7 @@ class Decoder : public InstDecoder
 
     uint32_t vlen;
     uint32_t elen;
-    bool _enableZcd;
+    bool _hasZcd;
     Addr jvtEntry;
 
     VTYPE vtype = (1ULL << 63); // vtype.vill = 1 at initial;

--- a/src/arch/riscv/faults.cc
+++ b/src/arch/riscv/faults.cc
@@ -87,8 +87,8 @@ RiscvFault::invoke(ThreadContext *tc, const StaticInstPtr &inst)
         // According to riscv-privileged-v1.11, if a NMI occurs at the middle
         // of a M-mode trap handler, the state (epc/cause) will be overwritten
         // and is not necessary recoverable unless smrnmi enabled.
-        warn_if(!isa->enableSmrnmi() && isNonMaskableInterrupt() &&
-                pp == PRV_M && status.mie == 0,
+        warn_if(!isa->reportsExtension("Smrnmi") && isNonMaskableInterrupt() &&
+                    pp == PRV_M && status.mie == 0,
                 "NMI overwriting M-mode trap handler state");
 
         // Set fault handler privilege mode

--- a/src/arch/riscv/faults.hh
+++ b/src/arch/riscv/faults.hh
@@ -74,7 +74,7 @@ class RiscvFault : public FaultBase
 
     bool isResumableNonMaskableInterrupt(ISA* isa) const
     {
-        return isa->enableSmrnmi() && isNonMaskableInterrupt();
+        return isa->reportsExtension("Smrnmi") && isNonMaskableInterrupt();
     }
 
     bool isPlainException() const {

--- a/src/arch/riscv/interrupts.hh
+++ b/src/arch/riscv/interrupts.hh
@@ -89,7 +89,8 @@ class Interrupts : public BaseInterrupts
     bool checkInterrupts() const override
     {
         ISA* isa = static_cast<ISA*>(tc->getIsaPtr());
-        if (isa->enableSmrnmi() && tc->readMiscReg(MISCREG_NMIE) == 0) {
+        if (isa->reportsExtension("Smrnmi") &&
+            tc->readMiscReg(MISCREG_NMIE) == 0) {
             return false;
         }
         return checkNonMaskableInterrupt() ||

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -32,6 +32,7 @@
 
 #include "arch/riscv/isa.hh"
 
+#include <algorithm>
 #include <ctime>
 #include <set>
 #include <sstream>
@@ -299,11 +300,14 @@ RegClass ccRegClass(CCRegClass, CCRegClassName, 0, debug::IntRegs);
 
 } // anonymous namespace
 
-ISA::ISA(const Params &p) : BaseISA(p, "riscv"),
-    _rvType(p.riscv_type), enableRvv(p.enable_rvv), vlen(p.vlen), elen(p.elen),
-    _privilegeModeSet(p.privilege_mode_set),
-    _wfiResumeOnPending(p.wfi_resume_on_pending), _enableZcd(p.enable_Zcd),
-    _enableSmrnmi(p.enable_Smrnmi)
+ISA::ISA(const Params &p)
+    : BaseISA(p, "riscv"),
+      _rvType(p.riscv_profile == enums::RVI20U32 ? enums::RV32 : enums::RV64),
+      vlen(p.vlen),
+      elen(p.elen),
+      _privilegeModeSet(p.privilege_mode_set),
+      _reportedExtensions(p.reported_extensions),
+      _wfiResumeOnPending(p.wfi_resume_on_pending)
 {
     _regClasses.push_back(&intRegClass);
     _regClasses.push_back(&floatRegClass);
@@ -314,15 +318,44 @@ ISA::ISA(const Params &p) : BaseISA(p, "riscv"),
     _regClasses.push_back(&ccRegClass);
     _regClasses.push_back(&miscRegClass);
 
-    if (enableRvv) {
+    if (hasVectorExtension()) {
         fatal_if(p.vlen < p.elen, "VLEN should be greater or equal",
                  "than ELEN. Ch. 2RISC-V vector spec.");
 
-        inform("RVV enabled, VLEN = %d bits, ELEN = %d bits", p.vlen, p.elen);
+        inform("RISC-V vector extension enabled, VLEN = %d bits, "
+               "ELEN = %d bits",
+               p.vlen, p.elen);
     }
 
     miscRegFile.resize(NUM_PHYS_MISCREGS);
     clear();
+}
+
+bool
+ISA::reportsExtension(std::string_view extension) const
+{
+    return std::any_of(_reportedExtensions.begin(), _reportedExtensions.end(),
+                       [extension](const std::string &reported) {
+                           return std::string_view(reported) == extension;
+                       });
+}
+
+bool
+ISA::reportsAllExtensions(
+    std::initializer_list<std::string_view> extensions) const
+{
+    return std::all_of(extensions.begin(), extensions.end(),
+                       [this](std::string_view extension) {
+                           return reportsExtension(extension);
+                       });
+}
+
+bool
+ISA::hasVectorExtension() const
+{
+    return reportsExtension("V") || reportsExtension("Zve32x") ||
+           reportsExtension("Zve32f") || reportsExtension("Zve64x") ||
+           reportsExtension("Zve64f") || reportsExtension("Zve64d");
 }
 
 bool ISA::inUserMode() const
@@ -368,8 +401,14 @@ void ISA::clear()
     MISA misa = 0;
     STATUS status = 0;
 
-    // default config arch isa string is rv64(32)imafdc
-    misa.rvi = misa.rvm = misa.rva = misa.rvf = misa.rvd = misa.rvc = 1;
+    // MISA reports the effective extension set exposed to software.
+    misa.rvi = 1;
+    misa.rvm = reportsExtension("M");
+    misa.rva = reportsExtension("A");
+    misa.rvf = reportsExtension("F");
+    misa.rvd = reportsExtension("D");
+    misa.rvc = reportsExtension("C");
+    misa.rvb = reportsExtension("B");
 
     switch (getPrivilegeModeSet()) {
         case enums::M:
@@ -381,8 +420,11 @@ void ISA::clear()
           misa.rvs = misa.rvu = 1;
           break;
         case enums::MHSU:
-          misa.rvh = misa.rvs = misa.rvu = 1;
-          inform("RVH enabled.");
+            misa.rvh = reportsExtension("H");
+            misa.rvs = misa.rvu = 1;
+            if (misa.rvh) {
+                inform("RVH enabled.");
+            }
           break;
         default:
           panic("Privilege mode set config should not reach here");
@@ -408,8 +450,9 @@ void ISA::clear()
               vsstatus.uxl = 2;
               vsstatus.fs = FPUStatus::INITIAL;
 
-              if (getEnableRvv())
-                vsstatus.vs = VPUStatus::INITIAL;
+              if (hasVectorExtension()) {
+                  vsstatus.vs = VPUStatus::INITIAL;
+              }
 
               miscRegFile[MISCREG_VSSTATUS] = vsstatus;
           }
@@ -417,10 +460,10 @@ void ISA::clear()
         default:
           panic("%s: Unknown _rvType: %d", name(), (int)_rvType);
     }
-    if (getEnableRvv()) {
+    if (hasVectorExtension()) {
         status.vs = VPUStatus::INITIAL;
-        misa.rvv = 1;
     }
+    misa.rvv = reportsExtension("V");
 
     miscRegFile[MISCREG_ISA] = misa;
     miscRegFile[MISCREG_STATUS] = status;
@@ -429,7 +472,7 @@ void ISA::clear()
     // don't set it to zero; software may try to determine the supported
     // triggers, starting at zero. simply set a different value here.
     miscRegFile[MISCREG_TSELECT] = 1;
-    miscRegFile[MISCREG_NMIE] = enableSmrnmi() ? 0 : 1;
+    miscRegFile[MISCREG_NMIE] = reportsExtension("Smrnmi") ? 0 : 1;
 }
 
 Fault
@@ -976,7 +1019,7 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                             2, 0) != 0) {
                     new_misa.rvc = new_misa.rvc | cur_misa.rvc;
                 }
-                if (!getEnableRvv()) {
+                if (!reportsExtension("V")) {
                     new_misa.rvv = 0;
                 }
                 new_misa.rvs = cur_misa.rvs;
@@ -992,8 +1035,8 @@ ISA::setMiscReg(RegIndex idx, RegVal val)
                     val &= ~(STATUS_SXL_MASK | STATUS_UXL_MASK);
                     val |= cur & (STATUS_SXL_MASK | STATUS_UXL_MASK);
                 }
-                if (!getEnableRvv()) {
-                    // Always OFF is rvv is disabled.
+                if (!hasVectorExtension()) {
+                    // Always OFF if no vector extension is enabled.
                     val &= ~STATUS_VS_MASK;
                 }
                 setMiscRegNoEffect(idx, val);
@@ -1475,16 +1518,19 @@ Fault
 updateVPUStatus(
     ExecContext *xc, ExtMachInst machInst, bool set_dirty, bool check_vill)
 {
+    auto *isa = static_cast<ISA *>(xc->tcBase()->getIsaPtr());
     MISA misa = xc->readMiscReg(MISCREG_ISA);
     STATUS status = xc->readMiscReg(MISCREG_STATUS);
     STATUS vsstatus = misa.rvh && virtualizationEnabled(xc) ?
         xc->readMiscReg(MISCREG_VSSTATUS) : 0;
 
-    if (!misa.rvv || status.vs == VPUStatus::OFF ||
+    if (!isa->hasVectorExtension() ||
+        (isa->reportsExtension("V") && !misa.rvv) ||
+        status.vs == VPUStatus::OFF ||
         (misa.rvh && virtualizationEnabled(xc) &&
          vsstatus.vs == VPUStatus::OFF)) {
         return std::make_shared<IllegalInstFault>(
-            "RVV is disabled or VPU is off", machInst);
+            "Vector extension is disabled or VPU is off", machInst);
     }
 
     if (check_vill && machInst.vill) {

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -35,7 +35,9 @@
 #ifndef __ARCH_RISCV_ISA_HH__
 #define __ARCH_RISCV_ISA_HH__
 
+#include <initializer_list>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -80,8 +82,6 @@ class ISA : public BaseISA
   protected:
     RiscvType _rvType;
     std::vector<RegVal> miscRegFile;
-    bool enableRvv;
-
     bool hpmCounterEnabled(int counter) const;
 
     // Load reserve - store conditional monitor
@@ -104,6 +104,9 @@ class ISA : public BaseISA
      */
     PrivilegeModeSet _privilegeModeSet;
 
+    /** Effective implemented extensions exposed to software. */
+    std::vector<std::string> _reportedExtensions;
+
     /**
      * The WFI instruction can halt the execution of a hart.
      * If this variable is set true, the execution resumes if
@@ -112,20 +115,6 @@ class ISA : public BaseISA
      * interrupt becomes pending.
     */
     const bool _wfiResumeOnPending;
-
-    /**
-     * Enable Zcd extensions.
-     * Set the option to false implies the Zcmp and Zcmt is enable as c.fsdsp
-     * is overlap with them.
-     * Refs: https://github.com/riscv/riscv-isa-manual/blob/main/src/zc.adoc
-     */
-    bool _enableZcd;
-
-    /**
-     * Resumable non-maskable interrupt
-     * Set true to make NMI recoverable
-     */
-    bool _enableSmrnmi;
 
   public:
     using Params = RiscvISAParams;
@@ -186,7 +175,10 @@ class ISA : public BaseISA
 
     RiscvType rvType() const { return _rvType; }
 
-    bool getEnableRvv() const { return enableRvv; }
+    bool reportsExtension(std::string_view extension) const;
+    bool reportsAllExtensions(
+        std::initializer_list<std::string_view> extensions) const;
+    bool hasVectorExtension() const;
 
     bool virtualizationEnabled() const;
 
@@ -207,10 +199,6 @@ class ISA : public BaseISA
     PrivilegeModeSet getPrivilegeModeSet() { return _privilegeModeSet; }
 
     bool resumeOnPending() { return _wfiResumeOnPending; }
-
-    bool enableZcd() { return _enableZcd; }
-
-    bool enableSmrnmi() { return _enableSmrnmi; }
 
     virtual Addr getFaultHandlerAddr(
         RegIndex idx, uint64_t cause, bool intr) const;

--- a/src/arch/riscv/isa/bitfields.isa
+++ b/src/arch/riscv/isa/bitfields.isa
@@ -34,7 +34,7 @@
 // Bitfield definitions.
 //
 def bitfield RVTYPE rv_type;
-def bitfield ENABLE_ZCD enable_zcd;
+def bitfield HAS_ZCD has_zcd;
 
 def bitfield QUADRANT <1:0>;
 def bitfield OPCODE5 <6:2>;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -54,7 +54,7 @@ decode QUADRANT default Unknown::unknown() {
             Rp2 = rvSext(sp + imm);
         }}, uint64_t);
         format CompressedLoad {
-            0x1: decode ENABLE_ZCD {
+            0x1: decode HAS_ZCD {
                 0x1: c_fld({{
                     offset = CIMM3 << 3 | CIMM2 << 6;
                 }}, {{
@@ -143,7 +143,7 @@ decode QUADRANT default Unknown::unknown() {
             }
         }
         format CompressedStore {
-            0x5: decode ENABLE_ZCD {
+            0x5: decode HAS_ZCD {
                 0x1: c_fsd({{
                     offset = CIMM3 << 3 | CIMM2 << 6;
                 }}, {{
@@ -371,7 +371,7 @@ decode QUADRANT default Unknown::unknown() {
             Rc1 = rvSext(Rc1 << imm);
         }}, uint64_t);
         format CompressedLoad {
-            0x1: decode ENABLE_ZCD {
+            0x1: decode HAS_ZCD {
                 0x1: c_fldsp({{
                     offset = CIMM5<4:3> << 3 |
                              CIMM1 << 5 |
@@ -466,7 +466,7 @@ decode QUADRANT default Unknown::unknown() {
             }
         }
         format CompressedStore {
-            0x5: decode ENABLE_ZCD {
+            0x5: decode HAS_ZCD {
                 0x0: decode CFUNCT6LOW3 {
                     0x0: decode JTINDEX5TO7 {
                         0x0: CmJalt::cm_jt({{
@@ -6403,7 +6403,7 @@ decode QUADRANT default Unknown::unknown() {
                     0x38: mnret({{
                         auto isa = dynamic_cast<RiscvISA::ISA*>(
                             xc->tcBase()->getIsaPtr());
-                        if (!isa->enableSmrnmi()) {
+                        if (!isa->reportsExtension("Smrnmi")) {
                             return std::make_shared<IllegalInstFault>(
                                         "mnret requires smrnmi enabled.",
                                         machInst);

--- a/src/arch/riscv/isa/formats/standard.isa
+++ b/src/arch/riscv/isa/formats/standard.isa
@@ -356,7 +356,8 @@ def template CSRExecute {{
                     machInst);
         }
 
-        if (csr_data_it->second.requireSmrnmi && !isa->enableSmrnmi()) {
+        if (csr_data_it->second.requireSmrnmi &&
+                !isa->reportsExtension("Smrnmi")) {
             return std::make_shared<IllegalInstFault>(
                     csprintf("%s requires Smrnmi enabled\n",
                              csrName),

--- a/src/arch/riscv/linux/se_workload.cc
+++ b/src/arch/riscv/linux/se_workload.cc
@@ -43,8 +43,9 @@
 
 #include <sys/syscall.h>
 
-#include "arch/riscv/process.hh"
 #include "arch/riscv/insts/static_inst.hh"
+#include "arch/riscv/isa.hh"
+#include "arch/riscv/process.hh"
 #include "arch/riscv/regs/misc.hh"
 #include "base/loader/object_file.hh"
 #include "base/trace.hh"
@@ -297,44 +298,170 @@ hwprobe_one_pair(ThreadContext *tc, RiscvLinux::riscv_hwprobe *pair,
         break;
     case RiscvLinux::IMAExt0:
         {
-            MISA misa = tc->readMiscRegNoEffect(MISCREG_ISA);
-            RiscvLinux::key_ima_ext_0_t *ext = (RiscvLinux::key_ima_ext_0_t *)&pair->value;
-            if (misa.rvf && misa.rvd) ext->FD = 1;
-            if (misa.rvc) ext->C = 1;
-            if (misa.rvv) ext->V = 1;
+        auto *isa = static_cast<RiscvISA::ISA *>(tc->getIsaPtr());
+        RiscvLinux::key_ima_ext_0_t *ext =
+            (RiscvLinux::key_ima_ext_0_t *)&pair->value;
+        if (isa->reportsAllExtensions({"F", "D"})) {
+            ext->FD = 1;
+        }
+        if (isa->reportsExtension("C")) {
+            ext->C = 1;
+        }
+        if (isa->reportsExtension("V")) {
+            ext->V = 1;
+        }
+        if (isa->reportsExtension("Zba")) {
             ext->ZBA = 1;
+        }
+        if (isa->reportsExtension("Zbb")) {
             ext->ZBB = 1;
+        }
+        if (isa->reportsExtension("Zbs")) {
             ext->ZBS = 1;
+        }
+        if (isa->reportsExtension("Zicboz")) {
             ext->ZICBOZ = 1;
+        }
+        if (isa->reportsExtension("Zbc")) {
             ext->ZBC = 1;
+        }
+        if (isa->reportsExtension("Zbkb")) {
             ext->ZBKB = 1;
+        }
+        if (isa->reportsExtension("Zbkc")) {
             ext->ZBKC = 1;
+        }
+        if (isa->reportsExtension("Zbkx")) {
             ext->ZBKX = 1;
+        }
+        if (isa->reportsExtension("Zknd")) {
             ext->ZKND = 1;
+        }
+        if (isa->reportsExtension("Zkne")) {
             ext->ZKNE = 1;
+        }
+        if (isa->reportsExtension("Zknh")) {
             ext->ZKNH = 1;
+        }
+        if (isa->reportsExtension("Zksed")) {
             ext->ZKSED = 1;
+        }
+        if (isa->reportsExtension("Zksh")) {
             ext->ZKSH = 1;
+        }
+        if (isa->reportsExtension("Zkt")) {
             ext->ZKT = 1;
+        }
+        if (isa->reportsExtension("Zvbb")) {
+            ext->ZVBB = 1;
+        }
+        if (isa->reportsExtension("Zvbc")) {
+            ext->ZVBC = 1;
+        }
+        if (isa->reportsExtension("Zvkb")) {
+            ext->ZVKB = 1;
+        }
+        if (isa->reportsExtension("Zvkg")) {
+            ext->ZVKG = 1;
+        }
+        if (isa->reportsExtension("Zvkned")) {
+            ext->ZVKNED = 1;
+        }
+        if (isa->reportsExtension("Zvknha")) {
+            ext->ZVKNHA = 1;
+        }
+        if (isa->reportsExtension("Zvknhb")) {
+            ext->ZVKNHB = 1;
+        }
+        if (isa->reportsExtension("Zvksed")) {
+            ext->ZVKSED = 1;
+        }
+        if (isa->reportsExtension("Zvksh")) {
+            ext->ZVKSH = 1;
+        }
+        if (isa->reportsExtension("Zvkt")) {
+            ext->ZVKT = 1;
+        }
+        if (isa->reportsExtension("Zfh")) {
             ext->ZFH = 1;
+        }
+        if (isa->reportsExtension("Zfhmin")) {
             ext->ZFHMIN = 1;
+        }
+        if (isa->reportsExtension("Zihintntl")) {
+            ext->ZIHINTNTL = 1;
+        }
+        if (isa->reportsExtension("Zvfh")) {
             ext->ZVFH = 1;
+        }
+        if (isa->reportsExtension("Zvfhmin")) {
             ext->ZVFHMIN = 1;
+        }
+        if (isa->reportsExtension("Zfa")) {
             ext->ZFA = 1;
+        }
+        if (isa->reportsExtension("Ztso")) {
+            ext->ZTSO = 1;
+        }
+        if (isa->reportsExtension("Zacas")) {
+            ext->ZACAS = 1;
+        }
+        if (isa->reportsExtension("Zicond")) {
             ext->ZICOND = 1;
+        }
+        if (isa->reportsExtension("Zihintpause")) {
+            ext->ZIHINTPAUSE = 1;
+        }
+        if (isa->reportsExtension("Zve32x") || isa->reportsExtension("V")) {
+            ext->ZVE32X = 1;
+        }
+        if (isa->reportsExtension("Zve32f") ||
+            isa->reportsAllExtensions({"V", "F"})) {
+            ext->ZVE32F = 1;
+        }
+        if (isa->reportsExtension("Zve64x") || isa->reportsExtension("V")) {
+            ext->ZVE64X = 1;
+        }
+        if (isa->reportsExtension("Zve64f") ||
+            isa->reportsAllExtensions({"V", "F"})) {
+            ext->ZVE64F = 1;
+        }
+        if (isa->reportsExtension("Zve64d") ||
+            isa->reportsAllExtensions({"V", "F", "D"})) {
             ext->ZVE64D = 1;
+        }
+        if (isa->reportsExtension("Zimop")) {
+            ext->ZIMOP = 1;
+        }
+        if (isa->reportsExtension("Zca")) {
+            ext->ZCA = 1;
+        }
+        if (isa->reportsExtension("Zcb")) {
             ext->ZCB = 1;
+        }
+        if (isa->reportsExtension("Zcd")) {
             ext->ZCD = 1;
+        }
+        if (isa->reportsExtension("Zcf")) {
             ext->ZCF = 1;
         }
-        break;
+        if (isa->reportsExtension("Zcmop")) {
+            ext->ZCMOP = 1;
+        }
+        if (isa->reportsExtension("Zawrs")) {
+            ext->ZAWRS = 1;
+        }
+    } break;
     case RiscvLinux::Cpuperf0:
     case RiscvLinux::MisalignedScalarPerf:
         pair->value = RiscvLinux::Slow;
         break;
-    case RiscvLinux::ZicbozBlockSize:
-        pair->value = tc->getSystemPtr()->cacheLineSize();
-        break;
+    case RiscvLinux::ZicbozBlockSize: {
+        auto *isa = static_cast<RiscvISA::ISA *>(tc->getIsaPtr());
+        pair->value = isa->reportsExtension("Zicboz")
+                          ? tc->getSystemPtr()->cacheLineSize()
+                          : 0;
+    } break;
     case RiscvLinux::HighestVirtAddress:
         pair->value = tc->getProcessPtr()->memState->getMmapEnd();
         break;

--- a/src/arch/riscv/tlb.cc
+++ b/src/arch/riscv/tlb.cc
@@ -488,7 +488,8 @@ TLB::getMemAccessInfo(ThreadContext *tc, BaseMMU::Mode mode,
     ISA* isa = dynamic_cast<ISA*>(tc->getIsaPtr());
     assert(isa);
 
-    bool nmie = !isa->enableSmrnmi() || tc->readMiscRegNoEffect(MISCREG_NMIE);
+    bool nmie = !isa->reportsExtension("Smrnmi") ||
+                tc->readMiscRegNoEffect(MISCREG_NMIE);
     bool in_mprv = nmie && (status.mprv == 1);
     bool virt = misa.rvh ? virtualizationEnabled(tc) : false;
     bool force_virt = false;

--- a/src/arch/riscv/types.hh
+++ b/src/arch/riscv/types.hh
@@ -58,7 +58,7 @@ BitUnion64(ExtMachInst)
     // Decoder state
     Bitfield<63, 62>    rv_type;
     Bitfield<61>        compressed;
-    Bitfield<60>        enable_zcd;
+    Bitfield<60> has_zcd;
     // More bits for vector extension
     Bitfield<57, 41>    vl;     // [0, 2**16]
     Bitfield<40>        vill;

--- a/src/python/gem5/components/boards/riscv_board.py
+++ b/src/python/gem5/components/boards/riscv_board.py
@@ -325,13 +325,13 @@ class RiscvBoard(
             node.append(FdtPropertyStrings("device_type", "cpu"))
             node.append(FdtPropertyWords("reg", state.CPUAddrCells(i)))
             node.append(FdtPropertyStrings("mmu-type", "riscv,sv48"))
-            if core.core.isa[0].enable_Zicbom_fs.value:
+            if core.core.isa[0].reports_extension("Zicbom"):
                 node.append(
                     FdtPropertyWords(
                         "riscv,cbom-block-size", self.get_cache_line_size()
                     )
                 )
-            if core.core.isa[0].enable_Zicboz_fs.value:
+            if core.core.isa[0].reports_extension("Zicboz"):
                 node.append(
                     FdtPropertyWords(
                         "riscv,cboz-block-size", self.get_cache_line_size()

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_core.py
@@ -215,4 +215,5 @@ class U74Core(BaseCPUCore):
         core_id,
     ):
         super().__init__(core=U74CPU(cpu_id=core_id), isa=ISA.RISCV)
-        self.core.isa[0].enable_rvv = False
+        self.core.isa[0].riscv_profile = "RVA20S64"
+        self.core.isa[0].extra_extensions = []

--- a/tests/gem5/riscv-unittests/asmtest/configs/riscv_asmtest.py
+++ b/tests/gem5/riscv-unittests/asmtest/configs/riscv_asmtest.py
@@ -96,7 +96,20 @@ processor = SimpleProcessor(
 if args.riscv_32bits:
     for simple_core in processor.cores:
         for i in range(len(simple_core.core.isa)):
-            simple_core.core.isa[i].riscv_type = "RV32"
+            isa = simple_core.core.isa[i]
+            isa.riscv_profile = "RVI20U32"
+            isa.extra_extensions = [
+                "M",
+                "A",
+                "F",
+                "D",
+                "C",
+                "Zba",
+                "Zbb",
+                "Zbs",
+                "Zicsr",
+                "Zifencei",
+            ]
 
 motherboard = SimpleBoard(
     clk_freq="3GHz",


### PR DESCRIPTION
This change replaces the independent RISC-V ISA extension parameters with profile-based extension reporting.

Previously, RISC-V extensions were configured and reported through a combination of hard-coded defaults and individual parameters such as:

- `riscv_type`
- `enable_rvv`
- `enable_Zicbom_fs`
- `enable_Zicboz_fs`
- `enable_Zcd`
- `enable_Smrnmi`

This made it difficult to keep `misa`, device-tree ISA strings, Linux `riscv_hwprobe`, and internal extension checks consistent.

The new interface consists of:

- `riscv_profile`, which selects a standard RISC-V application profile.
- `extra_extensions`, which adds implemented extensions outside the selected profile.
- A central extension registry describing which standard extensions gem5 currently implements and can report.
- An internal flattened extension list passed from Python configuration to the C++ ISA implementation.

## Profile semantics

Profiles in this implementation are informative and are used to determine which capabilities gem5 reports to software.

Selecting a profile does not claim that gem5 fully implements that profile, and the profile mechanism is not intended to provide general instruction decoding or execution enforcement.

For a selected profile, gem5:

1. Obtains the mandatory extensions defined by the profile.
2. Adds the extensions requested through `extra_extensions`.
3. Validates that the requested names are recognized standard extensions.
4. Activates, for reporting, only extensions marked as implemented by gem5.
5. Prints a warning containing the mandatory profile extensions that could  not be activated.

This allows the profile definitions to remain architecturally accurate while clearly exposing the subset currently supported by gem5.

For example, selecting `RVA23S64` does not silently claim complete RVA23S64 compliance. gem5 reports the implemented mandatory extensions and prints the mandatory extensions that are not currently activated.

## Supported profiles

The following profile names are introduced:

- `RVI20U32`
- `RVI20U64`
- `RVA20U64`
- `RVA20S64`
- `RVA22U64`
- `RVA22S64`
- `RVA23U64`
- `RVA23S64`
- `RVB23U64`
- `RVB23S64`

XLEN is derived from the selected profile, replacing the separate `riscv_type` parameter.

## Extension reporting

Python computes the effective reportable extension set and passes it to the C++ ISA implementation.

The resulting set is used consistently by:

- `misa` initialization.
- Device-tree `riscv,isa` generation.
- Linux `riscv_hwprobe`.
- Zicbom and Zicboz device-tree properties.
- Vector-extension availability checks.
- Zcd compressed-instruction decoding selection.
- Smrnmi behavior and CSR availability.
- Other RISC-V components that need to query an extension.

The C++ ISA exposes `reportsExtension()` and `reportsAllExtensions()` so consumers no longer need their own extension-specific configuration parameters.

## Implied extensions

The reporting code handles the fixed relationships required by the ISA:

- `Zba + Zbb + Zbs` imply `B`.
- `C` implies `Zca`.
- `C + D` imply `Zcd`.
- On RV32, `C + F` imply `Zcf`.

Implied extensions are available to internal extension queries while
redundant names are omitted from the generated ISA string.

## Preserved defaults

The change preserves the effective behavior of the previous generic RISC-V ISA defaults:

- RV64 remains the default XLEN.
- RVV remains enabled.
- Zicbom remains enabled and reported.
- Zicboz remains enabled and reported.
- `C + D` continue to enable Zcd.
- Smrnmi remains disabled by default.
- Existing base integer, multiplication, atomic, floating-point, and compressed capabilities remain reported.

Additional implemented extensions compatible with the default configuration can be reported through `extra_extensions`.

