### PR TITLE
util: Improve Vagrant runner lifecycle and VM images

### DIFF
--- a/util/github-runners-vagrant/README.md
+++ b/util/github-runners-vagrant/README.md
@@ -1,100 +1,223 @@
-# Setting up a Github Actions Runner with Vagrant
+# Vagrant GitHub Actions runners
 
-This directory provides a way to setup Github Actions runners using Vagrant to host them in Virtual machines.
+Each VM runs one ephemeral GitHub registration at a time. The VM persists
+between jobs. `action-run.sh` is supervised by the guest's
+`gem5-runner.service`; logs go to the guest journal. This does not make the VM
+disposable or establish a security boundary between jobs.
 
-This tutorial has been written with the assumption of running on a machine with Ubuntu 22.04.
-Setting up a runner on a different OS may require some changes.
+All `sudo` in the provisioning scripts is **inside the guest**. On Loupe, run
+host commands as `vagrant` using the existing `sudo -u vagrant` access. These
+tools use the installed Vagrant, libvirt, Python, qemu-img and libguestfs tools;
+they do not require new host packages, host sysctls, or host administrator access.
 
-Before anything else, copy this directory, "util/github-runners-vagrant", to the root of the location on your host system you wish to setup the VMs from.
-The CWD is assumed to be this directory.
+## Configuration and operation
 
-## Install Dependencies
+Set `NUM_RUNNERS`, `PERSONAL_ACCESS_TOKEN`, `GITHUB_ORG`, and `HOSTNAME` in
+`Vagrantfile`. Keep the real configuration private. On Loupe the authoritative
+copy is `/runners/Vagrantfile`. The credential design is unchanged in scope:
+registration uses the existing PAT. The guest service reads it from the
+root-only `/etc/gem5-runner.env`; the controller removes it from the environment
+before starting the runner. Never publish this file or package it in a box.
+
+If `gem5-resource-cache` exists beside `Vagrantfile`, it is shared at
+`/gem5-resource-cache` using the existing 9p configuration. Installation records
+the actual mount tag in a guest systemd mount unit, loads its virtio transport
+early, and orders the mount before the runner,
+so ordinary guest reboots do not depend on Vagrant remounting the cache over SSH.
+
+Optional `runner-settings.json` overrides individual machines. For example:
+
+```json
+{
+  "loupe-1": {
+    "box": "gem5/runner-ubuntu2204",
+    "box_version": "2026.9.8.1",
+    "prebuilt": true,
+    "storage_pool": "loupe-ssd",
+    "disk_cache": "none",
+    "cpus": 4,
+    "memory": 32768
+  }
+}
+```
+
+A prebuilt box skips package provisioning; scripts and service configuration are
+still installed. Changes to a VM's box require a replacement VM. Changing a
+JSON field does not migrate an existing disk or update its guest kernel.
+
+Run Vagrant from the deployment directory with the correct `VAGRANT_HOME`.
+Provisioning refuses to overwrite an active controller. For a new VM:
 
 ```sh
-sudo apt install vagrant
-sudo apt-get build-dep vagrant ruby-libvirt
-sudo apt-get install qemu libvirt-daemon-system libvirt-clients ebtables dnsmasq-base libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
-
-# Note: The vagrant-libvirt APT package does not work as intended. We must
-# remove it from the system otherwise errors will occur (we will install it
-# later using the vagrant plugin command).
-sudo apt purge vagrant-libvirt
+cd /runners
+VAGRANT_HOME=/runners vagrant up loupe-1 --provider=libvirt
 ```
 
-## Install Vagrant Plugins
-
-Once everything is set properly, set the `VAGRANT_HOME` environment variable to the directory in which the Vagrant files and other scripts are stored (i.e., the CWD).
-For example:
+Inside a guest, inspect the service and its explicit state:
 
 ```sh
-export VAGRANT_HOME=`pwd`
+cat ~/runner-state/status
+sudo journalctl -u gem5-runner.service --since '1 hour ago'
+sudo systemctl status gem5-runner.service
 ```
 
-After this, install the relevant vagrant plugins:
+Health gates check Docker access **as the runner user**, free bytes and inodes,
+container execution, bidirectional workspace bind mounts, and the shared cache.
+After three failed health attempts, failures persist `~/runner-state/quarantine` and stop registration. After fixing
+the reported issue, run `./runner-health.sh`, remove that marker, and start the
+service. Do not repeatedly restart a quarantined runner without fixing it.
 
