### PR TITLE
base: Add support for Zstd compressed images

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -889,6 +889,9 @@ for variant_path in variant_paths:
                   'and/or zlib.h header file.\n'
                   'Please install zlib and try again.')
 
+        conf.env['HAVE_ZSTD'] = conf.CheckLibWithHeader(
+            'zstd', 'zstd.h', 'C++', call='ZSTD_versionNumber();')
+
     if not GetOption('without_tcmalloc'):
         with gem5_scons.Configure(env) as conf:
             if conf.CheckLib('tcmalloc_minimal'):
@@ -950,6 +953,7 @@ for variant_path in variant_paths:
 
     # Variables which were determined with Configure.
     env['CONF'] = {}
+    env['CONF']['HAVE_ZSTD'] = env['HAVE_ZSTD']
 
     # Walk the tree and execute all SConsopts scripts that wil add to the
     # above variables

--- a/src/base/loader/SConscript
+++ b/src/base/loader/SConscript
@@ -1,5 +1,17 @@
 # -*- mode:python -*-
 
+# Copyright (c) 2026 Arm Limited
+# All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 2006 The Regents of The University of Michigan
 # All rights reserved.
 #
@@ -28,10 +40,18 @@
 
 Import('*')
 
+Source('compression_file_format.cc')
 Source('dtb_file.cc')
 Source('elf_object.cc')
+Source('gzip_compression.cc')
 Source('image_file_data.cc')
-GTest('image_file_data.test', 'image_file_data.test.cc', 'image_file_data.cc')
+image_file_data_test_sources = [
+    'image_file_data.test.cc',
+    'image_file_data.cc',
+    'compression_file_format.cc',
+    'gzip_compression.cc',
+]
+GTest('image_file_data.test', *image_file_data_test_sources)
 Source('memory_image.cc')
 Source('object_file.cc')
 Source('symtab.cc')

--- a/src/base/loader/SConscript
+++ b/src/base/loader/SConscript
@@ -51,6 +51,9 @@ image_file_data_test_sources = [
     'compression_file_format.cc',
     'gzip_compression.cc',
 ]
+if env['CONF']['HAVE_ZSTD']:
+    Source('zstd_compression.cc')
+    image_file_data_test_sources.append('zstd_compression.cc')
 GTest('image_file_data.test', *image_file_data_test_sources)
 Source('memory_image.cc')
 Source('object_file.cc')

--- a/src/base/loader/compression_file_format.cc
+++ b/src/base/loader/compression_file_format.cc
@@ -38,14 +38,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "base/loader/image_file_data.hh"
+#include "base/loader/compression_file_format.hh"
 
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/types.h>
 #include <unistd.h>
 
-#include "base/loader/compression_file_format.hh"
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "base/loader/gzip_compression.hh"
 #include "base/logging.hh"
 
 namespace gem5
