### PR TITLE
mem: Refactor BackdoorManager to support dynamic address range updates

### DIFF
--- a/src/mem/backdoor_manager.cc
+++ b/src/mem/backdoor_manager.cc
@@ -45,10 +45,26 @@ namespace gem5
 
 BackdoorManager::BackdoorManager(const std::vector<AddrRange> &original_ranges,
                                  const std::vector<AddrRange> &remapped_ranges)
-    : originalRanges(original_ranges),
-      remappedRanges(remapped_ranges),
-      backdoorLists(original_ranges.size())
+    : originalRanges(original_ranges), remappedRanges(remapped_ranges)
 {
+}
+
+void
+BackdoorManager::updateAddrRange(const std::vector<AddrRange> &original_ranges,
+                                 const std::vector<AddrRange> &remapped_ranges)
+{
+    /* The entries in the map is not erased, so we don't need to re-register
+     * the callback when the same backdoor is returned again.
+     */
+    for (auto &pair : backdoorMap) {
+        auto &backdoor_list = pair.second;
+        for (auto &backdoor_ptr : backdoor_list) {
+            backdoor_ptr->invalidate();
+        }
+        backdoor_list.clear();
+    }
+    originalRanges = original_ranges;
+    remappedRanges = remapped_ranges;
 }
 
 MemBackdoorPtr
@@ -66,7 +82,28 @@ MemBackdoorPtr
 BackdoorManager::createRevertedBackdoor(MemBackdoorPtr backdoor,
                                         const AddrRange &pkt_range)
 {
-    std::unique_ptr<MemBackdoor> reverted_backdoor = std::make_unique<MemBackdoor>();
+    auto it = backdoorMap.find(backdoor);
+    /* If the backdoor is not registered yet, register the callback to inform
+     * the backdoor to clear the map when invalidated. The entry in the map
+     * will be implicitly added later.
+     */
+    if (it == backdoorMap.end()) {
+        backdoor->addInvalidationCallback([this](const MemBackdoor &backdoor) {
+            auto &backdoorMap = this->backdoorMap;
+            auto it = backdoorMap.find(&backdoor);
+            if (it == backdoorMap.end()) {
+                return;
+            }
+            auto &backdoor_list = it->second;
+            for (auto &backdoor_ptr : backdoor_list) {
+                backdoor_ptr->invalidate();
+            }
+            backdoorMap.erase(it);
+        });
+    }
+
+    std::unique_ptr<MemBackdoor> reverted_backdoor =
+        std::make_unique<MemBackdoor>();
     reverted_backdoor->flags(backdoor->flags());
     reverted_backdoor->ptr(backdoor->ptr());
 
@@ -101,18 +138,15 @@ BackdoorManager::createRevertedBackdoor(MemBackdoorPtr backdoor,
             reverted_backdoor->ptr(backdoor->ptr() + shrinked_offset);
 
             /**
-             * Bind the life cycle of the created backdoor with the target
-             * backdoor. Invalid and delete the created backdoor when the
-             * target backdoor is invalidated.
+             * The created backdoors will be invalidated and deleted when the
+             * target backdoor is invalidated, or the manager is reset.
              */
             MemBackdoorPtr reverted_backdoor_raw_ptr = reverted_backdoor.get();
-            auto it = backdoorLists[i].insert(backdoorLists[i].end(),
-                                              std::move(reverted_backdoor));
-            backdoor->addInvalidationCallback(
-                [this, i, it](const MemBackdoor &backdoor) {
-                    (*it)->invalidate();  // *it is unique_ptr reverted_backdoor
-                    this->backdoorLists[i].erase(it);
-                });
+            /**
+             * If the backdoor is not registered yet, the following statement
+             * will also implicitly insert an entry to the map with empty list.
+             */
+            backdoorMap[backdoor].push_back(std::move(reverted_backdoor));
             return reverted_backdoor_raw_ptr;
         }
     }
