### PR TITLE
mem-ruby: add transition_no_stall

### DIFF
--- a/src/mem/slicc/ast/TransitionDeclAST.py
+++ b/src/mem/slicc/ast/TransitionDeclAST.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
 # Copyright (c) 2009 The Hewlett-Packard Development Company
 # All rights reserved.
@@ -31,7 +43,14 @@ from slicc.symbols import Transition
 
 class TransitionDeclAST(DeclAST):
     def __init__(
-        self, slicc, request_types, states, events, next_state, actions
+        self,
+        slicc,
+        request_types,
+        states,
+        events,
+        next_state,
+        actions,
+        transition_decl_type,
     ):
         super().__init__(slicc)
 
@@ -40,6 +59,8 @@ class TransitionDeclAST(DeclAST):
         self.events = events
         self.next_state = next_state
         self.actions = actions
+        assert transition_decl_type in ["transition", "transition_no_stall"]
+        self.no_stall = transition_decl_type == "transition_no_stall"
 
     def __repr__(self):
         return "[TransitionDecl: ]"
@@ -83,5 +104,6 @@ class TransitionDeclAST(DeclAST):
                     self.actions,
                     self.request_types,
                     self.location,
+                    self.no_stall,
                 )
                 machine.addTransition(t)

--- a/src/mem/slicc/parser.py
+++ b/src/mem/slicc/parser.py
@@ -152,6 +152,7 @@ class SLICC(Grammar):
         "out_port": "OUT_PORT",
         "action": "ACTION",
         "transition": "TRANS",
+        "transition_no_stall": "TRANS_NO_STALL",
         "structure": "STRUCT",
         "external_type": "EXTERN_TYPE",
         "enumeration": "ENUM",
@@ -370,20 +371,32 @@ class SLICC(Grammar):
         p[0] = ast.OutPortDeclAST(self, p[3], p[5], p[7], p[8])
 
     def p_decl__trans0(self, p):
-        "decl : TRANS '(' idents ',' idents ',' ident_or_star ')' idents"
-        p[0] = ast.TransitionDeclAST(self, [], p[3], p[5], p[7], p[9])
+        """
+        decl : TRANS '(' idents ',' idents ',' ident_or_star ')' idents
+            | TRANS_NO_STALL '(' idents ',' idents ',' ident_or_star ')' idents
+        """
+        p[0] = ast.TransitionDeclAST(self, [], p[3], p[5], p[7], p[9], p[1])
 
     def p_decl__trans1(self, p):
-        "decl : TRANS '(' idents ',' idents ')' idents"
-        p[0] = ast.TransitionDeclAST(self, [], p[3], p[5], None, p[7])
+        """
+        decl : TRANS '(' idents ',' idents ')' idents
+            | TRANS_NO_STALL '(' idents ',' idents ')' idents
+        """
+        p[0] = ast.TransitionDeclAST(self, [], p[3], p[5], None, p[7], p[1])
 
     def p_decl__trans2(self, p):
-        "decl : TRANS '(' idents ',' idents ',' ident_or_star ')' idents idents"
-        p[0] = ast.TransitionDeclAST(self, p[9], p[3], p[5], p[7], p[10])
+        """
+            decl : TRANS '(' idents ',' idents ',' ident_or_star ')' idents idents
+        | TRANS_NO_STALL '(' idents ',' idents ',' ident_or_star ')' idents idents
+        """
+        p[0] = ast.TransitionDeclAST(self, p[9], p[3], p[5], p[7], p[10], p[1])
 
     def p_decl__trans3(self, p):
-        "decl : TRANS '(' idents ',' idents ')' idents idents"
-        p[0] = ast.TransitionDeclAST(self, p[7], p[3], p[5], None, p[8])
+        """
+        decl : TRANS '(' idents ',' idents ')' idents idents
+            | TRANS_NO_STALL '(' idents ',' idents ')' idents idents
+        """
+        p[0] = ast.TransitionDeclAST(self, p[7], p[3], p[5], None, p[8], p[1])
 
     def p_decl__extern0(self, p):
         "decl : EXTERN_TYPE '(' type pairs ')' SEMI"

--- a/src/mem/slicc/symbols/Transition.py
+++ b/src/mem/slicc/symbols/Transition.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2026 ARM Limited
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
 # Copyright (c) 1999-2008 Mark D. Hill and David A. Wood
 # Copyright (c) 2009 The Hewlett-Packard Development Company
 # All rights reserved.
@@ -40,6 +52,7 @@ class Transition(Symbol):
         actions,
         request_types,
         location,
+        ignore_resources,
     ):
         ident = f"{state}|{event}"
         super().__init__(table, ident, location)
@@ -64,12 +77,15 @@ class Transition(Symbol):
         self.request_types = [machine.request_types[s] for s in request_types]
         self.resources = {}
 
-        for action in self.actions:
-            for var, value in action.resources.items():
-                num = int(value)
-                if var in self.resources:
-                    num += int(value)
-                self.resources[var] = str(num)
+        if ignore_resources:
+            print("%s: transition ignores resource allocation" % location)
+        else:
+            for action in self.actions:
+                for var, value in action.resources.items():
+                    num = int(value)
+                    if var in self.resources:
+                        num += int(value)
+                    self.resources[var] = str(num)
 
     def __repr__(self):
         return "[Transition: ({!r}, {!r}) -> {!r}, {!r}]".format(


### PR DESCRIPTION
This is a rebased copy of #3084, preserving its single commit, authorship, and functional changes while resolving its conflict with the current `develop` branch.

This PR is intended as a fallback that can be merged if the original author does not update #3084, so the change does not block creating the next release-staging branch from `develop`. If #3084 is updated and merged, this PR can be closed.

The only manual conflict was in `src/mem/slicc/parser.py`. The resolution retains the current upstream `Arm Limited` spelling while preserving #3084's addition of the 2026 copyright year. No functional changes were added beyond #3084.

Validation:

- `git diff --check upstream/develop...HEAD`
- `python3 -m py_compile src/mem/slicc/ast/TransitionDeclAST.py src/mem/slicc/parser.py src/mem/slicc/symbols/Transition.py`
- targeted pre-commit hooks for the three modified files
- standalone SLICC generation of the `MI_example` protocol with one transition changed to `transition_no_stall`; parsing, AST processing, and generation of 113 C++ files completed successfully