### PR TITLE
arch-riscv: Fix signed arithmetic and sticky vxsat in RVV

### DIFF
--- a/src/arch/riscv/insts/vector.cc
+++ b/src/arch/riscv/insts/vector.cc
@@ -548,9 +548,11 @@ VMaskMergeMicroInst::generateDisassembly(Addr pc,
 Fault
 VxsatMicroInst::execute(ExecContext* xc, trace::InstRecord* traceData) const
 {
-    xc->setMiscReg(MISCREG_VXSAT, *vxsat);
-    auto vcsr = xc->readMiscReg(MISCREG_VCSR);
-    xc->setMiscReg(MISCREG_VCSR, ((vcsr&~1)|*vxsat));
+    if (*vxsat) {
+        xc->setMiscReg(MISCREG_VXSAT, *vxsat);
+        auto vcsr = xc->readMiscReg(MISCREG_VCSR);
+        xc->setMiscReg(MISCREG_VCSR, ((vcsr & ~1) | *vxsat));
+    }
     return NoFault;
 }
 

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -3801,7 +3801,7 @@ decode QUADRANT default Unknown::unknown() {
                             vxsatptr);
                     }}, OPIVV, SimdAddOp);
                     0x21: vsadd_vv({{
-                        Vd_vu[i] = sat_add<vi>(Vs2_vu[i], Vs1_vu[i],
+                        Vd_vi[i] = sat_add<vi>(Vs2_vi[i], Vs1_vi[i],
                             vxsatptr);
                     }}, OPIVV, SimdAddOp);
                     0x22: vssubu_vv({{
@@ -3809,7 +3809,7 @@ decode QUADRANT default Unknown::unknown() {
                             vxsatptr);
                     }}, OPIVV, SimdAddOp);
                     0x23: vssub_vv({{
-                        Vd_vu[i] = sat_sub<vi>(Vs2_vu[i], Vs1_vu[i],
+                        Vd_vi[i] = sat_sub<vi>(Vs2_vi[i], Vs1_vi[i],
                             vxsatptr);
                     }}, OPIVV, SimdAddOp);
                     0x27: vsmul_vv({{
@@ -4404,8 +4404,8 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPMVV, SimdAddOp);
 
                     0x9: vaadd_vv({{
-                        __uint128_t res = (__uint128_t)Vs2_vi[i] + Vs1_vi[i];
-                        res = int_rounding<__uint128_t>(
+                        __int128_t res = (__int128_t)Vs2_vi[i] + Vs1_vi[i];
+                        res = int_rounding<__int128_t>(
                             res,
                             xc->readMiscReg(MISCREG_VXRM),
                             1
@@ -4424,8 +4424,8 @@ decode QUADRANT default Unknown::unknown() {
                         }}, OPMVV, SimdAddOp);
 
                     0xb: vasub_vv({{
-                        __uint128_t res = (__uint128_t)Vs2_vi[i] - Vs1_vi[i];
-                        res = int_rounding<__uint128_t>(
+                        __int128_t res = (__int128_t)Vs2_vi[i] - Vs1_vi[i];
+                        res = int_rounding<__int128_t>(
                             res,
                             xc->readMiscReg(MISCREG_VXRM),
                             1
@@ -5040,7 +5040,7 @@ decode QUADRANT default Unknown::unknown() {
                             vxsatptr);
                     }}, OPIVX, SimdAddOp);
                     0x21: vsadd_vx({{
-                        Vd_vu[i] = sat_add<vi>(Vs2_vu[i], Rs1_vu,
+                        Vd_vi[i] = sat_add<vi>(Vs2_vi[i], Rs1_vi,
                             vxsatptr);
                     }}, OPIVX, SimdAddOp);
                     0x22: vssubu_vx({{
@@ -5048,7 +5048,7 @@ decode QUADRANT default Unknown::unknown() {
                             vxsatptr);
                     }}, OPIVX, SimdAddOp);
                     0x23: vssub_vx({{
-                        Vd_vu[i] = sat_sub<vi>(Vs2_vu[i], Rs1_vu,
+                        Vd_vi[i] = sat_sub<vi>(Vs2_vi[i], Rs1_vi,
                             vxsatptr);
                     }}, OPIVX, SimdAddOp);
                     0x27: vsmul_vx({{


### PR DESCRIPTION
## Summary
In RVV fixed-point instructions, `vxsat` CSR updates unconditionally overwrite previous saturation states instead of behaving as sticky bits. Additionally, signed fixed-point instructions (`vsadd`, `vssub`, `vaadd`, `vasub`) incorrectly use unsigned arithmetic casting, corrupting sign extension and rounding.

## Solution
* `src/arch/riscv/insts/vector.cc`: Wrapped CSR writes in `if (*vxsat)` within `VxsatMicroInst::execute` to ensure `vxsat` remains sticky across instructions.
* `src/arch/riscv/isa/decoder.isa`: Replaced unsigned types (`_vu`, `__uint128_t`) with signed types (`_vi`, `__int128_t`) for `vsadd`, `vssub`, `vaadd`, and `vasub` to enforce correct signed saturation and rounding.

Fixes #2677