### PR TITLE
mem: Refactor TracingExtension and defer string formatting

### DIFF
--- a/src/mem/port.cc
+++ b/src/mem/port.cc
@@ -59,12 +59,9 @@ TracingExtension::clone() const
 }
 
 void
-TracingExtension::add(const RequestPort *request_port,
-                      const ResponsePort *response_port, gem5::Addr addr)
+TracingExtension::add(const RequestPort *request_port, gem5::Addr addr)
 {
-    trace_.push_back(TraceEntry{.request_port = request_port,
-                                .response_port = response_port,
-                                .addr = addr});
+    trace_.push_back(TraceEntry{.request_port = request_port, .addr = addr});
 }
 
 void
@@ -87,15 +84,17 @@ TracingExtension::getTraceInString() const
     std::stringstream port_trace;
     port_trace << "Port trace of the Packet (" << std::endl
                << "[Destination] ";
-    for (auto rit = trace_.rbegin(); rit != trace_.rend(); rit++) {
-        if (rit->response_port) {
-            port_trace << rit->response_port->name() << std::endl;
-        }
-        if (std::next(rit) == trace_.rend()) {
-            port_trace << "[Source] ";
-        }
-        if (rit->request_port) {
-            port_trace << rit->request_port->name()
+    for (auto rit = trace_.rbegin(); rit != trace_.rend(); ++rit) {
+        const RequestPort *req_port = rit->request_port;
+        if (req_port) {
+            const ResponsePort *resp_port = req_port->getResponsePort();
+            if (resp_port) {
+                port_trace << resp_port->name() << std::endl;
+            }
+            if (std::next(rit) == trace_.rend()) {
+                port_trace << "[Source] ";
+            }
+            port_trace << req_port->name()
                        << csprintf(" addr=%#llx", rit->addr) << std::endl;
         }
     }
@@ -248,7 +247,7 @@ RequestPort::addTrace(PacketPtr pkt) const
         ext = std::make_shared<TracingExtension>();
         pkt->setExtension(ext);
     }
-    ext->add(this, _responsePort, pkt->getAddr());
+    ext->add(this, pkt->getAddr());
 }
 
 void

--- a/src/mem/port.cc
+++ b/src/mem/port.cc
@@ -52,6 +52,75 @@
 namespace gem5
 {
 
+std::unique_ptr<ExtensionBase>
+TracingExtension::clone() const
+{
+    return std::make_unique<TracingExtension>(trace_);
+}
+
+void
+TracingExtension::add(const RequestPort *request_port,
+                      const ResponsePort *response_port, gem5::Addr addr)
+{
+    trace_.push_back(TraceEntry{.request_port = request_port,
+                                .response_port = response_port,
+                                .addr = addr});
+}
+
+void
+TracingExtension::remove()
+{
+    if (!trace_.empty()) {
+        trace_.pop_back();
+    }
+}
+
+bool
+TracingExtension::empty() const
+{
+    return trace_.empty();
+}
+
+std::string
+TracingExtension::getTraceInString() const
+{
+    std::stringstream port_trace;
+    port_trace << "Port trace of the Packet (" << std::endl
+               << "[Destination] ";
+    for (auto rit = trace_.rbegin(); rit != trace_.rend(); rit++) {
+        if (rit->response_port) {
+            port_trace << rit->response_port->name() << std::endl;
+        }
+        if (std::next(rit) == trace_.rend()) {
+            port_trace << "[Source] ";
+        }
+        if (rit->request_port) {
+            port_trace << rit->request_port->name()
+                       << csprintf(" addr=%#llx", rit->addr) << std::endl;
+        }
+    }
+    port_trace << ")";
+    return port_trace.str();
+}
+
+std::optional<std::string>
+TracingExtension::getTraceSource() const
+{
+    if (trace_.empty() || !trace_[0].request_port) {
+        return std::nullopt;
+    }
+    return trace_[0].request_port->name();
+}
+
+void
+TracingExtension::dumpPortTrace(const gem5::PacketPtr pkt)
+{
+    auto ext = pkt->getExtension<gem5::TracingExtension>();
+    if (ext) {
+        warn("%s", ext->getTraceInString());
+    }
+}
+
 namespace
 {
 
@@ -179,7 +248,7 @@ RequestPort::addTrace(PacketPtr pkt) const
         ext = std::make_shared<TracingExtension>();
         pkt->setExtension(ext);
     }
-    ext->add(name(), _responsePort->name(), pkt->getAddr());
+    ext->add(this, _responsePort, pkt->getAddr());
 }
 
 void
@@ -188,8 +257,13 @@ RequestPort::removeTrace(PacketPtr pkt) const
     if (!gem5::debug::PortTrace || !pkt)
         return;
     auto ext = pkt->getExtension<TracingExtension>();
