### PR TITLE
sim: Add getGdbListenerOutput method to Workload

### DIFF
--- a/src/base/remote_gdb.cc
+++ b/src/base/remote_gdb.cc
@@ -452,6 +452,17 @@ BaseRemoteGDB::hostSocket() const
     return *listener;
 }
 
+std::string
+BaseRemoteGDB::getListenerOutput() const
+{
+    if (!listener || !listener->islistening())
+        return "";
+
+    std::stringstream ss;
+    listener->output(ss);
+    return ss.str();
+}
+
 void
 BaseRemoteGDB::attach(int f)
 {

--- a/src/base/remote_gdb.cc
+++ b/src/base/remote_gdb.cc
@@ -455,8 +455,9 @@ BaseRemoteGDB::hostSocket() const
 std::string
 BaseRemoteGDB::getListenerOutput() const
 {
-    if (!listener || !listener->islistening())
+    if (!listener || !listener->islistening()) {
         return "";
+    }
 
     std::stringstream ss;
     listener->output(ss);

--- a/src/base/remote_gdb.hh
+++ b/src/base/remote_gdb.hh
@@ -162,6 +162,7 @@ class BaseRemoteGDB
     void connect();
 
     const ListenSocket &hostSocket() const;
+    std::string getListenerOutput() const;
 
     void attach(int fd);
     void detach();

--- a/src/sim/Workload.py
+++ b/src/sim/Workload.py
@@ -62,6 +62,14 @@ class Workload(SimObject):
         """
         pass
 
+    @cxxMethod
+    def getGdbListenerOutput(self):
+        """
+        Returns the actual bound address of the remote GDB listener as a string.
+        Returns an empty string if no listener is attached.
+        """
+        pass
+
 
 class StubWorkload(Workload):
     type = "StubWorkload"

--- a/src/sim/workload.cc
+++ b/src/sim/workload.cc
@@ -79,24 +79,27 @@ Workload::trapToGdb(GDBSignal signal, ContextID ctx_id)
         return true;
     }
     return false;
-};
+}
+
 bool
-Workload::sendToGdb(std::string msg){
-     if (gdb)
+Workload::sendToGdb(std::string msg)
+{
+    if (gdb) {
         return gdb->sendMessage(msg);
-    else
+    } else {
         return false;
- }
+    }
+}
 
 std::string
 Workload::getGdbListenerOutput() const
 {
-    if (!gdb)
+    if (!gdb) {
         return "";
+    }
 
     return gdb->getListenerOutput();
 }
-
 
 void
 Workload::startup()

--- a/src/sim/workload.cc
+++ b/src/sim/workload.cc
@@ -88,6 +88,15 @@ Workload::sendToGdb(std::string msg){
         return false;
  }
 
+std::string
+Workload::getGdbListenerOutput() const
+{
+    if (!gdb)
+        return "";
+
+    return gdb->getListenerOutput();
+}
+
 
 void
 Workload::startup()

--- a/src/sim/workload.hh
+++ b/src/sim/workload.hh
@@ -94,6 +94,7 @@ class Workload : public SimObject
     // system object, this helper can be removed.
     bool trapToGdb(GDBSignal sig, ContextID ctx_id);
     bool sendToGdb(std::string msg);
+    std::string getGdbListenerOutput() const;
 
     virtual void registerThreadContext(ThreadContext *tc);
     virtual void replaceThreadContext(ThreadContext *tc);


### PR DESCRIPTION
Expose getListenerOutput on BaseRemoteGDB and getGdbListenerOutput on Workload to query the actual bound runtime socket address of the remote GDB listener.