### PR TITLE
tests: Share the gem5 resource cache across runners

### DIFF
--- a/.github/workflows/ci-daily-codecov.yaml
+++ b/.github/workflows/ci-daily-codecov.yaml
@@ -120,7 +120,12 @@ jobs:
             matrix:
                 test-type: ${{ fromJson(needs.flatten-length-and-testdir-matrices.outputs.test-dirs-matrix-flattened) }}
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        container:
+            image: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 1800 # 30 hours
         needs: [get-date, get-testlib-dirs, flatten-length-and-testdir-matrices]
         steps:
@@ -139,8 +144,15 @@ jobs:
               id: run-tests
               timeout-minutes: 1770
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run ${{ matrix.test-type.testdir }} --length ${{ matrix.test-type.length }} --gcov=test-only -j$(nproc) -vv --exclude-tags
-                  gcn_gpu
+              run: |
+                  resource_dir="$GEM5_RESOURCE_DIR"
+                  # These legacy fixtures do not checksum or lock downloads.
+                  case "${{ matrix.test-type.testdir }}" in
+                    gem5/cpu_tests|gem5/fdp_tests|gem5/m5threads_test_atomic)
+                      resource_dir="$RUNNER_TEMP/gem5-testlib-downloads"
+                      ;;
+                  esac
+                  ./main.py run ${{ matrix.test-type.testdir }} --length ${{ matrix.test-type.length }} --gcov=test-only -j$(nproc) -vv --exclude-tags gcn_gpu --bin-path "$resource_dir"
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
@@ -167,7 +179,12 @@ jobs:
             matrix:
                 test-length: [quick, long]
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
+        container:
+            image: ghcr.io/gem5/gcn-gpu:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 1620 # 27 hours. Sum of daily and CI test timeout
         needs: get-date
 
@@ -191,7 +208,7 @@ jobs:
             - name: Run Testlib GPU Tests
               id: run-tests
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --length=${{ matrix.test-length }} -vvv --gcov=test-only -j $(nproc) --host gcn_gpu --isa=VEGA_X86
+              run: ./main.py run --length=${{ matrix.test-length }} -vvv --gcov=test-only -j $(nproc) --host gcn_gpu --isa=VEGA_X86 --bin-path "$GEM5_RESOURCE_DIR"
               timeout-minutes: 1590
 
             - name: Upload results
@@ -267,7 +284,12 @@ jobs:
 # Get code coverage for dramsys-tests (from the Daily Tests).
     dramsys-tests:
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        container:
+            image: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 360 # 6 hours
         steps:
             - uses: actions/checkout@v7

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -142,7 +142,12 @@ jobs:
     testlib-long-tests:
         name: long-tests
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        container:
+            image: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 1440 # 24 hours for entire matrix to run
         needs:
             - build-all-gem5
@@ -167,7 +172,15 @@ jobs:
               id: run-tests
               timeout-minutes: 1410
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run ${{ matrix.test-type }} -j$(nproc) --length=long -vv -t $(nproc) --exclude-tags gcn_gpu
+              run: |
+                  resource_dir="$GEM5_RESOURCE_DIR"
+                  # These legacy fixtures do not checksum or lock downloads.
+                  case "${{ matrix.test-type }}" in
+                    gem5/cpu_tests|gem5/fdp_tests|gem5/m5threads_test_atomic)
+                      resource_dir="$RUNNER_TEMP/gem5-testlib-downloads"
+                      ;;
+                  esac
+                  ./main.py run ${{ matrix.test-type }} -j$(nproc) --length=long -vv -t $(nproc) --exclude-tags gcn_gpu --bin-path "$resource_dir"
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
@@ -187,7 +200,12 @@ jobs:
 
     gpu-tests:
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
+        container:
+            image: ghcr.io/gem5/gcn-gpu:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 1440 # 24 hours
         needs:
             - get-date
@@ -207,7 +225,7 @@ jobs:
               id: run-tests
               timeout-minutes: 1410
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --length=long -vvv -j $(nproc) --host gcn_gpu --isa=VEGA_X86
+              run: ./main.py run --length=long -vvv -j $(nproc) --host gcn_gpu --isa=VEGA_X86 --bin-path "$GEM5_RESOURCE_DIR"
 
             - name: Upload results
               if: always()
@@ -262,7 +280,12 @@ jobs:
 
     dramsys-tests:
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        container:
+            image: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 360 # 6 hours
         steps:
             - uses: actions/checkout@v7

--- a/.github/workflows/weekly-tests.yaml
+++ b/.github/workflows/weekly-tests.yaml
@@ -60,7 +60,12 @@ jobs:
             matrix:
                 test-type: ${{ fromJson(needs.get-testlib-very-long-dirs.outputs.test-dirs-matrix) }}
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        container:
+            image: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 4320 # 3 days
         needs: [get-date, get-testlib-very-long-dirs]
         steps:
