### PR TITLE
cpu-o3: Avoid unused instruction-result storage

### DIFF
--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -86,7 +86,9 @@ DynInst::DynInst(const Arrays &arrays, const StaticInstPtr &static_inst,
     status.reset();
 
     instFlags.reset();
-    instFlags[RecordResult] = true;
+    // Only the checker CPU consumes recorded destination values. Preserve
+    // recording for CPU-less DynInst objects used outside normal execution.
+    instFlags[RecordResult] = !cpu || cpu->checker;
     instFlags[Predicate] = true;
     instFlags[MemAccPredicate] = true;
 

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -44,6 +44,7 @@
 
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <queue>
 #include <string>
 
@@ -209,10 +210,10 @@ class DynInst : public ExecContext, public RefCounted
     std::bitset<NumStatus> status;
 
   protected:
-    /** The result of the instruction; assumes an instruction can have many
-     *  destination registers.
+    /** Results retained for the optional checker CPU. The queue is allocated
+     *  lazily because ordinary O3CPU execution never consumes these values.
      */
-    std::queue<InstResult> instResult;
+    std::unique_ptr<std::queue<InstResult>> instResult;
 
     /** PC state for this instruction. */
     std::unique_ptr<PCStateBase> pc;
@@ -702,31 +703,36 @@ class DynInst : public ExecContext, public RefCounted
     /** Returns the logical register index of the i'th source register. */
     const RegId& srcRegIdx(int i) const { return staticInst->srcRegIdx(i); }
 
-    /** Return the size of the instResult queue. */
-    uint8_t resultSize() { return instResult.size(); }
+    /** Return the size of the instResult queue. O(1) time and space. */
+    uint8_t resultSize() { return instResult ? instResult->size() : 0; }
 
-    /** Pops a result off the instResult queue.
+    /** Pops a result off the instResult queue. O(1) time and space.
      * If the result stack is empty, return the default value.
      * */
     InstResult
     popResult(InstResult dflt=InstResult())
     {
-        if (!instResult.empty()) {
-            InstResult t = instResult.front();
-            instResult.pop();
+        if (instResult && !instResult->empty()) {
+            InstResult t = instResult->front();
+            instResult->pop();
             return t;
         }
         return dflt;
     }
 
-    /** Pushes a result onto the instResult queue. */
+    /** Pushes a result onto the instResult queue. Amortised O(1) time and
+     *  O(n) space for n recorded results.
+     */
     /** @{ */
     template<typename T>
     void
     setResult(const RegClass &reg_class, T &&t)
     {
         if (instFlags[RecordResult]) {
-            instResult.emplace(reg_class, std::forward<T>(t));
+            if (!instResult) {
+                instResult = std::make_unique<std::queue<InstResult>>();
+            }
+            instResult->emplace(reg_class, std::forward<T>(t));
         }
     }
     /** @} */

--- a/util/o3_perf/README.md
+++ b/util/o3_perf/README.md
@@ -1,0 +1,99 @@
+# O3CPU host-performance benchmark
+
+This directory contains a deterministic benchmark for measuring the host
+throughput of gem5's X86 O3CPU model. It is intended for local performance
+engineering and does not impose a wall-clock threshold on correctness CI.
+
+The target contains six small workloads:
+
+- `arithmetic`: independent integer arithmetic with a small working set;
+- `branch`: deterministic irregular branches;
+- `stream`: sequential loads and stores;
+- `pointer`: dependent, shuffled loads;
+- `mixed`: arithmetic, branches, loads, and stores; and
+- `queue`: independent integer operations plus a configurable dependency
+  chain.
+
+The gem5 configuration supplies small, medium, and large O3CPU parameter
+sets. These are synthetic scaling points and do not claim to model any
+commercial processor.
+
+## Build
+
+Build the target with a fixed compiler and flags. For example:
+
+```sh
+mkdir -p build/o3-perf
+gcc -O2 -g -static -fno-pie -no-pie \
+    -fno-tree-vectorize -fno-unroll-loops \
+    -Wall -Wextra -Werror \
+    -o build/o3-perf/o3_microbench.x86 \
+    util/o3_perf/o3_microbench.c
+scons build/X86/gem5.opt -j "$(nproc)"
+```
+
+Record the compiler version, target hash, gem5 hash, and gem5 build flags
+with the results. The harness records both binary hashes automatically.
+
+## Run
+
+A plain single-binary run is useful for calibration:
+
+```sh
+python3 util/o3_perf/run_benchmarks.py \
+    --gem5 baseline=build/X86/gem5.opt \
+    --config-script util/o3_perf/o3_se.py \
+    --target build/o3-perf/o3_microbench.x86 \
+    --output-root build/o3-perf/baseline \
+    --baseline-commit "$(git rev-parse HEAD)" \
+    --build-type gem5.opt \
+    --build-flags "record exact SCons and compiler flags here"
+```
+
+For a comparison, give the harness both binaries:
+
+```sh
+python3 util/o3_perf/run_benchmarks.py \
+    --gem5 baseline=/path/to/gem5-baseline.opt \
+    --gem5 candidate=/path/to/gem5-candidate.opt \
+    --config-script util/o3_perf/o3_se.py \
+    --target build/o3-perf/o3_microbench.x86 \
+    --output-root build/o3-perf/comparison-session-1 \
+    --baseline-commit BASELINE_COMMIT \
+    --build-type gem5.opt \
+    --build-flags "identical flags used for both binaries" \
+    --session session-1 \
+    --runs 8
+```
+
+The two-binary order alternates between `A B B A` and `B A A B` blocks.
+Use a quiet host on AC power, pin the process to an otherwise idle core,
+and collect at least two sessions. Do not combine results from binaries
+built with different compilers, flags, libraries, or source baselines.
+
+`raw_runs.csv` contains per-run host timing, peak RSS, simulated
+statistics, exit information, and hashes. `summary.csv` contains the
+median, quartiles, range, coefficient of variation, and simulated
+instructions per host second.
+
+The optional `--counter-mode perf` records host hardware counters through
+`perf stat`. Use it in a separate profiler-overhead run rather than for
+ordinary wall-clock results. Unsupported counters are recorded as such;
+they must not be inferred from timing or simulated statistics.
+
+## Correctness comparison
+
+Compare the complete `stats.txt` files from corresponding baseline and
+candidate runs:
+
+```sh
+python3 util/o3_perf/compare_stats.py \
+    /path/to/baseline/stats.txt \
+    /path/to/candidate/stats.txt \
+    --output statistics_comparison.json
+```
+
+The comparison requires exact equality for simulated statistics and
+reports any missing statistic. Statistics whose names start with `host`
+are reported separately because host timing and rate values are expected
+to change between runs.

--- a/util/o3_perf/compare_stats.py
+++ b/util/o3_perf/compare_stats.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Magnushst
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def parse_stats(path):
+    statistics = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        fields = line.split()
+        if len(fields) < 2 or fields[0].startswith("-"):
+            continue
+        try:
+            value = float(fields[1])
+        except ValueError:
+            continue
+        statistics[fields[0]] = value
+    return statistics
+
+
+def values_equal(left, right):
+    if math.isnan(left) and math.isnan(right):
+        return True
+    return left == right
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("baseline")
+    parser.add_argument("candidate")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    baseline = parse_stats(args.baseline)
+    candidate = parse_stats(args.candidate)
+    result = {
+        "baseline": str(Path(args.baseline).resolve()),
+        "candidate": str(Path(args.candidate).resolve()),
+        "compared": 0,
+        "missing_from_baseline": [],
+        "missing_from_candidate": [],
+        "host_only_differences": [],
+        "simulated_semantic_differences": [],
+    }
+
+    baseline_names = set(baseline)
+    candidate_names = set(candidate)
+    result["missing_from_baseline"] = sorted(candidate_names - baseline_names)
+    result["missing_from_candidate"] = sorted(baseline_names - candidate_names)
+
+    for name in sorted(baseline_names & candidate_names):
+        result["compared"] += 1
+        if values_equal(baseline[name], candidate[name]):
+            continue
+        difference = {
+            "name": name,
+            "baseline": baseline[name],
+            "candidate": candidate[name],
+        }
+        if name.startswith("host"):
+            result["host_only_differences"].append(difference)
+        else:
+            result["simulated_semantic_differences"].append(difference)
+
+    result["match"] = not (
+        result["missing_from_baseline"]
+        or result["missing_from_candidate"]
+        or result["simulated_semantic_differences"]
+    )
+    Path(args.output).write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    raise SystemExit(0 if result["match"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/o3_perf/compare_stats.py
+++ b/util/o3_perf/compare_stats.py
@@ -28,7 +28,10 @@
 
 import argparse
 import json
-import math
+from decimal import (
+    Decimal,
+    InvalidOperation,
+)
 from pathlib import Path
 
 
@@ -39,16 +42,16 @@ def parse_stats(path):
         if len(fields) < 2 or fields[0].startswith("-"):
             continue
         try:
-            value = float(fields[1])
-        except ValueError:
+            value = Decimal(fields[1])
+        except InvalidOperation:
             continue
         statistics[fields[0]] = value
     return statistics
 
 
 def values_equal(left, right):
-    if math.isnan(left) and math.isnan(right):
-        return True
+    if left.is_nan() or right.is_nan():
+        return left.is_nan() and right.is_nan()
     return left == right
 
 
@@ -82,8 +85,8 @@ def main():
             continue
         difference = {
             "name": name,
-            "baseline": baseline[name],
-            "candidate": candidate[name],
+            "baseline": str(baseline[name]),
+            "candidate": str(candidate[name]),
         }
         if name.startswith("host"):
             result["host_only_differences"].append(difference)

--- a/util/o3_perf/o3_microbench.c
+++ b/util/o3_perf/o3_microbench.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026 Magnushst
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static volatile uint64_t sink;
+
+static uint64_t
+parse_u64(const char *text, const char *name)
+{
+    char *end = NULL;
+    errno = 0;
+    const unsigned long long value = strtoull(text, &end, 0);
+    if (errno || !end || *end != '\0') {
+        fprintf(stderr, "invalid %s: %s\n", name, text);
+        exit(2);
+    }
+    return (uint64_t)value;
+}
+
+static inline uint64_t
+xorshift64(uint64_t value)
+{
+    value ^= value << 13;
+    value ^= value >> 7;
+    value ^= value << 17;
+    return value;
+}
+
+static uint64_t
+arithmetic(uint64_t iterations)
+{
+    uint64_t a = 0x9e3779b97f4a7c15ULL;
+    uint64_t b = 0xbf58476d1ce4e5b9ULL;
+    uint64_t c = 0x94d049bb133111ebULL;
+    uint64_t d = 0xd6e8feb86659fd93ULL;
+    for (uint64_t i = 0; i < iterations; ++i) {
+        a = (a + b) ^ (c >> 11);
+        b = (b * 33) + (d ^ i);
+        c = (c + d) ^ (a << 7);
+        d = (d * 17) + (b >> 5);
+    }
+    return a ^ b ^ c ^ d;
+}
+
+static uint64_t
+branch_heavy(uint64_t iterations)
+{
+    uint64_t state = 0x243f6a8885a308d3ULL;
+    uint64_t result = 0;
+    for (uint64_t i = 0; i < iterations; ++i) {
+        state = xorshift64(state);
+        if (state & 1) {
+            result += state ^ i;
+        } else {
+            result -= (state >> 3) + i;
+        }
+        if ((state & 0x18) == 0x18) {
+            result ^= state << 9;
+        }
+    }
+    return result ^ state;
+}
+
+static uint64_t
+streaming(uint64_t iterations, size_t elements)
+{
+    uint64_t *a = malloc(elements * sizeof(*a));
+    uint64_t *b = malloc(elements * sizeof(*b));
+    if (!a || !b) {
+        fputs("allocation failed\n", stderr);
+        exit(2);
+    }
+    for (size_t i = 0; i < elements; ++i) {
+        a[i] = (uint64_t)i * 17 + 3;
+        b[i] = (uint64_t)i ^ 0x5a5a5a5a5a5a5a5aULL;
+    }
+    for (uint64_t pass = 0; pass < iterations; ++pass) {
+        for (size_t i = 0; i < elements; ++i) {
+            a[i] = a[i] + (b[i] ^ pass);
+            b[i] = (b[i] << 1) ^ (a[i] >> 3);
+        }
+    }
+    uint64_t result = 0;
+    for (size_t i = 0; i < elements; i += 257) {
+        result ^= a[i] + b[i];
+    }
+    free(b);
+    free(a);
+    return result;
+}
+
+static uint64_t
+pointer_chase(uint64_t iterations, size_t elements)
+{
+    uint32_t *order = malloc(elements * sizeof(*order));
+    uint32_t *next = malloc(elements * sizeof(*next));
+    if (!order || !next || elements > UINT32_MAX) {
+        fputs("allocation failed or working set too large\n", stderr);
+        exit(2);
+    }
+    for (size_t i = 0; i < elements; ++i) {
+        order[i] = (uint32_t)i;
+    }
+    uint64_t state = 0x13198a2e03707344ULL;
+    for (size_t i = elements - 1; i > 0; --i) {
+        state = xorshift64(state);
+        const size_t other = state % (i + 1);
+        const uint32_t tmp = order[i];
+        order[i] = order[other];
+        order[other] = tmp;
+    }
+    for (size_t i = 0; i < elements; ++i) {
+        next[order[i]] = order[(i + 1) % elements];
+    }
+    uint32_t current = order[0];
+    for (uint64_t i = 0; i < iterations; ++i) {
+        current = next[current];
+    }
+    const uint64_t result = current ^ state;
+    free(next);
+    free(order);
+    return result;
+}
+
+static uint64_t
+mixed(uint64_t iterations, size_t elements)
+{
+    uint64_t *data = malloc(elements * sizeof(*data));
+    if (!data) {
+        fputs("allocation failed\n", stderr);
+        exit(2);
+    }
+    for (size_t i = 0; i < elements; ++i) {
+        data[i] = (uint64_t)i * 0x9e3779b1U;
+    }
+    uint64_t state = 0xa4093822299f31d0ULL;
+    uint64_t result = 0;
+    for (uint64_t i = 0; i < iterations; ++i) {
+        state = xorshift64(state);
+        const size_t index = (state >> 16) % elements;
+        const uint64_t value = data[index];
+        if ((value ^ state) & 4) {
+            result += value * 13 + i;
+        } else {
+            result ^= (value >> 7) + state;
+        }
+        data[index] = value + result + (state & 0xff);
+    }
+    result ^= data[state % elements];
+    free(data);
+    return result;
+}
+
+static uint64_t
+queue_pressure(uint64_t iterations, unsigned dependency_steps)
+{
+    uint64_t a0 = 1, a1 = 3, a2 = 5, a3 = 7;
+    uint64_t a4 = 11, a5 = 13, a6 = 17, a7 = 19;
+    uint64_t dependency = 0x082efa98ec4e6c89ULL;
+    for (uint64_t i = 0; i < iterations; ++i) {
+        a0 = a0 * 3 + i;
+        a1 = a1 * 5 + i;
+        a2 = a2 * 7 + i;
+        a3 = a3 * 11 + i;
+        a4 = a4 * 13 + i;
+        a5 = a5 * 17 + i;
+        a6 = a6 * 19 + i;
+        a7 = a7 * 23 + i;
+        for (unsigned step = 0; step < dependency_steps; ++step) {
+            dependency = dependency * 33 + (dependency >> 11) + i;
+        }
+    }
+    return a0 ^ a1 ^ a2 ^ a3 ^ a4 ^ a5 ^ a6 ^ a7 ^ dependency;
+}
+
+static void
+usage(const char *program)
+{
+    fprintf(
+        stderr,
+        "usage: %s MODE ITERATIONS [SIZE_OR_DEPENDENCY]\n"
+        "modes: arithmetic branch stream pointer mixed queue\n",
+        program);
+    exit(2);
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc < 3) {
+        usage(argv[0]);
+    }
+    const char *mode = argv[1];
+    const uint64_t iterations = parse_u64(argv[2], "iterations");
+    const uint64_t parameter =
+        argc > 3 ? parse_u64(argv[3], "size/dependency") : 65536;
+    uint64_t result;
+
+    if (!strcmp(mode, "arithmetic")) {
+        result = arithmetic(iterations);
+    } else if (!strcmp(mode, "branch")) {
+        result = branch_heavy(iterations);
+    } else if (!strcmp(mode, "stream")) {
+        result = streaming(iterations, (size_t)parameter);
+    } else if (!strcmp(mode, "pointer")) {
+        result = pointer_chase(iterations, (size_t)parameter);
+    } else if (!strcmp(mode, "mixed")) {
+        result = mixed(iterations, (size_t)parameter);
+    } else if (!strcmp(mode, "queue")) {
+        result = queue_pressure(iterations, (unsigned)parameter);
+    } else {
+        usage(argv[0]);
+    }
+
+    sink = result;
+    printf("%s:%" PRIu64 "\n", mode, result);
+    return sink == UINT64_MAX;
+}

--- a/util/o3_perf/o3_microbench.c
+++ b/util/o3_perf/o3_microbench.c
@@ -26,6 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
@@ -41,7 +42,8 @@ parse_u64(const char *text, const char *name)
     char *end = NULL;
     errno = 0;
     const unsigned long long value = strtoull(text, &end, 0);
-    if (errno || !end || *end != '\0') {
+    /* strtoull skips leading whitespace and accepts a sign. */
+    if (!isdigit((unsigned char)text[0]) || errno || *end != '\0') {
         fprintf(stderr, "invalid %s: %s\n", name, text);
         exit(2);
     }
@@ -123,10 +125,14 @@ streaming(uint64_t iterations, size_t elements)
 static uint64_t
 pointer_chase(uint64_t iterations, size_t elements)
 {
+    if (elements == 0 || elements > UINT32_MAX) {
+        fputs("invalid working set size\n", stderr);
+        exit(2);
+    }
     uint32_t *order = malloc(elements * sizeof(*order));
     uint32_t *next = malloc(elements * sizeof(*next));
-    if (!order || !next || elements > UINT32_MAX) {
-        fputs("allocation failed or working set too large\n", stderr);
+    if (!order || !next) {
+        fputs("allocation failed\n", stderr);
         exit(2);
     }
     for (size_t i = 0; i < elements; ++i) {
@@ -156,6 +162,10 @@ pointer_chase(uint64_t iterations, size_t elements)
 static uint64_t
 mixed(uint64_t iterations, size_t elements)
 {
+    if (elements == 0) {
+        fputs("invalid working set size\n", stderr);
+        exit(2);
+    }
     uint64_t *data = malloc(elements * sizeof(*data));
     if (!data) {
         fputs("allocation failed\n", stderr);

--- a/util/o3_perf/o3_se.py
+++ b/util/o3_perf/o3_se.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Magnushst
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+
+import m5
+from m5.objects import (
+    X86O3CPU,
+    AddrRange,
+    Cache,
+    DDR3_1600_8x8,
+    L2XBar,
+    MemCtrl,
+    Process,
+    Root,
+    SEWorkload,
+    SrcClockDomain,
+    System,
+    SystemXBar,
+    VoltageDomain,
+)
+
+
+class L1Cache(Cache):
+    assoc = 2
+    data_latency = 2
+    mshrs = 4
+    response_latency = 2
+    size = "32KiB"
+    tag_latency = 2
+    tgts_per_mshr = 20
+
+
+class L2Cache(Cache):
+    assoc = 8
+    data_latency = 20
+    mshrs = 16
+    response_latency = 20
+    size = "256KiB"
+    tag_latency = 20
+    tgts_per_mshr = 12
+
+
+CPU_CONFIGS = {
+    "o3-small": {
+        "fetchWidth": 4,
+        "decodeWidth": 4,
+        "renameWidth": 4,
+        "dispatchWidth": 4,
+        "issueWidth": 4,
+        "wbWidth": 4,
+        "commitWidth": 4,
+        "numROBEntries": 64,
+        "iq_entries": 32,
+        "LQEntries": 16,
+        "SQEntries": 16,
+        "numPhysIntRegs": 128,
+    },
+    "o3-medium": {
+        "fetchWidth": 8,
+        "decodeWidth": 8,
+        "renameWidth": 8,
+        "dispatchWidth": 8,
+        "issueWidth": 8,
+        "wbWidth": 8,
+        "commitWidth": 8,
+        "numROBEntries": 192,
+        "iq_entries": 64,
+        "LQEntries": 32,
+        "SQEntries": 32,
+        "numPhysIntRegs": 256,
+    },
+    "o3-large": {
+        "fetchWidth": 12,
+        "decodeWidth": 12,
+        "renameWidth": 12,
+        "dispatchWidth": 12,
+        "issueWidth": 12,
+        "wbWidth": 12,
+        "commitWidth": 12,
+        "numROBEntries": 384,
+        "iq_entries": 128,
+        "LQEntries": 64,
+        "SQEntries": 64,
+        "numPhysIntRegs": 512,
+    },
+}
+
+
+def configure_cpu(cpu, name):
+    parameters = CPU_CONFIGS[name]
+    for parameter, value in parameters.items():
+        if parameter != "iq_entries":
+            setattr(cpu, parameter, value)
+    cpu.instQueues[0].numEntries = parameters["iq_entries"]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--workload", required=True)
+    parser.add_argument("--iterations", required=True, type=int)
+    parser.add_argument("--parameter", type=int)
+    parser.add_argument(
+        "--cpu-config",
+        choices=CPU_CONFIGS,
+        default="o3-medium",
+    )
+    parser.add_argument("--seed", default=1, type=int)
+    args = parser.parse_args()
+    m5.core.seedRandom(args.seed)
+
+    system = System()
+    system.clk_domain = SrcClockDomain(
+        clock="1GHz", voltage_domain=VoltageDomain()
+    )
+    system.cpu_voltage_domain = VoltageDomain()
+    system.cpu_clk_domain = SrcClockDomain(
+        clock="3GHz", voltage_domain=system.cpu_voltage_domain
+    )
+    system.mem_mode = "timing"
+    system.mem_ranges = [AddrRange("8GiB")]
+
+    system.cpu = X86O3CPU(
+        cpu_id=0,
+        clk_domain=system.cpu_clk_domain,
+    )
+    configure_cpu(system.cpu, args.cpu_config)
+
+    system.cpu.icache = L1Cache()
+    system.cpu.dcache = L1Cache()
+    system.l2bus = L2XBar()
+    system.l2cache = L2Cache()
+    system.membus = SystemXBar()
+
+    system.cpu.icache.cpu_side = system.cpu.icache_port
+    system.cpu.dcache.cpu_side = system.cpu.dcache_port
+    system.cpu.icache.mem_side = system.l2bus.cpu_side_ports
+    system.cpu.dcache.mem_side = system.l2bus.cpu_side_ports
+    system.l2cache.cpu_side = system.l2bus.mem_side_ports
+    system.l2cache.mem_side = system.membus.cpu_side_ports
+
+    system.cpu.createInterruptController()
+    system.cpu.interrupts[0].pio = system.membus.mem_side_ports
+    system.cpu.interrupts[0].int_requestor = system.membus.cpu_side_ports
+    system.cpu.interrupts[0].int_responder = system.membus.mem_side_ports
+
+    system.mem_ctrl = MemCtrl()
+    system.mem_ctrl.dram = DDR3_1600_8x8()
+    system.mem_ctrl.dram.range = system.mem_ranges[0]
+    system.mem_ctrl.port = system.membus.mem_side_ports
+    system.system_port = system.membus.cpu_side_ports
+
+    command = [args.binary, args.workload, str(args.iterations)]
+    if args.parameter is not None:
+        command.append(str(args.parameter))
+    process = Process(pid=100)
+    process.cmd = command
+    process.executable = args.binary
+    system.cpu.workload = process
+    system.cpu.createThreads()
+    system.workload = SEWorkload.init_compatible(args.binary)
+
+    root = Root(full_system=False, system=system)
+    m5.instantiate()
+    exit_event = m5.simulate()
+    print(f"Exiting @ tick {m5.curTick()} because " f"{exit_event.getCause()}")
+
+
+if __name__ == "__m5_main__":
+    main()

--- a/util/o3_perf/run_benchmarks.py
+++ b/util/o3_perf/run_benchmarks.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Magnushst
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import csv
+import hashlib
+import math
+import os
+import re
+import statistics
+import subprocess
+import time
+from collections import defaultdict
+from pathlib import Path
+
+WORKLOADS = {
+    "arithmetic": (150_000, None),
+    "branch": (80_000, None),
+    "stream": (1, 32_768),
+    "pointer": (30_000, 16_384),
+    "mixed": (25_000, 8_192),
+    "queue": (80_000, 4),
+}
+
+PERF_EVENTS = (
+    "instructions",
+    "cycles",
+    "branches",
+    "branch-misses",
+    "cache-references",
+    "cache-misses",
+)
+
+RAW_FIELDS = [
+    "sequence",
+    "session",
+    "label",
+    "baseline_commit",
+    "gem5_binary",
+    "gem5_sha256",
+    "build_type",
+    "build_flags",
+    "target_binary",
+    "target_sha256",
+    "workload",
+    "iterations",
+    "parameter",
+    "cpu_config",
+    "target_isa",
+    "seed",
+    "affinity",
+    "wall_seconds",
+    "user_seconds",
+    "system_seconds",
+    "peak_rss_kib",
+    "major_page_faults",
+    "minor_page_faults",
+    "voluntary_context_switches",
+    "involuntary_context_switches",
+    "host_instructions",
+    "host_cycles",
+    "host_ipc",
+    "host_branches",
+    "host_branch_misses",
+    "host_cache_references",
+    "host_cache_misses",
+    "simulated_instructions",
+    "simulated_cycles",
+    "simulated_ipc",
+    "simulation_ticks",
+    "simulated_insts_per_host_second",
+    "simulated_cycles_per_host_second",
+    "exit_code",
+    "exit_cause",
+    "target_output",
+    "counter_status",
+    "output_directory",
+]
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_key_values(path):
+    values = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+    return values
+
+
+def parse_stats(path):
+    values = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        fields = line.split()
+        if len(fields) < 2 or fields[0].startswith("-"):
+            continue
+        try:
+            values[fields[0]] = float(fields[1])
+        except ValueError:
+            continue
+    return values
+
+
+def parse_perf_stat(path):
+    values = {}
+    if not path.exists():
+        return values
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split(";")
+        if len(fields) < 3:
+            continue
+        value = fields[0].strip()
+        event = fields[2].strip()
+        if value.startswith("<"):
+            values[event] = math.nan
+            continue
+        try:
+            values[event] = float(value)
+        except ValueError:
+            continue
+    return values
+
+
+def metric(stats, *names):
+    for name in names:
+        if name in stats:
+            return stats[name]
+    return math.nan
+
+
+def label_sequence(labels, runs):
+    if len(labels) == 1:
+        return labels * runs
+    if len(labels) != 2:
+        raise ValueError("exactly one or two gem5 binaries are supported")
+    left, right = labels
+    sequence = []
+    counts = {left: 0, right: 0}
+    blocks = ([left, right, right, left], [right, left, left, right])
+    block_index = 0
+    while any(count < runs for count in counts.values()):
+        for label in blocks[block_index % 2]:
+            if counts[label] < runs:
+                sequence.append(label)
+                counts[label] += 1
+        block_index += 1
+    return sequence
+
+
+def run_case(args, binaries, label, workload, cpu_config, sequence):
+    iterations, parameter = WORKLOADS[workload]
+    output = (
+        args.output_root
+        / "runs"
+        / workload
+        / cpu_config
+        / f"{sequence:03d}-{label}"
+    )
+    output.mkdir(parents=True)
+    time_file = output / "time.txt"
+    stdout_file = output / "stdout.txt"
+    stderr_file = output / "stderr.txt"
+    perf_file = output / "perf-stat.txt"
+    gem5 = binaries[label]
+
+    time_command = [
+        "/usr/bin/time",
+        "--output",
+        str(time_file),
+        "--format",
+        (
+            "elapsed=%e\nuser=%U\nsystem=%S\npeak_rss_kib=%M\n"
+            "major_page_faults=%F\nminor_page_faults=%R\n"
+            "voluntary_context_switches=%w\n"
+            "involuntary_context_switches=%c"
+        ),
+    ]
+    gem5_command = [
+        "taskset",
+        "--cpu-list",
+        args.affinity,
+        str(gem5),
+        "--outdir",
+        str(output),
+        "--listener-mode=off",
+        str(args.config_script),
+        "--binary",
+        str(args.target),
+        "--workload",
+        workload,
+        "--iterations",
+        str(iterations),
+        "--cpu-config",
+        cpu_config,
+        "--seed",
+        str(args.seed),
+    ]
+    if parameter is not None:
+        gem5_command.extend(["--parameter", str(parameter)])
+    if args.counter_mode == "perf":
+        gem5_command = [
+            "perf",
+            "stat",
+            "--output",
+            str(perf_file),
+            "--field-separator",
+            ";",
+            "--event",
+            ",".join(PERF_EVENTS),
+            *gem5_command,
+        ]
+    command = [*time_command, *gem5_command]
+
+    started = time.perf_counter()
+    with stdout_file.open("w", encoding="utf-8") as stdout, stderr_file.open(
+        "w", encoding="utf-8"
+    ) as stderr:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=stdout,
+            stderr=stderr,
+            text=True,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+    harness_wall = time.perf_counter() - started
+
+    timing = parse_key_values(time_file)
+    host_counters = parse_perf_stat(perf_file)
+    stats_path = output / "stats.txt"
+    stats = parse_stats(stats_path) if stats_path.exists() else {}
+    stdout_text = stdout_file.read_text(encoding="utf-8")
+    exit_match = re.search(
+        r"Exiting @ tick \d+ because (.+)",
+        stdout_text,
+    )
+    output_match = re.search(
+        rf"^{re.escape(workload)}:(\d+)$",
+        stdout_text,
+        re.MULTILINE,
+    )
+    wall_seconds = float(timing.get("elapsed", harness_wall))
+    simulated_instructions = metric(stats, "simInsts")
+    simulated_cycles = metric(stats, "system.cpu.numCycles")
+    simulated_ipc = (
+        simulated_instructions / simulated_cycles
+        if simulated_cycles
+        else math.nan
+    )
+    host_instructions = host_counters.get("instructions", math.nan)
+    host_cycles = host_counters.get("cycles", math.nan)
+    host_ipc = (
+        host_instructions / host_cycles
+        if host_cycles and not math.isnan(host_cycles)
+        else math.nan
+    )
+    collected_counters = sum(
+        not math.isnan(host_counters.get(event, math.nan))
+        for event in PERF_EVENTS
+    )
+    if args.counter_mode == "none":
+        counter_status = "not collected"
+    elif collected_counters == len(PERF_EVENTS):
+        counter_status = "collected"
+    elif collected_counters:
+        counter_status = "partially supported"
+    else:
+        counter_status = "unsupported"
+
+    return {
+        "sequence": sequence,
+        "session": args.session,
+        "label": label,
+        "baseline_commit": args.baseline_commit,
+        "gem5_binary": str(gem5.resolve()),
+        "gem5_sha256": args.gem5_hashes[label],
+        "build_type": args.build_type,
+        "build_flags": args.build_flags,
+        "target_binary": str(args.target.resolve()),
+        "target_sha256": args.target_hash,
+        "workload": workload,
+        "iterations": iterations,
+        "parameter": "" if parameter is None else parameter,
+        "cpu_config": cpu_config,
+        "target_isa": "X86",
+        "seed": args.seed,
+        "affinity": args.affinity,
+        "wall_seconds": wall_seconds,
+        "user_seconds": float(timing.get("user", "nan")),
+        "system_seconds": float(timing.get("system", "nan")),
+        "peak_rss_kib": int(timing.get("peak_rss_kib", "0")),
+        "major_page_faults": int(timing.get("major_page_faults", "0")),
+        "minor_page_faults": int(timing.get("minor_page_faults", "0")),
+        "voluntary_context_switches": int(
+            timing.get("voluntary_context_switches", "0")
+        ),
+        "involuntary_context_switches": int(
+            timing.get("involuntary_context_switches", "0")
+        ),
+        "host_instructions": host_instructions,
+        "host_cycles": host_cycles,
+        "host_ipc": host_ipc,
+        "host_branches": host_counters.get("branches", math.nan),
+        "host_branch_misses": host_counters.get("branch-misses", math.nan),
+        "host_cache_references": host_counters.get(
+            "cache-references", math.nan
+        ),
+        "host_cache_misses": host_counters.get("cache-misses", math.nan),
+        "simulated_instructions": simulated_instructions,
+        "simulated_cycles": simulated_cycles,
+        "simulated_ipc": simulated_ipc,
+        "simulation_ticks": metric(stats, "simTicks"),
+        "simulated_insts_per_host_second": (
+            simulated_instructions / wall_seconds
+        ),
+        "simulated_cycles_per_host_second": (simulated_cycles / wall_seconds),
+        "exit_code": completed.returncode,
+        "exit_cause": exit_match.group(1) if exit_match else "",
+        "target_output": output_match.group(1) if output_match else "",
+        "counter_status": counter_status,
+        "output_directory": str(output.resolve()),
+    }
+
+
+def percentile(values, probability):
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * probability
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (
+        position - lower
+    )
+
+
+def summarise(rows, output):
+    groups = defaultdict(list)
+    for row in rows:
+        groups[(row["label"], row["workload"], row["cpu_config"])].append(
+            float(row["wall_seconds"])
+        )
+    with output.open("w", newline="", encoding="utf-8") as stream:
+        fields = [
+            "label",
+            "workload",
+            "cpu_config",
+            "runs",
+            "median_wall_seconds",
+            "p25_wall_seconds",
+            "p75_wall_seconds",
+            "minimum_wall_seconds",
+            "maximum_wall_seconds",
+            "coefficient_of_variation",
+            "median_simulated_insts_per_host_second",
+        ]
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+        for (label, workload, cpu_config), values in sorted(groups.items()):
+            mean = statistics.mean(values)
+            cv = (
+                statistics.stdev(values) / mean
+                if len(values) > 1 and mean
+                else 0.0
+            )
+            writer.writerow(
+                {
+                    "label": label,
+                    "workload": workload,
+                    "cpu_config": cpu_config,
+                    "runs": len(values),
+                    "median_wall_seconds": statistics.median(values),
+                    "p25_wall_seconds": percentile(values, 0.25),
+                    "p75_wall_seconds": percentile(values, 0.75),
+                    "minimum_wall_seconds": min(values),
+                    "maximum_wall_seconds": max(values),
+                    "coefficient_of_variation": cv,
+                    "median_simulated_insts_per_host_second": (
+                        statistics.median(
+                            float(row["simulated_insts_per_host_second"])
+                            for row in rows
+                            if row["label"] == label
+                            and row["workload"] == workload
+                            and row["cpu_config"] == cpu_config
+                        )
+                    ),
+                }
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--gem5",
+        action="append",
+        required=True,
+        metavar="LABEL=PATH",
+    )
+    parser.add_argument("--config-script", required=True, type=Path)
+    parser.add_argument("--target", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--baseline-commit", required=True)
+    parser.add_argument("--build-flags", required=True)
+    parser.add_argument("--build-type", required=True)
+    parser.add_argument("--session", default="session-1")
+    parser.add_argument("--affinity", default="2")
+    parser.add_argument("--seed", default=1, type=int)
+    parser.add_argument("--runs", default=8, type=int)
+    parser.add_argument(
+        "--counter-mode",
+        choices=("none", "perf"),
+        default="none",
+    )
+    parser.add_argument(
+        "--workloads",
+        nargs="+",
+        choices=WORKLOADS,
+        default=list(WORKLOADS),
+    )
+    parser.add_argument(
+        "--cpu-configs",
+        nargs="+",
+        choices=("o3-small", "o3-medium", "o3-large"),
+        default=("o3-small", "o3-medium", "o3-large"),
+    )
+    args = parser.parse_args()
+
+    binaries = {}
+    for specification in args.gem5:
+        label, separator, path = specification.partition("=")
+        if not label or not separator or not path:
+            parser.error(f"invalid --gem5 value: {specification}")
+        binaries[label] = Path(path)
+    labels = list(binaries)
+    args.gem5_hashes = {
+        label: sha256(binary) for label, binary in binaries.items()
+    }
+    args.target_hash = sha256(args.target)
+    args.output_root.mkdir(parents=True)
+
+    rows = []
+    raw_path = args.output_root / "raw_runs.csv"
+    sequence = 0
+    for workload in args.workloads:
+        for cpu_config in args.cpu_configs:
+            for label in label_sequence(labels, args.runs):
+                sequence += 1
+                row = run_case(
+                    args,
+                    binaries,
+                    label,
+                    workload,
+                    cpu_config,
+                    sequence,
+                )
+                rows.append(row)
+                with raw_path.open(
+                    "w",
+                    newline="",
+                    encoding="utf-8",
+                ) as stream:
+                    writer = csv.DictWriter(stream, fieldnames=RAW_FIELDS)
+                    writer.writeheader()
+                    writer.writerows(rows)
+                print(
+                    f"{sequence}: {label} {workload} {cpu_config} "
+                    f"{row['wall_seconds']:.3f}s exit={row['exit_code']}",
+                    flush=True,
+                )
+                if (
+                    row["exit_code"] != 0
+                    or not row["exit_cause"]
+                    or not row["target_output"]
+                ):
+                    raise SystemExit(
+                        "gem5 run failed or produced incomplete output"
+                    )
+    summarise(rows, args.output_root / "summary.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/o3_perf/run_benchmarks.py
+++ b/util/o3_perf/run_benchmarks.py
@@ -458,6 +458,8 @@ def main():
         default=("o3-small", "o3-medium", "o3-large"),
     )
     args = parser.parse_args()
+    if args.runs < 1:
+        parser.error("--runs must be at least 1")
 
     binaries = {}
     for specification in args.gem5:

--- a/util/o3_perf/run_benchmarks.py
+++ b/util/o3_perf/run_benchmarks.py
@@ -466,6 +466,8 @@ def main():
         label, separator, path = specification.partition("=")
         if not label or not separator or not path:
             parser.error(f"invalid --gem5 value: {specification}")
+        if label in binaries:
+            parser.error(f"duplicate --gem5 label: {label}")
         binaries[label] = Path(path)
     labels = list(binaries)
     args.gem5_hashes = {


### PR DESCRIPTION
## Summary

- Avoid recording destination results during normal O3CPU execution, where no checker CPU can consume them.
- Allocate the checker result FIFO only on first use, while retaining the existing CPU-less DynInst and checker-enabled behaviours.
- Reduce `sizeof(gem5::o3::DynInst)` from 512 to 440 bytes in the measured X86 build.
- Add `util/o3_perf`, a reproducible local X86 O3CPU host-throughput harness that records provenance, complete simulated statistics, and optional counters without adding timing thresholds to CI.

## Performance

The interleaved local host-throughput matrix covered six workloads and three O3CPU configurations. The initial three-run matrix had a +3.71% median speed-up. Repeating the two anomalous cells seven times gave a conservative cross-cell median of +3.13%, with no confirmed regression.

These are WSL2 wall-clock diagnostic measurements; hardware PMU counters were unavailable.

## Testing

- `scons build/X86/gem5.opt -j 12`
- `scons build/X86/gem5.debug -j 12`
- `scons build/X86/unittests.opt -j 12`
  - 1,051 tests passed; 11 existing tests were disabled or skipped.
- Normal and checker-enabled O3CPU smoke tests.
- 54 primary baseline/candidate pairs matched across 89,094 simulated statistic values.
- 14 confirmation pairs matched across 23,317 simulated statistic values.
- Checker-enabled baseline/candidate comparison matched all 1,697 simulated statistic values.
- `git diff --check` and the gem5 style checker.