### PR TITLE
arch-x86: fix IOPL extraction in the STI and CLI microcode

### DIFF
--- a/src/arch/x86/isa/insts/general_purpose/flags/set_and_clear.py
+++ b/src/arch/x86/isa/insts/general_purpose/flags/set_and_clear.py
@@ -71,7 +71,7 @@ def macroop STI {
 
     # Extract the IOPL.
     srli t2, t1, 12, dataSize=8
-    andi t2, t1, 0x3, dataSize=8
+    andi t2, t2, 0x3, dataSize=8
 
     # Find the CPL.
     rdm5reg t3, dataSize=8
@@ -129,7 +129,7 @@ def macroop CLI {
 
     # Extract the IOPL.
     srli t2, t1, 12, dataSize=8
-    andi t2, t1, 0x3, dataSize=8
+    andi t2, t2, 0x3, dataSize=8
 
     # Find the CPL.
     rdm5reg t3, dataSize=8


### PR DESCRIPTION
## Summary

Fixes #2912.

The `STI` and `CLI` macroops extract the current IOPL from RFLAGS to decide whether a `CPL > IOPL` access must raise `#GP`. The sequence shifts RFLAGS right by 12 to align the IOPL field (bits 13:12) into the low two bits, but then masks the *original* RFLAGS value instead of the shifted one:

```
srli t2, t1, 12, dataSize=8
andi t2, t1, 0x3, dataSize=8   # masks raw RFLAGS, not the shifted value
```

So the computed "IOPL" is actually `RFLAGS & 0x3` = reserved bit 1 (always set) OR the carry flag, i.e. 2 or 3, rather than the real IOPL. A CPL=3 program that sets CF (for example with `stc`) can therefore execute `STI`/`CLI` without taking the required `#GP` fault. This is exactly what breaks booting `configs/example/gem5_library/x86-ubuntu-run.py` as noted in the issue: a low-IOPL library that executes `cli` is wrongly permitted.

The fix masks the shifted value (`t2`) instead, matching the CPL extraction a few lines below which already does shift-then-mask correctly (`srli t3, t3, 4; andi t3, t3, 0x3`).

## Verification

Using the reporter's reproducer as a freestanding SE-mode binary (gem5 SE mode runs x86 user code at CPL=3):

```asm
_start:
    stc
    cli
    mov $60, %rax
    xor %rdi, %rdi
    syscall
```

- **Before (unpatched):** the program runs to completion and exits 0 — the `cli` is wrongly permitted.
- **After (patched):** gem5 reports `fault (General-Protection) detected @ PC (0x401001=>0x401002)` at the `cli` instruction — the architecturally correct `#GP`.

A control binary that performs only the `exit` syscall (no `cli`) exits cleanly on both builds, confirming the change only affects the privileged path.
