### PR TITLE
sim: Replace Event::instanceCounter and remove EVENTQ_DEBUG

### DIFF
--- a/src/sim/eventq.cc
+++ b/src/sim/eventq.cc
@@ -413,8 +413,8 @@ const std::string
 Event::instanceString() const
 {
 #ifndef NDEBUG
-    if (origin_queue != nullptr) {
-        return csprintf("[Origin: %s, #%d]", origin_queue->name(), instance);
+    if (originQueue != nullptr) {
+        return csprintf("[Origin: %s, #%d]", originQueue->name(), instance);
     } else {
         // Event has not been scheduled yet.
         return csprintf("[Origin: %s, #%d]", "UNKNOWN", instance);

--- a/src/sim/eventq.cc
+++ b/src/sim/eventq.cc
@@ -70,10 +70,6 @@ getEventQueue(uint32_t index)
     return mainEventQueue[index];
 }
 
-#ifndef NDEBUG
-Counter Event::instanceCounter = 0;
-#endif
-
 Event::~Event()
 {
     assert(!scheduled());
@@ -417,7 +413,12 @@ const std::string
 Event::instanceString() const
 {
 #ifndef NDEBUG
-    return csprintf("%d", instance);
+    if (origin_queue != nullptr) {
+        return csprintf("[Origin: %s, #%d]", origin_queue->name(), instance);
+    } else {
+        // Event has not been scheduled yet.
+        return csprintf("[Origin: %s, #%d]", "UNKNOWN", instance);
+    }
 #else
     return csprintf("%#x", (uintptr_t)this);
 #endif
@@ -428,13 +429,7 @@ Event::dump() const
 {
     cprintf("Event %s (%s)\n", name(), description());
     cprintf("Flags: %#x\n", flags);
-#ifdef EVENTQ_DEBUG
-    cprintf("Created: %d\n", whenCreated);
-#endif
     if (scheduled()) {
-#ifdef EVENTQ_DEBUG
-        cprintf("Scheduled at  %d\n", whenScheduled);
-#endif
         cprintf("Scheduled for %d, priority %d\n", when(), _priority);
     } else {
         cprintf("Not Scheduled\n");

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -276,9 +276,6 @@ class Event : public EventBase, public Serializable
     Flags flags;
 
 #ifndef NDEBUG
-    /// Global counter to generate unique IDs for Event instances
-    static Counter instanceCounter;
-
     /// This event's unique ID.  We can also use pointer values for
     /// this but they're not consistent across runs making debugging
     /// more difficult.  Thus we use a global counter value when
@@ -288,11 +285,9 @@ class Event : public EventBase, public Serializable
     /// queue to which this event belongs (though it may or may not be
     /// scheduled on this queue yet)
     EventQueue *queue;
-#endif
 
-#ifdef EVENTQ_DEBUG
-    Tick whenCreated;   //!< time created
-    Tick whenScheduled; //!< time scheduled
+    // The queue from which this event was scheduled.
+    EventQueue *origin_queue;
 #endif
 
     void
@@ -301,9 +296,6 @@ class Event : public EventBase, public Serializable
         _when = when;
 #ifndef NDEBUG
         queue = q;
-#endif
-#ifdef EVENTQ_DEBUG
-        whenScheduled = curTick();
 #endif
     }
 
@@ -410,12 +402,8 @@ class Event : public EventBase, public Serializable
     {
         assert(f.noneSet(~PublicWrite));
 #ifndef NDEBUG
-        instance = ++instanceCounter;
-        queue = NULL;
-#endif
-#ifdef EVENTQ_DEBUG
-        whenCreated = curTick();
-        whenScheduled = 0;
+        queue = nullptr;
+        origin_queue = nullptr;
 #endif
     }
 
@@ -661,6 +649,11 @@ class EventQueue
 
     EventQueue(const EventQueue &);
 
+#ifndef NDEBUG
+    // Counter for events created from this event queue.
+    Counter eventCounter = 0;
+#endif
+
   public:
     class ScopedMigration
     {
@@ -759,6 +752,11 @@ class EventQueue
         assert(when >= getCurTick());
         assert(!event->scheduled());
         assert(event->initialized());
+
+#ifndef NDEBUG
+        event->instance = curEventQueue()->incrementAndGetEventCounter();
+        event->origin_queue = curEventQueue();
+#endif
 
         event->setWhen(when, this);
 
@@ -960,6 +958,14 @@ class EventQueue
      * @warn Only use this method after unserializing an Event.
      */
     void checkpointReschedule(Event *event);
+
+#ifndef NDEBUG
+    Counter
+    incrementAndGetEventCounter()
+    {
+        return ++eventCounter;
+    }
+#endif
 
     virtual ~EventQueue()
     {

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -287,7 +287,7 @@ class Event : public EventBase, public Serializable
     EventQueue *queue;
 
     // The queue from which this event was scheduled.
-    EventQueue *origin_queue;
+    EventQueue *originQueue;
 #endif
 
     void
@@ -403,7 +403,7 @@ class Event : public EventBase, public Serializable
         assert(f.noneSet(~PublicWrite));
 #ifndef NDEBUG
         queue = nullptr;
-        origin_queue = nullptr;
+        originQueue = nullptr;
 #endif
     }
 
@@ -755,7 +755,7 @@ class EventQueue
 
 #ifndef NDEBUG
         event->instance = curEventQueue()->incrementAndGetEventCounter();
-        event->origin_queue = curEventQueue();
+        event->originQueue = curEventQueue();
 #endif
 
         event->setWhen(when, this);


### PR DESCRIPTION
The Event::instanceCounter is used to generate unique IDs across all queues for Event instances when generating traces for debugging gem5. Multiple threads can write to the same counter at the same time, and so making it thread-safe is necessary. We replace it with an EventQueue local counter and the trace outputs the name of the queue where an Event is scheduled. 

Additionally, this PR removes the unused EVENTQ_DEBUG macro and associated member variables (whenCreated, whenScheduled) as they are not defined or used.