### PR TITLE
misc: Add gem5 v26.0 release notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,455 @@
+# Version 26.0
+
+gem5 Version 26.0 is the first major release of 2026. This release consists
+of 774 commits contributed through 379 merged GitHub pull requests from 84
+unique contributors.
+
+## Major Highlights
+
+* **RISC-V KVM and broader architectural coverage.**
+  gem5 can now use KVM acceleration on RISC-V hosts through the new
+  `RiscvKvmCPU`. The release also adds Sv48 and Sv57 address translation,
+  profile-based ISA-extension reporting, and scalar and vector BF16
+  extensions
+  ([#3053](https://github.com/gem5/gem5/pull/3053),
+  [#3086](https://github.com/gem5/gem5/pull/3086),
+  [#3320](https://github.com/gem5/gem5/pull/3320),
+  [#3273](https://github.com/gem5/gem5/pull/3273)).
+
+* **Arm SME2, SME2.1, and additional Armv9 support.**
+  The Arm ISA now implements FEAT_SME2 and FEAT_SME2p1, adds Armv9.0 and
+  Armv9.4 release objects, implements FEAT_WFxT, and completes the remaining
+  Armv8.2 crypto instructions used by the supplied Neoverse V2 model
+  ([#2992](https://github.com/gem5/gem5/pull/2992),
+  [#2839](https://github.com/gem5/gem5/pull/2839),
+  [#3015](https://github.com/gem5/gem5/pull/3015),
+  [#3182](https://github.com/gem5/gem5/pull/3182)).
+
+* **Richer branch-prediction models.**
+  A new indirect-target TAGE (ITTAGE) predictor models changing indirect
+  branch targets. The decoupled front end can now model conditional-predictor
+  and BTB latency, predictor overriding, and configurable multi-level BTB
+  hierarchies
+  ([#2906](https://github.com/gem5/gem5/pull/2906),
+  [#2817](https://github.com/gem5/gem5/pull/2817),
+  [#2822](https://github.com/gem5/gem5/pull/2822)).
+
+* **AMBA CHI-TLM and mesh-based standard-library systems.**
+  gem5 now bundles Arm's public AMBA TLM 2.0 library and uses it to test CHI
+  transaction-level integration. New standard-library CHI cache hierarchies
+  support user-described CustomMesh topologies, with configurable internal
+  and external channel counts and link latencies
+  ([#3339](https://github.com/gem5/gem5/pull/3339),
+  [#3215](https://github.com/gem5/gem5/pull/3215),
+  [#3146](https://github.com/gem5/gem5/pull/3146)).
+
+* **Modern AMD GPU software and instruction support.**
+  The GPU full-system configurations can boot ROCm 7.2 and ROCm 7.14 on
+  MI300X, including the ACPI support required by newer kernels. Vega/CDNA3
+  instruction coverage now includes operations used by Triton, additional
+  matrix instructions, and 16-bit data types. Optional BLIT-kernel emulation
+  can substantially reduce simulation time for copy-heavy workloads
+  ([#3234](https://github.com/gem5/gem5/pull/3234),
+  [#3458](https://github.com/gem5/gem5/pull/3458),
+  [#3184](https://github.com/gem5/gem5/pull/3184),
+  [#3198](https://github.com/gem5/gem5/pull/3198),
+  [#3213](https://github.com/gem5/gem5/pull/3213),
+  [#3149](https://github.com/gem5/gem5/pull/3149)).
+
+* **Unified simulation-exit handling.**
+  Hypercall identifiers and payload dispatch are now the primary exit model
+  in the Python standard library. Guest code, C++, and Python share canonical
+  identifiers, while an explicit compatibility path preserves classic exit
+  causes, codes, scheduling, priorities, and repetition semantics
+  ([#2983](https://github.com/gem5/gem5/pull/2983)).
+
+* **More flexible memory-system modeling.**
+  `AddrRange` now supports sparse address spaces and modulo-based
+  interleaving, enabling non-power-of-two channel counts without forcing
+  memory objects to model holes themselves. The release also adds HBM3 6.4
+  Gbps and HBM3E 9.6 Gbps presets, multi-channel simple memory, and
+  standard-library LPDDR5 interfaces
+  ([#2861](https://github.com/gem5/gem5/pull/2861),
+  [#3271](https://github.com/gem5/gem5/pull/3271),
+  [#3335](https://github.com/gem5/gem5/pull/3335),
+  [#3211](https://github.com/gem5/gem5/pull/3211)).
+
+## Compatibility and API Changes
+
+* **C++20 is now required.**
+  gem5's build selects the C++20 language standard. Out-of-tree C++ code and
+  custom toolchains must therefore be C++20-compatible
+  ([#3028](https://github.com/gem5/gem5/pull/3028)).
+
+* **RISC-V ISA selection is profile-based.**
+  The previous independent `riscv_type`, `enable_rvv`, `enable_Zicbom_fs`,
+  `enable_Zicboz_fs`, `enable_Zcd`, and `enable_Smrnmi` parameters have been
+  replaced by `riscv_profile` and `extra_extensions`. The selected profile
+  controls reported capabilities rather than claiming complete profile
+  implementation. gem5 warns about mandatory profile extensions that it
+  cannot report
+  ([#3320](https://github.com/gem5/gem5/pull/3320)).
+
+* **Simulation-exit APIs have clearer roles.**
+  New code should use `exitSimulationLoop` or `exitSimulationLoopNow` with a
+  built-in `ExitHypercall` or a custom numeric identifier. Code that must
+  preserve a classic cause and code should use
+  `exitSimulationLoopClassic` or `exitSimulationLoopClassicNow`.
+  `exitSimLoop` is deprecated, and the transitional
+  `exitSimLoopWithHypercall` and `exitSimLoopWithClassicGenerator` APIs have
+  been removed. Existing `ExitEvent` handlers remain supported through the
+  compatibility path
+  ([#2983](https://github.com/gem5/gem5/pull/2983)).
+
+* **Python cannot override C++ SimObject lifecycle methods.**
+  The `init`, `regProbePoints`, `regProbeListeners`, `initState`, and
+  `loadState` phases are now dispatched in batches from C++. Python
+  overrides of these methods are rejected because they would otherwise be
+  silently skipped. Port binding between C++ SimObjects is also batched,
+  reducing large-system instantiation time
+  ([#3290](https://github.com/gem5/gem5/pull/3290)).
+
+* **Address-range construction has been generalized.**
+  `AddrRange` mapping policy is now explicit and can represent masked or
+  modulo interleaving and sparse ranges. Existing contiguous and masked
+  ranges remain supported, while memory components can use the new policy
+  factories for non-power-of-two channel counts and holes
+  ([#2861](https://github.com/gem5/gem5/pull/2861)).
+
+* **The minimum Protocol Buffers compiler is version 3.0.0.**
+  Builds using an older `protoc` now fail during configuration with a clear
+  diagnostic
+  ([#3101](https://github.com/gem5/gem5/pull/3101)).
+
+* **Older GPU disk images are being retired.**
+  The standard-library GPU setup now provides the ACPI tables and direct
+  `amdgpu` loading needed by ROCm 7.2. ROCm 6.4 and older disk images are no
+  longer detected through the former `amdgpu.ko` workaround. ROCm 7.0 images
+  remain supported during the transition
+  ([#3234](https://github.com/gem5/gem5/pull/3234)).
+
+## User-Facing Enhancements
+
+* **More capable syscall-emulation workloads.**
+  Arm, x86, and RISC-V SE-mode handling was expanded so more contemporary
+  binaries run without configuration-specific workarounds. Arm also gains
+  Linux syscall 403 (`clock_gettime`), and `dup2` and `wait4` now more closely
+  follow Linux file-descriptor and wait-status behavior
+  ([#2998](https://github.com/gem5/gem5/pull/2998),
+  [#2960](https://github.com/gem5/gem5/pull/2960),
+  [#3343](https://github.com/gem5/gem5/pull/3343)).
+
+* **CSV and MultiSim statistics.**
+  A new statistics visitor writes CSV output, and the Python statistics code
+  has been refactored to make additional output formats easier to implement.
+  MultiSim child simulations can return statistics to their parent process
+  for aggregation and analysis
+  ([#2776](https://github.com/gem5/gem5/pull/2776),
+  [#2078](https://github.com/gem5/gem5/pull/2078)).
+
+* **Zstandard-compressed images.**
+  gem5 can load Zstandard-compressed images when built with the optional
+  `libzstd` dependency. Existing uncompressed and gzip-compressed image
+  support is unchanged
+  ([#3400](https://github.com/gem5/gem5/pull/3400)).
+
+* **More readable terminal diagnostics.**
+  Panic, fatal, warning, information, and TestLib messages use color when
+  stderr is a terminal. `NO_COLOR` disables color and `FORCE_COLOR` enables
+  it for redirected output
+  ([#3204](https://github.com/gem5/gem5/pull/3204)).
+
+* **PCI-to-PCI bridges.**
+  The new `PciToPciBridge` models a Type 1 PCI bridge, downstream buses, and
+  request forwarding. An x86 example demonstrates root-port configuration
+  ([#2561](https://github.com/gem5/gem5/pull/2561)).
+
+* **Independent processor and cache clock domains.**
+  Standard-library processors can set their CPU frequency independently, and
+  private cache hierarchies now use the processor clock domain. The
+  `SimpleSwitchableProcessor` also accepts a `clk_freq` setting
+  ([#3365](https://github.com/gem5/gem5/pull/3365),
+  [#3376](https://github.com/gem5/gem5/pull/3376),
+  [#3388](https://github.com/gem5/gem5/pull/3388)).
+
+* **Additional observability.**
+  Panic output includes the current simulation tick, execution traces can
+  annotate faulting instructions, statistics code can look up an individual
+  value in a vector statistic at run time, and workloads expose GDB listener
+  output to Python
+  ([#3074](https://github.com/gem5/gem5/pull/3074),
+  [#2941](https://github.com/gem5/gem5/pull/2941),
+  [#3241](https://github.com/gem5/gem5/pull/3241),
+  [#3331](https://github.com/gem5/gem5/pull/3331)).
+
+## CPU Models and Branch Prediction
+
+* **ITTAGE indirect prediction.**
+  The new ITTAGE model predicts indirect branches with changing targets and
+  falls back to the BTB for stable targets
+  ([#2906](https://github.com/gem5/gem5/pull/2906)).
+
+* **Configurable predictor and BTB latency.**
+  The decoupled front end can model conditional-predictor access latency and
+  an overriding predictor with a different latency. It can also use a
+  configurable multi-level BTB whose deeper levels override misses from
+  faster levels
+  ([#2817](https://github.com/gem5/gem5/pull/2817),
+  [#2822](https://github.com/gem5/gem5/pull/2822)).
+
+* **Distributed-IQ load balancing.**
+  The O3 CPU's new `LeastLoaded` insertion policy distributes instructions
+  among eligible instruction queues. `FirstMatch` names the previous
+  behavior
+  ([#3115](https://github.com/gem5/gem5/pull/3115)).
+
+* **CPU correctness and stability fixes.**
+  Fixes cover O3 CPU switching, instructions with no capable functional
+  unit, delayed miscellaneous-register dependencies, no-access LSQ requests,
+  SimpleBTB eviction, branch-predictor overrides after squash, and undefined
+  behavior in TAGE and the loop predictor
+  ([#3375](https://github.com/gem5/gem5/pull/3375),
+  [#3073](https://github.com/gem5/gem5/pull/3073),
+  [#3243](https://github.com/gem5/gem5/pull/3243),
+  [#3022](https://github.com/gem5/gem5/pull/3022),
+  [#3280](https://github.com/gem5/gem5/pull/3280),
+  [#3044](https://github.com/gem5/gem5/pull/3044),
+  [#3266](https://github.com/gem5/gem5/pull/3266),
+  [#3377](https://github.com/gem5/gem5/pull/3377)).
+
+## Arm ISA Changes and Improvements
+
+* **FEAT_SME2 and FEAT_SME2p1.**
+  The implementation adds SME2 instructions, architectural state, decoding,
+  tracing, checkpoint upgrading, and system-register support
+  ([#2992](https://github.com/gem5/gem5/pull/2992)).
+
+* **New release and feature definitions.**
+  `Armv90` and `Armv94` release objects allow configurations to select the
+  corresponding architectural feature sets. FEAT_WFxT adds timed
+  wait-for-event and wait-for-interrupt behavior
+  ([#2839](https://github.com/gem5/gem5/pull/2839),
+  [#3015](https://github.com/gem5/gem5/pull/3015)).
+
+* **Crypto and instruction support.**
+  The remaining Armv8.2 crypto instructions and 64-bit `PMULL` are now
+  implemented, and `STP` can be represented with a single store micro-op
+  where appropriate
+  ([#3182](https://github.com/gem5/gem5/pull/3182),
+  [#2988](https://github.com/gem5/gem5/pull/2988),
+  [#2828](https://github.com/gem5/gem5/pull/2828)).
+
+* **Correctness fixes.**
+  Fixes include CRC32CX and SHA1H execution, SVE vector-length handling at
+  EL2, stage-specific permission-fault handling, EL0 reads of ID registers
+  in SE mode, and preservation of global TLB entries during ASID-targeted
+  invalidation
+  ([#2990](https://github.com/gem5/gem5/pull/2990),
+  [#3090](https://github.com/gem5/gem5/pull/3090),
+  [#2974](https://github.com/gem5/gem5/pull/2974),
+  [#2981](https://github.com/gem5/gem5/pull/2981),
+  [#3381](https://github.com/gem5/gem5/pull/3381),
+  [#3425](https://github.com/gem5/gem5/pull/3425)).
+
+## RISC-V ISA Changes and Improvements
+
+* **KVM acceleration.**
+  `RiscvKvmCPU` enables full-system KVM acceleration on compatible RISC-V
+  hosts. The release includes a standard-library Ubuntu example and the
+  required interrupt, MMU, PMP, KVM, and `m5` operation integration
+  ([#3053](https://github.com/gem5/gem5/pull/3053)).
+
+* **Virtual-memory and extension reporting.**
+  Sv48 and Sv57 join Sv39 as supported address-translation modes.
+  Profile-based extension selection keeps `misa`, device-tree ISA strings,
+  Linux `riscv_hwprobe`, and internal feature checks consistent
+  ([#3086](https://github.com/gem5/gem5/pull/3086),
+  [#3320](https://github.com/gem5/gem5/pull/3320)).
+
+* **BF16 and vector instruction coverage.**
+  The Zfbfmin, Zvfbfmin, and Zvfbfwma extensions add scalar BF16 conversion,
+  vector conversions, and vector widening multiply-accumulate. RVV integer
+  rounding and saturation operations now use the correct rounding mode and
+  update `VXSAT`
+  ([#3273](https://github.com/gem5/gem5/pull/3273),
+  [#2994](https://github.com/gem5/gem5/pull/2994)).
+
+* **RVV correctness fixes.**
+  Numerous fixes address vector slide, reduction, gather, compress, masked
+  strided load, fractional-LMUL segment, destination-index, and
+  register-array bounds behavior
+  ([#3048](https://github.com/gem5/gem5/pull/3048),
+  [#3223](https://github.com/gem5/gem5/pull/3223),
+  [#3275](https://github.com/gem5/gem5/pull/3275),
+  [#3104](https://github.com/gem5/gem5/pull/3104),
+  [#3162](https://github.com/gem5/gem5/pull/3162),
+  [#3308](https://github.com/gem5/gem5/pull/3308),
+  [#3109](https://github.com/gem5/gem5/pull/3109),
+  [#3112](https://github.com/gem5/gem5/pull/3112),
+  [#3163](https://github.com/gem5/gem5/pull/3163)).
+
+* **Scalar and system fixes.**
+  RV64I and RV64M word operations now sign-extend correctly, PMP state is
+  checkpointed, `mcycle` and `minstret` are writable, and the SE auxiliary
+  vector supplies `AT_BASE`
+  ([#3123](https://github.com/gem5/gem5/pull/3123),
+  [#3131](https://github.com/gem5/gem5/pull/3131),
+  [#3001](https://github.com/gem5/gem5/pull/3001),
+  [#3304](https://github.com/gem5/gem5/pull/3304),
+  [#3240](https://github.com/gem5/gem5/pull/3240)).
+
+## x86 ISA Changes and Improvements
+
+* **FSGSBASE support.**
+  The `RDFSBASE`, `RDGSBASE`, `WRFSBASE`, and `WRGSBASE` instructions are
+  implemented for SE and full-system use, including CPUID reporting and
+  `CR4.FSGSBASE` handling
+  ([#2891](https://github.com/gem5/gem5/pull/2891)).
+
+* **Additional instructions and fixes.**
+  The release implements `SGDT` and `SIDT`, corrects call return-PC
+  construction, widens register-operation immediates, fixes x87 and SSE
+  operand widths, and improves segment, TLB, `STI`, and `CLI` behavior
+  ([#3348](https://github.com/gem5/gem5/pull/3348),
+  [#2905](https://github.com/gem5/gem5/pull/2905),
+  [#2858](https://github.com/gem5/gem5/pull/2858),
+  [#3026](https://github.com/gem5/gem5/pull/3026),
+  [#3171](https://github.com/gem5/gem5/pull/3171),
+  [#2881](https://github.com/gem5/gem5/pull/2881),
+  [#2884](https://github.com/gem5/gem5/pull/2884),
+  [#2748](https://github.com/gem5/gem5/pull/2748),
+  [#3389](https://github.com/gem5/gem5/pull/3389)).
+
+## GPU Model Enhancements
+
+* **ROCm 7.2 and 7.14 full-system support.**
+  x86 ACPI FADT and DSDT support allows recent kernels to load WMI and the
+  AMDGPU driver without the former module-loading workaround. Both
+  standard-library and classic MI300X configurations can boot ROCm 7.2 and
+  7.14 images
+  ([#3234](https://github.com/gem5/gem5/pull/3234),
+  [#3458](https://github.com/gem5/gem5/pull/3458)).
+
+* **Expanded CDNA3/Vega instructions.**
+  New coverage includes Triton-generated operations, MXFP BF16 and integer
+  matrix instructions, mixed FP8/BF8 matrix operations, and instructions for
+  16-bit data types
+  ([#3184](https://github.com/gem5/gem5/pull/3184),
+  [#3198](https://github.com/gem5/gem5/pull/3198),
+  [#3213](https://github.com/gem5/gem5/pull/3213)).
+
+* **Faster BLIT handling and better exit control.**
+  Optional emulation of aligned copy BLIT kernels avoids detailed execution
+  for supported transfers. Standard-library simulations also expose GPU
+  kernel-start and related exit events for per-kernel statistics handling
+  ([#3149](https://github.com/gem5/gem5/pull/3149),
+  [#3107](https://github.com/gem5/gem5/pull/3107)).
+
+## Memory System and AMBA CHI
+
+* **Bundled AMBA TLM 2.0 integration.**
+  The public Arm AMBA TLM library is built into gem5 by default. Developers
+  can pass `TLM_PATH` to link an alternative implementation. A TestLib
+  configuration begins exercising CHI integration against the library
+  ([#3339](https://github.com/gem5/gem5/pull/3339)).
+
+* **CHI-TLM controller and generator improvements.**
+  The CHI-TLM path now supports response/data separation, CBusy and P-credit
+  handling, out-of-order reads, snoops, backpressure, richer Python payload
+  and transaction APIs, and additional channel and route statistics
+  ([#3137](https://github.com/gem5/gem5/pull/3137),
+  [#3133](https://github.com/gem5/gem5/pull/3133),
+  [#3202](https://github.com/gem5/gem5/pull/3202),
+  [#3316](https://github.com/gem5/gem5/pull/3316),
+  [#3317](https://github.com/gem5/gem5/pull/3317),
+  [#3369](https://github.com/gem5/gem5/pull/3369),
+  [#2851](https://github.com/gem5/gem5/pull/2851),
+  [#3153](https://github.com/gem5/gem5/pull/3153),
+  [#3175](https://github.com/gem5/gem5/pull/3175),
+  [#3228](https://github.com/gem5/gem5/pull/3228),
+  [#3134](https://github.com/gem5/gem5/pull/3134)).
+
+* **CHI stash flows.**
+  Ruby CHI now implements end-to-end `StashOnceShared` and
+  `StashOnceUnique` transactions, including hierarchical forwarding,
+  snoop processing, and data pull. Requests can originate from the Sequencer
+  or TLM controller, and MemTest can inject stash operations for validation
+  ([#2975](https://github.com/gem5/gem5/pull/2975)).
+
+* **CustomMesh standard-library hierarchies.**
+  `PrivateL1PrivateL2MeshCacheHierarchy` and
+  `PrivateL1PrivateL2SharedL3MeshCacheHierarchy` allow standard-library
+  systems to describe CHI node placement and mesh links through a topology
+  module. Dot output and SimpleNetwork options help inspect and tune the
+  resulting topology
+  ([#3215](https://github.com/gem5/gem5/pull/3215),
+  [#3327](https://github.com/gem5/gem5/pull/3327),
+  [#3244](https://github.com/gem5/gem5/pull/3244)).
+
+* **Dedicated Garnet links by virtual network.**
+  Mesh_XY with XY routing can use `--per-vnet-links` to create separate
+  physical links for each virtual network. Existing configurations retain
+  shared links by default, and per-link/per-vnet flit statistics expose the
+  resulting traffic isolation
+  ([#3060](https://github.com/gem5/gem5/pull/3060)).
+
+* **Memory interfaces and backends.**
+  New HBM3/HBM3E and LPDDR5 standard-library interfaces expand available
+  memory technologies. `MultiChannelSimpleMemory` provides controllable
+  aggregate bandwidth without modeling a specific DRAM protocol.
+  `SimpleMemory` can select fixed, uniform, or normal-distribution access
+  latency. DRAMSys is updated to version 5.6.0
+  ([#3271](https://github.com/gem5/gem5/pull/3271),
+  [#3211](https://github.com/gem5/gem5/pull/3211),
+  [#3335](https://github.com/gem5/gem5/pull/3335),
+  [#3088](https://github.com/gem5/gem5/pull/3088),
+  [#3295](https://github.com/gem5/gem5/pull/3295)).
+
+* **Draining and checkpoint correctness.**
+  Ruby controllers can account for outstanding transient transactions while
+  draining, checkpoint restore can skip unused memory chunks, and memory
+  backdoors can be disabled or updated when address ranges change
+  ([#3358](https://github.com/gem5/gem5/pull/3358),
+  [#2794](https://github.com/gem5/gem5/pull/2794),
+  [#3333](https://github.com/gem5/gem5/pull/3333),
+  [#3334](https://github.com/gem5/gem5/pull/3334)).
+
+## Build, Tooling, and Testing
+
+* **New compiler and host support.**
+  gem5 builds as C++20, officially supports GCC 15.2, and can build and run
+  natively on LoongArch64 hosts. LoongArch support is for the host platform;
+  it does not add a simulated LoongArch ISA
+  ([#3028](https://github.com/gem5/gem5/pull/3028),
+  [#3125](https://github.com/gem5/gem5/pull/3125),
+  [#3309](https://github.com/gem5/gem5/pull/3309)).
+
+* **Debugging-oriented build options.**
+  `--with-tsan` enables ThreadSanitizer, `--gdb-index` can reduce GDB symbol
+  loading time with a compatible linker, and `--no-omit-frame-pointer`
+  improves stack reconstruction by profiling tools
+  ([#3461](https://github.com/gem5/gem5/pull/3461),
+  [#3247](https://github.com/gem5/gem5/pull/3247),
+  [#3246](https://github.com/gem5/gem5/pull/3246)).
+
+* **Faster and more reliable builds.**
+  SCons avoids needless recompilation, removes stale SLICC outputs, correctly
+  detects `clang++` supplied through `CXX`, and builds `util/m5` with SCons
+  4.6 and newer
+  ([#3226](https://github.com/gem5/gem5/pull/3226),
+  [#3233](https://github.com/gem5/gem5/pull/3233),
+  [#3249](https://github.com/gem5/gem5/pull/3249),
+  [#3232](https://github.com/gem5/gem5/pull/3232)).
+
+* **Broader coverage and failure artifacts.**
+  TestLib can collect gcovr coverage, CI uploads broader Codecov data,
+  timed-out tests preserve artifacts, and Daily/Weekly jobs no longer mask
+  failures with `continue-on-error`
+  ([#2860](https://github.com/gem5/gem5/pull/2860),
+  [#3007](https://github.com/gem5/gem5/pull/3007),
+  [#2877](https://github.com/gem5/gem5/pull/2877),
+  [#2940](https://github.com/gem5/gem5/pull/2940)).
+
 # Version 25.0.0.1
 
 **[HOTFIX]** This is a hotfix release incorporating the following critical fixes highlighted below. This release addresses urgent issues that required immediate attention outside the regular release schedule.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,6 +3,7 @@
 gem5 Version 26.0 is the first major release of 2026. This release consists
 of 774 commits contributed through 379 merged GitHub pull requests from 84
 unique contributors.
+<!-- Refresh these statistics after #3281, #3287, and #3401 merge. -->
 
 ## Major Highlights
 
@@ -48,13 +49,15 @@ unique contributors.
   MI300X, including the ACPI support required by newer kernels. Vega/CDNA3
   instruction coverage now includes operations used by Triton, additional
   matrix instructions, and 16-bit data types. Optional BLIT-kernel emulation
-  can substantially reduce simulation time for copy-heavy workloads
+  can substantially reduce simulation time for copy-heavy workloads. Public
+  examples and regression coverage now exercise MI200 and MI355X GPUFS
   ([#3234](https://github.com/gem5/gem5/pull/3234),
   [#3458](https://github.com/gem5/gem5/pull/3458),
   [#3184](https://github.com/gem5/gem5/pull/3184),
   [#3198](https://github.com/gem5/gem5/pull/3198),
   [#3213](https://github.com/gem5/gem5/pull/3213),
-  [#3149](https://github.com/gem5/gem5/pull/3149)).
+  [#3149](https://github.com/gem5/gem5/pull/3149),
+  [#3401](https://github.com/gem5/gem5/pull/3401)).
 
 * **Unified simulation-exit handling.**
   Hypercall identifiers and payload dispatch are now the primary exit model
@@ -80,6 +83,12 @@ unique contributors.
   gem5's build selects the C++20 language standard. Out-of-tree C++ code and
   custom toolchains must therefore be C++20-compatible
   ([#3028](https://github.com/gem5/gem5/pull/3028)).
+
+* **Python 3.10 or newer is required.**
+  Python 3.6 through 3.9 are no longer supported. The embedded interpreter
+  check, active Python sources, type annotations, and formatting hooks now
+  target Python 3.10 and newer
+  ([#3281](https://github.com/gem5/gem5/pull/3281)).
 
 * **RISC-V ISA selection is profile-based.**
   The previous independent `riscv_type`, `enable_rvv`, `enable_Zicbom_fs`,
@@ -116,10 +125,13 @@ unique contributors.
   factories for non-power-of-two channel counts and holes
   ([#2861](https://github.com/gem5/gem5/pull/2861)).
 
-* **The minimum Protocol Buffers compiler is version 3.0.0.**
-  Builds using an older `protoc` now fail during configuration with a clear
-  diagnostic
-  ([#3101](https://github.com/gem5/gem5/pull/3101)).
+* **Dependency floors follow supported Ubuntu LTS releases.**
+  Required dependencies now include SCons 4.0+, zlib 1.2+, and GNU m4 1.4+.
+  Optional trace, framebuffer, disassembly, and statistics features require
+  `protoc` 3.12+, libpng 1.6+, Capstone 4+, and HDF5 1.10+, respectively.
+  Missing or older optional libraries disable the associated feature rather
+  than failing the entire build
+  ([#3287](https://github.com/gem5/gem5/pull/3287)).
 
 * **Older GPU disk images are being retired.**
   The standard-library GPU setup now provides the ACPI tables and direct
@@ -152,6 +164,13 @@ unique contributors.
   `libzstd` dependency. Existing uncompressed and gzip-compressed image
   support is unchanged
   ([#3400](https://github.com/gem5/gem5/pull/3400)).
+
+* **Sparse disk-image resources by default.**
+  Disk-image downloads, copies, and gzip decompression preserve a sparse
+  representation to avoid allocating large zero-filled regions.
+  Callers can request dense output with `sparse=False`, and
+  `util/obtain-resource.py` provides `--no-sparse`
+  ([#3401](https://github.com/gem5/gem5/pull/3401)).
 
 * **More readable terminal diagnostics.**
   Panic, fatal, warning, information, and TestLib messages use color when
@@ -345,6 +364,15 @@ unique contributors.
   ([#3149](https://github.com/gem5/gem5/pull/3149),
   [#3107](https://github.com/gem5/gem5/pull/3107)).
 
+* **MI200 and MI355X GPUFS examples and regression coverage.**
+  Public standard-library examples share the board, resource, and checkpoint
+  configuration used by the tests. Daily coverage cold-boots MI200-family
+  (`gfx90a`) and MI355X (`gfx950`) systems, while pull-request CI restores a
+  warmed MI355X checkpoint and verifies a second real GPU kernel. The
+  deprecated `gcn-gpu` image and active tests that depended on it have been
+  removed
+  ([#3401](https://github.com/gem5/gem5/pull/3401)).
+
 ## Memory System and AMBA CHI
 
 * **Bundled AMBA TLM 2.0 integration.**
@@ -408,21 +436,33 @@ unique contributors.
 * **Draining and checkpoint correctness.**
   Ruby controllers can account for outstanding transient transactions while
   draining, checkpoint restore can skip unused memory chunks, and memory
-  backdoors can be disabled or updated when address ranges change
+  backdoors can be disabled or updated when address ranges change. Objects
+  created during an active drain now enter the next pass safely, and HBM
+  controllers account for both pseudo channels before checkpoint completion
   ([#3358](https://github.com/gem5/gem5/pull/3358),
   [#2794](https://github.com/gem5/gem5/pull/2794),
   [#3333](https://github.com/gem5/gem5/pull/3333),
-  [#3334](https://github.com/gem5/gem5/pull/3334)).
+  [#3334](https://github.com/gem5/gem5/pull/3334),
+  [#3401](https://github.com/gem5/gem5/pull/3401)).
 
 ## Build, Tooling, and Testing
 
-* **New compiler and host support.**
-  gem5 builds as C++20, officially supports GCC 15.2, and can build and run
+* **Updated compiler and host support.**
+  gem5 builds as C++20 and officially supports GCC major versions 11 through
+  16 and Clang major versions 14 through 22. It can also build and run
   natively on LoongArch64 hosts. LoongArch support is for the host platform;
   it does not add a simulated LoongArch ISA
   ([#3028](https://github.com/gem5/gem5/pull/3028),
   [#3125](https://github.com/gem5/gem5/pull/3125),
+  [#3287](https://github.com/gem5/gem5/pull/3287),
   [#3309](https://github.com/gem5/gem5/pull/3309)).
+
+* **Current Ubuntu LTS dependency images.**
+  The all-dependencies images cover Ubuntu 22.04, 24.04, and 26.04 and prefer
+  supported distribution packages. Ubuntu 26.04 supplies the base for the
+  newest GCC and Clang images; the Ubuntu 22.04 image builds CMake 3.25 for
+  the current DRAMSys integration
+  ([#3287](https://github.com/gem5/gem5/pull/3287)).
 
 * **Debugging-oriented build options.**
   `--with-tsan` enables ThreadSanitizer, `--gdb-index` can reduce GDB symbol
@@ -444,11 +484,13 @@ unique contributors.
 * **Broader coverage and failure artifacts.**
   TestLib can collect gcovr coverage, CI uploads broader Codecov data,
   timed-out tests preserve artifacts, and Daily/Weekly jobs no longer mask
-  failures with `continue-on-error`
+  failures with `continue-on-error`. GPUFS suites now run through the standard
+  `ALL` CI and Daily matrices with the standard Ubuntu dependencies image
   ([#2860](https://github.com/gem5/gem5/pull/2860),
   [#3007](https://github.com/gem5/gem5/pull/3007),
   [#2877](https://github.com/gem5/gem5/pull/2877),
-  [#2940](https://github.com/gem5/gem5/pull/2940)).
+  [#2940](https://github.com/gem5/gem5/pull/2940),
+  [#3401](https://github.com/gem5/gem5/pull/3401)).
 
 # Version 25.0.0.1
 


### PR DESCRIPTION
## Overview

This PR updates RELEASE-NOTES.md for the gem5 v26.0.0.0 major release. The new v26.0 section:

- summarizes the 774-commit release range represented by 379 merged upstream pull requests from 84 contributors;
- explains the major RISC-V, Arm, CPU, GPU, memory-system, statistics, and tooling changes;
- calls out compatibility and migration requirements for C++20, Python 3.10, RISC-V ISA profiles, simulation-exit APIs, SimObject lifecycle methods, address ranges, dependency floors, compiler ranges, and GPU disk images; and
- links 122 relevant pull requests so users can follow each notable change to its implementation and discussion.

The inventory covers `7f06b2fdbe` (the v25.1 staging parent) through the current `release-staging-v26-0` head, `7db0dd50b4`. Of the 122 linked PRs, 119 are represented in that release range; #3281, #3287, and #3401 are planned v26.0.0.0 additions. The aggregate release statistics will be refreshed after those PRs merge into staging.