### PR TITLE
stdlib: Allow independent setting of CPU frequency

### DIFF
--- a/configs/deprecated/example/gem5_library/riscv-fs.py
+++ b/configs/deprecated/example/gem5_library/riscv-fs.py
@@ -66,7 +66,10 @@ memory = SingleChannelDDR3_1600()
 
 # Setup a single core Processor.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.RISCV,
+    num_cores=1,
+    clk_freq="1GHz",
 )
 
 # Setup the board.

--- a/configs/example/arm/fdp_neoverse_v2.py
+++ b/configs/example/arm/fdp_neoverse_v2.py
@@ -223,7 +223,8 @@ cache_hierarchy = CacheHierarchy()
 # Create the processor with one core
 
 processor = BaseCPUProcessor(
-    cores=[BaseCPUCore(neoverse_v2.NeoverseV2(), isa=ISA.ARM)]
+    cores=[BaseCPUCore(neoverse_v2.NeoverseV2(), isa=ISA.ARM)],
+    clk_freq="3GHz",
 )
 
 for core in processor.cores:

--- a/configs/example/gem5_library/arm-hello.py
+++ b/configs/example/gem5_library/arm-hello.py
@@ -62,7 +62,9 @@ cache_hierarchy = NoCache()
 memory = SingleChannelDDR3_1600(size="32MiB")
 
 # We use a simple Timing processor with one core.
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1, clk_freq="3GHz"
+)
 
 # The gem5 library simple board which can be used to run SE-mode simulations.
 board = SimpleBoard(

--- a/configs/example/gem5_library/arm-ubuntu-run.py
+++ b/configs/example/gem5_library/arm-ubuntu-run.py
@@ -72,7 +72,9 @@ memory = DualChannelDDR4_2400(size="2GiB")
 
 # Here we set up the processor. We use a simple processor with TIMING cores.
 # This config script was also tested with ATOMIC cores.
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, num_cores=2, isa=ISA.ARM)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, num_cores=2, isa=ISA.ARM, clk_freq="3GHz"
+)
 
 # The ArmBoard requires a `release` to be specified. This adds all the
 # extensions or features to the system. We are setting this to Armv8

--- a/configs/example/gem5_library/caches/octopi-cache-example.py
+++ b/configs/example/gem5_library/caches/octopi-cache-example.py
@@ -82,6 +82,7 @@ processor = SimpleProcessor(
     cpu_type=CPUTypes.TIMING,
     isa=ISA.ARM,
     num_cores=num_ccds * num_cores_per_ccd,
+    clk_freq="4GHz",
 )
 
 release = ArmDefaultRelease()

--- a/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/riscv-hello-restore-checkpoint.py
@@ -68,7 +68,10 @@ memory = SingleChannelDDR3_1600(size="32MiB")
 
 # We use a simple Timing processor with one core.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.RISCV,
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
 # The gem5 library simple board which can be used to run SE-mode simulations.

--- a/configs/example/gem5_library/checkpoints/riscv-hello-save-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/riscv-hello-save-checkpoint.py
@@ -81,7 +81,10 @@ memory = SingleChannelDDR3_1600(size="32MiB")
 
 # We use a simple Timing processor with one core.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.RISCV,
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
 # The gem5 library simple board which can be used to run SE-mode simulations.

