### PR TITLE
mem-ruby: Set txnId in CHI prepareRequestRetry

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-funcs.sm
@@ -734,6 +734,7 @@ void prepareRequestRetry(TBE tbe, CHIRequestMsg & out_msg) {
   out_msg.allowRetry := false;
 
   out_msg.addr := tbe.addr;
+  out_msg.txnId := tbe.txnId;
   out_msg.requestor := machineID;
   out_msg.fwdRequestor := tbe.requestor;
   out_msg.stashNID := tbe.stashNID;


### PR DESCRIPTION
In gem5 Ruby CHI protocol (`CHI-cache-funcs.sm`), when a cache prepares a retried request after receiving a RetryAck and subsequent RetryCredit (via `prepareRequestRetry()`), `out_msg.txnId := tbe.txnId;` was missing. As a result, retried `CHIRequestMsg` instances defaulted to `txnId = 0`, causing transaction ID tracking mismatches and lost response routing at downstream controllers.

This patch sets `out_msg.txnId := tbe.txnId;` in `prepareRequestRetry()`, matching the behavior of `prepareRequest()`.