### PR TITLE
cpu-pin, arch-x86: implement PinCPU, a Pin-based functional CPU for x86 SE mode

### DIFF
--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -101,6 +101,11 @@ cpu-minor:
 cpu-o3:
     status: orphaned
 
+cpu-pin:
+    status: maintained
+    maintainers:
+        - Nicholas Mosier <nh.mosier@gmail.com>
+
 cpu-simple:
     status: orphaned
     experts:

--- a/configs/example/pincpu/bbhist.py
+++ b/configs/example/pincpu/bbhist.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2012-2013 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Copyright (c) 2006-2008 The Regents of The University of Michigan
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Run the SE workload using PinCPU, count the number of times each basic
+# block executes, and dump it to file at the end of the execution.
+
+import argparse
+import json
+import os
+import sys
+import types
+
+from m5.util import addToPath
+
+addToPath("../../")
+
+from common import (
+    CacheConfig,
+    CpuConfig,
+    MemConfig,
+    ObjectList,
+)
+from common.Caches import *
+from common.FileSystemConfig import config_filesystem
+
+from util import (
+    make_parser,
+    make_process,
+)
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.params import NULL
+from m5.util import (
+    fatal,
+    warn,
+)
+
+from gem5.isas import ISA
+
+parser = make_parser()
+parser.add_argument(
+    "--bbhist",
+    required=True,
+    type=os.path.abspath,
+    help="Path to bbhist output file",
+)
+args = parser.parse_args()
+process = make_process(args)
+
+CPUClass = ObjectList.cpu_list.get("X86PinCPU")
+assert int(CPUClass.numThreads) == 1
+assert not args.smt
+assert args.num_cpus == 1
+
+# PinCPU is single threaded, and the asserts above require a single CPU.
+np = 1
+mp0_path = process.executable
+system = System(
+    cpu=[CPUClass(cpu_id=i) for i in range(np)],
+    mem_mode=CPUClass.memory_mode(),
+    mem_ranges=[AddrRange(args.mem_size)],
+    cache_line_size=args.cacheline_size,
+)
+system.shared_backstore = f"physmem"
+system.auto_unlink_shared_backstore = True
+# PinCPU passes the backstore fd to the Pin subprocess; an anonymous
+# segment keeps it out of /dev/shm and releases it when both exit.
+system.anonymous_shared_backstore = True
+cpu = system.cpu[0]
+
+# Create a top-level voltage domain
+system.voltage_domain = VoltageDomain(voltage=args.sys_voltage)
+
+# Create a source clock for the system and set the clock period
+system.clk_domain = SrcClockDomain(
+    clock=args.sys_clock, voltage_domain=system.voltage_domain
+)
+
+# Create a CPU voltage domain
+system.cpu_voltage_domain = VoltageDomain()
+
+# Create a separate clock domain for the CPUs
+system.cpu_clk_domain = SrcClockDomain(
+    clock=args.cpu_clock, voltage_domain=system.cpu_voltage_domain
+)
+
+# If elastic tracing is enabled, then configure the cpu and attach the elastic
+# trace probe
+if args.elastic_trace_en:
+    CpuConfig.config_etrace(CPUClass, system.cpu, args)
+
+
+# Set pin params.
+cpu = system.cpu[0]
+cpu.pinToolArgs = "-bbhist 1"
+
+# for cpu in system.cpu:
+#     cpu.usePerf = True
+
+# All cpus belong to a common cpu_clk_domain, therefore running at a common
+# frequency.
+cpu.clk_domain = system.cpu_clk_domain
+
+system.m5ops_base = max(0xFFFF0000, Addr(args.mem_size).getValue())
+
+process.maxStackSize = args.max_stack_size
+
+cpu.workload = process
+cpu.createThreads()
+
+system.membus = SystemXBar()
+system.system_port = system.membus.cpu_side_ports
+CacheConfig.config_cache(args, system)
+MemConfig.config_mem(args, system)
+config_filesystem(system, args)
+
+system.workload = SEWorkload.init_compatible(mp0_path)
+
+root = Root(full_system=False, system=system)
+m5.instantiate()
+
+# Launch the pin subprocess,
+# so we can set syscall breakpoints.
+m5.simulate(0)
+exit_sysnos = [
+    60,  # exit
+    231,  # exit_group
+]
+for exit_sysno in exit_sysnos:
+    cpu.executePinCommand(f"sysbreak {exit_sysno}")
+exit_cause = m5.simulate().getCause()
+if exit_cause != "pin-breakpoint":
+    print(
+        f"bbhist: simulation stopped with unexpected reason "
+        f"'{exit_cause}' (expected 'pin-breakpoint')",
+        file=sys.stderr,
+    )
+    exit(1)
+bbhist = cpu.executePinCommand("bbhist dump")
+
+with open(args.bbhist, "w") as f:
+    f.write(bbhist)
+
+exit_cause = m5.simulate().getCause()
+if exit_cause != "exiting with last active thread context":
+    print(f"bbhist: unexpected exit reason:", exit_cause, file=sys.stderr)
+    exit(1)
+print("Exited:", exit_cause, file=sys.stderr)

--- a/configs/example/pincpu/bbv.py
+++ b/configs/example/pincpu/bbv.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2012-2013 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Copyright (c) 2006-2008 The Regents of The University of Michigan
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Run a SE workload under PinCPU, collecting a basic block vector (BBV)
+# profile.
+
+import argparse
+import collections
+import json
+import os
+import sys
+import types
+
+from m5.util import addToPath
+
+addToPath("../../")
+
+from common import (
+    CacheConfig,
+    CpuConfig,
+    MemConfig,
+    ObjectList,
+)
+from common.Caches import *
+from common.FileSystemConfig import config_filesystem
+
+from util import (
+    make_parser,
+    make_process,
+)
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.params import NULL
+from m5.util import (
+    fatal,
+    warn,
+)
+
+from gem5.isas import ISA
+
+parser = make_parser()
+parser.add_argument(
+    "--bbv",
+    required=True,
+    type=os.path.abspath,
+    help="Path to basic block trace file",
+)
+parser.add_argument(
+    "--bbvinfo",
+    type=os.path.abspath,
+    help="Path to basic block extra info file",
+)
+parser.add_argument(
+    "--warmup",
+    required=True,
+    type=int,
+    help="Warmup period, in number of instructions",
+)
+parser.add_argument(
+    "--interval",
+    required=True,
+    type=int,
+    help="Interval size, in number of instructions",
+)
+parser.add_argument(
+    "--tolerance",
+    type=int,
+    default=2,
+    help="Interval tolerance factor",
+)
+args = parser.parse_args()
+process = make_process(args)
+
+CPUClass = ObjectList.cpu_list.get("X86PinCPU")
+assert int(CPUClass.numThreads) == 1
+assert not args.smt
+assert args.num_cpus == 1
+
+# PinCPU is single threaded, and the asserts above require a single CPU.
+np = 1
+mp0_path = process.executable
+system = System(
+    cpu=[CPUClass(cpu_id=i) for i in range(np)],
+    mem_mode=CPUClass.memory_mode(),
+    mem_ranges=[AddrRange(args.mem_size)],
+    cache_line_size=args.cacheline_size,
+)
+system.shared_backstore = f"physmem"
+system.auto_unlink_shared_backstore = True
+# PinCPU passes the backstore fd to the Pin subprocess; an anonymous
+# segment keeps it out of /dev/shm and releases it when both exit.
+system.anonymous_shared_backstore = True
+cpu = system.cpu[0]
+
+# Create a top-level voltage domain
+system.voltage_domain = VoltageDomain(voltage=args.sys_voltage)
+
+# Create a source clock for the system and set the clock period
+system.clk_domain = SrcClockDomain(
+    clock=args.sys_clock, voltage_domain=system.voltage_domain
+)
+
+# Create a CPU voltage domain
+system.cpu_voltage_domain = VoltageDomain()
+
+# Create a separate clock domain for the CPUs
+system.cpu_clk_domain = SrcClockDomain(
+    clock=args.cpu_clock, voltage_domain=system.cpu_voltage_domain
+)
+
+# If elastic tracing is enabled, then configure the cpu and attach the elastic
+# trace probe
+if args.elastic_trace_en:
+    CpuConfig.config_etrace(CPUClass, system.cpu, args)
+
+
+# Set pin params.
+cpu = system.cpu[0]
+cpu.pinToolArgs = "-bbhist 1"
+cpu.countInsts = True
+
+# for cpu in system.cpu:
+#     cpu.usePerf = True
+
+# All cpus belong to a common cpu_clk_domain, therefore running at a common
+# frequency.
+cpu.clk_domain = system.cpu_clk_domain
+
+system.m5ops_base = max(0xFFFF0000, Addr(args.mem_size).getValue())
+
+process.maxStackSize = args.max_stack_size
+
+cpu.workload = process
+cpu.createThreads()
+
+system.membus = SystemXBar()
+system.system_port = system.membus.cpu_side_ports
+CacheConfig.config_cache(args, system)
+MemConfig.config_mem(args, system)
+config_filesystem(system, args)
+
+system.workload = SEWorkload.init_compatible(mp0_path)
+
+root = Root(full_system=False, system=system)
+m5.instantiate()
+
+# Launch the pin subprocess, so we can
+# set syscall breakpoints.
+m5.simulate(0)
+exit_sysnos = [
+    60,  # exit
+    231,  # exit_group
+]
+for exit_sysno in exit_sysnos:
+    cpu.executePinCommand(f"sysbreak {exit_sysno}")
+
+clean_exit_cause = "exiting with last active thread context"
+break_exit_cause = "pin-breakpoint"
+
+
+def run_until(cmd: str):
+    cpu.executePinCommand(cmd)
+    exit_cause = m5.simulate()
+    if exit_cause == clean_exit_cause:
+        return True
+    if exit_cause != break_exit_cause:
+        print(
+            f"bbv: expected exit cause '{break_exit_cause}', "
+            f"got '{exit_cause}'",
+            file=sys.stderr,
+        )
+        exit(1)
+    return False
+
+
+class Exit(BaseException):
+    pass
+
+
+def run_for_n(counter: str, n: int):
+    # TODO: Should standardize command to 'count <name>'
+    count = int(cpu.executePinCommand(f"{counter}count"))
+    cpu.executePinCommand(f"breakpoint {counter} {count + n}")
+    exit_cause = m5.simulate().getCause()
+    if exit_cause == clean_exit_cause:
+        raise Exit()
+    if exit_cause != break_exit_cause:
+        print(
+            f"bbv: expected exit cause '{break_exit_cause}', "
+            f"got '{exit_cause}'",
+            file=sys.stderr,
+        )
+        exit(1)
+
+
+def run_for_n_insts(n: int):
+    run_for_n("inst", n)
+    return int(cpu.executePinCommand("instcount"))
+
+
+def parse_bbhist(s: str) -> list:
+    lines = s.split("\n")
+    assert len(lines[-1]) == 0
+    lines = lines[:-1]
+    result = list()
+
+    total_insts = 0
+    for line in lines:
+        count, block = line.split()
+        count = int(count)
+        block = block.split(",")
+        result.append((block, count))
+        total_insts += count * len(block)
+    return result, total_insts
+
+
+block_to_id_dict = dict()
+
+
+def block_to_id(block: str) -> int:
+    block = str(block)
+    if block not in block_to_id_dict:
+        block_to_id_dict[block] = len(block_to_id_dict) + 1
+    return block_to_id_dict[block]
+
+
+def dump_bbhist(s: str, f, good: bool):
+    # Check if this interval is of a sane length.
+    f.write("T")
+    l, total_insts = parse_bbhist(s)
+    if total_insts <= args.interval * args.tolerance:
+        for block, count in l:
+            assert count > 0
+            id = block_to_id(block)
+            weight = count * len(block)
+            f.write(f" :{id}:{weight}")
+    else:
+        f.write(" :1:1")
+    f.write("\n")
+
+
+# Instruction counts at each interval boundary.
+warmups = [0]
+intervals = []
+bbhists = []
+
+f_bbv = open(args.bbv, "w")
+
+try:
+    # Prime the loop by running for <warmup> instructions
+    # and then discarding and resetting the bbhist.
+    intervals.append(run_for_n_insts(args.warmup))
+
+    cpu.executePinCommand("bbhist reset")
+
+    while True:
+        # Run for <interval> - <warmup> instructions.
+        warmups.append(run_for_n_insts(args.interval - args.warmup))
+
+        # Run to the end of the current interval (<warmup> instructions).
+        intervals.append(run_for_n_insts(args.warmup))
+
+        # Dump and reset the bbhist.
+        bbhist = cpu.executePinCommand("bbhist dump")
+        idx = len(bbhists)
+        warmup = warmups[idx]
+        interval_begin = intervals[idx]
+        interval_end = intervals[idx + 1]
+        good = (
+            interval_end - warmup
+            <= (args.warmup + args.interval) * args.tolerance
+        )
+        dump_bbhist(bbhist, f_bbv, good)
+        bbhists.append(None)
+        cpu.executePinCommand("bbhist reset")
+        print(f"bbv: dumped interval {len(bbhists)}!", file=sys.stderr)
+
+except Exit:
+    pass
+
+# The workload exited cleanly.
+# Now, process the data into proper files.
+#   - bbv.txt: The basic block vector file.
+#   - bbv.info.txt: Metadata about the vector file, organized into triples:
+#     warmup-begin warmup-end/interval-begin interval-end
+
+assert len(warmups) >= len(intervals) and len(warmups) >= len(bbhists)
+assert (
+    len(warmups) - len(intervals) <= 1 and len(intervals) - len(bbhists) <= 1
+)
+
+# Generate bbv.info.txt.
+if args.bbvinfo:
+    with open(args.bbvinfo, "w") as f:
+        for i in range(len(bbhists)):
+            warmup = warmups[i]
+            interval_begin = intervals[i]
+            interval_end = intervals[i + 1]
+            print(warmup, interval_begin, interval_end, file=f)

--- a/configs/example/pincpu/cpt.py
+++ b/configs/example/pincpu/cpt.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2012-2013 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Copyright (c) 2006-2008 The Regents of The University of Michigan
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Checkpoint a SE workload using PinCPU.
+
+import argparse
+import os
+import sys
+
+from m5.util import addToPath
+
+addToPath("../../")
+
+from common import (
+    CacheConfig,
+    CpuConfig,
+    MemConfig,
+    ObjectList,
+)
+from common.Caches import *
+from common.FileSystemConfig import config_filesystem
+
+from util import (
+    make_parser,
+    make_process,
+)
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.params import NULL
+from m5.util import (
+    fatal,
+    warn,
+)
+
+from gem5.isas import ISA
+
+parser = make_parser()
+
+
+def instruction_counts(s):
+    """Parse a comma separated list of positive instruction counts."""
+    try:
+        counts = [int(part) for part in s.split(",")]
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"expected a comma separated list of integers, got '{s}'"
+        )
+    if any(count <= 0 for count in counts):
+        raise argparse.ArgumentTypeError("instruction counts must be positive")
+    return counts
+
+
+parser.add_argument(
+    "--checkpoint-at",
+    metavar="INSTS",
+    type=instruction_counts,
+    required=True,
+    help="Comma separated instruction counts at which to take a checkpoint, "
+    "e.g. --checkpoint-at 1000000,5000000",
+)
+args = parser.parse_args()
+process = make_process(args)
+
+CPUClass = ObjectList.cpu_list.get("X86PinCPU")
+assert int(CPUClass.numThreads) == 1
+assert not args.smt
+assert args.num_cpus == 1
+
+np = 1
+mp0_path = process.executable
+system = System(
+    cpu=[CPUClass(cpu_id=i) for i in range(np)],
+    mem_mode=CPUClass.memory_mode(),
+    mem_ranges=[AddrRange(args.mem_size)],
+    cache_line_size=args.cacheline_size,
+)
+system.shared_backstore = f"physmem"
+system.auto_unlink_shared_backstore = True
+# PinCPU passes the backstore fd to the Pin subprocess; an anonymous
+# segment keeps it out of /dev/shm and releases it when both exit.
+system.anonymous_shared_backstore = True
+cpu = system.cpu[0]
+
+# Create a top-level voltage domain
+system.voltage_domain = VoltageDomain(voltage=args.sys_voltage)
+
+# Create a source clock for the system and set the clock period
+system.clk_domain = SrcClockDomain(
+    clock=args.sys_clock, voltage_domain=system.voltage_domain
+)
+
+# Create a CPU voltage domain
+system.cpu_voltage_domain = VoltageDomain()
+
+# Create a separate clock domain for the CPUs
+system.cpu_clk_domain = SrcClockDomain(
+    clock=args.cpu_clock, voltage_domain=system.cpu_voltage_domain
+)
+
+# If elastic tracing is enabled, then configure the cpu and attach the elastic
+# trace probe
+if args.elastic_trace_en:
+    CpuConfig.config_etrace(CPUClass, system.cpu, args)
+
+
+# Set pin params. countInsts enables the instcount plugin, which is what
+# registers the "inst" counter that `breakpoint inst` resolves through.
+cpu.countInsts = True
+
+# All cpus belong to a common cpu_clk_domain, therefore running at a common
+# frequency.
+cpu.clk_domain = system.cpu_clk_domain
+
+system.m5ops_base = max(0xFFFF0000, Addr(args.mem_size).getValue())
+
+process.maxStackSize = args.max_stack_size
+
+cpu.workload = process
+cpu.createThreads()
+
+system.membus = SystemXBar()
+system.system_port = system.membus.cpu_side_ports
+CacheConfig.config_cache(args, system)
+MemConfig.config_mem(args, system)
+config_filesystem(system, args)
+
+system.workload = SEWorkload.init_compatible(mp0_path)
+
+root = Root(full_system=False, system=system)
+
+m5.instantiate()
+
+# gem5 runs SimObject::startup() on the first call to m5.simulate(), and that
+# is where PinCPU launches the Pin subprocess. Nothing can be asked of Pin
+# before then, so get it running with a zero length simulation.
+m5.simulate(0)
+
+m5.options.outdir = os.path.abspath(m5.options.outdir)
+
+# The simulation only moves forward, so visit the requested points in order.
+# Duplicates would ask us to stop twice in the same place.
+checkpoint_insts = sorted(set(args.checkpoint_at))
+
+
+WORKLOAD_DONE = "exiting with last active thread context"
+
+
+def run_until(target):
+    """Run until the guest has retired `target` instructions.
+
+    Returns the instruction count actually reached, which may overshoot
+    slightly: Pin stops at the end of the basic block containing the
+    breakpoint, not at the exact instruction. Returns None if the workload
+    finished first.
+    """
+    cpu.executePinCommand(f"breakpoint inst {target}")
+    exit_cause = m5.simulate().getCause()
+    if exit_cause == WORKLOAD_DONE:
+        return None
+    if exit_cause != "pin-breakpoint":
+        print(f"cpt: unexpected exit cause: {exit_cause}", file=sys.stderr)
+        exit(1)
+    return int(cpu.executePinCommand("instcount"))
+
+
+for target in checkpoint_insts:
+    inst = run_until(target)
+    if inst is None:
+        # A shorter workload than the requested points; the remaining ones are
+        # unreachable too, since the list is sorted.
+        print(
+            f"cpt: workload finished before instruction {target}, "
+            f"skipping this and any later checkpoints",
+            file=sys.stderr,
+        )
+        break
+
+    path = os.path.join(m5.options.outdir, f"cpt.{inst}")
+    m5.checkpoint(path)
+    m5.stats.dump()
+    print(f"cpt: checkpoint at instruction {inst} -> {path}", file=sys.stderr)
+else:
+    # Every checkpoint was taken, so the workload still has work left.
+    exit_cause = m5.simulate().getCause()
+    if exit_cause != WORKLOAD_DONE:
+        print(f"cpt: unexpected exit cause: {exit_cause}", file=sys.stderr)
+        exit(1)

