### PR TITLE
mem-ruby: Handle snoops in the TlmController

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/controller.cc
+++ b/src/mem/ruby/protocol/chi/tlm/controller.cc
@@ -104,9 +104,12 @@ CacheController::recvSnoopMsg(const CHIRequestMsg *msg)
 
     payload->address = msg->m_addr;
     payload->ns = msg->m_ns;
+    payload->ret_to_src = msg->m_retToSrc;
     phase.channel = ARM::CHI::CHANNEL_SNP;
     phase.snp_opcode = ruby_to_tlm::snpOpcode(msg->m_type);
     phase.txn_id = msg->m_txnId;
+    phase.src_id = ruby_to_tlm::srcId(msg->m_requestor);
+    phase.fwd_nid = ruby_to_tlm::srcId(msg->m_fwdRequestor);
 
     bw(payload, &phase);
 
@@ -446,8 +449,7 @@ CacheController::sendDataMsg(ARM::CHI::Payload &payload,
     data_msg->m_addr = ruby::makeLineAddress(payload.address, cacheLineBits);
     data_msg->m_responder = getMachineID();
     data_msg->m_type = tlm_to_ruby::datOpcode(phase.dat_opcode, phase.resp);
-    data_msg->m_Destination.add(
-        mapAddressToDownstreamMachine(payload.address));
+    data_msg->m_Destination.add(tlm_to_ruby::srcId(phase.tgt_id));
     data_msg->m_txnId = phase.txn_id;
     data_msg->m_dataBlk.setData(payload.data, 0, cacheLineSize);
 
@@ -474,8 +476,9 @@ CacheController::sendResponseMsg(ARM::CHI::Payload &payload,
 
     res_msg->m_addr = ruby::makeLineAddress(payload.address, cacheLineBits);
     res_msg->m_responder = getMachineID();
-    res_msg->m_type = tlm_to_ruby::rspOpcode(phase.rsp_opcode, phase.resp);
-    res_msg->m_Destination.add(mapAddressToDownstreamMachine(payload.address));
+    res_msg->m_type =
+        tlm_to_ruby::rspOpcode(phase.rsp_opcode, phase.resp, phase.fwd_state);
+    res_msg->m_Destination.add(tlm_to_ruby::srcId(phase.tgt_id));
     res_msg->m_txnId = phase.txn_id;
 
     sendResponseMsg(res_msg);

--- a/src/mem/ruby/protocol/chi/tlm/utils.cc
+++ b/src/mem/ruby/protocol/chi/tlm/utils.cc
@@ -308,13 +308,26 @@ datOpcode(DatOpcode dat, Resp resp)
         }
       case DAT_OPCODE_SNP_RESP_DATA:
         RESP_CASE(CHIDataType_SnpRespData)
+      case DAT_OPCODE_COMP_DATA:
+          switch (resp) {
+              case RESP_I:
+                  return CHIDataType_CompData_I;
+              case RESP_UC:
+                  return CHIDataType_CompData_UC;
+              case RESP_SC:
+                  return CHIDataType_CompData_SC;
+              case RESP_SD_PD:
+                  return CHIDataType_CompData_SD_PD;
+              default:
+                  panic("");
+          }
       default:
         panic("Unsupported Translation: %s\n", datOpcodeToName(dat));
     }
 }
 
 CHIResponseType
