### PR TITLE
cpu-o3: fix doSquash assert on commit-released non-spec inst

### DIFF
--- a/src/cpu/o3/inst_queue.cc
+++ b/src/cpu/o3/inst_queue.cc
@@ -1495,11 +1495,14 @@ InstructionQueue::doSquash(ThreadID tid)
                 // nonSpecInsts already when they are ready, and so we
                 // cannot always expect to find them
                 if (ns_inst_it == nonSpecInsts.end()) {
-                    // loads that became ready but stalled on a
-                    // blocked cache are alreayd removed from
-                    // nonSpecInsts, and have not faulted
+                    // Non-speculative instructions may already have been
+                    // removed from nonSpecInsts after commit releases
+                    // them for execution -- a barrier still at the ROB
+                    // head is the common case. Memory references may
+                    // also have been removed after becoming ready.
                     assert(squashed_inst->getFault() != NoFault ||
-                           squashed_inst->isMemRef());
+                           squashed_inst->isMemRef() ||
+                           squashed_inst->isAtCommit());
                 } else {
 
                     (*ns_inst_it).second = NULL;


### PR DESCRIPTION
### Summary

`InstructionQueue::doSquash()` asserts that an instruction missing from `nonSpecInsts` either faulted or is a memory reference (`src/cpu/o3/inst_queue.cc:1501` on `develop`):

```cpp
assert(squashed_inst->getFault() != NoFault ||
squashed_inst->isMemRef());
```

That enumeration is incomplete. There is a third legitimate way to be absent from the map -- commit already released the instruction to execute -- and the assert fires on a valid pipeline state.

### Root cause

`scheduleNonSpec()` removes the instruction it releases from `nonSpecInsts`, regardless of whether it is a memory reference (`inst_queue.cc:1135`). The sequence is:

1. The instruction reaches the ROB head and commit sets `nonSpecSeqNum`.
2. IEW calls `scheduleNonSpec()`, which calls `setAtCommit()` (`inst_queue.cc:1123`) and then erases the map entry.
3. The instruction has been released by commit and is eligible to issue, but remains at the ROB head until execution completes.

`IEW::tick()` calls `scheduleReadyInsts()` (`iew.cc:1518`) **before** it processes `nonSpecSeqNum` (`iew.cc:1557`), so an instruction released this cycle cannot issue until the next one. The exposure is therefore at least a cycle wide: `AtCommit` is set, themap entry is gone, and the instruction has not yet executed.

If commit squashes in that window, `squashAll()` squashes from `rob->readHeadInst(tid)->seqNum - 1` (`src/cpu/o3/commit.cc:510`) -- deliberately including the head itself. A non-speculative, non-memref instruction is therefore squashed with no fault set, andneither existing assert term holds.

`scheduleNonSpec()` is the only release path that erases. Commit's other path, for strictly ordered loads, calls `setAtCommit()` directly (`iew.cc:1563`) and goes through `replayMemInst()`, which does not touch `nonSpecInsts` -- such a load is still found by`doSquash()` and takes the `else` branch, so it never reaches this assert. `nonSpecInsts.erase` has only two call sites: `scheduleNonSpec()` and `doSquash()` itself.

The comment above the assert only anticipated the memref case ("loads that became ready but stalled on a blocked cache"), which is why the third case was never enumerated.

### Reproduction

Observed on an 8-core Arm full-system run as a `DMB ISH` inside the Linux futex path:

```
src/cpu/o3/inst_queue.cc: InstructionQueue::doSquash(ThreadID):
Assertion `squashed_inst->getFault() != NoFault || squashed_inst->isMemRef()' failed.

PC          : 0xffff8000800facbc  = futex_wait_setup+0x1fc  (Linux 6.18.19)
encoding    : d5033bbf  =  dmb ish
squash path : squashFromTC, same PC, one cycle earlier
abort tick  : 582065644041   (identical across two independent runs)
```

A barrier is inserted via `insertBarrier()` -> `insertNonSpec()`. It is not a load or a store, so `isMemRef()` is false, and it does not fault -- so it reaches this path failing both terms.

I do not have a minimal reproducer -- this is a long multi-core FS run. The defect is provable from the source above independently of the workload, and the PC, encoding, kernel function, squash path and abort tick are given so the state is unambiguous.

### Fix

Add `isAtCommit()` as a third accepted term:

```cpp
assert(squashed_inst->getFault() != NoFault ||
squashed_inst->isMemRef() ||
squashed_inst->isAtCommit());
```

`isAtCommit()` is exactly the flag `scheduleNonSpec()` sets immediately before erasing the entry, so it identifies precisely the missing case and nothing else.

The change only **widens** what the assert accepts, so there is no behaviour change on any path where it already passed. The assert still catches a genuinely absent instruction meeting none of the three conditions.

### Notes

- Validated by re-running the exact configuration that previously aborted: it now completes cleanly.
- Builds against `develop` `9296e581` (`scons build/RISCV/gem5.opt`, exit 0, no new warnings); `clang-format` clean with the CI toolchain (Ubuntu 24.04, `clang-format 18.1.3`).
