### PR TITLE
configs: ROCm 7.2 and 7.14 support for MI300X

### DIFF
--- a/configs/example/gpufs/mi300.py
+++ b/configs/example/gpufs/mi300.py
@@ -69,12 +69,10 @@ fi
 
 if [ -f /home/gem5/load_amdgpu.sh ]; then
     sh /home/gem5/load_amdgpu.sh
-elif [ ! -f /lib/modules/`uname -r`/updates/dkms/amdgpu.ko ]; then
-    echo "ERROR: Missing DKMS package for kernel `uname -r`. Exiting gem5."
-    /sbin/m5 exit
 else
+    echo 'options amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2' > /etc/modprobe.d/amdgpu.conf
     # Backward compatibility with old disk images (ROCm 6.1)
-    modprobe -v amdgpu ip_block_mask=0x6f ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2
+    modprobe -v amdgpu
 fi
 
 echo "Running {} {}"

--- a/configs/example/gpufs/system/system.py
+++ b/configs/example/gpufs/system/system.py
@@ -37,6 +37,10 @@ from example.gpufs.Disjoint_VIPER import *
 from ruby import Ruby
 from system.amdgpu import *
 
+from m5.objects import (
+    X86ACPIDSDT,
+    X86ACPIFADT,
+)
 from m5.util import panic
 
 
@@ -54,6 +58,8 @@ def makeGpuFSSystem(args):
         "drm_kms_helper.fbdev_emulation=0",
         "modprobe.blacklist=amdgpu",
         "modprobe.blacklist=psmouse",
+        # Tell linux to use MP table for PCI IRQs and not ACPI.
+        "pci=noacpi",
     ]
     cmdline = " ".join(boot_options)
 
@@ -72,6 +78,13 @@ def makeGpuFSSystem(args):
         test_mem_mode, args.num_cpus, bm, True, cmdline=cmdline
     )
     system.workload.object_file = binary(args.kernel)
+
+    # FADT pointing at a minimal DSDT. This prevents Linux from disabling
+    # ACPI which is needed by the WMI module which is a dependency for
+    # the amdgpu module.
+    fadt = X86ACPIFADT(dsdt=X86ACPIDSDT(), oem_id="gem5")
+    system.workload.acpi_description_table_pointer.rsdt.entries.append(fadt)
+    system.workload.acpi_description_table_pointer.xsdt.entries.append(fadt)
 
     # Set the cache line size for the entire system.
     system.cache_line_size = args.cacheline_size


### PR DESCRIPTION
This adds support for ROCm 7.2 and 7.14 which require new ACPI tables so that the WMI driver loads. Previously a workaround was used, but the workaround is no longer possible due to how newer Linux versions handle module symbols.

These changes were already made for stdlib in PR #3234 but there have been several requests for classic config support. Confirmed ROCm 7.0, 7.2, and 7.14 boot and can run square.