-rspOpcode(RspOpcode opc, Resp resp)
+rspOpcode(RspOpcode opc, Resp resp, Resp fwd_state)
 {
     switch(opc) {
       case RSP_OPCODE_COMP_ACK: return CHIResponseType_CompAck;
@@ -323,8 +336,57 @@ rspOpcode(RspOpcode opc, Resp resp)
       case RSP_OPCODE_SNP_RESP:
         switch (resp) {
           case RESP_I: return CHIResponseType_SnpResp_I;
+          case RESP_SC:
+              return CHIResponseType_SnpResp_SC;
           default: panic("Invalid resp %d for %d\n", resp, opc);
         }
+      case RSP_OPCODE_SNP_RESP_FWDED:
+          switch (resp) {
+              case RESP_I:
+                  switch (fwd_state) {
+                      case RESP_UC:
+                          return CHIResponseType_SnpResp_I_Fwded_UC;
+                      case RESP_UD_PD:
+                          return CHIResponseType_SnpResp_I_Fwded_UD_PD;
+                      default:
+                          panic(
+                              "Invalid fwd_state %d for resp %d, opcode %d\n",
+                              fwd_state, resp, opc);
+                  }
+              case RESP_SC:
+                  switch (fwd_state) {
+                      case RESP_I:
+                          return CHIResponseType_SnpResp_SC_Fwded_I;
+                      case RESP_SC:
+                          return CHIResponseType_SnpResp_SC_Fwded_SC;
+                      case RESP_SD_PD:
+                          return CHIResponseType_SnpResp_SC_Fwded_SD_PD;
+                      default:
+                          panic(
+                              "Invalid fwd_state %d for resp %d, opcode %d\n",
+                              fwd_state, resp, opc);
+                  }
+              case RESP_UC:
+                  switch (fwd_state) {
+                      case RESP_I:
+                          return CHIResponseType_SnpResp_UC_Fwded_I;
+                      default:
+                          panic(
+                              "Invalid fwd_state %d for resp %d, opcode %d\n",
+                              fwd_state, resp, opc);
+                  }
+              case RESP_SD:
+                  switch (fwd_state) {
+                      case RESP_I:
+                          return CHIResponseType_SnpResp_SD_Fwded_I;
+                      default:
+                          panic(
+                              "Invalid fwd_state %d for resp %d, opcode %d\n",
+                              fwd_state, resp, opc);
+                  }
+              default:
+                  panic("Invalid resp %d for %d\n", resp, opc);
+          }
       default:
         panic("Unsupported Translation: %s\n", rspOpcodeToName(opc));
     };
@@ -424,6 +486,8 @@ snpOpcode(CHIRequestType snp)
         return SNP_OPCODE_SNP_ONCE;
       case CHIRequestType_SnpShared:
         return SNP_OPCODE_SNP_SHARED;
+      case CHIRequestType_SnpSharedFwd:
+          return SNP_OPCODE_SNP_SHARED_FWD;
       case CHIRequestType_SnpCleanInvalid:
         return SNP_OPCODE_SNP_CLEAN_INVALID;
       case CHIRequestType_SnpUnique:

--- a/src/mem/ruby/protocol/chi/tlm/utils.hh
+++ b/src/mem/ruby/protocol/chi/tlm/utils.hh
@@ -59,7 +59,9 @@ namespace tlm_to_ruby {
 
 ruby::CHI::CHIRequestType reqOpcode(ARM::CHI::ReqOpcode req);
 ruby::CHI::CHIDataType datOpcode(ARM::CHI::DatOpcode dat, ARM::CHI::Resp resp);
-ruby::CHI::CHIResponseType rspOpcode(ARM::CHI::RspOpcode res, ARM::CHI::Resp resp);
+ruby::CHI::CHIResponseType rspOpcode(ARM::CHI::RspOpcode res,
+                                     ARM::CHI::Resp resp,
+                                     ARM::CHI::Resp fwd_state);
 ruby::MachineID srcId(uint16_t src_id);
 }
 


### PR DESCRIPTION
With this commit we properly handle snoop requests at the TlmController:

1) We start translating relevant fields like:
* ret_to_src
* src_id
* fwd_nid

2) When responding to a snoop, we make sure we forward the message to the right controller. We cannot use the mapAddressToDownstreamMachine as usual because that would direct the message to the HN.
We use the tgt_id instead, assuming the RN implementation is properly initializing it to be the snoop request src_id (for responses to the HN) or the fwd_nid (for responses to the RN)

Change-Id: I4c30bc294757beb719cf58705ed8e91fb7aba919