### PR TITLE
arch-arm: Do not flush global TLB entries on TLBI by ASID

### DIFF
--- a/src/arch/arm/tlbi_op.cc
+++ b/src/arch/arm/tlbi_op.cc
@@ -156,10 +156,9 @@ TLBIASID::operator()(ThreadContext* tc)
 bool
 TLBIASID::matchEntry(TlbEntry* te, vmid_t vmid) const
 {
-    return te->valid && te->asid == asid &&
-        ss == te->ss &&
-        te->checkRegime(targetRegime) &&
-        (te->vmid == vmid || !el2Enabled || !useVMID(targetRegime));
+    return te->valid && (!te->global || te->partial) && te->asid == asid &&
+           ss == te->ss && te->checkRegime(targetRegime) &&
+           (te->vmid == vmid || !el2Enabled || !useVMID(targetRegime));
 }
 
 void


### PR DESCRIPTION
### Summary
According to the ARMv8 Architecture Reference Manual, TLB invalidation operations by ASID (`TLBI ASIDE1`, `ITLBIASID`, and `DTLBIASID`) should only flush entries that match the specified ASID and are either intermediate translation table levels (partial walks) or non-global entries.

Previously, `TLBIASID::matchEntry()` did not check the global flag, causing non-partial global entries sharing the same ASID to be evicted.

### Solution
Added `(textedit>global || te->partial)` to `TLBIASID::matchEntry()` so that global final leaf translations are preserved while partial walks continue to be invalidated.

Fixes #3010