### PR TITLE
misc: Add clk_freq when initializing SimpleSwitchableProcessor

### DIFF
--- a/configs/deprecated/example/gem5_library/x86-parsec-benchmarks.py
+++ b/configs/deprecated/example/gem5_library/x86-parsec-benchmarks.py
@@ -151,6 +151,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we setup the board. The X86Board allows for Full-System X86 simulations

--- a/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/arm-ubuntu-run-with-kvm.py
@@ -85,6 +85,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.ARM,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # The ArmBoard requires a `release` to be specified. This adds all the

--- a/configs/example/gem5_library/multisim/multisim-fs-x86-npb.py
+++ b/configs/example/gem5_library/multisim/multisim-fs-x86-npb.py
@@ -100,6 +100,7 @@ for benchmark in ["bt", "cg", "ep", "ft", "is", "lu", "mg", "sp", "ua"]:
             switch_core_type=CPUTypes.TIMING,
             isa=ISA.X86,
             num_cores=num_cores,
+            clk_freq="3GHz",
         )
         board = X86Board(
             clk_freq="3GHz",

--- a/configs/example/gem5_library/x86-gapbs-benchmarks.py
+++ b/configs/example/gem5_library/x86-gapbs-benchmarks.py
@@ -117,6 +117,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we set up the board. The X86Board allows for FS mode (full system) and

--- a/configs/example/gem5_library/x86-npb-benchmarks.py
+++ b/configs/example/gem5_library/x86-npb-benchmarks.py
@@ -132,6 +132,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we set up the board. The X86Board allows for FS mode (full system) or

--- a/configs/example/gem5_library/x86-spec-cpu2006-benchmarks.py
+++ b/configs/example/gem5_library/x86-spec-cpu2006-benchmarks.py
@@ -219,6 +219,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we setup the board. The X86Board allows for Full-System X86 simulations

--- a/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
+++ b/configs/example/gem5_library/x86-spec-cpu2017-benchmarks.py
@@ -228,6 +228,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we setup the board. The X86Board allows for Full-System X86 simulations

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm-no-perf.py
@@ -94,6 +94,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we tell the KVM CPU (the starting CPU) not to use perf.

--- a/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
+++ b/configs/example/gem5_library/x86-ubuntu-run-with-kvm.py
@@ -92,6 +92,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.TIMING,
     isa=ISA.X86,
     num_cores=2,
+    clk_freq="3GHz",
 )
 
 # Here we set up the board. The X86Board allows for FS mode (full system) or

--- a/tests/gem5/kvm_fork_tests/configs/boot_kvm_fork_run.py
+++ b/tests/gem5/kvm_fork_tests/configs/boot_kvm_fork_run.py
@@ -166,6 +166,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=get_cpu_type_from_str(args.cpu),
     isa=ISA.X86,
     num_cores=args.num_cpus,
+    clk_freq="3GHz",
 )
 
 # Setup the motherboard.

--- a/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
+++ b/tests/gem5/kvm_switch_tests/configs/boot_kvm_switch_exit.py
@@ -153,6 +153,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=get_cpu_type_from_str(args.cpu),
     isa=ISA.X86,
     num_cores=args.num_cpus,
+    clk_freq="3GHz",
 )
 
 # Setup the motherboard.

--- a/tests/gem5/multisim/configs/x86-processor-switch.py
+++ b/tests/gem5/multisim/configs/x86-processor-switch.py
@@ -63,6 +63,7 @@ for start_type in core_types:
             switch_core_type=switch_type,
             isa=ISA.X86,
             num_cores=1,
+            clk_freq="3GHz",
         )
 
         board = X86Board(

--- a/tests/gem5/parsec_benchmarks/configs/parsec_disk_run.py
+++ b/tests/gem5/parsec_benchmarks/configs/parsec_disk_run.py
@@ -183,6 +183,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=roi_type,
     isa=ISA.X86,
     num_cores=args.num_cpus,
+    clk_freq="3GHz",
 )
 
 # Setup the board.

--- a/tests/gem5/processor_switch_tests/configs/checkpoint/cross-product-switch-afterboot-take-cpt-arm.py
+++ b/tests/gem5/processor_switch_tests/configs/checkpoint/cross-product-switch-afterboot-take-cpt-arm.py
@@ -97,6 +97,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.ATOMIC,
     isa=ISA.ARM,
     num_cores=args.num_cores,
+    clk_freq="3GHz",
 )
 
 # The ArmBoard requires a `release` to be specified. This adds all the

--- a/tests/gem5/processor_switch_tests/configs/checkpoint/cross-product-switch-afterboot-take-cpt-riscv.py
+++ b/tests/gem5/processor_switch_tests/configs/checkpoint/cross-product-switch-afterboot-take-cpt-riscv.py
@@ -87,6 +87,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.ATOMIC,
     isa=ISA.RISCV,
     num_cores=args.num_cores,
+    clk_freq="3GHz",
 )
 
 # Here we setup the board. The RiscvBoard allows for Full-System RISCV

--- a/tests/gem5/processor_switch_tests/configs/checkpoint/cross-product-switch-afterboot-take-cpt-x86.py
+++ b/tests/gem5/processor_switch_tests/configs/checkpoint/cross-product-switch-afterboot-take-cpt-x86.py
@@ -86,6 +86,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=CPUTypes.KVM,
     isa=ISA.X86,
     num_cores=args.num_cores,
+    clk_freq="3GHz",
 )
 
 board = X86Board(

--- a/tests/gem5/processor_switch_tests/configs/cross-product-switch-afterboot.py
+++ b/tests/gem5/processor_switch_tests/configs/cross-product-switch-afterboot.py
@@ -184,6 +184,7 @@ if args.isa == "x86":
         switch_core_type=get_cpu_type_from_str(args.switch_cores),
         isa=ISA.X86,
         num_cores=args.num_cores,
+        clk_freq="3GHz",
     )
 
     board = X86Board(
@@ -223,6 +224,7 @@ elif args.isa == "arm":
         switch_core_type=get_cpu_type_from_str(args.switch_cores),
         isa=ISA.ARM,
         num_cores=args.num_cores,
+        clk_freq="3GHz",
     )
 
     release = ArmDefaultRelease.for_kvm()
@@ -266,6 +268,7 @@ elif args.isa == "riscv":
         switch_core_type=get_cpu_type_from_str(args.switch_cores),
         isa=ISA.RISCV,
         num_cores=args.num_cores,
+        clk_freq="3GHz",
     )
 
     board = RiscvBoard(

--- a/tests/gem5/processor_switch_tests/configs/cross-product-switch-matmul.py
+++ b/tests/gem5/processor_switch_tests/configs/cross-product-switch-matmul.py
@@ -116,6 +116,7 @@ processor = SimpleSwitchableProcessor(
     switch_core_type=get_cpu_type_from_str(args.switch_cores),
     num_cores=1,
     isa=get_isa_from_str(args.isa),
+    clk_freq="3GHz",
 )
 
 board = SimpleBoard(


### PR DESCRIPTION
This commit makes it so that the `clk_freq` argument is passed when SimpleSwitchableProcessor is initialized in various config files. This fixes failures in the weekly and daily tests introduced by https://github.com/gem5/gem5/pull/3365.