-    panic_if(!ext, "There is no TracingExtension in the packet.");
-    ext->remove();
+    // PortTrace might be enabled at any time in the simulation,
+    // thus relaxing the logic here.
+    if (!ext) {
+        warn("There is no TracingExtension in the packet.");
+    } else {
+        ext->remove();
+    }
 }
 
 /**

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -71,6 +71,7 @@ class MasterPort;
 class SlavePort;
 
 class ResponsePort;
+class RequestPort;
 
 /**
  * TracingExtension is an Extension of the Packet for recording the trace
@@ -80,76 +81,43 @@ class ResponsePort;
 class TracingExtension : public gem5::Extension<Packet, TracingExtension>
 {
   public:
+    struct TraceEntry
+    {
+        const RequestPort *request_port;
+        const ResponsePort *response_port;
+        gem5::Addr addr;
+    };
+
     TracingExtension() = default;
-    TracingExtension(const std::vector<std::string> &q) { trace_ = q; }
 
-    std::unique_ptr<ExtensionBase>
-    clone() const override
-    { return std::make_unique<TracingExtension>(trace_); }
+    explicit TracingExtension(const std::vector<TraceEntry> &q) : trace_(q) {}
 
-    void
-    add(std::string request_port, std::string response_port, gem5::Addr addr)
-    {
-        trace_.push_back(request_port + csprintf(" addr=%#llx", addr));
-        trace_.push_back(response_port);
-    }
+    std::unique_ptr<ExtensionBase> clone() const override;
 
-    void
-    remove()
-    {
-        trace_.pop_back(); // Remove the response port name.
-        trace_.pop_back(); // Remove the request port name.
-    }
+    /* Adds a trace to port trace vector. First in, first out. */
+    void add(const RequestPort *request_port,
+             const ResponsePort *response_port, gem5::Addr addr);
 
-    bool
-    empty()
-    { return trace_.empty(); }
+    /* Removes a trace to port trace vector. */
+    void remove();
 
-    std::vector<std::string> &
-    getTrace()
-    { return trace_; }
+    /* @return `true` if port trace vector is empty. */
+    bool empty() const;
 
-    std::string
-    getTraceInString() const
-    {
-        std::stringstream port_trace;
-        port_trace << "Port trace of the Packet (" << std::endl
-                   << "[Destination] ";
-        for (auto rit = trace_.rbegin(); rit != trace_.rend(); rit++) {
-            if (std::next(rit) == trace_.rend()) {
-                port_trace << "[Source] ";
-            }
-            port_trace << *rit << std::endl;
-        }
-        port_trace << ")";
-        return port_trace.str();
-    }
+    /* @return the entire port trace in string. */
+    std::string getTraceInString() const;
 
     /**
      * @return the source port of the trace, return std::nullopt if the trace
-     * is empty
+     * is empty.
      */
-    std::optional<std::string>
-    getTraceSource() const
-    {
-        if (trace_.empty()) {
-            return std::nullopt;
-        }
-        return trace_[0];
-    }
+    std::optional<std::string> getTraceSource() const;
 
-    static void
-    dumpPortTrace(const gem5::PacketPtr pkt)
-    {
-        auto ext = pkt->getExtension<gem5::TracingExtension>();
-        if (ext) {
-            DPRINTF(PortTrace, "%s\n", ext->getTraceInString());
-        }
-    }
+    static void dumpPortTrace(const gem5::PacketPtr pkt);
 
   private:
-    // Ordered from the original source to the current point in the trace
-    std::vector<std::string> trace_;
+    /* Ordered from the original source to the current point in the trace. */
+    std::vector<TraceEntry> trace_;
 };
 
 /**

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -84,7 +84,6 @@ class TracingExtension : public gem5::Extension<Packet, TracingExtension>
     struct TraceEntry
     {
         const RequestPort *request_port;
-        const ResponsePort *response_port;
         gem5::Addr addr;
     };
 
@@ -95,8 +94,7 @@ class TracingExtension : public gem5::Extension<Packet, TracingExtension>
     std::unique_ptr<ExtensionBase> clone() const override;
 
     /* Adds a trace to port trace vector. First in, first out. */
-    void add(const RequestPort *request_port,
-             const ResponsePort *response_port, gem5::Addr addr);
+    void add(const RequestPort *request_port, gem5::Addr addr);
 
     /* Removes a trace to port trace vector. */
     void remove();
@@ -142,6 +140,12 @@ class RequestPort: public Port, public AtomicRequestProtocol,
     RequestPort(const std::string& name, PortID id=InvalidPortID);
 
     virtual ~RequestPort();
+
+    const ResponsePort *
+    getResponsePort() const
+    {
+        return _responsePort;
+    }
 
     /**
      * Bind this request port to a response port. This also does the


### PR DESCRIPTION
1. Move TracingExtension implementation details from port.hh to port.cc.
2. Store TraceEntry structs (pointers and address) instead of formatted strings in TracingExtension. When PortTrace is enabled, numerous traces are added to the container. Deferring string formatting to getTraceInString avoids unnecessary string allocations and constructions for traces that are never printed.
3. Relax logic in RequestPort::removeTrace to issue a warning instead of panicking if TracingExtension is absent, allowing PortTrace to be enabled dynamically during simulation.