--- a/configs/example/pincpu/se.py
+++ b/configs/example/pincpu/se.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2012-2013 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Copyright (c) 2006-2008 The Regents of The University of Michigan
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Run a SE workload with PinCPU.
+
+import argparse
+import json
+import os
+import sys
+import types
+
+from m5.util import addToPath
+
+addToPath("../../")
+
+from common import (
+    CacheConfig,
+    CpuConfig,
+    MemConfig,
+    ObjectList,
+)
+from common.Caches import *
+from common.FileSystemConfig import config_filesystem
+
+from util import (
+    make_parser,
+    make_process,
+)
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.params import NULL
+from m5.util import (
+    fatal,
+    warn,
+)
+
+from gem5.isas import ISA
+
+parser = make_parser()
+parser.add_argument("--pin-args", default="")
+parser.add_argument("--pin-tool-args", default="")
+parser.add_argument("--instcount", action="store_true")
+args = parser.parse_args()
+process = make_process(args)
+
+CPUClass = ObjectList.cpu_list.get("X86PinCPU")
+assert int(CPUClass.numThreads) == 1
+assert not args.smt
+assert args.num_cpus == 1
+
+# PinCPU is single threaded, and the asserts above require a single CPU.
+np = 1
+mp0_path = process.executable
+system = System(
+    cpu=[CPUClass(cpu_id=i) for i in range(np)],
+    mem_mode=CPUClass.memory_mode(),
+    mem_ranges=[AddrRange(args.mem_size)],
+    cache_line_size=args.cacheline_size,
+)
+system.shared_backstore = f"physmem"
+system.auto_unlink_shared_backstore = True
+# PinCPU passes the backstore fd to the Pin subprocess; an anonymous
+# segment keeps it out of /dev/shm and releases it when both exit.
+system.anonymous_shared_backstore = True
+cpu = system.cpu[0]
+
+# Create a top-level voltage domain
+system.voltage_domain = VoltageDomain(voltage=args.sys_voltage)
+
+# Create a source clock for the system and set the clock period
+system.clk_domain = SrcClockDomain(
+    clock=args.sys_clock, voltage_domain=system.voltage_domain
+)
+
+# Create a CPU voltage domain
+system.cpu_voltage_domain = VoltageDomain()
+
+# Create a separate clock domain for the CPUs
+system.cpu_clk_domain = SrcClockDomain(
+    clock=args.cpu_clock, voltage_domain=system.cpu_voltage_domain
+)
+
+# If elastic tracing is enabled, then configure the cpu and attach the elastic
+# trace probe
+if args.elastic_trace_en:
+    CpuConfig.config_etrace(CPUClass, system.cpu, args)
+
+
+# Set pin params.
+cpu = system.cpu[0]
+cpu.pinArgs = args.pin_args
+cpu.pinToolArgs = args.pin_tool_args
+cpu.countInsts = args.instcount
+
+# for cpu in system.cpu:
+#     cpu.usePerf = True
+
+# All cpus belong to a common cpu_clk_domain, therefore running at a common
+# frequency.
+cpu.clk_domain = system.cpu_clk_domain
+
+system.m5ops_base = max(0xFFFF0000, Addr(args.mem_size).getValue())
+
+process.maxStackSize = args.max_stack_size
+
+cpu.workload = process
+cpu.createThreads()
+
+system.membus = SystemXBar()
+system.system_port = system.membus.cpu_side_ports
+CacheConfig.config_cache(args, system)
+MemConfig.config_mem(args, system)
+config_filesystem(system, args)
+
+system.workload = SEWorkload.init_compatible(mp0_path)
+
+root = Root(full_system=False, system=system)
+m5.instantiate()
+exit_event = m5.simulate()
+print(f"[*] workload exited {exit_event.getCode()}", file=sys.stderr)
+exit(exit_event.getCode())

--- a/configs/example/pincpu/util.py
+++ b/configs/example/pincpu/util.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from argparse import ArgumentParser
+
+from m5.objects import Process
+from m5.util import addToPath
+
+addToPath("../../")
+
+from common import Options
+
+
+def make_parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--chdir",
+        default=".",
+        help="Set working directory of simulated process",
+    )
+    parser.add_argument("--max-stack-size", type=str, default="64MB")
+    Options.addCommonOptions(parser)
+    Options.addSEOptions(parser)
+    parser.add_argument("cmd", help="Executable to simulate")
+    parser.add_argument(
+        "args", nargs="*", help="Arguments to pass to executable"
+    )
+
+    # FIXME: Shouldn't hard-code this. Should generate the path at build
+    # time, like other
+    # m5 paths.
+    gem5_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    )
+    parser.add_argument(
+        "--pin",
+        default=os.path.join(gem5_root, "pin", "pin"),
+        help="Path to Intel Pin executable",
+    )
+    parser.add_argument(
+        "--pin-tool",
+        default=os.path.join(gem5_root, "pintool", "build", "libclient.so"),
+        help="Path to host PinTool",
+    ),
+    parser.add_argument(
+        "--pin-guest",
+        default=os.path.join(gem5_root, "pintool", "build", "guest"),
+        help="Path to Pin guest",
+    )
+
+    parser.add_argument("--stdin", default="/dev/stdin")
+    parser.add_argument("--stdout", default="stdout.txt")
+    parser.add_argument("--stderr", default="stderr.txt")
+
+    return parser
+
+
+# Shift the address space down, to avoid collisions with Pin's
+# internal mappings.
+ADDR_SPACE_SHIFT = -0x100000000000
+
+
+def make_process(args) -> Process:
+    process = Process(pid=100)
+    process.addrSpaceShift = ADDR_SPACE_SHIFT
+    process.executable = args.cmd
+    process.cwd = os.path.abspath(args.chdir)
+    # process.gid = os.getgid()
+    process.maxStackSize = args.max_stack_size
+
+    # Clear out the environment.
+    process.env = []
+
+    process.cmd = [args.cmd, *args.args]
+
+    # Get stdin path.
+    process.input = (
+        args.stdin
+        if os.path.isabs(args.stdin)
+        else os.path.join(args.chdir, args.stdin)
+    )
+    process.output = args.stdout
+    process.errout = args.stderr
+
+    return process

--- a/ext/pin/.gitignore
+++ b/ext/pin/.gitignore
@@ -1,0 +1,9 @@
+README
+doc/
+extras/
+ia32/
+intel64/
+licensing/
+pin
+pin.sig
+source/

--- a/ext/pin/configure
+++ b/ext/pin/configure
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run this script to download and extract Intel Pin, for use by the PinCPU model.
+
+set -e
+
+PIN_URL=https://software.intel.com/sites/landingpage/pintool/downloads/pin-external-3.31-98869-gfa6f126a8-gcc-linux.tar.gz
+
+usage() {
+    cat <<EOF
+usage: $0 [-h]
+EOF
+}
+
+while getopts "h" optc; do
+    case $optc in
+        h)
+            usage
+            exit
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+dir="$(dirname "${BASH_SOURCE[0]}")"
+
+wget -O- $PIN_URL | tar -C "${dir}" -x --gzip --strip-components=1

--- a/ext/testlib/configuration.py
+++ b/ext/testlib/configuration.py
@@ -276,6 +276,7 @@ def define_constants(constants):
     constants.host_gcn_gpu_tag = "gcn_gpu"
 
     constants.kvm_tag = "kvm"
