### PR TITLE
mem-ruby: Handle snoops in the TlmGenerator

### DIFF
--- a/src/mem/ruby/protocol/chi/tlm/SnoopHandler.py
+++ b/src/mem/ruby/protocol/chi/tlm/SnoopHandler.py
@@ -1,5 +1,5 @@
 # -*- mode:python -*-
-# Copyright (c) 2024-2026 Arm Limited
+# Copyright (c) 2026 Arm Limited
 # All rights reserved.
 #
 # The license below extends only to copyright in the software and shall
@@ -34,35 +34,61 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import("*")
 
-if not env['CONF']['RUBY_PROTOCOL_CHI']:
-    Return()
+from m5.params import *
+from m5.SimObject import (
+    PyBindMethod,
+    SimObject,
+)
 
-PySource("m5.tlm_chi", "python/__init__.py")
-PySource("m5.tlm_chi", "python/port.py")
-PySource("m5.tlm_chi", "python/utils.py")
-SimObject(
-    'SnoopHandler.py',
-    sim_objects=['SnoopHandler', 'PySnoopHandler'],
-    tags=['arm isa']
-)
-SimObject(
-    "TlmController.py",
-    sim_objects=["TlmController"],
-    tags=['arm isa']
-)
-SimObject(
-    'TlmGenerator.py',
-    sim_objects=['TlmGenerator'],
-    tags=['arm isa']
-)
-Source("utils.cc", tags=['arm isa'])
-Source("controller.cc", tags=['arm isa'])
-Source('snp_handler.cc', tags=['arm isa'])
-Source('py_snoop_handler.cc', tags=['arm isa'])
-Source('tlm_chi.cc', tags=['arm isa', 'python'])
-Source('tlm_chi_gen.cc', tags=['arm isa', 'python'])
-Source('generator.cc', tags=['arm isa'])
-DebugFlag("TLM", tags=['arm isa'])
-DebugFlag("TLMPort", tags=['arm isa'])
+
+class SnoopHandler(SimObject):
+    abstract = True
+    type = "SnoopHandler"
+    cxx_header = "mem/ruby/protocol/chi/tlm/snp_handler.hh"
+    cxx_class = "gem5::tlm::chi::SnoopHandler"
+
+
+class PySnoopHandler(SnoopHandler):
+    type = "PySnoopHandler"
+    cxx_header = "mem/ruby/protocol/chi/tlm/py_snoop_handler.hh"
+    cxx_class = "gem5::tlm::chi::PySnoopHandler"
+
+    cxx_exports = [PyBindMethod("addSnoop")]
+
+    discard_after_snoop = Param.Bool(
+        True,
+        "Discard a programmed transaction once callbacks have run for a "
+        "matching snoop",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._snoop_transactions = []
+        self._cc_initialized = False
+
+    def add_snoop(self, address):
+        from m5.tlm_chi.utils import (
+            Channel,
+            Resp,
+            RspOpcode,
+            SnoopResponse,
+            TlmPhase,
+        )
+
+        phase = TlmPhase()
+        phase.channel = Channel.RSP
+        phase.opcode = RspOpcode.SNP_RESP
+        phase.resp = Resp.RESP_I
+
+        transaction = SnoopResponse(phase)
+        self._snoop_transactions.append((address, transaction))
+        if self._cc_initialized:
+            self.getCCObject().addSnoop(address, transaction)
+        return transaction
+
+    def createCCObject(self):
+        super().createCCObject()
+        for address, transaction in self._snoop_transactions:
+            self.getCCObject().addSnoop(address, transaction)
+        self._cc_initialized = True

--- a/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
+++ b/src/mem/ruby/protocol/chi/tlm/TlmGenerator.py
@@ -37,6 +37,7 @@
 
 from m5.objects.CBusy import CBusyTracker
 from m5.objects.ClockedObject import ClockedObject
+from m5.objects.SnoopHandler import PySnoopHandler
 from m5.objects.TlmController import TlmController
 from m5.params import *
 from m5.SimObject import (
@@ -95,6 +96,9 @@ class TlmGenerator(ClockedObject):
     )
     cbusy_tracker = Param.BackpressureTracker(
         CBusyTracker(), "Tracks observed incoming CBusy levels"
+    )
+    snp_handler = Param.SnoopHandler(
+        PySnoopHandler(), "Handler for incoming snoop transactions"
     )
 
     in_port = TlmSinkPort("CHI TLM input/response port")

--- a/src/mem/ruby/protocol/chi/tlm/generator.cc
+++ b/src/mem/ruby/protocol/chi/tlm/generator.cc
@@ -39,6 +39,7 @@
 
 #include "debug/TLM.hh"
 #include "mem/ruby/protocol/chi/tlm/controller.hh"
+#include "mem/ruby/protocol/chi/tlm/snp_handler.hh"
 #include "sim/sim_exit.hh"
 
 namespace gem5 {
@@ -79,12 +80,16 @@ TlmGenerator::Transaction::Transaction(ARM::CHI::Payload *pa,
       _phase(ph),
       _start(0)
 {
-    _payload->ref();
+    if (_payload) {
+        _payload->ref();
+    }
 }
 
 TlmGenerator::Transaction::~Transaction()
 {
-    _payload->unref();
+    if (_payload) {
+        _payload->unref();
+    }
 }
 
 void
@@ -147,7 +152,7 @@ TlmGenerator::Transaction::runCallbacks()
 
         if (wait) {
             if (timeout) {
-                parent->scheduleEvaluation(timeout, this);
+                scheduleEvaluation(timeout);
             }
             break;
         }
@@ -158,6 +163,12 @@ TlmGenerator::Transaction::runCallbacks()
     if (it == actions.end()) {
         parent->terminate(this);
     }
+}
+
+void
+TlmGenerator::Transaction::scheduleEvaluation(unsigned timeout)
+{
+    parent->scheduleEvaluation(timeout, this);
 }
 
 void
@@ -179,6 +190,7 @@ TlmGenerator::TlmGenerator(const Params &p)
       inPort(name() + ".in_port", 0, this),
       suiteFailure(false),
       cbusyTracker(p.cbusy_tracker),
+      snpHandler(p.snp_handler),
       stats(this)
 {
     inPort.onChange([this](const TlmData &data) {
@@ -186,6 +198,10 @@ TlmGenerator::TlmGenerator(const Params &p)
         auto phase = data.second;
         this->recv(payload, phase);
     });
+
+    if (snpHandler) {
+        snpHandler->setGenerator(this);
+    }
 
     registerExitCallback([this](){ passFailCheck(); });
 }
@@ -253,7 +269,14 @@ TlmGenerator::send(Transaction *transaction)
     auto payload = transaction->payload();
     ARM::CHI::Phase &phase = transaction->phase();
 
-    DPRINTF(TLM, "[c%d] send %s\n", cpuId, transactionToString(*payload, phase));
+    send(payload, phase);
+}
+
+void
+TlmGenerator::send(ARM::CHI::Payload *payload, ARM::CHI::Phase &phase)
+{
+    DPRINTF(TLM, "[c%d] send %s\n", cpuId,
+            transactionToString(*payload, phase));
 
     auto tlm_data = TlmData(payload, &phase);
     outPort.send(tlm_data);
@@ -343,6 +366,10 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
 {
     DPRINTF(TLM, "[c%d] rcvd %s\n", cpuId, transactionToString(*payload, *phase));
 
+    if (handleSnoop(payload, phase)) {
+        return;
+    }
+
     handleCBusy(phase);
 
     if (handlePCredit(phase)) {
@@ -357,6 +384,16 @@ TlmGenerator::recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
         it->second->runCallbacks();
     } else {
         warn("%u: Transaction untested\n", phase->txn_id);
+    }
+}
+
+bool
+TlmGenerator::handleSnoop(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
+{
+    if (snpHandler && phase->channel == ARM::CHI::CHANNEL_SNP) {
+        return snpHandler->snoop(payload, phase);
+    } else {
+        return false;
     }
 }
 

--- a/src/mem/ruby/protocol/chi/tlm/generator.hh
+++ b/src/mem/ruby/protocol/chi/tlm/generator.hh
@@ -56,6 +56,7 @@ namespace gem5 {
 namespace tlm::chi {
 
 class CacheController;
+class SnoopHandler;
 
 /**
  * TlmGenerator: this class is basically a CHI-tlm traffic generator.
@@ -222,7 +223,7 @@ class TlmGenerator : public ClockedObject
 
         Transaction(const Transaction &rhs) = delete;
         Transaction(ARM::CHI::Payload *pa, ARM::CHI::Phase &ph);
-        ~Transaction();
+        virtual ~Transaction();
 
         /**
          * Registers the TlmGenerator in the transaction. This is
@@ -268,11 +269,18 @@ class TlmGenerator : public ClockedObject
          * in insertion order until a waiting callback is
          * encountered (or if there is a failing assertion)
          */
-        void runCallbacks();
+        virtual void runCallbacks();
 
         EventFunctionWrapper runCallbacksEvent;
 
         ARM::CHI::Payload* payload() const { return _payload; }
+        void
+        setPayload(ARM::CHI::Payload *payload)
+        {
+            assert(!_payload);
+            _payload = payload;
+            _payload->ref();
+        }
         ARM::CHI::Phase& phase() { return _phase; }
         Tick
         start() const
@@ -285,10 +293,14 @@ class TlmGenerator : public ClockedObject
             _start = when;
         }
 
-      private:
+      protected:
+        void scheduleEvaluation(unsigned timeout);
+
+      protected:
         Actions actions;
         bool passed;
 
+      private:
         TlmGenerator *parent;
         ARM::CHI::Payload *_payload;
         ARM::CHI::Phase _phase;
@@ -345,8 +357,12 @@ class TlmGenerator : public ClockedObject
     void terminate(Transaction *transaction);
     void scheduleEvaluation(unsigned cycles, Transaction *transaction);
 
+    void send(ARM::CHI::Payload *payload, ARM::CHI::Phase &phase);
     void recv(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
     void passFailCheck();
+
+    /** Handle an incoming snoop transaction */
+    bool handleSnoop(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
 
     /**
      * Check if incoming request is a RetryAck
@@ -451,6 +467,9 @@ class TlmGenerator : public ClockedObject
 
     /** Tracks responder-reported CBusy values observed by the generator */
     ruby::BackpressureTracker *cbusyTracker;
+
+    /** Handles incoming snoop transactions */
+    SnoopHandler *snpHandler;
 
     struct Stats : public statistics::Group
     {

--- a/src/mem/ruby/protocol/chi/tlm/py_snoop_handler.cc
+++ b/src/mem/ruby/protocol/chi/tlm/py_snoop_handler.cc
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/tlm/py_snoop_handler.hh"
+
+namespace gem5
+{
+
+namespace tlm::chi
+{
+
+PySnoopHandler::PySnoopHandler(const Params &p)
+    : SnoopHandler(p), discardAfterSnoop(p.discard_after_snoop)
+{}
+
+void
+PySnoopHandler::addSnoop(Addr address, SnoopResponse *transaction)
+{
+    panic_if(!transaction, "Cannot register a null snoop transaction\n");
+    transaction->setDiscardAfterSnoop(discardAfterSnoop);
+    snoopTransactions[address].push_back(transaction);
+}
+
+bool
+PySnoopHandler::handleSnoop(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
+{
+    auto it = snoopTransactions.find(payload->address);
+    if (it == snoopTransactions.end()) {
+        return false;
+    }
+
+    auto &transactions = it->second;
+    panic_if(transactions.empty(),
+             "Snoop transaction list unexpectedly empty\n");
+
+    auto transaction = transactions.front();
+    transaction->setGenerator(generator);
+
+    // Set the payload
+    transaction->setPayload(payload);
+
+    // Copy the new phase
+    transaction->phase() = *phase;
+
+    // Check existing expectations
+    transaction->runCallbacks();
+
+    if (discardAfterSnoop) {
+        transactions.pop_front();
+    }
+
+    if (transactions.empty()) {
+        snoopTransactions.erase(it);
+    }
+
+    return true;
+}
+
+} // namespace tlm::chi
+
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/py_snoop_handler.hh
+++ b/src/mem/ruby/protocol/chi/tlm/py_snoop_handler.hh
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_TLM_PY_SNOOP_HANDLER_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_TLM_PY_SNOOP_HANDLER_HH__
+
+#include <list>
+#include <unordered_map>
+
+#include "mem/ruby/protocol/chi/tlm/snp_handler.hh"
+#include "params/PySnoopHandler.hh"
+
+namespace gem5
+{
+
+namespace tlm::chi
+{
+
+/**
+ * The PySnoopHandler is following the same principle behind the TlmGenerator;
+ * similar to Transactions which are defined and injected from python, we
+ * define SnoopResponses whose handling logic resides purely in python.  There
+ * is no internal state inside the PySnoopHandler.  We use the following API
+ * to generate SnoopResponse objects and return a handle to the response.
+ *
+ * snoop = snoop_handler.add_snoop(address)
+ *
+ * This will inform the SnoopHandler it is expected to receive a
+ * SNP request at the provided address. A user should then attach
+ * Transaction::Actions to the SnoopResponse which will entirely
+ * dictate how the handler will react to such snoop.
+ */
+class PySnoopHandler : public SnoopHandler
+{
+  public:
+    PARAMS(PySnoopHandler);
+    PySnoopHandler(const Params &p);
+
+    void addSnoop(Addr address, SnoopResponse *transaction);
+
+  protected:
+    bool handleSnoop(ARM::CHI::Payload *payload,
+                     ARM::CHI::Phase *phase) override;
+
+    /**
+     * True if the SnoopResponse transaction has to be discarded
+     * when all its actions/callbacks have been called or whether
+     * it will remain allocated to the matching address.
+     **/
+    const bool discardAfterSnoop;
+
+    std::unordered_map<Addr, std::list<SnoopResponse *>> snoopTransactions;
+};
+
+} // namespace tlm::chi
+
+} // namespace gem5
+
+#endif // __MEM_RUBY_PROTOCOL_CHI_TLM_PY_SNOOP_HANDLER_HH__

--- a/src/mem/ruby/protocol/chi/tlm/snp_handler.cc
+++ b/src/mem/ruby/protocol/chi/tlm/snp_handler.cc
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mem/ruby/protocol/chi/tlm/snp_handler.hh"
+
+namespace gem5
+{
+
+namespace tlm::chi
+{
+
+SnoopResponse::SnoopResponse(ARM::CHI::Phase &ph) : Transaction(nullptr, ph)
+{}
+
+void
+SnoopResponse::setSnoopHandler(SnoopHandler *_handler)
+{
+    handler = _handler;
+}
+
+void
+SnoopResponse::setDiscardAfterSnoop(bool discard)
+{
+    discardAfterSnoop = discard;
+}
+
+void
+SnoopResponse::runCallbacks()
+{
+    auto it = actions.begin();
+    while (it != actions.end()) {
+        const bool is_passing = (*it)->run(this);
+        if (!is_passing) {
+            passed = false;
+        }
+        bool wait = (*it)->wait();
+
+        unsigned timeout = (*it)->waitCycles();
+
+        if (discardAfterSnoop) {
+            it = actions.erase(it);
+        } else {
+            ++it;
+        }
+
+        if (wait) {
+            if (timeout) {
+                scheduleEvaluation(timeout);
+            }
+            break;
+        }
+    }
+}
+
+SnoopHandler::SnoopHandler(const Params &p)
+    : SimObject(p), generator(nullptr), stats(this)
+{}
+
+void
+SnoopHandler::setGenerator(TlmGenerator *gen)
+{
+    generator = gen;
+}
+
+bool
+SnoopHandler::snoop(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase)
+{
+    stats.record(phase);
+    return handleSnoop(payload, phase);
+}
+
+SnoopHandler::SnoopStats::SnoopStats(statistics::Group *parent)
+    : statistics::Group(parent, "snoops"),
+      ADD_STAT(snoopLCrdReturn, statistics::units::Count::get(),
+               "Number of SnpLCrdReturn snoop requests"),
+      ADD_STAT(snoopShared, statistics::units::Count::get(),
+               "Number of SnpShared snoop requests"),
+      ADD_STAT(snoopClean, statistics::units::Count::get(),
+               "Number of SnpClean snoop requests"),
+      ADD_STAT(snoopOnce, statistics::units::Count::get(),
+               "Number of SnpOnce snoop requests"),
+      ADD_STAT(snoopNotSharedDirty, statistics::units::Count::get(),
+               "Number of SnpNotSharedDirty snoop requests"),
+      ADD_STAT(snoopUniqueStash, statistics::units::Count::get(),
+               "Number of SnpUniqueStash snoop requests"),
+      ADD_STAT(snoopMakeInvalidStash, statistics::units::Count::get(),
+               "Number of SnpMakeInvalidStash snoop requests"),
+      ADD_STAT(snoopUnique, statistics::units::Count::get(),
+               "Number of SnpUnique snoop requests"),
+      ADD_STAT(snoopCleanShared, statistics::units::Count::get(),
+               "Number of SnpCleanShared snoop requests"),
+      ADD_STAT(snoopCleanInvalid, statistics::units::Count::get(),
+               "Number of SnpCleanInvalid snoop requests"),
+      ADD_STAT(snoopMakeInvalid, statistics::units::Count::get(),
+               "Number of SnpMakeInvalid snoop requests"),
+      ADD_STAT(snoopStashUnique, statistics::units::Count::get(),
+               "Number of SnpStashUnique snoop requests"),
+      ADD_STAT(snoopStashShared, statistics::units::Count::get(),
+               "Number of SnpStashShared snoop requests"),
+      ADD_STAT(snoopDvmOp, statistics::units::Count::get(),
+               "Number of SnpDvmOp snoop requests"),
+      ADD_STAT(snoopQuery, statistics::units::Count::get(),
+               "Number of SnpQuery snoop requests"),
+      ADD_STAT(snoopSharedFwd, statistics::units::Count::get(),
+               "Number of SnpSharedFwd snoop requests"),
+      ADD_STAT(snoopCleanFwd, statistics::units::Count::get(),
+               "Number of SnpCleanFwd snoop requests"),
+      ADD_STAT(snoopOnceFwd, statistics::units::Count::get(),
+               "Number of SnpOnceFwd snoop requests"),
+      ADD_STAT(snoopNotSharedDirtyFwd, statistics::units::Count::get(),
+               "Number of SnpNotSharedDirtyFwd snoop requests"),
+      ADD_STAT(snoopPreferUnique, statistics::units::Count::get(),
+               "Number of SnpPreferUnique snoop requests"),
+      ADD_STAT(snoopPreferUniqueFwd, statistics::units::Count::get(),
+               "Number of SnpPreferUniqueFwd snoop requests"),
+      ADD_STAT(snoopUniqueFwd, statistics::units::Count::get(),
+               "Number of SnpUniqueFwd snoop requests")
+{}
+
+void
+SnoopHandler::SnoopStats::record(ARM::CHI::Phase *phase)
+{
+    switch (phase->snp_opcode) {
+        case ARM::CHI::SNP_OPCODE_SNP_LCRD_RETURN:
+            ++snoopLCrdReturn;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_SHARED:
+            ++snoopShared;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_CLEAN:
+            ++snoopClean;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_ONCE:
+            ++snoopOnce;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_NOT_SHARED_DIRTY:
+            ++snoopNotSharedDirty;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_UNIQUE_STASH:
+            ++snoopUniqueStash;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_MAKE_INVALID_STASH:
+            ++snoopMakeInvalidStash;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_UNIQUE:
+            ++snoopUnique;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_CLEAN_SHARED:
+            ++snoopCleanShared;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_CLEAN_INVALID:
+            ++snoopCleanInvalid;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_MAKE_INVALID:
+            ++snoopMakeInvalid;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_STASH_UNIQUE:
+            ++snoopStashUnique;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_STASH_SHARED:
+            ++snoopStashShared;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_DVM_OP:
+            ++snoopDvmOp;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_QUERY:
+            ++snoopQuery;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_SHARED_FWD:
+            ++snoopSharedFwd;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_CLEAN_FWD:
+            ++snoopCleanFwd;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_ONCE_FWD:
+            ++snoopOnceFwd;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_NOT_SHARED_DIRTY_FWD:
+            ++snoopNotSharedDirtyFwd;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_PREFER_UNIQUE:
+            ++snoopPreferUnique;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_PREFER_UNIQUE_FWD:
+            ++snoopPreferUniqueFwd;
+            break;
+        case ARM::CHI::SNP_OPCODE_SNP_UNIQUE_FWD:
+            ++snoopUniqueFwd;
+            break;
+        case ARM::CHI::SNP_OPCODE_MASK:
+            break;
+    }
+}
+
+} // namespace tlm::chi
+
+} // namespace gem5

--- a/src/mem/ruby/protocol/chi/tlm/snp_handler.hh
+++ b/src/mem/ruby/protocol/chi/tlm/snp_handler.hh
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __MEM_RUBY_PROTOCOL_CHI_TLM_SNP_HANDLER_HH__
+#define __MEM_RUBY_PROTOCOL_CHI_TLM_SNP_HANDLER_HH__
+
+#include <ARM/TLM/arm_chi_payload.h>
+#include <ARM/TLM/arm_chi_phase.h>
+
+#include "base/statistics.hh"
+#include "mem/ruby/protocol/chi/tlm/generator.hh"
+#include "params/SnoopHandler.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5
+{
+
+namespace tlm::chi
+{
+
+class SnoopHandler;
+class TlmGenerator;
+
+class SnoopResponse : public TlmGenerator::Transaction
+{
+  public:
+    SnoopResponse(ARM::CHI::Phase &ph);
+
+    void setSnoopHandler(SnoopHandler *handler);
+
+    void setDiscardAfterSnoop(bool discard);
+    void runCallbacks() override;
+
+  private:
+    bool discardAfterSnoop = true;
+    SnoopHandler *handler = nullptr;
+};
+
+/**
+ * A SnoopHandlder is in charge of responding to any
+ * snoop the TlmGenerator might receive.
+ *
+ * This is not mandatory for a TlmGenerator: there are cases
+ * where we don't expect a snoop and in such cases having
+ * a snoop handler in un-necessary. Snoops can be handled
+ * in many different ways.
+ * Someone could potentially write a very simple SnoopHandler
+ * which simply assumes there is no line present in the
+ * modelled RN. Some others could for example model a rudimentary
+ * cache which keeps track of filled lines and return data
+ * accordingly.
+ */
+class SnoopHandler : public SimObject
+{
+  public:
+    PARAMS(SnoopHandler);
+    SnoopHandler(const Params &p);
+
+    void setGenerator(TlmGenerator *gen);
+    bool snoop(ARM::CHI::Payload *payload, ARM::CHI::Phase *phase);
+
+  protected:
+    virtual bool handleSnoop(ARM::CHI::Payload *payload,
+                             ARM::CHI::Phase *phase) = 0;
+
+    TlmGenerator *generator = nullptr;
+
+    struct SnoopStats : public statistics::Group
+    {
+        SnoopStats(statistics::Group *parent);
+
+        void record(ARM::CHI::Phase *phase);
+
+        statistics::Scalar snoopLCrdReturn;
+        statistics::Scalar snoopShared;
+        statistics::Scalar snoopClean;
+        statistics::Scalar snoopOnce;
+        statistics::Scalar snoopNotSharedDirty;
+        statistics::Scalar snoopUniqueStash;
+        statistics::Scalar snoopMakeInvalidStash;
+        statistics::Scalar snoopUnique;
+        statistics::Scalar snoopCleanShared;
+        statistics::Scalar snoopCleanInvalid;
+        statistics::Scalar snoopMakeInvalid;
+        statistics::Scalar snoopStashUnique;
+        statistics::Scalar snoopStashShared;
+        statistics::Scalar snoopDvmOp;
+        statistics::Scalar snoopQuery;
+        statistics::Scalar snoopSharedFwd;
+        statistics::Scalar snoopCleanFwd;
+        statistics::Scalar snoopOnceFwd;
+        statistics::Scalar snoopNotSharedDirtyFwd;
+        statistics::Scalar snoopPreferUnique;
+        statistics::Scalar snoopPreferUniqueFwd;
+        statistics::Scalar snoopUniqueFwd;
+    };
+
+    SnoopStats stats;
+};
+
+} // namespace tlm::chi
+
+} // namespace gem5
+
+#endif // __MEM_RUBY_PROTOCOL_CHI_TLM_SNP_HANDLER_HH__

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi.cc
@@ -89,6 +89,9 @@ tlm_chi_pybind(pybind11::module_ &m_internal)
         .def_property(
             "ns", [](const Payload &p) { return p.ns; },
             [](Payload &p, bool val) { p.ns = val; })
+        .def_property(
+            "ret_to_src", [](const Payload &p) { return p.ret_to_src; },
+            [](Payload &p, bool val) { p.ret_to_src = val; })
         .def_readwrite("byte_enable", &Payload::byte_enable);
 
     py::class_<Phase>(tlm_chi, "TlmPhase")
@@ -97,6 +100,7 @@ tlm_chi_pybind(pybind11::module_ &m_internal)
         .def_readwrite("src_id", &Phase::src_id)
         .def_readwrite("tgt_id", &Phase::tgt_id)
         .def_readwrite("stash_nid", &Phase::stash_nid)
+        .def_readwrite("fwd_nid", &Phase::fwd_nid)
         .def_readwrite("opcode", &Phase::raw_opcode)
         .def_property(
             "channel", [](const Phase &p) { return p.channel; },

--- a/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
+++ b/src/mem/ruby/protocol/chi/tlm/tlm_chi_gen.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Arm Limited
+ * Copyright (c) 2024-2026 Arm Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -39,6 +39,7 @@
 #include <ARM/TLM/arm_chi_phase.h>
 
 #include "mem/ruby/protocol/chi/tlm/generator.hh"
+#include "mem/ruby/protocol/chi/tlm/snp_handler.hh"
 // This is required by Transaction::expect
 #include "pybind11/functional.h"
 #include "python/pybind11/pybind.hh"
@@ -106,6 +107,10 @@ tlm_chi_generator_pybind(pybind11::module_ &m_tlm_chi)
                                &tlm::chi::TlmGenerator::Transaction::payload)
         .def_property_readonly("start",
                                &tlm::chi::TlmGenerator::Transaction::start);
+
+    py::class_<tlm::chi::SnoopResponse, tlm::chi::TlmGenerator::Transaction>(
+        tlm_chi_gen, "SnoopResponse")
+        .def(py::init<Phase &>());
 }
 
 EmbeddedPyBind embed_("tlm_chi_gen", &tlm_chi_generator_pybind, "tlm_chi");

--- a/tests/gem5/chi_tlm_tests/configs/suites/snp_shared_unit.py
+++ b/tests/gem5/chi_tlm_tests/configs/suites/snp_shared_unit.py
@@ -1,0 +1,300 @@
+# -*- mode:python -*-
+# Copyright (c) 2026 Arm Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import m5
+from m5.objects.SnoopHandler import PySnoopHandler
+from m5.tlm_chi.utils import *
+
+ADDRESS = 0x80000000
+CACHELINE_SIZE = 64
+GENERATOR0_ID = 0
+GENERATOR1_ID = 1
+FIRST_TXN_ID = 0
+SECOND_TXN_ID = 1
+
+SNOOP_RESPONSES = []
+
+
+def payload_gen(address):
+    payload = TlmPayload()
+    payload.address = address
+    payload.ns = True
+    payload.size = Size.SIZE_64
+    return payload
+
+
+def phase_gen(src_id, txn_id):
+    phase = TlmPhase()
+    phase.opcode = ReqOpcode.READ_SHARED
+    phase.txn_id = txn_id
+    phase.src_id = src_id
+    phase.tgt_id = 0
+    phase.exp_comp_ack = True
+    return phase
+
+
+def channel_check_gen(exp):
+    def channel_check(transaction):
+        return expect_equal(transaction.phase.channel, exp)
+
+    return channel_check
+
+
+def opcode_check_gen(exp):
+    def opcode_check(transaction):
+        return expect_equal(transaction.phase.opcode, exp)
+
+    return opcode_check
+
+
+def cacheline_check_gen(exp):
+    def cacheline_check(transaction):
+        return expect_equal(transaction.phase.resp, exp)
+
+    return cacheline_check
+
+
+def data_id_check_gen(exp):
+    def data_id_check(transaction):
+        return expect_equal(transaction.phase.data_id, exp)
+
+    return data_id_check
+
+
+def wait_data(transaction):
+    return True
+
+
+def cycles(num_cycles):
+    def nothing(transaction):
+        return True
+
+    return nothing, num_cycles
+
+
+def do_comp_ack(transaction):
+    transaction.phase.channel = Channel.RSP
+    transaction.phase.opcode = RspOpcode.COMP_ACK
+    transaction.send()
+    return False
+
+
+def do_snp_resp_fwded_gen(resp, fwd_state):
+    def do_snp_resp_sc(transaction):
+        ret_to_src = transaction.payload.ret_to_src
+        assert ret_to_src == False, "ret_to_src should be False"
+
+        snoop_data = SNOOP_RESPONSES[0]
+        transaction.phase.channel = Channel.RSP
+        transaction.phase.opcode = RspOpcode.SNP_RESP_FWDED
+        transaction.phase.resp = resp
+        transaction.phase.fwd_state = fwd_state
+        transaction.phase.txn_id = snoop_data["txn_id"]
+        transaction.phase.tgt_id = snoop_data["src_id"]
+        transaction.send()
+
+    return do_snp_resp_sc
+
+
+def do_snp_comp_data_gen(data_id, resp):
+    def do_snp_comp_data(transaction):
+        snoop_data = SNOOP_RESPONSES[0]
+        transaction.phase.channel = Channel.DAT
+        transaction.phase.opcode = DatOpcode.COMP_DATA
+        transaction.phase.resp = resp
+        transaction.phase.txn_id = snoop_data["txn_id"]
+        transaction.phase.tgt_id = snoop_data["fwd_nid"]
+
+        if data_id == 0:
+            transaction.payload.byte_enable = 0x00000000FFFFFFFF
+        else:
+            transaction.payload.byte_enable = 0xFFFFFFFF00000000
+
+        transaction.phase.data_id = data_id
+        transaction.send()
+
+    return do_snp_comp_data
+
+
+def record_snoop(transaction):
+    SNOOP_RESPONSES.append(
+        {
+            "address": ADDRESS,
+            "txn_id": transaction.phase.txn_id,
+            "fwd_nid": transaction.phase.fwd_nid,
+            "src_id": transaction.phase.src_id,
+        }
+    )
+    return True
+
+
+def req_out_verifier(generator, expected):
+    def verifier(*args):
+        m5.stats.prepare()
+        stat = generator.resolveStat("reqOut")
+        actual = int(stat.total)
+        assert actual == expected, (
+            "TlmGenerator reqOut mismatch: "
+            f"expected={expected}, actual={actual}"
+        )
+
+    return verifier
+
+
+def snoop_seen_verifier(generator, expected):
+    def verifier(*args):
+        m5.stats.prepare()
+        stat = generator.snp_handler.resolveStat("snoops.snoopSharedFwd")
+        actual = int(stat.total)
+        assert actual == expected, (
+            "SnpShared callback count mismatch: "
+            f"expected={expected}, actual={actual}"
+        )
+
+    return verifier
+
+
+def init(board):
+    cores = board.get_processor().get_cores()
+    if len(cores) != 2:
+        raise Exception("This suite should be run with 2 TLM generators")
+
+    for generator in cores:
+        generator.snp_handler = PySnoopHandler(discard_after_snoop=True)
+
+
+def tear_down(board):
+    m5.stats.reset()
+
+
+def test_snp_resp_sc_fwded_sc(generators):
+    generator0 = generators[0]
+    generator1 = generators[1]
+
+    tran = generator0.inject(
+        payload_gen(ADDRESS), phase_gen(GENERATOR0_ID, FIRST_TXN_ID)
+    )
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_UC))
+    tran.ASSERT(data_id_check_gen(0))
+    tran.DO_WAIT(wait_data)
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_UC))
+    tran.ASSERT(data_id_check_gen(2))
+    tran.DO(do_comp_ack)
+
+    yield req_out_verifier(generator0, 1)
+
+    snoop = generator0.snp_handler.add_snoop(ADDRESS)
+    snoop.DO(record_snoop)
+    snoop.DO(do_snp_comp_data_gen(0, Resp.RESP_SC))
+    snoop.DO_WAIT_FOR(*cycles(1))
+    snoop.DO(do_snp_comp_data_gen(2, Resp.RESP_SC))
+    snoop.DO_WAIT_FOR(*cycles(1))
+    snoop.DO(do_snp_resp_fwded_gen(Resp.RESP_SC, Resp.RESP_SC))
+
+    tran = generator1.inject(
+        payload_gen(ADDRESS), phase_gen(GENERATOR1_ID, SECOND_TXN_ID)
+    )
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_SC))
+    tran.ASSERT(data_id_check_gen(0))
+    tran.DO_WAIT(wait_data)
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_SC))
+    tran.ASSERT(data_id_check_gen(2))
+    tran.DO(do_comp_ack)
+
+    yield snoop_seen_verifier(generator0, 1)
+
+    tear_down(None)
+
+
+def test_snp_resp_sc_fwded_sd(generators):
+    generator0 = generators[0]
+    generator1 = generators[1]
+
+    tran = generator0.inject(
+        payload_gen(ADDRESS + 64), phase_gen(GENERATOR0_ID, FIRST_TXN_ID)
+    )
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_UC))
+    tran.ASSERT(data_id_check_gen(0))
+    tran.DO_WAIT(wait_data)
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_UC))
+    tran.ASSERT(data_id_check_gen(2))
+    tran.DO(do_comp_ack)
+
+    yield req_out_verifier(generator0, 1)
+
+    snoop = generator0.snp_handler.add_snoop(ADDRESS + 64)
+    snoop.DO(record_snoop)
+    snoop.DO(do_snp_comp_data_gen(0, Resp.RESP_SD_PD))
+    snoop.DO_WAIT_FOR(*cycles(1))
+    snoop.DO(do_snp_comp_data_gen(2, Resp.RESP_SD_PD))
+    snoop.DO_WAIT_FOR(*cycles(1))
+    snoop.DO(do_snp_resp_fwded_gen(Resp.RESP_SC, Resp.RESP_SD_PD))
+
+    tran = generator1.inject(
+        payload_gen(ADDRESS + 64), phase_gen(GENERATOR1_ID, SECOND_TXN_ID)
+    )
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_SD_PD))
+    tran.ASSERT(data_id_check_gen(0))
+    tran.DO_WAIT(wait_data)
+    tran.ASSERT(channel_check_gen(Channel.DAT))
+    tran.ASSERT(opcode_check_gen(DatOpcode.COMP_DATA))
+    tran.ASSERT(cacheline_check_gen(Resp.RESP_SD_PD))
+    tran.ASSERT(data_id_check_gen(2))
+    tran.DO(do_comp_ack)
+
+    yield snoop_seen_verifier(generator0, 1)
+
+    tear_down(None)
+
+
+def test_all(generators):
+    yield from test_snp_resp_sc_fwded_sc(generators)
+
+    yield from test_snp_resp_sc_fwded_sd(generators)