-``` sh
-vagrant plugin install dotenv
-vagrant plugin install vagrant-libvirt
-vagrant plugin install vagrant-reload
-```
-
-## Creating the virtual machines
-
-The Vagrantfile in this directory defines the VMs that can be built and used to create a GitHub Actions runner.
-This standard VM has 4-cores, 16GB of RAM, and 60GB of disk space.
-This is sufficient to both compile gem5 and run most simulations.
-
-At the top of the Vagrantfile, there are a few variables that must be set prior to creating the VMs.
-
-* `NUM_RUNNERS`: The number of runners to create.
-* `PERSONAL_ACCESS_TOKEN`: The GitHub personal access token to use.
-You can generate a Personal Access Token [here](https://github.com/settings/tokens)
-Make sure to set admin permissions on this token.
-* `GITHUB_ORG`: The GitHub organization to add the runners to.
-E.g., if the URL to your organization is https://github.com/orgs/gem5, then the variable should be set to "gem5".
-* `HOSTNAME` : The hostname of the VM to be created (note, this will be appended with a number to create a unique hostname for each VM).
-E.g., if set to `my-machine` and the number of runners set to `2`, two VMs will be created.
-One called `my-machine-1` and the other `my-machine-2`.
-
-When set simply run:
+To drain:
 
 ```sh
-vagrant up --provider=libvirt
+mkdir -p ~/runner-state
+touch ~/runner-state/drain
+# Wait until runner-state/status says "drained" and the service is inactive.
 ```
 
-This should automatically create your machines then configure and start up a Github Actions runner in each.
-You can check the status of the runner here: https://github.com/organizations/{GITHUB_ORG}/settings/actions/runners
+An already idle listener can take **one final job** before draining. The marker
+is checked at registration boundaries; it intentionally does not cancel an idle
+listener based on a potentially stale GitHub busy flag. After draining, perform
+maintenance, remove the marker and start the service. `systemctl stop` itself is
+not a safe drain: it can terminate a running job.
 
-If the runner ever shows as offline, you can rerun the `vagrant up --provider=libvirt` command to make sure everything is working properly.
+## Cleanup and image retention
 
-## Troubleshooting
+After a job, the controller deletes `_work`, removes the dedicated VM's
+containers and unused volumes/networks, and limits Docker builder cache to
+4 GB. It retains `ghcr.io/gem5/*` images and the small health image, subject to a
+32 GiB conservative image-size cap and 20 GiB free-space floor. Shared layers
+are counted repeatedly, so the cap errs toward freeing space. Oldest-created
+images are evicted first when a limit is exceeded. Other images are removed.
+This deliberately avoids an age filter that would repeatedly delete an old but
+frequently pulled image. Recent diagnostic logs are retained for seven days.
 
-### The default libvirt disk image storage pool is on the wrong drive
+The environment settings `RUNNER_IMAGE_CACHE_GIB`, `RUNNER_MIN_FREE_GIB`, and
+`HEALTH_IMAGE` can override these defaults. Job containers continue pulling their
+configured tags through GitHub Actions, so retaining a layer does not freeze
+`:latest` permanently. Retained images share the existing VM trust model.
 
-By default libvirt will store disk images in "/var/lib/libvirt/images".
-This is not ideal as it is on a small root partition.
-A solution to this is to change the default storage location.
-To do so, do the following:
+## Migrating an existing legacy loop
+
+Copy the new scripts, unit file, and `migrate-runner.py` into a guest staging
+directory such as `~/.runner-update`. Then, as the guest `vagrant` user:
 
 ```sh
-virsh pool-list --all # Confirm here a "default" pool exist. We'll modify this.
-virsh pool-dumpxml default >default-pool.xml # We take a dump of the default then removed it.
-virsh pool-destroy default
-virsh pool-undefine default
-vim default-pool.xml # Change the image path to the desired path
-virsh pool-define default-pool.xml # From here we re-add the default.
-virsh pool-start default
-virsh pool-autostart default
+cd ~/.runner-update
+nohup python3 migrate-runner.py > migration.log 2>&1 < /dev/null &
 ```
 
-### Error: "Vagrant failed to initialize at a very early stage"
+The migration first saves the old scripts and private recovery arguments in
+`~/runner-backups/<UTC timestamp>/`. It pauses only the outer legacy shell,
+leaving its listener and job running. After all its live children and runner
+workers exit, it replaces the shell, cleans the completed job, checks health,
+and installs the service. Ordinary termination signals resume the old shell
+if replacement has not begun. Do not SIGKILL the migration during a drain; if
+that happens, inspect its log and resume the recorded legacy PID with SIGCONT
+only after confirming its command still matches the backed-up controller.
 
-W set the `VAGRANT_HOME` environment variable to the CWD.
-It's likely this has become unset The solution is simple.
-Within the directory containing "Vagrantfile":
+An unexpected controller count, changed process, or installation failure stops
+the migration rather than guessing. A failed installation after replacement
+leaves the runner offline for inspection; its backup remains available.
+
+## SSD canaries and versioned images
+
+Keep the existing default pool. A separate directory pool on Loupe's existing
+`/nobackup` SSD permits a canary without moving the fleet or `/nobackup/docker`.
+Create the directory and pool as `vagrant` using libvirt's existing access:
 
 ```sh
-VAGRANT_HOME=`pwd` vagrant <command>
+mkdir -m 0711 /nobackup/loupe-ssd
+virsh -c qemu:///system pool-define-as loupe-ssd dir --target /nobackup/loupe-ssd
+virsh -c qemu:///system pool-start loupe-ssd
+virsh -c qemu:///system pool-autostart loupe-ssd
 ```
 
-You may want to set `VAGRANT_HOME` in your .bashrc or .zshrc.
+Do not rerun creation over an existing pool. Use per-VM `storage_pool` and
+`disk_cache: "none"` overrides for new canaries, and confirm the resulting XML.
+A fast root disk can improve local extraction and Docker I/O; the shared 9p
+resource cache still resides on the original disk. Measure real job preparation
+and execution times before increasing fleet size or moving more VMs.
+
+Build boxes in a **separate directory and Vagrant home**. Vagrant merges the
+Vagrantfile in `VAGRANT_HOME` with the project's file; pointing a builder at
+Loupe's `/runners` home also loads the fleet definition. A private home can reuse
+the existing `gems` and `boxes` through symlinks, without copying
+`/runners/Vagrantfile`. Give it a local `plugins.json` copied from the existing
+registry with only `vagrant-libvirt` and `vagrant-reload` enabled. Loupe also has
+an unrelated `reload` plugin which loads Rails and breaks `vagrant box add`;
+exclude that entry from the private registry. The production registry need not
+change. A separate SSD-backed `boxes` directory can avoid copying new boxes
+through the busy fleet disk. Copy this directory's scripts and `Vagrantfile-image`
+into the builder directory, naming that file `Vagrantfile` there.
+
+The image recipe updates kernel dependencies, installs Docker and runner
+2.337.0 with a SHA-256 check, reboots, prewarms the common Ubuntu gem5 image,
+and runs a container health check. It records package and Docker inventories
+inside the guest. It never registers a runner or receives a PAT. Test real
+container compilation and cleanup before packaging.
+
+After shutting down the builder, package a **new version**:
+
+```sh
+python3 package-image.py BUILDER_DOMAIN loupe-ssd 2026.9.8.1 \
+  /nobackup/loupe-boxes/2026.9.8.1 /path/to/vagrant.pub
+VAGRANT_HOME=/path/to/private-vagrant-home vagrant box add \
+  /nobackup/loupe-boxes/2026.9.8.1/box-catalog.json
+```
+
+Loupe's `/boot/vmlinuz-*` files are root-only. For libguestfs, extract a
+user-owned copy of the matching **already installed** kernel package and point
+supermin at it and the matching, readable host modules. For example, as vagrant:
+
+```sh
+mkdir -p /var/lib/vagrant/loupe-libguestfs-kernel
+cd /var/lib/vagrant/loupe-libguestfs-kernel
+apt-get download linux-image-6.8.0-139-generic=6.8.0-139.139
+dpkg-deb -x linux-image-6.8.0-139-generic_6.8.0-139.139_amd64.deb extracted
+chmod u+r extracted/boot/vmlinuz-6.8.0-139-generic
+export SUPERMIN_KERNEL="$PWD/extracted/boot/vmlinuz-6.8.0-139-generic"
+export SUPERMIN_MODULES=/lib/modules/6.8.0-139-generic
+```
+
+Refresh the version/path together if the installed host kernel changes. This
+extracts a package into a private directory; it does not install a host package
+or change `/boot` permissions.
+
+The packaging command requires Python 3.11+, installed on Loupe. It refuses a
+running VM or an image containing runner credentials/workspace. It uses libvirt
+to flatten a separate volume, sanitizes that copy, replaces the builder's SSH
+authorization with the bootstrap public key, and regenerates host keys at first
+boot. The original builder disk is preserved. The catalog pins the version and
+archive checksum. Boot a fresh VM from that catalog, verify its new machine ID,
+SSH identity, Docker and mount behavior, and test an ordinary guest reboot before
+allowing jobs. Keep the prior box and cold VM disk until the canary is accepted.
+
+## Backups and rollback
+
+Before editing Loupe, keep a mode-0700 backup directory with a mode-0600 archive
+of deployment scripts, Vagrant state (including keys), runner settings, and
+plugin metadata. Save each domain XML and pool XML separately. These backups
+contain credentials; never attach them to issues or PRs. Do not copy live qcow2
+files as a purported consistent VM backup. Preserve a stopped original disk or
+use a new canary, leaving existing disks untouched.
+
+For a service rollback, first drain it. Save current settings, disable the new
+service inside the guest, restore the backed-up scripts, and launch the legacy
+script with its private `legacy-arguments.json` using a subprocess argument
+array (never paste credentials into logs). The controller backup is per guest;
+restoring `/runners` alone does not replace scripts already copied into guests.
+
+For an image rollback, drain and shut down the canary, retain its disk for
+inspection, and restore the previous version/settings or preserved cold domain.
+Do not delete the old box or disk before verifying the replacement. Deleting the
+new SSD pool is not necessary for rollback and must never delete an active VM's
+storage.
+
+## Validation
+
+On Linux, `python3 test_runner.py -v` tests failure gates, cleanup bounds,
+credential environment removal, duplicate-loop protection, and migration drain
+recovery without making Docker or GitHub writes. Also run ShellCheck on the
+shell scripts and `ruby -c` on both Vagrantfiles. Real Docker, mount, reboot,
+packaging, and fresh-box tests are still required for a deployment.

--- a/util/github-runners-vagrant/Vagrantfile
+++ b/util/github-runners-vagrant/Vagrantfile
@@ -27,63 +27,86 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-NUM_RUNNERS=0 # Set this to the desired number of runners.
-PERSONAL_ACCESS_TOKEN="<PERSONAL ACCESS TOKEN>"
-GITHUB_ORG="<GITHUB_ORG>"
-HOSTNAME="<VM NAME>"
+require "json"
+require "shellwords"
+
+NUM_RUNNERS = 0 # Set this to the desired number of runners.
+PERSONAL_ACCESS_TOKEN = "<PERSONAL ACCESS TOKEN>"
+GITHUB_ORG = "<GITHUB_ORG>"
+HOSTNAME = "<VM NAME>"
+RESOURCE_CACHE = File.expand_path("gem5-resource-cache", __dir__)
+settings_file = File.join(__dir__, "runner-settings.json")
+settings = File.exist?(settings_file) ? JSON.parse(File.read(settings_file)) : {}
 
 Vagrant.configure("2") do |config|
   config.ssh.username = "vagrant"
-  config.ssh.password = "vagrant"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  if File.directory?(RESOURCE_CACHE)
+    config.vm.synced_folder RESOURCE_CACHE, "/gem5-resource-cache",
+      type: "9p", accessmode: "mapped", access: "any",
+      mount_opts: "cache=none,msize=1048576"
+  end
 
   (1..NUM_RUNNERS).each do |i|
-
-    config.vm.define "#{HOSTNAME}-#{i}" do |runner|
-      runner.vm.hostname = "#{HOSTNAME}-#{i}"
-      runner.vm.box = "generic/ubuntu2204"
-      runner.vm.box_check_update = true
-
-      runner.vm.provider "libvirt" do |vb|
-        # Customize the amount of cpus, memory, and storage on the VM:
-        vb.cpus = "4".to_i
-        vb.memory = "16384".to_i
-        vb.machine_virtual_size = 128 # 128G is the minimum.
+    name = "#{HOSTNAME}-#{i}"
+    options = settings.fetch(name, {})
+    config.vm.define name do |runner|
+      runner.vm.hostname = name
+      runner.vm.box = options.fetch("box", "generic/ubuntu2204")
+      runner.vm.box_version = options.fetch("box_version", "4.3.6")
+      runner.vm.box_check_update = false
+      runner.vm.provider "libvirt" do |lv|
+        lv.cpus = options.fetch("cpus", 4)
+        lv.memory = options.fetch("memory", 32768)
+        lv.machine_virtual_size = 128
+        lv.storage_pool_name = options.fetch("storage_pool", "default")
+        if options.key?("disk_cache")
+          lv.disk_driver cache: options.fetch("disk_cache"), discard: "unmap"
+        end
       end
 
-      # sets up vm
-      runner.vm.provision :shell, path: "provision_root.sh"
-      runner.vm.provision :shell, privileged: false, path: "provision_nonroot.sh"
-      # The provision_root.sh adds the vagrant user to the docker group, so we need to reload the VM.
-      runner.vm.provision :reload
-      # Copy the "action-run.sh" script from the host to the VM.
-      runner.vm.provision "file", source: "./action-run.sh", destination: "/tmp/action-run.sh"
-      runner.vm.provision :shell, privileged: false,  inline: "cp /tmp/action-run.sh ."
-
-      # The following attempts to see if KVM can be used inside the docker
-      # container.
-      #
-      # Almost all github action jobs run within a docker container. Therefore
-      # to be compatible with KVM, KVM must be enabled inside the docker.
-      #
-      # We used existence of "kvm-works" in the VM home directory is how we
-      # indicate that KVM is working. It is created if the 'kvm-ok' command is
-      # successful. This is then passed to the action-run.sh script to indicate
-      # that the runner can be used for KVM via the `kvm` label.
-      runner.vm.provision :shell, privileged: false, run: 'always',  inline: <<-SHELL
-           rm -f kvm-works
-           docker run --device /dev/kvm -v$(pwd):/work -w /work --rm ubuntu:22.04 bash -c "apt update -y && apt install -y cpu-checker && kvm-ok"
-           status=$?
-           if [[ ${status} == 0 ]]; then
-                echo >&1 "Success. KVM enabled."
-                echo "success" > kvm-works
-           else
-                echo >&2 "Failure. KVM not enabled."
-           fi
-           exit 0
+      runner.vm.provision :shell, run: "always", inline: <<-SHELL
+        if systemctl is-active --quiet gem5-runner.service ||
+           pgrep -x Runner.Listener >/dev/null ||
+           pgrep -x Runner.Worker >/dev/null ||
+           pgrep -f '^(/bin/)?bash [^ ]*action-run.sh( |$)' >/dev/null; then
+          echo 'Drain and stop the runner before provisioning.' >&2
+          exit 1
+        fi
       SHELL
-      # Execute the actions-run.sh script on every boot. This configures and starts the runner.
-      # Note the 'kvm' label is applied to this runner if the "kvm-works" file eixsts. See above.
-      runner.vm.provision :shell, privileged: false, run: 'always', inline: "./action-run.sh #{PERSONAL_ACCESS_TOKEN} #{GITHUB_ORG} $(if [ -f 'kvm-works' ]; then echo 'kvm'; fi) >> action-run.log 2>&1 &"
+      unless options.fetch("prebuilt", false)
+        runner.vm.provision :shell, path: "provision_root.sh"
+        runner.vm.provision :reload
+      end
+      %w[action-run.sh runner-health.sh runner-cleanup.py provision_runner.sh
+         gem5-runner.service install-runner-service.sh].each do |file|
+        runner.vm.provision "file", source: File.join(__dir__, file),
+          destination: "/tmp/gem5-runner-#{file}", run: "always"
+      end
+      runner.vm.provision :shell, run: "always", inline: <<-SHELL
+        set -eu
+        for file in action-run.sh runner-health.sh runner-cleanup.py provision_runner.sh gem5-runner.service install-runner-service.sh; do
+          install -o vagrant -g vagrant -m 0755 "/tmp/gem5-runner-$file" "/home/vagrant/$file"
+        done
+      SHELL
+      runner.vm.provision :shell, privileged: false, run: "always", inline: <<-SHELL
+        cd /home/vagrant
+        ./provision_runner.sh
+      SHELL
+      # The service starts only after provisioning and group membership pass.
+      env = {
+        "PERSONAL_ACCESS_TOKEN" => PERSONAL_ACCESS_TOKEN,
+        "GITHUB_ORG" => GITHUB_ORG,
+        "RUNNER_LABELS" => options.fetch("labels", ""),
+        "RUNNER_RESOURCE_CACHE" => File.directory?(RESOURCE_CACHE) ? "/gem5-resource-cache" : ""
+      }
+      lines = env.map { |key, value| "#{key}=#{value}" }
+      runner.vm.provision :shell, run: "always", inline: <<-SHELL
+        set -eu
+        umask 077
+        printf '%s\n' #{lines.map { |line| Shellwords.escape(line) }.join(" ")} > /etc/gem5-runner.env
+        /home/vagrant/install-runner-service.sh
+      SHELL
     end
   end
 end

--- a/util/github-runners-vagrant/Vagrantfile-image
+++ b/util/github-runners-vagrant/Vagrantfile-image
@@ -1,0 +1,68 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Use a separate working directory and Vagrant home (see README).
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  config.vm.box_version = "4.3.6"
+  config.vm.box_check_update = false
+  config.vm.hostname = "gem5-image-builder"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.provider :libvirt do |lv|
+    lv.cpus = 4
+    lv.memory = 16384
+    lv.machine_virtual_size = 128
+    lv.storage_pool_name = ENV.fetch("GEM5_IMAGE_POOL", "loupe-ssd")
+    lv.disk_driver cache: "none", discard: "unmap"
+  end
+  config.vm.provision :shell, path: "provision_root.sh"
+  config.vm.provision :reload
+  %w[action-run.sh runner-health.sh runner-cleanup.py provision_runner.sh
+     gem5-runner.service install-runner-service.sh].each do |file|
+    config.vm.provision "file", source: File.join(__dir__, file),
+      destination: "/home/vagrant/#{file}"
+  end
+  config.vm.provision :shell, privileged: false, inline: <<-SHELL
+    set -eu
+    cd /home/vagrant
+    chmod +x ./*.sh ./runner-cleanup.py
+    ./provision_runner.sh
+    docker pull ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+    RUNNER_RESOURCE_CACHE='' ./runner-health.sh
+    ./bin/Runner.Listener --version
+    uname -r
+    dpkg-query -W > image-packages.txt
+    docker images --digests > image-docker-images.txt
+  SHELL
+  config.vm.provision :shell, inline: <<-SHELL
+    test ! -e /etc/gem5-runner.env
+    test ! -e /home/vagrant/.runner
+    /home/vagrant/install-runner-service.sh
+  SHELL
+end

--- a/util/github-runners-vagrant/action-run.sh
+++ b/util/github-runners-vagrant/action-run.sh
@@ -123,5 +123,7 @@ while true; do
         failures=0
     fi
     state ready
-    [[ -e "$state_dir/drain" ]] || sleep 180
+    if (( result != 0 )) && [[ ! -e "$state_dir/drain" ]]; then
+        sleep 180
+    fi
 done

--- a/util/github-runners-vagrant/action-run.sh
+++ b/util/github-runners-vagrant/action-run.sh
@@ -26,70 +26,102 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set -x
+# This loop owns one dedicated VM. A drain finishes the current job first.
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+pat="${PERSONAL_ACCESS_TOKEN:-${1:-}}"
+unset PERSONAL_ACCESS_TOKEN
+export GITHUB_ORG="${GITHUB_ORG:-${2:-}}"
+LABELS="${RUNNER_LABELS:-${3:-}}"
+state_dir="$PWD/runner-state"
+mkdir -p "$state_dir"
+exec 9>"$state_dir/lock"
+flock -n 9 || exit 0
 
-# No argument checking here, this is run directly in the Vagrantfile.
-PERSONAL_ACCESS_TOKEN="$1"
-GITHUB_ORG="$2"
-LABELS="$3"
-WORK_DIR="_work"
-
-# This checks there isn't another instance of this script running.
-# If this script is run twice then more than one runner can be active in the
-# VM and this causes problems.
-if [[ `pgrep -f $0` != "$$" ]]; then
-    echo "Another instance of shell already exist! Exiting"
-    exit
+state() {
+    printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" | tee "$state_dir/status.tmp"
+    mv "$state_dir/status.tmp" "$state_dir/status"
+}
+quarantine() {
+    state "quarantined: $*"
+    touch "$state_dir/quarantine"
+    exit 78
+}
+trap 'quarantine "controller failed at line $LINENO"' ERR
+if [[ -e "$state_dir/quarantine" ]]; then
+    state "quarantined: clear runner-state/quarantine after repair"
+    exit 78
 fi
+[[ -n "$pat" && -n "$GITHUB_ORG" ]] || \
+    quarantine "missing registration configuration"
+[[ -x ./config.sh && -x ./run.sh ]] || \
+    quarantine "runner package missing; run provision_runner.sh"
 
-# If the tarball isn't here then download it and extract it.
-# Note: we don't delete the tarball, we use it to check if we've already
-# downloaded it and extracted it.
-if [ ! -f "actions-runner-linux-x64-2.304.0.tar.gz" ]; then
-    wget https://github.com/actions/runner/releases/download/v2.304.0/actions-runner-linux-x64-2.304.0.tar.gz
-    tar xzf ./actions-runner-linux-x64-2.304.0.tar.gz
-fi
+api_token() {
+    curl --fail --silent --show-error --retry 3 --connect-timeout 15 \
+        --max-time 90 -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $pat" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/orgs/$GITHUB_ORG/actions/runners/$1-token" |
+        jq -er '.token | select(type == "string" and length > 0)'
+}
 
-# An infinite loop to re-configure and re-run the runner after each job.
+healthy() {
+    local attempt
+    for attempt in 1 2 3; do
+        if ./runner-health.sh; then
+            return 0
+        fi
+        state "health check failed (attempt $attempt of 3)"
+        [[ "$attempt" == 3 ]] || sleep 15
+    done
+    return 1
+}
+
+failures=0
 while true; do
-    # 1. Obtain the registration token.
-    token_curl=$(curl -L \
-    		      -X POST \
-    		      -H "Accept: application/vnd.github+json" \
-    		      -H "Authorization: Bearer ${PERSONAL_ACCESS_TOKEN}" \
-    		      -H "X-GitHub-Api-Version: 2022-11-28" \
-    		      https://api.github.com/orgs/${GITHUB_ORG}/actions/runners/registration-token)
-
-    token=$(echo ${token_curl} | jq -r '.token')
-
-    if [[ "${token}" == "null" ]];
-    then
-        # If "null" is returned, this can be because the GitHub API rate limit
-        # has been exceeded. To be safe we wait for 15 mintues before
-        # continuing.
-        sleep 900 # 15 minutes.
+    if [[ -e "$state_dir/drain" ]]; then
+        state drained
+        exit 0
+    fi
+    state checking
+    healthy || quarantine "pre-registration health check failed"
+    if [[ -f .runner ]]; then
+        removal_token=$(api_token remove) || \
+            quarantine "could not obtain removal token"
+        ./config.sh remove --token "$removal_token" || \
+            quarantine "could not remove previous registration"
+        unset removal_token
+    fi
+    # Transient API failures leave the VM offline and retry with a delay.
+    if ! registration_token=$(api_token registration); then
+        state "registration API unavailable; retrying in 180 seconds"
+        sleep 180
         continue
     fi
-
-    # 2. Configure the runner.
-    ./config.sh --unattended \
-                --url https://github.com/${GITHUB_ORG} \
-                --ephemeral \
-                --replace \
-                --work "${WORK_DIR}" \
-                --name "$(hostname)" \
-                --labels "${LABELS}" \
-                --token ${token}
-
-    # 3. Run the runner.
-    ./run.sh # This will complete with the runner being destroyed
-
-    # 4. Cleanup the machine
-    sudo rm -rf "${WORK_DIR}"
-    docker system prune --force --volumes --all
-
-    # 5. Sleep for a few minutes
-    #    GitHub has a api rate limit. This sleep ensures we dont ping GitHub
-    #    too frequently.
-    sleep 180 # 3 minutes.
+    if [[ -e "$state_dir/drain" ]]; then
+        state drained
+        exit 0
+    fi
+    args=(--unattended --url "https://github.com/$GITHUB_ORG" --ephemeral
+          --replace --work _work --name "$(hostname)")
+    [[ -z "$LABELS" ]] || args+=(--labels "$LABELS")
+    ./config.sh "${args[@]}" --token "$registration_token" || \
+        quarantine "runner configuration failed"
+    unset registration_token
+    state listening
+    result=0
+    ./run.sh || result=$?
+    state "cleaning; listener exit=$result"
+    timeout 900 ./runner-cleanup.py || quarantine "post-job cleanup failed"
+    healthy || quarantine "post-cleanup health check failed"
+    if (( result != 0 )); then
+        failures=$((failures + 1))
+        (( failures < 3 )) || quarantine "three consecutive listener failures"
+    else
+        failures=0
+    fi
+    state ready
+    [[ -e "$state_dir/drain" ]] || sleep 180
 done

--- a/util/github-runners-vagrant/gem5-runner.service
+++ b/util/github-runners-vagrant/gem5-runner.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=gem5 ephemeral GitHub Actions runner
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+RequiresMountsFor=/gem5-resource-cache
+ConditionPathExists=/etc/gem5-runner.env
+
+[Service]
+Type=simple
+User=vagrant
+SupplementaryGroups=docker
+WorkingDirectory=/home/vagrant
+EnvironmentFile=/etc/gem5-runner.env
+ExecStart=/home/vagrant/action-run.sh
+Restart=on-failure
+RestartSec=60
+RestartPreventExitStatus=78
+# Drain before stopping this service: stop deliberately terminates its job.
+TimeoutStopSec=120
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=gem5-runner
+
+[Install]
+WantedBy=multi-user.target

--- a/util/github-runners-vagrant/install-runner-service.sh
+++ b/util/github-runners-vagrant/install-runner-service.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Run inside the guest as root after copying the runner scripts.
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+install -m 0644 gem5-runner.service /etc/systemd/system/gem5-runner.service
+# Vagrant normally mounts 9p over SSH only. Persist its actual device tag so
+# an ordinary guest reboot has the cache before the runner service starts.
+if mountpoint -q /gem5-resource-cache; then
+    cache_tag=$(findmnt -n -t 9p -o SOURCE --target /gem5-resource-cache)
+    [[ "$cache_tag" =~ ^[a-zA-Z0-9._-]+$ ]]
+    # Loading the filesystem alone does not load its virtio transport early
+    # enough for a boot-time mount on Ubuntu 22.04.
+    printf '%s\n' 9pnet_virtio 9p > /etc/modules-load.d/gem5-resource-cache.conf
+    mount_unit=$(systemd-escape --path --suffix=mount /gem5-resource-cache)
+    cat > "/etc/systemd/system/$mount_unit" <<EOF
+[Unit]
+Description=gem5 shared resource cache
+Wants=systemd-modules-load.service
+After=systemd-modules-load.service
+Before=gem5-runner.service
+
+[Mount]
+What=$cache_tag
+Where=/gem5-resource-cache
+Type=9p
+Options=trans=virtio,version=9p2000.L,cache=none,msize=1048576
+
+[Install]
+WantedBy=local-fs.target
+EOF
+    systemctl daemon-reload
+    systemctl enable "$mount_unit"
+fi
+systemctl daemon-reload
+# Image builders omit credentials and leave the service disabled.
+if [[ -f /etc/gem5-runner.env ]]; then
+    systemctl enable --now gem5-runner.service
+fi

--- a/util/github-runners-vagrant/migrate-runner.py
+++ b/util/github-runners-vagrant/migrate-runner.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Replace the legacy loop after its current (or next assigned) job exits.
+
+Run as vagrant in a dedicated guest, from a staging directory containing the
+new scripts. Only the legacy parent shell is paused. Its listener, worker,
+containers, and build processes keep running. An idle listener can accept one
+last job; this intentionally favors job completion over immediate downtime.
+"""
+
+import fcntl
+import json
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+FILES = (
+    "action-run.sh",
+    "runner-health.sh",
+    "runner-cleanup.py",
+    "provision_runner.sh",
+    "install-runner-service.sh",
+    "gem5-runner.service",
+)
+
+
+def processes():
+    found = []
+    for path in Path("/proc").glob("[0-9]*/cmdline"):
+        try:
+            args = path.read_bytes().decode().strip("\0").split("\0")
+            status = (path.parent / "status").read_text().splitlines()
+            fields = dict(line.split(":", 1) for line in status)
+            found.append(
+                (
+                    int(path.parent.name),
+                    args,
+                    int(fields["PPid"]),
+                    fields["State"].strip()[0],
+                )
+            )
+        except (OSError, ValueError, UnicodeError):
+            continue
+    return found
+
+
+def main():
+    stage = Path(__file__).resolve().parent
+    home = Path.home()
+    with (home / "runner-migration.lock").open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        def interrupted(signum, frame):
+            raise InterruptedError(f"Migration interrupted by signal {signum}")
+
+        signal.signal(signal.SIGTERM, interrupted)
+        signal.signal(signal.SIGHUP, interrupted)
+        if (
+            subprocess.run(
+                ["systemctl", "is-active", "--quiet", "gem5-runner.service"]
+            ).returncode
+            == 0
+        ):
+            raise RuntimeError(
+                "Runner already uses the service; drain it normally"
+            )
+        for name in FILES:
+            if not (stage / name).is_file():
+                raise RuntimeError(f"Missing staged file: {name}")
+        loops = [
+            (pid, args)
+            for pid, args, _, _ in processes()
+            if len(args) >= 4
+            and Path(args[1]).name == "action-run.sh"
+            and Path(args[0]).name == "bash"
+        ]
+        if len(loops) != 1:
+            raise RuntimeError(
+                f"Expected exactly one legacy loop; found {len(loops)}"
+            )
+        pid, args = loops[0]
+        backup = (
+            home
+            / "runner-backups"
+            / time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        )
+        backup.mkdir(mode=0o700, parents=True, exist_ok=False)
+        for name in FILES:
+            if (home / name).exists():
+                shutil.copy2(home / name, backup / name)
+        # Private recovery state. Do not print, upload, or put it in an image.
+        recovery = backup / "legacy-arguments.json"
+        recovery.write_text(json.dumps(args))
+        recovery.chmod(0o600)
+        print(f"Backup: {backup}; pausing legacy parent {pid}", flush=True)
+        replaced = False
+        try:
+            os.kill(pid, signal.SIGSTOP)
+            while True:
+                running = processes()
+                current = next((p for p in running if p[0] == pid), None)
+                if current is None or current[1] != args:
+                    raise RuntimeError(
+                        "Legacy controller changed during drain"
+                    )
+                children = [p for p in running if p[2] == pid and p[3] != "Z"]
+                workers = [
+                    p
+                    for p in running
+                    if p[1]
+                    and Path(p[1][0]).name
+                    in ("Runner.Listener", "Runner.Worker")
+                ]
+                if not children and not workers:
+                    break
+                time.sleep(10)
+            print(
+                "Legacy job and child processes finished; installing",
+                flush=True,
+            )
+            # Kill only the paused shell, after its work has finished.
+            os.kill(pid, signal.SIGKILL)
+            replaced = True
+            for name in FILES:
+                temp = home / (name + ".new")
+                shutil.copy2(stage / name, temp)
+                temp.chmod(0o755)
+                temp.replace(home / name)
+            token, org = args[2:4]
+            labels = args[4] if len(args) > 4 else ""
+            for value in (token, org, labels):
+                if "\n" in value or "\r" in value:
+                    raise RuntimeError("Invalid environment value")
+            env = (
+                f"PERSONAL_ACCESS_TOKEN={token}\nGITHUB_ORG={org}\n"
+                f"RUNNER_LABELS={labels}\n"
+                "RUNNER_RESOURCE_CACHE=/gem5-resource-cache\n"
+            )
+            subprocess.run(
+                [
+                    "sudo",
+                    "-n",
+                    "sh",
+                    "-c",
+                    "umask 077; cat > /etc/gem5-runner.env",
+                ],
+                input=env,
+                text=True,
+                check=True,
+            )
+            # Refresh supplementary groups in case Docker was just provisioned.
+            subprocess.run(
+                [
+                    "sudo",
+                    "-n",
+                    "-u",
+                    "vagrant",
+                    str(home / "provision_runner.sh"),
+                ],
+                check=True,
+            )
+            for command in ("runner-cleanup.py", "runner-health.sh"):
+                subprocess.run(
+                    ["sudo", "-n", "-u", "vagrant", str(home / command)],
+                    check=True,
+                )
+            subprocess.run(
+                ["sudo", "-n", str(home / "install-runner-service.sh")],
+                check=True,
+            )
+            print(
+                "Service installed; inspect runner-state/status and journal",
+                flush=True,
+            )
+        except BaseException:
+            if not replaced and any(
+                p[0] == pid and p[1] == args for p in processes()
+            ):
+                os.kill(pid, signal.SIGCONT)
+            raise
+
+
+if __name__ == "__main__":
+    main()

--- a/util/github-runners-vagrant/package-image.py
+++ b/util/github-runners-vagrant/package-image.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Package a stopped, unregistered builder using existing libvirt privileges.
+
+The builder disk is preserved. Libvirt flattens a new volume before the user's
+image tools sanitize that copy. No host sudo, pool relocation, or live-disk copy.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def run(*args):
+    return subprocess.check_output(args, text=True).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("domain")
+    parser.add_argument("pool")
+    parser.add_argument("version")
+    parser.add_argument("output", type=Path)
+    parser.add_argument("public_key", type=Path)
+    args = parser.parse_args()
+    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+)+", args.version):
+        parser.error("version must be dotted numbers, e.g. 2026.9.8.1")
+    virsh = ["virsh", "-c", "qemu:///system"]
+    if run(*virsh, "domstate", args.domain) != "shut off":
+        parser.error("drain and shut down the builder before packaging")
+    args.output.mkdir(mode=0o700, parents=True, exist_ok=False)
+    xml = run(*virsh, "dumpxml", args.domain)
+    (args.output / "builder.xml").write_text(xml)
+    source = ET.fromstring(xml).find("./devices/disk[@device='disk']/source")
+    source_path = source.get("file")
+    volume_name = f"gem5-runner-{args.version}-flat.img"
+    pool_xml = ET.fromstring(run(*virsh, "pool-dumpxml", args.pool))
+    flat = Path(pool_xml.findtext("./target/path")) / volume_name
+    import os
+
+    volume = ET.Element("volume")
+    ET.SubElement(volume, "name").text = volume_name
+    ET.SubElement(volume, "capacity", unit="GiB").text = "128"
+    target = ET.SubElement(volume, "target")
+    ET.SubElement(target, "format", type="qcow2")
+    permissions = ET.SubElement(target, "permissions")
+    ET.SubElement(permissions, "owner").text = str(os.getuid())
+    ET.SubElement(permissions, "group").text = str(os.getgid())
+    ET.SubElement(permissions, "mode").text = "0600"
+    volume_xml = args.output / "flat-volume.xml"
+    volume_xml.write_text(ET.tostring(volume, encoding="unicode"))
+    run(*virsh, "vol-create-from", args.pool, str(volume_xml), source_path)
+    info = json.loads(run("qemu-img", "info", "--output=json", str(flat)))
+    if info.get("backing-filename"):
+        raise RuntimeError("libvirt clone was not flattened; refusing package")
+    # Check before sanitizing: a production VM is never an image builder.
+    names = run("virt-ls", "-a", str(flat), "/home/vagrant").splitlines()
+    if any(name in names for name in (".runner", ".credentials", "_work")):
+        raise RuntimeError("builder contains a registration or work directory")
+    if (
+        "gem5-runner.env"
+        in run("virt-ls", "-a", str(flat), "/etc").splitlines()
+    ):
+        raise RuntimeError("builder contains runner credentials")
+    run(
+        "virt-sysprep",
+        "-a",
+        str(flat),
+        "--operations",
+        "defaults",
+        "--ssh-inject",
+        f"vagrant:file:{args.public_key.resolve()}",
+        "--hostname",
+        "gem5-runner-base",
+        "--firstboot-command",
+        "ssh-keygen -A; systemctl restart ssh",
+    )
+    image = args.output / "box.img"
+    run("qemu-img", "convert", "-O", "qcow2", "-c", str(flat), str(image))
+    (args.output / "metadata.json").write_text(
+        json.dumps(
+            {"provider": "libvirt", "format": "qcow2", "virtual_size": 128}
+        )
+    )
+    (args.output / "Vagrantfile").write_text(
+        'Vagrant.configure("2") { |config| config.ssh.username = "vagrant" }\n'
+    )
+    box = args.output / "gem5-runner.box"
+    run(
+        "tar",
+        "-cf",
+        str(box),
+        "-C",
+        str(args.output),
+        "box.img",
+        "metadata.json",
+        "Vagrantfile",
+    )
+    digest = hashlib.file_digest(box.open("rb"), "sha256").hexdigest()
+    (args.output / "SHA256SUMS").write_text(f"{digest}  gem5-runner.box\n")
+    metadata = {
+        "name": "gem5/runner-ubuntu2204",
+        "versions": [
+            {
+                "version": args.version,
+                "providers": [
+                    {
+                        "name": "libvirt",
+                        "url": str(box.resolve()),
+                        "checksum_type": "sha256",
+                        "checksum": digest,
+                    }
+                ],
+            }
+        ],
+    }
+    manifest = args.output / "box-catalog.json"
+    manifest.write_text(json.dumps(metadata, indent=2) + "\n")
+    print(
+        f"Packaged {box}. Original builder disk and flat copy are preserved."
+    )
+    print(f"Add the version with: vagrant box add {manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/github-runners-vagrant/provision_root.sh
+++ b/util/github-runners-vagrant/provision_root.sh
@@ -26,69 +26,46 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# fail on unset variables and command errors
-set -eu -o pipefail # -x: is for debugging
+# All privileged operations here run inside the guest, never on the host.
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get upgrade -y
-apt-get install -y \
-  software-properties-common \
-  bash \
-  build-essential \
-  clang-format \
-  git \
-  git-lfs \
-  jq \
-  libffi-dev \
-  libssl-dev \
-  nkf \
-  python3 \
-  python3-dev \
-  python3-pip \
-  python3-venv \
-  shellcheck \
-  tree \
-  wget \
-  yamllint \
-  zstd \
-  jq \
-  apt-transport-https ca-certificates \
-  curl \
-  gnupg \
-  lsb-release \
-  cpu-checker
+# Include new kernel dependencies when updating the base box.
+apt-get --with-new-pkgs upgrade -y
+apt-get install -y linux-generic bash build-essential clang-format git git-lfs \
+    jq libffi-dev libssl-dev nkf python3 python3-dev python3-pip python3-venv \
+    shellcheck tree wget yamllint zstd ca-certificates curl gnupg lsb-release \
+    cpu-checker
 
-# Install docker
-apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update -y
-apt-get install -y docker-ce docker-ce-cli containerd.io
-
-# Add the Vagrant user to the docker group.
-# Note: The VM needs rebooted for this to take effect. `newgrp docker` doesn't
-# work.
+install -m 0755 -d /etc/apt/keyrings
+curl --fail --show-error --silent --retry 3 \
+    https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+# Replace the previous version of this provisioner's source definition.
+rm -f /etc/apt/sources.list.d/docker.list
+cat > /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release; echo "$VERSION_CODENAME")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io \
+    docker-buildx-plugin docker-compose-plugin
 usermod -aG docker vagrant