@@ -54,35 +56,94 @@ namespace gem5
 namespace loader
 {
 
-ImageFileData::ImageFileData(const std::string &fname, bool try_decompress)
+namespace
 {
-    _filename = fname;
 
-    // Open the file.
-    int fd = open(fname.c_str(), O_RDONLY);
-    fatal_if(fd < 0, "Failed to open file %s.\n"
-        "This error typically occurs when the file path specified is "
-        "incorrect.\n", fname);
+typedef std::vector<CompressionFileFormat *> CompressionFileFormatList;
 
-    if (try_decompress) {
-        fd = decompressImageFile(fd, fname);
-    }
-
-    // Find the length of the file by seeking to the end.
-    off_t off = lseek(fd, 0, SEEK_END);
-    fatal_if(off < 0, "Failed to determine size of file %s.\n", fname);
-    _len = static_cast<size_t>(off);
-
-    // Mmap the whole shebang.
-    _data = (uint8_t *)mmap(NULL, _len, PROT_READ, MAP_SHARED, fd, 0);
-    close(fd);
-
-    panic_if(_data == MAP_FAILED, "Failed to mmap file %s.\n", fname);
+CompressionFileFormatList &
+compressionFileFormats()
+{
+    static CompressionFileFormatList formats;
+    return formats;
 }
 
-ImageFileData::~ImageFileData()
+void
+registerBuiltinCompressionFileFormats()
 {
-    munmap((void *)_data, _len);
+    registerGzipCompressionFormat();
+}
+
+} // anonymous namespace
+
+CompressionFileFormat::CompressionFileFormat()
+{
+    compressionFileFormats().emplace_back(this);
+}
+
+bool
+CompressionFileFormat::hasMagic(int fd, const uint8_t *magic, size_t magic_len)
+{
+    std::vector<uint8_t> buf(magic_len);
+    ssize_t sz = pread(fd, buf.data(), magic_len, 0);
+    panic_if(sz < 0, "Couldn't read magic bytes from object file");
+    if (static_cast<size_t>(sz) != magic_len) {
+        return false;
+    }
+
+    return memcmp(buf.data(), magic, magic_len) == 0;
+}
+
+bool
+CompressionFileFormat::writeAll(int fd, const uint8_t *buf, size_t size)
+{
+    while (size > 0) {
+        ssize_t sz = write(fd, buf, size);
+        if (sz <= 0) {
+            return false;
+        }
+
+        size -= sz;
+        buf += sz;
+    }
+
+    return true;
+}
+
+int
+CompressionFileFormat::makeTempFile(const char *suffix)
+{
+    std::string tmpnam_str = std::string(P_tmpdir) + suffix;
+    char *tmpnam = tmpnam_str.data();
+    int fd = mkstemp(tmpnam);
+    if (fd < 0) {
+        return fd;
+    }
+
+    if (unlink(tmpnam) != 0) {
+        warn("couldn't remove temporary file %s\n", tmpnam);
+    }
+
+    return fd;
+}
+
+int
+decompressImageFile(int fd, const std::string &filename)
+{
+    registerBuiltinCompressionFileFormats();
+
+    for (const auto &format : compressionFileFormats()) {
+        if (!format->matches(fd)) {
+            continue;
+        }
+
+        int decompressed_fd = format->decompress(fd);
+        panic_if(decompressed_fd < 0, "Failed to uncompress %s file %s.\n",
+                 format->name(), filename);
+        return decompressed_fd;
+    }
+
+    return fd;
 }
 
 } // namespace loader

--- a/src/base/loader/compression_file_format.cc
+++ b/src/base/loader/compression_file_format.cc
@@ -48,6 +48,10 @@
 #include <vector>
 
 #include "base/loader/gzip_compression.hh"
+#include "config/have_zstd.hh"
+#if HAVE_ZSTD
+#include "base/loader/zstd_compression.hh"
+#endif
 #include "base/logging.hh"
 
 namespace gem5
@@ -72,6 +76,9 @@ void
 registerBuiltinCompressionFileFormats()
 {
     registerGzipCompressionFormat();
+#if HAVE_ZSTD
+    registerZstdCompressionFormat();
+#endif
 }
 
 } // anonymous namespace

--- a/src/base/loader/compression_file_format.hh
+++ b/src/base/loader/compression_file_format.hh
@@ -11,9 +11,6 @@
  * unmodified and in its entirety in all distributions of the software,
  * modified or unmodified, in source code or in binary form.
  *
