### PR TITLE
arch-arm: Replace unsigned with Request::Flags

### DIFF
--- a/src/arch/arm/insts/macromem.hh
+++ b/src/arch/arm/insts/macromem.hh
@@ -148,7 +148,7 @@ class MicroNeonMemOp : public MicroOp
   protected:
     RegIndex dest, ura;
     uint32_t imm;
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     MicroNeonMemOp(const char *mnem, ExtMachInst machInst, OpClass __opClass,
                    RegIndex _dest, RegIndex _ura, uint32_t _imm)
@@ -422,7 +422,7 @@ class MicroMemOp : public MicroIntImmOp
 {
   protected:
     bool up;
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     MicroMemOp(const char *mnem, ExtMachInst machInst, OpClass __opClass,
                RegIndex _ura, RegIndex _urb, bool _up, uint8_t _imm)
@@ -441,7 +441,7 @@ class MicroMemPairOp : public MicroOp
     RegIndex dest, dest2, urb;
     bool up;
     int32_t imm;
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     MicroMemPairOp(const char *mnem, ExtMachInst machInst, OpClass __opClass,
             RegIndex _dreg1, RegIndex _dreg2, RegIndex _base,

--- a/src/arch/arm/insts/mem64.cc
+++ b/src/arch/arm/insts/mem64.cc
@@ -81,9 +81,9 @@ void
 Memory64::setExcAcRel(bool exclusive, bool acrel)
 {
     if (exclusive)
-        memAccessFlags |= Request::LLSC;
+        memAccessFlags.set(Request::LLSC);
     else
-        memAccessFlags |= ArmISA::MMU::AllowUnaligned;
+        memAccessFlags.set(ArmISA::MMU::AllowUnaligned);
     if (acrel) {
         flags[IsWriteBarrier] = true;
         flags[IsReadBarrier] = true;

--- a/src/arch/arm/insts/mem64.hh
+++ b/src/arch/arm/insts/mem64.hh
@@ -148,7 +148,7 @@ class Memory64 : public MightBeMicro64
 
     void startDisassembly(std::ostream &os) const;
 
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     void setExcAcRel(bool exclusive, bool acrel);
 };

--- a/src/arch/arm/insts/sve_mem.hh
+++ b/src/arch/arm/insts/sve_mem.hh
@@ -57,7 +57,7 @@ class SveMemVecFillSpill : public ArmStaticInst
     /// True if the base register is SP (used for SP alignment checking).
     bool baseIsSP;
 
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     SveMemVecFillSpill(const char *mnem, ExtMachInst _machInst,
                        OpClass __opClass, RegIndex _dest,
@@ -83,7 +83,7 @@ class SveMemPredFillSpill : public ArmStaticInst
     /// True if the base register is SP (used for SP alignment checking).
     bool baseIsSP;
 
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     SveMemPredFillSpill(const char *mnem, ExtMachInst _machInst,
                         OpClass __opClass, RegIndex _dest,
@@ -110,7 +110,7 @@ class SveContigMemSS : public ArmStaticInst
     /// True if the base register is SP (used for SP alignment checking).
     bool baseIsSP;
 
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     SveContigMemSS(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
                    RegIndex _dest, RegIndex _gp, RegIndex _base,
@@ -137,7 +137,7 @@ class SveContigMemSI : public ArmStaticInst
     /// True if the base register is SP (used for SP alignment checking).
     bool baseIsSP;
 
-    unsigned memAccessFlags;
+    Request::Flags memAccessFlags;
 
     SveContigMemSI(const char *mnem, ExtMachInst _machInst, OpClass __opClass,
                    RegIndex _dest, RegIndex _gp, RegIndex _base,

--- a/src/arch/arm/insts/tme64ruby.cc
+++ b/src/arch/arm/insts/tme64ruby.cc
@@ -74,7 +74,7 @@ Tstart64::initiateAcc(ExecContext *xc,
         // These Requests are marked as NO_ACCESS to indicate that the request
         // should not be sent to the cache controller.
         if (htm_depth > 1) {
-            memAccessFlags = memAccessFlags | Request::NO_ACCESS;
+            memAccessFlags.set(Request::NO_ACCESS);
         }
 
         fault = xc->initiateMemMgmtCmd(memAccessFlags);
@@ -228,7 +228,7 @@ MicroTcommit64::initiateAcc(ExecContext *xc,
     // These Requests are marked as NO_ACCESS to indicate that the request
     // should not be sent to the cache controller.
     if (htm_depth > 1) {
-        memAccessFlags = memAccessFlags | Request::NO_ACCESS;
+        memAccessFlags.set(Request::NO_ACCESS);
     }
 
     fault = xc->initiateMemMgmtCmd(memAccessFlags);

--- a/src/arch/arm/isa/formats/fp.isa
+++ b/src/arch/arm/isa/formats/fp.isa
@@ -50,7 +50,7 @@ output header {{
     newNeonMemInst(const unsigned size,
                    const ExtMachInst &machInst,
                    const RegIndex dest, const RegIndex ra,
-                   const uint32_t imm, const unsigned extraMemFlags)
+                   const uint32_t imm, const Request::Flags extraMemFlags)
     {
         switch (size) {
           case 0:

--- a/src/arch/arm/isa/insts/branch.isa
+++ b/src/arch/arm/isa/insts/branch.isa
@@ -186,16 +186,16 @@ let {{
     for isTbh in (0, 1):
         if isTbh:
             eaCode = '''
-            unsigned memAccessFlags = ArmISA::MMU::AllowUnaligned |
-                                      ArmISA::MMU::AlignHalfWord;
+            Request::Flags memAccessFlags =
+                (ArmISA::MMU::AllowUnaligned | ArmISA::MMU::AlignHalfWord);
             EA = Op1 + Op2 * 2
             '''
             accCode = 'NPC = PC + 2 * (Mem_uh);\n'
             mnem = "tbh"
         else:
             eaCode = '''
-            unsigned memAccessFlags = ArmISA::MMU::AllowUnaligned |
-                                      ArmISA::MMU::AlignByte;
+            Request::Flags memAccessFlags =
+                (ArmISA::MMU::AllowUnaligned | ArmISA::MMU::AlignByte);
             EA = Op1 + Op2
             '''
             accCode = 'NPC = PC + 2 * (Mem_ub)'

--- a/src/arch/arm/isa/insts/mem.isa
+++ b/src/arch/arm/isa/insts/mem.isa
@@ -59,7 +59,7 @@ let {{
             memFlagsCasted = map(
                 lambda x: f'static_cast<unsigned>({x})', memFlags
             )
-            eaCode += '\n    unsigned memAccessFlags = '
+            eaCode += '\n    Request::Flags memAccessFlags = '
             eaCode += ('|'.join(memFlagsCasted) + ';')
 
             codeBlobs["ea_code"] = eaCode

--- a/src/arch/arm/isa/insts/misc64.isa
+++ b/src/arch/arm/isa/insts/misc64.isa
@@ -207,7 +207,7 @@ let {{
                 Request::STRICT_ORDER|Request::TLBI_SYNC;
 
             if (!PendingDvm) {
-                memAccessFlags = memAccessFlags | Request::NO_ACCESS;
+                memAccessFlags.set(Request::NO_ACCESS);
             }
 
             fault = xc->initiateMemMgmtCmd(memAccessFlags);

--- a/src/arch/arm/isa/templates/macromem.isa
+++ b/src/arch/arm/isa/templates/macromem.isa
@@ -131,11 +131,12 @@ def template MicroNeonMemDeclare {{
 
       public:
         %(class_name)s(ExtMachInst machInst, RegIndex _dest,
-                       RegIndex _ura, uint32_t _imm, unsigned extraMemFlags) :
+                       RegIndex _ura, uint32_t _imm,
+                       Request::Flags extraMemFlags) :
             %(base_class)s("%(mnemonic)s", machInst,
                               %(op_class)s, _dest, _ura, _imm)
         {
-            memAccessFlags |= extraMemFlags;
+            memAccessFlags.set(extraMemFlags);
             %(set_reg_idx_arr)s;
             %(constructor)s;
             if (!(condCode == COND_AL || condCode == COND_UC)) {

--- a/src/arch/arm/isa/templates/neon64.isa
+++ b/src/arch/arm/isa/templates/neon64.isa
@@ -288,14 +288,14 @@ def template MicroNeonMemDeclare64 {{
 
       public:
         %(class_name)s(ExtMachInst machInst, RegIndex _dest, RegIndex _ura,
-                       uint32_t _imm, unsigned extraMemFlags, bool _baseIsSP,
-                       uint8_t _accSize, uint8_t _eSize) :
+                       uint32_t _imm, Request::Flags extraMemFlags,
+                       bool _baseIsSP, uint8_t _accSize, uint8_t _eSize) :
             %(base_class)s("%(mnemonic)s", machInst, %(op_class)s, _dest,
                              _ura, _imm),
             baseIsSP(_baseIsSP), accSize(_accSize), eSize(_eSize)
         {
             %(set_reg_idx_arr)s;
-            memAccessFlags |= extraMemFlags;
+            memAccessFlags.set(extraMemFlags);
             %(constructor)s;
         }
 

--- a/src/arch/arm/isa/templates/sve_mem.isa
+++ b/src/arch/arm/isa/templates/sve_mem.isa
@@ -160,7 +160,7 @@ def template SveContigLoadExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -215,7 +215,7 @@ def template SveContigLoadUnpredExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -252,7 +252,7 @@ def template SveContigLoadInitiateAcc {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_src_decl)s;
@@ -308,7 +308,7 @@ def template SveContigStoreExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -367,7 +367,7 @@ def template SveContigStoreUnpredExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -407,7 +407,7 @@ def template SveContigStoreInitiateAcc {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -453,7 +453,7 @@ def template SveLoadAndReplExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<RegElemType>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -494,7 +494,7 @@ def template SveLoadAndReplInitiateAcc {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_src_decl)s;
@@ -561,7 +561,7 @@ def template SveIndexedMemVIMicroopDeclare {{
         int numElems;
         bool firstFault;
 
-        unsigned memAccessFlags;
+        Request::Flags memAccessFlags;
 
       public:
         %(class_name)s(const char* mnem, ExtMachInst machInst,
@@ -647,7 +647,7 @@ def template SveIndexedMemSVMicroopDeclare {{
         int numElems;
         bool firstFault;
 
-        unsigned memAccessFlags;
+        Request::Flags memAccessFlags;
 
       public:
         %(class_name)s(const char* mnem, ExtMachInst machInst,
@@ -734,7 +734,7 @@ def template SveIndexedMemVSMicroopDeclare {{
         int numElems;
         bool firstFault;
 
-        unsigned memAccessFlags;
+        Request::Flags memAccessFlags;
 
       public:
         %(class_name)s(const char* mnem, ExtMachInst machInst,
@@ -806,7 +806,7 @@ def template SveGatherLoadMicroopExecute {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -857,7 +857,7 @@ def template SveGatherLoadMicroopInitiateAcc {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_src_decl)s;
@@ -927,7 +927,7 @@ def template SveGatherLoadQuadMicroopExecute {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -982,7 +982,7 @@ def template SveGatherLoadQuadMicroopInitiateAcc {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_src_decl)s;
@@ -1055,7 +1055,7 @@ def template SveScatterStoreMicroopExecute {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1088,7 +1088,7 @@ def template SveScatterStoreMicroopInitiateAcc {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1129,7 +1129,7 @@ def template SveScatterStoreQuadMicroopExecute {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1166,7 +1166,7 @@ def template SveScatterStoreQuadMicroopInitiateAcc {{
         Addr EA;
         Fault fault = NoFault;
         [[maybe_unused]] bool aarch64 = true;
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(MemElemType), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1336,7 +1336,7 @@ def template SveStructMemSIMicroopDeclare {{
         uint8_t numRegs;
         int regIndex;
 
-        unsigned memAccessFlags;
+        Request::Flags memAccessFlags;
 
         bool baseIsSP;
 
@@ -1430,7 +1430,7 @@ def template SveStructLoadExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<Element>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(Element), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1489,7 +1489,7 @@ def template SveStructLoadInitiateAcc {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<Element>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(Element), this->memAccessFlags);
 
         %(op_src_decl)s;
@@ -1555,7 +1555,7 @@ def template SveStructStoreExecute {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<Element>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(Element), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1619,7 +1619,7 @@ def template SveStructStoreInitiateAcc {{
         [[maybe_unused]] bool aarch64 = true;
         unsigned eCount =
             ArmStaticInst::getCurSveVecLen<Element>(xc->tcBase());
-        unsigned memAccessFlags = addrAlignmentFlags(
+        Request::Flags memAccessFlags = addrAlignmentFlags(
             sizeof(Element), this->memAccessFlags);
 
         %(op_decl)s;
@@ -1678,7 +1678,7 @@ def template SveStructMemSSMicroopDeclare {{
         uint8_t numRegs;
         int regIndex;
 
-        unsigned memAccessFlags;
+        Request::Flags memAccessFlags;
 
         bool baseIsSP;
 

--- a/src/arch/arm/utility.cc
+++ b/src/arch/arm/utility.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2014, 2016-2020, 2022-2025 Arm Limited
+ * Copyright (c) 2009-2014, 2016-2020, 2022-2026 Arm Limited
  * All rights reserved.
  *
  * The license below extends only to copyright in the software and shall
@@ -543,31 +543,31 @@ SPAlignmentCheckEnabled(ThreadContext *tc)
     }
 }
 
-unsigned
-addrAlignmentFlags(int memsize, unsigned memAccessFlags)
+Request::Flags
+addrAlignmentFlags(int memsize, Request::Flags flags)
 {
-    unsigned flags = memAccessFlags & (~(unsigned)MMU::AlignmentMask);
+    flags.clear(MMU::AlignmentMask);
     switch (memsize) {
         case 1:
-            flags = flags | MMU::AlignByte;
+            flags.set(MMU::AlignByte);
             break;
         case 2:
-            flags = flags | MMU::AlignHalfWord;
+            flags.set(MMU::AlignHalfWord);
             break;
         case 4:
-            flags = flags | MMU::AlignWord;
+            flags.set(MMU::AlignWord);
             break;
         case 8:
-            flags = flags | MMU::AlignDoubleWord;
+            flags.set(MMU::AlignDoubleWord);
             break;
         case 16:
-            flags = flags | MMU::AlignQuadWord;
+            flags.set(MMU::AlignQuadWord);
             break;
         case 32:
-            flags = flags | MMU::AlignOctWord;
+            flags.set(MMU::AlignOctWord);
             break;
         default:
-            flags = flags | MMU::AllowUnaligned;
+            flags.set(MMU::AllowUnaligned);
             break;
     }
     return flags;

--- a/src/arch/arm/utility.hh
+++ b/src/arch/arm/utility.hh
@@ -269,7 +269,7 @@ mcrrMrrcIssBuild(bool isRead, uint32_t crm, RegIndex rt, RegIndex rt2,
 
 bool SPAlignmentCheckEnabled(ThreadContext *tc);
 
-unsigned addrAlignmentFlags(int memsize, unsigned memAccessFlags);
+Request::Flags addrAlignmentFlags(int memsize, Request::Flags flags);
 
 Addr truncPage(Addr addr);
 Addr roundPage(Addr addr);


### PR DESCRIPTION
Lots of arch-arm code is still using unsigned variable to hold request flags.
One of the biggest issue behind this is that in most machines (LP64) an unsigned is 32-bit while
the Request flags are usually 64-bit wide.

So every unsigned usage of memAccessFlags could potentially truncate the most significant 32 bits.
With this PR we make sure we use Request::Flags instead