### PR TITLE
stdlib: Properly configure the Network cntrl/data size

### DIFF
--- a/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
+++ b/src/python/gem5/components/cachehierarchies/chi/private_l1_private_l2_mesh_cache_hierarchy.py
@@ -179,6 +179,10 @@ class PrivateL1PrivateL2MeshCacheHierarchy(
         # virtual networks: 0=request, 1=snoop, 2=response, 3=data
         self.ruby_system.number_of_virtual_networks = 4
         self.ruby_system.network.number_of_virtual_networks = 4
+        self.ruby_system.network.control_msg_size = (
+            self._noc_params.cntrl_msg_size
+        )
+        self.ruby_system.network.data_msg_size = self._noc_params.data_width
 
         rnf_params = self._get_node_params(CHI_NodeType.CHI_RNF)
         hnf_params = self._get_node_params(CHI_NodeType.CHI_HNF)


### PR DESCRIPTION
Differently from what we do in the legacy configs/ruby/CHI.py library, we were setting cntrl/data message sizes to tune the network bandwidth for all channels, but we were not providing those sizes to the Network itself.

The result is that the data bandwidth was configured for 40B/cycle, but the data message was set to the default 64B value instead of the configurable value

Change-Id: I6a94941d16b881a5fa76103f11eddbefba2e807e