### PR TITLE
arch-riscv: change PTE parameter to reference in checkPTEPermissions

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -650,7 +650,7 @@ Walker::WalkerState::startFunctional(Addr &addr, unsigned &logBytes)
 }
 
 Fault
-Walker::WalkerState::checkPTEPermissions(PTE pte, WalkFlags &stepWalkFlags,
+Walker::WalkerState::checkPTEPermissions(PTE& pte, WalkFlags &stepWalkFlags,
                                          int level)
 {
     // If valid bit is off OR

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -165,7 +165,8 @@ namespace RiscvISA
             std::string name() const {return walker->name();}
 
           private:
-            Fault checkPTEPermissions(PTE pte, WalkFlags &stepWalkFlags,
+            // Mutates pte's access (a) and dirty (d) bits.
+            Fault checkPTEPermissions(PTE& pte, WalkFlags &stepWalkFlags,
                                       int level);
             Addr setupWalk(Addr vaddr);
             Fault stepWalk(PacketPtr &write);


### PR DESCRIPTION
`Walker::WalkerState::checkPTEPermissions()` takes the PTE by value, so the `pte.a = 1` / `pte.d = 1` it performs are discarded when it returns. 

An access through a leaf PTE with `A=0` completes without a page fault.