+systemctl enable --now docker
 
-kvm-ok
-kvm_ok_status=$?
-
-# `kvm-ok` will return a exit zero if the machine supports KVM, and non-zero
-# otherwise. If the machine support KVM, let's enable it.
-if [[ ${kvm_ok_status} == 0 ]]; then
-    apt install -y qemu-kvm \
-                   virt-manager \
-                  libvirt-daemon-system virtinst \
-                  libvirt-clients bridge-utils && \
-    sudo systemctl enable --now libvirtd && \
-    sudo systemctl start libvirtd && \
-    usermod -aG kvm vagrant && \
-    usermod -aG libvirt vagrant
+# Re-provisioning a disk which already fills its volume group is harmless.
+root_device=$(findmnt -n -o SOURCE /)
+if lvs "$root_device" >/dev/null 2>&1; then
+    volume_group=$(lvs --noheadings -o vg_name "$root_device" | xargs)
+    free_extents=$(vgs --noheadings -o vg_free_count "$volume_group" | xargs)
+    if (( free_extents > 0 )); then
+        lvextend --resizefs -l +100%FREE "$root_device"
+    fi
 fi
-
-# Cleanup
-apt-get autoremove -y
-
-# Resize the root partition to fill up all the free size on the disk
-lvextend -l +100%FREE $(df / --output=source | sed 1d)
-resize2fs $(df / --output=source | sed 1d)
+apt-get clean

