### PR TITLE
misc: launch ci-daily-codecov workflow alongside weekly tests

### DIFF
--- a/.github/workflows/ci-daily-codecov.yaml
+++ b/.github/workflows/ci-daily-codecov.yaml
@@ -5,14 +5,8 @@
 name: CI and Daily Tests for Codecov
 
 on:
-    # This is triggered after the Weekly Tests finish.
-    # It can also be triggered manually.
+    # This workflow is triggered alongside the weekly tests by scheduler.yaml.
     workflow_dispatch:
-    workflow_run:
-        workflows: [Weekly Tests]
-        types:
-            - completed
-
 
 jobs:
 
@@ -35,8 +29,6 @@ jobs:
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Run ALL/unittests.${{ matrix.type.build }} UnitTests
               run: scons build/ALL/unittests.${{ matrix.type.build }} --gcov -j $(nproc)
 
@@ -58,8 +50,6 @@ jobs:
             test-dirs-matrix-long: ${{ steps.dir-matrix.outputs.test-dirs-matrix-long }}
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Get directories for testlib-${{ matrix.type }}
               working-directory: ${{ github.workspace }}/tests
               id: dir-matrix
@@ -130,8 +120,6 @@ jobs:
         needs: [get-date, get-testlib-dirs, flatten-length-and-testdir-matrices]
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Cache build/ALL
               uses: actions/cache@v6
               with:
@@ -190,8 +178,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Cache build/VEGA_X86
               uses: actions/cache@v6
               with:
@@ -233,8 +219,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Build RISCV/libgem5_opt.so with SST
               run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style --gcov -j $(nproc)
             - name: Makefile ext/sst
@@ -260,8 +244,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Build ARM/gem5.opt
               run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources --gcov -j$(nproc)
             - name: disable systemc
@@ -293,8 +275,6 @@ jobs:
         timeout-minutes: 360 # 6 hours
         steps:
             - uses: actions/checkout@v7
-              with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
             - name: Checkout DRAMSys
               working-directory: ${{ github.workspace }}/ext/dramsys
               run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.3.1 --depth 1 DRAMSys

--- a/.github/workflows/scheduler.yaml
+++ b/.github/workflows/scheduler.yaml
@@ -51,11 +51,13 @@ jobs:
                   gh workflow run daily-tests.yaml --ref develop >/dev/null
                   echo "Daily test scheduled to run on develop branch."
 
-            - name: Weekly Tests
+            - name: Weekly Tests and CI-Daily Tests for Codecov
               if: github.event.schedule == '30 19 * * 5'
               run: |
                   gh workflow run weekly-tests.yaml --ref develop >/dev/null
-                  echo "Weekly test scheduled to run on develop branch."
+                  gh workflow run ci-daily-codecov.yaml --ref develop >/dev/null
+                  echo "Weekly test and runs of CI and Daily tests for code" \
+                  "coverage scheduled to run on develop branch."
 
             - name: Compiler Tests
               if: github.event.schedule == '30 21 * * 2'


### PR DESCRIPTION
Previously, the `ci-daily-codecov` workflow, which gets code coverage on a weekly basis for the CI and Daily tests, was set up to be launched when the Weekly tests finished. However, this causes the `ci-daily-codecov` workflow to run on the `stable` branch instead of the `develop` branch, which means that we would not get the most up to date code coverage results.

This commit modifies the `ci-daily-codecov` and `scheduler` workflows so the `ci-daily-codecov` workflow is instead directly launched by the `scheduler` workflow at the same time as the Weekly tests.