+    constants.pin_tag = "pin"
 
     constants.supported_tags = {
         constants.isa_tag_type: (

--- a/src/arch/x86/pin/Kconfig
+++ b/src/arch/x86/pin/Kconfig
@@ -1,4 +1,6 @@
-# Copyright 2022 Google LLC
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,7 +25,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config USE_X86_ISA
-    bool "X86 ISA support"
+config HAVE_PIN
+    bool
+    default "$(HAVE_PIN)"
 
-rsource "pin/Kconfig"
+config USE_PIN
+    depends on HAVE_PIN
+    depends on USE_X86_ISA
+    bool "Enable Pin CPU model"
+    default y

--- a/src/arch/x86/pin/SConscript
+++ b/src/arch/x86/pin/SConscript
@@ -1,4 +1,8 @@
-# Copyright 2022 Google LLC
+# -*- mode:python -*-
+
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,7 +27,25 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config USE_X86_ISA
-    bool "X86 ISA support"
+import os
 
-rsource "pin/Kconfig"
+Import('*')
+
+if not env['CONF']['USE_X86_ISA'] or not env['CONF']['USE_PIN']:
+    Return()
+
+env.TagImplies('pin', 'gem5 lib')
+
+SimObject('X86PinCPU.py', sim_objects=['X86PinCPU'], tags='pin')
+Source('cpu.cc', tags='pin')
+Source('message.cc', tags='pin')
+DebugFlag('PinCPU', tags='pin')
+
+guest_exe, client_pintool = SConscript(
+    Dir('#util/pincpu').File('SConscript').abspath,
+    variant_dir=os.path.join(env['BUILDDIR'], 'util', 'pincpu'),
+    duplicate=0,
+)
+
+# Make sure that SCons builds the guest binary and the pintools.
+env.Depends(File('X86PinCPU.py.cc'), [guest_exe, client_pintool])

--- a/src/arch/x86/pin/SConsopts
+++ b/src/arch/x86/pin/SConsopts
@@ -1,4 +1,6 @@
-# Copyright 2022 Google LLC
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,7 +25,31 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config USE_X86_ISA
-    bool "X86 ISA support"
+import os
 
-rsource "pin/Kconfig"
+Import('*')
+
+from gem5_scons import warning
+
+import gem5_scons
+
+gem5_root = Dir('#').srcnode().abspath
+
+# Pin is normally located at ext/pin, extracted by ext/pin/configure.
+# Let its path be overridden by an environment variable.
+requested_pin_dir = os.environ.get('PIN_DIR')
+main['CONF'].setdefault(
+    'PIN_DIR', requested_pin_dir or os.path.join(gem5_root, 'ext/pin')
+)
+
+with gem5_scons.Configure(main) as conf:
+    # Check if we should enable Pin.
+    main['CONF']['HAVE_PIN'] = False
+
+    pin_dir = main['CONF']['PIN_DIR']
+    pin_exe = os.path.join(pin_dir, "pin")
+
+    if os.path.isfile(pin_exe):
+        conf.env['CONF']['HAVE_PIN'] = True
+    elif requested_pin_dir:
+        warning(f"Pin executable does not exist at {pin_exe}")

--- a/src/arch/x86/pin/X86PinCPU.py
+++ b/src/arch/x86/pin/X86PinCPU.py
@@ -1,4 +1,6 @@
-# Copyright 2022 Google LLC
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -23,7 +25,52 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-config USE_X86_ISA
-    bool "X86 ISA support"
+import os
 
-rsource "pin/Kconfig"
+from m5.defines import buildEnv
+from m5.objects.BaseCPU import BaseCPU
+from m5.objects.X86CPU import X86CPU
+from m5.objects.X86MMU import X86MMU
+from m5.params import *
+from m5.SimObject import *
+
+
+class X86PinCPU(BaseCPU, X86CPU):
+    type = "X86PinCPU"
+    cxx_header = "arch/x86/pin/cpu.hh"
+    cxx_class = "gem5::X86ISA::PinCPU"
+
+    mmu = X86MMU()
+
+    @classmethod
+    def memory_mode(cls):
+        return "atomic"
+
+    @classmethod
+    def support_take_over(cls):
+        return False
+
+    @cxxMethod
+    def executePinCommand(command):
+        pass
+
+    pinExe = Param.String(
+        os.path.join(buildEnv["PIN_DIR"], "pin"),
+        "Path to Intel Pin executable",
+    )
+    pinGuest = Param.String(
+        "",
+        "Path to the guest program. If empty, it is looked up next to the "
+        "gem5 binary, where the build places it.",
+    )
+    pinTool = Param.String(
+        "",
+        "Path to the host PinTool. If empty, it is looked up next to the "
+        "gem5 binary, where the build places it.",
+    )
+    pinToolArgs = Param.String("", "Arguments to pass to PinTool")
+    pinArgs = Param.String("", "Arguments to pass to Pin")
+
+    countInsts = Param.Bool(
+        False, "Enable instruction counting (moderate performance penalty)"
+    )

--- a/src/arch/x86/pin/cpu.cc
+++ b/src/arch/x86/pin/cpu.cc
@@ -1,0 +1,831 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "arch/x86/pin/cpu.hh"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/times.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+
+#include "arch/x86/cpuid.hh"
+#include "arch/x86/isa.hh"
+#include "arch/x86/page_size.hh"
+#include "arch/x86/pin/message.h"
+#include "arch/x86/pin/regfile.h"
+#include "arch/x86/regs/int.hh"
+#include "arch/x86/utility.hh"
+#include "base/loader/symtab.hh"
+#include "base/output.hh"
+#include "cpu/simple_thread.hh"
+#include "debug/PinCPU.hh"
+#include "params/X86PinCPU.hh"
+#include "sim/faults.hh"
+#include "sim/sim_exit.hh"
+#include "sim/system.hh"
+
+namespace gem5
+{
+
+namespace X86ISA
+{
+
+static std::string
+gem5BinaryDir()
+{
+    char buf[PATH_MAX];
+    const ssize_t len = ::readlink("/proc/self/exe", buf, sizeof buf - 1);
+    fatal_if(len < 0, "readlink(/proc/self/exe) failed: %s",
+             std::strerror(errno));
+    buf[len] = '\0';
+    const std::string path(buf);
+    const size_t slash = path.rfind('/');
+    if (slash == std::string::npos) {
+        return ".";
+    }
+    return path.substr(0, slash);
+}
+
+static std::vector<std::string_view>
+split_by_spaces(std::string_view str)
+{
+    std::vector<std::string_view> result;
+    size_t pos = 0;
+    size_t size = str.size();
+
+    while (pos < size) {
+        // Skip any leading spaces
+        while (pos < size &&
+               std::isspace(static_cast<unsigned char>(str[pos]))) {
+            ++pos;
+        }
+
+        if (pos >= size) {
+            break;
+        }
+
+        // Find the end of the current word
+        size_t start = pos;
+        while (pos < size &&
+               !std::isspace(static_cast<unsigned char>(str[pos]))) {
+            ++pos;
+        }
+
+        // Create a string_view for the current word
+        result.emplace_back(str.substr(start, pos - start));
+    }
+
+    return result;
+}
+
+PinCPU::PinCPU(const X86PinCPUParams &params)
+    : BaseCPU(params),
+      tickEvent([this] { tick(); }, "X86PinCPU tick", false,
+                Event::CPU_Tick_Pri),
+      _status(Idle),
+      dataPort(name() + ".dcache_port", this),
+      instPort(name() + ".icache_port", this),
+      pinExe(params.pinExe),
+      pinGuest(params.pinGuest.empty()
+                   ? gem5BinaryDir() + "/util/pincpu/guest.elf"
+                   : params.pinGuest),
+      pinTool(params.pinTool.empty()
+                  ? gem5BinaryDir() + "/util/pincpu/libpintool.so"
+                  : params.pinTool),
+      pinPid(-1),
+      system(params.system)
+{
+    thread = std::make_unique<SimpleThread>(
+        this, /*thread_num*/ 0, params.system, params.workload[0], params.mmu,
+        params.isa[0], params.decoder[0]);
+    thread->setStatus(ThreadContext::Halted);
+    tc = thread->getTC();
+    threadContexts.push_back(tc);
+
+    if (params.countInsts) {
+        ctrInsts = 0;
+    }
+
+    // Parse PinTool arguments.
+    for (std::string_view sv : split_by_spaces(params.pinArgs)) {
+        pinArgs.emplace_back(sv);
+    }
+    for (std::string_view sv : split_by_spaces(params.pinToolArgs)) {
+        pinToolArgs.emplace_back(sv);
+    }
+}
+
+void
+PinCPU::haltContext()
+{
+    DPRINTF(PinCPU, "Halting Pin process\n");
+    // Tell Pin to exit.
+    assert(pinPid >= 0 && reqFd >= 0 && respFd >= 0);
+
+    Message msg;
+    msg.type = Message::Exit;
+    msg.send(reqFd);
+
+    close(reqFd);
+    close(respFd);
+
+    if (waitpid(pinPid, nullptr, 0) < 0) {
+        panic("waitpid failed!\n");
+    }
+
+    // Any later unmap callback must not try to talk to the dead pintool.
+    pinPid = -1;
+    reqFd = -1;
+    respFd = -1;
+
+    // Dump times.
+    struct tms tms;
+    if (times(&tms) < 0) {
+        panic("times(2) failed\n");
+    }
+    const auto tick = sysconf(_SC_CLK_TCK);
+    DPRINTF(PinCPU,
+            "user.pin: %fs, sys.pin: %fs, user.gem5: %fs, sys.gem5: %fs\n",
+            static_cast<double>(tms.tms_cutime) / tick,
+            static_cast<double>(tms.tms_cstime) / tick,
+            static_cast<double>(tms.tms_utime) / tick,
+            static_cast<double>(tms.tms_stime) / tick);
+}
+
+bool
+PinCPU::PinRequestPort::recvTimingResp(PacketPtr pkt)
+{ fatal("Unsupported: %s", __func__); }
+
+void
+PinCPU::PinRequestPort::recvReqRetry()
+{ fatal("Unsupported: %s", __func__); }
+
+Port &
+PinCPU::getDataPort()
+{ return dataPort; }
+
+Port &
+PinCPU::getInstPort()
+{ return instPort; }
+
+void
+PinCPU::wakeup(ThreadID tid)
+{ fatal("Unsupported: %s", __func__); }
+
+Counter
+PinCPU::totalInsts() const
+{ return ctrInsts ? *ctrInsts : 0; }
+
+Counter
+PinCPU::totalOps() const
+{
+    // Pin counts instructions, not micro-ops, so the two are reported as
+    // equal. Statistics derived from op counts are approximate.
+    warn_once("PinCPU reports op count as instruction count\n");
+    return totalInsts();
+}
+
+const std::string &
+PinCPU::getPinExe() const
+{ return pinExe; }
+
+const std::string &
+PinCPU::getPinTool() const
+{ return pinTool; }
+
+const std::string &
+PinCPU::getGuest() const
+{ return pinGuest; }
+
+void
+PinCPU::init()
+{
+    BaseCPU::init();
+    fatal_if(numThreads != 1, "Pin: Multithreading not supported");
+}
+
+void
+PinCPU::startup()
+{
+    BaseCPU::startup();
+
+    // Create pipes for bidirectional communication.
+    int req_fds[2];
+    if (pipe(req_fds) < 0) {
+        fatal("pipe failed: %s", std::strerror(errno));
+    }
+    int resp_fds[2];
+    if (pipe(resp_fds) < 0) {
+        fatal("pipe failed: %s", std::strerror(errno));
+    }
+    reqFd = req_fds[1];
+    respFd = resp_fds[0];
+    const int remote_req_fd = req_fds[0];
+    const int remote_resp_fd = resp_fds[1];
+
+    char req_path[32];
+    std::sprintf(req_path, "/dev/fd/%d", remote_req_fd);
+    char resp_path[32];
+    std::sprintf(resp_path, "/dev/fd/%d", remote_resp_fd);
+    const std::string pin_tool = getPinTool();
+    const std::string pin_exe = getPinExe();
+    const std::string guest_prog = getGuest();
+
+    std::stringstream shm_path_ss;
+    const auto &backing_store = system->getPhysMem().getBackingStore();
+    fatal_if(backing_store.size() != 1,
+             "Pin CPU supports only one backing store entry");
+    const int shm_fd = backing_store[0].shmFd;
+    fatal_if(shm_fd < 0, "Pin CPU requires shared memory backing store");
+    shm_path_ss << "/dev/fd/" << shm_fd;
+    const std::string shm_path = shm_path_ss.str();
+
+    int shm_fd_flags;
+    if ((shm_fd_flags = fcntl(shm_fd, F_GETFD)) < 0) {
+        fatal("fcntl FD_GETFD failed");
+    }
+    shm_fd_flags &= ~FD_CLOEXEC;
+    if (fcntl(shm_fd, F_SETFD, shm_fd_flags) < 0) {
+        fatal("fcntl FD_SETFD failed");
+    }
+
+    pinPid = fork();
+    if (pinPid < 0) {
+        fatal("fork: %s", std::strerror(errno));
+    } else if (pinPid == 0) {
+        // Create the log files for the guest.
+        const std::string guestout_path = simout.resolve("guestout.txt");
+        const int guestout_fd =
+            open(guestout_path.c_str(),
+                 O_WRONLY | O_APPEND | O_TRUNC | O_CREAT, 0664);
+        if (guestout_fd < 0) {
+            panic("Failed to create guestout.txt\n");
+        }
+        if (dup2(guestout_fd, STDOUT_FILENO) < 0) {
+            panic("dup2 failed\n");
+        }
+
+        const std::string guesterr_path = simout.resolve("guesterr.txt");
+        const int guesterr_fd =
+            open(guesterr_path.c_str(),
+                 O_WRONLY | O_APPEND | O_TRUNC | O_CREAT, 0664);
+        if (guesterr_fd < 0) {
+            panic("Failed to create guesterr.txt\n");
+        }
+        if (dup2(guesterr_fd, STDERR_FILENO) < 0) {
+            panic("dup2 failed\n");
+        }
+
+        // This is the Pin subprocess. Execute pin.
+        std::vector<std::string> args;
+        auto it = std::back_inserter(args);
+
+        // Pin executable.
+        *it++ = pin_exe;
+
+        // Pin args.
+        if (std::getenv("PIN_APPDEBUG")) {
+            *it++ = "-appdebug";
+            *it++ = "1";
+        }
+        if (std::getenv("PIN_TOOLDEBUG")) {
+            *it++ = "-pause_tool";
+            *it++ = "30";
+        }
+
+        it = std::copy(pinArgs.begin(), pinArgs.end(), it);
+
+        // Pintool.
+        *it++ = "-t";
+        *it++ = pin_tool;
+
+        // Pintool args.
+        *it++ = "-log";
+        *it++ = simout.resolve("pin.log");
+        *it++ = "-req_path";
+        *it++ = req_path;
+        *it++ = "-resp_path";
+        *it++ = resp_path;
+        *it++ = "-mem_path";
+        *it++ = shm_path;
+        *it++ = "-instcount";
+        *it++ = ctrInsts ? "1" : "0";
+
+        // Custom Pintool args.
+        it = std::copy(pinToolArgs.begin(), pinToolArgs.end(), it);
+
+        // Workload.
+        *it++ = "--";
+        *it++ = guest_prog;
+
+        std::vector<char *> args_c;
+        for (const std::string &s : args) {
+            args_c.push_back(const_cast<char *>(s.c_str()));
+        }
+        args_c.push_back(nullptr);
+
+        std::stringstream cmd_ss;
+        for (const std::string &arg : args) {
+            cmd_ss << arg << " ";
+        }
+        const std::string cmd_s = cmd_ss.str();
+        dprintf(guestout_fd, "Starting Pin: %s\n", cmd_s.c_str());
+
+        execvp(args_c[0], args_c.data());
+        fatal("execvp failed: %s: %s", args_c[0], std::strerror(errno));
+    }
+
+    // Close the remote end of the socket; it will remain open in the Pin
+    // subprocess.
+    close(req_fds[0]);  // Close read-end of request pipe.
+    close(resp_fds[1]); // Close write-end of response pipe.
+
+    // Send initial ACK.
+    Message msg;
+    msg.type = Message::Ack;
+    DPRINTF(PinCPU, "Sending initial ACK\n");
+    msg.send(reqFd);
+    DPRINTF(PinCPU, "Receiving initial ACK\n");
+    msg.recv(respFd);
+    panic_if(msg.type != Message::Ack,
+             "Received message other than ACK at pintool startup!\n");
+    DPRINTF(PinCPU, "received ACK from pintool\n");
+
+    // Pin discovers new mappings by faulting, but nothing tells it when gem5
+    // tears one down, so have MemState notify us.
+    tc->getProcessPtr()->memState->setUnmapCallback(
+        [this](Addr vaddr, Addr size) { unmapFromPin(vaddr, size); });
+
+    // Copy over initial state.
+    syncStateToPin(true);
+
+    // Map in code.
+    mapCode();
+}
+
+void
+PinCPU::mapCode()
+{
+    const Addr min = tc->getProcessPtr()->image.minAddr();
+    const Addr max = tc->getProcessPtr()->image.maxAddr();
+
+    // Map every part of the process image that translates. Holes in the image
+    // fault, and we want to skip them; incrementing the iterator would instead
+    // reattempt the same address, assuming the caller had fixed the fault. So
+    // restart the generator just past a faulting page rather than advancing
+    // through it. Note that the generator clamps each range to a page before
+    // attempting the translation, so a faulting range's size is the size of
+    // the page that faulted, which guarantees forward progress here.
+    Addr vaddr = min;
+    while (vaddr < max) {
+        const TranslationGenPtr ptr = tc->getMMUPtr()->translateFunctional(
+            vaddr, max - vaddr, tc, BaseMMU::Execute, 0);
+        TranslationGenConstIterator it = ptr->begin();
+        for (; it != ptr->end(); ++it) {
+            const TranslationGen::Range &range = *it;
+            if (range.fault != NoFault) {
+                break;
+            }
+            // Map with the permissions the range actually has. Mapping the
+            // whole image read/execute would fault again on the first write
+            // to a data page, forcing Pin to replace a mapping it already
+            // holds.
+            int prot = PROT_READ | PROT_EXEC;
+            const TranslationGenPtr w = tc->getMMUPtr()->translateFunctional(
+                range.vaddr, range.size, tc, BaseMMU::Write, 0);
+            if (w->begin()->fault == NoFault) {
+                prot |= PROT_WRITE;
+            }
+
+            DPRINTF(PinCPU,
+                    "Mapping in code range vaddr=%#x paddr=%#x size=%#x "
+                    "prot=%#x\n",
+                    range.vaddr, range.paddr, range.size, prot);
+            Message msg;
+            msg.type = Message::Map;
+            msg.map.vaddr = range.vaddr;
+            msg.map.paddr = range.paddr;
+            msg.map.size = range.size;
+            msg.map.prot = prot;
+            msg.send(reqFd);
+            msg.recv(respFd);
+            panic_if(msg.type != Message::Ack, "unexpected response\n");
+        }
+        if (it == ptr->end()) {
+            break;
+        }
+        vaddr = it->vaddr + it->size;
+    }
+}
+
+void
+PinCPU::activateContext(ThreadID tid)
+{
+    assert(tid == 0);
+    assert(thread);
+
+    schedule(tickEvent, clockEdge(Cycles(0)));
+    _status = Running;
+}
+
+void
+PinCPU::tick()
+{
+    assert(_status != Idle);
+    assert(_status == Running);
+
+    pinRun();
+
+    if (tc->status() == ThreadContext::Halting ||
+        tc->status() == ThreadContext::Halted) {
+        haltContext();
+    }
+
+    // This model is functional only. Pin reports what happened, not how long
+    // it took, so each interaction advances the clock by a single cycle and
+    // the resulting timing is not meaningful.
+    if (_status != Idle) {
+        schedule(tickEvent, clockEdge(ticksToCycles(1)));
+    }
+}
+
+void
+PinCPU::syncStateToPin(bool full)
+{
+    using namespace X86ISA;
+    Message msg;
+    msg.type = Message::SetRegs;
+    PinRegFile &rf = msg.regfile;
+
+    // Set integer registers.
+    rf.rax = tc->getReg(int_reg::Rax);
+    rf.rbx = tc->getReg(int_reg::Rbx);
+    rf.rcx = tc->getReg(int_reg::Rcx);
+    rf.rdx = tc->getReg(int_reg::Rdx);
+    rf.rdi = tc->getReg(int_reg::Rdi);
+    rf.rsi = tc->getReg(int_reg::Rsi);
+    rf.rbp = tc->getReg(int_reg::Rbp);
+    rf.rsp = tc->getReg(int_reg::Rsp);
+    rf.r8 = tc->getReg(int_reg::R8);
+    rf.r9 = tc->getReg(int_reg::R9);
+    rf.r10 = tc->getReg(int_reg::R10);
+    rf.r11 = tc->getReg(int_reg::R11);
+    rf.r12 = tc->getReg(int_reg::R12);
+    rf.r13 = tc->getReg(int_reg::R13);
+    rf.r14 = tc->getReg(int_reg::R14);
+    rf.r15 = tc->getReg(int_reg::R15);
+    rf.rip = tc->pcState().instAddr();
+
+    // Set floating-point registers.
+    for (int i = 0; i < 8; ++i) {
+        const double value64 = bitsToFloat64(tc->getReg(float_reg::fpr(i)));
+        storeFloat80(&rf.fprs[i][0], value64);
+    }
+    for (int i = 0; i < 16; ++i) {
+        rf.xmms[i][0] = tc->getReg(float_reg::xmmLow(i));
+        rf.xmms[i][1] = tc->getReg(float_reg::xmmHigh(i));
+    }
+    rf.fcw = tc->readMiscRegNoEffect(misc_reg::Fcw);
+    rf.fsw = tc->readMiscRegNoEffect(misc_reg::Fsw);
+    rf.ftag = tc->readMiscRegNoEffect(misc_reg::Ftag);
+
+    // Misc registers.
+    rf.rflags = getRFlags(tc);
+    rf.fs = tc->readMiscRegNoEffect(misc_reg::Fs);
+    rf.gs = tc->readMiscRegNoEffect(misc_reg::Gs);
+    rf.fs_base = tc->readMiscRegNoEffect(misc_reg::FsBase);
+    rf.gs_base = tc->readMiscRegNoEffect(misc_reg::GsBase);
+
+    // Send message.
+    msg.send(reqFd);
+    msg.recv(respFd);
+    panic_if(msg.type != Message::Ack,
+             "Got message other than ACK for SetRegs!\n");
+}
+
+void
+PinCPU::syncStateFromPin(bool full)
+{
+    using namespace X86ISA;
+
+    Message msg;
+    msg.type = Message::GetRegs;
+    msg.send(reqFd);
+    msg.recv(respFd);
+    panic_if(msg.type != Message::SetRegs,
+             "Got response other than SetRegs in response to GetRegs!\n");
+    const PinRegFile &rf = msg.regfile;
+
+    // Copy all integer registers.
+    tc->setReg(int_reg::Rax, rf.rax);
+    tc->setReg(int_reg::Rbx, rf.rbx);
+    tc->setReg(int_reg::Rcx, rf.rcx);
+    tc->setReg(int_reg::Rdx, rf.rdx);
+    tc->setReg(int_reg::Rdi, rf.rdi);
+    tc->setReg(int_reg::Rsi, rf.rsi);
+    tc->setReg(int_reg::Rbp, rf.rbp);
+    tc->setReg(int_reg::Rsp, rf.rsp);
+    tc->setReg(int_reg::R8, rf.r8);
+    tc->setReg(int_reg::R9, rf.r9);
+    tc->setReg(int_reg::R10, rf.r10);
+    tc->setReg(int_reg::R11, rf.r11);
+    tc->setReg(int_reg::R12, rf.r12);
+    tc->setReg(int_reg::R13, rf.r13);
+    tc->setReg(int_reg::R14, rf.r14);
+    tc->setReg(int_reg::R15, rf.r15);
+    tc->pcState(rf.rip);
+
+    // Floating-point registers.
+    for (int i = 0; i < 8; ++i) {
+        const double value64 = loadFloat80(rf.fprs[i]);
+        const uint64_t bits64 = floatToBits64(value64);
+        tc->setReg(float_reg::fpr(i), bits64);
+    }
+    for (int i = 0; i < 16; ++i) {
+        tc->setReg(float_reg::xmmLow(i), rf.xmms[i][0]);
+        tc->setReg(float_reg::xmmHigh(i), rf.xmms[i][1]);
+    }
+    tc->setMiscRegNoEffect(misc_reg::Fcw, rf.fcw);
+    tc->setMiscRegNoEffect(misc_reg::Fsw, rf.fsw);
+    tc->setMiscRegNoEffect(misc_reg::Ftag, rf.ftag);
+    tc->setMiscRegNoEffect(
+        misc_reg::Ftw,
+        rf.ftag); // Derived from ftag, as the KVM CPU also does.
+
+    // Misc registers.
+    setRFlags(tc, rf.rflags);
+    tc->setMiscRegNoEffect(misc_reg::Fs, rf.fs);
+    tc->setMiscRegNoEffect(misc_reg::Gs, rf.gs);
+    tc->setMiscRegNoEffect(misc_reg::FsBase, rf.fs_base);
+    tc->setMiscRegNoEffect(misc_reg::GsBase, rf.gs_base);
+}
+
+void
+PinCPU::pinRun()
+{
+    syncStateToPin(false);
+
+    // Tell it to run.
+    Message msg;
+    msg.type = Message::Run;
+    msg.send(reqFd);
+    msg.recv(respFd);
+    if (ctrInsts) {
+        const std::string instcount_s = executePinCommand("instcount");
+        const auto new_instcount = std::stoull(instcount_s);
+        assert(*ctrInsts <= new_instcount);
+        ctrInsts = new_instcount;
+    }
+
+    switch (msg.type) {
+        case Message::PageFault:
+            handlePageFault(msg.faultaddr);
+            break;
+
+        case Message::Syscall:
+            handleSyscall();
+            break;
+
+        case Message::Cpuid:
+            handleCPUID();
+            break;
+
+        case Message::Break:
+            syncStateFromPin(false);
+            exitSimLoopNow("pin-breakpoint");
+            break;
+
+        case Message::Ack:
+            break;
+
+        default:
+            panic("unhandled run response type (%d)\n", msg.type);
+    }
+}
+
+void
+PinCPU::handlePageFault(Addr vaddr)
+{
+    syncStateFromPin(false);
+
+    DPRINTF(PinCPU, "vaddr=%x\n", vaddr);
+    assert(vaddr);
+    vaddr &= ~(Addr)0xfff;
+
+    // New approach:
+    // Just start grabbing mappings until they aren't mergeable.
+    struct Entry
+    {
+        Addr vaddr;
+        Addr paddr;
+        size_t size;
+        int prot;
+    };
+    std::list<Entry> mappings;
+    const MemState &mem_state = *tc->getProcessPtr()->memState;
+    size_t size = PageBytes;
+    if (const VMA *vma = mem_state.getVMA(vaddr)) {
+        vaddr = vma->start();
+        size = vma->size();
+        DPRINTF(PinCPU, "VMA: %#x %#x %s\n", vma->start(), vma->end(),
+                vma->getName());
+    }
+    DPRINTF(PinCPU, "Preparing to map starting at vaddr=%#x size=%#x\n", vaddr,
+            size);
+
+    // Collect list of page mappings with permissions.
+    const auto translate_with_mode =
+        [&](BaseMMU::Mode mode) -> TranslationGenPtr {
+        return tc->getMMUPtr()->translateFunctional(vaddr, size, tc, mode, 0);
+    };
+    const auto r = translate_with_mode(BaseMMU::Read);
+    const auto w = translate_with_mode(BaseMMU::Write);
+    const auto x = translate_with_mode(BaseMMU::Execute);
+    for (auto r_it = r->begin(), w_it = w->begin(), x_it = x->begin();
+         r_it != r->end(); ++r_it, ++w_it, ++x_it) {
+        assert(w_it != w->end());
+        assert(x_it != x->end());
+        panic_if(r_it->fault != NoFault, "Page fault: vaddr=%#x fault=%s\n",
+                 r_it->vaddr, r_it->fault->name());
+        Entry entry;
+        entry.vaddr = r_it->vaddr;
+        entry.paddr = r_it->paddr;
+        entry.size = r_it->size;
+        entry.prot = PROT_READ;
+        if (w_it->fault == NoFault) {
+            entry.prot |= PROT_WRITE;
+        }
+        if (x_it->fault == NoFault) {
+            entry.prot |= PROT_EXEC;
+        }
+        mappings.push_back(entry);
+    }
+
+    // Combine into ranges.
+    assert(!mappings.empty());
+    for (auto it1 = mappings.begin(); std::next(it1) != mappings.end();) {
+        const auto it2 = std::next(it1);
+
+        // Can we combine the entries pointed to by it1 and it2?
+        Entry &e1 = *it1;
+        Entry &e2 = *it2;
+        assert(e1.vaddr + e1.size == e2.vaddr);
+        if (e1.prot == e2.prot && e1.paddr + e1.size == e2.paddr) {
+            // Yes, can combine!
+            e1.size += e2.size;
+            mappings.erase(it2);
+        } else {
+            // No, we can't combine, so advance.
+            ++it1;
+        }
+    }
+
+    // Send ranges over.
+    for (const Entry &e : mappings) {
+        DPRINTF(PinCPU, "Mapping vaddr=%#x paddr=%#x size=%#x prot=%#x\n",
+                e.vaddr, e.paddr, e.size, e.prot);
+        Message msg;
+        msg.type = Message::Map;
+        msg.map.vaddr = e.vaddr;
+        msg.map.paddr = e.paddr;
+        msg.map.size = e.size;
+        msg.map.prot = e.prot;
+        msg.send(reqFd);
+        msg.recv(respFd);
+        panic_if(msg.type != Message::Ack, "unexpected response\n");
+    }
+}
+
+void
+PinCPU::handleSyscall()
+{
+    syncStateFromPin(false);
+
+    tc->getSystemPtr()->workload->syscall(tc);
+}
+
+void
+PinCPU::unmapFromPin(Addr vaddr, Addr size)
+{
+    // MemState outlives the Pin process, and unmaps can happen before the
+    // pintool is up or after it has exited.
+    if (!isPinRunning()) {
+        return;
+    }
+
+    DPRINTF(PinCPU, "Pin: unmapping vaddr %#x-%#x\n", vaddr, vaddr + size);
+    Message msg;
+    msg.type = Message::Unmap;
+    msg.map.vaddr = vaddr;
+    msg.map.size = size;
+    msg.send(reqFd);
+    msg.recv(respFd);
+    panic_if(msg.type != Message::Ack, "unexpected response\n");
+}
+
+void
+PinCPU::handleCPUID()
+{
+    syncStateFromPin(false);
+
+    // Get function (EAX).
+    const uint32_t func = tc->getReg(X86ISA::int_reg::Rax);
+
+    // Get index (ECX).
+    const uint32_t index = tc->getReg(X86ISA::int_reg::Rcx);
+
+    DPRINTF(PinCPU, "CPUID: EAX=0x%x ECX=0x%x\n", func, index);
+
+    // Do CPUID.
+    X86ISA::ISA *isa = dynamic_cast<X86ISA::ISA *>(tc->getIsaPtr());
+    X86ISA::CpuidResult result;
+    isa->cpuid->doCpuid(tc, func, index, result);
+
+    // Set RAX, RBX, RCX, RDX.
+    tc->setReg(X86ISA::int_reg::Rax, result.rax);
+    tc->setReg(X86ISA::int_reg::Rbx, result.rbx);
+    tc->setReg(X86ISA::int_reg::Rdx, result.rdx);
+    tc->setReg(X86ISA::int_reg::Rcx, result.rcx);
+}
+
+void
+PinCPU::serializeThread(CheckpointOut &cp, ThreadID tid) const
+{
+    assert(tid == 0);
+    thread->serialize(cp);
+}
+
+std::string
+PinCPU::executePinCommand(const std::string &command)
+{
+    fatal_if(!isPinRunning(), "PinCPU has not been started up yet!\n");
+    Message msg;
+    msg.type = Message::ExecCommand;
+    fatal_if(command.size() >= sizeof msg.command, "Command too long!\n");
+    std::strcpy(msg.command, command.c_str());
+    msg.send(reqFd);
+    msg.recv(respFd);
+    panic_if(msg.type != Message::CommandResult,
+             "Received message other than CommandResult!\n");
+
+    size_t rem = msg.command_result_size;
+    std::string s;
+    while (rem > 0) {
+        char buf[1024];
+        const ssize_t bytes = read(respFd, buf, std::min(rem, sizeof buf));
+        if (bytes <= 0) {
+            panic("read failed: rem=%u\n", rem);
+        }
+        s.insert(s.end(), &buf[0], &buf[bytes]);
+        rem -= bytes;
+    }
+    assert(s.size() == msg.command_result_size);
+    return s;
+}
+
+bool
+PinCPU::isPinRunning() const
+{
+    if (pinPid < 0) {
+        return false;
+    }
+    assert(reqFd >= 0);
+    assert(respFd >= 0);
+    return true;
+}
+
+} // namespace X86ISA
+} // namespace gem5

--- a/src/arch/x86/pin/cpu.hh
+++ b/src/arch/x86/pin/cpu.hh
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_X86_PIN_CPU_HH__
+#define __ARCH_X86_PIN_CPU_HH__
+
+#include <memory>
+#include <optional>
+#include <set>
+
+#include "cpu/base.hh"
+#include "mem/port.hh"
+
+namespace gem5
+{
+
+// Forward declarations.
+class SimpleThread;
+class X86PinCPUParams;
+class System;
+
+namespace X86ISA
+{
+
+class PinCPU final : public BaseCPU
+{
+  public:
+    PinCPU(const X86PinCPUParams &params);
+
+    void init() override;
+    void startup() override;
+
+    void serializeThread(CheckpointOut &cp, ThreadID tid) const override;
+
+    void activateContext(ThreadID tid = 0) override;
+
+    class PinRequestPort final : public RequestPort
+    {
+      public:
+        PinRequestPort(const std::string &name, PinCPU *cpu)
+            : RequestPort(name), cpu(cpu)
+        {}
+
+      private:
+        PinCPU *cpu;
+
+        bool recvTimingResp(PacketPtr pkt) override;
+        void recvReqRetry() override;
+    };
+
+    Port &getDataPort() override;
+    Port &getInstPort() override;
+    void wakeup(ThreadID tid) override;
+    Counter totalInsts() const override;
+    Counter totalOps() const override;
+
+    void tick();
+
+    enum Status
+    {
+        Idle,
+        Running,
+    };
+
+  private:
+    std::unique_ptr<SimpleThread> thread;
+    ThreadContext *tc;
+    EventFunctionWrapper tickEvent;
+    Status _status;
+    PinRequestPort dataPort;
+    PinRequestPort instPort;
+
+    // Pin paths.
+    std::string pinExe;
+    std::string pinGuest;
+    std::string pinTool;
+    std::vector<std::string> pinArgs;
+    std::vector<std::string> pinToolArgs;
+
+    pid_t pinPid = -1;
+    int reqFd = -1;
+    int respFd = -1;
+    System *system;
+    std::optional<Counter> ctrInsts;
+
+    const std::string &getPinTool() const;
+    const std::string &getPinExe() const;
+    const std::string &getGuest() const;
+
+    void pinRun();
+
+    void syncStateToPin(bool full);
+    void syncStateFromPin(bool full);
+
+    void handlePageFault(Addr vaddr);
+    void handleSyscall();
+
+    void unmapFromPin(Addr vaddr, Addr size);
+
+    void handleCPUID();
+
+    void haltContext();
+
+    bool isPinRunning() const;
+
+    void mapCode();
+
+  public:
+    std::string executePinCommand(const std::string &command);
+};
+
+} // namespace X86ISA
+} // namespace gem5
+
+#endif // __ARCH_X86_PIN_CPU_HH__

--- a/src/arch/x86/pin/message.cc
+++ b/src/arch/x86/pin/message.cc
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+
+#include <cstdlib>
+
+#include "arch/x86/pin/message.h"
+#include "base/logging.hh"
+#include "debug/PinCPU.hh"
+
+namespace gem5
+{
+
+namespace X86ISA
+{
+
+void
+Message::send(int fd) const
+{
+    const uint8_t *data = reinterpret_cast<const uint8_t *>(this);
+    size_t size = sizeof *this;
+    while (size > 0) {
+        ssize_t bytes_written;
+        if ((bytes_written = write(fd, data, size)) < 0) {
+            panic("Failed to write message!\n");
+        }
+        data += bytes_written;
+        size -= bytes_written;
+    }
+}
+
+void
+Message::recv(int fd)
+{
+    // inform("receiving message\n");
+    type = (Type)-1;
+    uint8_t *data = reinterpret_cast<uint8_t *>(this);
+    size_t size = sizeof *this;
+    while (size > 0) {
+        ssize_t bytes_read = read(fd, data, size);
+        if (bytes_read < 0) {
+            panic("read failed: %s\n", std::strerror(errno));
+        } else if (bytes_read == 0) {
+            panic("Pin closed the pipe!\n");
+        }
+        data += bytes_read;
+        size -= bytes_read;
+    }
+    // inform("received message (type=%i)\n", type);
+}
+
+std::ostream &
+operator<<(std::ostream &os, const Message &msg)
+{
+    os << "pinmsg{.type=";
+    switch (msg.type) {
+        case Message::Ack:
+            os << "ACK";
+            break;
+        default:
+            panic("unhandled message type!\n");
+    }
+    os << "}";
+    return os;
+}
+
+} // namespace X86ISA
+} // namespace gem5

--- a/src/arch/x86/pin/message.h
+++ b/src/arch/x86/pin/message.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_X86_PIN_MESSAGE_H__
+#define __ARCH_X86_PIN_MESSAGE_H__
+
+#ifdef __cplusplus
+#include <cstdint>
+#include <ostream>
+
+#else
+#include <stdint.h>
+
+#endif
+
+#include "arch/x86/pin/regfile.h"
+
+#ifdef __cplusplus
+
+namespace gem5
+{
+
+namespace X86ISA
+{
+
+#endif
+
+struct Message
+{
+    enum Type
+    {
+        Invalid = 0,
+        Ack,
+        Map,
+        Abort,
+        Run,
+        PageFault,
+        Syscall,
+        Cpuid,
+        Exit,
+        GetRegs,
+        SetRegs,
+        Unmap,
+        AddSymbol,
+        ExecCommand,
+        CommandResult,
+        Break,
+        NumTypes
+    } type;
+    union
+    {
+        struct
+        {
+            uint64_t vaddr;
+            uint64_t paddr;
+            uint64_t size;
+            uint64_t prot;
+        } map; // For Type::Map
+
+        uint64_t faultaddr; // for PageFault
+
+        struct PinRegFile regfile; // Valid for GetRegs, SetRegs.
+
+        struct
+        {
+            char name[64];
+            uint64_t vaddr;
+        } symbol;
+
+        char command[64];
+        uint64_t command_result_size;
+    };
+
+    uint64_t inst_count; // Valid for all responses to RUN requests.
+
+#ifdef __cplusplus
+    void send(int sockfd) const;
+    void recv(int sockfd);
+#endif
+};
+
+#ifdef __cplusplus
+std::ostream &operator<<(std::ostream &os, const Message &msg);
+#endif
+
+#ifdef __cplusplus
+}
+}
+#endif
+
+#endif // __ARCH_X86_PIN_MESSAGE_H__

--- a/src/arch/x86/pin/regfile.h
+++ b/src/arch/x86/pin/regfile.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_X86_PIN_REGFILE_H__
+#define __ARCH_X86_PIN_REGFILE_H__
+
+#ifdef __cplusplus
+#include <cstdint>
+
+#else
+#include <stdint.h>
+
+#endif
+
+struct PinRegFile
+{
+    // Integer register file.
+    uint64_t rax, rbx, rcx, rdx, rsi, rdi, rsp, rbp;
+    uint64_t r8, r9, r10, r11, r12, r13, r14, r15;
+    uint64_t rip;
+
+    // Float register file.
+    uint8_t fprs[8][10];
+    uint64_t xmms[16][2];
+    uint16_t fcw, fsw, ftag;
+
+    // Misc register file.
+    uint64_t rflags;
+    uint16_t fs, gs;
+    uint64_t fs_base, gs_base;
+};
+
+#endif // __ARCH_X86_PIN_REGFILE_H__

--- a/src/arch/x86/process.cc
+++ b/src/arch/x86/process.cc
@@ -112,9 +112,14 @@ X86_64Process::X86_64Process(const ProcessParams &params,
 
     Addr brk_point = roundUp(image.maxAddr(), PageBytes);
     Addr stack_base = 0x7FFFFFFFF000ULL;
+    Addr mmap_top = 0x7FFFF7FFF000ULL;
+
+    stack_base += params.addrSpaceShift;
+    mmap_top += params.addrSpaceShift;
+
     Addr max_stack_size = params.maxStackSize;
     Addr next_thread_stack_base = stack_base - max_stack_size;
-    Addr mmap_end = std::min<Addr>(0x7FFFF7FFF000ULL, next_thread_stack_base);
+    Addr mmap_end = std::min<Addr>(mmap_top, next_thread_stack_base);
 
     memState = std::make_shared<MemState>(
             this, brk_point, stack_base, max_stack_size,

--- a/src/mem/physical.cc
+++ b/src/mem/physical.cc
@@ -82,11 +82,13 @@ PhysicalMemory::PhysicalMemory(const std::string &_name,
                                bool mmap_using_noreserve,
                                const std::string &shared_backstore,
                                bool auto_unlink_shared_backstore,
-                               bool is_sparse_restore)
+                               bool is_sparse_restore,
+                               bool anonymous_shared_backstore)
     : _name(_name),
       size(0),
       mmapUsingNoReserve(mmap_using_noreserve),
       sharedBackstore(shared_backstore),
+      anonymousSharedBackstore(anonymous_shared_backstore),
       sharedBackstoreSize(0),
       pageSize(sysconf(_SC_PAGE_SIZE)),
       isSparseRestore(is_sparse_restore)
@@ -267,7 +269,16 @@ PhysicalMemory::createBackingStore(
         sharedBackstoreSize += roundUp(range.size(), pageSize);
         DPRINTF(AddrRanges, "Sharing backing store as %s at offset %llu\n",
                 sharedBackstore.c_str(), (uint64_t)map_offset);
-        shm_fd = shm_open(sharedBackstore.c_str(), O_CREAT | O_RDWR, 0666);
+        if (anonymousSharedBackstore) {
+#if defined(__linux__)
+            shm_fd = memfd_create(sharedBackstore.c_str(), 0);
+#else
+            fatal("anonymous_shared_backstore requires memfd_create(2), "
+                  "which is only available on Linux.");
+#endif
+        } else {
+            shm_fd = shm_open(sharedBackstore.c_str(), O_CREAT | O_RDWR, 0666);
+        }
         if (shm_fd == -1)
                panic("Shared memory failed");
         if (ftruncate(shm_fd, sharedBackstoreSize))

--- a/src/mem/physical.hh
+++ b/src/mem/physical.hh
@@ -158,6 +158,9 @@ class PhysicalMemory : public Serializable
     const bool mmapUsingNoReserve;
 
     const std::string sharedBackstore;
+    // Whether the shared backing store is created anonymously with
+    // memfd_create(2) instead of shm_open(3). Linux only.
+    const bool anonymousSharedBackstore;
     uint64_t sharedBackstoreSize;
 
     long pageSize;
@@ -198,7 +201,8 @@ class PhysicalMemory : public Serializable
                    bool mmap_using_noreserve,
                    const std::string &shared_backstore,
                    bool auto_unlink_shared_backstore,
-                   bool is_sparse_restore = false);
+                   bool is_sparse_restore = false,
+                   bool anonymous_shared_backstore = false);
 
     /**
      * Unmap all the backing store we have used.

--- a/src/sim/Process.py
+++ b/src/sim/Process.py
@@ -51,6 +51,10 @@ class Process(SimObject):
                             table in an architecture-specific format",
     )
     kvmInSE = Param.Bool("false", "initialize the process for KvmCPU in SE")
+    addrSpaceShift = Param.Int64(
+        0,
+        "Shift the process's address space by this amount.",
+    )
     maxStackSize = Param.MemorySize("64MiB", "maximum size of the stack")
     zeroPages = Param.Bool(
         True,

--- a/src/sim/System.py
+++ b/src/sim/System.py
@@ -115,6 +115,11 @@ class System(SimObject):
         "preventing physical memory allocation for unused guest regions.",
     )
 
+    anonymous_shared_backstore = Param.Bool(
+        False,
+        "Create the shared backstore anonymously with memfd_create(2).",
+    )
+
     cache_line_size = Param.Unsigned(64, "Cache line size in bytes")
 
     redirect_paths = VectorParam.RedirectPath([], "Path redirections")

--- a/src/sim/mem_state.cc
+++ b/src/sim/mem_state.cc
@@ -103,6 +103,15 @@ MemState::isUnmapped(Addr start_addr, Addr length)
     return true;
 }
 
+const VMA *
+MemState::getVMA(Addr vaddr) const
+{
+    auto vma_it = std::find_if(
+        _vmaList.begin(), _vmaList.end(),
+        [vaddr](const VMA &vma) -> bool { return vma.contains(vaddr); });
+    return vma_it == _vmaList.end() ? nullptr : &*vma_it;
+}
+
 void
 MemState::updateBrkRegion(Addr old_brk, Addr new_brk)
 {
@@ -193,6 +202,10 @@ MemState::unmapRegion(Addr start_addr, Addr length)
 {
     Addr end_addr = start_addr + length;
     const AddrRange range(start_addr, end_addr);
+
+    if (_unmapCallback) {
+        _unmapCallback(start_addr, length);
+    }
 
     auto vma = std::begin(_vmaList);
     while (vma != std::end(_vmaList)) {
@@ -285,6 +298,10 @@ MemState::remapRegion(Addr start_addr, Addr new_start_addr, Addr length)
 
     Addr end_addr = start_addr + length;
     const AddrRange range(start_addr, end_addr);
+
+    if (_unmapCallback) {
+        _unmapCallback(start_addr, length);
+    }
 
     auto vma = std::begin(_vmaList);
     while (vma != std::end(_vmaList)) {

--- a/src/sim/mem_state.hh
+++ b/src/sim/mem_state.hh
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <functional>
 #include <list>
 #include <memory>
 #include <string>
@@ -114,6 +115,25 @@ class MemState : public Serializable
      * @return true if all pages in the range are unmapped in page table
      */
     bool isUnmapped(Addr start_addr, Addr length);
+
+    /**
+     * Find the memory region containing a virtual address.
+     *
+     * @param vaddr Virtual address to look up.
+     *
+     * @return the VMA containing vaddr, or nullptr if vaddr is not mapped.
+     */
+    const VMA *getVMA(Addr vaddr) const;
+
+    /**
+     * Callback to invoke when a virtual address range is unmapped.
+     */
+    using UnmapCallback = std::function<void(Addr start_addr, Addr length)>;
+
+    /** Register the unmap callback. */
+    void
+    setUnmapCallback(UnmapCallback callback)
+    { _unmapCallback = std::move(callback); }
 
     /**
      * Add a new memory region. The region represents a contiguous virtual
@@ -290,6 +310,8 @@ class MemState : public Serializable
      * support this or the unmapping method must be changed.
      */
     std::list<VMA> _vmaList;
+
+    UnmapCallback _unmapCallback;
 };
 
 } // namespace gem5