--- a/tests/gem5/chi_tlm_tests/test_chi_tlm.py
+++ b/tests/gem5/chi_tlm_tests/test_chi_tlm.py
@@ -83,3 +83,25 @@ gem5_verify_config(
     valid_hosts=constants.supported_hosts,
     length=constants.quick_tag,
 )
+
+gem5_verify_config(
+    name="chi-tlm-snp-shared",
+    fixtures=(),
+    verifiers=(),
+    config=joinpath(absdirpath(__file__), "configs", "ruby_mem_test.py"),
+    config_args=[
+        joinpath(
+            absdirpath(__file__),
+            "configs",
+            "suites",
+            "snp_shared_unit.py",
+        ),
+        "--num-cpus",
+        "2",
+        "--abs-max-tick",
+        "1000000",
+    ],
+    valid_isas=(constants.all_compiled_tag,),
+    valid_hosts=constants.supported_hosts,
+    length=constants.quick_tag,
+)


### PR DESCRIPTION
    
This commit adds a basic SnoopHandlder interface to the
TlmGenerator which is in charge of responding to any
snoop the TlmGenerator might receive.
    
This is not mandatory for a TlmGenerator: there are cases
where we don't expect a snoop and in such cases having
a snoop handler in un-necessary. Snoops can be handled
in many different ways.
Someone could potentially write a very simple SnoopHandler
which simply assumes there is no line present in the
modelled RN. Some others could for example model a rudimentary
cache which keeps track of filled lines and return data
accordingly.
    
In this commit we propose a SnoopHandler implementation (PySnoopHandler)
following the same principle behind the TlmGenerator; similar to
Transactions which are defined and injected from python, we define
SnoopResponses whose handling logic resides purely in python.
There is no internal state inside the PySnoopHandler.
We use the following API to generate SnoopResponse objects and return a
handle to the response.
    
    snoop = snoop_handler.add_snoop(address)
    
This will inform the SnoopHandler it is expected to receive a
SNP request at the provided address. A user should then attach
Transaction::Actions to the SnoopResponse which will entirely
dictate how the handler will react to such snoop.