- * Copyright (c) 2002-2004 The Regents of The University of Michigan
- * All rights reserved.
- *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met: redistributions of source code must retain the above copyright
@@ -38,15 +35,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "base/loader/image_file_data.hh"
+#ifndef __BASE_LOADER_COMPRESSION_FILE_FORMAT_HH__
+#define __BASE_LOADER_COMPRESSION_FILE_FORMAT_HH__
 
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include "base/loader/compression_file_format.hh"
-#include "base/logging.hh"
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
 namespace gem5
 {
@@ -54,36 +48,60 @@ namespace gem5
 namespace loader
 {
 
-ImageFileData::ImageFileData(const std::string &fname, bool try_decompress)
+/**
+ * Override this class when providing support for a new compression format
+ * for guest binaries (this means decompressing a guest binary on the fly
+ * before running it instead of manually decompressing it beforehand).
+ *
+ * The decompression works by decompressing the binary and by writing
+ * the output stream (writeAll) to a temporary file (makeTempFile)
+ * which will be mapped later on to the guest address space
+ *
+ * The class/interface has two main APIs that have to be implemented
+ *
+ * matches => returns true if the file pointed by the file descriptor
+ * has been compressed with the class format
+ *
+ * decompress => implements the decompression
+ */
+class CompressionFileFormat
 {
-    _filename = fname;
+  protected:
+    CompressionFileFormat();
+    virtual ~CompressionFileFormat() = default;
 
-    // Open the file.
-    int fd = open(fname.c_str(), O_RDONLY);
-    fatal_if(fd < 0, "Failed to open file %s.\n"
-        "This error typically occurs when the file path specified is "
-        "incorrect.\n", fname);
+    static bool hasMagic(int fd, const uint8_t *magic, size_t magic_len);
+    // Writes the output stream to a file fd. Returns false if there has
+    // been an error, true otherwise
+    static bool writeAll(int fd, const uint8_t *buf, size_t size);
+    static int makeTempFile(const char *suffix);
 
-    if (try_decompress) {
-        fd = decompressImageFile(fd, fname);
-    }
+  public:
+    CompressionFileFormat(const CompressionFileFormat &) = delete;
+    void operator=(const CompressionFileFormat &) = delete;
 
-    // Find the length of the file by seeking to the end.
-    off_t off = lseek(fd, 0, SEEK_END);
-    fatal_if(off < 0, "Failed to determine size of file %s.\n", fname);
-    _len = static_cast<size_t>(off);
+    /**
+     * Can the file fd be decompressed by this handler?
+     *
+     * @param fd file descriptor
+     * @return true if this can decompress fd, false otherwise
+     */
+    virtual bool matches(int fd) const = 0;
 
-    // Mmap the whole shebang.
-    _data = (uint8_t *)mmap(NULL, _len, PROT_READ, MAP_SHARED, fd, 0);
-    close(fd);
+    /**
+     * Decompress the file fd. Return the new file descriptor
+     * for the decompressed binary
+     *
+     * @param fd file descriptor
+     * @return new_fd pointing to the decompressed file
+     */
+    virtual int decompress(int fd) const = 0;
+    virtual const char *name() const = 0;
+};
 
-    panic_if(_data == MAP_FAILED, "Failed to mmap file %s.\n", fname);
-}
-
-ImageFileData::~ImageFileData()
-{
-    munmap((void *)_data, _len);
-}
+int decompressImageFile(int fd, const std::string &filename);
 
 } // namespace loader
 } // namespace gem5
+
+#endif // __BASE_LOADER_COMPRESSION_FILE_FORMAT_HH__

--- a/src/base/loader/gzip_compression.cc
+++ b/src/base/loader/gzip_compression.cc
@@ -38,15 +38,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "base/loader/image_file_data.hh"
+#include "base/loader/gzip_compression.hh"
 
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/types.h>
 #include <unistd.h>