--- a/configs/example/gem5_library/checkpoints/simpoints-se-checkpoint.py
+++ b/configs/example/gem5_library/checkpoints/simpoints-se-checkpoint.py
@@ -100,6 +100,7 @@ processor = SimpleProcessor(
     isa=ISA.X86,
     # SimPoints only works with one core
     num_cores=1,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/configs/example/gem5_library/checkpoints/simpoints-se-restore.py
+++ b/configs/example/gem5_library/checkpoints/simpoints-se-restore.py
@@ -93,6 +93,7 @@ processor = SimpleProcessor(
     cpu_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=1,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/configs/example/gem5_library/dramsys/arm-hello-dramsys.py
+++ b/configs/example/gem5_library/dramsys/arm-hello-dramsys.py
@@ -71,7 +71,9 @@ cache_hierarchy = PrivateL1CacheHierarchy(l1d_size="32KiB", l1i_size="32KiB")
 memory = DRAMSysDDR3_1600()
 
 # We use a simple Timing processor with one core.
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1, clk_freq="3GHz"
+)
 
 # The gem5 library simple board which can be used to run SE-mode simulations.
 board = SimpleBoard(

--- a/configs/example/gem5_library/exit_handling/user-exit-handler.py
+++ b/configs/example/gem5_library/exit_handling/user-exit-handler.py
@@ -66,7 +66,9 @@ args = parser.parse_args()
 # Create the system
 cache_hierarchy = NoCache()
 memory = SingleChannelDDR3_1600(size="512MB")
-processor = SimpleProcessor(cpu_type=CPUTypes.ATOMIC, isa=ISA.X86, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.ATOMIC, isa=ISA.X86, num_cores=1, clk_freq="1GHz"
+)
 
 # Create the board
 board = SimpleBoard(

--- a/configs/example/gem5_library/fdp-hello.py
+++ b/configs/example/gem5_library/fdp-hello.py
@@ -246,7 +246,10 @@ cache_hierarchy = CacheHierarchy(
 # Next setup the decoupled front-end. Its implemented in the O3 core.
 # Create the processor with one core
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.O3, isa=isa_choices[args.isa], num_cores=1
+    cpu_type=CPUTypes.O3,
+    isa=isa_choices[args.isa],
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
 for core in processor.cores:

--- a/configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py
+++ b/configs/example/gem5_library/looppoints/create-looppoint-checkpoints.py
@@ -104,6 +104,7 @@ processor = SimpleProcessor(
     isa=ISA.X86,
     # LoopPoint can work with multicore workloads
     num_cores=9,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/configs/example/gem5_library/looppoints/restore-looppoint-checkpoint.py
+++ b/configs/example/gem5_library/looppoints/restore-looppoint-checkpoint.py
@@ -111,6 +111,7 @@ processor = SimpleProcessor(
     # The number of cores must be equal or greater than that used when taking
     # the checkpoint.
     num_cores=9,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/configs/example/gem5_library/multisim/multisim-print-this.py
+++ b/configs/example/gem5_library/multisim/multisim-print-this.py
@@ -78,7 +78,10 @@ for process_id in range(5):
     cache_hierarchy = NoCache()
     memory = SingleChannelDDR3_1600(size="32MiB")
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=1
+        cpu_type=CPUTypes.TIMING,
+        isa=ISA.X86,
+        num_cores=1,
+        clk_freq="1GHz",
     )
     board = SimpleBoard(
         clk_freq="1GHz",

--- a/configs/example/gem5_library/power-hello.py
+++ b/configs/example/gem5_library/power-hello.py
@@ -63,7 +63,10 @@ memory = SingleChannelDDR4_2400(size="32MiB")
 
 # We use a simple ATOMIC processor with one core.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.ATOMIC, isa=ISA.POWER, num_cores=1
+    cpu_type=CPUTypes.ATOMIC,
+    isa=ISA.POWER,
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
 # The gem5 library simple board which can be used to run SE-mode simulations.

--- a/configs/example/gem5_library/riscv-rvv-example.py
+++ b/configs/example/gem5_library/riscv-rvv-example.py
@@ -100,7 +100,8 @@ cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
 memory = SingleChannelDDR3_1600()
 
 processor = BaseCPUProcessor(
-    cores=[RVVCore(args.elen, args.vlen, i) for i in range(args.cores)]
+    cores=[RVVCore(args.elen, args.vlen, i) for i in range(args.cores)],
+    clk_freq="1GHz",
 )
 
 board = SimpleBoard(

--- a/configs/example/gem5_library/riscv-ubuntu-run.py
+++ b/configs/example/gem5_library/riscv-ubuntu-run.py
@@ -67,7 +67,10 @@ memory = DualChannelDDR4_2400(size="3GiB")
 
 # Here we set up the processor. We use a simple processor.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=2
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.RISCV,
+    num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we set up the board. The RiscvBoard allows for FS mode (full system) and

--- a/configs/example/gem5_library/x86-global-inst-tracker.py
+++ b/configs/example/gem5_library/x86-global-inst-tracker.py
@@ -79,7 +79,9 @@ memory = SingleChannelDDR4_2400("1GB")
 
 # using 9 cores because when using openmp in SE mode, the number of cores
 # should be # cores + 1
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, num_cores=9, isa=ISA.X86)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, num_cores=9, isa=ISA.X86, clk_freq="1GHz"
+)
 
 # set up instruction tracker
 

--- a/configs/example/gem5_library/x86-mi300x-gpu.py
+++ b/configs/example/gem5_library/x86-mi300x-gpu.py
@@ -117,7 +117,9 @@ args = parser.parse_args()
 memory = SingleChannelDDR4_2400(size="8GiB")
 
 # Note: Only KVM and ATOMIC work due to buggy MOESI_AMD_Base protocol.
-processor = SimpleProcessor(cpu_type=CPUTypes.KVM, isa=ISA.X86, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.KVM, isa=ISA.X86, num_cores=1, clk_freq="3GHz"
+)
 
 for core in processor.cores:
     if core.is_kvm_core():

--- a/configs/example/gem5_library/x86-mi355x-gpu.py
+++ b/configs/example/gem5_library/x86-mi355x-gpu.py
@@ -117,7 +117,9 @@ args = parser.parse_args()
 memory = SingleChannelDDR4_2400(size="8GiB")
 
 # Note: Only KVM and ATOMIC work due to buggy MOESI_AMD_Base protocol.
-processor = SimpleProcessor(cpu_type=CPUTypes.KVM, isa=ISA.X86, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.KVM, isa=ISA.X86, num_cores=1, clk_freq="3GHz"
+)
 
 for core in processor.cores:
     if core.is_kvm_core():

--- a/configs/example/lupv/run_lupv.py
+++ b/configs/example/lupv/run_lupv.py
@@ -81,11 +81,17 @@ memory = SingleChannelDDR3_1600(size="128MiB")
 # Setup a single core Processor.
 if args.cpu_type == "atomic":
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.ATOMIC, num_cores=args.num_cpus, isa=ISA.RISCV
+        cpu_type=CPUTypes.ATOMIC,
+        num_cores=args.num_cpus,
+        isa=ISA.RISCV,
+        clk_freq="1GHz",
     )
 elif args.cpu_type == "timing":
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.TIMING, num_cores=args.num_cpus, isa=ISA.RISCV
+        cpu_type=CPUTypes.TIMING,
+        num_cores=args.num_cpus,
+        isa=ISA.RISCV,
+        clk_freq="1GHz",
     )
 
 # Setup the board.

--- a/src/python/gem5/components/processors/abstract_generator.py
+++ b/src/python/gem5/components/processors/abstract_generator.py
@@ -68,7 +68,7 @@ class AbstractGenerator(AbstractProcessor):
         Keyword (optional arguments) are still allowable in the constructor of
         the inheriting classes.
         """
-        super().__init__(cores=cores)
+        super().__init__(cores=cores, clk_freq="1GHz")
 
     @overrides(AbstractProcessor)
     def incorporate_processor(self, board: AbstractBoard) -> None:

--- a/src/python/gem5/components/processors/abstract_processor.py
+++ b/src/python/gem5/components/processors/abstract_processor.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2021 The Regents of the University of California
 # All rights reserved.
 #
@@ -34,8 +46,11 @@ from typing import (
 )
 
 from m5.objects import (
+    ClockDomain,
     Root,
+    SrcClockDomain,
     SubSystem,
+    VoltageDomain,
 )
 from m5.util import warn
 
@@ -52,13 +67,22 @@ class AbstractProcessor(SubSystem):
         self,
         cores: Optional[List[AbstractCore]] = None,
         isa: ISA = ISA.NULL,
+        *,
+        clk_freq: str,
     ) -> None:
         """Set the cores on the processor
 
         Cores are optional for some processor types. If a processor does not
         set the cores here, it must override ``get_num_cores`` and ``get_cores``.
+
+        :param clk_freq: The clock frequency for the processor's cores.
         """
         super().__init__()
+
+        self.voltage_domain = VoltageDomain()
+        self.clk_domain = SrcClockDomain(
+            clock=clk_freq, voltage_domain=self.voltage_domain
+        )
 
         if cores:
             # In the stdlib we assume the system processor conforms to a single
@@ -79,6 +103,10 @@ class AbstractProcessor(SubSystem):
 
     def get_isa(self) -> ISA:
         return self._isa
+
+    def get_clock_domain(self) -> ClockDomain:
+        """Get the processor's core clock domain."""
+        return self.clk_domain
 
     def get_total_instructions(self) -> int:
         """Return the number of instructions executed by all cores.

--- a/src/python/gem5/components/processors/base_cpu_processor.py
+++ b/src/python/gem5/components/processors/base_cpu_processor.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2022 The Regents of the University of California
 # All rights reserved.
 #
@@ -25,7 +37,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import List
+from typing import (
+    List,
+)
 
 import m5
 from m5.objects import (
@@ -61,8 +75,19 @@ class BaseCPUProcessor(AbstractProcessor):
     and is not officially supported.
     """
 
-    def __init__(self, cores: List[BaseCPUCore]):
-        super().__init__(cores=cores)
+    def __init__(
+        self,
+        cores: List[BaseCPUCore],
+        clk_freq: str,
+    ):
+        """
+        :param cores: The cores to include in this processor.
+        :param clk_freq: The clock frequency for the processor's cores.
+        """
+        super().__init__(cores=cores, clk_freq=clk_freq)
+
+        for core in self.get_cores():
+            core.get_simobject().clk_domain = self.get_clock_domain()
 
         if any(core.is_kvm_core() for core in self.get_cores()):
             from m5.objects import KvmVM

--- a/src/python/gem5/components/processors/decoupled_processor.py
+++ b/src/python/gem5/components/processors/decoupled_processor.py
@@ -25,8 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import Optional
-
 from m5.objects import (
     LTAGE,
     BranchPredictor,
@@ -49,7 +47,12 @@ class DecoupledProcessor(BaseCPUProcessor):
     """
 
     def __init__(
-        self, num_cores: int, isa: ISA, decoupled: bool = True
+        self,
+        num_cores: int,
+        isa: ISA,
+        decoupled: bool = True,
+        *,
+        clk_freq: str,
     ) -> None:
         """
         :param num_cores: The number of CPU cores in the processor.
@@ -57,12 +60,15 @@ class DecoupledProcessor(BaseCPUProcessor):
         :param isa: The ISA of the processor.
 
         :param decouple: Enable/Disable the decoupled frontend.
+
+        :param clk_freq: The clock frequency for the processor's cores.
         """
         super().__init__(
             cores=[
                 SimpleCore(cpu_type=CPUTypes.O3, core_id=i, isa=isa)
                 for i in range(num_cores)
-            ]
+            ],
+            clk_freq=clk_freq,
         )
 
         for c in self.get_cores():

--- a/src/python/gem5/components/processors/simple_processor.py
+++ b/src/python/gem5/components/processors/simple_processor.py
@@ -25,8 +25,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import Optional
-
 from m5.util import warn
 
 from ...isas import ISA
@@ -41,17 +39,26 @@ class SimpleProcessor(BaseCPUProcessor):
     same CPUType.
     """
 
-    def __init__(self, cpu_type: CPUTypes, num_cores: int, isa: ISA) -> None:
+    def __init__(
+        self,
+        cpu_type: CPUTypes,
+        num_cores: int,
+        isa: ISA,
+        clk_freq: str,
+    ) -> None:
         """
         :param cpu_type: The CPU type for each type in the processor.
 
         :param num_cores: The number of CPU cores in the processor.
 
         :param isa: The ISA of the processor.
+
+        :param clk_freq: The clock frequency for the processor's cores.
         """
         super().__init__(
             cores=[
                 SimpleCore(cpu_type=cpu_type, core_id=i, isa=isa)
                 for i in range(num_cores)
-            ]
+            ],
+            clk_freq=clk_freq,
         )

--- a/src/python/gem5/components/processors/simple_switchable_processor.py
+++ b/src/python/gem5/components/processors/simple_switchable_processor.py
@@ -24,8 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Optional
-
 from m5.util import warn
 
 from ...isas import ISA
@@ -55,6 +53,8 @@ class SimpleSwitchableProcessor(SwitchableProcessor):
         switch_core_type: CPUTypes,
         num_cores: int,
         isa: ISA = None,
+        *,
+        clk_freq: str,
     ) -> None:
         """
         :param starting_core_type: The CPU type for each type in the processor
@@ -64,6 +64,8 @@ class SimpleSwitchableProcessor(SwitchableProcessor):
         to.
 
         :param isa: The ISA of the processor.
+
+        :param clk_freq: The clock frequency for the processor's cores.
         """
 
         if num_cores <= 0:
@@ -87,7 +89,9 @@ class SimpleSwitchableProcessor(SwitchableProcessor):
         }
 
         super().__init__(
-            switchable_cores=switchable_cores, starting_cores=self._start_key
+            switchable_cores=switchable_cores,
+            starting_cores=self._start_key,
+            clk_freq=clk_freq,
         )
 
     @overrides(SwitchableProcessor)

--- a/src/python/gem5/components/processors/switchable_processor.py
+++ b/src/python/gem5/components/processors/switchable_processor.py
@@ -54,7 +54,14 @@ class SwitchableProcessor(AbstractProcessor):
         self,
         switchable_cores: Dict[str, List[SimpleCore]],
         starting_cores: str,
+        clk_freq: str,
     ) -> None:
