### PR TITLE
mem: Fix HeteroMemCtrl write queue drain condition

### DIFF
--- a/src/mem/hetero_mem_ctrl.cc
+++ b/src/mem/hetero_mem_ctrl.cc
@@ -426,7 +426,7 @@ HeteroMemCtrl::drain()
 
         // the only queue that is not drained automatically over time
         // is the write queue, thus kick things into action if needed
-        if (!totalWriteQueueSize && !nextReqEvent.scheduled()) {
+        if (totalWriteQueueSize && !nextReqEvent.scheduled()) {
             schedule(nextReqEvent, curTick());
         }
 


### PR DESCRIPTION
Fix the inverted write queue condition in `HeteroMemCtrl::drain()`.

When writes are pending and `nextReqEvent` is not scheduled, draining now restarts the request scheduler, matching `MemCtrl::drain()`. This prevents checkpoint draining from waiting for an unrelated DRAM refresh.

Fixes #3356

Testing:

* `pre-commit run --all-files`
* Built `build/NULL/gem5.opt` and `build/ALL/gem5.opt`
* C++ unit tests passed
* Reproduced #3356 with the provided reproducer; after the fix, the pending write is processed immediately and checkpoint drain advances simulated time by 0 ticks
* Quick system tests completed with one remaining GCN GPU test failure due to the local environment missing `libamdhip64.so.4`; the failure is due to the local test environment rather than the `HeteroMemCtrl` change