### PR TITLE
misc: Prepare staging-branch for v26.0 release

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -675,12 +675,6 @@ for variant_path in variant_paths:
                 ) or not conf.CheckLinkFlag('-Wl,--gdb-index'):
                     error('GDB index generation is not supported')
 
-        # Treat warnings as errors but white list some warnings that we
-        # want to allow (e.g., deprecation warnings).
-        env.Append(CCFLAGS=['-Werror',
-                             '-Wno-error=deprecated-declarations',
-                             '-Wno-error=deprecated',
-                            ])
     else:
         error('\n'.join((
               "Don't know what compiler options to use for your compiler.",

--- a/src/Doxyfile
+++ b/src/Doxyfile
@@ -31,7 +31,7 @@ PROJECT_NAME           = gem5
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = [DEVELOP-FOR-25.1]
+PROJECT_NUMBER         = v26.0.0.0
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/src/base/version.cc
+++ b/src/base/version.cc
@@ -32,6 +32,6 @@ namespace gem5
 /**
  * @ingroup api_base_utils
  */
-const char *gem5Version = "DEVELOP-FOR-25.1";
+const char *gem5Version = "26.0.0.0";
 
 } // namespace gem5

--- a/util/dockerfiles/docker-bake.hcl
+++ b/util/dockerfiles/docker-bake.hcl
@@ -41,7 +41,7 @@ variable "CACHE_TAG" {
 }
 
 variable "TAG" {
-  default = "latest"
+  default = "v26-0"
 }
 
 # Common attributes across all targets. Note: these can be overwritten.


### PR DESCRIPTION
## Overview

This PR applies the release-specific code changes for gem5 v26.0.0.0:

- set the runtime version to `26.0.0.0`;
- set the Doxygen project number to `v26.0.0.0`;
- stop treating compiler warnings as errors on the release branch; and
- set the Docker bake output tag to `v26-0`.

These changes follow the documented gem5 release procedure and the
recurring release-only changes made for v25.0 and v25.1.

`RELEASE-NOTES.md` is intentionally not changed. It will be handled as a
separate task.