### PR TITLE
configs: Fix duplicate key in the Benchmarks dict

### DIFF
--- a/configs/common/Benchmarks.py
+++ b/configs/common/Benchmarks.py
@@ -134,7 +134,7 @@ Benchmarks = {
     "ValMemLat": [SysConfig("micro_memlat.rcS", "512MiB")],
     "ValMemLat2MB": [SysConfig("micro_memlat2mb.rcS", "512MiB")],
     "ValMemLat8MB": [SysConfig("micro_memlat8mb.rcS", "512MiB")],
-    "ValMemLat": [SysConfig("micro_memlat8.rcS", "512MiB")],
+    "ValMemLat8": [SysConfig("micro_memlat8.rcS", "512MiB")],
     "ValTlbLat": [SysConfig("micro_tlblat.rcS", "512MiB")],
     "ValSysLat": [SysConfig("micro_syscall.rcS", "512MiB")],
     "ValCtxLat": [SysConfig("micro_ctx.rcS", "512MiB")],


### PR DESCRIPTION
## Summary

`configs/common/Benchmarks.py` defines the `Benchmarks` dict with two
entries under the same key, `"ValMemLat"`:

```python
"ValMemLat":     [SysConfig("micro_memlat.rcS",    "512MiB")],
"ValMemLat2MB":  [SysConfig("micro_memlat2mb.rcS", "512MiB")],
"ValMemLat8MB":  [SysConfig("micro_memlat8mb.rcS", "512MiB")],
"ValMemLat":     [SysConfig("micro_memlat8.rcS",   "512MiB")],   # <-- duplicate
```

A dict literal keeps the last binding, so the second entry silently
shadows the first and `micro_memlat.rcS` cannot be selected by any value
of `--benchmark`.

## The fix

Every other entry in this group pairs the key suffix with the matching
script suffix (`ValMemLat2MB` with `micro_memlat2mb.rcS`, `ValMemLat8MB`
with `micro_memlat8mb.rcS`), so the second entry is renamed to
`ValMemLat8` to match `micro_memlat8.rcS`.

## Behaviour change (please note)

This does change what `--benchmark=ValMemLat` resolves to:

| key | before | after |
| --- | --- | --- |
| `ValMemLat` | `micro_memlat8.rcS` | `micro_memlat.rcS` |
| `ValMemLat8` | *(did not exist)* | `micro_memlat8.rcS` |

The dict goes from 32 to 33 reachable entries and no script is left
unreachable.

If maintainers would rather not change the meaning of the existing
`ValMemLat` key, the alternative fix is to simply drop the duplicate
line. I am happy to switch to that if preferred — I chose the rename
because it keeps both scripts reachable and follows the naming
convention already used by the surrounding entries.

## How this was checked

- `black --check configs/common/Benchmarks.py` — no changes needed.
- `util/git-pre-commit.py` (gem5 style checker) — passes.
- `util/git-commit-msg.py` — passes (header 50/65 chars, longest body
  line 70/72 columns).
- Re-parsed the file with `ast` to confirm the dict no longer contains
  duplicate keys, and evaluated the key/script mapping before and after
  to produce the table above.

Note: I could not run the full `pre-commit` suite locally because the
host Python is 3.9 and the pinned `isort` hook requires >= 3.10. The
hooks relevant to this diff were run individually as listed above; the
remaining hooks (isort, pyupgrade, yamlfmt, clang-format) do not apply
to a one-line dict-key change.

The duplicate has been present since at least 2020.