--- a/src/sim/system.cc
+++ b/src/sim/system.cc
@@ -175,7 +175,7 @@ System::System(const Params &p)
       workload(p.workload),
       physmem(name() + ".physmem", p.memories, p.mmap_using_noreserve,
               p.shared_backstore, p.auto_unlink_shared_backstore,
-              p.is_sparse_restore),
+              p.is_sparse_restore, p.anonymous_shared_backstore),
       memoryMode(p.mem_mode),
       _cacheLineSize(p.cache_line_size),
       numWorkIds(p.num_work_ids),

--- a/src/sim/vma.hh
+++ b/src/sim/vma.hh
@@ -104,7 +104,9 @@ class VMA
      */
     void sliceRegionLeft(Addr slice_addr);
 
-    const std::string& getName() { return _vmaName; }
+    const std::string &
+    getName() const
+    { return _vmaName; }
     off_t getFileMappingOffset() const
     {
         return hasHostBuf() ? _origHostBuf->getOffset() : 0;
@@ -113,9 +115,15 @@ class VMA
     /**
      * Defer AddrRange related calls to the AddrRange.
      */
-    Addr size() { return _addrRange.size(); }
-    Addr start() { return _addrRange.start(); }
-    Addr end() { return _addrRange.end(); }
+    Addr
+    size() const
+    { return _addrRange.size(); }
+    Addr
+    start() const
+    { return _addrRange.start(); }
+    Addr
+    end() const
+    { return _addrRange.end(); }
 
     bool
     mergesWith(const AddrRange& r) const

--- a/tests/gem5/pincpu_tests/ref/Bubblesort
+++ b/tests/gem5/pincpu_tests/ref/Bubblesort
@@ -1,0 +1,2 @@
+Global frequency set at 1000000000000 ticks per second
+-50000

--- a/tests/gem5/pincpu_tests/ref/Bubblesort_checkpoint
+++ b/tests/gem5/pincpu_tests/ref/Bubblesort_checkpoint
@@ -1,0 +1,3 @@
+Global frequency set at 1000000000000 ticks per second
+Writing checkpoint
+-50000

--- a/tests/gem5/pincpu_tests/ref/FloatMM
+++ b/tests/gem5/pincpu_tests/ref/FloatMM
@@ -1,0 +1,2 @@
+Global frequency set at 1000000000000 ticks per second
+-776.000061

--- a/tests/gem5/pincpu_tests/ref/FloatMM_checkpoint
+++ b/tests/gem5/pincpu_tests/ref/FloatMM_checkpoint
@@ -1,0 +1,3 @@
+Global frequency set at 1000000000000 ticks per second
+Writing checkpoint
+-776.000061

--- a/tests/gem5/pincpu_tests/run.py
+++ b/tests/gem5/pincpu_tests/run.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Run a static SE workload under X86PinCPU.
+
+Usage: run.py <binary> [--checkpoint-at INSTS]
+"""
+
+import argparse
+import os
+import sys
+
+import m5
+from m5.objects import (
+    AddrRange,
+    DDR3_1600_8x8,
+    MemCtrl,
+    Process,
+    Root,
+    SEWorkload,
+    SrcClockDomain,
+    System,
+    SystemXBar,
+    VoltageDomain,
+)
+from m5.objects.X86PinCPU import X86PinCPU
+
+parser = argparse.ArgumentParser()
+parser.add_argument("binary", help="Static binary to run")
+parser.add_argument(
+    "--checkpoint-at",
+    type=int,
+    default=None,
+    help="Take a checkpoint after this many instructions, then continue",
+)
+args = parser.parse_args()
+
+process = Process(pid=100)
+process.executable = args.binary
+process.cmd = [args.binary]
+process.cwd = os.getcwd()
+process.addrSpaceShift = -0x100000000000
+
+system = System(
+    cpu=[X86PinCPU(cpu_id=0)],
+    mem_mode=X86PinCPU.memory_mode(),
+    mem_ranges=[AddrRange("512MiB")],
+    cache_line_size=64,
+)
+
+# PinCPU requires a backing store shared with the Pin subprocess.
+# Make it anonymous so it auto-deletes on exit and does not
+# pollute the shared memory namespace.
+system.shared_backstore = "physmem"
+system.auto_unlink_shared_backstore = True
+system.anonymous_shared_backstore = True
+
+system.voltage_domain = VoltageDomain()
+system.clk_domain = SrcClockDomain(
+    clock="1GHz", voltage_domain=system.voltage_domain
+)
+system.membus = SystemXBar()
+system.system_port = system.membus.cpu_side_ports
+system.workload = SEWorkload.init_compatible(process.executable)
+
+cpu = system.cpu[0]
+cpu.clk_domain = system.clk_domain
+
+if args.checkpoint_at is not None:
+    cpu.countInsts = True
+cpu.workload = process
+cpu.createThreads()
+cpu.createInterruptController()
+
+# PinCPU does not use these, but gem5 still requires them to be connected.
+cpu.icache_port = system.membus.cpu_side_ports
+cpu.dcache_port = system.membus.cpu_side_ports
+cpu.interrupts[0].pio = system.membus.mem_side_ports
+cpu.interrupts[0].int_requestor = system.membus.cpu_side_ports
+cpu.interrupts[0].int_responder = system.membus.mem_side_ports
+
+system.mem_ctrl = MemCtrl()
+system.mem_ctrl.dram = DDR3_1600_8x8(range=system.mem_ranges[0])
+system.mem_ctrl.port = system.membus.mem_side_ports
+
+root = Root(full_system=False, system=system)
+m5.instantiate()
+
+WORKLOAD_DONE = "exiting with last active thread context"
+
+if args.checkpoint_at is not None:
+    # Need to initialize the Pin subprocess before
+    # we can issue commands, like 'breakpoint inst'.
+    m5.simulate(0)
+
+    cpu.executePinCommand(f"breakpoint inst {args.checkpoint_at}")
+    exit_cause = m5.simulate().getCause()
+    if exit_cause != "pin-breakpoint":
+        print(f"unexpected exit cause: {exit_cause}", file=sys.stderr)
+        sys.exit(1)
+
+    inst = int(cpu.executePinCommand("instcount"))
+    m5.checkpoint(os.path.join(m5.options.outdir, "cpt"))
+    print(f"pincpu: checkpointed at instruction {inst}", file=sys.stderr)
+
+exit_cause = m5.simulate().getCause()
+if exit_cause != WORKLOAD_DONE:
+    print(f"unexpected exit cause: {exit_cause}", file=sys.stderr)
+    sys.exit(1)

--- a/tests/gem5/pincpu_tests/test.py
+++ b/tests/gem5/pincpu_tests/test.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for X86PinCPU.
+
+These require gem5 to be built with USE_PIN=y and require Pin to be
+installed at ext/pin.
+"""
+
+from testlib import *
+
+workloads = ("Bubblesort", "FloatMM")
+
+base_path = joinpath(config.bin_path, "pincpu_tests")
+base_url = config.resource_url + "/test-progs/cpu-tests/bin/x86"
+
+for workload in workloads:
+    workload_binary = DownloadedProgram(
+        f"{base_url}/{workload}", base_path, workload
+    )
+    binary = joinpath(workload_binary.path, workload)
+    ref_path = joinpath(getcwd(), "ref", workload)
+
+    # Run the workload.
+    gem5_verify_config(
+        name=f"pincpu_se_{workload}",
+        verifiers=(verifier.MatchStdout(ref_path),),
+        fixtures=(workload_binary,),
+        config=joinpath(getcwd(), "run.py"),
+        config_args=[binary],
+        valid_isas=(constants.x86_tag,),
+        valid_hosts=(constants.host_x86_64_tag,),
+        length=constants.quick_tag,
+        uses_pin=True,
+    )
+
+    # Run the workload, but interrupt it to take a checkpoint.
+    checkpoint_ref_path = joinpath(getcwd(), "ref", f"{workload}_checkpoint")
+    gem5_verify_config(
+        name=f"pincpu_checkpoint_{workload}",
+        verifiers=(verifier.MatchStdout(checkpoint_ref_path),),
+        fixtures=(workload_binary,),
+        config=joinpath(getcwd(), "run.py"),
+        config_args=[binary, "--checkpoint-at", "20000"],
+        valid_isas=(constants.x86_tag,),
+        valid_hosts=(constants.host_x86_64_tag,),
+        length=constants.quick_tag,
+        uses_pin=True,
+    )

--- a/tests/gem5/suite.py
+++ b/tests/gem5/suite.py
@@ -71,6 +71,7 @@ def gem5_verify_config(
     valid_hosts=constants.supported_hosts,
     protocol=None,
     uses_kvm=False,
+    uses_pin=False,
 ):
     """
     Helper class to generate common gem5 tests using verifiers.
@@ -99,6 +100,8 @@ def gem5_verify_config(
 
     :param uses_kvm: States if this verifier uses KVM. If so, the "kvm" tag
         will be included.
+    :param uses_pin: States if this test uses Intel Pin. If so, the "pin"
+        tag will be included.
     """
     fixtures = list(fixtures)
     testsuites = []
@@ -137,6 +140,9 @@ def gem5_verify_config(
 
                 if uses_kvm:
                     tags.append(constants.kvm_tag)
+
+                if uses_pin:
+                    tags.append(constants.pin_tag)
 
                 # Create the gem5 target for the specific architecture and
                 # variant.

--- a/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
+++ b/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile
@@ -73,3 +73,14 @@ RUN apt -y update && apt -y upgrade && apt -y install \
 # as it's a directory any user can access and write to. Given this only stores
 # caching information, the "/tmp" directory being wiped is not a concern.
 ENV XDG_CACHE_HOME=/tmp/
+
+# Install Intel Pin (optional) on x86-64 hosts, as it is required to build
+# and test the PinCPU model.
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        mkdir -p /opt/pin && \
+        wget -qO- https://software.intel.com/sites/landingpage/pintool/downloads/pin-external-3.31-98869-gfa6f126a8-gcc-linux.tar.gz \
+        | tar -C /opt/pin -x --gzip --strip-components=1 && \
+        test -f /opt/pin/pin;
+    fi
+ENV PIN_DIR=/opt/pin

--- a/util/pincpu/SConscript
+++ b/util/pincpu/SConscript
@@ -1,0 +1,167 @@
+# -*- mode:python -*-
+
+# Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+# Junior University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+Import('*')
+
+src_dir = Dir('.').srcnode().abspath
+pin_dir = env['CONF']['PIN_DIR']
+
+########################################################################
+#
+# The guest program: a freestanding program that Pin runs as its
+# application, and which gem5 steers via the message protocol in
+# arch/x86/pin/message.h.
+#
+
+guest_linker_script = os.path.join(src_dir, 'guest', 'guest.ld')
+
+# FIXME: Should just create a new environment from scratch, instead.
+guest_env = env.Clone()
+# FIXME: Re-enable -O3 optimizations.
+guest_env['CFLAGS'] = [
+    '-ffreestanding', '-fPIC', '-Wall', '-pedantic', '-O1',
+    '-fcf-protection=none',
+]
+guest_env.Append(CPPPATH=[src_dir])
+guest_env['LINKFLAGS'] = [
+    '-nostdlib', '-Wl,-e,main', '-static', '-T', guest_linker_script,
+    '-Wl,--no-relax',
+]
+guest_env['LIBS'] = []
+
+guest_exe = guest_env.Program(
+    target='guest.elf',
+    source=[
+        'guest/guest.c',
+        'guest/printf.c',
+        'guest/syscall.c',
+        'guest/ops.c',
+    ],
+    tags='pin',
+)
+guest_env.Depends(guest_exe, guest_linker_script)
+
+########################################################################
+#
+# The pintool that gem5 forks Pin with.
+#
+
+pintool_system_include_dirs = [
+    'extras/cxx/include',
+    'extras/crt/include',
+    'extras/crt/include/arch-x86_64',
+    'extras/crt/include/kernel/uapi',
+    'extras/crt/include/kernel/uapi/asm-x86',
+]
+pintool_include_dirs = [
+    'source/include/pin',
+    'source/include/pin/gen',
+    'extras/components/include',
+    'extras/xed-intel64/include/xed',
+]
+pintool_cxxflags = [
+    # FIXME: Re-enable both of these.
+    # -Wall
+    '-Wno-cast-function-type',
+    '-Wno-unknown-pragmas',
+    '-fno-stack-protector',
+    '-fno-exceptions',
+    '-funwind-tables',
+    '-fasynchronous-unwind-tables',
+    '-fno-rtti',
+    '-fPIC',
+    '-fabi-version=2',
+    '-faligned-new',
+    '-O3',
+    '-fomit-frame-pointer',
+    '-fno-strict-aliasing',
+    '-Wno-dangling-pointer',
+    '-g',
+]
+for sysinc in pintool_system_include_dirs:
+    pintool_cxxflags.extend(['-isystem', os.path.join(pin_dir, sysinc)])
+
+pintool_env = env.Clone()
+# TODO: Try extending?
+pintool_env.Append(CXXFLAGS=pintool_cxxflags)
+pintool_env.Append(CPPPATH=[src_dir])
+pintool_env.Append(CPPPATH=[os.path.join(pin_dir, inc)
+                           for inc in pintool_include_dirs])
+pintool_env.Append(CPPDEFINES={
+    'PIN_CRT': 1,
+    'TARGET_IA32E': None,
+    'HOST_IA32E': None,
+    'TARGET_LINUX': None,
+})
+pintool_env['LINKFLAGS'] = [
+    '-Wl,--hash-style=sysv',
+    '-Wl,-Bsymbolic',
+    f'-Wl,--version-script={pin_dir}/source/include/pin/pintool.ver',
+    '-fabi-version=2',
+    '-nostdlib',
+    '-fPIC',
+    os.path.join(pin_dir, 'intel64/runtime/pincrt/crtbeginS.o'),
+    os.path.join(pin_dir, 'intel64/runtime/pincrt/crtendS.o'),
+]
+pintool_libpaths = [
+    'intel64/runtime/pincrt',
+    'intel64/lib',
+    'intel64/lib-ext',
+    'extras/xed-intel64/lib',
+]
+pintool_env['LIBPATH'] = [os.path.join(pin_dir, libdir)
+                         for libdir in pintool_libpaths]
+pintool_env['LIBS'] = [
+    'pin',
+    'xed',
+    'pindwarf',
+    'dl-dynamic',
+    'c++',
+    'c++abi',
+    'm-dynamic',
+    'c-dynamic',
+    'unwind-dynamic',
+]
+
+pintool_pintool = pintool_env.SharedLibrary(
+    target='pintool',
+    source=[
+        'pintool.cc',
+        'plugin.cc',
+        'plugins/instcount.cc',
+        'plugins/breakpoint.cc',
+        'plugins/bbhist.cc',
+        'plugins/sysbreak.cc',
+    ],
+    tags='pin',
+)
+
+Return('guest_exe', 'pintool_pintool')

--- a/util/pincpu/debug.hh
+++ b/util/pincpu/debug.hh
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_DEBUG_HH__
+#define __UTIL_PINCPU_DEBUG_HH__
+
+#include <iostream>
+
+#define ENABLE_DEBUGGING 0
+
+#if ENABLE_DEBUGGING
+#define DEBUG(...)                                                            \
+    do {                                                                      \
+        __VA_ARGS__;                                                          \
+    } while (0)
+#else
+#define DEBUG(...)                                                            \
+    do {                                                                      \
+    } while (0)
+#endif
+
+#if ENABLE_DEBUGGING
+static inline std::ostream &
+dbgs()
+{ return std::cerr; }
+#else
+struct DummyPrinter
+{
+};
+
+static inline DummyPrinter
+dbgs()
+{ return DummyPrinter(); }
+
+template <typename T>
+DummyPrinter
+operator<<(DummyPrinter, const T &)
+{ return DummyPrinter(); }
+
+static inline DummyPrinter
+operator<<(DummyPrinter, std::ostream &(*)(std::ostream &))
+{ return DummyPrinter(); }
+
+static inline DummyPrinter
+operator<<(DummyPrinter, std::ios_base &(*)(std::ios_base &))
+{ return DummyPrinter(); }
+#endif
+
+#endif // __UTIL_PINCPU_DEBUG_HH__

--- a/util/pincpu/guest/guest.c
+++ b/util/pincpu/guest/guest.c
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <asm/prctl.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+
+#define STDERR_FILENO 2
+#define ENOMEM 12
+#define EEXIST 17
+
+#include "arch/x86/pin/message.h"
+#include "ops.h"
+#include "printf.h"
+#include "syscall.h"
+
+#ifdef printf
+#undef printf
+#endif
+#define printf(...)                                                           \
+    do {                                                                      \
+    } while (0)
+
+#define err(fmt, ...)                                                         \
+    do {                                                                      \
+        printf_("error: " fmt " (%d)\n" __VA_OPT__(, ) __VA_ARGS__, errno);   \
+    } while (0)
+
+// FIXME: Virtual
+#define vsyscall_base 0xffffffffff600000ULL
+#define vsyscall_end (vsyscall_base + 0x1000)
+
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+
+static void __attribute__((unused))
+do_assert_failure(const char *file, int line, const char *desc)
+{ printf_("%s:%d: assertion failed: %s\n", file, line, desc); }
+
+#define assert(pred)                                                          \
+    do {                                                                      \
+        if (!(pred))                                                          \
+            do_assert_failure(__FILE__, __LINE__, #pred);                     \
+    } while (false)
+
+static int req_fd;
+static int resp_fd;
+static int mem_fd;
+
+typedef struct Message Message;
+
+static void
+diagnose_ENOMEM(void)
+{
+    // Read /proc/self/maps.
+    int maps_fd;
+    if ((maps_fd = open("/proc/self/maps", O_RDONLY)) < 0) {
+        err("open: /proc/self/maps");
+        return;
+    }
+
+    // Count the number of maps present.
+    int num_maps = 0;
+    while (true) {
+        char c;
+        ssize_t bytes_read = read(maps_fd, &c, 1);
+        if (bytes_read < 0) {
+            err("read: /proc/self/maps");
+            return;
+        }
+        if (bytes_read == 0) {
+            break;
+        }
+        printf_("%c", c);
+        if (c == '\n') {
+            ++num_maps;
+        }
+    }
+
+    printf_("ENOMEM: num maps: %d\n", num_maps);
+}
+
+void
+read_all(int fd, void *data_, size_t size)
+{
+    char *data = (char *)data_;
+    while (size) {
+        const ssize_t bytes_read = read(fd, data, size);
+        if (bytes_read < 0) {
+            err("read");
+            pinop_abort();
+        }
+        data += bytes_read;
+        size -= bytes_read;
+    }
+}
+
+void
+write_all(int fd, const void *data_, size_t size)
+{
+    const char *data = (const char *)data_;
+    while (size) {
+        const ssize_t bytes_written = write(fd, data, size);
+        if (bytes_written < 0) {
+            err("write");
+            pinop_abort();
+        }
+        data += bytes_written;
+        size -= bytes_written;
+    }
+}
+
+void
+_putchar(char c)
+{ write(STDERR_FILENO, &c, 1); }
+
+void
+msg_read(Message *msg)
+{
+    printf("GUEST: reading request\n");
+    read_all(req_fd, msg, sizeof *msg);
+    printf("GUEST: read request\n");
+}
+
+void
+msg_write(const Message *msg)
+{ write_all(resp_fd, msg, sizeof *msg); }
+
+void
+main_event_loop(void)
+{
+    while (true) {
+        Message msg;
+        msg_read(&msg);
+
+        switch (msg.type) {
+            case Ack:
+                msg_write(&msg);
+                break;
+
+            case Map: {
+                // Check if vsyscall. This is special case.
+                bool is_vsyscall = false;
+                if (msg.map.vaddr == vsyscall_base) {
+                    printf("GUEST: fixing up vsyscall mapping 0x%" PRIx64
+                           "->0x%" PRIx64 "\n",
+                           msg.map.vaddr, msg.map.paddr);
+                    msg.map.vaddr = 0xcafebabe000;
+                    is_vsyscall = true;
+                }
+
+                // printf_("mapping page: %p->%p 0x%lx\n", (void *)
+                // msg.map.vaddr, (void *) msg.map.paddr, msg.map.size);
+                // MAP_FIXED_NOREPLACE rather than MAP_FIXED: the guest's
+                // address space shares this process with Pin, and MAP_FIXED
+                // would silently unmap whatever it landed on. A conflict here
+                // means the guest range overlaps Pin's own memory, which
+                // otherwise corrupts Pin and surfaces much later as an
+                // unrelated crash inside its code cache.
+                void *map;
+                if ((map = mmap((void *)msg.map.vaddr, msg.map.size,
+                                msg.map.prot, MAP_SHARED | MAP_FIXED_NOREPLACE,
+                                mem_fd, msg.map.paddr)) == MAP_FAILED) {
+                    if (errno == EEXIST) {
+                        printf_("error: guest mapping at %p (size %zu) "
+                                "overlaps memory already in use by Pin\n",
+                                (void *)msg.map.vaddr, msg.map.size);
+                    }
+                    err("mmap failed: vaddr=%p size=%zu paddr=%p",
+                        (void *)msg.map.vaddr, msg.map.size,
+                        (void *)msg.map.paddr);
+                    if (errno == ENOMEM) {
+                        diagnose_ENOMEM();
+                    }
+                    pinop_abort();
+                }
+                if (map != (void *)msg.map.vaddr) {
+                    printf_("error: mmap mapped wrong address\n");
+                    pinop_abort();
+                }
+                printf_("mapped page: %p->%p %p\n", (void *)msg.map.vaddr,
+                        (void *)msg.map.paddr, (void *)msg.map.size);
+                // printf_("first byte: %02hhx\n", * (uint8_t *) map);
+                if (is_vsyscall) {
+                    pinop_set_vsyscall_base((void *)vsyscall_base, map);
+                }
+                msg.type = Ack;
+                msg_write(&msg);
+            } break;
+
+            case Unmap: {
+                if (munmap((void *)msg.map.vaddr, msg.map.size) < 0) {
+                    printf_("error: munmap failed (%d): vaddr=%p "
+                            "size=0x%" PRIx64 "\n",
+                            errno, (void *)msg.map.vaddr, msg.map.size);
+                    pinop_abort();
+                }
+                printf_("unmapped page: %p\n", (void *)msg.map.vaddr);
+                msg.type = Ack;
+                msg_write(&msg);
+            } break;
+
+            case Run: {
+                printf("GUEST handling RUN request\n");
+                struct RunResult result;
+                pinop_run(&result);
+                Message msg;
+                msg.inst_count = pinop_get_instcount();
+                switch (result.result) {
+                    case RUNRESULT_PAGEFAULT:
+                        // Send this up to gem5.
+                        printf("GUEST: got page fault: %" PRIx64 "\n",
+                               result.addr);
+                        msg.type = PageFault;
+                        msg.faultaddr = result.addr;
+                        break;
+
+                    case RUNRESULT_SYSCALL:
+                        // Send this up to gem5.
+                        msg.type = Syscall;
+                        break;
+
+                    case RUNRESULT_CPUID:
+                        // Send up to gem5.
+                        msg.type = Cpuid;
+                        break;
+
+                    case RUNRESULT_BREAK:
+                        // Send up to gem5.
+                        msg.type = Break;
+                        break;
+
+                    default:
+                        printf_("GUEST ERROR: unhandled run result: %d\n",
+                                result.result);
+                        pinop_abort();
+                }
+
+                msg_write(&msg);
+            } break;
+
+            case SetRegs:
+                pinop_set_regs(&msg.regfile);
+                msg.type = Ack;
+                msg_write(&msg);
+                break;
+
+            case GetRegs:
+                pinop_get_regs(&msg.regfile);
+                msg.type = SetRegs;
+                msg_write(&msg);
+                break;
+
+            case Exit:
+                exit(0);
+
+            case AddSymbol:
+                pinop_add_symbol(msg.symbol.name, (void *)msg.symbol.vaddr);
+                msg.type = Ack;
+                msg_write(&msg);
+                break;
+
+            case ExecCommand: {
+                const size_t bytes = pinop_exec_command(msg.command);
+                msg.type = CommandResult;
+                msg.command_result_size = bytes;
+                msg_write(&msg);
+
+                // TODO: Should just send null-terminated string, once we use
+                // buffered files on the gem5 end.
+                for (size_t i = 0; i != bytes;) {
+                    char buf[1024];
+                    const size_t chunk = min(bytes - i, sizeof buf);
+                    pinop_read_command_result(buf, i, chunk);
+                    write_all(resp_fd, buf, chunk);
+                    i += chunk;
+                }
+            } break;
+
+            default:
+                printf_("error: bad message type (%d)\n", msg.type);
+                pinop_abort();
+        }
+
+        // printf("GUEST: handled message, going on to next iteration\n");
+    }
+}
+
+void main2(void);
+void switch_stacks(void *new_stack, void (*f)(void));
+void
+main(void)
+{
+    // Switch stacks.
+    printf_("Switching stacks...\n");
+    const uint64_t stack_base = 0xcafe0000000;
+    const uint64_t stack_size = 0x1000 * 32;
+    void *stack;
+    if ((stack = mmap((void *)stack_base, stack_size, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANON, -1, 0)) == MAP_FAILED) {
+        printf_("error: failed to map stack (errno=%d)\n", errno);
+        pinop_abort();
+    }
+    switch_stacks((uint8_t *)stack + stack_size, main2);
+}
+
+__attribute__((naked)) void
+switch_stacks(void *new_stack, void (*f)(void))
+{
+    asm volatile("mov %rsp, -8(%rdi)\n" // Save old stack.
+                 "mov %rdi, %rsp\n"     // Set to new stack.
+                 "sub $8, %rsp\n"
+                 "call *%rsi\n"
+                 "mov (%rsp), %rsp\n"
+                 "ret\n");
+}
+
+void
+main2(void)
+{
+    char path[256];
+    printf("GUEST: starting up\n");
+
+    // Open request file.
+    pinop_get_reqpath(path, sizeof path);
+    if ((req_fd = open(path, O_RDONLY)) < 0) {
+        printf("error: open failed: %s (%d)\n", path, errno);
+        pinop_abort();
+    }
+
+    printf("GUEST: opened request file\n");
+
+    // Open response file.
+    pinop_get_resppath(path, sizeof path);
+    if ((resp_fd = open(path, O_WRONLY)) < 0) {
+        err("open: %s", path);
+        pinop_abort();
+    }
+
+    // Open physmem file.
+    char mem_path[256];
+    pinop_get_mempath(mem_path, sizeof mem_path);
+    if ((mem_fd = open(mem_path, O_RDWR)) < 0) {
+        err("open: %s", mem_path);
+        pinop_abort();
+    }
+
+    // Initialize user context.
+    pinop_resetuser();
+
+    main_event_loop();
+
+    pinop_exit(0);
+}

--- a/util/pincpu/guest/guest.ld
+++ b/util/pincpu/guest/guest.ld
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Split the image into separate segments so that no LOAD segment ends up
+ * writable and executable at once. Without explicit PHDRS the linker merges
+ * everything into one RWX segment, which modern binutils warns about.
+ */
+PHDRS
+{
+    text   PT_LOAD FLAGS(5); /* R E */
+    rodata PT_LOAD FLAGS(4); /* R   */
+    data   PT_LOAD FLAGS(6); /* RW  */
+}
+
+SECTIONS
+{
+    . = 0xdead0000000;
+
+    .text : { *(.text .text.*) } :text
+
+    /* Segments need their own pages to carry distinct permissions. */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    .rodata            : { *(.rodata .rodata.*) }  :rodata
+    .eh_frame          : { *(.eh_frame) }          :rodata
+    .note.gnu.property : { *(.note.gnu.property) } :rodata
+    .note.gnu.build-id : { *(.note.gnu.build-id) } :rodata
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    .got     : { *(.got) }                 :data
+    .got.plt : { *(.got.plt) }             :data
+    .data    : { *(.data .data.*) }        :data
+    .bss     : { *(.bss .bss.*) *(COMMON) } :data
+}

--- a/util/pincpu/guest/ops.c
+++ b/util/pincpu/guest/ops.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ops.h"
+
+// TODO: macro for defining these, since they are all basically the same.
+
+void __attribute__((naked))
+pinop_get_reqpath(char *data, size_t size)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_GET_REQPATH));
+}
+
+void __attribute__((naked))
+pinop_get_resppath(char *data, size_t size)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_GET_RESPPATH));
+}
+
+void __attribute__((naked))
+pinop_get_mempath(char *data, size_t size)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_GET_MEMPATH));
+}
+
+void __attribute__((naked))
+pinop_exit(int code)
+{ asm volatile("movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_EXIT)); }
+
+void __attribute__((naked)) (pinop_abort)(const char *msg, size_t line)
+{
+    asm volatile("movq (%%rsp), %%rdx\n"
+                 "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_ABORT));
+}
+
+void __attribute__((naked))
+pinop_resetuser()
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_RESETUSER));
+}
+
+void __attribute__((naked))
+pinop_run(struct RunResult *result)
+{ asm volatile("movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_RUN)); }
+
+void __attribute__((naked))
+pinop_set_vsyscall_base(void *virt, void *phys)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_SET_VSYSCALL_BASE));
+}
+
+uint64_t __attribute__((naked))
+pinop_get_instcount(void)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_GET_INSTCOUNT));
+}
+
+void __attribute__((naked))
+pinop_set_regs(const struct PinRegFile *regfile)
+{ asm volatile("movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_SET_REGS)); }
+
+void __attribute__((naked))
+pinop_get_regs(struct PinRegFile *regfile)
+{ asm volatile("movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_GET_REGS)); }
+
+void __attribute__((naked))
+pinop_add_symbol(const char *name, void *vaddr)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_ADD_SYMBOL));
+}
+
+size_t __attribute__((naked))
+pinop_exec_command(const char *cmd)
+{
+    asm volatile(
+        "movb $0, (%0)\nret\n" ::"r"(pinops_addr_base + OP_EXEC_COMMAND));
+}
+
+void __attribute__((naked))
+pinop_read_command_result(char *buf, size_t idx, size_t size)
+{
+    asm volatile("movb $0, (%0)\nret\n" ::"r"(pinops_addr_base +
+                                              OP_READ_COMMAND_RESULT));
+}

--- a/util/pincpu/guest/printf.c
+++ b/util/pincpu/guest/printf.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "printf.h"
+
+/* Width of the integer argument, selected by the length modifier. */
+enum length
+{
+    LEN_INT,
+    LEN_CHAR, /* hh */
+    LEN_LONG, /* l  */
+    LEN_SIZE, /* z  */
+};
+
+static void
+emit(char c, int *count)
+{
+    _putchar(c);
+    *count += 1;
+}
+
+/*
+ * Render an integer in the given base, zero padded to `width` digits. Digits
+ * are generated least significant first and replayed in reverse, which avoids
+ * needing to find the leading digit up front.
+ */
+static void
+emit_uint(uintmax_t value, unsigned base, bool upper, unsigned width,
+          int *count)
+{
+    const char *const digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
+    char buf[20];
+    unsigned len = 0;
+
+    do {
+        buf[len++] = digits[value % base];
+        value /= base;
+    } while (value != 0 && len < sizeof buf);
+
+    while (width > len) {
+        emit('0', count);
+        --width;
+    }
+    while (len > 0) {
+        emit(buf[--len], count);
+    }
+}
+
+/*
+ * Fetch the next integer argument. Returns its magnitude, setting *negative
+ * for signed conversions of negative values.
+ */
+static uintmax_t
+next_int(va_list *va, enum length len, bool is_signed, bool *negative)
+{
+    *negative = false;
+
+    if (!is_signed) {
+        switch (len) {
+            case LEN_CHAR:
+                return (unsigned char)va_arg(*va, unsigned int);
+            case LEN_LONG:
+                return va_arg(*va, unsigned long);
+            case LEN_SIZE:
+                return va_arg(*va, size_t);
+            default:
+                return va_arg(*va, unsigned int);
+        }
+    }
+
+    intmax_t value;
+    switch (len) {
+        case LEN_CHAR:
+            value = (signed char)va_arg(*va, int);
+            break;
+        case LEN_LONG:
+            value = va_arg(*va, long);
+            break;
+        case LEN_SIZE:
+            value = va_arg(*va, ptrdiff_t);
+            break;
+        default:
+            value = va_arg(*va, int);
+            break;
+    }
+
+    *negative = value < 0;
+    /* Negate in the unsigned domain so INTMAX_MIN survives. */
+    return *negative ? -(uintmax_t)value : (uintmax_t)value;
+}
+
+int
+printf_(const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+
+    int count = 0;
+
+    for (const char *p = format; *p != '\0'; ++p) {
+        if (*p != '%') {
+            emit(*p, &count);
+            continue;
+        }
+        if (*++p == '\0') {
+            break;
+        }
+
+        /* Zero padded field width, as in %02hhx. */
+        unsigned width = 0;
+        if (*p == '0') {
+            ++p;
+        }
+        while (*p >= '0' && *p <= '9') {
+            width = width * 10 + (unsigned)(*p++ - '0');
+        }
+
+        enum length len = LEN_INT;
+        if (p[0] == 'h' && p[1] == 'h') {
+            p += 2;
+            len = LEN_CHAR;
+        } else if (*p == 'l') {
+            ++p;
+            len = LEN_LONG;
+        } else if (*p == 'z') {
+            ++p;
+            len = LEN_SIZE;
+        }
+
+        bool negative;
+        switch (*p) {
+            case 'd': {
+                const uintmax_t magnitude =
+                    next_int(&va, len, true, &negative);
+                if (negative) {
+                    emit('-', &count);
+                }
+                emit_uint(magnitude, 10, false, width, &count);
+                break;
+            }
+
+            case 'u':
+                emit_uint(next_int(&va, len, false, &negative), 10, false,
+                          width, &count);
+                break;
+
+            case 'x':
+                emit_uint(next_int(&va, len, false, &negative), 16, false,
+                          width, &count);
+                break;
+
+            case 'p':
+                /* Pointers print as zero padded uppercase hex, with no 0x. */
+                emit_uint((uintptr_t)va_arg(va, void *), 16, true,
+                          sizeof(void *) * 2, &count);
+                break;
+
+            case 'c':
+                emit((char)va_arg(va, int), &count);
+                break;
+
+            case 's': {
+                const char *s = va_arg(va, const char *);
+                if (s == NULL) {
+                    s = "(null)";
+                }
+                while (*s != '\0') {
+                    emit(*s++, &count);
+                }
+                break;
+            }
+
+            default:
+                /* Unsupported conversion: echo it so the mistake is visible.
+                 */
+                emit('%', &count);
+                emit(*p, &count);
+                break;
+        }
+    }
+
+    va_end(va);
+    return count;
+}

--- a/util/pincpu/guest/printf.h
+++ b/util/pincpu/guest/printf.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_GUEST_PRINTF_H__
+#define __UTIL_PINCPU_GUEST_PRINTF_H__
+
+/** Emit a single character. Supplied by the guest. */
+void _putchar(char character);
+
+/** Format to _putchar(). Returns the number of characters written. */
+int printf_(const char *format, ...) __attribute__((format(printf, 1, 2)));
+
+#define printf printf_
+
+#endif // __UTIL_PINCPU_GUEST_PRINTF_H__

--- a/util/pincpu/guest/syscall.c
+++ b/util/pincpu/guest/syscall.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+
+#include "syscall.h"
+
+#ifdef errno
+#undef errno
+#endif
+
+int errno;
+
+static inline int64_t
+set_errno_int(int64_t result)
+{
+    if (result >= -4096 && result < 0) {
+        errno = -result;
+        return -1;
+    } else {
+        return result;
+    }
+}
+
+static inline void *
+set_errno_ptr(void *value)
+{ return (void *)set_errno_int((intptr_t)value); }
+
+#define set_errno(result)                                                     \
+    _Generic((result), void *: set_errno_ptr, default: set_errno_int)(result)
+
+void
+exit(int code)
+{
+    asm volatile("movl %0, %%eax\n"
+                 "movl %1, %%edi\n"
+                 "syscall\n"
+                 "ud2\n" ::"i"(SYS_exit),
+                 "r"(code));
+    __builtin_unreachable();
+}
+
+ssize_t
+write(int fd, const void *data, size_t size)
+{
+    ssize_t result;
+    asm volatile("movl %1, %%eax\n"
+                 "movl %2, %%edi\n"
+                 "movq %3, %%rsi\n"
+                 "movq %4, %%rdx\n"
+                 "syscall\n"
+                 : "=a"(result)
+                 : "i"(SYS_write), "r"(fd), "r"(data), "r"(size));
+    return set_errno(result);
+}
+
+ssize_t
+read(int fd, void *data, size_t size)
+{
+    ssize_t result;
+    asm volatile("movl %1, %%eax\n"
+                 "movl %2, %%edi\n"
+                 "movq %3, %%rsi\n"
+                 "movq %4, %%rdx\n"
+                 "syscall\n"
+                 : "=a"(result)
+                 : "i"(SYS_read), "r"(fd), "r"(data), "r"(size));
+    return set_errno(result);
+}
+
+int
+open(const char *path, int flags, ...)
+{
+    int result;
+    asm volatile("movl %1, %%eax\n"
+                 "movq %2, %%rdi\n"
+                 "movl %3, %%esi\n"
+                 "syscall\n"
+                 : "=a"(result)
+                 : "i"(SYS_open), "r"(path), "r"(flags));
+    return set_errno(result);
+}
+
+void *
+mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
+    void *result;
+    asm volatile("movl %1, %%eax\n"
+                 "movq %2, %%rdi\n"
+                 "movq %3, %%rsi\n"
+                 "movl %4, %%edx\n"
+                 "movl %5, %%r10d\n"
+                 "movl %6, %%r8d\n"
+                 "movq %7, %%r9\n"
+                 "syscall\n"
+                 : "=a"(result)
+                 : "i"(SYS_mmap), "r"(addr), "r"(length), "r"(prot),
+                   "r"(flags), "r"(fd), "r"(offset));
+    return set_errno(result);
+}
+
+int
+munmap(void *addr, size_t length)
+{
+    int result;
+    asm volatile("movl %1, %%eax\n"
+                 "movq %2, %%rdi\n"
+                 "movq %3, %%rsi\n"
+                 "syscall\n"
+                 : "=a"(result)
+                 : "i"(SYS_munmap), "r"(addr), "r"(length));
+    return set_errno(result);
+}
+
+int
+arch_prctl(int code, unsigned long addr)
+{
+    int result;
+    asm volatile("movl %1, %%eax\n"
+                 "movl %2, %%edi\n"
+                 "movq %3, %%rsi\n"
+                 : "=a"(result)
+                 : "i"(SYS_arch_prctl), "r"(code), "r"(addr));
+    return set_errno(result);
+}