--- a/util/github-runners-vagrant/provision_runner.sh
+++ b/util/github-runners-vagrant/provision_runner.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Run as vagrant. Do not bake registrations or credentials into the box.
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+version=2.337.0
+checksum=70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613
+if [[ ! -x ./run.sh || ! -x ./config.sh ]]; then
+    archive=$(mktemp)
+    trap 'rm -f "$archive"' EXIT
+    curl --fail --show-error --silent --location --retry 3 \
+        "https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-x64-${version}.tar.gz" \
+        -o "$archive"
+    printf '%s  %s\n' "$checksum" "$archive" | sha256sum --check -
+    tar -xzf "$archive"
+fi
+# This small image is required by health checks; normal jobs cannot trigger a
+# network pull while the health gate is deciding whether to register.
+docker pull ubuntu:24.04

--- a/util/github-runners-vagrant/runner-cleanup.py
+++ b/util/github-runners-vagrant/runner-cleanup.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Clean a dedicated idle runner; retain a bounded cache of common images."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def docker(*args):
+    return subprocess.check_output(["docker", *args], text=True).strip()
+
+
+def cleanup():
+    os.chdir(Path(__file__).resolve().parent)
+    worker_status = subprocess.run(
+        ["pgrep", "-x", "Runner.Worker"], stdout=subprocess.DEVNULL
+    ).returncode
+    if worker_status != 1:
+        raise RuntimeError(
+            "Refusing cleanup: a worker exists or its state is unavailable"
+        )
+    subprocess.run(["sudo", "-n", "rm", "-rf", "--", "_work"], check=True)
+    containers = docker("ps", "-aq").split()
+    if containers:
+        docker("rm", "-f", *containers)
+    docker("volume", "prune", "--all", "--force")
+    docker("network", "prune", "--force")
+    docker("builder", "prune", "--all", "--force", "--keep-storage", "4GB")
+    ids = list(dict.fromkeys(docker("image", "ls", "-aq").split()))
+    images = json.loads(docker("image", "inspect", *ids)) if ids else []
+    health = docker(
+        "image",
+        "inspect",
+        "--format",
+        "{{.Id}}",
+        os.environ.get("HEALTH_IMAGE", "ubuntu:24.04"),
+    )
+    retained = []
+    for image in images:
+        tags = image.get("RepoTags") or []
+        if image["Id"] == health or any(
+            tag.startswith("ghcr.io/gem5/") for tag in tags
+        ):
+            retained.append(image)
+        else:
+            docker("image", "rm", "--force", image["Id"])
+    # Sum full image sizes conservatively: shared layers count more than once.
+    # This is a byte cap, not Docker's 'until' (image creation time) filter.
+    cap = int(os.environ.get("RUNNER_IMAGE_CACHE_GIB", "32")) * 1024**3
+    floor = int(os.environ.get("RUNNER_MIN_FREE_GIB", "20")) * 1024**3
+    size = sum(image["Size"] for image in retained)
+    for image in sorted(retained, key=lambda item: item["Created"]):
+        if size <= cap and shutil.disk_usage(".").free >= floor:
+            break
+        if image["Id"] == health:
+            continue
+        docker("image", "rm", "--force", image["Id"])
+        size -= image["Size"]
+    print(f"Retained image size (shared layers counted repeatedly): {size}")
+    # Diagnostics are rotated only after jobs, preserving recent failure logs.
+    import time
+
+    for log in Path("_diag").glob("*.log"):
+        if log.stat().st_mtime < time.time() - 7 * 86400:
+            log.unlink()
+
+
+if __name__ == "__main__":
+    cleanup()

