### PR TITLE
scons: Accept C23 attributes with older Clang

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -464,8 +464,10 @@ main['LTO_LINKFLAGS'] = []
 # compiler we're using.
 main['TCMALLOC_CCFLAGS'] = []
 
+CC_version = readCommand([main['CC'], '--version'], exception=False)
 CXX_version = readCommand([main['CXX'], '--version'], exception=False)
 
+main['CC_CLANG'] = CC_version and CC_version.find('clang') >= 0
 main['GCC'] = CXX_version and CXX_version.find('g++') >= 0 and \
               CXX_version.find('clang') < 0
 main['CLANG'] = CXX_version and CXX_version.find('clang') >= 0
@@ -695,6 +697,12 @@ for variant_path in variant_paths:
               "above you will need to ease fix SConstruct and ",
               "src/SConscript to support that compiler.")))
 
+    # Clang versions before 17 require this extension to accept C23-style
+    # attributes such as [[fallthrough]] in older C language modes.
+    if env['CC_CLANG'] and \
+            compareVersions(env['CCVERSION'], "17") < 0:
+        env.Append(CFLAGS=['-fdouble-square-bracket-attributes'])
+
     if env['GCC']:
         gcc_min_version = "11"
         gcc_max_version = "15.2"
@@ -745,11 +753,6 @@ for variant_path in variant_paths:
         clang_min_version = "14"
         clang_max_version = "19"
         clang_version = env['CXXVERSION']
-
-        # Clang versions before 17 require this extension to accept C23-style
-        # attributes such as [[fallthrough]] in older C language modes.
-        if compareVersions(clang_version, "17") < 0:
-            env.Append(CFLAGS=['-fdouble-square-bracket-attributes'])
 
         if compareVersions(clang_version, clang_min_version) < 0 or \
               compareVersions(clang_version, clang_max_version) > 0:

--- a/SConstruct
+++ b/SConstruct
@@ -745,6 +745,12 @@ for variant_path in variant_paths:
         clang_min_version = "14"
         clang_max_version = "19"
         clang_version = env['CXXVERSION']
+
+        # Clang versions before 17 require this extension to accept C23-style
+        # attributes such as [[fallthrough]] in older C language modes.
+        if compareVersions(clang_version, "17") < 0:
+            env.Append(CFLAGS=['-fdouble-square-bracket-attributes'])
+
         if compareVersions(clang_version, clang_min_version) < 0 or \
               compareVersions(clang_version, clang_max_version) > 0:
             warning(


### PR DESCRIPTION
## Summary

- Enable Clang's `-fdouble-square-bracket-attributes` option for C
  compilation with Clang versions older than 17.
- Keep gem5's C language mode unchanged.
- Avoid modifying the vendored sources under `ext/softfloat`.

## Why this is necessary

[Compiler Tests run #220](https://github.com/gem5/gem5/actions/runs/33571081326)
failed all six Clang 14 through 16 builds:

- Clang 14: `gem5.opt` and `gem5.fast`
- Clang 15: `gem5.opt` and `gem5.fast`
- Clang 16: `gem5.opt` and `gem5.fast`

Each job first fails while compiling `ext/softfloat/f16_roundToInt.c:66`:

```
error: expected expression
        [[fallthrough]];
        ^
```

There are 17 instances of this annotation across six SoftFloat C source
files. `[[fallthrough]]` is standard C syntax starting with C23, while these
compiler versions parse the files in the default C17 mode. Clang 17 and newer
accept the syntax and passed the same compiler workflow.

The preceding
[Compiler Tests run #219](https://github.com/gem5/gem5/actions/runs/32903180260)
did not reveal the problem because the older Clang container images did not
set `CC` and `CXX`. SCons therefore selected the default GCC toolchain inside
those containers, despite the Clang job labels. The refreshed images built
from #3287 set `CC=clang` and `CXX=clang++`, causing the jobs to exercise the
intended compilers and expose the existing incompatibility.

Reverting that image correction would only hide the problem. Modifying the
SoftFloat files would also create additional divergence from the imported
third-party source. Updating from SoftFloat 3d to 3e is not a narrow solution:
3e retains unannotated intentional fallthroughs and also introduces substantive
floating-point behavior changes that require separate validation.

## Approach

Clang 14, 15, and 16 provide
[`-fdouble-square-bracket-attributes`](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangCommandLineReference.html#cmdoption-clang-fdouble-square-bracket-attributes),
which enables `[[...]]` attributes in every C and C++ language mode. Applying
it through `CFLAGS` allows the existing C sources to compile without changing
the C standard or affecting C++ compilation. The version check restricts the
new option to Clang versions older than 17; behavior for Clang 17 and newer is
unchanged.

## Testing

- `python3 -m py_compile SConstruct`
- `scons -Q --help`
- `pre-commit run --files SConstruct`
- `git diff --check`
- Built `build/ALL/ext/softfloat/libsoftfloat.a` with SCons in each refreshed
  compiler container:
  - Clang 14, image digest `sha256:e508cfb30d8ec5f12bbebe9941048d38630aa0634d21c038804b30ad76721278`
  - Clang 15, image digest `sha256:ed93d8223b90e507fa2b9a20eaf0e36045daf87b26f86e02c4208340cc5c08fe`
  - Clang 16, image digest `sha256:b2cc03f94330eba2fff687c5bc1b4242f263fc5e1a42b134c8c5e4db2c8a9896`

The targeted SCons builds compile the complete SoftFloat library, including
all six source files containing the 17 annotations. Full `gem5.opt` and
`gem5.fast` coverage remains for a manual compiler workflow run against this
PR branch.
