### PR TITLE
arch-riscv: Keep fault-only-first trim state off StaticInst

### DIFF
--- a/src/arch/generic/isa.hh
+++ b/src/arch/generic/isa.hh
@@ -44,6 +44,7 @@
 
 #include "arch/generic/pcstate.hh"
 #include "base/logging.hh"
+#include "cpu/inst_seq.hh"
 #include "cpu/reg_class.hh"
 #include "mem/packet.hh"
 #include "mem/request.hh"
@@ -74,6 +75,12 @@ class BaseISA : public SimObject
   public:
     virtual PCStateBase *newPCState(Addr new_inst_addr=0) const = 0;
     virtual void clear() {}
+
+    /**
+     * Drop any ISA-side transient state tied to a dynamic instruction
+     * (e.g. after an O3 squash). Default: no-op.
+     */
+    virtual void clearTransientInstState(InstSeqNum /*sn*/) {}
 
     virtual RegVal readMiscRegNoEffect(RegIndex idx) const = 0;
     virtual RegVal readMiscReg(RegIndex idx) = 0;

--- a/src/arch/riscv/SConscript
+++ b/src/arch/riscv/SConscript
@@ -53,6 +53,7 @@ env.TagImplies('isa', 'riscv isa')
 
 Source('decoder.cc', tags=['riscv isa'])
 Source('faults.cc', tags=['riscv isa'])
+Source('fof.cc', tags=['riscv isa'])
 Source('interrupts.cc', tags=['riscv isa'])
 Source('isa.cc', tags=['riscv isa'])
 Source('process.cc', tags=['riscv isa'])

