### PR TITLE
Revert "misc: Skip the ext directory from git-clang-format"

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -55,7 +55,7 @@ jobs:
 
             - name: Run clang-format check
               run: |
-                  python util/run-git-clang-format.py --verbose --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }} --ignore ext
+                  python util/run-git-clang-format.py --verbose --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }}
 
     get-date:
     # We use the date to label caches. A cache is a a "hit" if the date is the


### PR DESCRIPTION
This PR Reverts gem5/gem5#3340

Differently from what was believed, using the --ignore option in the git-clang-format python script does not exclude directories when running git-clang-format over a commit. It simply excludes (during the pre-commit phase) files which have been modified but don't have to be checked.

Adding the --ignore in CI stops git-clang-format to properly execute:

    if disabled_files and not pathspecs:
        logger.warning("All changed files have been ignored. Doing nothing.")
        sys.exit(0)

This means at the moment our CI is not running git-clang-format.
We could sort of rewrite the script to support ignore but I believe at this point a simpler alternative will be to use hierarchical .clang-format files for ext directory:

```
DisableFormat: true
SortIncludes: Never
```

Will create a new PR once this has been merged