--- a/util/pincpu/guest/syscall.h
+++ b/util/pincpu/guest/syscall.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_GUEST_SYSCALL_H__
+#define __UTIL_PINCPU_GUEST_SYSCALL_H__
+
+#include <stddef.h>
+#include <sys/types.h>
+
+void __attribute__((noreturn)) exit(int code);
+ssize_t write(int fd, const void *data, size_t size);
+ssize_t read(int fd, void *data, size_t size);
+int open(const char *path, int flags, ...);
+void *mmap(void *addr, size_t length, int prot, int flags, int fd,
+           off_t offset);
+int munmap(void *addr, size_t length);
+int arch_prctl(int code, unsigned long addr);
+
+extern int errno;
+
+#endif // __UTIL_PINCPU_GUEST_SYSCALL_H__

--- a/util/pincpu/ops.h
+++ b/util/pincpu/ops.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_OPS_H__
+#define __UTIL_PINCPU_OPS_H__
+
+#ifdef __cplusplus
+#include <cstdint>
+
+#else
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#endif
+
+enum PinOp
+{
+    OP_GET_REQPATH,
+    OP_GET_RESPPATH,
+    OP_GET_MEMPATH,
+    OP_ABORT,
+    OP_EXIT,
+    OP_RUN,
+    OP_RESETUSER,
+    OP_SET_VSYSCALL_BASE,
+    OP_GET_INSTCOUNT,
+    OP_SET_REGS,
+    OP_GET_REGS,
+    OP_ADD_SYMBOL,
+    OP_EXEC_COMMAND,
+    OP_READ_COMMAND_RESULT,
+    OP_COUNT,
+};
+
+#define pinops_addr_base ((uint64_t)0xbaddecaf << 12)
+#define pinops_addr_end (pinops_addr_base + OP_COUNT)
+
+static inline bool
+is_pinop_addr(void *p)
+{
+    const uintptr_t s = (uintptr_t)p;
+    return pinops_addr_base <= s && s < pinops_addr_end;
+}
+
+// TODO: Need utility functions for setting this from pintool.
+struct RunResult
+{
+    enum RunResultType
+    {
+        RUNRESULT_PAGEFAULT,
+        RUNRESULT_SYSCALL,
+        RUNRESULT_CPUID,
+        RUNRESULT_BREAK,
+        RUNRESULT_INSTCOUNT,
+    } result;
+    union
+    {
+        uint64_t addr; // RUNRESULT_PAGEFAULT
+    };
+};
+
+// TODO: Only declare these in guest, not pintool.
+void pinop_get_reqpath(char *data, size_t size);
+void pinop_get_resppath(char *data, size_t size);
+void pinop_get_mempath(char *data, size_t size);
+void pinop_exit(int code);
+void pinop_abort(const char *msg, size_t line);
+void pinop_resetuser(void);
+void pinop_run(struct RunResult *result);
+void pinop_set_vsyscall_base(void *virt, void *phys);
+uint64_t pinop_get_instcount(void);
+
+struct PinRegFile;
+void pinop_set_regs(const struct PinRegFile *regfile);
+void pinop_get_regs(struct PinRegFile *regfile);
+
+void pinop_add_symbol(const char *name, void *vaddr);
+
+/// Returns the number of bytes in the command result.
+size_t pinop_exec_command(const char *s);
+void pinop_read_command_result(char *buf, size_t idx, size_t size);
+
+#define pinop_abort() (pinop_abort)(__FILE__, __LINE__)
+
+#endif // __UTIL_PINCPU_OPS_H__

