### PR TITLE
arch-riscv: Fix stale faultIdx and trimVl in fault-only-first loads

### DIFF
--- a/src/arch/riscv/isa/formats/vector_mem.isa
+++ b/src/arch/riscv/isa/formats/vector_mem.isa
@@ -49,6 +49,9 @@ def getFaultCode():
             fault = NoFault;
             trimVl = true;
         }
+    } else {
+        faultIdx = this->microVl;
+        trimVl = false;
     }
     '''
 


### PR DESCRIPTION
In RISC-V unit-stride fault-only-first load instructions (`vle*ff`), `faultIdx` and `trimVl` are `mutable` members of the `VleMicroInst` instruction object. Because static instruction objects are reused across dynamic executions, any state modified during execution must be reset on every invocation.

Previously, `getFaultCode()` only updated `faultIdx` and `trimVl` when a fault occurred (`fault != NoFault`). If a `vle*ff` micro-instruction faulted on an earlier execution, subsequent non-faulting executions of the same instruction would retain stale `faultIdx` and `trimVl` values. This caused `VlFFTrimVlMicroOp::calcVl()` to incorrectly truncate `vl` even when no fault occurred.

Fix this by adding an `else` branch in `getFaultCode()` to explicitly reset `faultIdx = this->microVl` and `trimVl = false` when no fault occurs.

---

related issue : #3325 