@@ -125,20 +159,11 @@ BackdoorManager::findBackdoor(const AddrRange &pkt_range) const
 {
     Addr addr = pkt_range.start();
     Addr size = pkt_range.size();
-    for (int i = 0; i < originalRanges.size(); ++i) {
-        /** The original ranges should be disjoint, so at most one range
-         * contains the begin address.
-         */
-        if (originalRanges[i].contains(addr)) {
-            if (!originalRanges[i].contains(addr + size - 1)) {
-                /** The request range doesn't fit in any address range. */
-                return nullptr;
-            }
-            for (const auto &backdoor : backdoorLists[i]) {
-                if (backdoor->range().contains(addr) &&
-                    backdoor->range().contains(addr + size - 1)) {
-                    return backdoor.get();
-                }
+    for (const auto &pair : backdoorMap) {
+        for (const auto &backdoor : pair.second) {
+            if (backdoor->range().contains(addr) &&
+                backdoor->range().contains(addr + size - 1)) {
+                return backdoor.get();
             }
         }
     }

--- a/src/mem/backdoor_manager.hh
+++ b/src/mem/backdoor_manager.hh
@@ -39,6 +39,7 @@
 #define __MEM_BACKDOOR_MANAGER_HH__
 
 #include <list>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -60,6 +61,13 @@ class BackdoorManager
 
     MemBackdoorPtr getRevertedBackdoor(MemBackdoorPtr backdoor,
                                        const AddrRange &pkt_range);
+    /**
+     * Invalidate and clear all managed reverted backdoors, then update the
+     * original/remapped address ranges. Map entries/callback registrations are
+     * kept.
+     */
+    void updateAddrRange(const std::vector<AddrRange> &original_ranges,
+                         const std::vector<AddrRange> &remapped_ranges);
 
   protected:
     /**
@@ -75,14 +83,15 @@ class BackdoorManager
      */
     MemBackdoorPtr findBackdoor(const AddrRange &pkt_range) const;
 
-    const std::vector<AddrRange> &originalRanges;
-    const std::vector<AddrRange> &remappedRanges;
+    std::vector<AddrRange> originalRanges;
+    std::vector<AddrRange> remappedRanges;
 
     /**
      * In this vector, each entry contains a list of backdoors that in the
      * range in original address view.
      */
-    std::vector<std::list<std::unique_ptr<MemBackdoor>>> backdoorLists;
+    std::map<const MemBackdoor *, std::list<std::unique_ptr<MemBackdoor>>>
+        backdoorMap;
 };
 }  // namespace gem5
 

--- a/src/mem/backdoor_manager.test.cc
+++ b/src/mem/backdoor_manager.test.cc
@@ -40,6 +40,10 @@ namespace backdoor_manager_test
 
 const std::vector<AddrRange> kOriginalRange({AddrRange(0x0, 0x1000)});
 const std::vector<AddrRange> kRemappedRange({AddrRange(0x1000, 0x2000)});
+const std::vector<AddrRange>
+    kUpdatedOriginalRange({AddrRange(0x2000, 0x3000)});
+const std::vector<AddrRange>
+    kUpdatedRemappedRange({AddrRange(0x4000, 0x5000)});
 
 class BackdoorManagerTest : public BackdoorManager, public ::testing::Test
 {
@@ -66,15 +70,16 @@ TEST_F(BackdoorManagerTest, BasicRemapTest)
 
     EXPECT_EQ(reverted_backdoor->range(), originalRanges[0]);
     EXPECT_EQ(reverted_backdoor->ptr(), dummy_ptr);
-    ASSERT_EQ(backdoorLists[0].size(), 1);
-    EXPECT_EQ(backdoorLists[0].begin()->get(), reverted_backdoor);
+    ASSERT_EQ(backdoorMap[&remapped_backdoor].size(), 1);
+    EXPECT_EQ(backdoorMap[&remapped_backdoor].begin()->get(),
+              reverted_backdoor);
 
     /**
      * After the target backdoor is invalidated, the new created backdoor should
      * be freed and removed from the backdoor list.
      */
     remapped_backdoor.invalidate();
-    EXPECT_EQ(backdoorLists[0].size(), 0);
+    EXPECT_EQ(backdoorMap[&remapped_backdoor].size(), 0);
 }
 
 TEST_F(BackdoorManagerTest, ShrinkTest)
@@ -122,7 +127,7 @@ TEST_F(BackdoorManagerTest, ReuseTest)
      */
     MemBackdoorPtr reverted_backdoor_0 =
         getRevertedBackdoor(&remapped_backdoor, pkt_range_0);
-    EXPECT_EQ(backdoorLists[0].size(), 1);
+    EXPECT_EQ(backdoorMap[&remapped_backdoor].size(), 1);
 
     /**
      * For the second packet, it should return the same backdoor as previous
@@ -131,9 +136,37 @@ TEST_F(BackdoorManagerTest, ReuseTest)
     MemBackdoorPtr reverted_backdoor_1 =
         getRevertedBackdoor(&remapped_backdoor, pkt_range_1);
     EXPECT_EQ(reverted_backdoor_0, reverted_backdoor_1);
-    EXPECT_EQ(backdoorLists[0].size(), 1);
+    EXPECT_EQ(backdoorMap[&remapped_backdoor].size(), 1);
 
     remapped_backdoor.invalidate();
+}
+
+TEST_F(BackdoorManagerTest, UpdateRangeTest)
+{
+    /**
+     * The backdoor range is remappedRanges[0], and should be reverted into
+     * originalRanges[0].
+     */
+    AddrRange pkt_range = originalRanges[0];
+
+    MemBackdoor remapped_backdoor(remappedRanges[0], dummy_ptr,
+                                  MemBackdoor::Flags::Readable);
+    MemBackdoorPtr reverted_backdoor =
+        getRevertedBackdoor(&remapped_backdoor, pkt_range);
+
+    EXPECT_EQ(reverted_backdoor->range(), originalRanges[0]);
+    EXPECT_EQ(reverted_backdoor->ptr(), dummy_ptr);
+    ASSERT_EQ(backdoorMap[&remapped_backdoor].size(), 1);
+    EXPECT_EQ(backdoorMap[&remapped_backdoor].begin()->get(),
+              reverted_backdoor);
+
+    /**
+     * After the address ranges are updated, all managed backdoor should be
+     * removed.
+     */
+    updateAddrRange(kUpdatedOriginalRange, kUpdatedRemappedRange);
+    EXPECT_NE(backdoorMap.find(&remapped_backdoor), backdoorMap.end());
+    EXPECT_EQ(backdoorMap[&remapped_backdoor].size(), 0);
 }
 
 }  // namespace backdoor_manager_test


### PR DESCRIPTION
We're about to support a new RangeAddrRemapper that can change the remapping during simulation. Once the range changes, all remapped backdoors should be invalidated and removed. The original design couldn't support this because of the invalidation callbacks.

This CL proposes a new structure for the backdoor manager to support this dynamic invalidation, and adds the `updateRanges` interface so that remappers can safely update the address ranges of the BackdoorManager during simulation. It also includes a minor line length formatting fix in `createRevertedBackdoor`.