--- a/util/pincpu/pintool.cc
+++ b/util/pincpu/pintool.cc
@@ -1,0 +1,956 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#include <unordered_map>
+
+#pragma GCC diagnostic pop
+#include <cstdint>
+#include <unordered_set>
+
+#include "arch/x86/pin/regfile.h"
+#include "debug.hh"
+#include "ops.h"
+
+#include "pin.H"
+#include "plugin.hh"
+
+static const char *prog;
+static KNOB<std::string> log_path(KNOB_MODE_WRITEONCE, "pintool", "log", "",
+                                  "specify path to log file");
+static std::ofstream log_;
+static KNOB<std::string> req_path(KNOB_MODE_WRITEONCE, "pintool", "req_path",
+                                  "",
+                                  "specify path to CPU communciation FIFO");
+static KNOB<std::string> resp_path(KNOB_MODE_WRITEONCE, "pintool", "resp_path",
+                                   "", "specify path to response FIFO");
+static KNOB<std::string> mem_path(KNOB_MODE_WRITEONCE, "pintool", "mem_path",
+                                  "", "specify path to physmem file");
+static KNOB<bool> enable_inst_count(KNOB_MODE_WRITEONCE, "pintool",
+                                    "inst_count", "1",
+                                    "enable instruction counting");
+static KNOB<bool> enable_trace(KNOB_MODE_WRITEONCE, "pintool", "trace", "0",
+                               "enable instruction tracing");
+
+static CONTEXT user_ctx;
+static CONTEXT saved_guest_ctx;
+static std::unordered_set<ADDRINT> guest_pages;
+static ADDRINT virtual_vsyscall_base = 0;
+static ADDRINT physical_vsyscall_base = 0;
+static uint64_t inst_count = 0;
+static std::unordered_map<ADDRINT, std::string> symbol_table;
+
+static uint64_t pinops_count = 0;
+
+#define EXTRA_SAFE_AND_SLOW 0
+
+static void CopyOutRunResult(CONTEXT *ctx, const RunResult &result);
+
+std::ofstream &
+log()
+{ return log_; }
+
+static ADDRINT
+getpage(ADDRINT addr)
+{ return addr & ~(ADDRINT)0xFFF; }
+
+void
+ContextSwitchToGuest(CONTEXT *ctx, RunResult result)
+{
+    // Save the user context.
+    PIN_SaveContext(ctx, &user_ctx);
+
+    // Swap in the guest context.
+    PIN_SaveContext(&saved_guest_ctx, ctx);
+
+    // Set the return value.
+    CopyOutRunResult(ctx, result);
+
+#if EXTRA_SAFE_AND_SLOW
+    // TODO: Probably too conservative.
+    PIN_RemoveInstrumentation();
+#endif
+}
+
+bool
+IsGuestCode(ADDRINT pc)
+{
+    // FIXME: Don't hard-code.
+    if (getpage(pc) == 0xdead0000000ULL) {
+        return true;
+    }
+    return guest_pages.count(getpage(pc)) != 0;
+}
+
+bool
+IsGuestCode(INS ins)
+{ return IsGuestCode(INS_Address(ins)); }
+
+bool
+IsGuestCode(TRACE trace)
+{ return IsGuestCode(TRACE_Address(trace)); }
+
+[[noreturn]] static void
+Abort()
+{
+    log_.close();
+    PIN_ExitApplication(1);
+}
+
+static std::string
+CopyUserString(ADDRINT addr)
+{
+    std::string s;
+    while (true) {
+        char c;
+        // TODO: Consider using PIN_SafeCopyEx.
+        if (PIN_SafeCopy(&c, (const void *)addr, 1) != 1) {
+            log_ << "error: failed to copy user string\n";
+            Abort();
+        }
+        if (c == '\0') {
+            break;
+        }
+        s.push_back(c);
+        ++addr;
+    }
+    return s;
+}
+
+static void
+CopyOutRunResult(CONTEXT *ctx, const RunResult &result)
+{
+    PIN_SafeCopy((RunResult *)PIN_GetContextReg(ctx, REG_RDI), &result,
+                 sizeof result);
+}
+
+static void
+HandleSyscall(CONTEXT *ctx, ADDRINT pc)
+{
+    dbgs() << "PINTOOL: handling syscall: 0x" << std::hex << pc
+           << ": number=" << std::dec << PIN_GetContextReg(ctx, REG_RAX)
+           << "\n";
+    assert(!IsGuestCode(pc));
+    PIN_SaveContext(ctx, &user_ctx);
+    PIN_SaveContext(&saved_guest_ctx, ctx);
+
+    // Update PC.
+    PIN_SetContextReg(&user_ctx, REG_RIP, pc);
+
+    // Run result is syscall.
+    RunResult result;
+    result.result = RunResult::RUNRESULT_SYSCALL;
+    CopyOutRunResult(ctx, result);
+    PIN_ExecuteAt(ctx);
+}
+
+static void
+HandleCPUID(CONTEXT *ctx, ADDRINT next_pc)
+{
+    dbgs() << "PINTOOL: handling cpuid: 0x" << std::hex << next_pc << "\n";
+
+    // TODO: Share with HandleSyscall.
+    assert(!IsGuestCode(next_pc));
+    PIN_SaveContext(ctx, &user_ctx);
+    PIN_SaveContext(&saved_guest_ctx, ctx);
+
+    // Update PC.
+    PIN_SetContextReg(&user_ctx, REG_RIP, next_pc);
+
+    // Run result is cpyid.
+    RunResult result;
+    result.result = RunResult::RUNRESULT_CPUID;
+    CopyOutRunResult(ctx, result);
+    PIN_ExecuteAt(ctx);
+}
+
+static ADDRINT
+HandleFSGSAccess(ADDRINT effaddr)
+{
+#if 0
+    dbgs() << "Translating FS/GS access: 0x" << effaddr << "\n";
+#endif
+    return effaddr;
+}
+
+static std::unordered_map<ADDRINT, PinOp> pinops_blacklist;
+
+static void
+HandleOp_RESETUSER(const CONTEXT *guest_ctx)
+{ PIN_SaveContext(guest_ctx, &user_ctx); }
+
+static ADDRINT
+HandleOp_GET_INSTCOUNT()
+{ return inst_count; }
+
+static void
+HandleOp_GetPath(const char *user_ptr, size_t size, std::string path)
+{
+    path.push_back('\0');
+    if (path.size() > size) {
+        std::cerr << "PINTOOL: path too large to fit in guest buffer: " << path
+                  << "\n";
+        Abort();
+    }
+    if (PIN_SafeCopy((void *)user_ptr, path.data(), path.size()) !=
+        path.size()) {
+        std::cerr << "PINTOOL: error: failed to copy\n";
+        Abort();
+    }
+}
+
+static void
+HandleOp_GET_REQPATH(const char *user_ptr, size_t size)
+{ HandleOp_GetPath(user_ptr, size, req_path.Value()); }
+
+static void
+HandleOp_GET_RESPPATH(const char *user_ptr, size_t size)
+{ HandleOp_GetPath(user_ptr, size, resp_path.Value()); }
+
+static void
+HandleOp_GET_MEMPATH(const char *user_ptr, size_t size)
+{ HandleOp_GetPath(user_ptr, size, mem_path.Value()); }
+
+static void
+HandleOp_SET_VSYSCALL_BASE(void *virt, void *phys)
+{
+    virtual_vsyscall_base = (ADDRINT)virt;
+    physical_vsyscall_base = (ADDRINT)phys;
+}
+
+[[noreturn]] static void
+HandleOp_EXIT(int32_t code)
+{
+    std::cerr << "Exiting " << std::dec << code << "\n";
+    PIN_ExitApplication(code);
+    std::abort(); // TODO: Unreachable
+}
+
+[[noreturn]] static void
+HandleOp_ABORT(const char *user_msg, size_t line, void *pc)
+{
+    std::cerr << "Aborting at pc " << pc << "\n";
+    std::cerr << CopyUserString(reinterpret_cast<ADDRINT>(user_msg)) << ":"
+              << line << "\n";
+    PIN_ExitApplication(1);
+    std::abort(); // TODO: Unreachable.
+}
+
+static void
+HandleOp_RUN(const CONTEXT *guest_ctx_ptr, ADDRINT next_pc)
+{
+    PIN_SaveContext(guest_ctx_ptr, &saved_guest_ctx);
+    PIN_SetContextReg(&saved_guest_ctx, REG_RIP, next_pc);
+    std::cerr << __FUNCTION__ << ": switching to user context\n";
+    PIN_ExecuteAt(&user_ctx);
+    std::abort(); // TODO: UNREACHABLE
+}
+
+static void
+HandleOp_SET_REGS(const PinRegFile *user_regfile_ptr)
+{
+    PinRegFile rf;
+    if (PIN_SafeCopy(&rf, user_regfile_ptr, sizeof rf) != sizeof rf) {
+        std::cerr << "PINTOOL: Failed to copy regfile\n";
+        Abort();
+    }
+    const auto set_reg = [](REG reg, uint64_t value) {
+        PIN_SetContextReg(&user_ctx, reg, value);
+    };
+
+    // Set integer registers.
+    set_reg(REG_RAX, rf.rax);
+    set_reg(REG_RBX, rf.rbx);
+    set_reg(REG_RCX, rf.rcx);
+    set_reg(REG_RDX, rf.rdx);
+    set_reg(REG_RDI, rf.rdi);
+    set_reg(REG_RSI, rf.rsi);
+    set_reg(REG_RSP, rf.rsp);
+    set_reg(REG_RBP, rf.rbp);
+    set_reg(REG_R8, rf.r8);
+    set_reg(REG_R9, rf.r9);
+    set_reg(REG_R10, rf.r10);
+    set_reg(REG_R11, rf.r11);
+    set_reg(REG_R12, rf.r12);
+    set_reg(REG_R13, rf.r13);
+    set_reg(REG_R14, rf.r14);
+    set_reg(REG_R15, rf.r15);
+    set_reg(REG_RIP, rf.rip);
+
+    // Set floating-point registers.
+    for (int i = 0; i < 8; ++i) {
+        PIN_SetContextRegval(&user_ctx, REG(REG_ST0 + i),
+                             (const uint8_t *)&rf.fprs[i]);
+    }
+    for (int i = 0; i < 16; ++i) {
+        PIN_SetContextRegval(&user_ctx, REG(REG_XMM0 + i),
+                             (const uint8_t *)&rf.xmms[i]);
+    }
+    set_reg(REG_FPCW, rf.fcw);
+    set_reg(REG_FPSW, rf.fsw);
+    set_reg(REG_FPTAG, rf.ftag);
+
+    // Misc regs.
+    set_reg(REG_RFLAGS, rf.rflags);
+    set_reg(REG_SEG_FS, rf.fs);
+    set_reg(REG_SEG_GS, rf.gs);
+    set_reg(REG_SEG_FS_BASE, rf.fs_base);
+    set_reg(REG_SEG_GS_BASE, rf.gs_base);
+
+    dbgs() << "DEBUG: setting REG_SEG_FS_BASE to 0x" << std::hex << rf.fs_base
+           << "\n";
+}
+
+static void
+HandleOp_GET_REGS(PinRegFile *user_regfile_ptr)
+{
+    PinRegFile rf;
+    std::memset(&rf, 0, sizeof rf);
+
+    const auto get_reg = [](REG reg, auto &value) {
+        value = PIN_GetContextReg(&user_ctx, reg);
+    };
+
+    // Get integer registers.
+    get_reg(REG_RAX, rf.rax);
+    get_reg(REG_RBX, rf.rbx);
+    get_reg(REG_RCX, rf.rcx);
+    get_reg(REG_RDX, rf.rdx);
+    get_reg(REG_RDI, rf.rdi);
+    get_reg(REG_RSI, rf.rsi);
+    get_reg(REG_RSP, rf.rsp);
+    get_reg(REG_RBP, rf.rbp);
+    get_reg(REG_R8, rf.r8);
+    get_reg(REG_R9, rf.r9);
+    get_reg(REG_R10, rf.r10);
+    get_reg(REG_R11, rf.r11);
+    get_reg(REG_R12, rf.r12);
+    get_reg(REG_R13, rf.r13);
+    get_reg(REG_R14, rf.r14);
+    get_reg(REG_R15, rf.r15);
+    get_reg(REG_RIP, rf.rip);
+
+    // Get floating-point registers.
+    for (int i = 0; i < 8; ++i) {
+        PIN_GetContextRegval(&user_ctx, REG(REG_ST0 + i),
+                             (uint8_t *)&rf.fprs[i]);
+    }
+    for (int i = 0; i < 16; ++i) {
+        PIN_GetContextRegval(&user_ctx, REG(REG_XMM0 + i),
+                             (uint8_t *)&rf.xmms[i]);
+    }
+    get_reg(REG_FPCW, rf.fcw);
+    get_reg(REG_FPSW, rf.fsw);
+    get_reg(REG_FPTAG, rf.ftag);
+
+    // Misc regs.
+    get_reg(REG_RFLAGS, rf.rflags);
+    get_reg(REG_SEG_FS, rf.fs);
+    get_reg(REG_SEG_GS, rf.gs);
+    get_reg(REG_SEG_FS_BASE, rf.fs_base);
+    get_reg(REG_SEG_GS_BASE, rf.gs_base);
+
+    // Copy out.
+    if (PIN_SafeCopy(user_regfile_ptr, &rf, sizeof rf) != sizeof rf) {
+        std::cerr << "PINTOOL: failed to copy regfile\n";
+        Abort();
+    }
+
+    dbgs() << "DEBUG: getting FS_BASE: 0x" << std::hex << rf.fs_base << "\n";
+}
+
+static void
+HandleOp_ADD_SYMBOL(ADDRINT name_vptr, ADDRINT vaddr)
+{
+    const std::string name = CopyUserString(name_vptr);
+    symbol_table[vaddr] = name;
+    // FIXME: Disabled because it's high-overhead.
+    // Should instead add a new pinop so gem5 can control when this happens.
+    // PIN_RemoveInstrumentation(); // So that any analyses depending on
+    // symbols will get to re-analyze with symbols.
+}
+
+static std::string
+ExecCommand(const std::string &cmd, const std::vector<std::string> &args)
+{
+    std::cerr << __FUNCTION__ << ": executing command: " << cmd;
+    for (const std::string &arg : args) {
+        std::cerr << " " << arg;
+    }
+    std::cerr << "\n";
+    for (Plugin *plugin : plugins) {
+        if (plugin->enabled()) {
+            std::string result;
+            if (plugin->command(cmd, args, result)) {
+                return result;
+            }
+        }
+    }
+    std::cerr << __FUNCTION__ << ": no plugin handled command: " << cmd
+              << "\n";
+    Abort();
+}
+
+static std::string gCommandResult;
+
+static ADDRINT
+HandleOp_EXEC_COMMAND(ADDRINT cmd_vptr)
+{
+    const std::string cmdline = CopyUserString(cmd_vptr);
+
+    // Tokenize.
+    std::vector<std::string> tokens;
+    tokens.emplace_back();
+    for (char c : cmdline) {
+        if (std::isspace(c)) {
+            tokens.emplace_back();
+        } else {
+            tokens.back().push_back(c);
+        }
+    }
+    if (tokens.empty()) {
+        std::cerr << __func__ << ": got empty command!\n";
+        Abort();
+    }
+    const std::string cmd = tokens.front();
+    tokens.erase(tokens.begin());
+
+    // Try to find plugin to handle the command.
+    gCommandResult = ExecCommand(cmd, tokens);
+    return gCommandResult.size();
+}
+
+static void
+HandleOp_READ_COMMAND_RESULT(ADDRINT buf_vptr, ADDRINT idx, ADDRINT len)
+{
+    assert(idx + len <= gCommandResult.size());
+    PIN_SafeCopy(reinterpret_cast<void *>(buf_vptr),
+                 gCommandResult.data() + idx, len);
+}
+
+const std::string *
+GetSymbol(ADDRINT addr)
+{
+    const auto it = symbol_table.find(addr);
+    return it == symbol_table.end() ? nullptr : &it->second;
+}
+
+static void
+Instrument_Instruction_PinOps(INS ins, void *)
+{
+    const ADDRINT pc = INS_Address(ins);
+    const auto it = pinops_blacklist.find(pc);
+    if (it == pinops_blacklist.end()) {
+        return;
+    }
+
+    const PinOp op = it->second;
+
+    dbgs() << "PINTOOL: instrumenting pinop instruction: 0x" << std::hex
+           << INS_Address(ins) << ": op=" << std::dec << op << "\n";
+
+    assert(INS_MemoryOperandCount(ins) == 1);
+
+    switch (op) {
+        case PinOp::OP_RESETUSER:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE,
+                                     (AFUNPTR)HandleOp_RESETUSER,
+                                     IARG_CONST_CONTEXT, IARG_END);
+            break;
+
+        case PinOp::OP_GET_INSTCOUNT:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE,
+                                     (AFUNPTR)HandleOp_GET_INSTCOUNT,
+                                     IARG_RETURN_REGS, REG_RAX, IARG_END);
+            break;
+
+        case PinOp::OP_GET_REQPATH:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_GET_REQPATH,
+                IARG_REG_VALUE, REG_RDI, IARG_REG_VALUE, REG_RSI, IARG_END);
+            break;
+
+        case PinOp::OP_GET_RESPPATH:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_GET_RESPPATH,
+                IARG_REG_VALUE, REG_RDI, IARG_REG_VALUE, REG_RSI, IARG_END);
+            break;
+
+        case PinOp::OP_GET_MEMPATH:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_GET_MEMPATH,
+                IARG_REG_VALUE, REG_RDI, IARG_REG_VALUE, REG_RSI, IARG_END);
+            break;
+
+        case PinOp::OP_SET_VSYSCALL_BASE:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_SET_VSYSCALL_BASE,
+                IARG_REG_VALUE, REG_RDI, IARG_REG_VALUE, REG_RSI, IARG_END);
+            break;
+
+        case PinOp::OP_EXIT:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE,
+                                     (AFUNPTR)HandleOp_EXIT, IARG_REG_VALUE,
+                                     REG_RDI, IARG_END);
+            break;
+
+        case PinOp::OP_ABORT:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE,
+                                     (AFUNPTR)HandleOp_ABORT, IARG_REG_VALUE,
+                                     REG_RDI, IARG_REG_VALUE, REG_RSI,
+                                     IARG_REG_VALUE, REG_RDX, IARG_END);
+            break;
+
+        case PinOp::OP_RUN:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_RUN,
+                                     IARG_CONST_CONTEXT, IARG_ADDRINT,
+                                     pc + INS_Size(ins), IARG_END);
+            break;
+
+        case PinOp::OP_SET_REGS:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE,
+                                     (AFUNPTR)HandleOp_SET_REGS,
+                                     IARG_REG_VALUE, REG_RDI, IARG_END);
+            break;
+
+        case PinOp::OP_GET_REGS:
+            INS_InsertPredicatedCall(ins, IPOINT_BEFORE,
+                                     (AFUNPTR)HandleOp_GET_REGS,
+                                     IARG_REG_VALUE, REG_RDI, IARG_END);
+            break;
+
+        case PinOp::OP_ADD_SYMBOL:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_ADD_SYMBOL,
+                IARG_REG_VALUE, REG_RDI, IARG_REG_VALUE, REG_RSI, IARG_END);
+            break;
+
+        case PinOp::OP_EXEC_COMMAND:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_EXEC_COMMAND,
+                IARG_REG_VALUE, REG_RDI, IARG_RETURN_REGS, REG_RAX, IARG_END);
+            break;
+
+        case PinOp::OP_READ_COMMAND_RESULT:
+            INS_InsertPredicatedCall(
+                ins, IPOINT_BEFORE, (AFUNPTR)HandleOp_READ_COMMAND_RESULT,
+                IARG_REG_VALUE, REG_RDI, IARG_REG_VALUE, REG_RSI,
+                IARG_REG_VALUE, REG_RDX, IARG_END);
+            break;
+
+        default:
+            std::cerr << "PINTOOL: fatal: unimplemented pinop " << std::dec
+                      << op << "\n";
+            Abort();
+    }
+
+    INS_Delete(ins);
+}
+
+// TODO: Break this into mini-instrumentation functions.
+static void
+Instruction(INS ins, void *)
+{
+    if (guest_pages.empty()) {
+        IMG img = APP_ImgHead();
+        assert(IMG_Valid(img));
+        assert(IMG_IsMainExecutable(img));
+        assert(IMG_IsStaticExecutable(img));
+        for (SEC sec = IMG_SecHead(img); SEC_Valid(sec); sec = SEC_Next(sec)) {
+            if (!SEC_Mapped(sec)) {
+                continue;
+            }
+            log_ << "section: " << std::hex << SEC_Address(sec) << "\n";
+            const ADDRINT start = SEC_Address(sec);
+            const ADDRINT end = start + SEC_Size(sec);
+            for (ADDRINT page = start & ~(ADDRINT)0xFFF; page < end;
+                 page += 0x1000) {
+                guest_pages.insert(page);
+            }
+        }
+        assert(!guest_pages.empty());
+    }
+
+    const ADDRINT addr = INS_Address(ins);
+    if (IsGuestCode(addr)) {
+        return;
+    }
+
+    // Application instruction.
+    dbgs() << "INSTRUMENT: 0x" << std::hex << INS_Address(ins) << std::endl;
+
+    // Instrument system calls. Replace them with traps into gem5.
+    if (INS_IsSyscall(ins)) {
+        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)HandleSyscall,
+                       IARG_CONTEXT, IARG_ADDRINT,
+                       INS_Address(ins) + INS_Size(ins), IARG_END);
+    }
+
+    // Handle CPUIDs.
+    if (INS_Opcode(ins) == XED_ICLASS_CPUID) {
+        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)HandleCPUID, IARG_CONTEXT,
+                       IARG_ADDRINT, INS_Address(ins) + INS_Size(ins),
+                       IARG_END);
+    }
+
+    // Accesses via the FS_BASE and GS_BASE registers are sensitive.
+    for (uint32_t i = 0; i < INS_MemoryOperandCount(ins); ++i) {
+        if (!(INS_MemoryOperandIsRead(ins, i) ||
+              INS_MemoryOperandIsWritten(ins, i))) {
+            continue;
+        }
+        REG seg_reg = INS_OperandMemorySegmentReg(
+            ins, INS_MemoryOperandIndexToOperandIndex(ins, i));
+        if (!REG_valid(seg_reg)) {
+            continue;
+        }
+        switch (seg_reg) {
+            case REG_SEG_FS:
+            case REG_SEG_GS:
+                break;
+            default:
+                std::cerr << "PINTOOL: error: unexpected segment register: "
+                          << REG_StringShort(seg_reg) << "\n";
+                std::abort();
+        }
+        dbgs() << "PINTOOL: found sensitive FS/GS instruction: 0x"
+               << INS_Address(ins) << ": " << INS_Disassemble(ins) << "\n";
+        // TODO: Shuold probably be predicated.
+        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)HandleFSGSAccess,
+                       IARG_MEMORYOP_EA, i, IARG_RETURN_REGS, REG_INST_G0 + i,
+                       IARG_CALL_ORDER, CALL_ORDER_LAST, IARG_END);
+        INS_RewriteMemoryOperand(ins, i, (REG)(REG_INST_G0 + i));
+    }
+}
+
+static ADDRINT
+HandleVsyscallAccess(ADDRINT effaddr, ADDRINT effsize, ADDRINT next_pc,
+                     const CONTEXT *ctx)
+{
+    assert(virtual_vsyscall_base && physical_vsyscall_base);
+    assert((virtual_vsyscall_base <= effaddr &&
+            effaddr + effsize <= virtual_vsyscall_base + 0x1000) ||
+           effaddr + effsize <= virtual_vsyscall_base ||
+           virtual_vsyscall_base + 0x1000 <= effaddr);
+    if (virtual_vsyscall_base <= effaddr &&
+        effaddr + effsize <= virtual_vsyscall_base + 0x1000) {
+        const ADDRINT offset = effaddr - virtual_vsyscall_base;
+        assert(physical_vsyscall_base);
+        return physical_vsyscall_base + offset;
+    } else {
+        return effaddr;
+    }
+}
+
+static std::unordered_set<ADDRINT> vsyscall_blacklist;
+
+// Fixup vsyscalls.
+static void
+Instruction_Vsyscall(INS ins, void *)
+{
+    if (IsGuestCode(ins) || vsyscall_blacklist.count(INS_Address(ins)) == 0) {
+        return;
+    }
+
+    dbgs()
+        << "PINTOOL: instrumenting instruction that has accessed vsyscall: 0x"
+        << INS_Address(ins) << "\n";
+
+    // FIXME: If we have a FS/GS access too this breaks.
+    for (uint32_t i = 0; i < INS_MemoryOperandCount(ins); ++i) {
+        INS_InsertPredicatedCall(
+            ins, IPOINT_BEFORE, (AFUNPTR)HandleVsyscallAccess,
+            IARG_MEMORYOP_EA, i, IARG_MEMORYOP_SIZE, i, IARG_ADDRINT,
+            INS_Address(ins) + INS_Size(ins), IARG_CONST_CONTEXT,
+            IARG_RETURN_REGS, REG_INST_G0 + i, IARG_CALL_ORDER,
+            CALL_ORDER_LAST, IARG_END);
+        INS_RewriteMemoryOperand(ins, i, (REG)(REG_INST_G0 + i));
+    }
+}
+
+static void
+HandleInstCount(ADDRINT num_insts)
+{ inst_count += num_insts; }
+
+static void
+Instrument_Trace_InstCount(TRACE trace, void *)
+{
+    if (IsGuestCode(trace)) {
+        return;
+    }
+    for (BBL bbl = TRACE_BblHead(trace); BBL_Valid(bbl); bbl = BBL_Next(bbl)) {
+        BBL_InsertCall(bbl, IPOINT_BEFORE, (AFUNPTR)HandleInstCount,
+                       IARG_ADDRINT, BBL_NumIns(bbl), IARG_END);
+    }
+}
+
+static void
+HandleTrace(ADDRINT pc)
+{
+    std::cerr << "TRACE: 0x" << std::hex << pc << std::endl;
+    log_ << "TRACE: 0x" << std::hex << pc << std::endl;
+}
+
+static void
+Instruction_Trace(INS ins, void *)
+{
+    if (IsGuestCode(ins)) {
+        return;
+    }
+    INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)HandleTrace, IARG_INST_PTR,
+                   IARG_END);
+}
+
+static bool
+InterceptSEGV(THREADID tid, int32_t sig, CONTEXT *ctx, bool has_handler,
+              const EXCEPTION_INFO *info, void *)
+{
+    std::cerr << "PINTOOL: Encountered SEGV: " << info->ToString() << "\n";
+
+    const auto code = PIN_GetExceptionCode(info);
+    const auto ex_class = PIN_GetExceptionClass(code);
+    if (ex_class != EXCEPTCLASS_ACCESS_FAULT) {
+        std::cerr << "PINTOOL: unexpected exception class (" << ex_class
+                  << ")\n";
+        return true;
+    }
+
+    assert(info->IsAccessFault());
+
+    ADDRINT fault_pc = info->GetExceptAddress();
+    ADDRINT fault_addr;
+    [[maybe_unused]] const bool fault_addr_result =
+        info->GetFaultyAccessAddress(&fault_addr);
+    assert(fault_addr_result);
+
+    std::cerr << "PINTOOL: SEGV at address 0x" << std::hex << fault_addr
+              << "\n";
+    std::cerr << "    at pc 0x" << fault_pc << "\n";
+
+    if (fault_addr == 0) {
+        std::cerr << "PINTOOL: null pointer dereference; aborting\n";
+        return true;
+    }
+
+    // Was this segfault in guest code?
+    if (IsGuestCode(fault_pc)) {
+        // If this is a pinop fault, then we just need to reinstrument it and
+        // add it to the pinop instruction list.
+        if (is_pinop_addr((void *)fault_addr)) {
+            std::cerr << "PINTOOL: detected new pinop instruction: 0x"
+                      << fault_pc << "\n";
+            pinops_blacklist[fault_pc] =
+                static_cast<PinOp>(fault_addr - pinops_addr_base);
+            PIN_RemoveInstrumentation(); // FIXME: Try just removing
+                                         // insturmentation in range, benchmark
+                                         // performance diff.
+            return false;
+        }
+
+        // Otherwise, we have an unknown guest fault.
+        std::cerr << "PINTOOL: guest faulted, aborting\n";
+        return true;
+    }
+
+    RunResult result;
+
+    // Was this a vsyscall access?
+    // NOTE: The proper thing to do here if the virtual vsyscall base hasn't
+    // been set yet is simply to deliver a page fault back to gem5.
+    if (virtual_vsyscall_base && virtual_vsyscall_base <= fault_addr &&
+        fault_addr < virtual_vsyscall_base + 0x1000) {
+        // Detected vsyscall access.
+        // Trick Pin into re-instrumenting the instruction.
+        std::cerr << "PINTOOL: detected vsyscall access\n";
+        vsyscall_blacklist.insert(fault_pc);
+        PIN_RemoveInstrumentation(); // FIXME: Try out removing instrumentation
+                                     // in range again.
+        return false;
+    } else {
+        result.result = RunResult::RUNRESULT_PAGEFAULT;
+        result.addr = fault_addr;
+    }
+
+    ContextSwitchToGuest(ctx, result);
+
+    return false;
+}
+
+static void
+usage(std::ostream &os)
+{
+    std::cerr << prog << ": gem5 pin CPU client\n";
+    std::cerr << KNOB_BASE::StringKnobSummary() << "\n";
+}
+
+static void
+Fini(int32_t code, void *)
+{
+    log_ << "Exiting: code = " << code << std::endl;
+    log_ << prog << ": Finished running the program, Pin exiting!"
+         << std::endl;
+    log_ << "STATS: total pinops: " << std::dec << pinops_count << std::endl;
+    log_ << "inst-count " << inst_count << std::endl;
+}
+
+template <class T>
+static int
+CheckPathArg(const T &arg)
+{
+    const std::string &value = arg.Value();
+    if (value.empty()) {
+        std::cerr << "error: required option: " << arg.Name() << "\n";
+        return -1;
+    }
+    OS_FILE_ATTRIBUTES attr;
+    if (OS_GetFileAttributes(value.c_str(), &attr).generic_err !=
+        OS_RETURN_CODE_NO_ERROR) {
+        std::cerr << "error: failed to open file: " << value << "\n";
+        return -1;
+    }
+    return 0;
+}
+
+static void
+HandleOOM(size_t size, void *)
+{
+    std::cerr << "Pin ran out of memory! Allocation size: " << size << "\n";
+
+    int fd = open("/proc/self/maps", O_RDONLY);
+    if (fd < 0) {
+        std::cerr << "error: failed to open /proc/self/maps\n";
+        return;
+    }
+    while (true) {
+        char buf[1024];
+        const ssize_t bytes = read(fd, buf, sizeof buf - 1);
+        if (bytes < 0) {
+            std::cerr << "error reading /proc/self/maps\n";
+            return;
+        }
+        if (bytes == 0) {
+            break;
+        }
+        buf[bytes] = '\0';
+        std::cerr << buf;
+    }
+    close(fd);
+}
+
+int
+main(int argc, char *argv[])
+{
+#if 0
+    PIN_InitSymbols();
+#endif
+
+    prog = argv[0];
+    if (PIN_Init(argc, argv)) {
+        usage(std::cerr);
+        return EXIT_FAILURE;
+    }
+
+    if (log_path.Value().empty()) {
+        std::cerr << "error: required option: -log\n";
+        return EXIT_FAILURE;
+    }
+    log_.open(log_path.Value());
+
+    if (CheckPathArg(req_path) < 0) {
+        return EXIT_FAILURE;
+    }
+    if (CheckPathArg(resp_path) < 0) {
+        return EXIT_FAILURE;
+    }
+
+    OS_FILE_ATTRIBUTES attr;
+    if (mem_path.Value().empty()) {
+        std::cerr << "error: required option: -mem_path\n";
+        return EXIT_FAILURE;
+    }
+    if (OS_GetFileAttributes(mem_path.Value().c_str(), &attr).generic_err !=
+        OS_RETURN_CODE_NO_ERROR) {
+        std::cerr << "error: failed to open file: " << mem_path.Value()
+                  << "\n";
+        return EXIT_FAILURE;
+    }
+
+    // TODO: Reason better about ordering here.
+    // INS_AddInstrumentFunction(Instrument_Instruction_PrintCall, nullptr);
+
+    if (enable_trace.Value()) {
+        INS_AddInstrumentFunction(Instruction_Trace, nullptr);
+    }
+    INS_AddInstrumentFunction(Instruction_Vsyscall, nullptr);
+
+    // TODO: Remove this!
+    if (enable_inst_count.Value()) {
+        TRACE_AddInstrumentFunction(Instrument_Trace_InstCount, nullptr);
+    }
+
+    // Register plugins.
+    std::map<int, std::vector<Plugin *>> prioritized_plugins;
+    for (Plugin *plugin : plugins) {
+        if (plugin->enabled()) {
+            prioritized_plugins[plugin->priority()].push_back(plugin);
+        }
+    }
+    for (const auto &[_, plugins] : prioritized_plugins) {
+        for (Plugin *plugin : plugins) {
+            std::cerr << "Registering plugin '" << plugin->name() << "'\n";
+            plugin->reg();
+        }
+    }
+
+    INS_AddInstrumentFunction(Instruction, nullptr);
+    INS_AddInstrumentFunction(Instrument_Instruction_PinOps, nullptr);
+    PIN_AddFiniFunction(Fini, nullptr);
+
+    PIN_InterceptSignal(SIGSEGV, InterceptSEGV, nullptr);
+
+    PIN_AddOutOfMemoryFunction(HandleOOM, nullptr);
+
+#if 0
+    PIN_SetSmcSupport(SMC_DISABLE);
+#endif
+
+    std::cerr << "runtime: starting program\n";
+
+    PIN_StartProgram();
+}

