### PR TITLE
arch-x86: Fix MOVQ_XMM_XMM to copy 64 bits

### DIFF
--- a/src/arch/x86/isa/insts/simd128/integer/data_transfer/move.py
+++ b/src/arch/x86/isa/insts/simd128/integer/data_transfer/move.py
@@ -35,7 +35,7 @@
 
 microcode = """
 def macroop MOVQ_XMM_XMM {
-    movfp xmml, xmmlm
+    movfp xmml, xmmlm, dataSize=8
     lfpimm xmmh, 0
 };
 


### PR DESCRIPTION
The reg-reg form of movq (F3 0F 7E) omitted dataSize=8 on its movfp microop, so it inherited the default 4-byte operand size and performed a 32-bit merge into the destination's low qword instead of a 64-bit copy: the upper 32 bits of the low qword kept their previous value. The memory forms (MOVQ_XMM_M, MOVQ_M_XMM) already specify dataSize=8.

This corrupts FP data. Observed under gem5 (Atomic and O3, FS mode) the merged exponent bits produced NaN results every frame, while the same binary computes correctly natively. With this fix the workload's outputs under gem5 are bit-identical to native execution.

## Minimal reproducer

```asm
movabs $0x1122334455667788, %rax
movq   %rax, %xmm0
movabs $0xdeadbeefdeadbeef, %rbx
movq   %rbx, %xmm1
movq   %xmm0, %xmm1        #  F3 0F 7E - should copy all 64 bits
movq   %xmm1, %rcx
```

Native: `rcx = 0x1122334455667788`.
gem5 before this patch: `rcx = 0xdeadbeef55667788` — the upper 32 bits
of the destination's low qword survive the "copy".