### PR TITLE
cpu-o3: Split unit-stride vector memops on pack width

### DIFF
--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -141,9 +141,9 @@ class BaseO3CPU(BaseCPU):
 
     LQEntries = Param.Unsigned(32, "Number of load queue entries")
     SQEntries = Param.Unsigned(32, "Number of store queue entries")
-    vecMemPackWidth = Param.Unsigned(
-        0,
-        "Unit-stride vector LSU split grain in bytes. 0 uses the cache line.",
+    vecMemPackWidth = OptionalParam.Unsigned(
+        "Unit-stride vector LSU split grain in bytes. "
+        "If unspecified, use the cache-line size.",
     )
     LSQDepCheckShift = Param.Unsigned(
         4, "Number of places to shift addr before check"

--- a/src/cpu/o3/BaseO3CPU.py
+++ b/src/cpu/o3/BaseO3CPU.py
@@ -141,6 +141,10 @@ class BaseO3CPU(BaseCPU):
 
     LQEntries = Param.Unsigned(32, "Number of load queue entries")
     SQEntries = Param.Unsigned(32, "Number of store queue entries")
+    vecMemPackWidth = Param.Unsigned(
+        0,
+        "Unit-stride vector LSU split grain in bytes. 0 uses the cache line.",
+    )
     LSQDepCheckShift = Param.Unsigned(
         4, "Number of places to shift addr before check"
     )

--- a/src/cpu/o3/SConscript
+++ b/src/cpu/o3/SConscript
@@ -100,3 +100,5 @@ if env['CONF']['BUILD_ISA']:
     # For backwards compatibility
     SimObject('O3CPU.py', sim_objects=[], tags=['isa'])
     SimObject('O3Checker.py', sim_objects=[], tags=['isa'])
+
+    GTest('vec_mem_pack.test', 'vec_mem_pack.test.cc')

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -49,6 +49,7 @@
 
 #include "arch/generic/mmu.hh"
 #include "base/amo.hh"
+#include "base/intmath.hh"
 #include "base/logging.hh"
 #include "base/stats/group.hh"
 #include "base/stats/units.hh"
@@ -153,10 +154,12 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
 {
     assert(numThreads > 0 && numThreads <= MaxThreads);
 
-    fatal_if(vecMemPackWidth != 0 &&
-             (vecMemPackWidth & (vecMemPackWidth - 1)) != 0,
-             "vecMemPackWidth must be 0 or a power of two, got %u",
-             vecMemPackWidth);
+    // 0 is not a valid grain (and is no longer a "use default" sentinel).
+    fatal_if(vecMemPackWidth.has_value() && *vecMemPackWidth == 0,
+             "vecMemPackWidth must be greater than zero");
+    fatal_if(vecMemPackWidth.has_value() && !isPowerOf2(*vecMemPackWidth),
+             "vecMemPackWidth must be a power of two, got %u",
+             *vecMemPackWidth);
 
     //**********************************************
     //************ Handle SMT Parameters ***********
@@ -202,8 +205,9 @@ LSQ::name() const
 unsigned
 LSQ::splitGrain(const DynInstPtr &inst) const
 {
-    return vecMemSplitGrain(vecMemPackWidth, cpu->cacheLineSize(),
-                            inst->opClass());
+    return vecMemSplitGrain(
+        vecMemPackWidth.value_or(cpu->cacheLineSize()),
+        cpu->cacheLineSize(), inst->opClass());
 }
 
 void
@@ -827,7 +831,8 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
 
         request->initiateTranslation();
 
-        if (vecMemPackWidth != 0 && isVecMemPackable(inst->opClass())) {
+        if (vecMemPackWidth.has_value() &&
+            isVecMemPackable(inst->opClass())) {
             thread[tid]->recordVecMemPack(request->_reqs.size());
         }
     }

--- a/src/cpu/o3/lsq.cc
+++ b/src/cpu/o3/lsq.cc
@@ -61,6 +61,7 @@
 #include "cpu/o3/iew.hh"
 #include "cpu/o3/limits.hh"
 #include "cpu/o3/lsq_unit.hh"
+#include "cpu/o3/vec_mem_pack.hh"
 #include "cpu/thread_context.hh"
 #include "cpu/utils.hh"
 #include "debug/Drain.hh"
@@ -134,6 +135,7 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       lsqPolicy(params.smtLSQPolicy),
       LQEntries(params.LQEntries),
       SQEntries(params.SQEntries),
+      vecMemPackWidth(params.vecMemPackWidth),
       maxLQEntries(maxLSQAllocation(lsqPolicy, LQEntries, params.numThreads,
                   params.smtLSQThreshold)),
       maxSQEntries(maxLSQAllocation(lsqPolicy, SQEntries, params.numThreads,
@@ -150,6 +152,11 @@ LSQ::LSQ(CPU *cpu_ptr, IEW *iew_ptr, const BaseO3CPUParams &params)
       retryRespEvent([this]{ sendRetryResp(); }, name())
 {
     assert(numThreads > 0 && numThreads <= MaxThreads);
+
+    fatal_if(vecMemPackWidth != 0 &&
+             (vecMemPackWidth & (vecMemPackWidth - 1)) != 0,
+             "vecMemPackWidth must be 0 or a power of two, got %u",
+             vecMemPackWidth);
 
     //**********************************************
     //************ Handle SMT Parameters ***********
@@ -190,6 +197,13 @@ std::string
 LSQ::name() const
 {
     return iewStage->name() + ".lsq";
+}
+
+unsigned
+LSQ::splitGrain(const DynInstPtr &inst) const
+{
+    return vecMemSplitGrain(vecMemPackWidth, cpu->cacheLineSize(),
+                            inst->opClass());
 }
 
 void
@@ -770,8 +784,8 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
     [[maybe_unused]] bool isAtomic = !isLoad && amo_op;
 
     ThreadID tid = cpu->contextToThread(inst->contextId());
-    auto cacheLineSize = cpu->cacheLineSize();
-    bool needs_burst = transferNeedsBurst(addr, size, cacheLineSize);
+    const unsigned split_grain = splitGrain(inst);
+    bool needs_burst = transferNeedsBurst(addr, size, split_grain);
     LSQRequest* request = nullptr;
 
     // Atomic requests that access data across cache line boundary are
@@ -812,6 +826,10 @@ LSQ::pushRequest(const DynInstPtr& inst, bool isLoad, uint8_t *data,
         inst->getFault() = NoFault;
 
         request->initiateTranslation();
+
+        if (vecMemPackWidth != 0 && isVecMemPackable(inst->opClass())) {
+            thread[tid]->recordVecMemPack(request->_reqs.size());
+        }
     }
 
     /* This is the place were instructions get the effAddr. */
@@ -971,10 +989,10 @@ SplitDataRequest::mainReq()
 void
 SplitDataRequest::initiateTranslation()
 {
-    auto cacheLineSize = _port.cacheLineSize();
+    const unsigned grain = _port.splitGrain(_inst);
     Addr base_addr = _addr;
-    Addr next_addr = addrBlockAlign(_addr + cacheLineSize, cacheLineSize);
-    Addr final_addr = addrBlockAlign(_addr + _size, cacheLineSize);
+    Addr next_addr = addrBlockAlign(_addr + grain, grain);
+    Addr final_addr = addrBlockAlign(_addr + _size, grain);
     uint32_t size_so_far = 0;
 
     _mainReq = std::make_shared<Request>(base_addr,
@@ -999,11 +1017,11 @@ SplitDataRequest::initiateTranslation()
     base_addr = next_addr;
     while (base_addr != final_addr) {
         auto it_start = _byteEnable.begin() + size_so_far;
-        auto it_end = _byteEnable.begin() + size_so_far + cacheLineSize;
-        addReq(base_addr, cacheLineSize,
+        auto it_end = _byteEnable.begin() + size_so_far + grain;
+        addReq(base_addr, grain,
                          std::vector<bool>(it_start, it_end));
-        size_so_far += cacheLineSize;
-        base_addr += cacheLineSize;
+        size_so_far += grain;
+        base_addr += grain;
     }
 
     /* Deal with the tail. */

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -45,6 +45,7 @@
 #include <cassert>
 #include <cstdint>
 #include <list>
+#include <optional>
 #include <vector>
 
 #include "arch/generic/mmu.hh"
@@ -961,8 +962,11 @@ class LSQ
     unsigned LQEntries;
     /** Total Size of SQ Entries. */
     unsigned SQEntries;
-    /** 0 uses the cache line. See BaseO3CPU.vecMemPackWidth. */
-    const unsigned vecMemPackWidth;
+    /**
+     * Unit-stride vector LSU split grain in bytes.
+     * Unspecified uses the cache-line size. See BaseO3CPU.vecMemPackWidth.
+     */
+    const std::optional<unsigned> vecMemPackWidth;
 
     /** Max LQ Size - Used to Enforce Sharing Policies. */
     unsigned maxLQEntries;

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -906,6 +906,9 @@ class LSQ
 
     RequestPort &getDataPort() { return dcachePort; }
 
+    /** Split alignment used by transferNeedsBurst / SplitDataRequest. */
+    unsigned splitGrain(const DynInstPtr &inst) const;
+
     void sendRetryResp();
 
   protected:
@@ -958,6 +961,8 @@ class LSQ
     unsigned LQEntries;
     /** Total Size of SQ Entries. */
     unsigned SQEntries;
+    /** 0 uses the cache line. See BaseO3CPU.vecMemPackWidth. */
+    const unsigned vecMemPackWidth;
 
     /** Max LQ Size - Used to Enforce Sharing Policies. */
     unsigned maxLQEntries;

--- a/src/cpu/o3/lsq_unit.cc
+++ b/src/cpu/o3/lsq_unit.cc
@@ -289,7 +289,11 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
       ADD_STAT(lqAvgOccupancy, statistics::units::Ratio::get(),
                "Average LQ Occupancy (UsedSlots/TotalSlots)"),
       ADD_STAT(sqAvgOccupancy, statistics::units::Ratio::get(),
-               "Average SQ Occupancy (UsedSlots/TotalSlots)")
+               "Average SQ Occupancy (UsedSlots/TotalSlots)"),
+      ADD_STAT(vecMemPackAccesses, statistics::units::Count::get(),
+               "Unit-stride vector accesses with pack width enabled"),
+      ADD_STAT(vecMemPackFlows, statistics::units::Count::get(),
+               "LSQ fragments for those accesses")
 {
     loadToUse
         .init(0, 299, 10)
@@ -298,6 +302,13 @@ LSQUnit::LSQUnitStats::LSQUnitStats(statistics::Group *parent)
     lqAvgOccupancy.precision(2);
 
     sqAvgOccupancy.precision(2);
+}
+
+void
+LSQUnit::recordVecMemPack(uint64_t flows)
+{
+    stats.vecMemPackAccesses++;
+    stats.vecMemPackFlows += flows;
 }
 
 void
@@ -1359,6 +1370,12 @@ unsigned int
 LSQUnit::cacheLineSize()
 {
     return cpu->cacheLineSize();
+}
+
+unsigned
+LSQUnit::splitGrain(const DynInstPtr &inst)
+{
+    return lsq->splitGrain(inst);
 }
 
 Fault

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -563,7 +563,7 @@ class LSQUnit
         /** SQ Occupancy */
         statistics::Average sqAvgOccupancy;
 
-        /** Unit-stride vector accesses with vecMemPackWidth != 0. */
+        /** Unit-stride vector accesses with vecMemPackWidth specified. */
         statistics::Scalar vecMemPackAccesses;
         /** LSQ fragments created for those accesses. */
         statistics::Scalar vecMemPackFlows;

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -376,6 +376,8 @@ class LSQUnit
     void recvRetry();
 
     unsigned int cacheLineSize();
+    unsigned splitGrain(const DynInstPtr &inst);
+
   private:
     /** Reset the LSQ state */
     void resetState();
@@ -560,9 +562,17 @@ class LSQUnit
         statistics::Average lqAvgOccupancy;
         /** SQ Occupancy */
         statistics::Average sqAvgOccupancy;
+
+        /** Unit-stride vector accesses with vecMemPackWidth != 0. */
+        statistics::Scalar vecMemPackAccesses;
+        /** LSQ fragments created for those accesses. */
+        statistics::Scalar vecMemPackFlows;
     } stats;
 
   public:
+    /** Record pack-width vector access fragments. */
+    void recordVecMemPack(uint64_t flows);
+
     /** Executes the load at the given index. */
     Fault read(LSQRequest *request, ssize_t load_idx);
 

--- a/src/cpu/o3/vec_mem_pack.hh
+++ b/src/cpu/o3/vec_mem_pack.hh
@@ -1,8 +1,29 @@
 /*
- * Copyright (c) 2026
+ * Copyright (c) 2026 Mao Weiming
  * All rights reserved.
  *
- * SPDX-License-Identifier: BSD-3-Clause
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __CPU_O3_VEC_MEM_PACK_HH__
@@ -34,13 +55,14 @@ isVecMemPackable(OpClass op)
 
 /**
  * Split grain for SplitDataRequest / transferNeedsBurst.
- * Returns cache_line when pack_width is 0 or the op is not packable,
- * otherwise min(pack_width, cache_line).
+ * Non-packable ops use cache_line; packable ops use min(pack_width, cache_line).
+ * pack_width is the resolved grain (LSQ maps an unspecified param to the
+ * cache-line size); 0 is not a default sentinel.
  */
 inline unsigned
 vecMemSplitGrain(unsigned pack_width, unsigned cache_line, OpClass op)
 {
-    if (pack_width == 0 || cache_line == 0 || !isVecMemPackable(op)) {
+    if (!isVecMemPackable(op)) {
         return cache_line;
     }
     return pack_width < cache_line ? pack_width : cache_line;

--- a/src/cpu/o3/vec_mem_pack.hh
+++ b/src/cpu/o3/vec_mem_pack.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __CPU_O3_VEC_MEM_PACK_HH__
+#define __CPU_O3_VEC_MEM_PACK_HH__
+
+#include "cpu/op_class.hh"
+
+namespace gem5
+{
+namespace o3
+{
+
+/** Contiguous unit-stride / mask / whole-register vector memops. */
+inline bool
+isVecMemPackable(OpClass op)
+{
+    switch (op) {
+      case SimdUnitStrideLoadOp:
+      case SimdUnitStrideStoreOp:
+      case SimdUnitStrideMaskLoadOp:
+      case SimdUnitStrideMaskStoreOp:
+      case SimdWholeRegisterLoadOp:
+      case SimdWholeRegisterStoreOp:
+        return true;
+      default:
+        return false;
+    }
+}
+
+/**
+ * Split grain for SplitDataRequest / transferNeedsBurst.
+ * Returns cache_line when pack_width is 0 or the op is not packable,
+ * otherwise min(pack_width, cache_line).
+ */
+inline unsigned
+vecMemSplitGrain(unsigned pack_width, unsigned cache_line, OpClass op)
+{
+    if (pack_width == 0 || cache_line == 0 || !isVecMemPackable(op)) {
+        return cache_line;
+    }
+    return pack_width < cache_line ? pack_width : cache_line;
+}
+
+} // namespace o3
+} // namespace gem5
+
+#endif // __CPU_O3_VEC_MEM_PACK_HH__

--- a/src/cpu/o3/vec_mem_pack.test.cc
+++ b/src/cpu/o3/vec_mem_pack.test.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <gtest/gtest.h>
+
+#include "cpu/o3/vec_mem_pack.hh"
+
+using gem5::o3::isVecMemPackable;
+using gem5::o3::vecMemSplitGrain;
+using gem5::SimdIndexedLoadOp;
+using gem5::SimdIndexedStoreOp;
+using gem5::SimdStridedLoadOp;
+using gem5::SimdUnitStrideFaultOnlyFirstLoadOp;
+using gem5::SimdUnitStrideLoadOp;
+using gem5::SimdUnitStrideMaskLoadOp;
+using gem5::SimdUnitStrideMaskStoreOp;
+using gem5::SimdUnitStrideSegmentedLoadOp;
+using gem5::SimdUnitStrideStoreOp;
+using gem5::SimdWholeRegisterLoadOp;
+using gem5::SimdWholeRegisterStoreOp;
+
+TEST(VecMemPack, PackableOps)
+{
+    EXPECT_TRUE(isVecMemPackable(SimdUnitStrideLoadOp));
+    EXPECT_TRUE(isVecMemPackable(SimdUnitStrideStoreOp));
+    EXPECT_TRUE(isVecMemPackable(SimdUnitStrideMaskLoadOp));
+    EXPECT_TRUE(isVecMemPackable(SimdUnitStrideMaskStoreOp));
+    EXPECT_TRUE(isVecMemPackable(SimdWholeRegisterLoadOp));
+    EXPECT_TRUE(isVecMemPackable(SimdWholeRegisterStoreOp));
+    EXPECT_FALSE(isVecMemPackable(SimdUnitStrideFaultOnlyFirstLoadOp));
+    EXPECT_FALSE(isVecMemPackable(SimdUnitStrideSegmentedLoadOp));
+    EXPECT_FALSE(isVecMemPackable(SimdIndexedLoadOp));
+    EXPECT_FALSE(isVecMemPackable(SimdIndexedStoreOp));
+    EXPECT_FALSE(isVecMemPackable(SimdStridedLoadOp));
+}
+
+TEST(VecMemPack, SplitGrain)
+{
+    EXPECT_EQ(vecMemSplitGrain(0, 64, SimdUnitStrideLoadOp), 64u);
+    EXPECT_EQ(vecMemSplitGrain(16, 64, SimdIndexedLoadOp), 64u);
+    EXPECT_EQ(vecMemSplitGrain(16, 64, SimdUnitStrideLoadOp), 16u);
+    EXPECT_EQ(vecMemSplitGrain(16, 16, SimdUnitStrideLoadOp), 16u);
+    EXPECT_EQ(vecMemSplitGrain(128, 64, SimdUnitStrideLoadOp), 64u);
+    EXPECT_EQ(vecMemSplitGrain(16, 0, SimdUnitStrideLoadOp), 0u);
+}

--- a/src/cpu/o3/vec_mem_pack.test.cc
+++ b/src/cpu/o3/vec_mem_pack.test.cc
@@ -1,8 +1,29 @@
 /*
- * Copyright (c) 2026
+ * Copyright (c) 2026 Mao Weiming
  * All rights reserved.
  *
- * SPDX-License-Identifier: BSD-3-Clause
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <gtest/gtest.h>
@@ -40,10 +61,10 @@ TEST(VecMemPack, PackableOps)
 
 TEST(VecMemPack, SplitGrain)
 {
-    EXPECT_EQ(vecMemSplitGrain(0, 64, SimdUnitStrideLoadOp), 64u);
     EXPECT_EQ(vecMemSplitGrain(16, 64, SimdIndexedLoadOp), 64u);
     EXPECT_EQ(vecMemSplitGrain(16, 64, SimdUnitStrideLoadOp), 16u);
     EXPECT_EQ(vecMemSplitGrain(16, 16, SimdUnitStrideLoadOp), 16u);
+    EXPECT_EQ(vecMemSplitGrain(64, 64, SimdUnitStrideLoadOp), 64u);
     EXPECT_EQ(vecMemSplitGrain(128, 64, SimdUnitStrideLoadOp), 64u);
     EXPECT_EQ(vecMemSplitGrain(16, 0, SimdUnitStrideLoadOp), 0u);
 }


### PR DESCRIPTION
## Summary

O3 only splits a request at the cache line. A unit-stride vector
access can cross a narrower LSU port grain inside one line and is
then issued as a single request.

`BaseO3CPU.vecMemPackWidth` (default 0) sets that grain. 0 keeps
the cache line. A power-of-two uses existing `SplitDataRequest` at
`min(pack, line)` for contiguous unit-stride / mask / whole-register
ops. Other configs and pack=0 are unchanged.

## Test plan

- [x] `vec_mem_pack.test`
- [x] SE pack = 0/4/8/16/32/64: functional match; pack=0 stats stay 0;
      pack=64 matches pack=0 L1D
- [ ] gem5 CI