### PR TITLE
configs: time-normalize L2 dynamic power in arm/fs_power.py

### DIFF
--- a/configs/example/arm/fs_power.py
+++ b/configs/example/arm/fs_power.py
@@ -82,7 +82,7 @@ class L2PowerOn(MathExprPowerModel):
         # Example to report l2 Cache overallAccesses
         # The estimated power is converted to Watt and will vary based
         # on the size of the cache
-        self.dyn = f"{l2_path}.overallAccesses * 0.000018000"
+        self.dyn = f"{l2_path}.overallAccesses * 0.000018000 / simSeconds"
         self.st = "(voltage * 3)/10"
 
 


### PR DESCRIPTION
## Summary

`L2PowerOn.dyn` in `configs/example/arm/fs_power.py` multiplies the cumulative
stat `overallAccesses` by a per-access coefficient but never divides by elapsed
simulated time, so the value it produces grows without bound with simulation
length instead of tracking an access rate.

The `CpuPowerOn` expression in the same file already applies the correct idiom
to the same class of stat. This change makes the L2 expression consistent with
it.

```diff
-        self.dyn = f"{l2_path}.overallAccesses * 0.000018000"
+        self.dyn = f"{l2_path}.overallAccesses * 0.000018000 / simSeconds"
```

## Why this is a dimensional error, not a modelling preference

The argument is entirely internal to the tree; no judgement about realistic
cache energy is needed.

| | |
|---|---|
| **The file states the intended unit.** The comment directly above the expression reads *"The estimated power is converted to Watt and will vary based on the size of the cache."* | `configs/example/arm/fs_power.py:83-84` |
| **`overallAccesses` is a cumulative count**, declared in units of `Count` and defined as `overallHits + overallMisses`. | `src/mem/cache/base.cc:2283`, `:2425` |
| **The expression's value is used directly, with no internal normalization.** `MathExprPowerModel::getDynamicPower()` is `{ return eval(dyn_expr); }`, and its doc comment says `@return Power (Watts)`. | `src/sim/power/mathexpr_powermodel.hh:71`, `:76` |
| **The aggregation adds no time term either** — `PowerModel::getDynamicPower()` is a weighted sum over power states with dimensionless weights. | `src/sim/power/power_model.cc:111-135` |
| **The same file already normalizes the same class of stat**, dividing `dcache.overallMisses` by `simSeconds`. | `configs/example/arm/fs_power.py:57-58` |

## Why it is not confined to the reported stat

A `PowerModel` registers with the enclosing `SubSystem`
(`src/sim/power/power_model.cc:72`), `SubSystem::getDynamicPower()` sums its
registered producers (`src/sim/sub_system.cc:56-60`), and `ThermalDomain` reads
that sum (`src/sim/power/thermal_domain.cc:90`). In `fs_power.py` the L2 sits
under `root.system.bigCluster`, so where this example is used together with a
thermal model, the un-normalized term is part of the power driving the thermal
solver.

## History

The expression has had no time normalization since it was introduced in
`537d6874c8` (*"config, arm, power: Example to report the power for the L2
Cache"*, 2018-09-14). It is an original oversight rather than a regression.

## Deliberately not included

- **The coefficient `0.000018000` is left untouched.** It is an example value and
  no part of this argument depends on its physical plausibility.
- **The missing `voltage *` factor is left untouched.** `CpuPowerOn.dyn`
  multiplies by `voltage` and `L2PowerOn.dyn` does not; that is a defensible
  unit-convention difference, not a defect, and bundling it would obscure a
  one-line dimensional fix.

## Anticipated questions

**`/ simSeconds` gives a running average, not an instantaneous rate.** Correct,
and that is exactly what the `CpuPowerOn` expression already does in the same
file. A windowed or delta-based rate would be a larger redesign of the example
and is out of scope here.

**Does this introduce a division-by-zero exposure?** None beyond what the
`CpuPowerOn` expression in the same file already carries, on the same timeline.

**This changes reported numbers.** Yes — reported L2 dynamic power changes by a
factor of `simSeconds`. The previously reported values were not in Watts, so
this corrects the quantity rather than retuning it.

## Verification

```bash
sed -n '56,58p;82,86p' configs/example/arm/fs_power.py   # the asymmetry
grep -n 'overallAccesses' src/mem/cache/base.cc          # Count; hits + misses
grep -n 'getDynamicPower' src/sim/power/mathexpr_powermodel.hh
git show 537d6874c8 -- configs/example/arm/fs_power.py   # never normalized
```
