### PR TITLE
misc: Dependabot modifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,4 @@ updates:
     # Labels on pull requests for version updates only
       labels:
           - misc
+          - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
           interval: monthly
       assignees:
           - Harshil2107
+          - erin-le
       commit-message:
           prefix: 'misc: '
     # Raise pull requests for version updates


### PR DESCRIPTION
This PR modifies the dependabot configuration in two ways:

1. PRs opened by dependabot will be labeled with the `dependencies` label
2. Another assignee (erin-le) will be added when dependabot opens a new PR