### PR TITLE
arch-arm: Allow EL0 reads of ID registers in SE mode

### DIFF
--- a/src/arch/arm/regs/misc.cc
+++ b/src/arch/arm/regs/misc.cc
@@ -3559,6 +3559,9 @@ Fault
 faultIdst(const MiscRegLUTEntry &entry,
     ThreadContext *tc, const MiscRegOp64 &inst)
 {
+    if (!FullSystem) {
+        return NoFault;
+    }
     if (HaveExt(tc, ArmExtension::FEAT_IDST)) {
         const HCR hcr = tc->readMiscReg(MISCREG_HCR_EL2);
         if (EL2Enabled(tc) && hcr.tge) {


### PR DESCRIPTION
When executing ARM64 binaries (such as SPEC CPU 2017 benchmarks or glibc startup routines) in gem5 System-call Emulation (SE) mode, some programs execute `mrs Xt, <sysreg>` instructions (e.g., `mrs x1, midr_el1`) to query CPU ID and capability registers.

Unlike real hardware or OS-managed environments where the Linux kernel in EL1 fields the trap and emulates these ID register reads for user-space processes (EL0), gem5 SE mode runs without an OS kernel and must directly emulate this behavior.

We update `faultIdst` in `src/arch/arm/regs/misc.cc` to immediately return `NoFault` when running in non-full system (`!FullSystem`) mode. This allows EL0 instructions in SE mode to read architectural ID registers (such as `MIDR_EL1`) without generating an architectural trap or undefined instruction fault.  Note that this follows the same pattern as many other instructions which trap in the same way on real hardware.  