### PR TITLE
sim-se: Fix dup2 target fd and wait4 exit status

### DIFF
--- a/src/sim/se_signal.cc
+++ b/src/sim/se_signal.cc
@@ -33,10 +33,12 @@
 namespace gem5
 {
 
-BasicSignal::BasicSignal(Process *send, Process *receive, int signal_val)
+BasicSignal::BasicSignal(Process *send, Process *receive, int signal_val,
+                         int exit_status)
     : sender(send),
       receiver(receive),
-      signalValue(signal_val)
+      signalValue(signal_val),
+      exitStatus(exit_status)
 {
 }
 

--- a/src/sim/se_signal.hh
+++ b/src/sim/se_signal.hh
@@ -42,8 +42,13 @@ class BasicSignal
     Process *sender;
     Process *receiver;
     int signalValue;
+    // wait()/wait4() status word for SIGCHLD (Linux WIFEXITED /
+    // WIFSIGNALED encoding). Stored when the child exits so the parent
+    // can report it.
+    int exitStatus;
 
-    BasicSignal(Process *sender, Process *receiver, int signal_val);
+    BasicSignal(Process *sender, Process *receiver, int signal_val,
+                int exit_status = 0);
     ~BasicSignal();
 };
 

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -133,9 +133,11 @@ exitImpl(SyscallDesc *desc, ThreadContext *tc, bool group, int status,
 
     // Encode a Linux wait(2) status word so wait4 can distinguish a
     // normal exit (WIFEXITED) from death by signal (WIFSIGNALED).
-    // Callers that kill via signal (e.g. tgkill) pass 128+sig.
+    // When signaled, `status` is the signal number: store it in the low
+    // 7 bits. Do not store the shell-style 128+sig value here -- that
+    // incorrectly sets WCOREDUMP for every fatal signal.
     const int wait_status =
-        signaled ? (status & 0xff) : ((status & 0xff) << 8);
+        signaled ? (status & 0x7f) : ((status & 0xff) << 8);
 
     if (group)
         *p->exitGroup = true;
@@ -275,11 +277,11 @@ exitGroupFunc(SyscallDesc *desc, ThreadContext *tc, int status)
 }
 
 SyscallReturn
-exitGroupSignaledFunc(SyscallDesc *desc, ThreadContext *tc, int status)
+exitGroupSignaledFunc(SyscallDesc *desc, ThreadContext *tc, int sig)
 {
-    // `status` is typically 128+sig from tgkill so wait4 reports
-    // WIFSIGNALED / WTERMSIG / WCOREDUMP correctly.
-    return exitImpl(desc, tc, true, status, true);
+    // `sig` is the terminating signal number. exitImpl encodes a wait(2)
+    // status with WIFSIGNALED / WTERMSIG for the parent wait4.
+    return exitImpl(desc, tc, true, sig, true);
 }
 
 SyscallReturn

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -590,15 +590,17 @@ dup2Func(SyscallDesc *desc, ThreadContext *tc, int old_tgt_fd, int new_tgt_fd)
 
     // Bound-check the destination against the guest FD table size.
     // Linux returns EBADF for an out-of-range newfd.
-    if (new_tgt_fd < 0 || new_tgt_fd >= p->fds->getSize())
+    if (new_tgt_fd < 0 || new_tgt_fd >= p->fds->getSize()) {
         return -EBADF;
+    }
 
     // dup2(oldfd, oldfd) is a no-op that returns oldfd when oldfd is valid.
     if (old_tgt_fd == new_tgt_fd) {
         auto old_hbp =
             std::dynamic_pointer_cast<HBFDEntry>((*p->fds)[old_tgt_fd]);
-        if (!old_hbp)
+        if (!old_hbp) {
             return -EBADF;
+        }
         return new_tgt_fd;
     }
 
@@ -613,8 +615,9 @@ dup2Func(SyscallDesc *desc, ThreadContext *tc, int old_tgt_fd, int new_tgt_fd)
      * viable numbers are; we execute the open call to retrieve one.
      */
     int tmp_fd = open("/dev/null", O_RDONLY);
