### PR TITLE
stdlib: Private caches to use Processor's clock domain

### DIFF
--- a/configs/example/arm/ruby_fs_mesh.py
+++ b/configs/example/arm/ruby_fs_mesh.py
@@ -112,14 +112,18 @@ class _LegacyCoreAdapter:
 
 
 class _LegacyProcessorAdapter:
-    def __init__(self, cpus: List):
-        self._cores = [_LegacyCoreAdapter(cpu) for cpu in cpus]
+    def __init__(self, cluster):
+        self._cluster = cluster
+        self._cores = [_LegacyCoreAdapter(cpu) for cpu in cluster]
 
     def get_cores(self):
         return self._cores
 
     def get_isa(self):
         return ISA.ARM
+
+    def get_clock_domain(self):
+        return self._cluster.clk_domain
 
 
 class _LegacyBoardAdapter:
@@ -189,18 +193,16 @@ def create(args):
         readfile=args.script,
     )
 
-    system.cpu_cluster = [
-        devices.ArmCpuCluster(
-            system,
-            args.num_cpus,
-            args.cpu_freq,
-            "1.0V",
-            cpu_class,
-            None,
-            None,
-            None,
-        )
-    ]
+    system.cpu_cluster = devices.ArmCpuCluster(
+        system,
+        args.num_cpus,
+        args.cpu_freq,
+        "1.0V",
+        cpu_class,
+        None,
+        None,
+        None,
+    )
 
     topology_config = load_topology_config(args.topology_config)
 
@@ -239,8 +241,7 @@ def create(args):
         )
     memory.set_memory_range(system.mem_ranges)
 
-    cpus = [cpu for cl in system.cpu_cluster for cpu in cl.cpus]
-    proc_adapter = _LegacyProcessorAdapter(cpus)
+    proc_adapter = _LegacyProcessorAdapter(system.cpu_cluster)
     board_adapter = _LegacyBoardAdapter(system, proc_adapter, memory)
 
     system.mesh_cache = cache_hierarchy()

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_cache_hierarchy.py
@@ -164,7 +164,7 @@ class PrivateL1CacheHierarchy(AbstractRubyCacheHierarchy):
             requires_send_evicts=core.requires_send_evicts(),
             cache_line_size=board.get_cache_line_size(),
             target_isa=board.get_processor().get_isa(),
