### PR TITLE
ext,util: Add public headers to integration builds

### DIFF
--- a/ext/sst/Makefile.linux
+++ b/ext/sst/Makefile.linux
@@ -4,7 +4,7 @@ ARCH=RISCV
 OFLAG=3
 
 LDFLAGS=-shared -fno-common ${shell pkg-config ${SST_VERSION} --libs} -L../../build/${ARCH}/ -Wl,-rpath ../../build/${ARCH}
-CXXFLAGS=-std=c++17 -g -O${OFLAG} -fPIC ${shell pkg-config ${SST_VERSION} --cflags} ${shell python3-config --includes} -I../../build/${ARCH}/ -I../../ext/pybind11/include/ -I../../build/softfloat/ -I../../ext
+CXXFLAGS=-std=c++17 -g -O${OFLAG} -fPIC ${shell pkg-config ${SST_VERSION} --cflags} ${shell python3-config --includes} -I../../build/${ARCH}/ -I../../include/ -I../../ext/pybind11/include/ -I../../build/softfloat/ -I../../ext
 CPPFLAGS+=-MMD -MP
 SRC=$(wildcard *.cc)
 

--- a/ext/sst/Makefile.mac
+++ b/ext/sst/Makefile.mac
@@ -4,7 +4,7 @@ ARCH=RISCV
 OFLAG=3
 
 LDFLAGS=-shared -fno-common ${shell pkg-config ${SST_VERSION} --libs} -L../../build/${ARCH}/ -Wl,-rpath ../../build/${ARCH}
-CXXFLAGS=-std=c++17 -g -O${OFLAG} -fPIC ${shell pkg-config ${SST_VERSION} --cflags} ${shell python3-config --includes} -I../../build/${ARCH}/ -I../../ext/pybind11/include/ -I../../build/softfloat/ -I../../ext
+CXXFLAGS=-std=c++17 -g -O${OFLAG} -fPIC ${shell pkg-config ${SST_VERSION} --cflags} ${shell python3-config --includes} -I../../build/${ARCH}/ -I../../include/ -I../../ext/pybind11/include/ -I../../build/softfloat/ -I../../ext
 CPPFLAGS+=-MMD -MP
 SRC=$(wildcard *.cc)
 

--- a/util/systemc/gem5_within_systemc/Makefile
+++ b/util/systemc/gem5_within_systemc/Makefile
@@ -40,6 +40,7 @@ SYSTEMC_INC = /opt/systemc/include
 SYSTEMC_LIB = /opt/systemc/lib-linux64
 
 CXXFLAGS = -I../../../build/$(ARCH) -L../../../build/$(ARCH) -I../../../ext/
+CXXFLAGS += -I../../../include/
 CXXFLAGS += -I$(SYSTEMC_INC) -L$(SYSTEMC_LIB)
 CXXFLAGS += -std=c++17
 CXXFLAGS += -g -DTRACING_ON


### PR DESCRIPTION
## Summary

- expose gem5's public headers to the Linux and macOS SST builds
- expose the same headers to the gem5-within-SystemC example

## Root cause

Daily Tests job [99327689611](https://github.com/gem5/gem5/actions/runs/33337769398/job/99327689611) built `RISCV/libgem5_opt.so` successfully, then failed while compiling `ext/sst/gem5.cc`:

```
../../build/RISCV/sim/sim_exit.hh:38:10: fatal error:
gem5/hypercall_ids.h: No such file or directory
```

`sim_exit.hh` now includes the public header
`include/gem5/hypercall_ids.h`, but the external integration Makefiles only
exposed the generated build tree and `ext/`. The SystemC embedding example
also includes `sim_exit.hh`, so it needs the same public include path.

## Validation

- `git diff --check`
- focused pre-commit hooks for all three changed Makefiles
- reproduced the missing-header failure with the exact `sst-env` image digest
  used by the failing job
- verified in that image that adding only `-Iinclude` makes the failing
  `sim_exit.hh` compiler check pass
- verified the SST Makefile dry runs include `-I../../include/`

The full Daily SST build and runtime test remain for CI validation; this PR is
draft while that end-to-end coverage is pending.
