### PR TITLE
stdlib: Fix typo in custom_mesh PR

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
@@ -342,10 +342,10 @@ class PrivateL1PrivateL2MeshCacheHierarchy(
 
                     # The latency for outbound messages to the network is defined by
                     # these parameters when enqueueing messages in the SLICC code
-                    cntrl.request_latency = outbound_latency
-                    cntrl.response_latency = outbound_latency
-                    cntrl.snoop_latency = outbound_latency
-                    cntrl.data_latency = outbound_latency
+                    ctrl.request_latency = outbound_latency
+                    ctrl.response_latency = outbound_latency
+                    ctrl.snoop_latency = outbound_latency
+                    ctrl.data_latency = outbound_latency
 
     def _create_hnfs(
         self, board: AbstractBoard, num_hnfs: int


### PR DESCRIPTION
This was introduced by the SimpleNetwork porting [1]

[1]: https://github.com/gem5/gem5/pull/3244

Change-Id: I0476a050bf3d86034d9bf8b539bddd37ae7a4d9c