### PR TITLE
mem: Preserve omitted state in Request copy constructor

### DIFF
--- a/src/mem/SConscript
+++ b/src/mem/SConscript
@@ -110,6 +110,7 @@ Source('port_terminator.cc')
 GTest('backdoor_manager.test', 'backdoor_manager.test.cc',
       'backdoor_manager.cc', with_tag('gem5_trace'))
 GTest('translation_gen.test', 'translation_gen.test.cc')
+GTest('request.test', 'request.test.cc')
 
 Source('translating_port_proxy.cc')
 Source('se_translating_port_proxy.cc')

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -516,7 +516,6 @@ class Request : public Extensible<Request>
         _flags.set(flags);
         privateFlags.set(VALID_PADDR|VALID_SIZE);
         _byteEnable = std::vector<bool>(size, true);
-        _isGPUFuncAccess = false;
     }
 
     Request(Addr vaddr, unsigned size, Flags flags,
@@ -526,7 +525,6 @@ class Request : public Extensible<Request>
         setVirt(vaddr, size, flags, id, pc, std::move(atomic_op));
         setContext(cid);
         _byteEnable = std::vector<bool>(size, true);
-        _isGPUFuncAccess = false;
     }
 
     Request(const Request &other)

--- a/src/mem/request.hh
+++ b/src/mem/request.hh
@@ -494,7 +494,7 @@ class Request : public Extensible<Request>
     /** The cause for HTM transaction abort */
     HtmFailureFaultCause _htmAbortCause = HtmFailureFaultCause::INVALID;
 
-    bool _isGPUFuncAccess;
+    bool _isGPUFuncAccess = false;
 
   public:
 
@@ -540,6 +540,9 @@ class Request : public Extensible<Request>
           privateFlags(other.privateFlags),
           _time(other._time),
           _taskId(other._taskId),
+          _streamId(other._streamId),
+          _substreamId(other._substreamId),
+          _systemReq(other._systemReq),
           _stashNID(other._stashNID),
           _stashLPID(other._stashLPID),
           _vaddr(other._vaddr),
@@ -548,6 +551,9 @@ class Request : public Extensible<Request>
           _pc(other._pc),
           _reqInstSeqNum(other._reqInstSeqNum),
           _localAccessor(other._localAccessor),
+          _instCount(other._instCount),
+          _htmAbortCause(other._htmAbortCause),
+          _isGPUFuncAccess(other._isGPUFuncAccess),
           translateDelta(other.translateDelta),
           accessDelta(other.accessDelta),
           depth(other.depth)

--- a/src/mem/request.test.cc
+++ b/src/mem/request.test.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 harukz
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mem/request.hh"
+
+namespace gem5
+{
+
+TEST(Request, CopyConstructorPreservesStreamId)
+{
+    Request original;
+    original.setStreamId(42);
+
+    Request copied(original);
+
+    ASSERT_TRUE(copied.hasStreamId());
+    EXPECT_EQ(copied.streamId(), 42);
+}
+
+TEST(Request, CopyConstructorPreservesSubstreamId)
+{
+    Request original;
+    original.setStreamId(42);
+    original.setSubstreamId(7);
+
+    Request copied(original);
+
+    ASSERT_TRUE(copied.hasSubstreamId());
+    EXPECT_EQ(copied.substreamId(), 7);
+}
+
+TEST(Request, CopyConstructorPreservesInstCount)
+{
+    Request original;
+    original.setInstCount(123);
+
+    Request copied(original);
+
+    ASSERT_TRUE(copied.hasInstCount());
+    EXPECT_EQ(copied.getInstCount(), 123);
+}
+
+TEST(Request, CopyConstructorPreservesHtmAbortCause)
+{
+    Request original;
+    original.setPaddr(0);
+    original.setFlags(Request::HTM_ABORT);
+    original.setHtmAbortCause(HtmFailureFaultCause::EXPLICIT);
+
+    Request copied(original);
+
+    ASSERT_TRUE(copied.hasHtmAbortCause());
+    EXPECT_EQ(
+        copied.getHtmAbortCause(),
+        HtmFailureFaultCause::EXPLICIT);
+}
+
+TEST(Request, CopyConstructorPreservesSystemReq)
+{
+    Request original;
+    original.setSystemReq(true);
+
+    Request copied(original);
+
+    EXPECT_TRUE(copied.systemReq());
+}
+
+TEST(Request, CopyConstructorPreservesGPUFuncAccess)
+{
+    Request original;
+    original.setGPUFuncAccess(true);
+
+    Request copied(original);
+
+    EXPECT_TRUE(copied.getGPUFuncAccess());
+}
+} // namespace gem5

--- a/src/mem/request.test.cc
+++ b/src/mem/request.test.cc
@@ -31,6 +31,9 @@
 
 namespace gem5
 {
+// TODO: This test file currently covers only the Request functionality
+// relevant to the copy constructor changes. Additional Request behavior
+// should be covered by future tests.
 
 TEST(Request, CopyConstructorPreservesStreamId)
 {


### PR DESCRIPTION
## Summary

Fixes #3429.

Previously, the `Request` copy constructor copied `privateFlags` but omitted several corresponding values. This could leave a copied request reporting valid state while holding the default value for that state.

The copy constructor also omitted the system-request and GPU functional-access state.

This change preserves the missing request state when copying a `Request` and adds regression tests for each affected field.

## Changes

- Preserve the following fields in the `Request` copy constructor:
  - `_streamId`
  - `_substreamId`
  - `_instCount`
  - `_htmAbortCause`
  - `_systemReq`
  - `_isGPUFuncAccess`
- Initialize `_isGPUFuncAccess` to `false`, consistent with the other `Request` constructors.
- Add `request.test.cc` with regression tests covering each field. If this separate test file is unnecessary, please let me know and I'll remove it.
- Register the new GTest target in `src/mem/SConscript`.

## Testing

```bash
scons build/ALL/mem/request.test.opt -j"$(nproc)"
./build/ALL/mem/request.test.opt
scons build/ALL/unittests.opt -j"$(nproc)"
git diff --check upstream/develop...HEAD
```

The new `Request` unit tests pass (6/6), and the full C++ unit test target also
passes.