@@ -84,10 +89,22 @@ jobs:
               # very-long without that flag.
               run: |
                   extra_gcov_args="--gcov=test-only"
+                  resource_dir="$GEM5_RESOURCE_DIR"
                   if [ "${{ matrix.test-type }}" = "gem5/x86_boot_tests" ]; then
                     extra_gcov_args=""
                   fi
-                  ./main.py run ${{ matrix.test-type }} --length=very-long ${extra_gcov_args} -j"$(nproc)" -vv --exclude-tags gcn_gpu
+                  # These legacy fixtures do not checksum or lock downloads.
+                  case "${{ matrix.test-type }}" in
+                    gem5/cpu_tests|gem5/fdp_tests|gem5/m5threads_test_atomic)
+                      resource_dir="$RUNNER_TEMP/gem5-testlib-downloads"
+                      ;;
+                  esac
+                  # This suite intentionally downloads and deletes every
+                  # resource version. Keep it out of the persistent cache.
+                  if [ "${{ matrix.test-type }}" = "gem5/gem5_resources" ]; then
+                    resource_dir="$RUNNER_TEMP/gem5-resource-download-test"
+                  fi
+                  ./main.py run ${{ matrix.test-type }} --length=very-long ${extra_gcov_args} -j"$(nproc)" -vv --exclude-tags gcn_gpu --bin-path "$resource_dir"
 
             - name: Sanitize test-dir for artifact name
               id: sanitize-test-dir
@@ -112,7 +129,12 @@ jobs:
         strategy:
             fail-fast: false
         runs-on: [self-hosted, linux, x64]
-        container: ghcr.io/gem5/gcn-gpu:latest
+        container:
+            image: ghcr.io/gem5/gcn-gpu:latest
+            volumes:
+                - /gem5-resource-cache:/gem5-resource-cache
+        env:
+            GEM5_RESOURCE_DIR: /gem5-resource-cache
         timeout-minutes: 4320 # 3 days
         needs: get-date
 
@@ -130,7 +152,7 @@ jobs:
             - name: Run Testlib GPU Tests
               id: run-tests
               working-directory: ${{ github.workspace }}/tests
-              run: ./main.py run --length=very-long -vvv --gcov=test-only -j $(nproc) --host gcn_gpu --isa=VEGA_X86
+              run: ./main.py run --length=very-long -vvv --gcov=test-only -j $(nproc) --host gcn_gpu --isa=VEGA_X86 --bin-path "$GEM5_RESOURCE_DIR"
               timeout-minutes: 4290
 
             - name: Upload results


### PR DESCRIPTION
## Why

The Daily, Weekly, and Codecov workflows run on ephemeral GitHub Actions
runners inside Loupe VMs. Each new runner currently downloads its own copy of
the gem5 resources needed by Testlib and the standard library. Those repeated
downloads consume bandwidth from the Azure-backed gem5 resources service and
increase its operating cost.

Loupe now exposes the same writable `/gem5-resource-cache` host directory in
every runner VM through a cache-disabled, mapped 9p mount. This change makes
the trusted scheduled workflows use that shared directory, allowing resources
downloaded by one job or VM to be reused by later jobs.

## What changes

- Bind-mount `/gem5-resource-cache` into the self-hosted containers used by
  the Daily, Weekly, and Codecov resource-consuming test jobs.
- Set `GEM5_RESOURCE_DIR=/gem5-resource-cache`. Standard-library
  `obtain_resource` calls therefore use their existing versioned,
  checksum-validated cache behavior.
- Pass the same directory through Testlib's `--bin-path` option. Test suites
  that explicitly pass a resource directory to their gem5 configuration use
  the shared cache as well.
- Keep `cpu_tests`, `fdp_tests`, and `m5threads_test_atomic` on runner-local
  storage because their legacy download fixtures do not provide the same
  checksum and locking guarantees.
- Keep `gem5_resources` on runner-local storage because that validation suite
  deliberately downloads and deletes resource versions.

No cache refresh job is needed. When resource metadata selects a new version,
`obtain_resource` uses a new `<resource-id>-<version>` cache entry. Existing
entries are checksum-validated and redownloaded when invalid. gem5's existing
atomic per-resource lockfiles remain in use to prevent simultaneous writers;
the PR does not replace them with advisory locks, which would not coordinate
between separate QEMU 9p servers.

## Security and scope

Only the trusted `workflow_dispatch`/scheduled Daily, Weekly, and Codecov
workflows receive the persistent mount. Pull-request CI jobs are unchanged, so
untrusted PR code cannot write persistent Loupe state.

This PR contains only workflow changes. The runner-side 9p mount is deployed
separately on Loupe and has been confirmed writable from all runner VMs.

## Validation

- rebased onto the current `develop` branch
- `pre-commit run --files` for all three changed workflows
- actionlint 1.7.7 for all three workflows, excluding its stale built-in
  runner-label warning for the existing `macos-26` label
- `git diff --check canonical/develop...HEAD`
