### PR TITLE
base: add this_thread::yield in the FairUncontendedMutex test

### DIFF
--- a/src/base/uncontended_mutex.test.cc
+++ b/src/base/uncontended_mutex.test.cc
@@ -131,6 +131,8 @@ TEST(FairUncontendedMutex, NoBarging)
                 }
                 --remaining_work;
                 ++workload[t];
+
+                std::this_thread::yield();
             }
         });
     }


### PR DESCRIPTION
 ## Summary
Fixes intermittent test flakiness in `FairUncontendedMutex.NoBarging` when running under high host CPU core contention or parallel test sweeps.

## Root Cause
In `FairUncontendedMutex.NoBarging`, the critical section takes nanoseconds. On heavily loaded systems or when running parallel test workers, the thread scheduled first by the OS kernel completes the entire workload before co-located threads get scheduled onto physical CPU cores to request lock tickets. This leads to false-positive workload imbalance test failures.

 ## How to Reproduce
Before this change, running parallel instances of the test reproduced the flakiness:
```bash
seq 1 500 | xargs -P $(nproc) -I {} sh -c './build/ALL/base/uncontended_mutex.test.opt --gtest_filter="FairUncontendedMutex.NoBarging" || echo "Run {} failed"
```

## Solution

Added  `std::this_thread::yield()`  inside the loop in `FairUncontendedMutex.NoBarging` . Calling  `yield()` yields the active thread's OS CPU time slice, ensuring that all 10 competing threads get scheduled to acquire
  tickets in  `FairUncontendedMutex`'s condition variable queue and receive a fair share of the workload.