### PR TITLE
mem-ruby: Fix existing issues in TlmController RSP handling

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -212,8 +212,6 @@ CacheController::Transaction::handle(const CHIResponseMsg *msg)
 bool
 CacheController::ReadTransaction::handle(const CHIDataMsg *msg)
 {
-    dataMsgCnt++;
-
     for (auto byte = 0; byte < controller->cacheLineSize; byte++) {
         if (msg->m_bitMask.test(byte))
             payload->data[byte] = msg->m_dataBlk.getByte(byte);
@@ -227,6 +225,12 @@ CacheController::ReadTransaction::handle(const CHIDataMsg *msg)
     phase.data_id = dataId(msg->m_addr + msg->m_bitMask.firstBitSet(true));
     phase.c_busy = msg->m_cbusy;
     phase.src_id = ruby_to_tlm::srcId(msg->m_responder);
+
+    dataMsgCnt++;
+    if (phase.dat_opcode == ARM::CHI::DAT_OPCODE_COMP_DATA) {
+        // A CompData counts as a (COMP) response
+        rspMsgCnt++;
+    }
 
     if (forward(msg)) {
         controller->bw(payload, &phase);

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -240,9 +240,19 @@ CacheController::ReadTransaction::handle(const CHIDataMsg *msg)
 }
 
 bool
+CacheController::ReadTransaction::compRespToMakeReadUnique(
+    const ARM::CHI::Phase &resp)
+{
+    return orig.req_opcode == ARM::CHI::REQ_OPCODE_MAKE_READ_UNIQUE &&
+           resp.channel == ARM::CHI::CHANNEL_RSP &&
+           resp.rsp_opcode == ARM::CHI::RSP_OPCODE_COMP;
+}
+
+bool
 CacheController::ReadTransaction::handleCompletion()
 {
-    if (dataMsgCnt == controller->dataMsgsPerLine && rspMsgCnt != 0) {
+    if (compRespToMakeReadUnique(phase) ||
+        (dataMsgCnt == controller->dataMsgsPerLine && rspMsgCnt != 0)) {
         if (phase.exp_comp_ack == false) {
             // This is a hack, we should fix it on the ruby side
             // The client is not sending a CompAck but ruby is
@@ -455,9 +465,9 @@ CacheController::sendResponseMsg(ARM::CHI::Payload &payload,
 }
 
 CacheController::Transaction::Transaction(CacheController *_controller,
-    ARM::CHI::Payload &_payload,
-    ARM::CHI::Phase &_phase)
-  : controller(_controller), payload(&_payload), phase(_phase)
+                                          ARM::CHI::Payload &_payload,
+                                          ARM::CHI::Phase &_phase)
+    : controller(_controller), payload(&_payload), phase(_phase), orig(_phase)
 {
     payload->ref();
 }

--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -206,7 +206,7 @@ CacheController::Transaction::handle(const CHIResponseMsg *msg)
     phase.src_id = ruby_to_tlm::srcId(msg->m_responder);
 
     controller->bw(payload, &phase);
-    return opcode != ARM::CHI::RSP_OPCODE_RETRY_ACK;
+    return true;
 }
 
 bool
@@ -249,10 +249,19 @@ CacheController::ReadTransaction::compRespToMakeReadUnique(
 }
 
 bool
+CacheController::ReadTransaction::retryAckResp(const ARM::CHI::Phase &resp)
+{
+    return resp.channel == ARM::CHI::CHANNEL_RSP &&
+           resp.rsp_opcode == ARM::CHI::RSP_OPCODE_RETRY_ACK;
+}
+
+bool
 CacheController::ReadTransaction::handleCompletion()
 {
-    if (compRespToMakeReadUnique(phase) ||
-        (dataMsgCnt == controller->dataMsgsPerLine && rspMsgCnt != 0)) {
+    if (retryAckResp(phase)) {
+        return true;
+    } else if (compRespToMakeReadUnique(phase) ||
+               (dataMsgCnt == controller->dataMsgsPerLine && rspMsgCnt != 0)) {
         if (phase.exp_comp_ack == false) {
             // This is a hack, we should fix it on the ruby side
             // The client is not sending a CompAck but ruby is
@@ -270,9 +279,9 @@ CacheController::ReadTransaction::handle(const CHIResponseMsg *msg)
 {
     /// TODO: remove this, DBID is not sent
     phase.dbid = msg->m_dbid;
-    const bool is_not_retry_ack = Transaction::handle(msg);
+    Transaction::handle(msg);
 
-    if (is_not_retry_ack) {
+    if (!retryAckResp(phase)) {
         assert(rspMsgCnt == 0);
         assert(phase.rsp_opcode == ARM::CHI::RSP_OPCODE_RESP_SEP_DATA);
         rspMsgCnt++;
@@ -325,7 +334,10 @@ CacheController::WriteTransaction::handle(const CHIResponseMsg *msg)
     phase.dbid = msg->m_dbid;
     Transaction::handle(msg);
 
-    return recvComp && recvDBID;
+    // RetryAck closes this Ruby request attempt; the TLM requester will
+    // resend the transaction after receiving P-credit.
+    return (opcode == ARM::CHI::RSP_OPCODE_RETRY_ACK) ||
+           (recvComp && recvDBID);
 }
 
 void
@@ -412,6 +424,11 @@ CacheController::sendRequestMsg(ARM::CHI::Payload &payload,
     req_msg->m_txnId = phase.txn_id;
     req_msg->m_ns = payload.ns;
     req_msg->m_lpid = payload.lpid;
+
+    panic_if(pendingTransactions.find(req_msg->m_txnId) !=
+                 pendingTransactions.end(),
+             "Duplicate pending transaction: %s\n",
+             transactionToString(payload, phase));
 
     sendRequestMsg(req_msg);
 

--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -174,6 +174,7 @@ class CacheController : public ruby::CHIGenericController
         bool forward(const CHIDataMsg *msg);
 
         bool handleCompletion();
+        bool retryAckResp(const ARM::CHI::Phase &resp);
         bool compRespToMakeReadUnique(const ARM::CHI::Phase &resp);
 
         uint8_t rspMsgCnt = 0;

--- a/src/mem/ruby/protocol/chi/tlm/controller.hh
+++ b/src/mem/ruby/protocol/chi/tlm/controller.hh
@@ -163,6 +163,8 @@ class CacheController : public ruby::CHIGenericController
         CacheController *controller;
         ARM::CHI::Payload *payload;
         ARM::CHI::Phase phase;
+        // Original phase of the REQ. Unmutable
+        const ARM::CHI::Phase orig;
     };
     struct ReadTransaction : public Transaction
     {
@@ -172,6 +174,7 @@ class CacheController : public ruby::CHIGenericController
         bool forward(const CHIDataMsg *msg);
 
         bool handleCompletion();
+        bool compRespToMakeReadUnique(const ARM::CHI::Phase &resp);
 
         uint8_t rspMsgCnt = 0;
         uint8_t dataMsgCnt = 0;


### PR DESCRIPTION
With this PR we fix some existing bugs in how the TlmController handles transaction responses:

1) Wrong handling of unified data+response for a READ: current logic only works for separate data and response messages. If the system is tuned to send a single message, it will send a CompData message in the DAT channel. Code at the moment will consider it a data message only and handleCompletion will never return true (respMsgCnt=0). This means the transaction will never be deallocated

2) Wrong handling of MakeReadUnique (MRU): MRU is a read transaction which permits the HN to not send any data back in case it is not needed. So we need to change ReadTransaction::handleCompletion to allow Transaction deallocation even if dataMsgCnt is 0

3) Wrong handling of RETRY_ACK: we currently do not deallocate a Transaction if we get a RETRY message from the HN. This means that whenever the transaction gets a P-credit and is issued back to the controller, a *NEW* Transaction object will be generated accordingly, replacing the existing one. This leads to an obious memory leak. With this PR we always deallocate a Transaction object