### PR TITLE
mem-dram: relax tCCD_L / tCCD_L_WR sanity check from <= to <

### DIFF
--- a/src/mem/dram_interface.cc
+++ b/src/mem/dram_interface.cc
@@ -717,16 +717,22 @@ DRAMInterface::DRAMInterface(const DRAMInterfaceParams &_p)
                   "groups per rank (%d) for equal banks per bank group\n",
                   banksPerRank, bankGroupsPerRank);
         }
-        // tCCD_L should be greater than minimal, back-to-back burst delay
-        if (tCCD_L <= tBURST) {
-            fatal("tCCD_L (%d) should be larger than the minimum bus delay "
+        // tCCD_L must not be shorter than the burst delay, otherwise
+        // back-to-back CAS in the same bank group would overlap on the
+        // data bus. The boundary case tCCD_L == tBURST is JEDEC-legal
+        // (tight-packed back-to-back CAS, zero overlap, zero gap) and
+        // occurs at speed bins where the nCK floor of tCCD_L lines up
+        // exactly with BL/2 * tCK — e.g. HBM3 6.4 Gbps
+        // (tCCD_L = 4 nCK = 2.5 ns = tBURST @ tCK = 0.625 ns).
+        if (tCCD_L < tBURST) {
+            fatal("tCCD_L (%d) must be at least the minimum bus delay "
                   "(%d) when bank groups per rank (%d) is greater than 1\n",
                   tCCD_L, tBURST, bankGroupsPerRank);
         }
-        // tCCD_L_WR should be greater than minimal, back-to-back burst delay
-        if (tCCD_L_WR <= tBURST) {
-            fatal("tCCD_L_WR (%d) should be larger than the minimum bus delay "
-                  " (%d) when bank groups per rank (%d) is greater than 1\n",
+        // Same argument for tCCD_L_WR.
+        if (tCCD_L_WR < tBURST) {
+            fatal("tCCD_L_WR (%d) must be at least the minimum bus delay "
+                  "(%d) when bank groups per rank (%d) is greater than 1\n",
                   tCCD_L_WR, tBURST, bankGroupsPerRank);
         }
         // tRRD_L is greater than minimal, same bank group ACT-to-ACT delay


### PR DESCRIPTION
The `tCCD_L` and `tCCD_L_WR` sanity checks in `DRAMInterface::DRAMInterface` were strict `<= tBURST`, but the boundary case `tCCD_L == tBURST` is JEDEC-legal — it corresponds to tight-packed back-to-back CAS within a bank group, with zero overlap and zero gap on the data bus. The physical hazard the check is trying to catch is `tCCD_L < tBURST` (bus overlap); strict `<` catches that without rejecting the boundary case.

## Why this matters now

The HBM3 6.4 Gbps preset added in #3271 sits exactly on this boundary:

- `tCK = 0.625 ns` (1.6 GHz CK, 6.4 Gbps DDR)
- `tCCD_L = max(4 nCK, 2.5 ns) = 2.5 ns` (JESD238B.01 Table 93 — nCK floor is active)
- `tBURST = BL/2 * tCK = 4 * 0.625 = 2.5 ns` (BL=8, JESD238B.01 Figure 32 / 40)

Both compute to 2.5 ns exactly, so the strict `<=` fatals at instantiation for a spec-correct configuration. Same story for `HBM_9600_8H_1x64` (the HBM3E 9.6 Gbps subclass), whose overrides land at `tCCD_L = tBURST = 1.67 ns`.

Reported by @Basemism in gem5/gem5#3271.

## Changes

- `src/mem/dram_interface.cc:721` — `tCCD_L <= tBURST` → `tCCD_L < tBURST`, with an inline comment explaining why the boundary case is legal and citing the HBM3 example.
- `src/mem/dram_interface.cc:727` — same for `tCCD_L_WR`.
- The unrelated `tRRD_L < tRRD` check just below is untouched — it already uses strict `<`, which is correct for that constraint.

## Reproducer / smoke test

Adds `configs/dram/hbm_bank_group_smoke.py`, which instantiates each preset at `bank_groups_per_rank = 4 > 1` and prints an "OK: ..." line.

```
build/NULL/gem5.opt configs/dram/hbm_bank_group_smoke.py --mem-type HBM_6400_8H_1x64
build/NULL/gem5.opt configs/dram/hbm_bank_group_smoke.py --mem-type HBM_9600_8H_1x64
```

Prior to this patch both invocations fatal during `m5.instantiate()`; after this patch both exit cleanly. Happy to also add a `tests/gem5/` entry wrapping this smoke config if that fits the review workflow — left it as a standalone reproducer for now to keep the diff minimal.