### PR TITLE
stdlib,tests: Coordinate shared GPU resource downloads

### DIFF
--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -240,18 +240,6 @@ jobs:
                     printf '%s\n' "$GITHUB_SHA" | cmp - "$(dirname "$manifest")/COMMIT"
                   done
 
-            - name: Prepare shared GPUFS resources
-              if: matrix.test-type == 'gem5/gpu'
-              timeout-minutes: 120
-              run: |
-                  # Both long GPU tests use the disk/kernel pair defined by
-                  # x86_gpu.py. Download or verify it once before parallel tests.
-                  build/ALL/gem5.opt configs/example/gem5_library/x86-mi355x-gpu.py \
-                    --download-resources-only \
-                    --resource-directory "$GEM5_RESOURCE_DIR" \
-                    --resource-lock-timeout 3600
-                  echo "GEM5_GPU_SKIP_CACHE_HASH_CHECK=1" >> "$GITHUB_ENV"
-
             - name: Run long ${{ matrix.test-type }} tests
               id: run-tests
               timeout-minutes: 1410

--- a/.github/workflows/daily-tests.yaml
+++ b/.github/workflows/daily-tests.yaml
@@ -240,6 +240,18 @@ jobs:
                     printf '%s\n' "$GITHUB_SHA" | cmp - "$(dirname "$manifest")/COMMIT"
                   done
 
+            - name: Prepare shared GPUFS resources
+              if: matrix.test-type == 'gem5/gpu'
+              timeout-minutes: 120
+              run: |
+                  # Both long GPU tests use the disk/kernel pair defined by
+                  # x86_gpu.py. Download or verify it once before parallel tests.
+                  build/ALL/gem5.opt configs/example/gem5_library/x86-mi355x-gpu.py \
+                    --download-resources-only \
+                    --resource-directory "$GEM5_RESOURCE_DIR" \
+                    --resource-lock-timeout 3600
+                  echo "GEM5_GPU_SKIP_CACHE_HASH_CHECK=1" >> "$GITHUB_ENV"
+
             - name: Run long ${{ matrix.test-type }} tests
               id: run-tests
               timeout-minutes: 1410

--- a/configs/example/gem5_library/x86_gpu.py
+++ b/configs/example/gem5_library/x86_gpu.py
@@ -247,19 +247,7 @@ def run_gpu_example(gpu_class, description):
 
     requires(coherence_protocol_required=CoherenceProtocol.GPU_VIPER)
     parser = create_parser(description)
-    parser.add_argument(
-        "--download-resources-only",
-        action="store_true",
-        help="prepare the GPUFS resources and exit without simulating",
-    )
     args = parser.parse_args()
-    if args.download_resources_only:
-        for resource in obtain_gpu_fs_resources(args):
-            print(f"GPUFS resource ready: {resource.get_local_path()}")
-        if args.checkpoint_resource:
-            checkpoint = obtain_checkpoint(args)
-            print(f"GPUFS checkpoint ready: {checkpoint.get_local_path()}")
-        return
     if not args.app and not (
         args.checkpoint_directory or args.checkpoint_resource
     ):

