### PR TITLE
stdlib: Store amdgpu modprobe parameters for reloads

### DIFF
--- a/src/python/gem5/components/devices/gpus/amdgpu.py
+++ b/src/python/gem5/components/devices/gpus/amdgpu.py
@@ -212,7 +212,8 @@ class MI210(BaseViperGPU):
             '    echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."\n'
             "    m5 exit\n"
             "else\n"
-            "    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0\n"
+            "    echo 'options amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0' > /etc/modprobe.d/amdgpu.conf\n"
+            "    modprobe -v amdgpu\n"
             "fi\n"
         )
 
@@ -338,7 +339,8 @@ class MI300X(BaseViperGPU):
             "    sh /home/gem5/load_amdgpu.sh\n"
             "else\n"
             # develop support
-            f"    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery={self._discovery_value}\n"
+            f"    echo 'options amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery={self._discovery_value}' > /etc/modprobe.d/amdgpu.conf\n"
+            "    modprobe -v amdgpu\n"
             "fi\n"
         )
 
@@ -406,7 +408,8 @@ class MI355X(MI300X):
             "    sh /home/gem5/load_amdgpu.sh\n"
             "else\n"
             # develop support
-            f"    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery={self._discovery_value}\n"
+            f"    echo 'options amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery={self._discovery_value}' > /etc/modprobe.d/amdgpu.conf\n"
+            "    modprobe -v amdgpu\n"
             "fi\n"
         )
 


### PR DESCRIPTION
Some device configuration changes require reloading the driver. This reload ignores the special kernel module parameters we are passing, which causes the driver reload to exercise code paths that gem5 does not support. To work around this, store the module paramters in a modprobe file then call a simple modprobe as the driver reload would do.

This is only done for the "new" get_driver_command function as it is most important for ROCm 7.2+ and supporting older versions would require modifying older, already deployed disk images.