### PR TITLE
misc: Skip the ext directory from git-clang-format

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -55,7 +55,7 @@ jobs:
 
             - name: Run clang-format check
               run: |
-                  python util/run-git-clang-format.py --verbose --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }}
+                  python util/run-git-clang-format.py --verbose --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }} --ignore ext
 
     get-date:
     # We use the date to label caches. A cache is a a "hit" if the date is the


### PR DESCRIPTION
The ext contains external repositories and we should aim at keeping the original formatting. It has to be noted clang-format recently introduced

.clang-format-ignore [1]

But it is unclear to me if CI is using a modern version of clang-format

[1]: https://clang.llvm.org/docs/ClangFormat.html#clang-format-ignore

Change-Id: Ibb6d6043ef94c7192f69de6b5b3c335ca9d60e53