--- a/src/arch/riscv/fof.cc
+++ b/src/arch/riscv/fof.cc
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 The gem5 Authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "arch/riscv/fof.hh"
+
+#include "arch/riscv/isa.hh"
+#include "cpu/exec_context.hh"
+#include "cpu/static_inst.hh"
+#include "cpu/thread_context.hh"
+
+namespace gem5
+{
+namespace RiscvISA
+{
+namespace
+{
+
+FoFTable &
+fofTable(ThreadContext *tc)
+{
+    return static_cast<ISA *>(tc->getIsaPtr())->fof();
+}
+
+bool
+useSeqKey(InstSeqNum sn)
+{
+    return sn != InvalidInstSeqNum;
+}
+
+} // anonymous namespace
+
+void
+FoFTable::set(InstSeqNum sn, const StaticInst *si, uint32_t fault_idx,
+              bool trim_vl)
+{
+    // Re-initiate with NoFault must not erase an already-recorded FoF trim
+    // for this dynamic / static micro (#3362 class of bug).
+    if (useSeqKey(sn)) {
+        auto it = bySeq.find(sn);
+        if (it != bySeq.end() && it->second.trimVl && !trim_vl)
+            return;
+        bySeq[sn] = Entry{si, fault_idx, trim_vl};
+    } else {
+        auto it = bySi.find(si);
+        if (it != bySi.end() && it->second.trimVl && !trim_vl)
+            return;
+        bySi[si] = Entry{si, fault_idx, trim_vl};
+    }
+}
+
+uint32_t
+FoFTable::faultIdx(InstSeqNum sn, const StaticInst *si) const
+{
+    if (useSeqKey(sn)) {
+        auto it = bySeq.find(sn);
+        if (it != bySeq.end())
+            return it->second.faultIdx;
+    } else {
+        auto it = bySi.find(si);
+        if (it != bySi.end())
+            return it->second.faultIdx;
+    }
+    // Unset: do not truncate the memacc element loop.
+    return (uint32_t)-1;
+}
+
+uint32_t
+FoFTable::reduce(InstSeqNum trim_sn,
+                 const std::vector<StaticInstPtr> &load_micros,
+                 uint32_t num_load_micros)
+{
+    const uint32_t n = std::min<uint32_t>(num_load_micros, load_micros.size());
+    uint32_t vl = 0;
+
+    if (useSeqKey(trim_sn)) {
+        for (uint32_t i = 0; i < n; ++i) {
+            InstSeqNum best_sn = 0;
+            const Entry *best = nullptr;
+            for (const auto &kv : bySeq) {
+                // Per-thread table: other harts never appear here. Same-thread
+                // sibling micros may have *gaps* in seqNum (SMT fetch), so do
+                // not assume they occupy [trim_sn-n, trim_sn). Take the
+                // youngest matching StaticInst still older than this trim.
+                if (kv.first >= trim_sn)
+                    continue;
+                if (kv.second.si != load_micros[i].get())
+                    continue;
+                if (!best || kv.first > best_sn) {
+                    best_sn = kv.first;
+                    best = &kv.second;
+                }
+            }
+            if (!best)
+                continue;
+            vl += best->faultIdx;
+            const bool stop = best->trimVl;
+            bySeq.erase(best_sn);
+            if (stop)
+                break;
+        }
+    } else {
+        for (uint32_t i = 0; i < n; ++i) {
+            const StaticInst *si = load_micros[i].get();
+            auto it = bySi.find(si);
+            if (it == bySi.end())
+                continue;
+            vl += it->second.faultIdx;
+            const bool stop = it->second.trimVl;
+            bySi.erase(it);
+            if (stop)
+                break;
+        }
+    }
+
+    return vl;
+}
+
+void
+FoFTable::clearSeq(InstSeqNum sn)
+{
+    if (useSeqKey(sn))
+        bySeq.erase(sn);
+}
+
+void
+FoFTable::clear()
+{
+    bySeq.clear();
+    bySi.clear();
+}
+
+void
+setFoFState(ExecContext *xc, const StaticInst *si, uint32_t fault_idx,
+            bool trim_vl)
+{
+    fofTable(xc->tcBase()).set(xc->getSeqNum(), si, fault_idx, trim_vl);
+}
+
+uint32_t
+getFoFFaultIdx(ExecContext *xc, const StaticInst *si)
+{
+    return fofTable(xc->tcBase()).faultIdx(xc->getSeqNum(), si);
+}
+
+uint32_t
+reduceFoFVl(ExecContext *xc, const std::vector<StaticInstPtr> &load_micros,
+            uint32_t num_load_micros)
+{
+    return fofTable(xc->tcBase())
+            .reduce(xc->getSeqNum(), load_micros, num_load_micros);
+}
+
+void
+clearFoFSeq(ThreadContext *tc, InstSeqNum sn)
+{
+    fofTable(tc).clearSeq(sn);
+}
+
+} // namespace RiscvISA
+} // namespace gem5

