### PR TITLE
tests: Add lsq-burst SE program to reproduce O3 IEW TimeBuffer overflow

### DIFF
--- a/tests/test-progs/lsq-burst/.gitignore
+++ b/tests/test-progs/lsq-burst/.gitignore
@@ -1,0 +1,1 @@
+src/lsq-burst

--- a/tests/test-progs/lsq-burst/README.md
+++ b/tests/test-progs/lsq-burst/README.md
@@ -1,0 +1,47 @@
+# lsq-burst
+
+Small SE-mode stress program that issues many independent cache-line-strided
+loads. It is intended to exercise high memory-level parallelism in the O3
+LSQ / IEW path.
+
+## Motivation
+
+Useful for reproducing
+[gem5 issue #3096](https://github.com/gem5/gem5/issues/3096): with a narrow
+writeback width, a burst of LSQ completions can push `IEW::instToCommit`
+past the `iewQueue` TimeBuffer `future` bound and abort with:
+
+```
+Assertion `idx >= -past && idx <= future' failed
+```
+
+## Build
+
+```sh
+cd tests/test-progs/lsq-burst/src
+make CROSS_COMPILE=riscv64-linux-gnu-
+make install
+```
+
+This produces `bin/riscv/linux/lsq-burst`.
+
+## Reproduce issue #3096 with the stock SE config
+
+Narrow the O3 pipeline so the per-cycle writeback capacity
+`(forwardComSize + 1) * wbWidth` is small, then run this binary:
+
+```sh
+./build/RISCV/gem5.opt configs/deprecated/example/se.py \
+  --cpu-type=RiscvO3CPU \
+  --caches \
+  --cmd=tests/test-progs/lsq-burst/bin/riscv/linux/lsq-burst \
+  -P 'system.cpu[0].wbWidth = 1' \
+  -P 'system.cpu[0].fetchWidth = 1' \
+  -P 'system.cpu[0].decodeWidth = 1' \
+  -P 'system.cpu[0].renameWidth = 1' \
+  -P 'system.cpu[0].issueWidth = 1' \
+  -P 'system.cpu[0].commitWidth = 1' \
+  -P 'system.cpu[0].squashWidth = 1'
+```
+
+On an unfixed tree this typically aborts quickly inside `IEW::instToCommit`.

--- a/tests/test-progs/lsq-burst/src/Makefile
+++ b/tests/test-progs/lsq-burst/src/Makefile
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Mao Weiming
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Build a statically linked RISC-V Linux binary for SE-mode simulation.
+#
+#   make CROSS_COMPILE=riscv64-linux-gnu-
+#   make install   # copies into ../bin/riscv/linux/
+
+CROSS_COMPILE ?= riscv64-linux-gnu-
+CC = $(CROSS_COMPILE)gcc
+CFLAGS = -O2 -static -march=rv64gc -mabi=lp64d
+OUT = lsq-burst
+BINDIR = ../bin/riscv/linux
+
+.PHONY: all install clean
+
+all: $(OUT)
+
+$(OUT): lsq-burst.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+install: $(OUT)
+	mkdir -p $(BINDIR)
+	cp $(OUT) $(BINDIR)/$(OUT)
+
+clean:
+	rm -f $(OUT)

--- a/tests/test-progs/lsq-burst/src/lsq-burst.c
+++ b/tests/test-progs/lsq-burst/src/lsq-burst.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Mao Weiming
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Stress many outstanding L1D misses so LSQ completions can flood
+ * IEW::instToCommit in one tick. Used to reproduce gem5 issue #3096
+ * (iewQueue TimeBuffer overflow when wbCycle exceeds forwardComSize).
+ *
+ * Stride-64 loads target distinct cache lines to maximize MLP. The
+ * working set is intentionally larger than a typical 32KiB L1D.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum { LINE = 64, LINES = 1 << 16 }; /* 4 MiB working set */
+
+static uint64_t
+pass(volatile uint8_t *buf, size_t nlines)
+{
+    uint64_t sum = 0;
+
+    for (size_t i = 0; i < nlines; i++) {
+        sum += buf[i * LINE];
+    }
+
+    return sum;
+}
+
+int
+main(void)
+{
+    size_t bytes = (size_t)LINES * LINE;
+    volatile uint8_t *buf = aligned_alloc(LINE, bytes);
+
+    if (!buf) {
+        perror("aligned_alloc");
+        return 1;
+    }
+
+    /* First-touch pages so later load passes are not dominated by faults. */
+    memset((void *)buf, 0x5a, bytes);
+
+    uint64_t s = 0;
+    for (int r = 0; r < 8; r++) {
+        /* Rotate the base so successive passes miss L1/L2 more often. */
+        size_t off = ((size_t)r * 17) % LINES;
+        s += pass(buf + off * LINE, LINES - off);
+        s += pass(buf, LINES / 2);
+    }
+
+    /* Dense independent loads to raise simultaneous LSQ wakeups. */
+    for (size_t i = 0; i < LINES; i++) {
+        s += buf[((i * 131) & (LINES - 1)) * LINE];
+        s += buf[((i * 17 + 3) & (LINES - 1)) * LINE];
+        s += buf[((i * 41 + 7) & (LINES - 1)) * LINE];
+        s += buf[((i * 73 + 11) & (LINES - 1)) * LINE];
+    }
+
+    printf("sum=%llu\n", (unsigned long long)s);
+    free((void *)buf);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `tests/test-progs/lsq-burst`, a small RISC-V SE stress program that issues many independent cache-line-strided loads.
- Document how to reproduce [issue #3096](https://github.com/gem5/gem5/issues/3096) using the stock `configs/deprecated/example/se.py` with a narrowed O3 writeback width.
- This PR only adds the test program (source + Makefile + README); it does not include a bug fix.

## Test plan
- [ ] Build the binary:
  ```sh
  cd tests/test-progs/lsq-burst/src
  make CROSS_COMPILE=riscv64-linux-gnu-
  make install
  ```
- [ ] On an unfixed tree, run with narrowed O3 widths and confirm the `iewQueue` TimeBuffer assertion in `IEW::instToCommit`:
  ```sh
  ./build/RISCV/gem5.opt configs/deprecated/example/se.py \
    --cpu-type=RiscvO3CPU --caches \
    --cmd=tests/test-progs/lsq-burst/bin/riscv/linux/lsq-burst \
    -P 'system.cpu[0].wbWidth = 1' \
    -P 'system.cpu[0].fetchWidth = 1' \
    -P 'system.cpu[0].decodeWidth = 1' \
    -P 'system.cpu[0].renameWidth = 1' \
    -P 'system.cpu[0].issueWidth = 1' \
    -P 'system.cpu[0].commitWidth = 1' \
    -P 'system.cpu[0].squashWidth = 1'
  ```