### PR TITLE
arch-riscv:  Do single-stage page translation when hgatp.mode == BARE

### DIFF
--- a/src/arch/riscv/pagetable_walker.cc
+++ b/src/arch/riscv/pagetable_walker.cc
@@ -416,12 +416,13 @@ Walker::WalkerState::walk()
         Addr paddr;
         walkType = WalkType::GstageOnly;
         fault = walkGStage(vaddr, paddr);
-    }
-    else if (memaccess.virt) {
+    } else if (memaccess.virt && hgatp.mode != AddrXlateMode::BARE) {
         walkType = WalkType::TwoStage;
         fault = walkTwoStage(vaddr);
-    }
-    else {
+    } else {
+        // Either the access is not virtual, or it is virtual with
+        // hgatp.mode == Bare. In the latter case G-stage translation is not
+        // performed at all.
         walkType = WalkType::OneStage;
         fault = walkOneStage(vaddr);
     }


### PR DESCRIPTION
A guest with G-stage translation disabled panics the model. With `V=1`, `vsatp` paged and `hgatp.MODE = Bare`, the first guest memory access that misses the TLB kills the simulator (`src/arch/riscv/pagetable.cc:112: panic: Unknown address translation mode 0`).

The previous behaviour selected walkTwoStage() for every virtual access with a non-Bare vsatp, causing walkGStage() to attempt a page-table walk even when hgatp.MODE=Bare. This calls the page-table helpers with translation mode Bare and panics.