--- a/util/github-runners-vagrant/runner-health.sh
+++ b/util/github-runners-vagrant/runner-health.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Run as the service user, including Docker access and bind-mount checks.
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+: "${HEALTH_IMAGE:=ubuntu:24.04}"
+: "${RUNNER_MIN_FREE_GIB:=20}"
+RUNNER_RESOURCE_CACHE=${RUNNER_RESOURCE_CACHE-/gem5-resource-cache}
+[[ $(id -u) != 0 ]]
+timeout 30 docker info >/dev/null
+available=$(df -B1 --output=avail . | tail -1)
+(( available >= RUNNER_MIN_FREE_GIB * 1024 * 1024 * 1024 ))
+inodes=$(df --output=iavail . | tail -1)
+(( inodes >= 100000 ))
+[[ -w . ]]
+probe=$(mktemp -d "$PWD/.runner-health.XXXXXXXX")
+trap 'sudo -n rm -rf -- "$probe"' EXIT
+printf 'host-to-container\n' > "$probe/input"
+args=(--rm --pull=never --network none -v "$probe:/probe")
+if [[ -n "$RUNNER_RESOURCE_CACHE" ]]; then
+    # A missing mount must never silently become a private local cache.
+    mountpoint -q "$RUNNER_RESOURCE_CACHE"
+    args+=(-v "$RUNNER_RESOURCE_CACHE:/cache")
+fi
+# Expand these expressions inside the container, not on the guest.
+# shellcheck disable=SC2016
+timeout 60 docker run "${args[@]}" "$HEALTH_IMAGE" sh -ec '
+    test "$(cat /probe/input)" = host-to-container
+    echo container-to-host > /probe/output
+    if [ -d /cache ]; then
+        file=$(mktemp /cache/.runner-health.XXXXXXXX)
+        echo cache-check > "$file"
+        test "$(cat "$file")" = cache-check
+        rm "$file"
+    fi
+'
+[[ $(cat "$probe/output") == container-to-host ]]
+sudo -n rm -rf -- "$probe"
+trap - EXIT
+echo "Runner health checks passed"