--- a/util/pincpu/pintool.hh
+++ b/util/pincpu/pintool.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_PINTOOL_HH__
+#define __UTIL_PINCPU_PINTOOL_HH__
+
+#include <fstream>
+#include <string>
+
+#include <pin.H>
+
+#include "ops.h"
+
+bool IsGuestCode(ADDRINT addr);
+bool IsGuestCode(INS ins);
+bool IsGuestCode(TRACE trace);
+std::ostream &log();
+
+const std::string *GetSymbol(ADDRINT addr);
+void ContextSwitchToGuest(CONTEXT *ctx, RunResult result);
+
+#endif // __UTIL_PINCPU_PINTOOL_HH__

--- a/util/pincpu/plugin.cc
+++ b/util/pincpu/plugin.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "plugin.hh"
+
+std::vector<Plugin *> plugins;
+
+Plugin::Plugin()
+{ plugins.push_back(this); }
+
+namespace
+{
+
+struct DummyPlugin : Plugin
+{
+    bool
+    reg() override
+    { return false; }
+    bool
+    command(const std::string &cmd, const std::vector<std::string> &args,
+            std::string &result) override
+    { return false; }
+};
+
+} // namespace

--- a/util/pincpu/plugin.hh
+++ b/util/pincpu/plugin.hh
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_PLUGIN_HH__
+#define __UTIL_PINCPU_PLUGIN_HH__
+
+#include <string>
+#include <vector>
+
+struct Plugin
+{
+    Plugin();
+    Plugin(const Plugin &) = delete;
+
+    virtual const char *name() const = 0;
+    virtual bool enabled() const = 0;
+    virtual bool reg() = 0;
+    virtual int
+    priority() const
+    {
+        return 0;
+    } // TODO: Replace with more flexible dependency-based mechanism.
+
+    // TODO: Merge cmd into args, so we just have an arg vector (like main
+    // functions).
+    // TODO: Consider making the result an ostream, not a string.
+    virtual bool
+    command(const std::string &cmd, const std::vector<std::string> &args,
+            std::string &result)
+    { return false; }
+};
+
+extern std::vector<Plugin *> plugins;
+
+#endif // __UTIL_PINCPU_PLUGIN_HH__

