### PR TITLE
arch-riscv: Add alignment check and NOP handling for vmv whole

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -1550,13 +1550,17 @@ def template VMvWholeMicroExecute {{
 Fault
 %(class_name)s::execute(ExecContext* xc, trace::InstRecord* traceData) const
 {
-    // TODO: Check register alignment.
-    // TODO: If vd is equal to vs2 the instruction is an architectural NOP.
 
     bool set_dirty = true;
     bool check_vill = false;
     Fault update_fault = updateVPUStatus(xc, machInst, set_dirty, check_vill);
     if (update_fault != NoFault) { return update_fault; }
+
+    uint32_t num_regs = machInst.simm3 + 1;
+    if ((machInst.vd % num_regs != 0) || (machInst.vs2 % num_regs != 0)) {
+            return std::make_shared<IllegalInstFault>("Vector register unaligned", machInst);
+    }
+    if (machInst.vd == machInst.vs2) { return NoFault; }
 
     %(op_decl)s;
     %(op_rd)s;


### PR DESCRIPTION
## Summary
The RISC-V Vector specification mandates that whole vector register move instructions (`vmv1r.v`, `vmv2r.v`, `vmv4r.v`, `vmv8r.v`) enforce register group alignment and act as an architectural NOP when `vd == vs2`. Previously, gem5 had pending TODO markers and executed unaligned or self-copy operations without validating these constraints.

## Solution
* Added register group alignment validation against `num_regs` (`machInst.simm3 + 1`) in `src/arch/riscv/isa/templates/vector_arith.isa`.
* Implemented `IllegalInstFault` generation when source (`vs2`) or destination (`vd`) register indices are not divisible by `num_regs`.
* Added early `NoFault` return when `machInst.vd == machInst.vs2` to satisfy the architectural NOP requirement without copying data.