-    if (tmp_fd == -1)
+    if (tmp_fd == -1) {
         return -errno;
+    }
     int res_fd = dup2(old_sim_fd, tmp_fd);
     if (res_fd == -1) {
         close(tmp_fd);

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -124,11 +124,18 @@ exitFutexWake(ThreadContext *tc, VPtr<> addr, uint64_t tgid)
 }
 
 static SyscallReturn
-exitImpl(SyscallDesc *desc, ThreadContext *tc, bool group, int status)
+exitImpl(SyscallDesc *desc, ThreadContext *tc, bool group, int status,
+         bool signaled = false)
 {
     auto p = tc->getProcessPtr();
 
     System *sys = tc->getSystemPtr();
+
+    // Encode a Linux wait(2) status word so wait4 can distinguish a
+    // normal exit (WIFEXITED) from death by signal (WIFSIGNALED).
+    // Callers that kill via signal (e.g. tgkill) pass 128+sig.
+    const int wait_status =
+        signaled ? (status & 0xff) : ((status & 0xff) << 8);
 
     if (group)
         *p->exitGroup = true;
@@ -199,7 +206,8 @@ exitImpl(SyscallDesc *desc, ThreadContext *tc, bool group, int status)
     if (last_thread) {
         if (parent) {
             assert(tg_lead);
-            sys->signalList.push_back(BasicSignal(tg_lead, parent, SIGCHLD));
+            sys->signalList.push_back(
+                BasicSignal(tg_lead, parent, SIGCHLD, wait_status));
         }
 
         /**
@@ -264,6 +272,14 @@ SyscallReturn
 exitGroupFunc(SyscallDesc *desc, ThreadContext *tc, int status)
 {
     return exitImpl(desc, tc, true, status);
+}
+
+SyscallReturn
+exitGroupSignaledFunc(SyscallDesc *desc, ThreadContext *tc, int status)
+{
+    // `status` is typically 128+sig from tgkill so wait4 reports
+    // WIFSIGNALED / WTERMSIG / WCOREDUMP correctly.
+    return exitImpl(desc, tc, true, status, true);
 }
 
 SyscallReturn
@@ -571,6 +587,21 @@ SyscallReturn
 dup2Func(SyscallDesc *desc, ThreadContext *tc, int old_tgt_fd, int new_tgt_fd)
 {
     auto p = tc->getProcessPtr();
+
+    // Bound-check the destination against the guest FD table size.
+    // Linux returns EBADF for an out-of-range newfd.
+    if (new_tgt_fd < 0 || new_tgt_fd >= p->fds->getSize())
+        return -EBADF;
+
+    // dup2(oldfd, oldfd) is a no-op that returns oldfd when oldfd is valid.
+    if (old_tgt_fd == new_tgt_fd) {
+        auto old_hbp =
+            std::dynamic_pointer_cast<HBFDEntry>((*p->fds)[old_tgt_fd]);
+        if (!old_hbp)
+            return -EBADF;
+        return new_tgt_fd;
+    }
+
     auto old_hbp = std::dynamic_pointer_cast<HBFDEntry>((*p->fds)[old_tgt_fd]);
     if (!old_hbp)
         return -EBADF;
@@ -581,18 +612,28 @@ dup2Func(SyscallDesc *desc, ThreadContext *tc, int old_tgt_fd, int new_tgt_fd)
      * the second parameter for dup2 (newfd), but we don't know what the
      * viable numbers are; we execute the open call to retrieve one.
      */
-    int res_fd = dup2(old_sim_fd, open("/dev/null", O_RDONLY));
-    if (res_fd == -1)
+    int tmp_fd = open("/dev/null", O_RDONLY);
+    if (tmp_fd == -1)
         return -errno;
+    int res_fd = dup2(old_sim_fd, tmp_fd);
+    if (res_fd == -1) {
+        close(tmp_fd);
+        return -errno;
+    }
 
+    // Close whatever currently occupies the requested target FD, then
+    // place the clone exactly at new_tgt_fd. Using allocFD() here was
+    // wrong: it always picks the next free slot (dup semantics) and
+    // ignores new_tgt_fd.
     auto new_hbp = std::dynamic_pointer_cast<HBFDEntry>((*p->fds)[new_tgt_fd]);
     if (new_hbp)
         p->fds->closeFDEntry(new_tgt_fd);
     new_hbp = std::dynamic_pointer_cast<HBFDEntry>(old_hbp->clone());
     new_hbp->setSimFD(res_fd);
     new_hbp->setCOE(false);
+    p->fds->setFDEntry(new_tgt_fd, new_hbp);
 
-    return p->fds->allocFD(new_hbp);
+    return new_tgt_fd;
 }
 
 SyscallReturn

--- a/src/sim/syscall_emul.cc
+++ b/src/sim/syscall_emul.cc
@@ -590,9 +590,11 @@ dup2Func(SyscallDesc *desc, ThreadContext *tc, int old_tgt_fd, int new_tgt_fd)
 {
     auto p = tc->getProcessPtr();
 
-    // Bound-check the destination against the guest FD table size.
-    // Linux returns EBADF for an out-of-range newfd.
-    if (new_tgt_fd < 0 || new_tgt_fd >= p->fds->getSize()) {
+    // Bound-check both fds against the guest FD table size before any
+    // FDArray::operator[] access (that path asserts on out-of-range
+    // indices). Linux returns EBADF for an out-of-range oldfd or newfd.
+    if (old_tgt_fd < 0 || old_tgt_fd >= p->fds->getSize() ||
+        new_tgt_fd < 0 || new_tgt_fd >= p->fds->getSize()) {
         return -EBADF;
     }
 

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -3054,9 +3054,13 @@ success:
     // Report the child's actual wait(2) status (normal exit or signal).
     // Previously this always wrote 0 (WIFEXITED with code 0), which hid
     // abnormal terminations such as raise(SIGABRT).
-    BufferArg statusBuf(statPtr, sizeof(int));
-    *(int *)statusBuf.bufferPtr() = iter->exitStatus;
-    statusBuf.copyOut(SETranslatingPortProxy(tc));
+    // Linux allows a NULL status pointer; skip the guest write in that case
+    // (same pattern as the rusagePtr guard above).
+    if (statPtr) {
+        BufferArg statusBuf(statPtr, sizeof(int));
+        *(int *)statusBuf.bufferPtr() = iter->exitStatus;
+        statusBuf.copyOut(SETranslatingPortProxy(tc));
+    }
 
     // Return the child PID.
     pid_t retval = iter->sender->pid();

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -153,6 +153,11 @@ SyscallReturn exitFunc(SyscallDesc *desc, ThreadContext *tc, int status);
 /// Target exit_group() handler: terminate simulation. (exit all threads)
 SyscallReturn exitGroupFunc(SyscallDesc *desc, ThreadContext *tc, int status);
 
+/// exit_group path used when a process is killed by a signal (e.g. via
+/// tgkill). `status` is typically 128+sig for wait4 WIFSIGNALED status.
+SyscallReturn exitGroupSignaledFunc(SyscallDesc *desc, ThreadContext *tc,
+                                    int status);
+
 /// Target set_tid_address() handler.
 SyscallReturn setTidAddressFunc(SyscallDesc *desc, ThreadContext *tc,
                                 VPtr<> tidPtr);
@@ -2706,8 +2711,7 @@ tgkillFunc(SyscallDesc *desc, ThreadContext *tc, int tgid, int tid, int sig)
         case OS::TGT_SIGINT:
         case OS::TGT_SIGTERM:
         case OS::TGT_SIGKILL:
-            exitGroupFunc(desc, tc, 128 + sig);
-            break;
+            return exitGroupSignaledFunc(desc, tc, 128 + sig);
         default:
             return -EINVAL;
     }
@@ -3047,10 +3051,11 @@ wait4Func(SyscallDesc *desc, ThreadContext *tc,
     return (options & OS::TGT_WNOHANG) ? 0 : SyscallReturn::retry();
 
 success:
-    // Set status to EXITED for WIFEXITED evaluations.
-    const int EXITED = 0;
+    // Report the child's actual wait(2) status (normal exit or signal).
+    // Previously this always wrote 0 (WIFEXITED with code 0), which hid
+    // abnormal terminations such as raise(SIGABRT).
     BufferArg statusBuf(statPtr, sizeof(int));
-    *(int *)statusBuf.bufferPtr() = EXITED;
+    *(int *)statusBuf.bufferPtr() = iter->exitStatus;
     statusBuf.copyOut(SETranslatingPortProxy(tc));
 
     // Return the child PID.

--- a/src/sim/syscall_emul.hh
+++ b/src/sim/syscall_emul.hh
@@ -154,9 +154,9 @@ SyscallReturn exitFunc(SyscallDesc *desc, ThreadContext *tc, int status);
 SyscallReturn exitGroupFunc(SyscallDesc *desc, ThreadContext *tc, int status);
 
 /// exit_group path used when a process is killed by a signal (e.g. via
-/// tgkill). `status` is typically 128+sig for wait4 WIFSIGNALED status.
+/// tgkill). `sig` is the terminating signal number used for wait4 status.
 SyscallReturn exitGroupSignaledFunc(SyscallDesc *desc, ThreadContext *tc,
-                                    int status);
+                                    int sig);
 
 /// Target set_tid_address() handler.
 SyscallReturn setTidAddressFunc(SyscallDesc *desc, ThreadContext *tc,
@@ -2711,7 +2711,7 @@ tgkillFunc(SyscallDesc *desc, ThreadContext *tc, int tgid, int tid, int sig)
         case OS::TGT_SIGINT:
         case OS::TGT_SIGTERM:
         case OS::TGT_SIGKILL:
-            return exitGroupSignaledFunc(desc, tc, 128 + sig);
+            return exitGroupSignaledFunc(desc, tc, sig);
         default:
             return -EINVAL;
     }


### PR DESCRIPTION
## Summary
- Fix `dup2` so the duplicated FD is placed at the requested `new_tgt_fd` instead of always allocating the next free descriptor via `allocFD()`.
- Fix `wait4` so it returns a Linux-encoded wait(2) status when a child exits normally or due to a signal (previously always reported status 0).
- Fatal `tgkill` exits go through `exitGroupSignaledFunc` with the **raw signal number**; `exitImpl` stores `sig & 0x7f` in the wait status (not shell-style `128+sig`, which incorrectly sets `WCOREDUMP`).
- Allow a NULL `status` pointer in `wait4` (Linux permits it); skip the guest write in that case.

## Fixes
Fixes #2750
Fixes #2754

## Test plan
Manual SE checks on `build/X86/gem5.opt` + `configs/deprecated/example/se.py` (fork cases use `--num-cpus=2`), with host baselines for the same static binaries:

- [x] `dup2(1, 100)` returns 100 and is usable
- [x] `dup2` edges: `(fd,fd)` no-op; overwrite occupied FD; `EBADF` for `-1` / huge / invalid oldfd; gem5 FD table boundary at 1024
- [x] Child `raise(SIGABRT)` / `raise(SIGTERM)`: parent sees `WIFSIGNALED` with correct `WTERMSIG` and **no** spurious `WCOREDUMP` (status is `6` / `15`, not `134`)
- [x] Child `_exit(42)`: `WIFEXITED` / `WEXITSTATUS==42`
- [x] Explicit `wait4(pid, &status, 0, NULL)`
- [x] `wait4(..., NULL, ...)` for signal and normal exit (null status pointer)
- [x] `wait4` with non-NULL `rusage` (ignored by SE, must not fault)

Notes: RV64 glibc `dup2` uses unimplemented `dup3` in SE; `dup2Func` itself was checked via legacy syscall 1041. RISCV SE fork/wait currently hangs due to a pre-existing host-vs-guest `SIGCHLD` number mismatch (unrelated to this change).
