### PR TITLE
cpu-probe: add hot PC profiling to PcCountTracker

### DIFF
--- a/src/cpu/probes/PcCountTracker.py
+++ b/src/cpu/probes/PcCountTracker.py
@@ -59,6 +59,21 @@ class PcCountTracker(ProbeListenerObject):
     cxx_header = "cpu/probes/pc_count_tracker.hh"
     cxx_class = "gem5::PcCountTracker"
 
+    cxx_exports = [
+        PyBindMethod("getHottestPcs"),
+    ]
+
     targets = VectorParam.PcCountPair("the target PC Count pairs")
     core = Param.BaseCPU("the connected cpu")
-    ptmanager = Param.PcCountTrackerManager("the PcCountTracker manager")
+    ptmanager = Param.PcCountTrackerManager(NULL, "the PcCountTracker manager")
+    enable_pc_profiling = Param.Bool(
+        False, "Enable recording of all committed PCs and counts"
+    )
+    granularity = Param.Unsigned(
+        0,
+        "Number of low bits to mask out when grouping PCs (0 = exact PC, 1 = 2B"
+        " alignment, 6 = 64B cache line alignment)",
+    )
+    filter_ranges = VectorParam.AddrRange(
+        [], "Only track PCs within these ranges (empty = track all)"
+    )

--- a/src/cpu/probes/pc_count_tracker.cc
+++ b/src/cpu/probes/pc_count_tracker.cc
@@ -28,6 +28,16 @@
 
 #include "cpu/probes/pc_count_tracker.hh"
 
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "base/logging.hh"
+#include "base/types.hh"
+#include "params/PcCountTracker.hh"
+#include "sim/probe/probe.hh"
+#include "sim/probe/probe_listener_object.hh"
 
 namespace gem5
 {
@@ -35,14 +45,27 @@ namespace gem5
 PcCountTracker::PcCountTracker(const PcCountTrackerParams &p)
     : ProbeListenerObject(p),
       cpuptr(p.core),
-      manager(p.ptmanager)
+      ptmanager(p.ptmanager),
+      enablePcProfiling(p.enable_pc_profiling),
+      filterRanges(p.filter_ranges)
 {
-    if (!cpuptr || !manager) {
-        fatal("%s is NULL", !cpuptr ? "CPU": "PcCountTrackerManager");
-    }
+    fatal_if(p.granularity >= sizeof(unsigned long long) * 8,
+             "granularity %d too large for %zu bits. Granularity is the bits "
+             "to mask,"
+             " not the size",
+             p.granularity, sizeof(unsigned long long) * 8);
+    pcMask = ~((1ULL << p.granularity) - 1);
+    fatal_if(!cpuptr, "CPU is NULL");
+    fatal_if(!ptmanager && !enablePcProfiling,
+             "PcCountTracker requires either a PcCountTrackerManager or "
+             "enable_pc_profiling=True");
     for (int i = 0; i < p.targets.size(); i++) {
         // initialize the set of targeting Program Counter addresses
         targetPC.insert(p.targets[i].getPC());
+    }
+    if (targetPC.size() == 1) {
+        singleTargetPC = *targetPC.begin();
+        hasSingleTarget = true;
     }
 }
 
@@ -60,11 +83,60 @@ PcCountTracker::regProbeListeners()
 
 void
 PcCountTracker::checkPc(const Addr& pc) {
-    if (targetPC.find(pc) != targetPC.end()) {
-        // if the PC is one of the target PCs, then notify the
-        // PcCounterTrackerManager by calling its `check_count` function
-        manager->checkCount(pc);
+    // Apply filter first
+    bool allow = filterRanges.empty();
+    for (const auto &range : filterRanges) {
+        if (range.contains(pc)) {
+            allow = true;
+            break;
+        }
     }
+    if (!allow) {
+        return;
+    }
+
+    Addr masked_pc = pc & pcMask;
+
+    if (enablePcProfiling) {
+        pcCounts[masked_pc]++;
+    }
+    if (ptmanager) {
+        if (hasSingleTarget) {
+            if (pc == singleTargetPC) {
+                ptmanager->checkCount(pc);
+            }
+        } else if (targetPC.find(pc) != targetPC.end()) {
+            ptmanager->checkCount(pc);
+        }
+    }
+}
+
+std::vector<std::pair<Addr, uint64_t>>
+PcCountTracker::getHottestPcs(unsigned n) const
+{
+    if (n == 0 || pcCounts.empty()) {
+        return {};
+    }
+
+    std::vector<std::pair<Addr, uint64_t>> sorted_pcs(pcCounts.begin(),
+                                                      pcCounts.end());
+    std::sort(sorted_pcs.begin(), sorted_pcs.end(),
+              [](const std::pair<Addr, uint64_t> &a,
+                 const std::pair<Addr, uint64_t> &b) {
+                  return a.second > b.second;
+              });
+
+    if (sorted_pcs.size() > n) {
+        sorted_pcs.resize(n);
+    }
+    return sorted_pcs;
+}
+
+void
+PcCountTracker::resetStats()
+{
+    ProbeListenerObject::resetStats();
+    pcCounts.clear();
 }
 
 } // namespace gem5

--- a/src/cpu/probes/pc_count_tracker.hh
+++ b/src/cpu/probes/pc_count_tracker.hh
@@ -29,8 +29,14 @@
 #ifndef __CPU_PROBES_PC_COUNT_TRACKER_HH__
 #define __CPU_PROBES_PC_COUNT_TRACKER_HH__
 
+#include <cstdint>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
+#include "base/addr_range.hh"
+#include "base/types.hh"
 #include "cpu/probes/pc_count_tracker_manager.hh"
 #include "params/PcCountTracker.hh"
 #include "sim/probe/probe_listener_object.hh"
@@ -54,18 +60,28 @@ class PcCountTracker : public ProbeListenerObject
      */
     void checkPc(const Addr& pc);
 
+    std::vector<std::pair<Addr, uint64_t>> getHottestPcs(unsigned n) const;
+    void resetStats() override;
+
   private:
     /**
      * a set of Program Counter addresses that should notify the
      * PcCounterTrackerManager for
      */
     std::unordered_set<Addr> targetPC;
+    Addr singleTargetPC = 0;
+    bool hasSingleTarget = false;
 
     /** the core this PcCountTracker is tracking at */
     BaseCPU *cpuptr;
 
     /** the PcCounterTrackerManager */
-    PcCountTrackerManager *manager;
+    PcCountTrackerManager *ptmanager;
+
+    bool enablePcProfiling;
+    Addr pcMask;
+    std::vector<AddrRange> filterRanges;
+    std::unordered_map<Addr, uint64_t> pcCounts;
 };
 }
 


### PR DESCRIPTION
This PR extends PcCountTracker (which provides support for exiting simulation when a target PC is executed a specified number of times) to report the hottest PCs during the simulation. This new feature allows users to find regions of code to focus performance debugging/analysis work on. The new mode for the tracker supports filtering by PC region and bucketing PCs together at a specific granularity in case the experimenter is worried about the space required to store hot PC information when profiling a large region of code.