### PR TITLE
tests: Fix test_linux_boot_mesh.py test name

### DIFF
--- a/tests/gem5/arm_boot_tests/test_linux_boot_mesh.py
+++ b/tests/gem5/arm_boot_tests/test_linux_boot_mesh.py
@@ -50,7 +50,7 @@ def test_boot_mesh(
     systemd: bool,
     to_tick: int,
 ):
-    name = f"{cpu}-cpu_{num_cpus}-cores_{mem_system}_" "arm_boot_test_mesh_2x4"
+    name = f"{cpu}-cpu_{num_cpus}-cores_arm_boot_test_mesh_2x4"
 
     config_args = [
         "--cpu",


### PR DESCRIPTION
The previous name, copy pasted from test_linux_boot.py was formatted using the mem_system variable which is not defined for custom mesh test (since it works with CHI only)

As a consequence testlib was throwing an exception

    exec(open(path).read(), newdict, newdict)
  File "<string>", line 103, in <module>
  File "<string>", line 53, in test_boot_mesh
NameError: name 'mem_system' is not defined
[...]
Ignoring all tests in this file.

Needless to say testlib was therefore silently ignoring the suite altogether, as can be seen by the log
above.

Change-Id: Idde3977e4553422eb223f4dea872e719ce37feac