### PR TITLE
dev: Allow a non zero sized IsaFake when ret_bad_addr=True

### DIFF
--- a/src/dev/Device.py
+++ b/src/dev/Device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2016,2019-2020 ARM Limited
+# Copyright (c) 2012-2016,2019-2020,2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -155,4 +155,4 @@ class IsaFake(BasicPioDevice):
 
 class BadAddr(IsaFake):
     pio_addr = 0
-    ret_bad_addr = Param.Bool(True, "Return pkt status bad address on access")
+    ret_bad_addr = True

--- a/src/dev/Device.py
+++ b/src/dev/Device.py
@@ -155,4 +155,5 @@ class IsaFake(BasicPioDevice):
 
 class BadAddr(IsaFake):
     pio_addr = 0
+    pio_size = 0
     ret_bad_addr = True

--- a/src/dev/isa_fake.cc
+++ b/src/dev/isa_fake.cc
@@ -41,8 +41,7 @@
 namespace gem5
 {
 
-IsaFake::IsaFake(const Params &p)
-    : BasicPioDevice(p, p.ret_bad_addr ? 0 : p.pio_size)
+IsaFake::IsaFake(const Params &p) : BasicPioDevice(p, p.pio_size)
 {
     retData8 = p.ret_data8;
     retData16 = p.ret_data16;


### PR DESCRIPTION
For some reason whenever the ret_bad_addr Param was set
to true, the IsaFake device was programmed to have no size.
This does not allow us mark a specific portion of memory
as "do not access here and I will return a bad addr response
if you do".

I believe the motivation for this is that a classic
XBar will use a BadAddr device as a default responder whenever
it is not able to map an incoming address to a port

default = RequestPort("Port for connecting an optional default responder")
badaddr_responder = BadAddr()
default = badaddr_responder.pio

As such it does not require BadAddr to have a real address range
(pio_addr, pio_size).
Its range is actually: "whatever is not recognised".

I believe this is not a property per se of the IsaFake device,
so we shouldn't carry the BadAddr device usage with a XBar
into the initialization of a IsaFake. Therefore we now simplify
IsaFake to make it less obscure, and we simply manually
initialize the BadAddr device to have a pio_size=0 in python