-
-#include "base/loader/compression_file_format.hh"
-#include "base/logging.hh"
+#include <zlib.h>
 
 namespace gem5
 {
@@ -54,35 +49,62 @@ namespace gem5
 namespace loader
 {
 
-ImageFileData::ImageFileData(const std::string &fname, bool try_decompress)
+GzipCompressionFormat::GzipCompressionFormat() : CompressionFileFormat()
+{}
+
+bool
+GzipCompressionFormat::matches(int fd) const
 {
-    _filename = fname;
-
-    // Open the file.
-    int fd = open(fname.c_str(), O_RDONLY);
-    fatal_if(fd < 0, "Failed to open file %s.\n"
-        "This error typically occurs when the file path specified is "
-        "incorrect.\n", fname);
-
-    if (try_decompress) {
-        fd = decompressImageFile(fd, fname);
-    }
-
-    // Find the length of the file by seeking to the end.
-    off_t off = lseek(fd, 0, SEEK_END);
-    fatal_if(off < 0, "Failed to determine size of file %s.\n", fname);
-    _len = static_cast<size_t>(off);
-
-    // Mmap the whole shebang.
-    _data = (uint8_t *)mmap(NULL, _len, PROT_READ, MAP_SHARED, fd, 0);
-    close(fd);
-
-    panic_if(_data == MAP_FAILED, "Failed to mmap file %s.\n", fname);
+    const uint8_t magic[] = {0x1f, 0x8b};
+    return hasMagic(fd, magic, sizeof(magic));
 }
 
-ImageFileData::~ImageFileData()
+int
+GzipCompressionFormat::decompress(int fd) const
 {
-    munmap((void *)_data, _len);
+    const size_t blk_sz = 4096;
+
+    gzFile fdz = gzdopen(fd, "rb");
+    if (!fdz) {
+        return -1;
+    }
+
+    fd = makeTempFile("/gem5-gz-obj-XXXXXX");
+    if (fd < 0) {
+        gzclose(fdz);
+        return fd;
+    }
+
+    auto buf = new uint8_t[blk_sz];
+    int r;
+    while ((r = gzread(fdz, buf, blk_sz)) > 0) {
+        if (!writeAll(fd, buf, r)) {
+            delete[] buf;
+            gzclose(fdz);
+            close(fd);
+            return -1;
+        }
+    }
+    delete[] buf;
+    gzclose(fdz);
+    if (r < 0) {
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+const char *
+GzipCompressionFormat::name() const
+{
+    return "gzip";
+}
+
+void
+registerGzipCompressionFormat()
+{
+    static GzipCompressionFormat gzipCompressionFormat;
 }
 
 } // namespace loader

--- a/src/base/loader/gzip_compression.hh
+++ b/src/base/loader/gzip_compression.hh
@@ -11,9 +11,6 @@
  * unmodified and in its entirety in all distributions of the software,
  * modified or unmodified, in source code or in binary form.
  *
- * Copyright (c) 2002-2004 The Regents of The University of Michigan
- * All rights reserved.
- *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met: redistributions of source code must retain the above copyright
@@ -38,15 +35,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "base/loader/image_file_data.hh"
-
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/types.h>
-#include <unistd.h>
+#ifndef __BASE_LOADER_GZIP_COMPRESSION_HH__
+#define __BASE_LOADER_GZIP_COMPRESSION_HH__
 
 #include "base/loader/compression_file_format.hh"
-#include "base/logging.hh"
 
 namespace gem5
 {
@@ -54,36 +46,19 @@ namespace gem5
 namespace loader
 {
 
-ImageFileData::ImageFileData(const std::string &fname, bool try_decompress)
+class GzipCompressionFormat : public CompressionFileFormat
 {
-    _filename = fname;
+  public:
+    GzipCompressionFormat();
 
-    // Open the file.
-    int fd = open(fname.c_str(), O_RDONLY);
-    fatal_if(fd < 0, "Failed to open file %s.\n"
-        "This error typically occurs when the file path specified is "
-        "incorrect.\n", fname);
+    bool matches(int fd) const override;
+    int decompress(int fd) const override;
+    const char *name() const override;
+};
 
-    if (try_decompress) {
-        fd = decompressImageFile(fd, fname);
-    }
-
-    // Find the length of the file by seeking to the end.
-    off_t off = lseek(fd, 0, SEEK_END);
-    fatal_if(off < 0, "Failed to determine size of file %s.\n", fname);
-    _len = static_cast<size_t>(off);
-
-    // Mmap the whole shebang.
-    _data = (uint8_t *)mmap(NULL, _len, PROT_READ, MAP_SHARED, fd, 0);
-    close(fd);
-
-    panic_if(_data == MAP_FAILED, "Failed to mmap file %s.\n", fname);
-}
-
-ImageFileData::~ImageFileData()
-{
-    munmap((void *)_data, _len);
-}
+void registerGzipCompressionFormat();
 
 } // namespace loader
 } // namespace gem5
+
+#endif // __BASE_LOADER_GZIP_COMPRESSION_HH__

--- a/src/base/loader/image_file_data.test.cc
+++ b/src/base/loader/image_file_data.test.cc
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2019 The Regents of the University of California
  * All rights reserved
  *
@@ -34,6 +46,7 @@
 
 #include "base/loader/image_file_data.hh"
 #include "base/loader/small_image_file.test.hh"
+#include "config/have_zstd.hh"
 
 using namespace gem5;
 using namespace loader;
@@ -108,4 +121,49 @@ TEST(ImageFileDataTest, GZipImage)
     unlink(filename);
     close(fd_gz);
     unlink(filename_gz);
+}
+
+TEST(ImageFileDataTest, ZstdImage)
+{
+#if HAVE_ZSTD
+    /*
+     * Create temporary files from our data blobs.
+     */
+    char filename_zstd[] = "image-XXXXXX";
+    int fd_zstd = mkstemp(filename_zstd);
+    ASSERT_NE(-1, fd_zstd);
+    ssize_t size_zstd =
+        write(fd_zstd, image_file_zstd, sizeof(image_file_zstd));
+
+    char filename[] = "image-XXXXXX";
+    int fd = mkstemp(filename);
+    ASSERT_NE(-1, fd);
+    ssize_t size = write(fd, image_file, sizeof(image_file));
+
+    /*
+     * ImageFileData decompresses a zstd file. image_file_zstd is just
+     * image_file zstd-compressed. Therefore ifd_zstd.len() should equal
+     * ifd.len() and ifd.data() should equal ifd_zstd.data().
+     */
+    ImageFileData ifd_zstd(filename_zstd);
+    ImageFileData ifd(filename);
+
+    EXPECT_EQ(ifd.len(), ifd_zstd.len());
+    EXPECT_EQ(size, ifd.len());
+    EXPECT_NE(size_zstd, ifd_zstd.len());
+
+    for (size_t index = 0; index < ifd.len(); index++) {
+        EXPECT_EQ(ifd.data()[index], ifd_zstd.data()[index]);
+    }
+
+    /*
+     * Close and delete the temporary files.
+     */
+    close(fd);
+    unlink(filename);
+    close(fd_zstd);
+    unlink(filename_zstd);
+#else
+    GTEST_SKIP() << "Skipping as ZSTD is not installed";
+#endif
 }

--- a/src/base/loader/small_image_file.test.hh
+++ b/src/base/loader/small_image_file.test.hh
@@ -1,4 +1,16 @@
 /*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
  * Copyright (c) 2019 The Regents of the University of California
  * All rights reserved
  *
@@ -138,6 +150,15 @@ const uint8_t image_file_gzipped[] = {
     0x51, 0xd1, 0x51, 0xd1, 0x41, 0x26, 0x0a, 0x00,
     0xc9, 0x58, 0x6c, 0x4e, 0xaa, 0x02, 0x00, 0x00
 };
+
+/**
+ * This is "image_file" compressed using Zstandard.
+ */
+const uint8_t image_file_zstd[] = {
+    0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x58, 0xed, 0x00, 0x00, 0xb0, 0x54,
+    0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x65,
+    0x73, 0x74, 0x20, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x2e, 0x0a, 0x01,
+    0x00, 0x22, 0x65, 0x35, 0x9b, 0x51, 0x33, 0xf2, 0xa2};
 
 } // namespace gem5
 

