### PR TITLE
mem-ruby: enqueue message with timestamp

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -395,6 +395,8 @@ void clearExpectedSnpResp(TBE tbe) {
 void initializeTBE(TBE tbe, Addr addr, int storSlot) {
   assert(is_valid(tbe));
 
+  tbe.timestamp := curTick();
+
   tbe.wakeup_pending_req := false;
   tbe.wakeup_pending_snp := false;
   tbe.wakeup_pending_tgr := false;
@@ -626,7 +628,7 @@ void scheduleSendData(TBE tbe, int when) {
     tbe.snd_pendEv := true;
     // enqueue send event
     tbe.pendAction := Event:TX_Data;
-    enqueue(triggerOutPort, TriggerMsg, intToCycles(when)) {
+    enqueue(triggerOutPort, TriggerMsg, intToCycles(when), false, tbe.timestamp) {
       out_msg.addr := tbe.addr;
       out_msg.from_hazard := tbe.is_req_hazard || tbe.is_repl_hazard;
     }

--- a/src/mem/ruby/protocol/chi/CHI-cache-ports.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-ports.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021, 2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -474,7 +474,7 @@ void processNextState(Addr address, TBE tbe, CacheEntry cache_entry) {
       tbe.actions.pop();
     }
     assert(tbe.pendAction != Event:null);
-    enqueue(triggerOutPort, TriggerMsg, trigger_latency) {
+    enqueue(triggerOutPort, TriggerMsg, trigger_latency, false, tbe.timestamp) {
       out_msg.addr := tbe.addr;
       // TODO - put usesTxnId on the TBE?
       out_msg.usesTxnId := tbe.is_dvm_tbe || tbe.is_dvm_snp_tbe;

--- a/src/mem/ruby/protocol/chi/CHI-cache.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache.sm
@@ -648,6 +648,8 @@ machine(MachineType:Cache, "Cache coherency protocol") :
 
   // TBE fields
   structure(TBE, desc="Transaction buffer entry definition") {
+    Tick timestamp, desc="Time this entry was allocated. Affects order of trigger events";
+
     // in which table was this allocated
     bool is_req_tbe, desc="Allocated in the request table";
     bool is_snp_tbe, desc="Allocated in the snoop table";

--- a/src/mem/ruby/slicc_interface/Message.hh
+++ b/src/mem/ruby/slicc_interface/Message.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 ARM Limited
+ * Copyright (c) 2021, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -66,7 +66,9 @@ class Message
         : m_block_size(block_size),
           m_time(curTime),
           m_LastEnqueueTime(curTime),
-          m_DelayedTicks(0), m_msg_counter(0)
+          m_DelayedTicks(0),
+          m_msg_counter(0),
+          m_transaction_time(MaxTick)
     { }
 
     Message(const Message &other) = default;
@@ -111,6 +113,17 @@ class Message
     void setMsgCounter(uint64_t c) { m_msg_counter = c; }
     uint64_t getMsgCounter() const { return m_msg_counter; }
 
+    void
+    setTransactionTime(Tick time)
+    {
+        m_transaction_time = time;
+    }
+    Tick
+    getTransactionTime() const
+    {
+        return m_transaction_time;
+    }
+
     // Functions related to network traversal
     virtual const NetDest& getDestination() const
     { panic("getDestination() called on wrong message!"); }
@@ -130,6 +143,8 @@ class Message
     Tick m_LastEnqueueTime; // my last enqueue time
     Tick m_DelayedTicks; // my delayed cycles
     uint64_t m_msg_counter; // FIXME, should this be a 64-bit value?
+    Tick m_transaction_time; // timestamp of the transaction that generated
+                             // this msg
 
     // Variables for required network traversal
     int incoming_link;
@@ -143,7 +158,10 @@ operator>(const MsgPtr &lhs, const MsgPtr &rhs)
     const Message *r = rhs.get();
 
     if (l->getLastEnqueueTime() == r->getLastEnqueueTime()) {
-        return l->getMsgCounter() > r->getMsgCounter();
+        if (l->getTransactionTime() == r->getTransactionTime()) {
+            return l->getMsgCounter() > r->getMsgCounter();
+        }
+        return l->getTransactionTime() > r->getTransactionTime();
     }
     return l->getLastEnqueueTime() > r->getLastEnqueueTime();
 }

--- a/src/mem/ruby/slicc_interface/SConscript
+++ b/src/mem/ruby/slicc_interface/SConscript
@@ -1,5 +1,17 @@
 # -*- mode:python -*-
 
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2009 The Hewlett-Packard Development Company
 # All rights reserved.
 #
@@ -36,3 +48,5 @@ SimObject('Controller.py', sim_objects=['RubyController'])
 Source('AbstractController.cc')
 Source('AbstractCacheEntry.cc')
 Source('RubyRequest.cc')
+
+GTest('message_order.test', 'message_order.test.cc')

--- a/src/mem/ruby/slicc_interface/message_order.test.cc
+++ b/src/mem/ruby/slicc_interface/message_order.test.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved.
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mem/ruby/slicc_interface/Message.hh"
+
+class TestMessage : public gem5::ruby::Message
+{
+  public:
+    TestMessage(gem5::Tick cur_time, int block_size)
+        : gem5::ruby::Message(cur_time, block_size, nullptr)
+    {}
+
+    gem5::ruby::MsgPtr
+    clone() const override
+    {
+        return gem5::ruby::MsgPtr(new TestMessage(*this));
+    }
+
+    void
+    print(std::ostream &out) const override
+    {
+        out << "TestMessage";
+    }
+};
+
+TEST(MessageOrdering, TransactionTimeOverridesCounter)
+{
+    gem5::ruby::MsgPtr a(new TestMessage(0, 64));
+    gem5::ruby::MsgPtr b(new TestMessage(0, 64));
+
+    a->setLastEnqueueTime(100);
+    b->setLastEnqueueTime(100);
+
+    a->setTransactionTime(10);
+    b->setTransactionTime(20);
+
+    a->setMsgCounter(999);
+    b->setMsgCounter(1);
+
+    EXPECT_FALSE(a > b);
+    EXPECT_TRUE(b > a);
+}
+
+TEST(MessageOrdering, MsgCounterStillBreaksTransactionTie)
+{
+    gem5::ruby::MsgPtr a(new TestMessage(0, 64));
+    gem5::ruby::MsgPtr b(new TestMessage(0, 64));
+
+    a->setLastEnqueueTime(100);
+    b->setLastEnqueueTime(100);
+
+    a->setTransactionTime(10);
+    b->setTransactionTime(10);
+
+    a->setMsgCounter(999);
+    b->setMsgCounter(1);
+
+    EXPECT_TRUE(a > b);
+    EXPECT_FALSE(b > a);
+}

--- a/src/mem/slicc/ast/EnqueueStatementAST.py
+++ b/src/mem/slicc/ast/EnqueueStatementAST.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2013 Advanced Micro Devices, Inc.
 # Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
 # Copyright (c) 2009 The Hewlett-Packard Development Company
@@ -38,6 +50,7 @@ class EnqueueStatementAST(StatementAST):
         type_ast,
         lexpr,
         bypass_strict_fifo,
+        texpr,
         statements,
     ):
         super().__init__(slicc)
@@ -46,6 +59,7 @@ class EnqueueStatementAST(StatementAST):
         self.type_ast = type_ast
         self.latexpr = lexpr
         self.bypass_strict_fifo = bypass_strict_fifo
+        self.timestampexpr = texpr
         self.statements = statements
 
     def __repr__(self):
@@ -83,6 +97,10 @@ class EnqueueStatementAST(StatementAST):
         # The other statements
         t = self.statements.generate(code, None)
         self.queue_name.assertType("OutPort")
+
+        if self.timestampexpr != None:
+            ret_type, rcode = self.timestampexpr.inline(True)
+            code("out_msg->setTransactionTime($rcode);")
 
         if self.latexpr != None:
             ret_type, rcode = self.latexpr.inline(True)

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -696,15 +696,27 @@ class SLICC(Grammar):
 
     def p_statement__enqueue(self, p):
         "statement : ENQUEUE '(' var ',' type ')' statements"
-        p[0] = ast.EnqueueStatementAST(self, p[3], p[5], None, None, p[7])
+        p[0] = ast.EnqueueStatementAST(
+            self, p[3], p[5], None, None, None, p[7]
+        )
 
     def p_statement__enqueue_latency(self, p):
         "statement : ENQUEUE '(' var ',' type ',' expr ')' statements"
-        p[0] = ast.EnqueueStatementAST(self, p[3], p[5], p[7], None, p[9])
+        p[0] = ast.EnqueueStatementAST(
+            self, p[3], p[5], p[7], None, None, p[9]
+        )
 
     def p_statement__enqueue_latency_bypass_strict_fifo(self, p):
         "statement : ENQUEUE '(' var ',' type ',' expr ',' expr ')' statements"
-        p[0] = ast.EnqueueStatementAST(self, p[3], p[5], p[7], p[9], p[11])
+        p[0] = ast.EnqueueStatementAST(
+            self, p[3], p[5], p[7], p[9], None, p[11]
+        )
+
+    def p_statement__enqueue_latency_bypass_strict_fifo_timestamp(self, p):
+        "statement : ENQUEUE '(' var ',' type ',' expr ',' expr ',' expr ')' statements"
+        p[0] = ast.EnqueueStatementAST(
+            self, p[3], p[5], p[7], p[9], p[11], p[13]
+        )
 
     def p_statement__defer_enqueueing(self, p):
         "statement : DEFER_ENQUEUEING '(' var ',' type ')' statements"


### PR DESCRIPTION
Added an 'enqueue' which takes a timestamp as an additional optional parameter. This timestamp is used to order messages scheduled in the same cycle in the message buffer. Also add a test script to verify the functionality of this change.