### PR TITLE
Add XGMI hive peer-to-peer support

### DIFF
--- a/configs/example/gem5_library/x86-mi300x-xgmi.py
+++ b/configs/example/gem5_library/x86-mi300x-xgmi.py
@@ -54,7 +54,10 @@ from gem5.components.processors.simple_processor import SimpleProcessor
 from gem5.isas import ISA
 from gem5.prebuilt.viper.board import ViperBoard
 from gem5.prebuilt.viper.cpu_cache_hierarchy import ViperCPUCacheHierarchy
-from gem5.resources.resource import DiskImageResource, FileResource
+from gem5.resources.resource import (
+    DiskImageResource,
+    FileResource,
+)
 from gem5.simulate.simulator import Simulator
 from gem5.utils.requires import requires
 

--- a/configs/example/gem5_library/x86-mi300x-xgmi.py
+++ b/configs/example/gem5_library/x86-mi300x-xgmi.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Script to run a full system GPU simulation.
+
+Usage:
+------
+```
+scons build/VEGA_X86/gem5.opt
+./build/VEGA_X86/gem5.opt
+    configs/example/gem5_library/x86-mi300x-xgmi.py
+    --image <disk image>
+    --kernel <kernel>
+    --app <gpu application>
+```
+"""
+
+import argparse
+
+from gem5.coherence_protocol import CoherenceProtocol
+from gem5.components.devices.gpus.amdgpu import MI300X
+from gem5.components.devices.gpus.xgmi import xGMIHive
+from gem5.components.memory import HBM2Stack
+from gem5.components.memory.single_channel import SingleChannelDDR4_2400
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.isas import ISA
+from gem5.prebuilt.viper.board import ViperBoard
+from gem5.prebuilt.viper.cpu_cache_hierarchy import ViperCPUCacheHierarchy
+from gem5.resources.resource import DiskImageResource, FileResource
+from gem5.simulate.simulator import Simulator
+from gem5.utils.requires import requires
+
+requires(coherence_protocol_required=CoherenceProtocol.GPU_VIPER)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--image", type=str, required=True)
+parser.add_argument("--kernel", type=str, required=True)
+parser.add_argument("--app", type=str, required=True)
+parser.add_argument("--kvm-perf", default=False, action="store_true")
+args = parser.parse_args()
+
+memory = SingleChannelDDR4_2400(size="8GiB")
+processor = SimpleProcessor(cpu_type=CPUTypes.KVM, isa=ISA.X86, num_cores=1)
+
+for core in processor.cores:
+    if core.is_kvm_core():
+        core.get_simobject().usePerf = args.kvm_perf
+
+hive = xGMIHive()
+gpu0 = MI300X(gpu_memory=HBM2Stack(size="4GiB"), num_cus=4, xgmi_hive=hive)
+gpu1 = MI300X(gpu_memory=HBM2Stack(size="4GiB"), num_cus=4, xgmi_hive=hive)
+gpu0.device.force_p2p_gart_remap = True
+gpu0.device.p2p_peer_id = 1
+gpu1.device.force_p2p_gart_remap = True
+gpu1.device.p2p_peer_id = 0
+
+cache_hierarchy = ViperCPUCacheHierarchy(
+    l1d_size="32KiB",
+    l1d_assoc=8,
+    l1i_size="32KiB",
+    l1i_assoc=8,
+    l2_size="1MiB",
+    l2_assoc=16,
+    l3_size="16MiB",
+    l3_assoc=16,
+)
+
+board = ViperBoard(
+    clk_freq="3GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+    gpus=[gpu0, gpu1],
+    xgmi_hives=[hive],
+)
+
+disk = DiskImageResource(local_path=args.image, root_partition="1")
+kernel = FileResource(local_path=args.kernel)
+board.set_kernel_disk_workload(
+    kernel=kernel,
+    disk_image=disk,
+    readfile_contents=board.make_gpu_app(gpu0, args.app, ""),
+)
+board.append_kernel_arg("idle=nomwait")
+board.append_kernel_arg("clearcpuid=clflushopt")
+
+simulator = Simulator(board=board)
+simulator.run()

--- a/simple_p2p.py
+++ b/simple_p2p.py
@@ -2,6 +2,7 @@
 
 import torch
 
+
 def run_p2p_test(N):
     print("Initializing PyTorch...")
     if not torch.cuda.is_available():
@@ -20,14 +21,16 @@ def run_p2p_test(N):
     cpu = torch.device("cpu")
 
     # 1. CPU -> GPU0
-    print(f"1. CPU -> GPU0: Allocating {N} floats on CPU and copying to {dev0}...")
+    print(
+        f"1. CPU -> GPU0: Allocating {N} floats on CPU and copying to {dev0}..."
+    )
     t_cpu = torch.full((N,), 1.0, device=cpu)
-    t0 = t_cpu.to(dev0) # Triggers Host -> Device copy
+    t0 = t_cpu.to(dev0)  # Triggers Host -> Device copy
     torch.cuda.synchronize(dev0)
 
     # 2. GPU0 -> GPU1 (P2P)
     print(f"2. GPU0 -> GPU1: Copying data from {dev0} to {dev1}...")
-    t1 = t0.to(dev1) # Triggers Device -> Device (XGMI) copy
+    t1 = t0.to(dev1)  # Triggers Device -> Device (XGMI) copy
     torch.cuda.synchronize(dev1)
 
     # 3. Compute on GPU1
@@ -38,12 +41,11 @@ def run_p2p_test(N):
 
     # 4. GPU1 -> CPU
     print(f"4. GPU1 -> CPU: Copying result from {dev1} back to CPU...")
-    t_final_cpu = t_result.to(cpu) # Triggers Device -> Host copy
+    t_final_cpu = t_result.to(cpu)  # Triggers Device -> Host copy
 
     print("Verifying data...")
     result = t_final_cpu.sum().item()
     return result
-
 
 
 test_num = 50
@@ -52,4 +54,6 @@ expected_val = float(test_num) * 2.0
 if abs(run_testing - expected_val) < 1e-5:
     print("SUCCESS: Data transferred and calculated correctly!")
 else:
-    print(f"FAILURE: Data mismatch. Expected {expected_val}, got {run_testing}")
+    print(
+        f"FAILURE: Data mismatch. Expected {expected_val}, got {run_testing}"
+    )

--- a/simple_p2p.py
+++ b/simple_p2p.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import torch
+
+def run_p2p_test(N):
+    print("Initializing PyTorch...")
+    if not torch.cuda.is_available():
+        print("Error: CUDA/ROCm not available.")
+        return
+
+    gpu_count = torch.cuda.device_count()
+    print(f"Detected {gpu_count} GPUs.")
+
+    if gpu_count < 2:
+        print("Error: Need at least 2 GPUs for Peer-to-Peer test.")
+        return
+
+    dev0 = torch.device("cuda:0")
+    dev1 = torch.device("cuda:1")
+    cpu = torch.device("cpu")
+
+    # 1. CPU -> GPU0
+    print(f"1. CPU -> GPU0: Allocating {N} floats on CPU and copying to {dev0}...")
+    t_cpu = torch.full((N,), 1.0, device=cpu)
+    t0 = t_cpu.to(dev0) # Triggers Host -> Device copy
+    torch.cuda.synchronize(dev0)
+
+    # 2. GPU0 -> GPU1 (P2P)
+    print(f"2. GPU0 -> GPU1: Copying data from {dev0} to {dev1}...")
+    t1 = t0.to(dev1) # Triggers Device -> Device (XGMI) copy
+    torch.cuda.synchronize(dev1)
+
+    # 3. Compute on GPU1
+    print(f"3. GPU1: Performing calculation (adding 1.0 to each element)...")
+    # This forces the CU to read the data that was just written by SDMA
+    t_result = t1 + 1.0
+    torch.cuda.synchronize(dev1)
+
+    # 4. GPU1 -> CPU
+    print(f"4. GPU1 -> CPU: Copying result from {dev1} back to CPU...")
+    t_final_cpu = t_result.to(cpu) # Triggers Device -> Host copy
+
+    print("Verifying data...")
+    result = t_final_cpu.sum().item()
+    return result
+
+
+
+test_num = 50
+run_testing = run_p2p_test(test_num)
+expected_val = float(test_num) * 2.0
+if abs(run_testing - expected_val) < 1e-5:
+    print("SUCCESS: Data transferred and calculated correctly!")
+else:
+    print(f"FAILURE: Data mismatch. Expected {expected_val}, got {run_testing}")

--- a/src/dev/amdgpu/AMDGPU.py
+++ b/src/dev/amdgpu/AMDGPU.py
@@ -70,6 +70,15 @@ class AMDGPUDevice(PciEndpoint):
     ProgIF = 0x00
 
     gpu_id = Param.Int(0, "ID of GPU, if multiple GPUs are instantiated")
+    xgmi_hive = Param.XGMIHive(
+        NULL, "XGMI hive this GPU belongs to or NULL if xGMI is disabled."
+    )
+    xgmi_node = Param.Int(0, "xGMI node id or 0 is xGMI is disabled.")
+    force_p2p_gart_remap = Param.Bool(
+        False,
+        "Force-remap GART PTEs for peer buffers into a peer BAR to enable true P2P.",
+    )
+    p2p_peer_id = Param.Int(1, "Peer GPU ID used for forced P2P GART remap.")
 
     # Use max possible BAR size for Vega 10. We can override with driver param
     BAR0 = PciMemBar(size="16GiB")

--- a/src/dev/amdgpu/amdgpu_device.cc
+++ b/src/dev/amdgpu/amdgpu_device.cc
@@ -63,7 +63,11 @@ AMDGPUDevice::AMDGPUDevice(const AMDGPUDeviceParams &p)
       _lastVMID(0),
       deviceMem(name() + ".deviceMem", p.memories, false, "", false),
       system(p.system),
-      gpuId(p.gpu_id)
+      gpuId(p.gpu_id),
+      xgmiHive(p.xgmi_hive),
+      xgmiNode(p.xgmi_node),
+      forceP2PGartRemap(p.force_p2p_gart_remap),
+      p2pPeerId(p.p2p_peer_id)
 {
     uint64_t vram_size = 0;
 
@@ -430,7 +434,11 @@ AMDGPUDevice::writeConfig(PacketPtr pkt)
 
             config().expansionROM = 0xfffff000;
         } else {
-            return PciEndpoint::writeConfig(pkt);
+            Tick delay = PciEndpoint::writeConfig(pkt);
+            if (xgmiHive) {
+                xgmiHive->updateAddressRange(gpuId, BARs[0]->range());
+            }
+            return delay;
         }
     }
 
@@ -559,7 +567,39 @@ AMDGPUDevice::writeFrame(PacketPtr pkt, Addr offset)
 
     // Record the value
     if (aperture == gpuvm.gartBase()) {
-        gpuvm.gartTable[aperture_offset] = pkt->getUintX(ByteOrder::little);
+        uint64_t pte_val = pkt->getUintX(ByteOrder::little);
+
+        if (forceP2PGartRemap && xgmiHive) {
+            const auto &devices = xgmiHive->getDevices();
+            auto peer_it = devices.find(p2pPeerId);
+            if (peer_it != devices.end()) {
+                const uint64_t lower_mask = (1ULL << 12) - 1;
+                Addr page_base = (pte_val >> 12) << 12;
+                Addr peer_frame_size = xgmiHive->getFrameSize(p2pPeerId);
+
+                if (page_base < peer_frame_size) {
+                    Addr peer_base = xgmiHive->getDeviceBase(p2pPeerId);
+                    Addr remapped = peer_base + page_base;
+                    uint64_t flags = pte_val & lower_mask;
+                    uint64_t remapped_pfn = remapped >> 12;
+                    pte_val = (remapped_pfn << 12) | flags;
+
+                    DPRINTF(AMDGPUDevice,
+                            "GART P2P remap peer %d: base %#lx offset %#lx -> %#lx\n",
+                            p2pPeerId, peer_base, page_base, remapped);
+                } else {
+                    DPRINTF(AMDGPUDevice,
+                            "GART P2P remap skipped for offset %#lx (peer %d size %#lx)\n",
+                            page_base, p2pPeerId, peer_frame_size);
+                }
+            } else {
+                DPRINTF(AMDGPUDevice,
+                        "GART P2P remap requested but peer %d not in hive\n",
+                        p2pPeerId);
+            }
+        }
+
+        gpuvm.gartTable[aperture_offset] = pte_val;
         DPRINTF(AMDGPUDevice, "GART translation %p -> %p\n", aperture_offset,
                 gpuvm.gartTable[aperture_offset]);
     }

--- a/src/dev/amdgpu/amdgpu_device.hh
+++ b/src/dev/amdgpu/amdgpu_device.hh
@@ -173,6 +173,17 @@ class AMDGPUDevice : public PciEndpoint
     const int gpuId;
     Addr vramSize;
 
+    /* XGMI */
+    bool xgmiEnabled = false;
+    XGMIHive *xgmiHive = nullptr;
+    int xgmiNode = 0;
+
+    // Optional: when enabled, remap GART PTEs for peer buffers into a
+    // peer GPU's BAR aperture instead of system memory. This allows "true"
+    // P2P when the emulated driver programs GART entries for peer buffers.
+    bool forceP2PGartRemap = false;
+    int p2pPeerId = 1;
+
   protected:
     /**
      * Methods inherited from PciEndpoint

--- a/src/dev/amdgpu/sdma_engine.cc
+++ b/src/dev/amdgpu/sdma_engine.cc
@@ -155,6 +155,11 @@ SDMAEngine::getDeviceAddress(Addr raw_addr)
         } else {
             device_addr = tmp_addr - gpuDevice->getVM().getMMHUBBase();
         }
+    } else if (gpuDevice->getXgmiHive()->isXgmiAddress(tmp_addr)) {
+        // If the address is in the XGMI Hive, it is a valid device address.
+        // We return the physical address directly as it will be handled
+        // by the XGMI logic in the copy function.
+        device_addr = tmp_addr;
     }
 
     return device_addr;
@@ -732,8 +737,21 @@ SDMAEngine::copy(SDMAQueue *q, sdmaCopy *pkt)
     // Read data from the source first, then call the copyReadData method
     uint8_t *dmaBuffer = new uint8_t[pkt->count];
     Addr device_addr = getDeviceAddress(pkt->source);
+
+    // Translate source address to physical address for XGMI check
+    Addr phys_source = pkt->source;
+    auto tgen = translate(pkt->source, 64);
+    if (tgen) {
+        auto addr_range = *(tgen->begin());
+        phys_source = addr_range.paddr;
+        DPRINTF(SDMAEngine, "Translation: Virt %#lx -> Phys %#lx\n", pkt->source, phys_source);
+    }
+
     if (device_addr) {
         DPRINTF(SDMAEngine, "Copying from device address %#lx\n", device_addr);
+        if (gpuDevice->getXgmiHive()->isXgmiAddress(phys_source)) {
+             DPRINTF(SDMAEngine, "Note: Address %#lx is also in XGMI Hive. Local path taken.\n", phys_source);
+        }
         auto cb = new EventFunctionWrapper(
             [=, this] { copyReadData(q, pkt, dmaBuffer); }, name());
 
@@ -754,6 +772,7 @@ SDMAEngine::copy(SDMAQueue *q, sdmaCopy *pkt)
             buffer_ptr += gen.size();
         }
     } else {
+        DPRINTF(SDMAEngine, "Copying from host address %#lx\n", pkt->source);
         auto cb = new DmaVirtCallback<uint64_t>(
             [=, this](const uint64_t &) { copyReadData(q, pkt, dmaBuffer); });
         dmaReadVirt(pkt->source, pkt->count, cb, (void *)dmaBuffer,
@@ -778,9 +797,32 @@ SDMAEngine::copyReadData(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer)
     }
 
     Addr device_addr = getDeviceAddress(pkt->dest);
+
+    // Translate destination address to physical address for XGMI check
+    Addr phys_dest = pkt->dest;
+    auto tgen = translate(pkt->dest, 64);
+    if (tgen) {
+        auto addr_range = *(tgen->begin());
+        phys_dest = addr_range.paddr;
+        DPRINTF(SDMAEngine, "Translation: Virt %#lx -> Phys %#lx\n", pkt->dest, phys_dest);
+    }
+
+    if (gpuDevice->getXgmiHive()) {
+        DPRINTF(SDMAEngine, "Hive Check: ID %d, Nodes %d. Addr %#lx isXgmi? %d\n",
+                gpuDevice->getXgmiHive()->getHiveId(),
+                gpuDevice->getXgmiHive()->getNodeCount(),
+                phys_dest,
+                gpuDevice->getXgmiHive()->isXgmiAddress(phys_dest));
+    } else {
+        DPRINTF(SDMAEngine, "Hive Check: No XGMI Hive configured.\n");
+    }
+
     // Write read data to the destination address then call the copyDone method
     if (device_addr) {
         DPRINTF(SDMAEngine, "Copying to device address %#lx\n", device_addr);
+        if (gpuDevice->getXgmiHive()->isXgmiAddress(phys_dest)) {
+             DPRINTF(SDMAEngine, "Note: Address %#lx is also in XGMI Hive. Local path taken.\n", phys_dest);
+        }
         auto cb = new EventFunctionWrapper(
             [=, this] { copyDone(q, pkt, dmaBuffer); }, name());
 
@@ -803,6 +845,9 @@ SDMAEngine::copyReadData(SDMAQueue *q, sdmaCopy *pkt, uint8_t *dmaBuffer)
         }
     } else {
         DPRINTF(SDMAEngine, "Copying to host address %#lx\n", pkt->dest);
+
+        // Defer L2 invalidation until after the host write completes to avoid
+        // racing with stale data still in memory.
         auto cb = new DmaVirtCallback<uint64_t>(
             [=, this](const uint64_t &) { copyDone(q, pkt, dmaBuffer); });
         dmaWriteVirt(pkt->dest, pkt->count, cb, (void *)dmaBuffer);

--- a/src/dev/amdgpu/xgmi_hive.hh
+++ b/src/dev/amdgpu/xgmi_hive.hh
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEV_AMDGPU_XGMI_HIVE_HH__
+#define __DEV_AMDGPU_XGMI_HIVE_HH__
+
+#include <map>
+#include <unordered_map>
+
+#include "params/XGMIHive.hh"
+#include "sim/sim_object.hh"
+
+namespace gem5
+{
+
+class AddrRange;
+class AMDGPUDevice;
+
+/*
+ * This class represents an xGMI hive, which is a collection of AMDGPU devices.
+ * A hive sits at the system level and manages global framebuffer (i.e., shared
+ * memory) address ranges.
+ */
+class XGMIHive : public SimObject
+{
+  public:
+    XGMIHive(const XGMIHiveParams &p);
+
+    // Called after all SimObjects are constructed. Here we can setup initial
+    // framebuffer offsets based on the number of nodes in the hive and their
+    // memory sizes.
+    void init() override;
+
+    // Called when an AMDGPU device is constructed to add information about
+    // its GPU ID and framebuffer size.
+    void addNode(AMDGPUDevice *device);
+
+    // Called when an AMDGPU device receives an update from the OS about its
+    // PCIe BAR0 address range. Communication of xGMI is seen as a system
+    // address in the PCIe BAR0 range.
+    void updateAddressRange(int gpuId, const AddrRange &bar0Range);
+
+    // Used to check if an address with the system bit set should be routed to
+    // another GPU in this hive or to the host.
+    bool isXgmiAddress(Addr addr) const;
+
+    // When xGMI is enabled a GPU's framebuffer addresses are offset by
+    // a base address determined by the hive. This function returns that base
+    // address for a given GPU ID.
+    Addr getXgmiBaseAddr(int gpuId) const;
+
+    int
+    getNodeCount() const
+    {
+        return gpuFrameSize.size();
+    }
+    Addr getFrameSize(int gpuId) const;
+
+    uint64_t getHiveId() const { return hiveId; }
+
+    int getDeviceId(Addr addr) const;
+    AMDGPUDevice *getDevice(int gpuId) const;
+    const std::unordered_map<int, AMDGPUDevice *>& getDevices() const { return gpuDevices; }
+    Addr getDeviceBase(int gpuId) const;
+
+  private:
+    const int hiveId = 0;
+
+    // For these ranges we use gem5's gpuId rather than xGMI node ID as gem5
+    // sets up the local frame buffer address ranges based on gpuId. This
+    // removes a lot of complexity which would otherwise needed to sort ranges
+    // based on xGMI node ID. The node ID itself is only used to pass to the
+    // driver via an MMIO. The frame sizes we want ordered for us.
+    std::unordered_map<int, AddrRange> gpuAddressRange;
+    std::unordered_map<int, AddrRange> gpuFrameOffset;
+    std::map<int, AddrRange> gpuFrameSize;
+    std::unordered_map<int, AMDGPUDevice *> gpuDevices;
+};
+
+} // namespace gem5
+
+#endif // __DEV_AMDGPU_XGMI_HIVE_HH__


### PR DESCRIPTION
This change adds XGMI hive support for multi-GPU AMDGPU simulations.

The changes:

- Add the `XGMIHive` device header and GPU configuration parameters.
- Support peer-to-peer GPU memory transfers through XGMI.
- Add optional GART remapping for peer GPU BAR apertures.
- Update SDMA handling for XGMI source and destination addresses.
- Add cache invalidation after peer-to-peer writes.
- Add an MI300X dual-GPU XGMI example configuration.
- Add a PyTorch peer-to-peer validation script.