### PR TITLE
sim,arch-x86: Fix GCC 16 compilation failures

### DIFF
--- a/src/arch/x86/insts/microop_args.hh
+++ b/src/arch/x86/insts/microop_args.hh
@@ -424,7 +424,7 @@ class InstOperands : public Base, public Operands...
     {
         std::stringstream response;
         Base::printMnemonic(response, this->instMnem, this->mnemonic);
-        int count = 0;
+        [[maybe_unused]] int count = 0;
         GEM5_FOR_EACH_IN_PACK(ccprintf(response, count++ ? ", " : ""),
                               Operands::print(response));
         return response.str();

--- a/src/sim/guest_abi/dispatch.hh
+++ b/src/sim/guest_abi/dispatch.hh
@@ -102,7 +102,7 @@ static void
 dumpArgsFrom(std::ostream &os, [[maybe_unused]] ThreadContext *tc,
         typename ABI::State &state)
 {
-    int count = 0;
+    [[maybe_unused]] int count = 0;
     // Extract all the arguments from the thread context and print them,
     // prefixed with either a ( or a , as appropriate.
     GEM5_FOR_EACH_IN_PACK(os << (count++ ? ", " : "("),

--- a/src/sim/simulate.cc
+++ b/src/sim/simulate.cc
@@ -171,7 +171,8 @@ static std::unique_ptr<SimulatorThreads> simulatorThreads;
 
 struct DescheduleDeleter
 {
-    void operator()(BaseGlobalEvent *event)
+    void
+    operator()(GlobalSyncEvent *event)
     {
         if (!event)
             return;


### PR DESCRIPTION
[Compiler Tests](https://github.com/gem5/gem5/actions/runs/34316343857) fail under GCC 16 on unused formatting counters and an array-bounds false positive during synchronization-event deletion. Mark the guest-ABI and x86 disassembly counters `[[maybe_unused]]` for empty parameter packs, and retain `GlobalSyncEvent*` in the deleter so GCC does not speculate on unrelated exit-event destructors. Formatting and deschedule-before-delete behavior are unchanged.

Reproduced the failures using the CI container pinned to `sha256:3fc9a417ec46797f000625c0955bfc2945b63e1064dcc4575659b5c1efb8ef1c`. With the fix, the focused event and x86 object builds pass, as do all seven guest-ABI unit tests. Additional formatting checks cover empty and nonempty argument packs; the full compiler matrix has not been rerun on this branch.
