### PR TITLE
misc: Pin clang-format for local hooks and CI

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -24,8 +24,8 @@ jobs:
             - uses: pre-commit/action@v3.0.1
 
     # Runs on the github hosted runner
-    # Iterates through all of the commits in the the PR and runs
-    # clang-format to make sure that nothing changes.
+    # Checks changed lines against the PR merge base with the same pinned
+    # clang-format version used by the local pre-commit hook.
     clang-format-check:
         runs-on: ubuntu-24.04
         if: github.event.pull_request.draft == false
@@ -40,9 +40,6 @@ jobs:
               with:
                   python-version: '3.10'
 
-            - name: Install clang-format
-              run: sudo apt-get install -y clang-format
-
             - name: Get merge base commit
               id: get-base-commit
               run: |
@@ -54,8 +51,11 @@ jobs:
                   echo "base_commit=$MERGE_BASE" >> $GITHUB_OUTPUT
 
             - name: Run clang-format check
-              run: |
-                  python util/run-git-clang-format.py --verbose --ci-pr-base-commit ${{ steps.get-base-commit.outputs.base_commit }}
+              uses: pre-commit/action@v3.0.1
+              with:
+                  extra_args: gem5-git-clang-format --all-files
+              env:
+                  GEM5_CI_PR_BASE_COMMIT: ${{ steps.get-base-commit.outputs.base_commit }}
 
     get-date:
     # We use the date to label caches. A cache is a a "hit" if the date is the

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -22,6 +22,10 @@ jobs:
               with:
                   python-version: '3.10'
             - uses: pre-commit/action@v3.0.1
+              env:
+                  # Formatting runs in the separate clang-format-check job
+                  # so its failures remain advisory.
+                  SKIP: gem5-git-clang-format
 
     # Runs on the github hosted runner
     # Checks changed lines against the PR merge base with the same pinned

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,11 +101,12 @@ repos:
             description: The gem5 style checker hook.
           - id: gem5-git-clang-format
             name: gem5 clang-format
-            entry: util/run-git-clang-format.py
+            entry: python util/run-git-clang-format.py
             args: [--pre-commit]
             always_run: true
             exclude: .*
-            language: system
+            language: python
+            additional_dependencies: [clang-format==18.1.8]
             description: Run git-clang-format on the commit.
           - id: gem5-commit-msg-checker
             name: gem5 commit msg checker


### PR DESCRIPTION
Local pre-commit and CI can produce opposite formatting when they use different system clang-format versions, as seen in #3341. Pin `clang-format==18.1.8` in the hook's isolated Python environment, retaining the clang-format 18 series used by CI.

Run the same hook in the separate `clang-format-check` job, with `.pre-commit-config.yaml` as the single source of the version pin. Pass `GEM5_CI_PR_BASE_COMMIT` to preserve the comparison against the PR merge base. Explicitly skip this hook in the main CI pre-commit job, with an explanatory comment, so formatting failures remain advisory while local commits still run the formatter.

Verified locally that staged-file and CI-style checks reject the one-line body from #3341, apply the same formatting, and pass after staging or committing it; an unrelated unformatted file stays unchanged. Also verified the explicit skip is confined to the main CI action. YAML checks and commit hooks pass.