--- a/src/base/loader/zstd_compression.cc
+++ b/src/base/loader/zstd_compression.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "base/loader/zstd_compression.hh"
+
+#include <unistd.h>
+#include <zstd.h>
+
+#include <vector>
+
+#include "base/logging.hh"
+
+namespace gem5
+{
+
+namespace loader
+{
+
+ZstdCompressionFormat::ZstdCompressionFormat() : CompressionFileFormat()
+{}
+
+bool
+ZstdCompressionFormat::matches(int fd) const
+{
+    const uint8_t magic[] = {0x28, 0xb5, 0x2f, 0xfd};
+    return hasMagic(fd, magic, sizeof(magic));
+    if (hasMagic(fd, magic, sizeof(magic))) {
+        return true;
+    }
+
+    // Testing for skippable frames
+    for (uint8_t variant = 0x50; variant <= 0x5f; ++variant) {
+        const uint8_t skippable_magic[] = {variant, 0x2a, 0x4d, 0x18};
+        if (hasMagic(fd, skippable_magic, sizeof(skippable_magic))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int
+ZstdCompressionFormat::decompress(int in_fd) const
+{
+    int out_fd = makeTempFile("/gem5-zstd-obj-XXXXXX");
+    if (out_fd < 0) {
+        close(in_fd);
+        return out_fd;
+    }
+
+    ZSTD_DStream *stream = ZSTD_createDStream();
+    if (!stream) {
+        close(in_fd);
+        close(out_fd);
+        return -1;
+    }
+
+    size_t ret = ZSTD_initDStream(stream);
+    if (ZSTD_isError(ret)) {
+        warn("couldn't initialize zstd decompressor: %s\n",
+             ZSTD_getErrorName(ret));
+        ZSTD_freeDStream(stream);
+        close(in_fd);
+        close(out_fd);
+        return -1;
+    }
+
+    std::vector<uint8_t> in_buf(ZSTD_DStreamInSize());
+    std::vector<uint8_t> out_buf(ZSTD_DStreamOutSize());
+
+    ret = 1;
+    ssize_t read_size = 0;
+    while ((read_size = read(in_fd, in_buf.data(), in_buf.size())) > 0) {
+        ZSTD_inBuffer input = {in_buf.data(), static_cast<size_t>(read_size),
+                               0};
+
+        bool output_full = false;
+        do {
+            ZSTD_outBuffer output = {out_buf.data(), out_buf.size(), 0};
+            ret = ZSTD_decompressStream(stream, &output, &input);
+            if (ZSTD_isError(ret)) {
+                warn("couldn't decompress zstd stream: %s\n",
+                     ZSTD_getErrorName(ret));
+                ZSTD_freeDStream(stream);
+                close(in_fd);
+                close(out_fd);
+                return -1;
+            }
+
+            if (!writeAll(out_fd, out_buf.data(), output.pos)) {
+                ZSTD_freeDStream(stream);
+                close(in_fd);
+                close(out_fd);
+                return -1;
+            }
+
+            output_full = output.pos == output.size;
+        } while (input.pos < input.size || (ret != 0 && output_full));
+    }
+
+    ZSTD_freeDStream(stream);
+    close(in_fd);
+
+    if (read_size < 0 || ret != 0) {
+        close(out_fd);
+        return -1;
+    }
+
+    return out_fd;
+}
+
+const char *
+ZstdCompressionFormat::name() const
+{
+    return "zstd";
+}
+
+void
+registerZstdCompressionFormat()
+{
+    static ZstdCompressionFormat zstdCompressionFormat;
+}
+
+} // namespace loader
+} // namespace gem5

--- a/src/base/loader/zstd_compression.hh
+++ b/src/base/loader/zstd_compression.hh
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Arm Limited
+ * All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __BASE_LOADER_ZSTD_COMPRESSION_HH__
+#define __BASE_LOADER_ZSTD_COMPRESSION_HH__
+
+#include "base/loader/compression_file_format.hh"
+
+namespace gem5
+{
+
+namespace loader
+{
+
+class ZstdCompressionFormat : public CompressionFileFormat
+{
+  public:
+    ZstdCompressionFormat();
+
+    bool matches(int fd) const override;
+    int decompress(int fd) const override;
+    const char *name() const override;
+};
+
+void registerZstdCompressionFormat();
+
+} // namespace loader
+} // namespace gem5
+
+#endif // __BASE_LOADER_ZSTD_COMPRESSION_HH__


### PR DESCRIPTION
When loading a binary into guest memory, we support ELFs
and GZIPPED ELFS. The latter is particularly useful as
it allows people to store huge binaries in compressed format.

With this commit we add support for ZSTD compressed images [1]
This is an optional dependency (differently from zlib)

[1]: https://github.com/facebook/zstd