### PR TITLE
tests: Increase SST daily test timeout

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -239,7 +239,7 @@ jobs:
     sst-test:
         runs-on: [self-hosted, linux, x64]
         container: ghcr.io/gem5/sst-env:latest
-        timeout-minutes: 180
+        timeout-minutes: 240
 
         steps:
             - uses: actions/checkout@v7


### PR DESCRIPTION
The Daily Tests `sst-test` job has a 180-minute timeout, but recent
successful runs routinely finish between 171 and 179 minutes. The job
was cancelled at exactly the timeout in both of these runs while the
SST simulation was still active:

- https://github.com/gem5/gem5/actions/runs/33228659723
- https://github.com/gem5/gem5/actions/runs/32444966263

Both failures show only GitHub timeout cancellation, without a gem5
assertion or simulation error. The newest failure also uses the same
commit and workflow as a successful run from the preceding day.

Increase the `sst-test` timeout from 180 to 240 minutes to provide margin
for normal runtime variation. This does not change the build or test
commands.

Validation:

- `git diff --check`
- `pre-commit run check-yaml --files .github/workflows/daily-tests.yaml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/daily-tests.yaml`
- repository pre-commit hooks run by `git commit`