--- a/util/github-runners-vagrant/test_runner.py
+++ b/util/github-runners-vagrant/test_runner.py
@@ -93,6 +93,45 @@ class ControllerTest(unittest.TestCase):
             "drained", (self.root / "runner-state/status").read_text()
         )
 
+    def test_successful_jobs_register_again_without_sleeping(self):
+        self.script("bin/sleep", 'echo "sleep $*" >> calls')
+        self.script(
+            "run.sh",
+            "echo run >> calls; "
+            "if test -e ran; then touch runner-state/drain; "
+            "else touch ran; fi",
+        )
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls().count("run"), 2)
+        self.assertFalse(any(c.startswith("sleep ") for c in self.calls()))
+
+    def test_listener_failure_retains_backoff(self):
+        self.script("bin/sleep", 'echo "sleep $*" >> calls')
+        self.script(
+            "run.sh",
+            "echo run >> calls; "
+            "if test -e ran; then touch runner-state/drain; "
+            "else touch ran; exit 1; fi",
+        )
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls().count("run"), 2)
+        self.assertEqual(self.calls().count("sleep 180"), 1)
+
+    def test_registration_failure_retains_backoff(self):
+        self.script("bin/sleep", 'echo "sleep $*" >> calls')
+        self.script(
+            "bin/curl",
+            "echo curl >> calls; "
+            "if test ! -e retried; then touch retried; exit 1; fi; "
+            "echo unused",
+        )
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls().count("run"), 1)
+        self.assertEqual(self.calls().count("sleep 180"), 1)
+
     def test_cleanup_failure_quarantines(self):
         self.script("runner-cleanup.py", "echo cleanup >> calls; exit 1")
         result = self.run_controller()