--- a/src/arch/riscv/fof.hh
+++ b/src/arch/riscv/fof.hh
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 The gem5 Authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ARCH_RISCV_FOF_HH__
+#define __ARCH_RISCV_FOF_HH__
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+#include "cpu/inst_seq.hh"
+#include "cpu/static_inst_fwd.hh"
+
+namespace gem5
+{
+
+class ExecContext;
+class ThreadContext;
+
+namespace RiscvISA
+{
+
+/**
+ * Fault-only-first (FoF) results for vector unit-stride / segment loads.
+ *
+ * Lives on RiscvISA::ISA (not ExecContext / StaticInst) so:
+ * - Generic CPU interfaces stay ISA-agnostic
+ * - O3 keys by DynInst seqNum (survives commit; cleared on squash)
+ * - In-order CPUs (getSeqNum() == InvalidInstSeqNum) key by StaticInst*
+ *
+ * O3 seqNums are CPU-wide: SMT fetch can insert another hart's instructions
+ * between micros of the same macro, so sibling FoF micros are not necessarily
+ * consecutive. Isolation from other harts comes from a per-thread ISA/table,
+ * not from assuming sn in [trim-n, trim).
+ */
+class FoFTable
+{
+  public:
+    struct Entry
+    {
+        const StaticInst *si = nullptr;
+        uint32_t faultIdx = 0;
+        bool trimVl = false;
+    };
+
+    void set(InstSeqNum sn, const StaticInst *si, uint32_t fault_idx,
+             bool trim_vl);
+    uint32_t faultIdx(InstSeqNum sn, const StaticInst *si) const;
+    uint32_t reduce(InstSeqNum trim_sn,
+                    const std::vector<StaticInstPtr> &load_micros,
+                    uint32_t num_load_micros);
+    void clearSeq(InstSeqNum sn);
+    void clear();
+
+  private:
+    // O3 / any model that reports a real dynamic seqNum.
+    std::unordered_map<InstSeqNum, Entry> bySeq;
+    // In-order models: StaticInst* is unique per micro within a macro.
+    std::unordered_map<const StaticInst *, Entry> bySi;
+};
+
+/** Sentinel: ExecContext has no dynamic sequence number (Simple/Minor/...). */
+static constexpr InstSeqNum InvalidInstSeqNum =
+    std::numeric_limits<InstSeqNum>::max();
+
+void setFoFState(ExecContext *xc, const StaticInst *si, uint32_t fault_idx,
+                 bool trim_vl);
+uint32_t getFoFFaultIdx(ExecContext *xc, const StaticInst *si);
+uint32_t reduceFoFVl(ExecContext *xc,
+                     const std::vector<StaticInstPtr> &load_micros,
+                     uint32_t num_load_micros);
+void clearFoFSeq(ThreadContext *tc, InstSeqNum sn);
+
+} // namespace RiscvISA
+} // namespace gem5
+
+#endif // __ARCH_RISCV_FOF_HH__

--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <string>
 
+#include "arch/riscv/fof.hh"
 #include "arch/riscv/insts/static_inst.hh"
 #include "arch/riscv/isa.hh"
 #include "arch/riscv/regs/misc.hh"
@@ -588,17 +589,11 @@ VlFFTrimVlMicroOp::VlFFTrimVlMicroOp(ExtMachInst _machInst, uint32_t _microVl,
 }
 
 uint32_t
-VlFFTrimVlMicroOp::calcVl() const
+VlFFTrimVlMicroOp::calcVl(ExecContext *xc) const
 {
-    uint32_t vl = 0;
-    for (uint8_t i=0; i<microIdx; i++) {
-        VleMicroInst& micro = static_cast<VleMicroInst&>(*microops[i]);
-        vl += micro.faultIdx;
-
-        if (micro.trimVl)
-            break;
-    }
-    return vl;
+    // microIdx is the number of FoF load micros that precede this trim micro
+    // in the macro (see Vle/VlSeg constructors). Results live on RiscvISA.
+    return RiscvISA::reduceFoFVl(xc, microops, microIdx);
 }
 
 Fault
@@ -613,7 +608,7 @@ VlFFTrimVlMicroOp::execute(ExecContext *xc, trace::InstRecord *traceData) const
     PCState pc;
     set(pc, xc->pcState());
 
-    uint32_t new_vl = calcVl();
+    uint32_t new_vl = calcVl(xc);
 
     tc->setMiscReg(MISCREG_VSTART, 0);
 
@@ -634,9 +629,10 @@ VlFFTrimVlMicroOp::branchTarget(ThreadContext *tc) const
 {
     PCStateBase *pc_ptr = tc->pcState().clone();
 
-    uint32_t new_vl = calcVl();
-
-    pc_ptr->as<PCState>().vl(new_vl);
+    // No ExecContext here (prediction / indirect target). Do not read
+    // StaticInst mutable FoF state. execute() installs the trimmed vl;
+    // keep the current architectural vl for the predicted PC.
+    pc_ptr->as<PCState>().vl(pc_ptr->as<PCState>().vl());
     return std::unique_ptr<PCStateBase>{pc_ptr};
 }
 

