### PR TITLE
tests: Restore macOS clean-build cache recovery

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -60,17 +60,13 @@ jobs:
               working-directory: ${{ github.workspace }}
               run: |
                   CMD="scons build/ALL/gem5.${{ matrix.type }} -j $(sysctl -n hw.ncpu)"
-                  ${CMD}
-                  status=$?
-                  if [ $status -ne 0 ]; then
+                  if ! ${CMD}; then
                       echo "Failed to build on top of cached build." 1>&2
                       echo "This may be due to env changes since the cache build." 1>&2
                       echo "Clearing cache and attempting another build..." 1>&2
                       rm -rf build
                       ${CMD}
-                      status=$?
                   fi
-                  exit $status
               timeout-minutes: 120
 
     build-all-gem5:


### PR DESCRIPTION
## Problem

Daily Tests run https://github.com/gem5/gem5/actions/runs/33993002878 failed both macOS compilation jobs after Homebrew upgraded Protobuf from 36.0 to 36.1. Each job restored a cache containing headers generated by 36.0, then failed against the 36.1 runtime.

The workflow already intends to delete the cached build and retry cleanly, but GitHub Actions runs the step with `bash -e`. The first failed `scons` command therefore exits the step before the recovery block.

## Change

Run the cached build as the `if` condition. Bash permits a conditional command to fail under `-e`, allowing the existing cleanup and retry to run. The clean retry remains an ordinary command, so another failure still fails the job.

## Validation

- `git diff --check`
- `pre-commit run check-yaml --files .github/workflows/daily-tests.yaml`
- `pre-commit run --files .github/workflows/daily-tests.yaml`
- Direct Bash checks for fallback execution and retry-failure propagation
- Independent standards and specification reviews