### PR TITLE
system-arm: set SCR_EL3 enable bits for Armv8.9 registers

### DIFF
--- a/system/arm/bootloader/arm64/boot.S
+++ b/system/arm/bootloader/arm64/boot.S
@@ -61,7 +61,10 @@ _start:
         orr	x0, x0, #(1 << 10)		// 64-bit EL2
         orr	x0, x0, #(1 << 16)		// Disable FEAT_PAuth traps (APK)
         orr	x0, x0, #(1 << 17)		// Disable FEAT_PAuth traps (API)
-        orr     x0, x0, #(1 << 38)              // Enable HXEn
+        orr     x0, x0, #(1 << 38)              // Enable HXEn (FEAT_HCX)
+        orr     x0, x0, #(1 << 43)              // Enable TCR2En (FEAT_TCR2)
+        orr     x0, x0, #(1 << 44)              // Enable SCTLR2En (FEAT_SCTLR2)
+        orr     x0, x0, #(1 << 45)              // Enable PIEn (FEAT_S1PIE)
         msr	scr_el3, x0
 
         mov	x0, #(1 << 8)			// Disable SVE trap to EL3


### PR DESCRIPTION
### Summary

The AArch64 bootloader sets `SCR_EL3.HXEn` (#2130) but not the enable bits for
the Armv8.9 system registers. gem5 advertises `FEAT_TCR2`, `FEAT_SCTLR2` and
`FEAT_S1PIE` in `ID_AA64MMFR3_EL1` whenever the release has them
(`src/arch/arm/regs/misc.cc:5836`), so a guest discovers them and writes
`TCR2_EL1` and `PIR_EL1`/`PIRE0_EL1` during early EL2 setup. Each write traps
to EL3 unless the matching bit is set, and this bootloader installs no EL3
vector table — so it vectors into zeroed memory and loops on undefined
instructions, before any console exists. The symptom is a 0-byte terminal.

Same failure mode #2130 fixed for `HCRX_EL2`, on the registers it didn't cover:

```
11302020: Secure Monitor Trap: PC:0x80d5b1e0 esr_el3: 0x62350404 inst: 0xd51c1240
11302353: Undefined Instruction:  PC:0x400 esr_el3: 0x2000000 inst: 0
11302686: Undefined Instruction:  PC:0x200 esr_el3: 0x2000000 inst: 0
...  repeating once per cycle, indefinitely
```

This adds `TCR2En` (43), `SCTLR2En` (44) and `PIEn` (45).

### Scope

`ArmDefaultRelease` does not include these three features, so a default
`ArmBoard` is unaffected. It bites `Armv89` and later — `Armv90`, `Armv92`,
`Armv93`, `Armv94` — and `ArmAllRelease` (`src/arch/arm/ArmSystem.py:342`).

### Why not FGTEn

gem5's `AA64MMFR0` bitunion has no `fgt` field, so `FEAT_FGT` is undiscoverable
and a guest never programs `HFGRTR_EL2`. The trap machinery is implemented and
gated only on `FGTEn`, so setting it arms fine-grained traps against an
all-zero `HFGRTR_EL2` — whose `nPirEL1`/`nPire0EL1`/`nAccdataEL1` are
inverted-sense, making `PIRE0_EL1` trap to EL2 in a loop. Tested: five bits
hangs, four bits boots. Glad to add it if `FEAT_FGT` is made discoverable.

### Safety

These bits only *remove* a trap — `PIEn` does not enable permission
indirection, `TCR2_EL1.PIE` does. `SCR_EL3` is EL3-only so a guest cannot
observe it. Every reader of `tcr2En`/`sctlr2En`/`piEn` is a fault handler
guarded by `HaveExt()`, and gem5 applies no res0 mask to `SCR_EL3`, so on a
release without the features the bits are written and never consulted.

### Testing

`VExpress_GEM5_V2` + GICv3, `Armv92`, single atomic core:

| Kernel | Before | After |
|---|---|---|
| 6.18.19 | 0-byte console, EL3 trap loop | boots, 35,511 bytes, 0 traps |
| 5.15.68 | 28,633 bytes, completes | byte-identical, completes |
| 5.4.65 | 26,133 bytes, completes | byte-identical, completes |

`SCTLR2_EL1` is not written by Linux's host boot path (only by KVM context
switch), so bit 44 is included for completeness rather than from an observed
trap — say the word and I will drop it.