--- a/src/arch/riscv/insts/vector.hh
+++ b/src/arch/riscv/insts/vector.hh
@@ -393,10 +393,6 @@ class VseMacroInst : public VectorMemMacroInst
 
 class VleMicroInst : public VectorMicroInst
 {
-  public:
-    mutable bool trimVl;
-    mutable uint32_t faultIdx;
-
   protected:
     Request::Flags memAccessFlags;
 
@@ -405,7 +401,6 @@ class VleMicroInst : public VectorMicroInst
                  uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl, _microIdx,
                           _elen, _vlen)
-        , trimVl(false), faultIdx(_microVl)
     {
         this->flags[IsLoad] = true;
     }
@@ -695,7 +690,7 @@ class VlFFTrimVlMicroOp : public VectorMicroInst
     VlFFTrimVlMicroOp(ExtMachInst _machInst, uint32_t _microVl,
                       uint32_t _microIdx, uint32_t _elen, uint32_t _vlen,
                       std::vector<StaticInstPtr>& _microops);
-    uint32_t calcVl() const;
+    uint32_t calcVl(ExecContext *xc) const;
     Fault execute(ExecContext *, trace::InstRecord *) const override;
     std::unique_ptr<PCStateBase> branchTarget(ThreadContext *) const override;
     std::string generateDisassembly(Addr, const loader::SymbolTable *)
@@ -719,8 +714,6 @@ class VlSegMicroInst : public VectorMicroInst
   protected:
     Request::Flags memAccessFlags;
     uint8_t regIdx;
-    mutable bool trimVl;
-    mutable uint32_t faultIdx;
 
     VlSegMicroInst(const char *mnem, ExtMachInst _machInst,
                    OpClass __opClass, uint32_t _microVl,
@@ -729,7 +722,6 @@ class VlSegMicroInst : public VectorMicroInst
                    uint32_t _elen, uint32_t _vlen)
         : VectorMicroInst(mnem, _machInst, __opClass, _microVl,
                           _microIdx, _elen, _vlen)
-        , trimVl(false), faultIdx(_microVl)
     {
       this->flags[IsLoad] = true;
     }

--- a/src/arch/riscv/isa.cc
+++ b/src/arch/riscv/isa.cc
@@ -473,6 +473,8 @@ void ISA::clear()
     // triggers, starting at zero. simply set a different value here.
     miscRegFile[MISCREG_TSELECT] = 1;
     miscRegFile[MISCREG_NMIE] = reportsExtension("Smrnmi") ? 0 : 1;
+
+    fofTable.clear();
 }
 
 Fault

--- a/src/arch/riscv/isa.hh
+++ b/src/arch/riscv/isa.hh
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include "arch/generic/isa.hh"
+#include "arch/riscv/fof.hh"
 #include "arch/riscv/pcstate.hh"
 #include "arch/riscv/regs/misc.hh"
 #include "arch/riscv/types.hh"
@@ -116,8 +117,20 @@ class ISA : public BaseISA
     */
     const bool _wfiResumeOnPending;
 
+    /** Per-thread FoF trim results (see arch/riscv/fof.hh). */
+    FoFTable fofTable;
+
   public:
     using Params = RiscvISAParams;