-            clk_domain=board.get_clock_domain(),
+            clk_domain=board.get_processor().get_clock_domain(),
         )
         cluster.icache = L1CacheController(
             size=self._size,
@@ -173,7 +173,7 @@ class PrivateL1CacheHierarchy(AbstractRubyCacheHierarchy):
             requires_send_evicts=core.requires_send_evicts(),
             cache_line_size=board.get_cache_line_size(),
             target_isa=board.get_processor().get_isa(),
-            clk_domain=board.get_clock_domain(),
+            clk_domain=board.get_processor().get_clock_domain(),
         )
 
         cluster.icache.sequencer = RubySequencer(

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_cache_hierarchy.py
@@ -200,7 +200,7 @@ class PrivateL1PrivateL2CacheHierarchy(
             requires_send_evicts=core.requires_send_evicts(),
             cache_line_size=board.get_cache_line_size(),
             target_isa=board.get_processor().get_isa(),
-            clk_domain=board.get_clock_domain(),
+            clk_domain=board.get_processor().get_clock_domain(),
         )
         cluster.icache = L1CacheController(
             size=self._l1i_size,
@@ -209,7 +209,7 @@ class PrivateL1PrivateL2CacheHierarchy(
             requires_send_evicts=core.requires_send_evicts(),
             cache_line_size=board.get_cache_line_size(),
             target_isa=board.get_processor().get_isa(),
-            clk_domain=board.get_clock_domain(),
+            clk_domain=board.get_processor().get_clock_domain(),
         )
 
         cluster.icache.sequencer = RubySequencer(
@@ -230,7 +230,7 @@ class PrivateL1PrivateL2CacheHierarchy(
             assoc=self._l2_assoc,
             network=self.ruby_system.network,
             cache_line_size=board.get_cache_line_size(),
-            clk_domain=board.get_clock_domain(),
+            clk_domain=board.get_processor().get_clock_domain(),
         )
 
         if board.has_io_bus():

--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
@@ -393,7 +393,7 @@ class PrivateL1PrivateL2MeshCacheHierarchy(
                 requires_send_evicts=core.requires_send_evicts(),
                 cache_line_size=board.get_cache_line_size(),
                 target_isa=board.get_processor().get_isa(),
-                clk_domain=board.get_clock_domain(),
+                clk_domain=board.get_processor().get_clock_domain(),
             )
             dcache.sc_lock_enabled = True
             icache = L1CacheController(
@@ -403,7 +403,7 @@ class PrivateL1PrivateL2MeshCacheHierarchy(
                 requires_send_evicts=core.requires_send_evicts(),
                 cache_line_size=board.get_cache_line_size(),
                 target_isa=board.get_processor().get_isa(),
-                clk_domain=board.get_clock_domain(),
+                clk_domain=board.get_processor().get_clock_domain(),
             )
 
             icache.sequencer = RubySequencer(
@@ -424,7 +424,7 @@ class PrivateL1PrivateL2MeshCacheHierarchy(
                 assoc=self._l2_assoc,
                 network=self.ruby_system.network,
                 cache_line_size=board.get_cache_line_size(),
-                clk_domain=board.get_clock_domain(),
+                clk_domain=board.get_processor().get_clock_domain(),
             )
 
             rnf = CHI_RNF(self.ruby_system, [dcache, icache, l2])

--- a/src/python/gem5/components/cachehierarchies/ruby/caches/prebuilt/octopi_cache/core_complex.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/caches/prebuilt/octopi_cache/core_complex.py
@@ -137,7 +137,7 @@ class CoreComplex(SubSystem, RubyNetworkComponent):
             core=core,
             cache_line_size=self._cache_line_size,
             target_isa=self._board.processor.get_isa(),
-            clk_domain=self._board.get_clock_domain(),
+            clk_domain=self._board.get_processor().get_clock_domain(),
         )
         cluster.l1_cache.sequencer = RubySequencer(
             version=core_id,
@@ -172,7 +172,7 @@ class CoreComplex(SubSystem, RubyNetworkComponent):
             cache_line_size=self._cache_line_size,
             cluster_id=self._core_complex_id,
             target_isa=self._board.processor.get_isa(),
-            clk_domain=self._board.get_clock_domain(),
+            clk_domain=self._board.get_processor().get_clock_domain(),
         )
         cluster.l2_cache.ruby_system = self._ruby_system
         # L0Cache in the ruby backend is l1 cache in stdlib

--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_three_level_cache_hierarchy.py
@@ -118,7 +118,7 @@ class MESIThreeLevelCacheHierarchy(
                 core=core,
                 cache_line_size=cache_line_size,
                 target_isa=board.processor.get_isa(),
-                clk_domain=board.get_clock_domain(),
+                clk_domain=board.get_processor().get_clock_domain(),
             )
 
             l1_cache.sequencer = RubySequencer(
@@ -162,7 +162,7 @@ class MESIThreeLevelCacheHierarchy(
                 cache_line_size=cache_line_size,
                 cluster_id=0,
                 target_isa=board.processor.get_isa(),
-                clk_domain=board.get_clock_domain(),
+                clk_domain=board.get_processor().get_clock_domain(),
             )
 
             l2_cache.ruby_system = self.ruby_system

--- a/src/python/gem5/components/cachehierarchies/ruby/mesi_two_level_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mesi_two_level_cache_hierarchy.py
@@ -112,7 +112,7 @@ class MESITwoLevelCacheHierarchy(
                 self._num_l2_banks,
                 cache_line_size,
                 board.processor.get_isa(),
-                board.get_clock_domain(),
+                board.get_processor().get_clock_domain(),
             )
 
             cache.sequencer = RubySequencer(

--- a/src/python/gem5/components/cachehierarchies/ruby/mi_example_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/ruby/mi_example_cache_hierarchy.py
@@ -94,7 +94,7 @@ class MIExampleCacheHierarchy(AbstractRubyCacheHierarchy):
                 core=core,
                 cache_line_size=board.get_cache_line_size(),
                 target_isa=board.get_processor().get_isa(),
-                clk_domain=board.get_clock_domain(),
+                clk_domain=board.get_processor().get_clock_domain(),
             )
 
             cache.sequencer = RubySequencer(

--- a/src/python/gem5/prebuilt/viper/cpu_cache_hierarchy.py
+++ b/src/python/gem5/prebuilt/viper/cpu_cache_hierarchy.py
@@ -130,7 +130,7 @@ class ViperCPUCacheHierarchy(AbstractRubyCacheHierarchy):
 
             cache.version = i // 2
             cache.ruby_system = self.ruby_system
-            cache.clk_domain = board.get_clock_domain()
+            cache.clk_domain = board.get_processor().get_clock_domain()
 
             cache.sequencer = RubySequencer(
                 version=i,
@@ -138,7 +138,7 @@ class ViperCPUCacheHierarchy(AbstractRubyCacheHierarchy):
                 ruby_system=self.ruby_system,
                 coreid=0,
                 is_cpu_sequencer=True,
-                clk_domain=board.get_clock_domain(),
+                clk_domain=cache.clk_domain,
             )
 
             cache.sequencer1 = RubySequencer(
@@ -147,7 +147,7 @@ class ViperCPUCacheHierarchy(AbstractRubyCacheHierarchy):
                 ruby_system=self.ruby_system,
                 coreid=1,
                 is_cpu_sequencer=True,
-                clk_domain=board.get_clock_domain(),
+                clk_domain=cache.clk_domain,
             )
 
             cache.sequencer.connectIOPorts(board.get_io_bus())


### PR DESCRIPTION
Private caches should be reusing the parent Processor's clock domain, instead of the Board one. This is a required change after [1] even if at the moment the Processor clk_freq in most configs is still set to the Board clk_freq
    
[1]: https://github.com/gem5/gem5/pull/3365