--- a/util/github-runners-vagrant/test_runner.py
+++ b/util/github-runners-vagrant/test_runner.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Controller failure-path tests; no Docker or GitHub writes are performed."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class ControllerTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        shutil.copy(Path(__file__).with_name("action-run.sh"), self.root)
+        (self.root / "runner-state").mkdir()
+        (self.root / "bin").mkdir()
+        self.script("bin/curl", "echo curl >> calls; echo unused")
+        self.script("bin/sleep", "true")
+        self.script("bin/jq", "cat >/dev/null; echo test-token")
+        self.script("config.sh", "echo config >> calls")
+        self.script("run.sh", "echo run >> calls; touch runner-state/drain")
+        self.script("runner-health.sh", "echo health >> calls")
+        self.script("runner-cleanup.py", "echo cleanup >> calls")
+
+    def script(self, name, body):
+        path = self.root / name
+        path.write_text("#!/bin/bash\nset -eu\n" + body + "\n")
+        path.chmod(0o755)
+
+    def run_controller(self):
+        env = dict(
+            os.environ,
+            PERSONAL_ACCESS_TOKEN="dummy",
+            GITHUB_ORG="test",
+            PATH=f"{self.root}/bin:" + os.environ["PATH"],
+        )
+        return subprocess.run(
+            ["bash", str(self.root / "action-run.sh")],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def calls(self):
+        path = self.root / "calls"
+        return path.read_text().splitlines() if path.exists() else []
+
+    def test_failed_health_never_registers(self):
+        self.script("runner-health.sh", "exit 1")
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 78, result.stderr)
+        self.assertEqual(self.calls(), [])
+        self.assertTrue((self.root / "runner-state/quarantine").exists())
+
+    def test_drain_completes_job_then_cleanup(self):
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.calls(),
+            ["health", "curl", "config", "run", "cleanup", "health"],
+        )
+        self.assertIn(
+            "drained", (self.root / "runner-state/status").read_text()
+        )
+
+    def test_cleanup_failure_quarantines(self):
+        self.script("runner-cleanup.py", "echo cleanup >> calls; exit 1")
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 78, result.stderr)
+        self.assertEqual(self.calls().count("config"), 1)
+        self.assertEqual(self.calls().count("health"), 1)
+
+    def test_post_cleanup_health_failure_quarantines(self):
+        self.script("runner-health.sh", "test ! -e ran")
+        self.script("run.sh", "touch ran runner-state/drain")
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 78, result.stderr)
+        self.assertEqual(self.calls().count("config"), 1)
+
+    def test_failed_configuration_never_runs(self):
+        self.script("config.sh", "exit 1")
+        result = self.run_controller()
+        self.assertEqual(result.returncode, 78, result.stderr)
+        self.assertNotIn("run", self.calls())
+
+    def test_existing_quarantine_stays_offline(self):
+        (self.root / "runner-state/quarantine").touch()
+        self.assertEqual(self.run_controller().returncode, 78)
+        self.assertEqual(self.calls(), [])
+
+    def test_existing_drain_stays_offline(self):
+        (self.root / "runner-state/drain").touch()
+        self.assertEqual(self.run_controller().returncode, 0)
+        self.assertEqual(self.calls(), [])
+
+    def test_pat_is_not_in_job_environment(self):
+        self.script(
+            "run.sh",
+            'test -z "${PERSONAL_ACCESS_TOKEN:-}"; '
+            "touch runner-state/drain",
+        )
+        self.assertEqual(self.run_controller().returncode, 0)
+
+    def test_lock_prevents_a_second_controller(self):
+        import fcntl
+
+        with (self.root / "runner-state/lock").open("w") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self.assertEqual(self.run_controller().returncode, 0)
+        self.assertEqual(self.calls(), [])
+
+
+class CleanupTest(unittest.TestCase):
+    def setUp(self):
+        import importlib.util
+        from unittest.mock import patch
+
+        spec = importlib.util.spec_from_file_location(
+            "runner_cleanup", Path(__file__).with_name("runner-cleanup.py")
+        )
+        self.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.module)
+        self.images = [
+            {
+                "Id": "health",
+                "RepoTags": ["ubuntu:24.04"],
+                "Size": 1,
+                "Created": "2026-01-01",
+            },
+            {
+                "Id": "gem5",
+                "RepoTags": ["ghcr.io/gem5/test:latest"],
+                "Size": 2 * 1024**3,
+                "Created": "2026-02-01",
+            },
+            {
+                "Id": "other",
+                "RepoTags": ["unrelated:latest"],
+                "Size": 1,
+                "Created": "2026-03-01",
+            },
+        ]
+        self.commands = []
+        self.worker = patch.object(self.module.subprocess, "run")
+        self.run = self.worker.start()
+        self.run.return_value.returncode = 1
+        self.addCleanup(self.worker.stop)
+        for obj, attr, value in [
+            (self.module.os, "chdir", lambda *args: None),
+            (self.module, "docker", self.docker),
+        ]:
+            mocker = patch.object(obj, attr, value)
+            mocker.start()
+            self.addCleanup(mocker.stop)
+        self.disk = patch.object(self.module.shutil, "disk_usage")
+        self.usage = self.disk.start()
+        self.usage.return_value.free = 100 * 1024**3
+        self.addCleanup(self.disk.stop)
+        self.env = patch.dict(
+            os.environ, RUNNER_IMAGE_CACHE_GIB="32", RUNNER_MIN_FREE_GIB="20"
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.logs = patch.object(self.module.Path, "glob", return_value=[])
+        self.logs.start()
+        self.addCleanup(self.logs.stop)
+
+    def docker(self, *args):
+        import json
+
+        self.commands.append(args)
+        if args == ("ps", "-aq"):
+            return "container"
+        if args == ("image", "ls", "-aq"):
+            return "health gem5 other"
+        if args[:3] == ("image", "inspect", "--format"):
+            return "health"
+        if args[:2] == ("image", "inspect"):
+            return json.dumps(self.images)
+        return ""
+
+    def removed(self):
+        return [cmd[-1] for cmd in self.commands if cmd[:2] == ("image", "rm")]
+
+    def test_active_worker_prevents_every_mutation(self):
+        self.run.return_value.returncode = 0
+        with self.assertRaises(RuntimeError):
+            self.module.cleanup()
+        self.assertEqual(self.commands, [])
+        self.assertEqual(self.run.call_count, 1)
+        self.assertEqual(self.run.call_args.args[0][0], "pgrep")
+
+    def test_retains_common_and_health_images(self):
+        self.module.cleanup()
+        self.assertEqual(self.removed(), ["other"])
+        self.assertIn(("rm", "-f", "container"), self.commands)
+        self.assertIn(("volume", "prune", "--all", "--force"), self.commands)
+
+    def test_unavailable_worker_state_prevents_cleanup(self):
+        self.run.return_value.returncode = 2
+        with self.assertRaises(RuntimeError):
+            self.module.cleanup()
+        self.assertEqual(self.commands, [])
+
+    def test_byte_cap_evicts_common_image_but_keeps_health(self):
+        os.environ["RUNNER_IMAGE_CACHE_GIB"] = "1"
+        self.module.cleanup()
+        self.assertEqual(self.removed(), ["other", "gem5"])
+
+    def test_free_space_floor_evicts_images(self):
+        self.usage.return_value.free = 1024**3
+        self.module.cleanup()
+        self.assertEqual(self.removed(), ["other", "gem5"])
+
+    def test_cleanup_error_does_not_continue_to_images(self):
+        self.run.side_effect = [
+            type("Result", (), {"returncode": 1})(),
+            subprocess.CalledProcessError(1, "rm"),
+        ]
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.module.cleanup()
+        self.assertEqual(self.commands, [])
+
+
+class MigrationTest(unittest.TestCase):
+    def setUp(self):
+        import importlib.util
+        from unittest.mock import patch
+
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.home = Path(self.temp.name) / "home"
+        self.stage = Path(self.temp.name) / "stage"
+        self.home.mkdir()
+        self.stage.mkdir()
+        spec = importlib.util.spec_from_file_location(
+            "migrate_runner", Path(__file__).with_name("migrate-runner.py")
+        )
+        self.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.module)
+        self.module.__file__ = str(self.stage / "migrate-runner.py")
+        for name in self.module.FILES:
+            (self.stage / name).write_text("new")
+            (self.home / name).write_text("old")
+        self.args = ["/bin/bash", "./action-run.sh", "dummy", "test"]
+        self.parent = (1234, self.args, 1, "T")
+        self.child = (1235, ["Runner.Worker"], 1234, "S")
+        self.mockers = []
+        for obj, attr in [
+            (self.module, "processes"),
+            (self.module.subprocess, "run"),
+            (self.module.os, "kill"),
+            (self.module.time, "sleep"),
+            (self.module.signal, "signal"),
+            (self.module.Path, "home"),
+        ]:
+            mocker = patch.object(obj, attr)
+            setattr(self, attr, mocker.start())
+            self.addCleanup(mocker.stop)
+        self.home.return_value = Path(self.temp.name) / "home"
+        self.run.return_value.returncode = 1
+        self.processes.side_effect = [
+            [self.parent],
+            [self.parent, self.child],
+            [self.parent],
+        ]
+
+    def test_waits_for_job_then_cleans_before_starting(self):
+        self.module.main()
+        self.sleep.assert_called_once_with(10)
+        signals = [call.args for call in self.kill.call_args_list]
+        self.assertEqual(
+            signals,
+            [
+                (1234, self.module.signal.SIGSTOP),
+                (1234, self.module.signal.SIGKILL),
+            ],
+        )
+        commands = [call.args[0] for call in self.run.call_args_list]
+        self.assertTrue(commands[-3][-1].endswith("runner-cleanup.py"))
+        self.assertTrue(commands[-2][-1].endswith("runner-health.sh"))
+        self.assertTrue(commands[-1][-1].endswith("install-runner-service.sh"))
+
+    def test_interrupted_drain_resumes_parent(self):
+        self.sleep.side_effect = InterruptedError("test interruption")
+        with self.assertRaises(InterruptedError):
+            self.module.main()
+        self.kill.assert_any_call(1234, self.module.signal.SIGCONT)
+        self.assertNotIn(
+            (1234, self.module.signal.SIGKILL),
+            [call.args for call in self.kill.call_args_list],
+        )
+        self.assertEqual(self.run.call_count, 1)
+
+    def test_changed_parent_is_not_killed_or_resumed(self):
+        other = (1234, ["unrelated"], 1, "S")
+        self.processes.side_effect = [[self.parent], [other], [other]]
+        with self.assertRaises(RuntimeError):
+            self.module.main()
+        self.kill.assert_called_once_with(1234, self.module.signal.SIGSTOP)
+
+    def test_ambiguous_legacy_loops_are_left_untouched(self):
+        self.processes.side_effect = [[self.parent, self.parent]]
+        with self.assertRaises(RuntimeError):
+            self.module.main()
+        self.kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Persistent runner VMs currently register without checking Docker and workspace mounts, discard reusable image layers after every job, and require substantial provisioning on each rebuild. Add a supervised controller with health gates, quarantine, job-boundary draining, bounded image retention, and journal logs. Healthy jobs proceed directly to the next registration after cleanup; registration and listener failures retain their backoff.

Provide a legacy-loop migration tool, per-VM storage settings, and a versioned image build/package path using existing unprivileged host access. All 22 controller, cleanup, and migration tests pass, including consecutive-job and failure-backoff coverage. The packaged image was also validated with Docker compilation, shared-resource caching, cleanup, and an ordinary reboot on Loupe.