+
+    FoFTable &fof() { return fofTable; }
+    const FoFTable &fof() const { return fofTable; }
+
+    void
+    clearTransientInstState(InstSeqNum sn) override
+    {
+        fofTable.clearSeq(sn);
+    }
 
     void clear() override;
 

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -679,7 +679,8 @@ decode QUADRANT default Unknown::unknown() {
                     0x10: decode NF {
                         0x00: VleOp::vle8ff_v({{
                             if ((machInst.vm || elem_mask(v0, ei)) &&
-                                i < this->microVl && i < this->faultIdx) {
+                                i < this->microVl &&
+                                i < RiscvISA::getFoFFaultIdx(xc, this)) {
                                 Vd_ub[i] = Mem_vc.as<uint8_t>()[i];
                             }
                         }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
@@ -862,7 +863,8 @@ decode QUADRANT default Unknown::unknown() {
                     0x10: decode NF {
                         0x00: VleOp::vle16ff_v({{
                             if ((machInst.vm || elem_mask(v0, ei)) &&
-                                i < this->microVl && i < this->faultIdx) {
+                                i < this->microVl &&
+                                i < RiscvISA::getFoFFaultIdx(xc, this)) {
                                 Vd_uh[i] = Mem_vc.as<uint16_t>()[i];
                             }
                         }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
@@ -1045,7 +1047,8 @@ decode QUADRANT default Unknown::unknown() {
                     0x10: decode NF {
                         0x00: VleOp::vle32ff_v({{
                             if ((machInst.vm || elem_mask(v0, ei)) &&
-                                i < this->microVl && i < this->faultIdx) {
+                                i < this->microVl &&
+                                i < RiscvISA::getFoFFaultIdx(xc, this)) {
                                 Vd_uw[i] = Mem_vc.as<uint32_t>()[i];
                             }
                         }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);
@@ -1228,7 +1231,8 @@ decode QUADRANT default Unknown::unknown() {
                     0x10: decode NF {
                         0x00: VleOp::vle64ff_v({{
                             if ((machInst.vm || elem_mask(v0, ei)) &&
-                                i < this->microVl && i < this->faultIdx) {
+                                i < this->microVl &&
+                                i < RiscvISA::getFoFFaultIdx(xc, this)) {
                                 Vd_ud[i] = Mem_vc.as<uint64_t>()[i];
                             }
                         }}, inst_flags=SimdUnitStrideFaultOnlyFirstLoadOp);

--- a/src/arch/riscv/isa/formats/vector_mem.isa
+++ b/src/arch/riscv/isa/formats/vector_mem.isa
@@ -41,14 +41,22 @@ def declareVMemTemplate(class_name):
 
 def getFaultCode():
     return '''
-    Addr fault_addr;
-    if (fault != NoFault && getFaultVAddr(fault, fault_addr)) {
-        assert(fault_addr >= EA);
-        faultIdx = (fault_addr - EA) / (width_EEW(machInst.width) / 8);
-        if (microIdx != 0 || faultIdx != 0) {
-            fault = NoFault;
-            trimVl = true;
+    {
+        // Publish FoF trim state on RiscvISA (not StaticInst / ExecContext):
+        // O3 reuses StaticInst across DynInsts (#3325 / #3362).
+        uint32_t fof_fault_idx = this->microVl;
+        bool fof_trim_vl = false;
+        Addr fault_addr;
+        if (fault != NoFault && getFaultVAddr(fault, fault_addr)) {
+            assert(fault_addr >= EA);
+            fof_fault_idx = (fault_addr - EA) /
+                (width_EEW(machInst.width) / 8);
+            if (microIdx != 0 || fof_fault_idx != 0) {
+                fault = NoFault;
+                fof_trim_vl = true;
+            }
         }
+        RiscvISA::setFoFState(xc, this, fof_fault_idx, fof_trim_vl);
     }
     '''
 

--- a/src/arch/riscv/isa/includes.isa
+++ b/src/arch/riscv/isa/includes.isa
@@ -100,6 +100,7 @@ output exec {{
 
 #include "arch/generic/memhelpers.hh"
 #include "arch/riscv/faults.hh"
+#include "arch/riscv/fof.hh"
 #include "arch/riscv/fp_inst.hh"
 #include "arch/riscv/mmu.hh"
 #include "arch/riscv/reg_abi.hh"

--- a/src/cpu/exec_context.hh
+++ b/src/cpu/exec_context.hh
@@ -42,8 +42,12 @@
 #ifndef __CPU_EXEC_CONTEXT_HH__
 #define __CPU_EXEC_CONTEXT_HH__
 
+#include <limits>
+#include <vector>
+
 #include "base/types.hh"
 #include "cpu/base.hh"
+#include "cpu/inst_seq.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/static_inst_fwd.hh"
 #include "cpu/translation.hh"
@@ -229,6 +233,19 @@ class ExecContext
     virtual AddressMonitor *getAddrMonitor() = 0;
 
     /** @} */
+
+    /**
+     * Dynamic instruction sequence number, if the CPU model assigns one.
+     * In-order models return InvalidInstSeqNum-equivalent max value via
+     * default. O3 DynInst overrides with its seqNum.
+     *
+     * Why here: arch-side transient state (e.g. RVV FoF) may key by seqNum
+     * without putting ISA-specific APIs on ExecContext.
+     */
+    virtual InstSeqNum getSeqNum() const
+    {
+        return std::numeric_limits<InstSeqNum>::max();
+    }
 };
 
 } // namespace gem5

--- a/src/cpu/o3/dyn_inst.cc
+++ b/src/cpu/o3/dyn_inst.cc
@@ -344,6 +344,10 @@ DynInst::setSquashed()
 {
     status.set(Squashed);
 
+    // Drop ISA-side FoF (or other) transient state for this dynamic inst.
+    if (cpu)
+        tcBase()->getIsaPtr()->clearTransientInstState(seqNum);
+
     if (!isPinnedRegsRenamed() || isPinnedRegsSquashDone())
         return;
 

--- a/src/cpu/o3/dyn_inst.hh
+++ b/src/cpu/o3/dyn_inst.hh
@@ -132,6 +132,12 @@ class DynInst : public ExecContext, public RefCounted
     /** The sequence number of the instruction. */
     InstSeqNum seqNum = 0;
 
+    InstSeqNum
+    getSeqNum() const override
+    {
+        return seqNum;
+    }
+
     /** The StaticInst used by this BaseDynInst. */
     const StaticInstPtr staticInst;
 

--- a/src/cpu/simple/exec_context.hh
+++ b/src/cpu/simple/exec_context.hh
@@ -452,4 +452,4 @@ class SimpleExecContext : public ExecContext
 
 } // namespace gem5
 
-#endif // __CPU_EXEC_CONTEXT_HH__
+#endif // __CPU_SIMPLE_EXEC_CONTEXT_HH__


### PR DESCRIPTION
## Summary
- RVV `vle*ff` stored `faultIdx`/`trimVl` as mutable fields on `StaticInst`. O3 reuses that object across DynInsts, so a later or speculative execution can see a stale FoF trim and install the wrong `vl` (livelock, #3325).
- Move FoF results to `RiscvISA::FoFTable`, keyed by DynInst `seqNum` on O3 (`StaticInst*` on in-order). `VlFFTrimVl` reduces from the table; squash clears the seqNum; a later NoFault `initiateAcc` must not erase an already-recorded trim (the #3362 failure mode).
- The table is per-thread ISA. O3 `seqNum` is CPU-wide, so SMT fetch may leave gaps between sibling micros; reduce selects the youngest matching `StaticInst` with `sn < trim_sn` rather than assuming consecutive numbers.

Fixes #3325.
Related: #3362 (workaround closed after `rvv-strlen-fault` O3 failed).

Out of scope: `vlseg*ff` reduce covering only the first-field micro prefix (pre-existing).

## Test plan
- [x] #3325 binary `001_b01_always_taken__c01_sequential_unit_stride` + `RiscvO3CPU` + caches: `validation=PASS` (no hang)
- [x] Same binary + `RiscvAtomicSimpleCPU`: `validation=PASS`
- [x] `rvv-strlen-fault` O3 `--vlen=256` and `--vlen=16384`: pass (the #3362 CI case)
- [x] Smoke: `rvv-strlen` / `rvv-memcpy` / `rvv-strcpy` O3 vlen=16384: pass
- [x] Dual-core and 4-core O3, two/four copies of the #3325 binary: all `validation=PASS`
- [x] SMT (`--smt`, one O3, two harts) #3325 and `rvv-strlen-fault`: both harts pass
- [x] SMT with `smtNumFetchingThreads=2` (same-cycle dual fetch): #3325 PASS; `strlen-fault` VLEN=16384 pass; mixed #3325 + strlen-fault pass
- [x] Dual-core TimingSimpleCPU and MinorCPU #3325: `validation=PASS`
- [ ] CI `se_mode/rvv_intrinsic_tests` (quick)