### PR TITLE
arch-riscv: fix reg overwrite on vector slide down instructions

### DIFF
--- a/src/arch/riscv/isa/templates/vector_arith.isa
+++ b/src/arch/riscv/isa/templates/vector_arith.isa
@@ -2318,8 +2318,8 @@ Fault
     const uint32_t vlmax = vtype_VLMAX(vtype, vlen);
 
     %(offset)s;
-    %(copy_old_vd)s;
     %(get_vs2_regs)s;
+    %(copy_old_vd)s;
     %(slide_loop)s;
     %(scalar_inject)s;
     %(op_wb)s;


### PR DESCRIPTION
Small ordering fix of the tail/mask policy code block to avoid overwriting the source registers of vector slide down instructions in the event of an destination/source architectural overlap for the non-reordering CPUs.

Related to #3313.