### PR TITLE
mem: Make the backdoor mechanism of SimpleMemory optional

### DIFF
--- a/src/mem/SimpleMemory.py
+++ b/src/mem/SimpleMemory.py
@@ -73,6 +73,7 @@ class SimpleMemory(AbstractMemory):
     bandwidth = Param.MemoryBandwidth(
         "12.8GiB/s", "Combined read and write bandwidth"
     )
+    enable_backdoor = Param.Bool(True, "Enable the backdoor mechanism")
 
     def controller(self):
         # Simple memory doesn't use a MemCtrl

--- a/src/mem/simple_mem.cc
+++ b/src/mem/simple_mem.cc
@@ -58,6 +58,7 @@ SimpleMemory::SimpleMemory(const SimpleMemoryParams &p)
       latencyDist(p.latency_dist),
       latencyDistParam(p.latency_dist_param),
       bandwidth(p.bandwidth),
+      enableBackdoor(p.enable_backdoor),
       isBusy(false),
       retryReq(false),
       retryResp(false),
@@ -99,7 +100,9 @@ Tick
 SimpleMemory::recvAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &_backdoor)
 {
     Tick latency = recvAtomic(pkt);
-    getBackdoor(_backdoor);
+    if (enableBackdoor) {
+        getBackdoor(_backdoor);
+    }
     return latency;
 }
 

--- a/src/mem/simple_mem.hh
+++ b/src/mem/simple_mem.hh
@@ -136,6 +136,12 @@ class SimpleMemory : public AbstractMemory
     const double bandwidth;
 
     /**
+     * Whether to enable the backdoor mechanism or not. If disabled, it will
+     * ignore the backdoor requests when receives.
+     */
+    const bool enableBackdoor;
+
+    /**
      * Track the state of the memory as either idle or busy, no need
      * for an enum with only two states.
      */


### PR DESCRIPTION
Sometimes a SimpleMemory is placed under a default port as the default
destination of an XBar. Some memory_side_ports are connected, so the
default port might not be continuous. It would be convenient if we could
just assign a universal address range to the SimpleMemory the XBar would
filter which address to be forwarded.
However, since SimpleMemory returns the backdoor for its whole address
range, the CPU would access all address range via the backdoor, even
though some of them were to be distributed to other mem_side_ports.
Thus, it require a device memory with the backdoor disabled.
This CL makes the backdoor optional to fulfill this usecase.

Change-Id: I98c490bed98c26f0372556840669742f876be74d