### PR TITLE
arch-riscv: Add support for amocas.w and amocas.d

### DIFF
--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2108,8 +2108,12 @@ decode QUADRANT default Unknown::unknown() {
                 }}, {{
                     TypedAtomicOpFunctor<uint32_t> *amo_op =
                           new AtomicGeneric3Op<uint32_t>(Rd_sd, Rs2_uw,
-                                  [](uint32_t* b, uint32_t a,
-                                  uint32_t c){ if (a == *b){ *b = c; } });
+                                  [](uint32_t* b, uint32_t a, uint32_t c){
+                                      uint32_t mem_data = letoh(*b);
+                                      if (a == mem_data){
+                                          *b = htole(c);
+                                      }
+                                  });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x8: AtomicMemOp::amoor_w({{
                     Rd_sd = Mem_sw;
@@ -2222,8 +2226,12 @@ decode QUADRANT default Unknown::unknown() {
                     }}, {{
                         TypedAtomicOpFunctor<uint64_t> *amo_op =
                             new AtomicGeneric3Op<uint64_t>(Rd_ud, Rs2_ud,
-                                    [](uint64_t* b, uint64_t a,
-                                    uint64_t c){ if (a == *b){ *b = c; } });
+                                    [](uint64_t* b, uint64_t a, uint64_t c){
+                                         uint64_t mem_data = letoh(*b);
+                                         if (a == mem_data){
+                                             *b = htole(c);
+                                         }
+                                    });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x8: AtomicMemOp::amoor_d({{
                         Rd_sd = Mem_sd;

--- a/src/arch/riscv/isa/decoder.isa
+++ b/src/arch/riscv/isa/decoder.isa
@@ -2066,14 +2066,6 @@ decode QUADRANT default Unknown::unknown() {
 
         0x0b: decode FUNCT3 {
             0x2: decode AMOFUNCT {
-                0x2: LoadReserved::lr_w({{
-                    Rd_sd = Mem_sw;
-                }}, mem_flags=[LLSC], xlate_flags=['LR']);
-                0x3: StoreCond::sc_w({{
-                    Mem_uw = Rs2_uw;
-                }}, {{
-                    Rd = rvSext(result);
-                }}, inst_flags=IsStoreConditional, mem_flags=LLSC);
                 0x0: AtomicMemOp::amoadd_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
@@ -2092,6 +2084,14 @@ decode QUADRANT default Unknown::unknown() {
                           new AtomicGenericOp<uint32_t>(Rs2_uw,
                                   [](uint32_t* b, uint32_t a){ *b = a; });
                 }}, mem_flags=ATOMIC_RETURN_OP);
+                0x2: LoadReserved::lr_w({{
+                    Rd_sd = Mem_sw;
+                }}, mem_flags=[LLSC], xlate_flags=['LR']);
+                0x3: StoreCond::sc_w({{
+                    Mem_uw = Rs2_uw;
+                }}, {{
+                    Rd = rvSext(result);
+                }}, inst_flags=IsStoreConditional, mem_flags=LLSC);
                 0x4: AtomicMemOp::amoxor_w({{
                     Rd_sd = Mem_sw;
                 }}, {{
@@ -2102,6 +2102,14 @@ decode QUADRANT default Unknown::unknown() {
                                       uint32_t new_data = mem_data ^ a;
                                       *b = htole(new_data);
                                   });
+                }}, mem_flags=ATOMIC_RETURN_OP);
+                0x5: AtomicMemOp::amocas_w({{
+                    Rd_sd = Mem_sw;
+                }}, {{
+                    TypedAtomicOpFunctor<uint32_t> *amo_op =
+                          new AtomicGeneric3Op<uint32_t>(Rd_sd, Rs2_uw,
+                                  [](uint32_t* b, uint32_t a,
+                                  uint32_t c){ if (a == *b){ *b = c; } });
                 }}, mem_flags=ATOMIC_RETURN_OP);
                 0x8: AtomicMemOp::amoor_w({{
                     Rd_sd = Mem_sw;
@@ -2172,14 +2180,6 @@ decode QUADRANT default Unknown::unknown() {
             }
             0x3: decode RVTYPE {
                 0x1: decode AMOFUNCT {
-                    0x2: LoadReserved::lr_d({{
-                        Rd_sd = Mem_sd;
-                    }}, mem_flags=[LLSC], xlate_flags=['LR']);
-                    0x3: StoreCond::sc_d({{
-                        Mem = Rs2;
-                    }}, {{
-                        Rd = result;
-                    }}, mem_flags=LLSC, inst_flags=IsStoreConditional);
                     0x0: AtomicMemOp::amoadd_d({{
                         Rd_sd = Mem_sd;
                     }}, {{
@@ -2198,6 +2198,14 @@ decode QUADRANT default Unknown::unknown() {
                               new AtomicGenericOp<uint64_t>(Rs2_ud,
                                       [](uint64_t* b, uint64_t a){ *b = a; });
                     }}, mem_flags=ATOMIC_RETURN_OP);
+                    0x2: LoadReserved::lr_d({{
+                        Rd_sd = Mem_sd;
+                    }}, mem_flags=[LLSC], xlate_flags=['LR']);
+                    0x3: StoreCond::sc_d({{
+                        Mem = Rs2;
+                    }}, {{
+                        Rd = result;
+                    }}, mem_flags=LLSC, inst_flags=IsStoreConditional);
                     0x4: AtomicMemOp::amoxor_d({{
                         Rd_sd = Mem_sd;
                     }}, {{
@@ -2208,6 +2216,14 @@ decode QUADRANT default Unknown::unknown() {
                                          uint64_t new_data = mem_data ^ a;
                                          *b = htole(new_data);
                                      });
+                    }}, mem_flags=ATOMIC_RETURN_OP);
+                    0x5: AtomicMemOp::amocas_d({{
+                        Rd_ud = Mem_ud;
+                    }}, {{
+                        TypedAtomicOpFunctor<uint64_t> *amo_op =
+                            new AtomicGeneric3Op<uint64_t>(Rd_ud, Rs2_ud,
+                                    [](uint64_t* b, uint64_t a,
+                                    uint64_t c){ if (a == *b){ *b = c; } });
                     }}, mem_flags=ATOMIC_RETURN_OP);
                     0x8: AtomicMemOp::amoor_d({{
                         Rd_sd = Mem_sd;

--- a/tests/gem5/riscv-unittests/asmtest/tests.py
+++ b/tests/gem5/riscv-unittests/asmtest/tests.py
@@ -51,6 +51,8 @@ rv64_binaries = (
     "rv64ua-ps-amoadd_w",
     "rv64ua-ps-amoand_d",
     "rv64ua-ps-amoand_w",
+    "rv64ua-ps-amocas_d",
+    "rv64ua-ps-amocas_w",
     "rv64ua-ps-amomax_d",
     "rv64ua-ps-amomax_w",
     "rv64ua-ps-amomaxu_d",
@@ -223,6 +225,7 @@ rv64_binaries = (
 rv32_binaries = (
     "rv32ua-ps-amoadd_w",
     "rv32ua-ps-amoand_w",
+    "rv32ua-ps-amocas_w",
     "rv32ua-ps-amomaxu_w",
     "rv32ua-ps-amomax_w",
     "rv32ua-ps-amominu_w",


### PR DESCRIPTION
Adds partial support Zacas extension. Introduces amocas.w (for RV32 and RV64) and amocas.d (for RV64) instructions. The remaining instructions of Zacas not implemented are amocas.d (for RV32) and amocas.q (for RV64 only). My intention is to complete them in a future PR.

I've reordered the LR and SC to follow the decoding of the Z extension.

Both instructions have been tested with the RISC-V tests [PR 492](https://github.com/riscv-software-src/riscv-tests/pull/492). Which I could add to the resources repo.