+        """
+        :param switchable_cores: A dictionary mapping processor names to the
+                                 cores that can be switched in.
+        :param starting_cores: The key of the cores to start with.
+        :param clk_freq: The clock frequency for the processor's cores.
+        """
         if starting_cores not in switchable_cores.keys():
             raise AssertionError(
                 f"Key {starting_cores} cannot be found in the "
@@ -67,7 +74,10 @@ class SwitchableProcessor(AbstractProcessor):
         # In the stdlib we assume the system processor conforms to a single
         # ISA target.
         assert len({core.get_isa() for core in self._current_cores}) == 1
-        super().__init__(isa=self._current_cores[0].get_isa())
+        super().__init__(
+            isa=self._current_cores[0].get_isa(),
+            clk_freq=clk_freq,
+        )
 
         for name, core_list in self._switchable_cores.items():
             # Use the names from the user as the member variables
@@ -75,6 +85,7 @@ class SwitchableProcessor(AbstractProcessor):
             setattr(self, name, core_list)
             for core in core_list:
                 core.set_switched_out(core not in self._current_cores)
+                core.get_simobject().clk_domain = self.get_clock_domain()
 
         self._prepare_kvm = any(
             core.is_kvm_core() for core in self._all_cores()

--- a/src/python/gem5/prebuilt/demo/arm_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/arm_demo_board.py
@@ -80,7 +80,10 @@ class ArmDemoBoard(ArmBoard):
 
         if use_kvm:
             processor = SimpleProcessor(
-                cpu_type=CPUTypes.KVM, num_cores=2, isa=ISA.ARM
+                cpu_type=CPUTypes.KVM,
+                num_cores=2,
+                isa=ISA.ARM,
+                clk_freq="3GHz",
             )
             # The ArmBoard requires a `release` to be specified. This adds all the
             # extensions or features to the system. We are setting this to for_kvm()
@@ -94,7 +97,10 @@ class ArmDemoBoard(ArmBoard):
 
         else:
             processor = SimpleProcessor(
-                cpu_type=CPUTypes.TIMING, num_cores=2, isa=ISA.ARM
+                cpu_type=CPUTypes.TIMING,
+                num_cores=2,
+                isa=ISA.ARM,
+                clk_freq="3GHz",
             )
             release = ArmDefaultRelease()
 

--- a/src/python/gem5/prebuilt/demo/riscv_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/riscv_demo_board.py
@@ -72,6 +72,7 @@ class RiscvDemoBoard(RiscvBoard):
             cpu_type=CPUTypes.TIMING,
             isa=ISA.RISCV,
             num_cores=2,
+            clk_freq="1.4GHz",
         )
 
         # Here we setup the parameters of the l1 and l2 caches.

--- a/src/python/gem5/prebuilt/demo/x86_demo_board.py
+++ b/src/python/gem5/prebuilt/demo/x86_demo_board.py
@@ -76,7 +76,10 @@ class X86DemoBoard(X86Board):
 
         memory = DualChannelDDR4_2400("4GiB")
         processor = SimpleProcessor(
-            cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=2
+            cpu_type=CPUTypes.TIMING,
+            isa=ISA.X86,
+            num_cores=2,
+            clk_freq="3GHz",
         )
 
         cache_hierarchy = PrivateL1SharedL2WalkCacheHierarchy(

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_board.py
@@ -137,7 +137,7 @@ class RISCVMatchedBoard(
 
         memory = U74Memory()
 
-        processor = U74Processor(is_fs=is_fs)
+        processor = U74Processor(is_fs=is_fs, clk_freq=clk_freq)
         super().__init__()
         AbstractBoard.__init__(
             self,

--- a/src/python/gem5/prebuilt/riscvmatched/riscvmatched_processor.py
+++ b/src/python/gem5/prebuilt/riscvmatched/riscvmatched_processor.py
@@ -43,9 +43,10 @@ class U74Processor(BaseCPUProcessor):
     def __init__(
         self,
         is_fs: bool,
+        clk_freq: str,
     ) -> None:
         self._cpu_type = CPUTypes.MINOR
-        super().__init__(cores=self._create_cores(is_fs))
+        super().__init__(cores=self._create_cores(is_fs), clk_freq=clk_freq)
 
     def _create_cores(self, is_fs: bool):
         if is_fs:

--- a/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
+++ b/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run.py
@@ -205,7 +205,10 @@ memory = memory_class(size="4GiB")
 cpu_type = get_cpu_type_from_str(args.cpu)
 
 processor = SimpleProcessor(
-    cpu_type=cpu_type, num_cores=args.num_cpus, isa=ISA.ARM
+    cpu_type=cpu_type,
+    num_cores=args.num_cpus,
+    isa=ISA.ARM,
+    clk_freq="1GHz",
 )
 
 

--- a/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run_mesh.py
+++ b/tests/gem5/arm_boot_tests/configs/arm_boot_exit_run_mesh.py
@@ -171,7 +171,10 @@ memory = ChanneledMemory(
 cpu_type = get_cpu_type_from_str(args.cpu)
 
 processor = SimpleProcessor(
-    cpu_type=cpu_type, num_cores=args.num_cpus, isa=ISA.ARM
+    cpu_type=cpu_type,
+    num_cores=args.num_cpus,
+    isa=ISA.ARM,
+    clk_freq="1GHz",
 )
 
 

--- a/tests/gem5/checkpoint_tests/configs/arm-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/arm-hello-restore-checkpoint.py
@@ -70,7 +70,9 @@ cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
 
 memory = SingleChannelDDR3_1600(size="32MiB")
 
-processor = SimpleProcessor(cpu_type=CPUTypes.ATOMIC, isa=ISA.ARM, num_cores=2)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.ATOMIC, isa=ISA.ARM, num_cores=2, clk_freq="3GHz"
+)
 
 board = SimpleBoard(
     clk_freq="3GHz",

--- a/tests/gem5/checkpoint_tests/configs/arm-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/arm-hello-save-checkpoint.py
@@ -56,7 +56,9 @@ cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
 )
 
 memory = SingleChannelDDR3_1600(size="32MiB")
-processor = SimpleProcessor(cpu_type=CPUTypes.ATOMIC, isa=ISA.ARM, num_cores=2)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.ATOMIC, isa=ISA.ARM, num_cores=2, clk_freq="3GHz"
+)
 board = SimpleBoard(
     clk_freq="3GHz",
     processor=processor,

--- a/tests/gem5/checkpoint_tests/configs/power-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/power-hello-restore-checkpoint.py
@@ -52,7 +52,10 @@ cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600(size="32MiB")
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.POWER, num_cores=2
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.POWER,
+    num_cores=2,
+    clk_freq="3GHz",
 )
 board = SimpleBoard(
     clk_freq="3GHz",

--- a/tests/gem5/checkpoint_tests/configs/power-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/power-hello-save-checkpoint.py
@@ -60,7 +60,10 @@ cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600(size="32MiB")
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.POWER, num_cores=2
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.POWER,
+    num_cores=2,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/tests/gem5/checkpoint_tests/configs/sparc-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/sparc-hello-restore-checkpoint.py
@@ -52,7 +52,10 @@ cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600(size="32MiB")
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.SPARC, num_cores=2
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.SPARC,
+    num_cores=2,
+    clk_freq="3GHz",
 )
 board = SimpleBoard(
     clk_freq="3GHz",

--- a/tests/gem5/checkpoint_tests/configs/sparc-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/sparc-hello-save-checkpoint.py
@@ -60,7 +60,10 @@ cache_hierarchy = NoCache()
 
 memory = SingleChannelDDR3_1600(size="32MiB")
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=ISA.SPARC, num_cores=2
+    cpu_type=CPUTypes.TIMING,
+    isa=ISA.SPARC,
+    num_cores=2,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-fs-restore-checkpoint.py
@@ -62,7 +62,9 @@ cache_hierarchy = PrivateL1PrivateL2WalkCacheHierarchy(
 memory = SingleChannelDDR3_1600(size="1GiB")
 
 # Setup a single core Processor.
-processor = SimpleProcessor(cpu_type=CPUTypes.O3, isa=ISA.X86, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.O3, isa=ISA.X86, num_cores=1, clk_freq="3GHz"
+)
 
 # Setup the board.
 board = X86Board(

--- a/tests/gem5/checkpoint_tests/configs/x86-fs-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-fs-save-checkpoint.py
@@ -71,7 +71,9 @@ cache_hierarchy = PrivateL1PrivateL2WalkCacheHierarchy(
 memory = SingleChannelDDR3_1600(size="1GiB")
 
 # Setup a single core Processor.
-processor = SimpleProcessor(cpu_type=CPUTypes.O3, isa=ISA.X86, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.O3, isa=ISA.X86, num_cores=1, clk_freq="3GHz"
+)
 
 # Setup the board.
 board = X86Board(

--- a/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-hello-restore-checkpoint.py
@@ -53,7 +53,9 @@ requires(isa_required=ISA.X86)
 cache_hierarchy = PrivateL1CacheHierarchy(l1d_size="16KiB", l1i_size="16KiB")
 
 memory = SingleChannelDDR3_1600(size="32MiB")
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=4)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=4, clk_freq="3GHz"
+)
 board = SimpleBoard(
     clk_freq="3GHz",
     processor=processor,

--- a/tests/gem5/checkpoint_tests/configs/x86-hello-save-checkpoint.py
+++ b/tests/gem5/checkpoint_tests/configs/x86-hello-save-checkpoint.py
@@ -61,7 +61,9 @@ requires(isa_required=ISA.X86)
 cache_hierarchy = PrivateL1CacheHierarchy(l1d_size="16KiB", l1i_size="16KiB")
 
 memory = SingleChannelDDR3_1600(size="32MiB")
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=4)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, isa=ISA.X86, num_cores=4, clk_freq="3GHz"
+)
 
 board = SimpleBoard(
     clk_freq="3GHz",

--- a/tests/gem5/chi_protocol/configs/chi-with-isa.py
+++ b/tests/gem5/chi_protocol/configs/chi-with-isa.py
@@ -123,6 +123,7 @@ processor = SimpleProcessor(
     cpu_type=CPUTypes.TIMING,
     isa=isa,
     num_cores=args.num_cores,
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(

--- a/tests/gem5/config_output_files/configs/arm-hello.py
+++ b/tests/gem5/config_output_files/configs/arm-hello.py
@@ -77,7 +77,9 @@ cache_hierarchy = NoCache()
 memory = SingleChannelDDR3_1600(size="32MiB")
 
 # We use a simple Timing processor with one core.
-processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1)
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.TIMING, isa=ISA.ARM, num_cores=1, clk_freq="3GHz"
+)
 
 # The gem5 library simple board which can be used to run SE-mode simulations.
 board = SimpleBoard(

--- a/tests/gem5/insttest_se/configs/simple_binary_run.py
+++ b/tests/gem5/insttest_se/configs/simple_binary_run.py
@@ -110,6 +110,7 @@ processor = SimpleProcessor(
     cpu_type=cpu_enum,
     isa=isa_enum,
     num_cores=1,
+    clk_freq="3GHz",
 )
 
 motherboard = SimpleBoard(

--- a/tests/gem5/m5_util/configs/se-m5-exit.py
+++ b/tests/gem5/m5_util/configs/se-m5-exit.py
@@ -118,6 +118,7 @@ processor = SimpleProcessor(
     cpu_type=CPUTypes.ATOMIC,
     isa=isa,
     num_cores=1,
+    clk_freq="3GHz",
 )
 
 motherboard = SimpleBoard(

--- a/tests/gem5/multisim/configs/hello-restore-checkpoint.py
+++ b/tests/gem5/multisim/configs/hello-restore-checkpoint.py
@@ -46,7 +46,9 @@ for isa in [ISA.RISCV, ISA.ARM, ISA.X86]:
 
     memory = SingleChannelDDR3_1600(size="32MiB")
 
-    processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1)
+    processor = SimpleProcessor(
+        cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1, clk_freq="3GHz"
+    )
 
     board = SimpleBoard(
         clk_freq="3GHz",

--- a/tests/gem5/multisim/configs/hello-save-checkpoint-hypercall.py
+++ b/tests/gem5/multisim/configs/hello-save-checkpoint-hypercall.py
@@ -73,7 +73,9 @@ for isa in [ISA.RISCV, ISA.ARM, ISA.X86]:
 
     memory = SingleChannelDDR3_1600(size="32MiB")
 
-    processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1)
+    processor = SimpleProcessor(
+        cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1, clk_freq="3GHz"
+    )
 
     board = SimpleBoard(
         clk_freq="3GHz",

--- a/tests/gem5/multisim/configs/longer-workloads.py
+++ b/tests/gem5/multisim/configs/longer-workloads.py
@@ -46,7 +46,10 @@ for npb_workload in ["bt", "cg", "ep", "ft"]:
     )
     memory = SingleChannelDDR3_1600(size="3GiB")
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.ATOMIC, isa=ISA.X86, num_cores=1
+        cpu_type=CPUTypes.ATOMIC,
+        isa=ISA.X86,
+        num_cores=1,
+        clk_freq="1GHz",
     )
     board = X86Board(
         clk_freq="1GHz",

--- a/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
+++ b/tests/gem5/multisim/configs/riscv-hello-restore-checkpoints.py
@@ -49,7 +49,10 @@ for ticks in [500000, 1000000, 1500000]:
     memory = SingleChannelDDR3_1600(size="32MiB")
 
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
+        cpu_type=CPUTypes.TIMING,
+        isa=ISA.RISCV,
+        num_cores=1,
+        clk_freq="3GHz",
     )
 
     board = SimpleBoard(

--- a/tests/gem5/multisim/configs/riscv-hello-save-checkpoint-hypercall.py
+++ b/tests/gem5/multisim/configs/riscv-hello-save-checkpoint-hypercall.py
@@ -74,7 +74,10 @@ for ticks in [500_000, 1_000_000, 1_500_000]:
     memory = SingleChannelDDR3_1600(size="32MiB")
 
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.TIMING, isa=ISA.RISCV, num_cores=1
+        cpu_type=CPUTypes.TIMING,
+        isa=ISA.RISCV,
+        num_cores=1,
+        clk_freq="3GHz",
     )
 
     board = SimpleBoard(

--- a/tests/gem5/multisim/configs/varying-length-10-proc.py
+++ b/tests/gem5/multisim/configs/varying-length-10-proc.py
@@ -52,7 +52,10 @@ for no_systemd in [True, False]:
     )
     memory = SingleChannelDDR3_1600(size="3GiB")
     processor = SimpleProcessor(
-        cpu_type=CPUTypes.ATOMIC, isa=ISA.RISCV, num_cores=1
+        cpu_type=CPUTypes.ATOMIC,
+        isa=ISA.RISCV,
+        num_cores=1,
+        clk_freq="3GHz",
     )
 
     board = RiscvBoard(
@@ -91,7 +94,10 @@ for isa in [ISA.X86, ISA.ARM]:
         memory = SingleChannelDDR3_1600(size="32MiB")
 
         processor = SimpleProcessor(
-            cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1
+            cpu_type=CPUTypes.TIMING,
+            isa=isa,
+            num_cores=1,
+            clk_freq="3GHz",
         )
 
         board = SimpleBoard(

--- a/tests/gem5/regression_tests/configs/hello-world-binary.py
+++ b/tests/gem5/regression_tests/configs/hello-world-binary.py
@@ -95,7 +95,10 @@ memory = SingleChannelSimpleMemory(
 
 # We use a simple Timing processor with one core.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=get_isa_from_str(args.isa), num_cores=1
+    cpu_type=CPUTypes.TIMING,
+    isa=get_isa_from_str(args.isa),
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
 # The gem5 library simple board which can be used to run simple SE-mode

--- a/tests/gem5/regression_tests/configs/matrix-multiply.py
+++ b/tests/gem5/regression_tests/configs/matrix-multiply.py
@@ -95,7 +95,10 @@ memory = SingleChannelSimpleMemory(
 
 # We use a simple Timing processor with one core.
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.TIMING, isa=get_isa_from_str(args.isa), num_cores=1
+    cpu_type=CPUTypes.TIMING,
+    isa=get_isa_from_str(args.isa),
+    num_cores=1,
+    clk_freq="3GHz",
 )
 
 # The gem5 library simple board which can be used to run simple SE-mode

--- a/tests/gem5/riscv-unittests/asmtest/configs/riscv_asmtest.py
+++ b/tests/gem5/riscv-unittests/asmtest/configs/riscv_asmtest.py
@@ -91,6 +91,7 @@ processor = SimpleProcessor(
     cpu_type=get_cpu_type_from_str(args.cpu),
     isa=ISA.RISCV,
     num_cores=args.num_cores,
+    clk_freq="3GHz",
 )
 
 if args.riscv_32bits:

--- a/tests/gem5/riscv_boot_tests/configs/riscv_boot_exit_run.py
+++ b/tests/gem5/riscv_boot_tests/configs/riscv_boot_exit_run.py
@@ -150,7 +150,10 @@ else:
     )
 
 processor = SimpleProcessor(
-    cpu_type=cpu_type, isa=ISA.RISCV, num_cores=args.num_cpus
+    cpu_type=cpu_type,
+    isa=ISA.RISCV,
+    num_cores=args.num_cpus,
+    clk_freq="1GHz",
 )
 
 # Setup the board.

--- a/tests/gem5/se_mode/hello_se/configs/simple_binary_run.py
+++ b/tests/gem5/se_mode/hello_se/configs/simple_binary_run.py
@@ -120,6 +120,7 @@ processor = SimpleProcessor(
     cpu_type=cpu_enum,
     isa=isa_enum,
     num_cores=args.num_cores,
+    clk_freq="3GHz",
 )
 
 motherboard = SimpleBoard(

--- a/tests/gem5/stats/configs/simple_binary_run.py
+++ b/tests/gem5/stats/configs/simple_binary_run.py
@@ -92,6 +92,7 @@ processor = SimpleProcessor(
     cpu_type=CPUTypes.ATOMIC,
     isa=ISA.ARM,
     num_cores=1,
+    clk_freq="3GHz",
 )
 
 motherboard = SimpleBoard(

--- a/tests/gem5/stdlib/configs/hypercall-exit-check.py
+++ b/tests/gem5/stdlib/configs/hypercall-exit-check.py
@@ -72,7 +72,10 @@ board = SimpleBoard(
     memory=SingleChannelDDR3_1600(),
     cache_hierarchy=NoCache(),
     processor=SimpleProcessor(
-        cpu_type=CPUTypes.ATOMIC, isa=ISA.X86, num_cores=1
+        cpu_type=CPUTypes.ATOMIC,
+        isa=ISA.X86,
+        num_cores=1,
+        clk_freq="3GHz",
     ),
 )
 

--- a/tests/gem5/stdlib/configs/simple_binary_run.py
+++ b/tests/gem5/stdlib/configs/simple_binary_run.py
@@ -102,9 +102,7 @@ cores = [
     for i in range(1)
 ]
 
-processor = BaseCPUProcessor(
-    cores=cores,
-)
+processor = BaseCPUProcessor(cores=cores, clk_freq="3GHz")
 
 motherboard = SimpleBoard(
     clk_freq="3GHz",

--- a/tests/gem5/stdlib/configs/simulator_exit_event_run.py
+++ b/tests/gem5/stdlib/configs/simulator_exit_event_run.py
@@ -90,6 +90,7 @@ processor = SimpleProcessor(
     cpu_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=1,
+    clk_freq="3GHz",
 )
 
 motherboard = SimpleBoard(

--- a/tests/gem5/stdlib/configs/tick-exit.py
+++ b/tests/gem5/stdlib/configs/tick-exit.py
@@ -68,6 +68,7 @@ motherboard = SimpleBoard(
         cpu_type=CPUTypes.TIMING,
         isa=ISA.X86,
         num_cores=1,
+        clk_freq="3GHz",
     ),
     memory=SingleChannelDDR3_1600(),
     cache_hierarchy=NoCache(),

--- a/tests/gem5/stdlib/configs/tick-to-max.py
+++ b/tests/gem5/stdlib/configs/tick-to-max.py
@@ -91,6 +91,7 @@ motherboard = SimpleBoard(
         cpu_type=CPUTypes.TIMING,
         isa=ISA.X86,
         num_cores=1,
+        clk_freq="3GHz",
     ),
     memory=SingleChannelDDR3_1600(),
     cache_hierarchy=NoCache(),

--- a/tests/gem5/suite_tests/configs/suite_run_workload.py
+++ b/tests/gem5/suite_tests/configs/suite_run_workload.py
@@ -102,7 +102,9 @@ memory = SingleChannelDDR3_1600(size="3GiB")
 
 
 def get_processor(isa):
-    processor = SimpleProcessor(cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1)
+    processor = SimpleProcessor(
+        cpu_type=CPUTypes.TIMING, isa=isa, num_cores=1, clk_freq="1GHz"
+    )
     return processor
 
 

--- a/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
+++ b/tests/gem5/x86_boot_tests/configs/x86_boot_exit_run.py
@@ -169,6 +169,7 @@ processor = SimpleProcessor(
     cpu_type=get_cpu_type_from_str(args.cpu),
     isa=ISA.X86,
     num_cores=args.num_cpus,
+    clk_freq="3GHz",
 )
 
 # Setup the motherboard.


### PR DESCRIPTION
One of the many things preventing the widespread adoption of stdlib is that it starts from the unreal assumption that all components in a simulator will be part of the same clock domain.

At the moment most stdlib platforms (with some exceptions) assume every component from CPU to caches and interconnect will use the board clock_domain.

With this commit we allow setting a separate clk_domain for the Processor/Cores.

We add a core_frequency parameter to the AbstractProcessor which is using to define a new Processor clk_domain. We delegate to parent classes to attach this clk_domain to the child cores. According to gem5 magic this might not be needed but relying on Parent.clk_domain assignment is too risky when there is such an important parameter to be set. We leve the board.clk_domain to clock the rest of the board, meaning interconnects,devices and so on.

Change-Id: Id44f183f8ba9106eb03c11a548a72f1a624295dd