--- a/util/pincpu/plugins/bbhist.cc
+++ b/util/pincpu/plugins/bbhist.cc
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cassert>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <pin.H>
+
+#include "pintool.hh"
+#include "plugin.hh"
+
+namespace
+{
+
+KNOB<bool> enable(KNOB_MODE_WRITEONCE, "pintool", "bbhist", "0",
+                  "Enable basic block histogram collection");
+
+std::vector<ADDRINT>
+getInstVec(BBL bbl)
+{
+    std::vector<ADDRINT> insts;
+    for (INS ins = BBL_InsHead(bbl); INS_Valid(ins); ins = INS_Next(ins)) {
+        insts.push_back(INS_Address(ins));
+    }
+    return insts;
+}
+
+std::string
+getBlockName(BBL bbl)
+{
+    std::string name;
+    bool first = true;
+    for (INS ins = BBL_InsHead(bbl); INS_Valid(ins); ins = INS_Next(ins)) {
+        char buf[256];
+        std::sprintf(buf, "%s%lx", first ? "" : ",", INS_Address(ins));
+        name += buf;
+        first = false;
+    }
+    return name;
+}
+
+struct BlockData
+{
+    ADDRINT hits;
+    std::string name;
+
+    BlockData(BBL bbl) : hits(0) { name = getBlockName(bbl); }
+};
+
+std::map<std::vector<ADDRINT>, BlockData> blocks;
+
+BlockData &
+getBlockData(BBL bbl)
+{ return blocks.emplace(getInstVec(bbl), bbl).first->second; }
+
+void
+Analyze(ADDRINT *counter)
+{ ++*counter; }
+
+void
+InstrumentBBL(BBL bbl)
+{
+    ADDRINT &counter = getBlockData(bbl).hits;
+    BBL_InsertCall(bbl, IPOINT_BEFORE, (AFUNPTR)Analyze, IARG_PTR, &counter,
+                   IARG_END);
+}
+
+void
+InstrumentTRACE(TRACE trace, void *)
+{
+    if (IsGuestCode(trace)) {
+        return;
+    }
+    for (BBL bbl = TRACE_BblHead(trace); BBL_Valid(bbl); bbl = BBL_Next(bbl)) {
+        InstrumentBBL(bbl);
+    }
+}
+
+void
+Dump(std::string &s)
+{
+    for (const auto &[insts, block] : blocks) {
+        if (block.hits) {
+            s += std::to_string(block.hits) + ' ' + block.name + '\n';
+        }
+    }
+}
+
+void
+Reset()
+{
+    for (auto &[insts, block] : blocks) {
+        block.hits = 0;
+    }
+}
+
+struct BasicBlockHistogramPlugin final : Plugin
+{
+    const char *
+    name() const override
+    { return "bbhist"; }
+
+    int
+    priority() const override
+    { return 1; }
+
+    bool
+    enabled() const override
+    { return enable.Value(); }
+
+    bool
+    reg() override
+    {
+        TRACE_AddInstrumentFunction(InstrumentTRACE, nullptr);
+        return true;
+    }
+
+    bool
+    command(const std::string &cmd, const std::vector<std::string> &args,
+            std::string &result) override
+    {
+        if (cmd != "bbhist") {
+            return false;
+        }
+
+        if (args.at(0) == "dump") {
+            Dump(result);
+            return true;
+        } else if (args.at(0) == "reset") {
+            Reset();
+            return true;
+        }
+
+        std::cerr << "bbhist: error: bad usage\n";
+        std::cerr << "usage: bbhist (dump|reset)\n";
+        std::abort();
+    }
+} plugin;
+
+} // namespace

--- a/util/pincpu/plugins/breakpoint.cc
+++ b/util/pincpu/plugins/breakpoint.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <list>
+
+#include <pin.H>
+
+#include "breakpoint.hh"
+#include "ops.h"
+#include "pintool.hh"
+#include "plugin.hh"
+
+static std::map<std::string, const ADDRINT *> counters;
+static std::map<const ADDRINT *, ADDRINT> breakpoints;
+
+static void
+SetBreakpoint(const ADDRINT *counter, ADDRINT target)
+{
+    // Remove instrumentation if we're adding a new type of breakpoint.
+    if (!breakpoints.count(counter)) {
+        PIN_RemoveInstrumentation();
+    }
+    breakpoints[counter] = target;
+}
+
+static void
+ClearBreakpoint(const ADDRINT *counter)
+{ breakpoints.at(counter) = std::numeric_limits<ADDRINT>::max(); }
+
+static ADDRINT
+AnalyzeIf(ADDRINT *target, const ADDRINT *counter)
+{ return *counter >= *target; }
+
+static void
+AnalyzeThen(CONTEXT *ctx, const ADDRINT *counter)
+{
+    ClearBreakpoint(counter);
+    RunResult result;
+    result.result = result.RUNRESULT_BREAK;
+    std::cerr << "instbreak: switching to guest\n";
+    ContextSwitchToGuest(ctx, result);
+    PIN_ExecuteAt(ctx);
+}
+
+static void
+Instrument(TRACE trace, void *)
+{
+    if (IsGuestCode(trace)) {
+        return;
+    }
+    for (const auto &[counter, target] : breakpoints) {
+        TRACE_InsertIfCall(trace, IPOINT_BEFORE, (AFUNPTR)AnalyzeIf,
+                           IARG_ADDRINT, &target, IARG_PTR, counter, IARG_END);
+        TRACE_InsertThenCall(trace, IPOINT_BEFORE, (AFUNPTR)AnalyzeThen,
+                             IARG_CONTEXT, IARG_PTR, counter, IARG_END);
+    }
+}
+
+void
+RegisterCounter(const std::string &name, const ADDRINT *counter)
+{ counters[name] = counter; }
+
+namespace
+{
+struct BreakpointPlugin final : Plugin
+{
+    const char *
+    name() const override
+    { return "breakpoint"; }
+
+    int
+    priority() const override
+    { return -1; }
+
+    bool
+    enabled() const override
+    { return true; }
+
+    bool
+    reg() override
+    {
+        TRACE_AddInstrumentFunction(Instrument, nullptr);
+        return true;
+    }
+
+    bool
+    command(const std::string &cmd, const std::vector<std::string> &args,
+            std::string &result) override
+    {
+        if (cmd != "breakpoint") {
+            return false;
+        }
+
+        if (args.size() != 2) {
+            std::cerr << "breakpoint: error: bad usage\n";
+            std::cerr << "usage: breakpoint <counter> <target>\n";
+            std::abort();
+        }
+
+        const ADDRINT target = std::stoull(args.at(1));
+        const std::string &counter_name = args.at(0);
+        const auto counter_it = counters.find(counter_name);
+        if (counter_it == counters.end()) {
+            std::cerr << "breakpoint: error: no such counter: " << counter_name
+                      << "\n";
+            std::abort();
+        }
+
+        SetBreakpoint(counter_it->second, target);
+        return true;
+    }
+} plugin;
+} // namespace

--- a/util/pincpu/plugins/breakpoint.hh
+++ b/util/pincpu/plugins/breakpoint.hh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_PLUGINS_BREAKPOINT_HH__
+#define __UTIL_PINCPU_PLUGINS_BREAKPOINT_HH__
+
+#include <string>
+
+// TODO: Move to separate file, like counters.hh/cc.
+void RegisterCounter(const std::string &name, const ADDRINT *counter);
+
+#endif // __UTIL_PINCPU_PLUGINS_BREAKPOINT_HH__

--- a/util/pincpu/plugins/instcount.cc
+++ b/util/pincpu/plugins/instcount.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <string>
+
+#include <pin.H>
+
+#include "breakpoint.hh"
+#include "instcount.hh"
+#include "pintool.hh"
+#include "plugin.hh"
+
+static KNOB<bool> enable(KNOB_MODE_WRITEONCE, "pintool", "instcount", "0",
+                         "Enable instruction counting");
+
+// TODO: Make this static.
+ADDRINT instcount;
+
+static void
+Analyze(ADDRINT n)
+{ instcount += n; }
+
+static void
+Instrument(TRACE trace, void *)
+{
+    if (IsGuestCode(trace)) {
+        return;
+    }
+    for (BBL bbl = TRACE_BblHead(trace); BBL_Valid(bbl); bbl = BBL_Next(bbl)) {
+        BBL_InsertCall(bbl, IPOINT_BEFORE, (AFUNPTR)Analyze, IARG_ADDRINT,
+                       BBL_NumIns(bbl), IARG_END);
+    }
+}
+
+static void
+Finish(int32_t code, void *)
+{ std::cerr << "instcount=" << std::dec << instcount << std::endl; }
+
+namespace
+{
+struct InstCountPlugin final : Plugin
+{
+    const char *
+    name() const override
+    { return "instcount"; }
+
+    int
+    priority() const override
+    { return 1; }
+
+    bool
+    enabled() const override
+    { return enable.Value(); }
+
+    bool
+    reg() override
+    {
+        assert(enabled());
+        TRACE_AddInstrumentFunction(Instrument, nullptr);
+        RegisterCounter("inst", &instcount);
+        PIN_AddFiniFunction(Finish, nullptr);
+        return true;
+    }
+
+    bool
+    command(const std::string &cmd, const std::vector<std::string> &args,
+            std::string &result) override
+    {
+        if (cmd == "instcount") {
+            result = std::to_string(instcount);
+            return true;
+        }
+
+        return false;
+    }
+} plugin;
+} // namespace

--- a/util/pincpu/plugins/instcount.hh
+++ b/util/pincpu/plugins/instcount.hh
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __UTIL_PINCPU_PLUGINS_INSTCOUNT_HH__
+#define __UTIL_PINCPU_PLUGINS_INSTCOUNT_HH__
+
+#include <pin.H>
+
+extern ADDRINT instcount;
+
+#endif // __UTIL_PINCPU_PLUGINS_INSTCOUNT_HH__

--- a/util/pincpu/plugins/sysbreak.cc
+++ b/util/pincpu/plugins/sysbreak.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 The Board of Trustees of the Leland Stanford
+ * Junior University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <set>
+
+#include "pintool.hh"
+#include "plugin.hh"
+
+static std::set<ADDRINT> sysbreaks;
+
+static void
+Analyze(ADDRINT sysno, CONTEXT *ctx)
+{
+    if (!sysbreaks.erase(sysno)) {
+        return;
+    }
+    // TODO: Factor this out into shared code for breaking.
+    RunResult result;
+    result.result = result.RUNRESULT_BREAK;
+    std::cerr << "instbreak: switching to guest\n";
+    ContextSwitchToGuest(ctx, result);
+    PIN_ExecuteAt(ctx);
+}
+
+static void
+Instrument(INS ins, void *)
+{
+    if (IsGuestCode(ins) || !INS_IsSyscall(ins)) {
+        return;
+    }
+
+    INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)Analyze, IARG_SYSCALL_NUMBER,
+                   IARG_CONTEXT, IARG_END);
+}
+
+namespace
+{
+struct SyscallBreakpointPlugin final : Plugin
+{
+    const char *
+    name() const override
+    { return "sysbreak"; }
+
+    int
+    priority() const override
+    { return -1; }
+
+    bool
+    enabled() const override
+    { return true; }
+
+    bool
+    reg() override
+    {
+        INS_AddInstrumentFunction(Instrument, nullptr);
+        return true;
+    }
+
+    bool
+    command(const std::string &cmd, const std::vector<std::string> &args,
+            std::string &result) override
+    {
+        if (cmd != "sysbreak") {
+            return false;
+        }
+
+        if (args.size() != 1) {
+            std::cerr << "sysbreak: error: bad usage\n";
+            std::cerr << "usage: sysbreak <sysno>\n";
+            std::abort(); // TODO: Add return value for bad usage.
+        }
+
+        const ADDRINT sysno = std::stoull(args.at(0));
+        sysbreaks.insert(sysno);
+        return true;
+    }
+} plugin;
+} // namespace


### PR DESCRIPTION
Implement PinCPU, a fast-forwarding, functional CPU model for x86-64 SE mode capable of dynamic binary instrumentation. Like KvmCPU, PinCPU can fast-forward SE workloads. Unlike KvmCPU, PinCPU can also dynamically instrument the workloads' execution, using Intel Pin plugins
(examples can be found in util/pincpu/plugins/).

Example plugins are provided, including one (bbhist.cc) for generating basic block vector (BBV) profiles of the workload, a necessary step in the SimPoint methodology [Perelman+, SIGMETRICS'03]. Example scripts for driving PinCPU simulations are found in configs/example/pincpu/. One such script, bbv.py, uses PinCPU to collect BBV profiles for the workload.

PinCPU works by spawning an Intel Pin subprocess
and running a guest (util/pincpu/guest/) inside it that communicates with the main gem5 process to orchestrate the workload.

Because this commit adds a new CPU model, it also adds a corresponding new entry in MAINTAINERS.yaml. Because it introduces a new external dependency, Intel Pin, it modifies the all-dependencies Dockerfile so that its tests can run in CI.

For more information on PinCPU's applications, see the presentation on PinCPU at the 2025 gem5 workshop: https://www.gem5.org/_pages/static/events/isca_2025/ 01-pincpu-gem5-2025-06-21-export.pdf

Beyond the tests included in the commit, I have tested PinCPU on the ref inputs to the C/C++ SPEC2017 intspeed benchmarks; all complete successfully under PinCPU.

Change-Id: I7e39fef84d282feda37c3827ac86ca4ece17c081