--- a/configs/example/gem5_library/x86_gpu.py
+++ b/configs/example/gem5_library/x86_gpu.py
@@ -89,6 +89,17 @@ def create_parser(description):
         help="directory used for resources obtained by gem5",
     )
     parser.add_argument(
+        "--skip-cache-hash-check",
+        action="store_true",
+        help="trust existing cached resources without hashing; emits warnings",
+    )
+    parser.add_argument(
+        "--resource-lock-timeout",
+        type=float,
+        default=3600,
+        help="seconds to wait for a resource lock (default: 3600)",
+    )
+    parser.add_argument(
         "--disk-resource-version",
         default=GPUFS_DISK_RESOURCE_VERSION,
         help="version of the GPUFS disk image resource",
@@ -138,7 +149,11 @@ def create_parser(description):
 
 
 def _resource_kwargs(args, resource_version):
-    kwargs = {"resource_version": resource_version}
+    kwargs = {
+        "resource_version": resource_version,
+        "skip_cache_hash_check": args.skip_cache_hash_check,
+        "lock_timeout": args.resource_lock_timeout,
+    }
     if args.resource_directory:
         args.resource_directory.mkdir(parents=True, exist_ok=True)
         kwargs["resource_directory"] = str(args.resource_directory)
@@ -232,7 +247,19 @@ def run_gpu_example(gpu_class, description):
 
     requires(coherence_protocol_required=CoherenceProtocol.GPU_VIPER)
     parser = create_parser(description)
+    parser.add_argument(
+        "--download-resources-only",
+        action="store_true",
+        help="prepare the GPUFS resources and exit without simulating",
+    )
     args = parser.parse_args()
+    if args.download_resources_only:
+        for resource in obtain_gpu_fs_resources(args):
+            print(f"GPUFS resource ready: {resource.get_local_path()}")
+        if args.checkpoint_resource:
+            checkpoint = obtain_checkpoint(args)
+            print(f"GPUFS checkpoint ready: {checkpoint.get_local_path()}")
+        return
     if not args.app and not (
         args.checkpoint_directory or args.checkpoint_resource
     ):

--- a/src/python/gem5/resources/downloader.py
+++ b/src/python/gem5/resources/downloader.py
@@ -26,6 +26,7 @@
 
 import gzip
 import hashlib
+import math
 import os
 import random
 import shutil
@@ -443,6 +444,8 @@ def get_resource(
     gem5_version: str | None = core.gem5Version,
     quiet: bool = False,
     sparse: bool = True,
+    skip_cache_hash_check: bool = False,
+    lock_timeout: float = 900,
 ) -> None:
     """
     Obtains a gem5 resource and stored it to a specified location. If the
@@ -484,18 +487,46 @@ def get_resource(
     :param quiet: If ``True``, no output will be printed to the console (baring
                   exceptions). ``False`` by default.
 
+    :param skip_cache_hash_check: Trust an existing cache path without hashing
+                   its contents, and warn even when ``quiet`` is set. Defaults
+                   to ``False``. Cached disk images keep their current storage
+                   representation. Missing resources are downloaded normally.
+
+    :param lock_timeout: Maximum seconds to wait for the resource lock. Defaults
+                   to 900. Must be finite and non-negative.
+
     :raises Exception: An exception is thrown if a file is already present at
                        ``to_path`` but it does not have the correct md5 sum. An
                        exception will also be thrown is a directory is present
                        at ``to_path``.
     """
 
-    # We apply a lock for a specific resource. This is to avoid circumstances
-    # where multiple instances of gem5 are running and trying to obtain the
-    # same resources at once. The timeout here is somewhat arbitarily put at 15
-    # minutes.Most resources should be downloaded and decompressed in this
-    # timeframe, even on the most constrained of systems.
-    with FileLock(f"{to_path}.lock", timeout=900):
+    if not isinstance(skip_cache_hash_check, bool):
+        raise TypeError("skip_cache_hash_check must be a bool.")
+    if isinstance(lock_timeout, bool) or not isinstance(
+        lock_timeout, (int, float)
+    ):
+        raise TypeError("lock_timeout must be a finite non-negative number.")
+    if not math.isfinite(lock_timeout) or lock_timeout < 0:
+        raise ValueError("lock_timeout must be a finite non-negative number.")
+
+    def report_wait(elapsed):
+        print(
+            f"Waiting for resource '{resource_name}' at '{to_path}': "
+            f"{elapsed:.0f}s elapsed, {lock_timeout:g}s timeout. "
+            "Another process may be downloading or verifying it.",
+            flush=True,
+        )
+
+    # Keep exclusive-create locking even when hashes are skipped: another
+    # process may still be writing the cache entry. Retain the existing lock
+    # path for compatibility with other gem5 processes sharing the cache.
+    with FileLock(
+        f"{to_path}.lock",
+        timeout=lock_timeout,
+        delay=1,
+        on_wait=None if quiet else report_wait,
+    ):
         resource_json = get_resource_json_obj(
             resource_name,
             resource_version=resource_version,
@@ -517,6 +548,14 @@ def get_resource(
         make_sparse = sparse and is_disk_image
 
         if os.path.exists(to_path):
+            if skip_cache_hash_check:
+                warn(
+                    f"Using cached resource '{resource_name}' at '{to_path}' "
+                    "without checking its hash (skip_cache_hash_check=True). "
+                    "The cache path is trusted; corrupted or incorrect "
+                    "contents will not be detected."
+                )
+                return
             if os.path.isfile(to_path):
                 md5 = md5_file(Path(to_path))
             else:

--- a/src/python/gem5/resources/resource.py
+++ b/src/python/gem5/resources/resource.py
@@ -924,6 +924,8 @@ def obtain_resource(
     to_path: str | None = None,
     quiet: bool = False,
     sparse: bool = True,
+    skip_cache_hash_check: bool = False,
+    lock_timeout: float = 900,
 ) -> AbstractResource:
     """
     This function primarily serves as a factory for resources. It will return
@@ -953,13 +955,24 @@ def obtain_resource(
                          version. If `None`, this filtering is not performed.
     :param to_path: The path to which the resource is to be downloaded. If
                     ``None``, the resource will be downloaded to the resource directory
-                    with the file/directory name equal to the ID of the resource.
+                    with the file/directory name ``<id>-<resource_version>``.
                     **Note**: Usage of this parameter will override the
                     ``resource_directory`` parameter.
     :param quiet: If ``True``, suppress output. ``False`` by default.
     :param sparse: If ``True``, request a sparse local representation of a
                    disk image resource. If ``False``, disable sparse
                    downloading. ``True`` by default.
+    :param skip_cache_hash_check: If ``True``, reuse an existing cache path
+                   without verifying its contents, and emit a warning even
+                   when ``quiet`` is set. ``False`` by default. The default
+                   cache name includes the resource ID and version; with
+                   ``to_path``, the caller is responsible for the mapping.
+                   Cached disk images retain their current sparse/dense
+                   representation. Missing resources follow the normal
+                   download path. Applies to workload and suite resources too.
+    :param lock_timeout: Maximum seconds to wait for another process to finish
+                   using a resource lock. Defaults to 900 (15 minutes). Must
+                   be finite and non-negative; zero attempts acquisition once.
     """
 
     # Some basic validation. Resource_id must be of type string and not empty.
@@ -975,6 +988,9 @@ def obtain_resource(
 
     if not isinstance(sparse, bool):
         raise TypeError(f"sparse must be a bool, got {type(sparse).__name__}.")
+
+    if not isinstance(skip_cache_hash_check, bool):
+        raise TypeError("skip_cache_hash_check must be a bool.")
 
     # Obtain the resource object entry for this resource
     resource_json = get_resource_json_obj(
@@ -995,6 +1011,8 @@ def obtain_resource(
         gem5_version=gem5_version,
         quiet=quiet,
         sparse=sparse,
+        skip_cache_hash_check=skip_cache_hash_check,
+        lock_timeout=lock_timeout,
     )
 
     # The 'workload' and 'suite' are special and need some translating into
@@ -1009,6 +1027,8 @@ def obtain_resource(
             gem5_version,
             quiet,
             sparse=sparse,
+            skip_cache_hash_check=skip_cache_hash_check,
+            lock_timeout=lock_timeout,
         )
 
     if resource_json.get("category") == "workload":
@@ -1021,6 +1041,8 @@ def obtain_resource(
             gem5_version,
             quiet,
             sparse=sparse,
+            skip_cache_hash_check=skip_cache_hash_check,
+            lock_timeout=lock_timeout,
         )
 
     # Check the schema of the 'resource_json' object.
@@ -1166,6 +1188,8 @@ def _get_suite(
     gem5_version: str,
     quiet: bool,
     sparse: bool = True,
+    skip_cache_hash_check: bool = False,
+    lock_timeout: float = 900,
 ) -> dict[str, Any]:
     """
     :param suite: The suite JSON object.
@@ -1182,6 +1206,8 @@ def _get_suite(
                          version.
     :param quiet: If ``True``, suppress output. ``False`` by default.
     :param sparse: Whether nested disk images should be materialized sparsely.
+    :param skip_cache_hash_check: Whether to trust cached nested resources.
+    :param lock_timeout: Maximum seconds to wait for each resource lock.
     """
     # Mapping input groups to workload IDs
     id_input_group_dict = {}
@@ -1226,6 +1252,8 @@ def _get_suite(
             gem5_version,
             quiet,
             sparse=sparse,
+            skip_cache_hash_check=skip_cache_hash_check,
+            lock_timeout=lock_timeout,
         )
         _resources_schema_validator(workload_dict)
         workload_input_group_dict[
@@ -1248,6 +1276,8 @@ def _get_workload(
     gem5_version: str,
     quiet: bool,
     sparse: bool = True,
+    skip_cache_hash_check: bool = False,
+    lock_timeout: float = 900,
 ) -> dict[str, Any]:
     """
     :param workload: The workload JSON object.
@@ -1264,6 +1294,8 @@ def _get_workload(
                          version.
     :param quiet: If ``True``, suppress output. ``False`` by default.
     :param sparse: Whether nested disk images should be materialized sparsely.
+    :param skip_cache_hash_check: Whether to trust cached nested resources.
+    :param lock_timeout: Maximum seconds to wait for each resource lock.
     """
 
     db_query = []
@@ -1340,6 +1372,8 @@ def _get_workload(
             gem5_version=gem5_version,
             quiet=quiet,
             sparse=sparse,
+            skip_cache_hash_check=skip_cache_hash_check,
+            lock_timeout=lock_timeout,
         )
 
         _resources_schema_validator(resource_match)
@@ -1410,6 +1444,8 @@ def _get_to_path_and_downloader_partial(
     gem5_version: str,
     quiet: bool,
     sparse: bool = True,
+    skip_cache_hash_check: bool = False,
+    lock_timeout: float = 900,
 ) -> tuple[str, partial | None]:
 
     if "resource_version" not in resource_json:
@@ -1489,6 +1525,8 @@ def _get_to_path_and_downloader_partial(
             gem5_version=gem5_version,
             quiet=quiet,
             sparse=sparse,
+            skip_cache_hash_check=skip_cache_hash_check,
+            lock_timeout=lock_timeout,
         )
     return to_path, downloader
 

--- a/src/python/gem5/utils/filelock.py
+++ b/src/python/gem5/utils/filelock.py
@@ -38,9 +38,13 @@ class FileLock:
     compatible as it doesn't rely on ``msvcrt`` or ``fcntl`` for the locking.
     """
 
-    def __init__(self, file_name, timeout=10, delay=0.05):
+    def __init__(self, file_name, timeout=10, delay=0.05, on_wait=None):
         """Prepare the file locker. Specify the file to lock and optionally
         the maximum timeout and the delay between each attempt to lock.
+
+        If supplied, ``on_wait`` is called with the elapsed wait in seconds
+        on contention and once per minute thereafter. It does not indicate
+        whether the lock holder is making progress.
         """
         if timeout is not None and delay is None:
             raise ValueError(
@@ -51,6 +55,7 @@ class FileLock:
         self.file_name = file_name
         self.timeout = timeout
         self.delay = delay
+        self.on_wait = on_wait
 
     def acquire(self):
         """Acquire the lock, if possible. If the lock is in use, it check again
@@ -58,7 +63,8 @@ class FileLock:
         exceeds ``timeout`` number of seconds, in which case it throws
         an exception.
         """
-        start_time = time.time()
+        start_time = time.monotonic()
+        next_notice = 0
         while True:
             try:
                 self.fd = os.open(
@@ -70,10 +76,9 @@ class FileLock:
                 if e.errno != errno.EEXIST:
                     raise
                 solution_message = (
-                    "This is likely due to the existence"
-                    " of the lock file '{}'. If there's no other process"
-                    " the lock file, you can manually delete the lock file and"
-                    " rerun the script.".format(self.lockfile)
+                    f"Lock file: '{self.lockfile}'. Another process may be "
+                    "using this resource. Only remove the lock after "
+                    "confirming no process on any sharing host owns it."
                 )
                 if self.timeout is None:
                     raise FileLockException(
@@ -81,11 +86,16 @@ class FileLock:
                             self.file_name, solution_message
                         )
                     )
-                if (time.time() - start_time) >= self.timeout:
+                elapsed = time.monotonic() - start_time
+                if elapsed >= self.timeout:
                     raise FileLockException(
-                        f"Timeout occured. {solution_message}"
+                        f"Timed out after {elapsed:.0f} seconds waiting for "
+                        f"{self.file_name}. {solution_message}"
                     )
-                time.sleep(self.delay)
+                if self.on_wait is not None and elapsed >= next_notice:
+                    self.on_wait(elapsed)
+                    next_notice = elapsed + 60
+                time.sleep(min(self.delay, self.timeout - elapsed))
 
     #        self.is_locked = True
 

--- a/tests/gem5/gpu/test_gpu_fs.py
+++ b/tests/gem5/gpu/test_gpu_fs.py
@@ -24,6 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import re
 
 from testlib import *
@@ -46,6 +47,13 @@ mi355x_checkpoint_resource_version = "1.0.0"
 def gpu_fs_test(name, config_file, expected_gpu, length):
     """Register a GPUFS driver smoke test for one simulated GPU model."""
 
+    # Daily sets this only after its shared GPUFS prefetch has succeeded.
+    # Standalone TestLib runs continue to verify cached resource hashes.
+    cache_args = (
+        ("--skip-cache-hash-check",)
+        if os.environ.get("GEM5_GPU_SKIP_CACHE_HASH_CHECK") == "1"
+        else ()
+    )
     gem5_verify_config(
         name=name,
         verifiers=(
@@ -66,7 +74,8 @@ def gpu_fs_test(name, config_file, expected_gpu, length):
             gpu_check_script,
             "--opts",
             expected_gpu,
-        ),
+        )
+        + cache_args,
         valid_isas=(constants.all_compiled_tag,),
         valid_hosts=constants.supported_hosts,
         length=length,

--- a/tests/gem5/gpu/test_gpu_fs.py
+++ b/tests/gem5/gpu/test_gpu_fs.py
@@ -24,7 +24,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import re
 
 from testlib import *
@@ -47,13 +46,6 @@ mi355x_checkpoint_resource_version = "1.0.0"
 def gpu_fs_test(name, config_file, expected_gpu, length):
     """Register a GPUFS driver smoke test for one simulated GPU model."""
 
-    # Daily sets this only after its shared GPUFS prefetch has succeeded.
-    # Standalone TestLib runs continue to verify cached resource hashes.
-    cache_args = (
-        ("--skip-cache-hash-check",)
-        if os.environ.get("GEM5_GPU_SKIP_CACHE_HASH_CHECK") == "1"
-        else ()
-    )
     gem5_verify_config(
         name=name,
         verifiers=(
@@ -66,6 +58,11 @@ def gpu_fs_test(name, config_file, expected_gpu, length):
         config_args=(
             "--resource-directory",
             resource_directory,
+            # One test fills a cold shared cache while the other waits for
+            # its lock. Reuse the completed resources without rehashing them.
+            "--skip-cache-hash-check",
+            "--resource-lock-timeout",
+            "3600",
             "--cpu-type",
             "atomic",
             "--num-cus",
@@ -74,8 +71,7 @@ def gpu_fs_test(name, config_file, expected_gpu, length):
             gpu_check_script,
             "--opts",
             expected_gpu,
-        )
-        + cache_args,
+        ),
         valid_isas=(constants.all_compiled_tag,),
         valid_hosts=constants.supported_hosts,
         length=length,

--- a/tests/pyunit/stdlib/resources/pyunit_resource_cache.py
+++ b/tests/pyunit/stdlib/resources/pyunit_resource_cache.py
@@ -29,6 +29,8 @@ import copy
 import gzip
 import hashlib
 import io
+import runpy
+import sys
 import tempfile
 import threading
 import unittest
@@ -75,6 +77,57 @@ class ResourceCacheTestSuite(unittest.TestCase):
         return obtain_resource(
             "test-image", resource_directory=str(self.root), **kwargs
         ).get_local_path()
+
+    def run_resource_cli(self, *args):
+        script = (
+            Path(__file__).resolve().parents[4] / "util/obtain-resource.py"
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        argv = [str(script), "test-image", "-p", str(self.destination), *args]
+        with patch.object(sys, "argv", argv), contextlib.redirect_stdout(
+            stdout
+        ), contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as exit_status:
+                runpy.run_path(
+                    str(script),
+                    run_name="__m5_main__",
+                    init_globals={"exit": sys.exit},
+                )
+        self.assertEqual(0, exit_status.exception.code)
+        return stdout.getvalue(), stderr.getvalue()
+
+    def test_cli_materializes_missing_resource_in_both_output_modes(self):
+        for quiet in (False, True):
+            with self.subTest(quiet=quiet), patch(
+                "gem5.resources.downloader.md5_file"
+            ) as cached_hash:
+                stdout, _ = self.run_resource_cli(*(["-q"] if quiet else []))
+                self.assertEqual(self.contents, self.destination.read_bytes())
+                self.assertEqual(not quiet, "Resource at:" in stdout)
+                # Printing the result must not trigger a second acquisition.
+                cached_hash.assert_not_called()
+                self.destination.unlink()
+
+    def test_quiet_cli_warns_when_trusting_cached_resource(self):
+        self.destination.write_bytes(b"trusted cache")
+        with patch("gem5.resources.downloader.md5_file") as cached_hash:
+            stdout, stderr = self.run_resource_cli(
+                "-q", "--skip-cache-hash-check"
+            )
+        self.assertNotIn("Resource at:", stdout)
+        self.assertEqual(1, stderr.count("without checking its hash"))
+        cached_hash.assert_not_called()
+        self.assertEqual(b"trusted cache", self.destination.read_bytes())
+
+    def test_quiet_cli_respects_active_resource_lock(self):
+        self.destination.write_bytes(self.contents)
+        with FileLock(f"{self.destination}.lock") as owner:
+            with self.assertRaises(FileLockException):
+                self.run_resource_cli(
+                    "-q", "--skip-cache-hash-check", "--lock-timeout", "0"
+                )
+            self.assertTrue(Path(owner.lockfile).exists())
 
     def test_default_rejects_bad_cached_contents(self):
         self.destination.write_bytes(b"bad image")

--- a/tests/pyunit/stdlib/resources/pyunit_resource_cache.py
+++ b/tests/pyunit/stdlib/resources/pyunit_resource_cache.py
@@ -35,6 +35,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from gem5.resources.downloader import _write_sparse_file
 from gem5.resources.resource import obtain_resource
 from gem5.utils.filelock import (
     FileLock,
@@ -150,41 +151,69 @@ class ResourceCacheTestSuite(unittest.TestCase):
             self.assertTrue(Path(owner.lockfile).exists())
         self.assertFalse(Path(f"{self.destination}.lock.lock").exists())
 
-    def test_waiter_uses_resource_after_publisher_releases_lock(self):
+    def test_concurrent_opt_out_requests_materialize_once(self):
         started = threading.Event()
         publish = threading.Event()
+        errors = []
+        results = []
+
+        def write_resource(*args, **kwargs):
+            # Pause the real download writer while it owns the resource lock.
+            started.set()
+            if not publish.wait(5):
+                raise RuntimeError("The second resource request did not wait")
+            return _write_sparse_file(*args, **kwargs)
 
         def publisher():
-            with FileLock(f"{self.destination}.lock"):
-                started.set()
-                if publish.wait(5):
-                    self.destination.write_bytes(self.contents)
+            try:
+                results.append(
+                    self.obtain(skip_cache_hash_check=True, lock_timeout=5)
+                )
+            except Exception as error:
+                errors.append(error)
 
-        thread = threading.Thread(target=publisher)
-        thread.start()
-        try:
-            self.assertTrue(started.wait(5))
-            # Waiting output signals the owner to finish. Use a real lock
-            # rather than mocking acquisition or its exclusive-create rules.
-            output = io.StringIO()
-            real_write = output.write
+        output = io.StringIO()
+        real_write = output.write
 
-            def write(message):
-                result = real_write(message)
-                if "Waiting for resource" in message:
-                    publish.set()
-                return result
+        def write(message):
+            result = real_write(message)
+            if "Waiting for resource" in message:
+                publish.set()
+            return result
 
-            with patch.object(
-                output, "write", side_effect=write
-            ), contextlib.redirect_stdout(output):
-                self.obtain(lock_timeout=5)
-            self.assertIn("test-image", output.getvalue())
-            self.assertEqual(self.contents, self.destination.read_bytes())
-        finally:
-            publish.set()
-            thread.join(6)
-        self.assertFalse(thread.is_alive())
+        with patch(
+            "gem5.resources.downloader._write_sparse_file",
+            side_effect=write_resource,
+        ) as writer, patch(
+            "gem5.resources.downloader.md5_file"
+        ) as hash_file, patch(
+            "gem5.resources.downloader.warn"
+        ) as warn, patch.object(
+            output, "write", side_effect=write
+        ), contextlib.redirect_stdout(
+            output
+        ):
+            thread = threading.Thread(target=publisher)
+            thread.start()
+            try:
+                self.assertTrue(started.wait(5))
+                # Contention output lets the owner finish its download. Both
+                # callers use the real exclusive-create lock and downloader.
+                results.append(
+                    self.obtain(skip_cache_hash_check=True, lock_timeout=5)
+                )
+            finally:
+                publish.set()
+                thread.join(6)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual([], errors)
+            self.assertEqual([str(self.destination)] * 2, results)
+            writer.assert_called_once()
+            hash_file.assert_not_called()
+            warn.assert_called_once()
+        self.assertIn("Waiting for resource", output.getvalue())
+        self.assertEqual(self.contents, self.destination.read_bytes())
+        self.assertFalse(Path(f"{self.destination}.lock.lock").exists())
 
     def test_invalid_cache_option(self):
         for value in (None, "false", 1):

--- a/tests/pyunit/stdlib/resources/pyunit_resource_cache.py
+++ b/tests/pyunit/stdlib/resources/pyunit_resource_cache.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 The Regents of The University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import contextlib
+import copy
+import gzip
+import hashlib
+import io
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gem5.resources.resource import obtain_resource
+from gem5.utils.filelock import (
+    FileLock,
+    FileLockException,
+)
+
+
+class ResourceCacheTestSuite(unittest.TestCase):
+    """Exercise cache trust, download integrity, and real lock contention."""
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.destination = self.root / "test-image-1.0.0"
+        self.contents = b"image contents" + b"\0" * 4096
+        source = self.root / "source.gz"
+        source.write_bytes(gzip.compress(self.contents))
+        self.metadata = {
+            "id": "test-image",
+            "category": "disk-image",
+            "resource_version": "1.0.0",
+            "url": source.as_uri(),
+            "is_zipped": True,
+            "md5sum": hashlib.md5(self.contents).hexdigest(),
+            "root_partition": "1",
+        }
+        for module in ("resource", "downloader"):
+            patcher = patch(
+                f"gem5.resources.{module}.get_resource_json_obj",
+                return_value=self.metadata,
+            )
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def obtain(self, **kwargs):
+        return obtain_resource(
+            "test-image", resource_directory=str(self.root), **kwargs
+        ).get_local_path()
+
+    def test_default_rejects_bad_cached_contents(self):
+        self.destination.write_bytes(b"bad image")
+        with self.assertRaisesRegex(Exception, "md5 value is invalid"):
+            self.obtain(download_md5_mismatch=False)
+        self.assertFalse(Path(f"{self.destination}.lock.lock").exists())
+
+    def test_opt_out_reuses_path_without_hashing_or_rewriting(self):
+        self.destination.write_bytes(b"trusted without checking")
+        for sparse in (True, False):
+            with self.subTest(sparse=sparse), patch(
+                "gem5.resources.downloader.md5_file"
+            ) as hash_file, patch(
+                "gem5.resources.downloader._sparsify_file"
+            ) as sparsify, patch(
+                "gem5.resources.downloader._densify_file"
+            ) as densify, patch(
+                "gem5.resources.downloader.warn"
+            ) as warn:
+                result = self.obtain(
+                    skip_cache_hash_check=True,
+                    download_md5_mismatch=False,
+                    quiet=True,
+                    sparse=sparse,
+                )
+                self.assertEqual(str(self.destination), result)
+                hash_file.assert_not_called()
+                sparsify.assert_not_called()
+                densify.assert_not_called()
+                warn.assert_called_once()
+                self.assertIn(
+                    "without checking its hash", warn.call_args.args[0]
+                )
+        self.assertEqual(
+            b"trusted without checking", self.destination.read_bytes()
+        )
+
+    def test_opt_out_reuses_cached_directory(self):
+        self.metadata["category"] = "directory"
+        self.destination.mkdir()
+        with patch("gem5.resources.downloader.md5_dir") as hash_dir, patch(
+            "gem5.resources.downloader.warn"
+        ) as warn:
+            self.obtain(skip_cache_hash_check=True)
+        hash_dir.assert_not_called()
+        warn.assert_called_once()
+
+    def test_quiet_opt_out_still_prints_warning(self):
+        self.destination.write_bytes(self.contents)
+        output = io.StringIO()
+        with contextlib.redirect_stderr(output):
+            self.obtain(skip_cache_hash_check=True, quiet=True)
+        self.assertIn("without checking its hash", output.getvalue())
+
+    def test_opt_out_still_downloads_missing_resource(self):
+        with patch("gem5.resources.downloader.warn") as warn:
+            self.obtain(skip_cache_hash_check=True)
+        warn.assert_not_called()
+        self.assertEqual(self.contents, self.destination.read_bytes())
+
+    def test_opt_out_keeps_new_sparse_download_hash_validation(self):
+        self.metadata["md5sum"] = "0" * 32
+        with self.assertRaisesRegex(Exception, "invalid MD5 checksum"):
+            self.obtain(skip_cache_hash_check=True)
+        self.assertFalse(self.destination.exists())
+        self.assertEqual([], list(self.root.glob(".*.part")))
+
+    def test_opt_out_still_respects_active_lock(self):
+        self.destination.write_bytes(self.contents)
+        with FileLock(f"{self.destination}.lock") as owner:
+            with self.assertRaisesRegex(FileLockException, "Timed out"):
+                self.obtain(skip_cache_hash_check=True, lock_timeout=0)
+            # A timed-out waiter must not delete the owner's lock.
+            self.assertTrue(Path(owner.lockfile).exists())
+        self.assertFalse(Path(f"{self.destination}.lock.lock").exists())
+
+    def test_waiter_uses_resource_after_publisher_releases_lock(self):
+        started = threading.Event()
+        publish = threading.Event()
+
+        def publisher():
+            with FileLock(f"{self.destination}.lock"):
+                started.set()
+                if publish.wait(5):
+                    self.destination.write_bytes(self.contents)
+
+        thread = threading.Thread(target=publisher)
+        thread.start()
+        try:
+            self.assertTrue(started.wait(5))
+            # Waiting output signals the owner to finish. Use a real lock
+            # rather than mocking acquisition or its exclusive-create rules.
+            output = io.StringIO()
+            real_write = output.write
+
+            def write(message):
+                result = real_write(message)
+                if "Waiting for resource" in message:
+                    publish.set()
+                return result
+
+            with patch.object(
+                output, "write", side_effect=write
+            ), contextlib.redirect_stdout(output):
+                self.obtain(lock_timeout=5)
+            self.assertIn("test-image", output.getvalue())
+            self.assertEqual(self.contents, self.destination.read_bytes())
+        finally:
+            publish.set()
+            thread.join(6)
+        self.assertFalse(thread.is_alive())
+
+    def test_invalid_cache_option(self):
+        for value in (None, "false", 1):
+            with self.subTest(value=value), self.assertRaises(TypeError):
+                self.obtain(skip_cache_hash_check=value)
+
+    def test_invalid_lock_timeout(self):
+        for value in (None, "60", True, -1, float("inf"), float("nan")):
+            with self.subTest(value=value), self.assertRaises(
+                (TypeError, ValueError)
+            ):
+                self.obtain(lock_timeout=value)
+
+    def test_options_propagate_through_workload_and_suite(self):
+        workload = {
+            "category": "workload",
+            "id": "test-workload",
+            "resource_version": "1.0.0",
+            "function": "set_kernel_disk_workload",
+            "resources": {
+                "disk_image": {"id": "test-image", "resource_version": "1.0.0"}
+            },
+        }
+        suite = {
+            "category": "suite",
+            "id": "test-suite",
+            "resource_version": "1.0.0",
+            "workloads": [
+                {
+                    "id": "test-workload",
+                    "resource_version": "1.0.0",
+                    "input_group": ["test"],
+                }
+            ],
+        }
+        self.destination.write_bytes(b"trusted cache")
+        for top in (workload, suite):
+            with self.subTest(category=top["category"]), patch(
+                "gem5.resources.resource.get_resource_json_obj",
+                return_value=copy.deepcopy(top),
+            ), patch(
+                "gem5.resources.resource.get_multiple_resource_json_obj",
+                side_effect=(
+                    [copy.deepcopy([workload]), [self.metadata]]
+                    if top is suite
+                    else [[self.metadata]]
+                ),
+            ), patch(
+                "gem5.resources.downloader.warn"
+            ) as warn:
+                resource = obtain_resource(
+                    top["id"],
+                    resource_directory=str(self.root),
+                    skip_cache_hash_check=True,
+                    lock_timeout=0,
+                )
+                if top is suite:
+                    resource = next(iter(resource))
+                disk = resource.get_parameters()["disk_image"]
+                self.assertEqual(str(self.destination), disk.get_local_path())
+                warn.assert_called_once()
+                with FileLock(f"{self.destination}.lock"), self.assertRaises(
+                    FileLockException
+                ):
+                    disk.get_local_path()
+
+
+class FileLockWaitTestSuite(unittest.TestCase):
+    def test_reports_once_per_minute_and_preserves_owner_on_timeout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            name = str(Path(directory) / "resource")
+            notices = []
+            with FileLock(name) as owner:
+                with patch(
+                    "gem5.utils.filelock.time.monotonic",
+                    side_effect=[0, 0, 30, 60, 90],
+                ), patch("gem5.utils.filelock.time.sleep"):
+                    with self.assertRaisesRegex(
+                        FileLockException, "90 seconds"
+                    ):
+                        with FileLock(
+                            name, timeout=90, on_wait=notices.append
+                        ):
+                            self.fail("Acquired an already owned lock")
+                self.assertTrue(Path(owner.lockfile).exists())
+            self.assertEqual([0, 60], notices)
+
+    def test_exception_releases_lock(self):
+        with tempfile.TemporaryDirectory() as directory:
+            name = str(Path(directory) / "resource")
+            with self.assertRaisesRegex(RuntimeError, "test"):
+                with FileLock(name):
+                    raise RuntimeError("test")
+            with FileLock(name, timeout=0):
+                pass

--- a/util/obtain-resource.py
+++ b/util/obtain-resource.py
@@ -108,8 +108,11 @@ if __name__ == "__m5_main__":
         lock_timeout=args.lock_timeout,
     )
 
+    # Acquisition is lazy; quiet mode suppresses the path print, not the
+    # download, locking, or cache-trust warning.
+    local_path = resource.get_local_path()
     if not args.quiet:
-        print(f"Resource at: '" + str(resource.get_local_path()) + "'")
+        print(f"Resource at: '{local_path}'")
 
     exit(0)
 

--- a/util/obtain-resource.py
+++ b/util/obtain-resource.py
@@ -71,6 +71,17 @@ if __name__ == "__m5_main__":
         help="Suppress output.",
     )
 
+    parser.add_argument(
+        "--skip-cache-hash-check",
+        action="store_true",
+        help="Trust an existing cache path without hashing; emits a warning.",
+    )
+    parser.add_argument(
+        "--lock-timeout",
+        type=float,
+        default=900,
+        help="Seconds to wait for the resource lock (default: 900).",
+    )
     sparse_group = parser.add_mutually_exclusive_group()
     sparse_group.add_argument(
         "--sparse",
@@ -93,6 +104,8 @@ if __name__ == "__m5_main__":
         quiet=args.quiet,
         to_path=args.path,
         sparse=args.sparse,
+        skip_cache_hash_check=args.skip_cache_hash_check,
+        lock_timeout=args.lock_timeout,
     )
 
     if not args.quiet:


### PR DESCRIPTION
Parallel GPUFS tests can exceed the 15-minute resource-lock wait while one test downloads the shared 55 GiB image. Both long GPU tests now explicitly pass `--skip-cache-hash-check` and `--resource-lock-timeout 3600`. One request fills a cold shared cache while the other waits for its lock, then reuses the completed resource without rehashing it. Lock contention is reported once per minute.

Add opt-in `obtain_resource(..., skip_cache_hash_check=True)` and configurable `lock_timeout`, including workload/suite propagation and CLI options. Cache trust emits a warning even in quiet mode, preserves locking, and leaves fresh-download validation unchanged. Hash checks remain enabled by default; cached images retain their existing sparse/dense representation when checking is skipped.

49 resource/lock tests passed using minimal native-binding placeholders, including two concurrent cache-trusting requests that materialize a cold resource once, plus CLI checks for quiet downloads, warnings, and locking. Bounded GPU config checks, TestLib selection, and pre-commit also passed. Full GPU simulations have not been rerun; this change does not address slow simulated GPU execution.

