### PR TITLE
mem-ruby: Implement draining for AbstractController

### DIFF
--- a/src/mem/ruby/slicc_interface/AbstractController.cc
+++ b/src/mem/ruby/slicc_interface/AbstractController.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017,2019-2022 ARM Limited
+ * Copyright (c) 2017,2019-2022, 2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -117,6 +117,16 @@ AbstractController::init()
     upstreamDestinations.resize();
     for (auto abs_cntrl : params().upstream_destinations) {
         upstreamDestinations.add(abs_cntrl->getMachineID());
+    }
+}
+
+DrainState
+AbstractController::drain()
+{
+    if (noInTransactions()) {
+        return DrainState::Drained;
+    } else {
+        return DrainState::Draining;
     }
 }
 

--- a/src/mem/ruby/slicc_interface/AbstractController.hh
+++ b/src/mem/ruby/slicc_interface/AbstractController.hh
@@ -89,6 +89,8 @@ class AbstractController : public ClockedObject, public Consumer
     AbstractController(const Params &p);
     void init();
 
+    DrainState drain() override;
+
     NodeID getVersion() const { return m_machineID.getNum(); }
     MachineType getType() const { return m_machineID.getType(); }
 
@@ -268,6 +270,13 @@ class AbstractController : public ClockedObject, public Consumer
     std::unordered_map<Addr, TransMapPair> m_inTransUnaddressed;
     std::unordered_map<Addr, TransMapPair> m_outTransUnaddressed;
 
+    //! True if there are no incoming transactions
+    bool
+    noInTransactions() const
+    {
+        return m_inTransAddressed.empty() && m_inTransUnaddressed.empty();
+    }
+
     /**
      * Profiles an event that initiates a protocol transactions for a specific
      * line (e.g. events triggered by incoming request messages).
@@ -330,7 +339,10 @@ class AbstractController : public ClockedObject, public Consumer
         stats.inTransLatHist[iter->second.transaction]->sample(
                                 ticksToCycles(curTick() - trans.time));
 
-       m_inTrans.erase(iter);
+        m_inTrans.erase(iter);
+        if (drainState() == DrainState::Draining && noInTransactions()) {
+            signalDrainDone();
+        }
     }
 
     /**

--- a/src/mem/ruby/slicc_interface/AbstractController.hh
+++ b/src/mem/ruby/slicc_interface/AbstractController.hh
@@ -87,7 +87,7 @@ class AbstractController : public ClockedObject, public Consumer
   public:
     PARAMS(RubyController);
     AbstractController(const Params &p);
-    void init();
+    void init() override;
 
     DrainState drain() override;
 
@@ -115,10 +115,8 @@ class AbstractController : public ClockedObject, public Consumer
 
     virtual AccessPermission getAccessPermission(const Addr &addr) = 0;
 
-    virtual void print(std::ostream & out) const = 0;
-    virtual void wakeup() = 0;
-    virtual void resetStats() = 0;
-    virtual void regStats();
+    void resetStats() override = 0;
+    void regStats() override;
 
     virtual void recordCacheTrace(int cntrl, CacheRecorder* tr) = 0;
     virtual Sequencer* getCPUSequencer() const = 0;
@@ -194,7 +192,7 @@ class AbstractController : public ClockedObject, public Consumer
 
     /** A function used to return the port associated with this bus object. */
     Port &getPort(const std::string &if_name,
-                  PortID idx=InvalidPortID);
+                  PortID idx = InvalidPortID) override;
 
     bool recvTimingResp(PacketPtr pkt);
     Tick recvAtomic(PacketPtr pkt);


### PR DESCRIPTION
This patch implements draining for the AsbtractController by relying on the existing map of outstanding transactions.

Ok so why are we doing this? Wasn't draining already supported in ruby?

At the moment it looks like the only logic making sure transient state is drained in ruby is in the RubyPort/Sequencer. [1] Which is effectively the input into the ruby memory sub-system. In a way it makes sense, assuming the system always reacts from stimuli passing through the RubyPort, if no outstanding request is allocatd at the RubyPort, we can infer the system is drained.

However this is not really an architected solution. There's always in fact a chance that there is some transient activity happening after a CPU/DMA initiate request has completed (and cleared the RubyPort).

Think for instance of a READ which initiates a writeback. A read might be completed and the RubyPort marks ruby as a whole as drained, while the cache controller is in the meantime in the process of writing back a potentially dirty line.

With this patch we mark a controller as draining if there are pending incoming transactions, and drained in the other case

Note 1:
I didn't come across this issue with the traditional hierarchy but by experimenting with a RubyPort-less system (with the TlmController) which as a consequence doesn't implement draining at all for the memory subsystem.

Note 2:
An initial implementation that works for CHI is provided here. Other sm controllers for other protocols have to either override the drain method according to their internal data structures or start using the incomingTransaction logic

[1]: https://github.com/gem5/gem5/blob/stable/\
    src/mem/ruby/system/RubyPort.cc#L608

Change-Id: I74fa32587cefae76ac716bdc9d7fd59e3489beb9

Reviewed-by: Andreas Sandberg <andreas.sandberg@arm.com>