### PR TITLE
sim, mem-ruby: Add assertions to prevent scheduling events in the past and fix data race in MessageBuffer

### DIFF
--- a/src/mem/ruby/common/Consumer.cc
+++ b/src/mem/ruby/common/Consumer.cc
@@ -40,6 +40,10 @@
 
 #include "mem/ruby/common/Consumer.hh"
 
+#include <cassert>
+
+#include "base/logging.hh"
+
 namespace gem5
 {
 
@@ -55,15 +59,26 @@ Consumer::Consumer(ClockedObject *_em, Event::Priority ev_prio)
 void
 Consumer::scheduleEvent(Cycles timeDelta)
 {
-    m_wakeup_ticks.insert(em->clockEdge(timeDelta));
+    // m_wakeup_ticks is a shared variable whose "home" event queue is the
+    // one for the object associated with thie consumer.
+    assert(em->eventQueue() == curEventQueue());
+    Tick when = em->clockEdge(timeDelta);
+    gem5_assert(when >= em->clockEdge(),
+                "Cannot schedule wakeups in the past");
+    m_wakeup_ticks.insert(when);
     scheduleNextWakeup();
 }
 
 void
 Consumer::scheduleEventAbsolute(Tick evt_time)
 {
-    m_wakeup_ticks.insert(
-        divCeil(evt_time, em->clockPeriod()) * em->clockPeriod());
+    // m_wakeup_ticks is a shared variable whose "home" event queue is the
+    // one for the object associated with thie consumer.
+    assert(em->eventQueue() == curEventQueue());
+    Tick when = divCeil(evt_time, em->clockPeriod()) * em->clockPeriod();
+    gem5_assert(when >= em->clockEdge(),
+                "Cannot schedule wakeups in the past");
+    m_wakeup_ticks.insert(when);
     scheduleNextWakeup();
 }
 
@@ -74,7 +89,6 @@ Consumer::scheduleNextWakeup()
     auto it = m_wakeup_ticks.lower_bound(em->clockEdge());
     if (it != m_wakeup_ticks.end()) {
         Tick when = *it;
-        assert(when >= em->clockEdge());
         if (m_wakeup_event.scheduled() && (when < m_wakeup_event.when()))
             em->reschedule(m_wakeup_event, when, true);
         else if (!m_wakeup_event.scheduled())

--- a/src/mem/ruby/common/Consumer.cc
+++ b/src/mem/ruby/common/Consumer.cc
@@ -57,12 +57,12 @@ Consumer::Consumer(ClockedObject *_em, Event::Priority ev_prio)
 { }
 
 void
-Consumer::scheduleEvent(Cycles timeDelta)
+Consumer::scheduleEvent(Cycles time_delta)
 {
     // m_wakeup_ticks is a shared variable whose "home" event queue is the
     // one for the object associated with thie consumer.
     assert(em->eventQueue() == curEventQueue());
-    Tick when = em->clockEdge(timeDelta);
+    Tick when = em->clockEdge(time_delta);
     gem5_assert(when >= em->clockEdge(),
                 "Cannot schedule wakeups in the past");
     m_wakeup_ticks.insert(when);

--- a/src/mem/ruby/common/Consumer.hh
+++ b/src/mem/ruby/common/Consumer.hh
@@ -50,7 +50,9 @@
 #include <iostream>
 #include <set>
 
+#include "base/types.hh"
 #include "sim/clocked_object.hh"
+#include "sim/eventq.hh"
 
 namespace gem5
 {

--- a/src/mem/ruby/common/Consumer.hh
+++ b/src/mem/ruby/common/Consumer.hh
@@ -86,8 +86,8 @@ class Consumer
         return em;
     }
 
-    void scheduleEventAbsolute(Tick timeAbs);
-    void scheduleEvent(Cycles timeDelta);
+    void scheduleEventAbsolute(Tick evt_time);
+    void scheduleEvent(Cycles time_delta);
 
   private:
     std::set<Tick> m_wakeup_ticks;

--- a/src/mem/ruby/network/MessageBuffer.cc
+++ b/src/mem/ruby/network/MessageBuffer.cc
@@ -47,6 +47,7 @@
 #include "base/random.hh"
 #include "base/stl_helpers.hh"
 #include "debug/RubyQueue.hh"
+#include "sim/eventq.hh"
 
 namespace gem5
 {
@@ -229,6 +230,14 @@ MessageBuffer::enqueue(MsgPtr message, Tick current_time, Tick delta,
                        bool ruby_is_random, bool ruby_warmup,
                        bool bypassStrictFIFO)
 {
+    // Enqueue moves messages from one event queue (producer) to
+    // another (consumer). These event queues can be on different threads
+    // resulting in a thread domain crossing between two Ruby components.
+    // MessageBuffer maintains a shared state between the producer and consumer
+    // resulting in data races for these variables. copedMigration prevents
+    // these by migrating this function call to the consumer's event queue
+    EventQueue::ScopedMigration migration(
+        m_consumer->getObject()->eventQueue());
     // record current time incase we have a pop that also adjusts my size
     if (m_time_last_time_enqueue < current_time) {
         m_msgs_this_cycle = 0;  // first msg this cycle

--- a/src/sim/eventq.cc
+++ b/src/sim/eventq.cc
@@ -449,8 +449,12 @@ EventQueue::EventQueue(const std::string &n)
 void
 EventQueue::asyncInsert(Event *event)
 {
+    gem5_assert(
+        event->when() >= _nextSimQuantum,
+        "Asynchronous event must be scheduled after the next sim quantum");
     async_queue_mutex.lock();
     async_queue.push_back(event);
+    event->trace("async inserted");
     async_queue_mutex.unlock();
 }
 

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -749,9 +749,7 @@ class EventQueue
     void name(const std::string &st) { objName = st; }
     /** @}*/ //end of api_eventq group
 
-    void
-    setNextSimQuantum(Tick when)
-    { _nextSimQuantum = when; }
+    void setNextSimQuantum(Tick when) { _nextSimQuantum = when; }
 
     /**
      * Schedule the given event on this queue. Safe to call from any thread.

--- a/src/sim/eventq.hh
+++ b/src/sim/eventq.hh
@@ -620,6 +620,7 @@ class EventQueue
     std::string objName;
     Event *head;
     Tick _curTick;
+    Tick _nextSimQuantum;
 
     //! Mutex to protect async queue.
     FairUncontendedMutex async_queue_mutex;
@@ -747,6 +748,10 @@ class EventQueue
     virtual const std::string name() const { return objName; }
     void name(const std::string &st) { objName = st; }
     /** @}*/ //end of api_eventq group
+
+    void
+    setNextSimQuantum(Tick when)
+    { _nextSimQuantum = when; }
 
     /**
      * Schedule the given event on this queue. Safe to call from any thread.

--- a/src/sim/global_event.cc
+++ b/src/sim/global_event.cc
@@ -158,7 +158,11 @@ void
 GlobalSyncEvent::process()
 {
     if (repeat) {
-        schedule(curTick() + repeat);
+        Tick next_sim_quantum = curTick() + repeat;
+        schedule(next_sim_quantum);
+        for (int i = 0; i < numMainEventQueues; ++i) {
+            mainEventQueue[i]->setNextSimQuantum(next_sim_quantum);
+        }
     }
 }
 

--- a/src/sim/global_event.hh
+++ b/src/sim/global_event.hh
@@ -229,6 +229,9 @@ class GlobalSyncEvent : public BaseGlobalEventTemplate<GlobalSyncEvent>
         : Base(p, f), repeat(_repeat)
     {
         schedule(when);
+        for (int i = 0; i < numMainEventQueues; ++i) {
+            mainEventQueue[i]->setNextSimQuantum(when);
+        }
     }
 
     virtual ~GlobalSyncEvent (){}


### PR DESCRIPTION
This PR introduces tracking for the next simulation quantum in EventQueue, which is updated by GlobalSyncEvent. It adds assertions to ensure that asynchronous events are scheduled after the next simulation quantum, and that Ruby Consumer wakeups are not scheduled in the past. This PR also adds ScopedMigration to enqueue in MessageBuffer to prevent data races in the buffer.