### PR TITLE
misc: add remaining labels to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -79,6 +79,10 @@ dev:
     - changed-files:
           - all-globs-to-any-file: [src/dev/**, '!src/dev/arm/**', '!src/dev/hsa/**', '!src/dev/virtio/**']
 
+dev-amdgpu:
+    - changed-files:
+          - all-globs-to-any-file: src/dev/amdgpu/**
+
 dev-arm:
     - changed-files:
           - any-glob-to-any-file: src/dev/arm/**
@@ -96,6 +100,10 @@ doc:
           - any-glob-to-any-file: [CODE-OF-CONDUCT.md, CONTRIBUTING.md, COPYING, KCONFIG.md, LICENSE, MAINTAINERS.yaml, RELEASE-NOTES.md, TESTING.md]
           - all-globs-to-any-file: ['**/README.md', '!tests/gem5/**/README.md'] # Don't apply the `doc` label for changes to README files for tests
 
+mem-dram:
+    - changed-files:
+          - any-glob-to-any-file: [src/mem/dram**, src/mem/DRAM**, src/python/gem5/components/memory/dram**, src/python/gem5/components/memory/dram_interfaces/**]
+
 ext:
     - changed-files:
           - all-globs-to-any-file: [ext/**, '!ext/testlib/**']
@@ -108,9 +116,17 @@ fastmodel:
     - changed-files:
           - any-glob-to-any-file: src/arch/arm/fastmodel/**
 
+gdb:
+    - changed-files:
+          - any-glob-to-any-file: [ext/gdbremote/**, '**/remote_gdb.**']
+
 github:
     - changed-files:
           - any-glob-to-any-file: .github/**
+
+gpu:
+    - changed-files:
+          - any-glob-to-any-file: [configs/example/gpufs/**, src/python/gem5/components/devices/gpus/**, src/python/gem5/prebuilt/viper/**]
 
 gpu-compute:
     - changed-files:
@@ -144,6 +160,10 @@ resources:
     - changed-files:
           - any-glob-to-any-file: src/python/gem5/resources/**
 
+scons:
+    - changed-files:
+          - any-glob-to-any-file: SConstruct
+
 sim:
     - changed-files:
           - all-globs-to-any-file: [src/sim/**, '!**/se_**.**', '!**/syscall**.**', '!**/se_binary_workload.py', '!src/sim/process.**', '!src/sim/fd_**.**']
@@ -152,9 +172,19 @@ sim-se:
     - changed-files:
           - any-glob-to-any-file: ['**/se_**.**', '**/syscall**.**', '**/se_binary_workload.py', src/sim/process.**, src/sim/fd_**.**]
 
+# The `stats` label should also be applied manually where relevant, as there
+# can be stats related changes in files that don't match these globs
+stats:
+    - changed-files:
+          - all-globs-to-any-file: ['**/stats/**', '!src/base/stats/**']
+
 stdlib:
     - changed-files:
           - all-globs-to-any-file: [src/python/gem5/**, '!src/python/gem5/resources/**']
+
+system-arm:
+    - changed-files:
+          - all-globs-to-any-file: system/arm/**
 
 systemc:
     - changed-files:


### PR DESCRIPTION
This commit adds several labels that are present in the GitHub labels, but weren't in `labeler.yml`, which labels PRs. With this commit, `labeler.yml` includes all active labels that should be applied to PRs, i.e. labels excluding archived labels and labels that are only used for issues.