### PR TITLE
sim: Remove event queue asserts that cross thread boundaries

### DIFF
--- a/src/sim/eventq.cc
+++ b/src/sim/eventq.cc
@@ -133,6 +133,8 @@ Event::releaseImpl()
 void
 EventQueue::insert(Event *event)
 {
+    gem5_assert(event->when() >= getCurTick(),
+                "Event must be inserted at or after the current tick.");
     // Deal with the head case
     if (!head || *event <= *head) {
         head = Event::insertBefore(event, head);

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -749,7 +749,6 @@ class EventQueue
     void
     schedule(Event *event, Tick when, bool global=false)
     {
-        assert(when >= getCurTick());
         assert(!event->scheduled());
         assert(event->initialized());
 
@@ -811,10 +810,10 @@ class EventQueue
     void
     reschedule(Event *event, Tick when, bool always=false)
     {
+        assert(!inParallelMode || this == curEventQueue());
         assert(when >= getCurTick());
         assert(always || event->scheduled());
         assert(event->initialized());
-        assert(!inParallelMode || this == curEventQueue());
 
         if (event->scheduled()) {
             remove(event);


### PR DESCRIPTION
`schedule` can be called from different event queues executing on different threads resulting in `getCurTick()` accessing data on a different thread that is not protected by locks/atomics. This PR moves the assert for checking if an event is not scheduled in the past to `insert()` prevent cross-thread data accesses. 

`reschedule` is also refactored to call `getCurTick()` after it has verified that the method is being called from the "home" event queue.